### PR TITLE
chore(crashtracking): update codeowners so that profiling owns native crashtracking files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,11 +138,13 @@ scripts/iast/*                      @DataDog/asm-python
 
 
 # Profiling
-ddtrace/profiling                   @DataDog/profiling-python
+ddtrace/profiling                            @DataDog/profiling-python
 ddtrace/internal/settings/profiling.py       @DataDog/profiling-python
-ddtrace/internal/datadog/profiling  @DataDog/profiling-python
-tests/profiling                     @DataDog/profiling-python
-.gitlab/tests/profiling.yml         @DataDog/profiling-python
+ddtrace/internal/datadog/profiling           @DataDog/profiling-python
+ddtrace/src/native/crashtracker              @DataDog/profiling-python
+ddtrace/internal/core/crashtracking.py       @DataDog/profiling-python
+tests/profiling                              @DataDog/profiling-python
+.gitlab/tests/profiling.yml                  @DataDog/profiling-python
 
 # MLObs
 ddtrace/llmobs/                                               @DataDog/ml-observability


### PR DESCRIPTION
## Description

Profiling should own crashtracking code


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
