### PR TITLE
feat(profiling): add `process_id` tag

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -32,6 +32,7 @@ extern "C"
     bool ddup_is_initialized();
     void ddup_start();
     void ddup_set_runtime_id(std::string_view runtime_id);
+    void ddup_set_process_id();
     void ddup_profile_set_endpoints(std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints);
     void ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts);
     bool ddup_upload();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
@@ -26,6 +26,7 @@ namespace Datadog {
     X(runtime_version, "runtime_version")                                                                              \
     X(runtime, "runtime")                                                                                              \
     X(runtime_id, "runtime-id")                                                                                        \
+    X(process_id, "process_id")                                                                                        \
     X(profiler_version, "profiler_version")                                                                            \
     X(library_version, "library_version")                                                                              \
     X(profile_seq, "profile_seq")                                                                                      \

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
@@ -20,6 +20,7 @@ class UploaderBuilder
     static inline std::string version;
     static inline std::string runtime{ g_runtime_name };
     static inline std::string runtime_id;
+    static inline std::string process_id;
     static inline std::string runtime_version;
     static inline std::string profiler_version;
     static inline std::string url{ "http://localhost:8126" };
@@ -36,6 +37,7 @@ class UploaderBuilder
     static void set_version(std::string_view _version);
     static void set_runtime(std::string_view _runtime);
     static void set_runtime_id(std::string_view _runtime_id);
+    static void set_process_id();
     static void set_runtime_version(std::string_view _runtime_version);
     static void set_profiler_version(std::string_view _profiler_version);
     static void set_url(std::string_view _url);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -73,6 +73,12 @@ ddup_set_runtime_id(std::string_view runtime_id) // cppcheck-suppress unusedFunc
 }
 
 void
+ddup_set_process_id() // cppcheck-suppress unusedFunction
+{
+    Datadog::UploaderBuilder::set_process_id();
+}
+
+void
 ddup_config_runtime_version(std::string_view runtime_version) // cppcheck-suppress unusedFunction
 {
     Datadog::UploaderBuilder::set_runtime_version(runtime_version);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -3,10 +3,10 @@
 #include "libdatadog_helpers.hpp"
 #include "sample.hpp"
 
-#include <mutex>
 #include <numeric>
 #include <string>
 #include <string_view>
+#include <unistd.h>
 #include <utility>
 #include <vector>
 
@@ -48,6 +48,13 @@ Datadog::UploaderBuilder::set_runtime_id(std::string_view _runtime_id)
     if (!_runtime_id.empty()) {
         runtime_id = _runtime_id;
     }
+}
+
+void
+Datadog::UploaderBuilder::set_process_id()
+{
+    auto pid = getpid();
+    process_id = std::to_string(pid);
 }
 
 void
@@ -134,6 +141,7 @@ Datadog::UploaderBuilder::build()
         { ExportTagKey::runtime_id, runtime_id },
         { ExportTagKey::runtime_version, runtime_version },
         { ExportTagKey::profiler_version, profiler_version },
+        { ExportTagKey::process_id, process_id },
     };
 
     for (const auto& [tag, data] : tag_data) {

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -55,6 +55,7 @@ cdef extern from "ddup_interface.hpp":
 
     void ddup_start()
     void ddup_set_runtime_id(string_view _id)
+    void ddup_set_process_id()
     void ddup_profile_set_endpoints(unordered_map[int64_t, string_view] span_ids_to_endpoints)
     void ddup_profile_add_endpoint_counts(unordered_map[string_view, int64_t] trace_endpoints_to_counts)
     void ddup_config_set_max_timeout_ms(uint64_t max_timeout_ms)
@@ -386,6 +387,7 @@ def upload(tracer: Optional[Tracer] = ddtrace.tracer, enable_code_provenance: Op
     global _code_provenance_set
 
     call_func_with_str(ddup_set_runtime_id, get_runtime_id())
+    ddup_set_process_id()
 
     processor = tracer._endpoint_call_counter_span_processor
     endpoint_counts, endpoint_to_span_ids = processor.reset()

--- a/releasenotes/notes/profiling-add-process-id-tag-d26d87b20716310f.yaml
+++ b/releasenotes/notes/profiling-add-process-id-tag-d26d87b20716310f.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    profiling: This adds the ``process_id`` tag to profiles. The value of this tag is the current process ID (PID).


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13206

This PR adds a new `process_id` tag to Profiles captured by dd-trace-py. The value of this tag is the PID of the current process. Due to the way it is populated (in the `UploaderBuilder`, and not once per process), it is by definition updated automatically in forks.

Note that we could also have a `set_process_id` function in `ddup` (as opposed to the function determining the PID itself), but I figured the native implementation would be more efficient than having to marshall a Python string object.