### PR TITLE
chore(profiling): fix 'test_semaphore_and_bounded_semaphore_collectors_coexist' test

### DIFF
--- a/tests/profiling/collector/test_utils.py
+++ b/tests/profiling/collector/test_utils.py
@@ -1,0 +1,21 @@
+"""Shared utilities for profiling collector tests."""
+
+from ddtrace.internal.datadog.profiling import ddup
+
+
+def init_ddup(test_name: str) -> None:
+    """Initialize ddup for profiling tests.
+
+    Must be called before using any lock collectors.
+
+    Args:
+        test_name: Name of the test, used for service name and output filename.
+    """
+    assert ddup.is_available, "ddup is not available"
+    ddup.config(
+        env="test",
+        service=test_name,
+        version="1.0",
+        output_filename="/tmp/" + test_name,
+    )
+    ddup.start()


### PR DESCRIPTION
## Description

Fix a segfault in the test_semaphore_and_bounded_semaphore_collectors_coexist test that occurred on Python 3.12. The test was missing the required ddup.config() and ddup.start() initialization before using lock collectors.

This test was introduced in #15375 (unsure how it passed there...), but it should be working now.

## What Happened
The test used `ThreadingSemaphoreCollector` and `ThreadingBoundedSemaphoreCollector` without initializing the ddup module first. When the profiler tried to push sample data via handle.push_acquire(), it crashed with a segfault because the C extension's internal state (memory buffers, output file handles) was uninitialized.

## Changes
* Added ddup initialization to test_semaphore_and_bounded_semaphore_collectors_coexist (the fix itself)
* Extracted init_ddup() helper into new tests/profiling/collector/test_utils.py module (drive-by)
* Updated 3 tests to use the shared helper, reducing code duplication (drive-by)

## Testing
* CI