### PR TITLE
feat(profiling): add threading.Condition support to Python Lock profiler

### DIFF
--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 import threading
+from types import ModuleType
 import typing
+from typing import Type
 
 from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace.internal.datadog.profiling import stack
@@ -26,36 +28,48 @@ class _ProfiledThreadingBoundedSemaphore(_lock._ProfiledLock):
     pass
 
 
+class _ProfiledThreadingCondition(_lock._ProfiledLock):
+    pass
+
+
 class ThreadingLockCollector(_lock.LockCollector):
     """Record threading.Lock usage."""
 
-    PROFILED_LOCK_CLASS = _ProfiledThreadingLock
-    MODULE = threading
-    PATCHED_LOCK_NAME = "Lock"
+    PROFILED_LOCK_CLASS: Type[_ProfiledThreadingLock] = _ProfiledThreadingLock
+    MODULE: ModuleType = threading
+    PATCHED_LOCK_NAME: str = "Lock"
 
 
 class ThreadingRLockCollector(_lock.LockCollector):
     """Record threading.RLock usage."""
 
-    PROFILED_LOCK_CLASS = _ProfiledThreadingRLock
-    MODULE = threading
-    PATCHED_LOCK_NAME = "RLock"
+    PROFILED_LOCK_CLASS: Type[_ProfiledThreadingRLock] = _ProfiledThreadingRLock
+    MODULE: ModuleType = threading
+    PATCHED_LOCK_NAME: str = "RLock"
 
 
 class ThreadingSemaphoreCollector(_lock.LockCollector):
     """Record threading.Semaphore usage."""
 
-    PROFILED_LOCK_CLASS = _ProfiledThreadingSemaphore
-    MODULE = threading
-    PATCHED_LOCK_NAME = "Semaphore"
+    PROFILED_LOCK_CLASS: Type[_ProfiledThreadingSemaphore] = _ProfiledThreadingSemaphore
+    MODULE: ModuleType = threading
+    PATCHED_LOCK_NAME: str = "Semaphore"
 
 
 class ThreadingBoundedSemaphoreCollector(_lock.LockCollector):
     """Record threading.BoundedSemaphore usage."""
 
-    PROFILED_LOCK_CLASS = _ProfiledThreadingBoundedSemaphore
-    MODULE = threading
-    PATCHED_LOCK_NAME = "BoundedSemaphore"
+    PROFILED_LOCK_CLASS: Type[_ProfiledThreadingBoundedSemaphore] = _ProfiledThreadingBoundedSemaphore
+    MODULE: ModuleType = threading
+    PATCHED_LOCK_NAME: str = "BoundedSemaphore"
+
+
+class ThreadingConditionCollector(_lock.LockCollector):
+    """Record threading.Condition usage."""
+
+    PROFILED_LOCK_CLASS: Type[_ProfiledThreadingCondition] = _ProfiledThreadingCondition
+    MODULE: ModuleType = threading
+    PATCHED_LOCK_NAME: str = "Condition"
 
 
 # Also patch threading.Thread so echion can track thread lifetimes

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -227,6 +227,7 @@ class _ProfilerInstance(service.Service):
                 ("threading", lambda _: start_collector(threading.ThreadingRLockCollector)),
                 ("threading", lambda _: start_collector(threading.ThreadingSemaphoreCollector)),
                 ("threading", lambda _: start_collector(threading.ThreadingBoundedSemaphoreCollector)),
+                ("threading", lambda _: start_collector(threading.ThreadingConditionCollector)),
                 ("asyncio", lambda _: start_collector(asyncio.AsyncioLockCollector)),
                 ("asyncio", lambda _: start_collector(asyncio.AsyncioSemaphoreCollector)),
                 ("asyncio", lambda _: start_collector(asyncio.AsyncioBoundedSemaphoreCollector)),

--- a/releasenotes/notes/Added-support-for-profiling-of-threading.Condition-objects-to-the-Python-Lock-profiler-2125e897cb26415c.yaml
+++ b/releasenotes/notes/Added-support-for-profiling-of-threading.Condition-objects-to-the-Python-Lock-profiler-2125e897cb26415c.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    profiling: Add support for ``threading.Condition`` locking type profiling in Python.
+    The Lock profiler now provides visibility into ``threading.Condition`` usage, helping
+    identify contention in multi-threaded applications using condition variables.
+

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -25,6 +25,7 @@ from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
+from ddtrace.profiling.collector.threading import ThreadingConditionCollector
 from ddtrace.profiling.collector.threading import ThreadingLockCollector
 from ddtrace.profiling.collector.threading import ThreadingRLockCollector
 from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
