### PR TITLE
ci: run changelog and pr name checks in merge group

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     # Important that we run on `labeled` and `unlabeled` to pick up `changelog/no-changelog` being added/removed
     # DEV: [opened, reopened, synchronize] is the default

--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -1,5 +1,6 @@
 name: pr-name
 on:
+  merge_group:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
     branches-ignore:
@@ -22,6 +23,8 @@ jobs:
           npm install @commitlint/lint@18.6.1 @commitlint/load@18.6.1 @commitlint/config-conventional@18.6.2 @actions/core
       - name: Lint PR name
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        # Only validate on pull requests
+        if: github.event_name == 'pull_request'
         with:
           script: |
             const load = require('@commitlint/load').default;


### PR DESCRIPTION
## Description

These are both required checks to merge into `main`, so they need to run and pass when a `merge_group` is being tested.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
