### PR TITLE
chore(langchain): make langchain runnable lambda test less flaky

### DIFF
--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -956,7 +956,8 @@ def test_llmobs_runnable_with_span_links(langchain_core, llmobs_events):
     llmobs_events.sort(key=lambda span: span["start_ns"])
 
     # assert output -> output links for runnable sequence span from last two runnable lambdas
-    assert llmobs_events[0]["span_links"] == [
+    # the order of the links is not guaranteed
+    expected_links = [
         {
             "trace_id": mock.ANY,
             "span_id": llmobs_events[2]["span_id"],
@@ -968,6 +969,9 @@ def test_llmobs_runnable_with_span_links(langchain_core, llmobs_events):
             "attributes": {"from": "output", "to": "output"},
         },
     ]
+    assert len(llmobs_events[0]["span_links"]) == len(expected_links)
+    for expected_link in expected_links:
+        assert expected_link in llmobs_events[0]["span_links"]
 
     # assert input -> input links for add_1 span
     assert llmobs_events[1]["span_links"] == [


### PR DESCRIPTION
## Description

One of the tests added in #15477 asserts a list of span links, but since we only care about content and not order, asserting the raw lists sometimes flaked if the list was out of order (which doesn't matter for span links). so instead, since we cannot hash them into a set because they're dicts, we assert one expected element at a time.

## Testing

updating the test itself, will check on the health of it after it merges

## Risks

none, passed still locally
