### PR TITLE
fix(writer): avoid flushing while forking [backport 4.0]

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -203,8 +203,6 @@ class Tracer(object):
         self._sampler.sample(span)
 
     def _sample_before_fork(self) -> None:
-        if isinstance(self._span_aggregator.writer, AgentWriterInterface):
-            self._span_aggregator.writer.before_fork()
         span = self.current_root_span()
         if span is not None and span.context.sampling_priority is None:
             self.sample(span)

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -366,8 +366,12 @@ PeriodicThread_stop(PeriodicThread* self, PyObject* args)
         return NULL;
     }
 
-    self->_stopping = true;
-    self->_request->set();
+    if (!self->_after_fork) {
+        // The thread is no longer running so it makes no sense to stop it.
+        // Attempting to acquire the Event lock could deadlock.
+        self->_stopping = true;
+        self->_request->set();
+    }
 
     Py_RETURN_NONE;
 }

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1,6 +1,7 @@
 import abc
 import binascii
 from collections import defaultdict
+import functools
 import gzip
 import logging
 import os
@@ -12,9 +13,11 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import TextIO
+import weakref
 
 import ddtrace
 from ddtrace import config
+from ddtrace.internal import forksafe
 from ddtrace.internal.dist_computing.utils import in_ray_job
 from ddtrace.internal.hostname import get_hostname
 import ddtrace.internal.native as native
@@ -76,6 +79,29 @@ class NoEncodableSpansError(Exception):
 # 2s timeout, the java tracer has a 10s timeout, so we set the window size
 # to 10 buckets of 1s duration.
 DEFAULT_SMA_WINDOW = 10
+
+
+def make_weak_method_hook(bound_method):
+    """
+    Wrap a bound method so that it is called via a weakref to its instance.
+    If the instance has been garbage-collected, the hook is a no-op.
+    """
+    if not hasattr(bound_method, "__self__") or bound_method.__self__ is None:
+        raise TypeError("make_weak_method_hook expects a bound method")
+
+    instance = bound_method.__self__
+    func = bound_method.__func__
+    instance_ref = weakref.ref(instance)
+
+    @functools.wraps(func)
+    def hook(*args, **kwargs):
+        inst = instance_ref()
+        if inst is None:
+            # The instance was garbage-collected
+            return
+        return func(inst, *args, **kwargs)
+
+    return hook
 
 
 def _human_size(nbytes: float) -> str:
