### PR TITLE
fix(profiling): do not remove links for just-created Tasks

### DIFF
--- a/releasenotes/notes/profiling-fix-task-link-race-condition-891ac5c86af8a7c1.yaml
+++ b/releasenotes/notes/profiling-fix-task-link-race-condition-891ac5c86af8a7c1.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: This fix resolves a race condition leading to incorrect stacks being reported
+    for asyncio parent/child Tasks (e.g. when using ``asyncio.gather``).

--- a/tests/profiling/collector/test_asyncio_as_completed.py
+++ b/tests/profiling/collector/test_asyncio_as_completed.py
@@ -15,8 +15,11 @@ def test_asyncio_as_completed() -> None:
     from sys import version_info as PYVERSION
 
     from ddtrace.internal.datadog.profiling import stack_v2
+    from ddtrace.internal.logger import get_logger
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+
+    LOG = get_logger(__name__)
 
     assert stack_v2.is_available, stack_v2.failure_msg
 
@@ -30,9 +33,12 @@ def test_asyncio_as_completed() -> None:
     async def main() -> None:
         # Create a mix of Tasks and Coroutines
         futures = [
-            asyncio.create_task(wait_and_return_delay(i / 10)) if i % 2 == 0 else wait_and_return_delay(i / 10)
-            for i in range(10)
+            asyncio.create_task(wait_and_return_delay(float(i) / 10))
+            if i % 2 == 0
+            else wait_and_return_delay(float(i) / 10)
+            for i in range(2, 12)
         ]
+        assert len(futures) == 10
 
         # Randomize the order of the futures
         random.shuffle(futures)
@@ -61,6 +67,17 @@ def test_asyncio_as_completed() -> None:
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 
+    task_names_in_profile = sorted(
+        set(
+            [
+                (profile.string_table[label.str])
+                for sample in profile.sample
+                for label in sample.label
+                if profile.string_table[label.key] == "task name"
+            ]
+        )
+    )
+
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
 
@@ -73,7 +90,7 @@ def test_asyncio_as_completed() -> None:
         pprof_utils.StackLocation(
             function_name="main",
             filename="test_asyncio_as_completed.py",
-            line_no=main.__code__.co_firstlineno + 14,
+            line_no=main.__code__.co_firstlineno + 17,
         ),
     ]
 
@@ -91,11 +108,45 @@ def test_asyncio_as_completed() -> None:
             ),
         ] + locations
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=locations,
-        ),
-    )
+    # Now, check that we have seen those locations for each Task we've created.
+    # (They should be named Task-2 .. Task-11, which is the automatic name assigned to Tasks by asyncio.create_task)
+    # Note: we expect one Task to not be seen (and thus accept to recover from one failure). The reason
+    # is that there is a bug in ddtrace that makes one Task (randomly picked) appear "as part of" the Parent Task,
+    # and this Task thus gets the Parent Task's name and not its own.
+    seen_all_except_one = True
+    seen_task_names: set[str] = set()
+    for i in range(2, 12):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+
+            seen_task_names.add(f"Task-{i}")
+        except AssertionError:
+            if not seen_all_except_one:
+                LOG.error(
+                    f"More than one Task has not been seen; i = {i} "  # noqa: G004
+                    f"seen_task_names = {seen_task_names} "
+                    f"task_names_in_profile = {task_names_in_profile}"
+                )
+                raise
+
+            # This is the bug situation.
+            # Check that we have seen the expected locations for the Parent Task (Task-1)
+            # If that isn't the case, then something else is broken.
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name="Task-1",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+            seen_all_except_one = False


### PR DESCRIPTION
## Description

Echion PR: https://github.com/P403n1x87/echion/pull/210

This PR fixes a race condition happening around linking Parent and Children Tasks when using utilities like `asyncio.gather` or `asyncio.as_completed`.

### The problem

The race condition would manifest in the following way
1.  User calls e.g. `asyncio.as_completed` from `parent_task`
2. Our patch creates  Tasks for each awaitable passed to the function and inserts resulting Task objects into the Task Links Map (one of each is `new_task`)
3. A Sample is taken exactly at that moment, Task Link Map cleanup logic kicks in.
  a. `new_task` was created only just now, so was not part of the `all_tasks` `MirrorSet` snapshotted by the Sampler
  b. The cleanup logic sees that there's a link from `new_task` to `parent_task` but `new_task` isn't in `all_tasks`
  c. The cleanup logic assumes that means `new_task` previously existed but has completed, deduces the link must be removed
  d. Link is removed
4. `new_task` starts executing, but isn't linked to `parent_task` because we've cleaned it up before it got a chance to start 

### Proposed fix

The fix I propose is to introduce a new `previous_task_objects` set which contains the addresses of all existing Task objects at the time we previously sampled.   
If we see a Task object in the Task Links Map that doesn't exist in `all_tasks`, then two things are possible: either the Task used to exist and the link should be removed, or the Task was just created and the link should stay. To determine which case we're in, we look at `previous_task_objects` –  if the Task is there then it previously existed and just completed (⇒ need to remove); if not, it was just created (⇒ shouldn't remove). 

### Admitted caveat

I think this comes with one caveat: if we sample very rarely (which may happen in certain circumstances with adaptive sampling), then we could miss certain Tasks and never get rid of their links:

```py
async def super_quick():
  return None

async def parent():
  await asyncio.sleep(1.0)
  asyncio.gather(asyncio.create_task(super_quick()))
```

Given that super_quick will be… super quick, the following could happen:

* We sample; we see parent ; `all_tasks = { parent }; task_links = {} ; previous_all_tasks = { parent }`
* Parent continues, calls `asyncio.gather(...)` creates another Task ; `all_tasks = { parent, super_quick }; task_links = { super_quick -> parent }`
* (We don’t sample yet because we rarely sample…)
* Task execution continues, `super_quick` runs super quickly and finishes ; `all_tasks = { parent }; task_links = { super_quick -> parent }`
* We sample; we see only parent (only Task in existence at that point); `current all_tasks = { parent }`; 
  * `previous_all_tasks = { parent }` (still from the first sample we took) and `task_links = { super_quick -> parent }`
  * Our “debouncing” logic considers that `super_quick` is a new Task [because it’s not in `previous_all_tasks`] and doesn’t remove the link

⇒ The link will never go away because we’ll keep repeating this (potentially adding/removing other Tasks and Links, but this specific one will stay forever)

### Additional change

The PR also fixes an issue with our patch for `as_completed` that would crash if `parent` was `None`. I don't think this can ever happen (since `as_completed` is necessarily called from a Task), but better safe than sorry. 

### Testing

As this change fixes a race condition, it is pretty hard to strictly speaking test it. `dd-trace-py` already has a test that flaked in the past due to it (and that flaked in Echion as well): [`test_asyncio_as_completed`](https://github.com/datadog/dd-trace-py/blob/5b8add2c81604dafaa2b6c772c18efed71a6ae19/tests/profiling/collector/test_asyncio_as_completed.py#L62)