### PR TITLE
Very brief design spike to add async to python instrumentation.

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -450,6 +450,16 @@ class Experiment:
         }
         return experiment_result
 
+    async def run_async(
+        self,
+        jobs: int = 1,
+        raise_errors: bool = False,
+        sample_size: Optional[int] = None,
+    ) -> ExperimentResult:
+        import asyncio
+
+        return await asyncio.to_thread(self.run, jobs, raise_errors, sample_size)
+
     @property
     def url(self) -> str:
         # FIXME: will not work for subdomain orgs


### PR DESCRIPTION
This *just* adds a simple async layer on top of the existing _run method on Experiment, without touching the internals.

I *think* this is sufficient, since there isn't really anything in the internals of experiment that really needs to be made async as well.

## Description

Experiment running is long lived and there should be an async version, but the specific thing motivating this was feedback from Phil on cmd-i's usage, but this is not meant to be merges as-is, just want something to share as a design spike. 

## Testing

TBD

## Risks

