### PR TITLE
fix(profiling): call `ddup_start` in `ddup_start_sample`

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -164,6 +164,10 @@ ddup_start() // cppcheck-suppress unusedFunction
 Datadog::Sample*
 ddup_start_sample() // cppcheck-suppress unusedFunction
 {
+    // Ensure profile_state is initialized before creating Sample objects.
+    // ddup_start() uses std::call_once, so it's safe to call multiple times.
+    ddup_start();
+
     return Datadog::SampleManager::start_sample();
 }
 

--- a/releasenotes/notes/profiling-add-missing-init-call-ff50a23981c7a790.yaml
+++ b/releasenotes/notes/profiling-add-missing-init-call-ff50a23981c7a790.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: This fix resolves an issue where the Lock profiler would not call the necessary initialization function,
+    which would sometimes result in crashes.


### PR DESCRIPTION
## Description

This fixes a segmentation fault detected in CI. Note that this segmentation fault is probably not new, but used to be ignored "thanks to" (or... due to) automatic retries, we think.

Ideally, we should do something like `memalloc` does it (see after) but doing the same in the Lock Collector doesn't make the segmentation faults go away. 
https://github.com/DataDog/dd-trace-py/blob/b8c8b1921d66a9ff82aafb360337774627f9aeed/ddtrace/profiling/collector/_memalloc.cpp#L113-L116

[Example job](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1296903981)

```
tests/profiling/collector/test_asyncio.py::test_repr[py3.9] PASSED
tests/profiling/collector/test_asyncio.py::TestAsyncioLockCollector::test_asyncio_lock_events[py3.9] Fatal Python error: Segmentation fault
Thread 0x000079758b5f06c0 (most recent call first):
<no Python frame>
Thread 0x0000797598f3a6c0 (most recent call first):
<no Python frame>
Current thread 0x000079759b6a1b80 (most recent call first):
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/profiling/collector/_lock.py", line 180 in _flush_sample
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/profiling/collector/_lock.py", line 130 in _acquire
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/profiling/collector/_lock.py", line 103 in acquire
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/tests/profiling/collector/test_asyncio.py", line 57 in test_asyncio_lock_events
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/asyncio/events.py", line 80 in _run
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/asyncio/base_events.py", line 1905 in _run_once
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/asyncio/base_events.py", line 601 in run_forever
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/asyncio/base_events.py", line 634 in run_until_complete
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pytest_asyncio/plugin.py", line 532 in inner
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/python.py", line 157 in pytest_pyfunc_call
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/python.py", line 1671 in runtest
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/runner.py", line 178 in pytest_runtest_call
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/runner.py", line 246 in <lambda>
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/runner.py", line 344 in from_call
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/runner.py", line 245 in call_and_report
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/runner.py", line 136 in runtestprotocol
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/contrib/internal/pytest/_plugin_v2.py", line 684 in _pytest_run_one_test
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/contrib/internal/pytest/_plugin_v2.py", line 673 in pytest_runtest_protocol
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/main.py", line 367 in pytest_runtestloop
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/main.py", line 343 in _main
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/main.py", line 289 in wrap_session
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/main.py", line 336 in pytest_cmdline_main
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/config/__init__.py", line 175 in main
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3923_160a7fd24d7f0e7c/lib/python3.9/site-packages/pytest/__main__.py", line 9 in <module>
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/runpy.py", line 87 in _run_code
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/runpy.py", line 228 in run_module
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/tests/profiling/run.py", line 7 in <module>
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/runpy.py", line 87 in _run_code
  File "/home/bits/.pyenv/versions/3.9.23/lib/python3.9/runpy.py", line 197 in _run_module_as_main
Test failed with exit code -11
```