### PR TITLE
feat(profiling): add asyncio.Condition support to Python Lock profiler

### DIFF
--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.locks
 from types import ModuleType
+from typing import Optional
 from typing import Type
 
 from . import _lock
+
+
+# Internal module file for asyncio lock detection
+# This is used to detect locks created internally by Semaphore/Condition
+_ASYNCIO_LOCKS_FILE: Optional[str] = asyncio.locks.__file__
 
 
 class _ProfiledAsyncioLock(_lock._ProfiledLock):
@@ -19,12 +26,17 @@ class _ProfiledAsyncioBoundedSemaphore(_lock._ProfiledLock):
     pass
 
 
+class _ProfiledAsyncioCondition(_lock._ProfiledLock):
+    pass
+
+
 class AsyncioLockCollector(_lock.LockCollector):
     """Record asyncio.Lock usage."""
 
     PROFILED_LOCK_CLASS: Type[_ProfiledAsyncioLock] = _ProfiledAsyncioLock
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "Lock"
+    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE
 
 
 class AsyncioSemaphoreCollector(_lock.LockCollector):
@@ -33,6 +45,7 @@ class AsyncioSemaphoreCollector(_lock.LockCollector):
     PROFILED_LOCK_CLASS: Type[_ProfiledAsyncioSemaphore] = _ProfiledAsyncioSemaphore
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "Semaphore"
+    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE
 
 
 class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
@@ -41,3 +54,13 @@ class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
     PROFILED_LOCK_CLASS: Type[_ProfiledAsyncioBoundedSemaphore] = _ProfiledAsyncioBoundedSemaphore
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "BoundedSemaphore"
+    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE
+
+
+class AsyncioConditionCollector(_lock.LockCollector):
+    """Record asyncio.Condition usage."""
+
+    PROFILED_LOCK_CLASS: Type[_ProfiledAsyncioCondition] = _ProfiledAsyncioCondition
+    MODULE: ModuleType = asyncio
+    PATCHED_LOCK_NAME: str = "Condition"
+    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -222,6 +222,7 @@ class _ProfilerInstance(service.Service):
                 ("asyncio", lambda _: start_collector(asyncio.AsyncioLockCollector)),
                 ("asyncio", lambda _: start_collector(asyncio.AsyncioSemaphoreCollector)),
                 ("asyncio", lambda _: start_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
+                ("asyncio", lambda _: start_collector(asyncio.AsyncioConditionCollector)),
             ]
 
             for module, hook in self._collectors_on_import:

--- a/releasenotes/notes/Added-support-for-profiling-of-asyncio.Condition-objects-to-the-Python-Lock-profiler-0324360536e549fa.yaml
+++ b/releasenotes/notes/Added-support-for-profiling-of-asyncio.Condition-objects-to-the-Python-Lock-profiler-0324360536e549fa.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    profiling: Add support for ``asyncio.Condition`` locking type profiling in Python.
+    The Lock profiler now provides visibility into ``asyncio.Condition`` usage, helping
+    identify contention in async applications using condition variables.
+

--- a/tests/profiling/collector/test_asyncio.py
+++ b/tests/profiling/collector/test_asyncio.py
@@ -16,6 +16,7 @@ import pytest
 from ddtrace import ext
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector.asyncio import AsyncioBoundedSemaphoreCollector
+from ddtrace.profiling.collector.asyncio import AsyncioConditionCollector
 from ddtrace.profiling.collector.asyncio import AsyncioLockCollector
 from ddtrace.profiling.collector.asyncio import AsyncioSemaphoreCollector
 from tests.profiling.collector import pprof_utils
@@ -29,10 +30,12 @@ init_linenos(__file__)
 PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
 
 # Type aliases for supported classes
-LockTypeInst = Union[asyncio.Lock, asyncio.Semaphore, asyncio.BoundedSemaphore]
+LockTypeInst = Union[asyncio.Lock, asyncio.Semaphore, asyncio.BoundedSemaphore, asyncio.Condition]
 LockTypeClass = Type[LockTypeInst]
 
-CollectorTypeInst = Union[AsyncioLockCollector, AsyncioSemaphoreCollector, AsyncioBoundedSemaphoreCollector]
+CollectorTypeInst = Union[
+    AsyncioLockCollector, AsyncioSemaphoreCollector, AsyncioBoundedSemaphoreCollector, AsyncioConditionCollector
+]
 CollectorTypeClass = Type[CollectorTypeInst]
 
 