@@ -40,12 +41,19 @@ PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
 
 # threading.Lock and threading.RLock are factory functions that return _thread types.
 # We reference the underlying _thread types directly to avoid creating instances at import time.
-LockTypeInst = Union[_thread.LockType, _thread.RLock, threading.Semaphore, threading.BoundedSemaphore]
+# threading.Semaphore, threading.BoundedSemaphore, and threading.Condition are Python classes, not factory functions.
+LockTypeInst = Union[
+    _thread.LockType, _thread.RLock, threading.Semaphore, threading.BoundedSemaphore, threading.Condition
+]
 LockTypeClass = Type[LockTypeInst]
 
 # Type alias for collector instances
 CollectorTypeInst = Union[
-    ThreadingLockCollector, ThreadingRLockCollector, ThreadingSemaphoreCollector, ThreadingBoundedSemaphoreCollector
+    ThreadingLockCollector,
+    ThreadingRLockCollector,
+    ThreadingSemaphoreCollector,
+    ThreadingBoundedSemaphoreCollector,
+    ThreadingConditionCollector,
 ]
 CollectorTypeClass = Type[CollectorTypeInst]
 
@@ -98,6 +106,10 @@ class Bar:
         (
             ThreadingBoundedSemaphoreCollector,
             "ThreadingBoundedSemaphoreCollector(status=<ServiceStatus.STOPPED: 'stopped'>, capture_pct=1.0, nframes=64, tracer=None)",  # noqa: E501
+        ),
+        (
+            ThreadingConditionCollector,
+            "ThreadingConditionCollector(status=<ServiceStatus.STOPPED: 'stopped'>, capture_pct=1.0, nframes=64, tracer=None)",  # noqa: E501
         ),
     ],
 )
@@ -1653,3 +1665,15 @@ class TestThreadingBoundedSemaphoreCollector(BaseSemaphoreTest):
             # This proves our profiling wrapper doesn't break BoundedSemaphore's behavior
             with pytest.raises(ValueError, match="Semaphore released too many times"):
                 sem.release()
+
+
+class TestThreadingConditionCollector(BaseThreadingLockCollectorTest):
+    """Test threading.Condition profiling."""
+
+    @property
+    def collector_class(self) -> Type[ThreadingConditionCollector]:
+        return ThreadingConditionCollector
+
+    @property
+    def lock_class(self) -> Type[threading.Condition]:
+        return threading.Condition


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-12728

**_note_** 
this PR implements profiling the time to acquire `Condition`'s underlying lock. While this data is somewhat useful on its own (more contention data better than less?), it would be more valuable to profile how long a Condition was waited on before signaling, etc. This would require `ddup` API changes, and new backend/UI work to display the new data type. As such, this rich implementation will be pushed to Q1 (?) 2026.
**_end note_** 

### Description
Adds profiling support for `threading.Condition` to the Python Lock profiler. This extends the lock profiling capability to include condition variables in asynchronous applications.

### Motivation
`threading.Condition` is a synchronization primitive that allows tasks to wait for a specific condition. Profiling Condition usage helps identify:
- Contention points where tasks are waiting on conditions
- Long wait times in producer/consumer patterns
- Potential bottlenecks in coordination logic

## Testing
### Unit testing
- Added `TestThreadingConditionCollector`, inheriting base tests from `BaseThreadingLockCollectorTest`

### Manual testing
```
$ DD_SERVICE=lock-demo-threading-condition-v5 python scripts/demo_lock_profiling.py threading-condition
...
Open this URL to view lock profiling data in Datadog:

  https://app.datadoghq.com/profiling/explorer?query=service%3Alock-demo-threading-condition-v5
```

* Line 165: `cond = threading.Condition()`
[Data in Prod](https://app.datadoghq.com/profiling/explorer?query=service%3Alock-demo-threading-condition-v5&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&my_code=enabled&profile_type=lock-hold-time&refresh_mode=paused&viz=flame_graph&from_ts=1768243323190&to_ts=1768246923190&live=false)

<img width="1310" height="585" alt="Screenshot 2026-01-12 at 2 52 47 PM" src="https://github.com/user-attachments/assets/37b8cf0d-a15f-4098-afcc-8ea0c52cd572" />