### PR TITLE
feat(mcp): intent capture

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -24,6 +24,8 @@ OUTPUT_DOCUMENTS = "_ml_obs.meta.output.documents"
 OUTPUT_MESSAGES = "_ml_obs.meta.output.messages"
 OUTPUT_VALUE = "_ml_obs.meta.output.value"
 
+MCP_TOOL_CALL_INTENT = "_ml_obs.meta.intent"
+
 SPAN_START_WHILE_DISABLED_WARNING = (
     "Span started with LLMObs disabled."
     " If using ddtrace-run, ensure DD_LLMOBS_ENABLED is set to 1. Else, use LLMObs.enable()."

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -73,6 +73,7 @@ from ddtrace.llmobs._constants import INPUT_VALUE
 from ddtrace.llmobs._constants import INSTRUMENTATION_METHOD_ANNOTATED
 from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import LLMOBS_TRACE_ID
+from ddtrace.llmobs._constants import MCP_TOOL_CALL_INTENT
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import ML_APP
@@ -390,6 +391,9 @@ class LLMObs(Service):
 
         if span._get_ctx_item(TOOL_DEFINITIONS) is not None:
             meta["tool_definitions"] = span._get_ctx_item(TOOL_DEFINITIONS) or []
+        intent = span._get_ctx_item(MCP_TOOL_CALL_INTENT)
+        if intent is not None:
+            meta["intent"] = str(intent)
         if span.error:
             meta["error"] = _ErrorField(
                 message=span.get_tag(ERROR_MSG) or "",

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -102,6 +102,7 @@ class _Meta(TypedDict, total=False):
     expected_output: _MetaIO
     evaluations: Any
     tool_definitions: List[ToolDefinition]
+    intent: str
 
 
 class _SpanLink(TypedDict):

--- a/releasenotes/notes/add-feature-to-capture-user-intent-of-mcp-server-tool-calls-87ce1280fffe8f75.yaml
+++ b/releasenotes/notes/add-feature-to-capture-user-intent-of-mcp-server-tool-calls-87ce1280fffe8f75.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: Adds ability to automatically capture the intent and context of an MCP server tool call to modelcontextprotocol/python-sdk servers using the ``DD_MCP_CAPTURE_INTENT`` environment variable.


### PR DESCRIPTION
## Description

Add user intent capture to tools as an opt-in feature per the design in [the tech spec](https://docs.google.com/document/d/1LVcwSAFY7RV6rSBEPR3JV8vW_IBcWQH4Vhrf5yQk-xA/edit?tab=t.0#heading=h.s9gjuqfckbdw).

The same functionality as the other SDKs https://github.com/DataDog/dd-trace-go/pull/4209 and https://github.com/DataDog/dd-trace-go/pull/4123 

In summary, this means modifying the tool schemas to add an intent parameter for the client to pass, then recording that value on the span.

Because this is visible to users and mutates the schema and data, it's opt-in.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

Ensured the intent does come through on the span 

![image.png](https://app.graphite.com/user-attachments/assets/060b85e3-de45-415b-befc-ef387c35285d.png)



<!-- Describe your testing strategy or note what tests are included -->

## Risks

Unlike most tracers, this does mutate data which could lead to unexpected behavior for the server or client.

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->