### PR TITLE
chore(llmobs): make tests checking api key more flexible when checking error message

### DIFF
--- a/tests/llmobs/test_llmobs_span_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_span_agentless_writer.py
@@ -88,15 +88,20 @@ def test_send_completion_bad_api_key(mock_writer_logs):
     llmobs_span_writer = LLMObsSpanWriter(1, 1, is_agentless=True, _site=DD_SITE, _api_key="<bad-api-key>")
     llmobs_span_writer.enqueue(_completion_event())
     llmobs_span_writer.periodic()
-    mock_writer_logs.error.assert_called_with(
-        "failed to send %d LLMObs %s events to %s, got response code %d, status: %s",
-        1,
-        "span",
-        "https://llmobs-intake.datad0g.com/api/v2/llmobs",
-        403,
-        b'{"errors":[{"status":"403","title":"Forbidden","detail":"API key is missing"}]}',
-        extra={"send_to_telemetry": False},
-    )
+    # Verify the error was logged - extract the actual response body for flexible assertion
+    mock_writer_logs.error.assert_called_once()
+    call_args = mock_writer_logs.error.call_args
+    assert call_args[0][0] == "failed to send %d LLMObs %s events to %s, got response code %d, status: %s"
+    assert call_args[0][1] == 1  # num events
+    assert call_args[0][2] == "span"
+    assert call_args[0][3] == "https://llmobs-intake.datad0g.com/api/v2/llmobs"
+    assert call_args[0][4] == 403
+    # The API may return "API key is missing" or "API key is invalid"
+    actual_response = call_args[0][5]
+    assert b'"status":"403"' in actual_response
+    assert b'"title":"Forbidden"' in actual_response
+    assert b"API key is missing" in actual_response or b"API key is invalid" in actual_response
+    assert call_args[1] == {"extra": {"send_to_telemetry": False}}
 
 
 def test_send_completion_no_api_key(mock_writer_logs):
@@ -158,4 +163,7 @@ llmobs_span_writer.enqueue(_completion_event())
     assert status == 0, err
     assert out == b""
     assert b"got response code 403" in err
-    assert b'status: b\'{"errors":[{"status":"403","title":"Forbidden","detail":"API key is missing"}]}\'\n' in err
+    # The API may return "API key is missing" or "API key is invalid"
+    assert b'"status":"403"' in err
+    assert b'"title":"Forbidden"' in err
+    assert b"API key is missing" in err or b"API key is invalid" in err


### PR DESCRIPTION
## Description

These fail occasionally flipping back and forth between  API key is missing" and sometimes "API key is invalid". https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1307834825

Not sure what causes the difference, but to protect against it, going to make the tests accept either.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