@@ -50,6 +53,10 @@ CollectorTypeClass = Type[CollectorTypeInst]
         (
             AsyncioBoundedSemaphoreCollector,
             "AsyncioBoundedSemaphoreCollector(status=<ServiceStatus.STOPPED: 'stopped'>, capture_pct=1.0, nframes=64, tracer=None)",  # noqa: E501
+        ),
+        (
+            AsyncioConditionCollector,
+            "AsyncioConditionCollector(status=<ServiceStatus.STOPPED: 'stopped'>, capture_pct=1.0, nframes=64, tracer=None)",  # noqa: E501
         ),
     ],
 )
@@ -263,3 +270,15 @@ class TestAsyncioBoundedSemaphoreCollector(BaseAsyncioLockCollectorTest):
             # BoundedSemaphore should raise ValueError when releasing more than initial value
             with pytest.raises(ValueError, match="BoundedSemaphore released too many times"):
                 bs.release()
+
+
+class TestAsyncioConditionCollector(BaseAsyncioLockCollectorTest):
+    """Test asyncio.Condition profiling."""
+
+    @property
+    def collector_class(self) -> Type[AsyncioConditionCollector]:
+        return AsyncioConditionCollector
+
+    @property
+    def lock_class(self) -> Type[asyncio.Condition]:
+        return asyncio.Condition

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -140,6 +140,7 @@ def test_default_collectors():
         assert any(isinstance(c, asyncio.AsyncioLockCollector) for c in p._profiler._collectors)
         assert any(isinstance(c, asyncio.AsyncioSemaphoreCollector) for c in p._profiler._collectors)
         assert any(isinstance(c, asyncio.AsyncioBoundedSemaphoreCollector) for c in p._profiler._collectors)
+        assert any(isinstance(c, asyncio.AsyncioConditionCollector) for c in p._profiler._collectors)
     p.stop(flush=False)
 
 


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-12724

**_note_** 
this PR implements profiling the time to acquire `Condition`'s underlying lock. While this data is somewhat useful on its own (more contention data better than less?), it would be more valuable to profile how long a Condition was waited on before signaling, etc. This would require `ddup` API changes, and new backend/UI work to display the new data type. As such, this rich implementation will be pushed to Q1 (?) 2026.
**_end note_** 

### Description
Adds profiling support for `asyncio.Condition` to the Python Lock profiler. This extends the lock profiling capability to include condition variables in asynchronous applications.

### Motivation
`asyncio.Condition` is a synchronization primitive that allows tasks to wait for a specific condition. Profiling Condition usage helps identify:
- Contention points where tasks are waiting on conditions
- Long wait times in producer/consumer patterns
- Potential bottlenecks in async coordination logic

### Changes
1. **New Collector:** Added `AsyncioConditionCollector` in `ddtrace/profiling/collector/asyncio.py`.
2. **Internal Lock Detection:** `asyncio.Condition` also creates an internal `asyncio.Lock`, and since we now have a handful of lock types following the same pattern, the `is_internal` logic was generalized by adding a `INTERNAL_MODULE_FILE` class attribute to `LockCollector`.

## Testing
### Unit testing
- Added `TestAsyncioConditionCollector` with `test_condition_wait_notify` test
- Inherits base tests from `BaseAsyncioLockCollectorTest`

### Manual testing
```
$ DD_SERVICE=lock-demo-asyncio-condition python scripts/demo_lock_profiling.py asyncio-condition
...
Open this URL to view lock profiling data in Datadog:

  https://app.datadoghq.com/profiling/explorer?query=service%3Alock-demo-asyncio-condition
```

* Line 99: `async_condition = asyncio.Condition()`
[Data in Prod](https://app.datadoghq.com/profiling/explorer?query=service%3Alock-demo-asyncio-condition&my_code=enabled&profile_type=lock-acquire-time&refresh_mode=paused&viz=flame_graph&from_ts=1766074412749&to_ts=1766078012749&live=false)

<img width="1594" height="447" alt="Screenshot 2025-12-18 at 12 15 08 PM" src="https://github.com/user-attachments/assets/c3fcca35-aed7-4b85-b43c-c244e76ddd38" />