### PR TITLE
chore(profiling): add stub files for config

### DIFF
--- a/ddtrace/internal/settings/_core.py
+++ b/ddtrace/internal/settings/_core.py
@@ -1,9 +1,8 @@
 from collections import ChainMap
 from enum import Enum
 import os
-from typing import Dict  # noqa:F401
-from typing import Optional  # noqa:F401
-from typing import Union  # noqa:F401
+from typing import Dict
+from typing import Optional
 
 from envier import Env
 

--- a/ddtrace/internal/settings/_core.pyi
+++ b/ddtrace/internal/settings/_core.pyi
@@ -1,0 +1,34 @@
+from enum import Enum
+from typing import Dict
+from typing import Optional
+from typing import cast
+
+from envier import Env
+
+FLEET_CONFIG: Dict[str, str]
+LOCAL_CONFIG: Dict[str, str]
+FLEET_CONFIG_IDS: Dict[str, str]
+
+class ValueSource(str, Enum):
+    FLEET_STABLE_CONFIG = cast(str, ...)
+    ENV_VAR = cast(str, ...)
+    LOCAL_STABLE_CONFIG = cast(str, ...)
+    CODE = cast(str, ...)
+    DEFAULT = cast(str, ...)
+    UNKNOWN = cast(str, ...)
+    OTEL_ENV_VAR = cast(str, ...)
+
+class DDConfig(Env):
+    fleet_source: Dict[str, str]
+    local_source: Dict[str, str]
+    env_source: Dict[str, str]
+    _value_source: Dict[str, str]
+    config_id: Optional[str]
+
+    def __init__(
+        self,
+        source: Optional[Dict[str, str]] = None,
+        parent: Optional[Env] = None,
+        dynamic: Optional[Dict[str, str]] = None,
+    ) -> None: ...
+    def value_source(self, env_name: str) -> str: ...

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import itertools
 import math
 import os
 import typing as t
+
+from envier import Env
 
 from ddtrace.ext.git import COMMIT_SHA
 from ddtrace.ext.git import MAIN_PACKAGE
@@ -19,11 +23,14 @@ from ddtrace.internal.utils.formats import parse_tags_str
 logger = get_logger(__name__)
 
 
-def _derive_default_heap_sample_size(heap_config, default_heap_sample_size=1024 * 1024):
-    # type: (ProfilingConfigHeap, int) -> int
+def _derive_default_heap_sample_size(
+    heap_config: Env,
+    default_heap_sample_size: int = 1024 * 1024,
+) -> int:
+    assert isinstance(heap_config, ProfilingConfigHeap)  # nosec: assert is used for type checking
     heap_sample_size = heap_config._sample_size
     if heap_sample_size is not None:
-        return heap_sample_size
+        return t.cast(int, heap_sample_size)
 
     if not heap_config.enabled:
         return 0
@@ -363,28 +370,28 @@ if not ddup_is_available:
     logger.warning("Failed to load ddup module (%s), disabling profiling", msg)
     telemetry_writer.add_log(
         TELEMETRY_LOG_LEVEL.ERROR,
-        "Failed to load ddup module (%s), disabling profiling" % ddup_failure_msg,
+        f"Failed to load ddup module ({ddup_failure_msg}), disabling profiling",
     )
-    config.enabled = False
+    config.enabled = False  # pyright: ignore[reportAttributeAccessIssue]
 
 # We also need to check if stack_v2 module is available, and turn if off
 # if it s not.
 stack_v2_failure_msg, stack_v2_is_available = _check_for_stack_v2_available()
-if config.stack.enabled and not stack_v2_is_available:
+if config.stack.enabled and not stack_v2_is_available:  # pyright: ignore[reportAttributeAccessIssue]
     msg = stack_v2_failure_msg or "stack_v2 not available"
     logger.warning("Failed to load stack_v2 module (%s), falling back to v1 stack sampler", msg)
     telemetry_writer.add_log(
         TELEMETRY_LOG_LEVEL.ERROR,
         "Failed to load stack_v2 module (%s), disabling profiling" % msg,
     )
-    config.stack.enabled = False
+    config.stack.enabled = False  # pyright: ignore[reportAttributeAccessIssue]
 
 # Enrich tags with git metadata and DD_TAGS
-config.tags = _enrich_tags(config.tags)
+config.tags = _enrich_tags(config.tags)  # pyright: ignore[reportAttributeAccessIssue]
 
 
-def config_str(config):
-    configured_features = []
+def config_str(config) -> str:
+    configured_features: list[str] = []
     if config.stack.enabled:
         configured_features.append("stack_v2")
     if config.lock.enabled:

--- a/ddtrace/internal/settings/profiling.pyi
+++ b/ddtrace/internal/settings/profiling.pyi
@@ -1,0 +1,55 @@
+from typing import Dict
+from typing import Optional
+
+from ddtrace.internal.settings._core import DDConfig
+
+class ProfilingConfig(DDConfig):
+    enabled: bool
+    agentless: bool
+    code_provenance: bool
+    endpoint_collection: bool
+    output_pprof: Optional[str]
+    upload_interval: float
+    capture_pct: float
+    max_frames: int
+    ignore_profiler: bool
+    max_time_usage_pct: float
+    api_timeout_ms: int
+    timeline_enabled: bool
+    tags: Dict[str, str]
+    enable_asserts: bool
+    sample_pool_capacity: int
+    stack: ProfilingConfigStack
+    lock: ProfilingConfigLock
+    memory: ProfilingConfigMemory
+    heap: ProfilingConfigHeap
+    pytorch: ProfilingConfigPytorch
+
+class ProfilingConfigStack(DDConfig):
+    enabled: bool
+    v2_adaptive_sampling: bool
+
+class ProfilingConfigLock(DDConfig):
+    enabled: bool
+    name_inspect_dir: bool
+
+class ProfilingConfigMemory(DDConfig):
+    enabled: bool
+    events_buffer: int
+
+class ProfilingConfigHeap(DDConfig):
+    enabled: bool
+    _sample_size: Optional[int]
+    sample_size: int
+
+class ProfilingConfigPytorch(DDConfig):
+    enabled: bool
+    events_limit: int
+
+config: ProfilingConfig
+ddup_failure_msg: Optional[str]
+ddup_is_available: bool
+stack_v2_failure_msg: Optional[str]
+stack_v2_is_available: bool
+
+def config_str(config: ProfilingConfig) -> str: ...


### PR DESCRIPTION
## Description

This improves static typing in Profiling modules by providing a correct stub file. Previously, `pyright` would be unhappy with typing when using `envier` `EnvVariable`'s –  now it's OK.