### PR TITLE
fix(profiling): remove defunct Task names from StringTable

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <string>
 
+#include <echion/errors.h>
 #include <echion/long.h>
 #include <echion/render.h>
 #include <echion/vm.h>
@@ -148,6 +149,12 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
             return ErrorKind::LookupError;
 
         return std::ref(it->second);
+    };
+
+    inline void remove(Key key)
+    {
+        const std::lock_guard<std::mutex> lock(table_lock);
+        this->erase(key);
     };
 
     StringTable()

--- a/releasenotes/notes/profiling-remove-completed-task-names-from-string-table-95cf3cfdea0f6244.yaml
+++ b/releasenotes/notes/profiling-remove-completed-task-names-from-string-table-95cf3cfdea0f6244.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: This changes fixes a possible memory leak caused by keeping the names of completed asyncio Tasks in
+    memory forever.


### PR DESCRIPTION
## Description

Related PRs:
* Dependency: (none)
* Dependent: https://github.com/DataDog/dd-trace-py/pull/15673

https://datadoghq.atlassian.net/browse/PROF-13291

This PR updates the echion logic so that the names of `asyncio` Tasks that have completed are removed from the `StringTable` as soon as we detect relevant Tasks have completed. 

There are mostly two reasons for that:
- `StringTable::key(Task*)` really is just `reinterpret_cast<uintptr_t>(Task*)` which means we can have collisions if an address is reused by the Python runtime.
  - It sounds unlikely at first but it very probably happens, especially over long time periods (see https://datadoghq.atlassian.net/browse/PROF-13207). 
  - If an address is reused, then we will assume two completely different Tasks have the same name (the name of the first Task that ran). This means they will share the same Flame Graph (once the Profiles are aggregated), and also that it could lead to nonsensical Stacks (e.g. the Stack of the second Task under the name of the first).  
- It also technically is a memory leak... It makes sense to store certain things forever in the `StringTable` (file names, function names, etc.) but Tasks are ephemeral (although more or less long-running), so keeping the name of each Task forever is... a leak. 