@@ -486,10 +512,6 @@ class AgentWriterInterface(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def before_fork(self) -> None:
-        pass
-
-    @abc.abstractmethod
     def flush_queue(self, raise_exc: bool = False) -> None:
         pass
 
@@ -686,9 +708,6 @@ class AgentWriter(HTTPWriter, AgentWriterInterface):
         headers["X-Datadog-Trace-Count"] = str(count)
         return headers
 
-    def before_fork(self) -> None:
-        pass
-
     def set_test_session_token(self, token: Optional[str]) -> None:
         self._headers["X-Datadog-Test-Session-Token"] = token or ""
 
@@ -777,6 +796,12 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._max_payload_size = max_payload_size
         self._test_session_token = test_session_token
 
+        # Condition variable to coordinate the flushing with forking
+        self._forking_cv = threading.Condition()
+        self._disable_flush = False
+        # Number of threads currently flushing
+        self._count_flushing = 0
+
         self._clients = [client]
         self.dogstatsd = dogstatsd
         self._metrics: Dict[str, int] = defaultdict(int)
@@ -786,7 +811,29 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._compute_stats_enabled = compute_stats_enabled
         self._response_cb = response_callback
         self._stats_opt_out = stats_opt_out
+
+        try:
+            before_fork_hook = make_weak_method_hook(self._before_fork)
+            after_fork_hook = make_weak_method_hook(self._after_fork)
+
+            forksafe.register_before_fork(before_fork_hook)
+            self._before_fork_hook = before_fork_hook
+
+            forksafe.register_after_parent(after_fork_hook)
+            self._after_fork_hook = after_fork_hook
+        except TypeError:
+            log.warning("Failed to register NativeWriter fork hook")
+
         self._exporter = self._create_exporter()
+
+    def __del__(self):
+        if self._before_fork_hook:
+            forksafe.unregister_before_fork(self._before_fork_hook)
+            self._before_fork_hook = None
+
+        if self._after_fork_hook:
+            forksafe.unregister_parent(self._after_fork_hook)
+            self._after_fork_hook = None
 
     def _create_exporter(self) -> native.TraceExporter:
         """
@@ -834,6 +881,11 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
 
         return builder.build()
 
+    def _after_fork(self):
+        with self._forking_cv:
+            self._disable_flush = False
+            self._forking_cv.notify_all()
+
     def set_test_session_token(self, token: Optional[str]) -> None:
         """
         Set the test session token and recreate the exporter with the new configuration.
@@ -852,9 +904,6 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             # Writers like AgentWriter may not start until the first trace is encoded.
             # Stopping them before that will raise a ServiceStatusError.
             pass
-
-        # Stop the trace exporter worker
-        self._exporter.stop_worker()
 
         api_version = "v0.4" if appsec_enabled else self._api_version
         return self.__class__(
@@ -932,6 +981,10 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
 
     def _send_payload(self, payload: bytes, count: int, client: WriterClientBase):
         try:
+            with self._forking_cv:
+                # postpone flush if we are forking
+                self._forking_cv.wait_for(lambda: not self._disable_flush)
+                self._count_flushing += 1
             response_body = self._exporter.send(payload, count)
         except native.RequestError as e:
             try:
@@ -944,6 +997,11 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             else:
                 raise e
         finally:
+            with self._forking_cv:
+                self._count_flushing -= 1
+                if self._count_flushing == 0:
+                    # wake before_fork hook if it's waiting
+                    self._forking_cv.notify_all()
             self._metrics["sent_traces"] += count
 
         if self._response_cb:
@@ -1062,11 +1120,26 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self,
         timeout: Optional[float] = None,
     ) -> None:
-        # FIXME: don't join() on stop(), let the caller handle this
-        super(NativeWriter, self)._stop_service()
-        self.join(timeout=timeout)
+        try:
+            # FIXME: don't join() on stop(), let the caller handle this
+            super(NativeWriter, self)._stop_service()
+            self.join(timeout=timeout)
+        # Native threads should be stopped even if the writer is not running
+        finally:
+            self._exporter.stop_worker()
+            if self._before_fork_hook:
+                forksafe.unregister_before_fork(self._before_fork_hook)
+                self._before_fork_hook = None
+            if self._after_fork_hook:
+                forksafe.unregister_parent(self._after_fork_hook)
+                self._after_fork_hook = None
 
-    def before_fork(self) -> None:
+    def _before_fork(self) -> None:
+        # Mark the writer as forking to avoid restarting threads before the fork
+        with self._forking_cv:
+            # Prevent new flush from being started
+            self._disable_flush = True
+            self._forking_cv.wait_for(lambda: self._count_flushing == 0)
         self._exporter.stop_worker()
 
     def on_shutdown(self):

--- a/releasenotes/notes/fix-potential-deadlock-in-writer-9372315daf885df5.yaml
+++ b/releasenotes/notes/fix-potential-deadlock-in-writer-9372315daf885df5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Resolves a potential deadlock when forking.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -644,6 +644,11 @@ class DummyWriter(DummyWriterMixin, AgentWriterInterface):
         spans = DummyWriterMixin.pop(self)
         if self._trace_flush_enabled:
             flush_test_tracer_spans(self)
+        # Stop the writer threads in case the writer is no longer used.
+        # Otherwise we risk accumulating threads and file descriptors causing crashes
+        # In case the writer is used again it will be restarted by native side.
+        if isinstance(self._inner_writer, NativeWriter):
+            self._inner_writer._exporter.stop_worker()
         return spans
 
     def recreate(self, appsec_enabled: Optional[bool] = None) -> "DummyWriter":


### PR DESCRIPTION
Fix a race condition where `_exporter.send` between the execution of `stop_workers` in the before fork hook and the actual fork takes place. Since `send` recreates the tokio runtime if it has been stopped, this undoes the `stop_workers` call and causes the writer to deadlock in child.

Also fixes a potential deadlock happening when attempting to lock the `_request` Event in periodic service `stop` after a fork.

This has been tested locally in an airflow cluster which has been shown to deadlock.

<!-- Note any risks associated with this change, or "None" if no risks -->

<!-- Any other information that would be helpful for reviewers -->

