### PR TITLE
test(llmobs): update expected API error message in agentless writer tests [backport 3.19]

### DIFF
--- a/tests/llmobs/test_llmobs_span_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_span_agentless_writer.py
@@ -94,7 +94,7 @@ def test_send_completion_bad_api_key(mock_writer_logs):
         "span",
         "https://llmobs-intake.datad0g.com/api/v2/llmobs",
         403,
-        b'{"errors":[{"status":"403","title":"Forbidden","detail":"API key is invalid"}]}',
+        b'{"errors":[{"status":"403","title":"Forbidden","detail":"API key is missing"}]}',
     )
 
 
@@ -157,4 +157,4 @@ llmobs_span_writer.enqueue(_completion_event())
     assert status == 0, err
     assert out == b""
     assert b"got response code 403" in err
-    assert b'status: b\'{"errors":[{"status":"403","title":"Forbidden","detail":"API key is invalid"}]}\'\n' in err
+    assert b'status: b\'{"errors":[{"status":"403","title":"Forbidden","detail":"API key is missing"}]}\'\n' in err


### PR DESCRIPTION
Backport aaf94672717fcfa48a3c5f438b02d6706dcb89dd from #15670 to 3.19.

## Description

The Datadog LLMObs intake API now returns 'API key is missing' instead of 'API key is invalid' for invalid API keys. Update tests to expect the new server-side error message.

## Testing

Tests were failing on `main`

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
