### PR TITLE
feat(profiling): add Profile duration to internal payload

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -71,6 +71,8 @@ extern "C"
 
     void ddup_increment_sampling_event_count();
     void ddup_increment_sample_count();
+    void ddup_set_profile_start_if_unset();
+    void ddup_set_profile_end();
 
     void ddup_flush_sample(Datadog::Sample* sample);
     // Stack v2 specific flush, which reverses the locations

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <chrono>
 #include <cstddef>
-
+#include <optional>
 #include <string>
 
 namespace Datadog {
@@ -22,6 +23,14 @@ class ProfilerStats
     // Number of sampling events (one per collection cycle)
     size_t sampling_event_count = 0;
 
+    using point_in_time = std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>;
+
+    // The time the Sampler started collecting data for this Profile
+    std::optional<point_in_time> profile_start;
+
+    // The time the Sampler finished collecting data for the last Sample of this Profile
+    std::optional<point_in_time> profile_end;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -31,6 +40,10 @@ class ProfilerStats
 
     void increment_sampling_event_count(size_t k_sampling_event_count = 1);
     size_t get_sampling_event_count();
+
+    void set_profile_start_if_unset();
+    void set_profile_end();
+    std::optional<std::chrono::duration<unsigned long long, std::nano>> get_profile_duration();
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -324,6 +324,20 @@ ddup_increment_sample_count() // cppcheck-suppress unusedFunction
 }
 
 void
+ddup_set_profile_start_if_unset() // cppcheck-suppress unusedFunction
+{
+    auto borrowed = Datadog::Sample::profile_borrow();
+    borrowed.stats().set_profile_start_if_unset();
+}
+
+void
+ddup_set_profile_end() // cppcheck-suppress unusedFunction
+{
+    auto borrowed = Datadog::Sample::profile_borrow();
+    borrowed.stats().set_profile_end();
+}
+
+void
 ddup_flush_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
 {
     sample->flush_sample();
@@ -352,6 +366,8 @@ ddup_upload() // cppcheck-suppress unusedFunction
         }
         return false;
     }
+
+    ddup_set_profile_end();
 
     // Build the Uploader, which takes care of serializing the Profile and capturing ProfilerStats.
     // This takes a reference in a way that locks the areas where the profile might

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -43,6 +43,32 @@ Datadog::ProfilerStats::reset_state()
 {
     sample_count = 0;
     sampling_event_count = 0;
+    profile_start = std::nullopt;
+    profile_end = std::nullopt;
+}
+
+void
+Datadog::ProfilerStats::set_profile_start_if_unset()
+{
+    if (!profile_start) {
+        profile_start = std::chrono::steady_clock::now();
+    }
+}
+
+void
+Datadog::ProfilerStats::set_profile_end()
+{
+    profile_end = std::chrono::steady_clock::now();
+}
+
+std::optional<std::chrono::duration<unsigned long long, std::nano>>
+Datadog::ProfilerStats::get_profile_duration()
+{
+    if (profile_start && profile_end) {
+        return *profile_end - *profile_start;
+    }
+
+    return std::nullopt;
 }
 
 std::string
@@ -52,6 +78,13 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     internal_metadata_json.reserve(128);
 
     internal_metadata_json += "{";
+
+    auto maybe_profile_duration = get_profile_duration();
+    if (maybe_profile_duration) {
+        internal_metadata_json += R"("profile_duration_ns": )";
+        append_to_string(internal_metadata_json, maybe_profile_duration->count());
+        internal_metadata_json += ",";
+    }
 
     internal_metadata_json += R"("sample_count": )";
     append_to_string(internal_metadata_json, sample_count);

--- a/ddtrace/internal/datadog/profiling/stack_v2/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/sampler.cpp
@@ -165,6 +165,8 @@ Sampler::sampling_thread(const uint64_t seq_num)
         auto wall_time_us = duration_cast<microseconds>(sample_time_now - sample_time_prev).count();
         sample_time_prev = sample_time_now;
 
+        ddup_set_profile_start_if_unset();
+
         // Perform the sample
         for_each_interp([&](InterpreterInfo& interp) -> void {
             for_each_thread(interp, [&](PyThreadState* tstate, ThreadInfo& thread) {


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13194

Related PRs
* Dependent: https://github.com/DataDog/dd-trace-py/pull/15574

This adds a new field in the Profile internal metadata: Profile duration. 

Specifically, Profile duration in that case means _the time elapsed between the moment the Sampler started capturing the first Sample, to the time the Scheduler started uploading the Profile_. This definition is not perfect (for example, one may consider that the duration of the Profile starts as soon as uploading the previous Profile has finished), but I think at the end of the day it only is a matter of conventions.   
If you think I should change how it is computed, or if you think we should have more than one duration field (e.g. time between start of first Sample and end of last Sample for the Profile, and/or time from the end of the last Upload to the start of the current Upload, and/or something else), feel free to add a comment and I can add it. 

The PR also adds a test for the feature. The test explicitly disables adaptive sampling as adaptive sampling and first upload are a cocktail that ends up creating weirdly-shaped Profiles whose duration isn't exactly the one we'd expect. 

Note this PR doesn't have a changelog entry as the new field is internal/not visible to users.