### PR TITLE
chore(profiling): detect cycles in asyncio

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
@@ -306,9 +306,21 @@ TaskInfo::unwind(FrameStack& stack, size_t& upper_python_stack_size)
     std::stack<PyObject*> coro_frames;
 
     // Unwind the coro chain
+    // Detect cycles in the await chain to prevent infinite loops.
+    // This can happen if the Profiler samples during as the Task is running,
+    // or due to memory corruption/race conditions when reading coroutine pointers.
+    std::unordered_set<GenInfo*> seen_coros;
+    std::unordered_set<size_t> pure_coro_frames;
     for (auto py_coro = this->coro.get(); py_coro != NULL; py_coro = py_coro->await.get()) {
-        if (py_coro->frame != NULL)
+        if (seen_coros.find(py_coro) != seen_coros.end()) {
+            break;
+        }
+
+        seen_coros.insert(py_coro);
+
+        if (py_coro->frame != NULL) {
             coro_frames.push(py_coro->frame);
+        }
     }
 
     // Total number of frames added to the Stack

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
@@ -307,10 +307,9 @@ TaskInfo::unwind(FrameStack& stack, size_t& upper_python_stack_size)
 
     // Unwind the coro chain
     // Detect cycles in the await chain to prevent infinite loops.
-    // This can happen if the Profiler samples during as the Task is running,
+    // This can happen if the Profiler samples as the Task is running,
     // or due to memory corruption/race conditions when reading coroutine pointers.
     std::unordered_set<GenInfo*> seen_coros;
-    std::unordered_set<size_t> pure_coro_frames;
     for (auto py_coro = this->coro.get(); py_coro != NULL; py_coro = py_coro->await.get()) {
         if (seen_coros.find(py_coro) != seen_coros.end()) {
             break;


### PR DESCRIPTION
## Description

This PR adds detection for cycles in asyncio Tasks and asyncio coroutine chains. Failing to do that could lead to infinite loops / memory starvation in two cases (1) there actually is a loop in a Task or coroutine chain (2) there isn't a cycle, but we copied memory at two different instants and the state changed in between our copies, making it appear (to us) as if there were some, making us loop forever (and insert a LOT of items into collections). 

Looking at [Profiles](https://ddstaging.datadoghq.com/profiling/explorer?query=language%3A%28ebpf%20OR%20native%29%20%28workspace%3A%2Akowalski%2A%20OR%20host%3A%2Akowalski%2A%29%20service%3Akowalski-python&agg_m=%40prof_core_cpu_cores&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=sum&fromUser=true&group_by=line&my_code=enabled&profiling-flame-graph__filter=file%3A%22%2Fhome%2Fbits%2Fgo%2Fsrc%2Fgithub.com%2FDataDog%2Fdd-trace-py%2Fddtrace%2Finternal%2Fdatadog%2Fprofiling%2Fstack%2Fechion%2Fechion%2Ftasks.h%22%20show_from%28function%3A%22start_thread%20%28pthread_create.c%29%22%29%20show_from%28function%3A%22call_sampling_thread%28void%2A%29%20%28sampler.cpp%29%22%29&refresh_mode=paused&top_n=100&top_o=top&viz=flame_graph&x_missing=true&from_ts=1766418646453&to_ts=1766419546453&live=false) of the Python Profiler, it seems like the additional overhead (of building the set, bookkeeping, and whether it contains a certain element) is cheap enough – 14ms per minute over ~290ms per minute (~5% increase). I think it is fine to merge as-is (especially as it does fix a very real problem which can make the whole Python process grind to a halt as the Profiler starts spending all its time trying to satisfy an infinite hunger for more memory).

<img width="1964" height="1236" alt="image" src="https://github.com/user-attachments/assets/dd9a6015-a9a7-4326-b178-38b9111d0f52" />


<!-- https://github.com/DataDog/dd-trace-py/pull/15674 -->