### PR TITLE
refactor(profiling): make `StringTable::lookup` `const`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/strings.h
@@ -139,12 +139,12 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
         return k;
     };
 
-    [[nodiscard]] inline Result<std::reference_wrapper<std::string>> lookup(Key key)
+    [[nodiscard]] inline Result<std::reference_wrapper<const std::string>> lookup(Key key) const
     {
         const std::lock_guard<std::mutex> lock(table_lock);
 
-        auto it = this->find(key);
-        if (it == this->end())
+        const auto it = this->find(key);
+        if (it == this->cend())
             return ErrorKind::LookupError;
 
         return std::ref(it->second);
@@ -159,7 +159,7 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
     };
 
   private:
-    std::mutex table_lock;
+    mutable std::mutex table_lock;
 };
 
 // We make this a reference to a heap-allocated object so that we can avoid


### PR DESCRIPTION
## What does this PR do?

This PR updates the `StringTable::lookup` method to be `const`. This required making the `std::mutex` we have `mutable`, which is OK – `mutable` is typically used for that.

Additionally, it also makes the return type `std::reference_wrapper<const std::string>` as I don't think we should allow callers of `lookup` to change the underlying data, which the previous signature would allow. 

> [[cppreference]](https://en.cppreference.com/w/cpp/language/cv.html#mutable) mutable is used to specify that the member does not affect the externally visible state of the class (as often used for mutexes, memo caches, lazy evaluation, and access instrumentation).

Echion PR: https://github.com/P403n1x87/echion/pull/209