### PR TITLE
docs: update release instructions for explicit versioning

### DIFF
--- a/docs/contributing-release.rst
+++ b/docs/contributing-release.rst
@@ -62,7 +62,7 @@ Ensure you have followed the prerequisite steps above.
     $ git checkout -b X.Y
     $ git push -u origin X.Y
 
-2. If you're releasing an X.Y.0 version, update the ``version`` attribute in ``pyproject.toml`` to the dev
+2. If you're releasing an X.Y.0 version, update the ``version`` attribute in ``pyproject.toml`` to the ``dev``
    version of the next minor release line.
    For example if you're releasing 5.2.0, update the version attribute to ``5.3.0.dev0``.
    Commit and push this change to a branch off of main and open a pull request.

--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -8,7 +8,7 @@ else
     brew install enchant
     export PYENCHANT_LIBRARY_PATH=$(brew --prefix enchant)/lib/libenchant-2.dylib
   fi
-  sphinx-build -vvv -W -b spelling docs docs/_build/spelling
+  sphinx-build -vvv -W -b spelling docs docs/_build/spelling || (cat docs/_build/spelling/*.spelling && exit 1)
 fi
 reno lint
 sphinx-build -vvv -W -b html docs docs/_build/html


### PR DESCRIPTION
This change updates the release instructions to account for the new versioning system in which the version is expected to be hardcoded in pyproject.toml.