### PR TITLE
chore(ci): fix 'testing' suitespec

### DIFF
--- a/tests/ci_visibility/suitespec.yml
+++ b/tests/ci_visibility/suitespec.yml
@@ -54,6 +54,7 @@ suites:
       - '@ci_visibility'
       - '@coverage'
       - '@codeowners'
+      - '@testing'
       - tests/contrib/pytest/*
       - tests/contrib/pytest_benchmark/*
       - tests/contrib/pytest_bdd/*
@@ -87,6 +88,7 @@ suites:
       - '@pytest'
       - '@unittest'
       - '@selenium'
+      - '@testing'
       - tests/contrib/selenium/*
       - tests/snapshots/test_selenium*
     runner: riot
@@ -98,6 +100,7 @@ suites:
       - '@unittest'
       - '@ci_visibility'
       - '@coverage'
+      - '@testing'
       - tests/contrib/unittest/*
       - tests/snapshots/tests.contrib.unittest.*
     runner: riot


### PR DESCRIPTION
## Description

The `testing` suitespec did not include the `testing` component. This PR fixes it.

## Testing

N/A.

## Risks

None.

## Additional Notes

None.
