### PR TITLE
feat(profiling): add adaptive sampling metadata to internal payload

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstddef>
-
+#include <optional>
 #include <string>
 
 namespace Datadog {
@@ -22,6 +22,9 @@ class ProfilerStats
     // Number of sampling events (one per collection cycle)
     size_t sampling_event_count = 0;
 
+    // The latest sampling interval (in microseconds) as determined by adaptive sampling
+    std::optional<size_t> sampling_interval_us;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -31,6 +34,9 @@ class ProfilerStats
 
     void increment_sampling_event_count(size_t k_sampling_event_count = 1);
     size_t get_sampling_event_count();
+
+    void set_sampling_interval_us(size_t interval_us);
+    std::optional<size_t> get_sampling_interval_us();
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -43,6 +43,19 @@ Datadog::ProfilerStats::reset_state()
 {
     sample_count = 0;
     sampling_event_count = 0;
+    sampling_interval_us = std::nullopt;
+}
+
+void
+Datadog::ProfilerStats::set_sampling_interval_us(size_t interval_us)
+{
+    sampling_interval_us = interval_us;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_sampling_interval_us()
+{
+    return sampling_interval_us;
 }
 
 std::string
@@ -52,6 +65,13 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     internal_metadata_json.reserve(128);
 
     internal_metadata_json += "{";
+
+    auto maybe_sampling_interval = get_sampling_interval_us();
+    if (maybe_sampling_interval) {
+        internal_metadata_json += R"("sampling_interval_us": )";
+        append_to_string(internal_metadata_json, *maybe_sampling_interval);
+        internal_metadata_json += ",";
+    }
 
     internal_metadata_json += R"("sample_count": )";
     append_to_string(internal_metadata_json, sample_count);

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -137,6 +137,7 @@ Sampler::adapt_sampling_interval()
     }
 
     sample_interval_us.store(new_interval);
+    Sample::profile_borrow().stats().set_sampling_interval_us(new_interval);
 
     // Update the counters for the next iteration
     process_count = new_process_count;
@@ -203,6 +204,7 @@ Sampler::set_interval(double new_interval_s)
 {
     microsecond_t new_interval_us = static_cast<microsecond_t>(new_interval_s * 1e6);
     sample_interval_us.store(new_interval_us);
+    Sample::profile_borrow().stats().set_sampling_interval_us(new_interval_us);
 }
 
 Sampler::Sampler()

--- a/tests/profiling/collector/test_internal_adaptive_sampling.py
+++ b/tests/profiling/collector/test_internal_adaptive_sampling.py
@@ -1,0 +1,82 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_internal_adaptive_sampling",
+        # Upload every second
+        DD_PROFILING_UPLOAD_INTERVAL="1",
+        # Enable adaptive sampling to test sampling_interval_us field
+        _DD_PROFILING_STACK_V2_ADAPTIVE_SAMPLING_ENABLED="1",
+    ),
+    err=None,
+)
+def test_internal_adaptive_sampling():
+    import asyncio
+    import glob
+    import json
+    import os
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+
+    sleep_time = 0.2
+    loop_run_time = 4
+
+    async def stuff() -> None:
+        start_time = time.time()
+        while time.time() < start_time + loop_run_time:
+            await asyncio.sleep(sleep_time)
+
+        await asyncio.get_running_loop().run_in_executor(executor=None, func=lambda: time.sleep(1))
+
+    async def hello():
+        t1 = asyncio.create_task(stuff(), name="sleep 1")
+        t2 = asyncio.create_task(stuff(), name="sleep 2")
+        await stuff()
+        return (t1, t2)
+
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
+
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        main_task = loop.create_task(hello(), name="main")
+        loop.run_until_complete(main_task)
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+
+    # We expect to find at least one Profile with more Samples than Sampling Events (i.e. one Profile with more
+    # than one Thread) because the Thread is short-lived, so we cannot guarantee we will see it more than once.
+    found_at_least_one_with_more_samples_than_sampling_events = False
+    for i, f in enumerate(files):
+        with open(f, "r") as fp:
+            internal_metadata = json.load(fp)
+
+            assert internal_metadata is not None
+            assert "sample_count" in internal_metadata
+            assert internal_metadata["sample_count"] > 0
+
+            assert "sampling_event_count" in internal_metadata
+            assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]
+
+            # With adaptive sampling enabled, we should have the sampling_interval_us field
+            assert "sampling_interval_us" in internal_metadata
+            assert internal_metadata["sampling_interval_us"] > 0, (
+                f"Sampling interval should be positive: {internal_metadata['sampling_interval_us']}"
+            )
+
+            if internal_metadata["sample_count"] > internal_metadata["sampling_event_count"]:
+                found_at_least_one_with_more_samples_than_sampling_events = True
+
+    assert found_at_least_one_with_more_samples_than_sampling_events, (
+        "Expected at least one file with more samples than sampling events"
+    )


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13194

This PR adds a new "internal metric field" to the Python Profiles: the (latest, at the time of uploading) adaptive sampling rate. There have been cases recently where having such a metric would have helped understanding issues/answering questions about the Profiling data we saw (example: very low number of Samples in reliability environment apps). 

The PR adds a  test to make sure we properly set the field in the internal payload.

Note: this PR doesn't have a changelog as that new field is not visible to the user.

## Testing

This has been tested on a workspace –  the Profiles sent by this version of `ddtrace` contain the right field when queried from the EvP.

<img width="718" height="318" alt="image" src="https://github.com/user-attachments/assets/e95d4c0f-76f8-4fec-9933-636cb0413c2a" />
