### PR TITLE
chore: clearly mark incompatibility with 3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ version = "4.1.0.dev0"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }
-requires-python = ">=3.9"
+# ddtrace has many sub-components which can break when CPython internals
+# change over versions, .e.g. profiling. So we explicitly mark incompatibility
+# with versions we don't support yet.
+requires-python = ">=3.9,<3.15"
 authors = [
     { name = "Datadog, Inc.", email = "dev@datadoghq.com" },
 ]


### PR DESCRIPTION
## Description

Explicitly mark incompatibility with 3.15, current CPython main branch. 
<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
