### PR TITLE
chore: co-own crashtracker between core and profiling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -144,6 +144,13 @@ ddtrace/internal/datadog/profiling  @DataDog/profiling-python
 tests/profiling                     @DataDog/profiling-python
 .gitlab/tests/profiling.yml         @DataDog/profiling-python
 
+# Crashtracker
+ddtrace/internal/core/crashtracking.py       @DataDog/profiling-python @DataDog/apm-core-python
+ddtrace/internal/settings/crashtracker.py   @DataDog/profiling-python @DataDog/apm-core-python
+ddtrace/commands/_dd_crashtracker_receiver.py @DataDog/profiling-python @DataDog/apm-core-python
+tests/internal/crashtracker/                 @DataDog/profiling-python @DataDog/apm-core-python
+src/native/crashtracker*                     @DataDog/profiling-python @DataDog/apm-core-python
+
 # MLObs
 ddtrace/llmobs/                                               @DataDog/ml-observability
 ddtrace/contrib/internal/openai                               @DataDog/ml-observability


### PR DESCRIPTION
## Description

@gyuheon0h has been actively working on crashtracker related codes in dd-trace-py, and most of them are reviewed by profiling team members.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
