### PR TITLE
fix(profiling): call `ddup_start` in `ddup_start_sample`

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -164,6 +164,10 @@ ddup_start() // cppcheck-suppress unusedFunction
 Datadog::Sample*
 ddup_start_sample() // cppcheck-suppress unusedFunction
 {
+    // Ensure profile_state is initialized before creating Sample objects.
+    // ddup_start() uses std::call_once, so it's safe to call multiple times.
+    ddup_start();
+
     return Datadog::SampleManager::start_sample();
 }
 

--- a/releasenotes/notes/profiling-add-missing-init-call-ff50a23981c7a790.yaml
+++ b/releasenotes/notes/profiling-add-missing-init-call-ff50a23981c7a790.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: This fix resolves an issue where the Lock profiler would not call the necessary initialization function,
+    which would sometimes result in crashes.


### PR DESCRIPTION
## Description

This was accidentally merged into another open PR, then replicated here: https://github.com/DataDog/dd-trace-py/pull/15658