### PR TITLE
chore: ensure messages are not modified before span serialization

### DIFF
--- a/ddtrace/appsec/ai_guard/_api_client.py
+++ b/ddtrace/appsec/ai_guard/_api_client.py
@@ -1,7 +1,7 @@
 """AI Guard client for security evaluation of agentic AI workflows."""
 
-import json
 from copy import deepcopy
+import json
 from typing import Any
 from typing import List
 from typing import Literal

--- a/tests/appsec/ai_guard/api/test_api_client.py
+++ b/tests/appsec/ai_guard/api/test_api_client.py
@@ -240,14 +240,20 @@ def test_span_meta_content_truncation(mock_execute_request, telemetry_mock, ai_g
 def test_message_immutability(mock_execute_request, telemetry_mock, ai_guard_client, tracer):
     mock_execute_request.return_value = mock_evaluate_response("ALLOW")
 
-    messages = [Message(role="assistant", tool_calls=[ToolCall(id="call_1", function=Function(name="test", arguments="{}"))])]
-    with tracer.trace('test'):
+    messages = [
+        Message(role="assistant", tool_calls=[ToolCall(id="call_1", function=Function(name="test", arguments="{}"))])
+    ]
+    with tracer.trace("test"):
         ai_guard_client.evaluate(messages)
         # Update messages before being flushed
         messages[0].get("tool_calls").append(ToolCall(id="call_2", function=Function(name="test", arguments="{}")))
-        messages.append(Message(role="assistant", tool_calls=[ToolCall(id="call_2", function=Function(name="test", arguments="{}"))]))
+        messages.append(
+            Message(
+                role="assistant", tool_calls=[ToolCall(id="call_2", function=Function(name="test", arguments="{}"))]
+            )
+        )
 
-    span = tracer.get_spans()[1] # AI Guard span
+    span = tracer.get_spans()[1]  # AI Guard span
     meta = span._get_struct_tag(AI_GUARD.TAG)
     messages = meta["messages"]
     assert len(messages) == 1


### PR DESCRIPTION
## Description

- Ensure AIGuard messages are copied before being added to the meta struct so later mutations (e.g., adding tool calls) do not affect the serialized payload.
- Propagate evaluation tags from the AI Guard response into the Evaluation object.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
