### PR TITLE
ci: set default values for cpus and mem_limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,8 +187,10 @@ services:
         #  dockerfile: Dockerfile
         image: ghcr.io/datadog/dd-trace-py/testrunner:1802bf8a83c7826f8414f7dcc18cb29067f7e690@sha256:8ca2c0c6b34db4e0ef7f5ab55f717908ed2b9ae197b2c11b48b7359a1549a202
         command: bash
-        cpus: "${DD_TEST_CPUS}"
-        mem_limit: "${DD_TEST_MEMORY}"
+        # Resource limits: defaults to 0 (unlimited, uses all available system resources)
+        # Set DD_TEST_CPUS (e.g., "4") and DD_TEST_MEMORY (e.g., "8g") to apply limits
+        cpus: "${DD_TEST_CPUS:-0}"
+        mem_limit: "${DD_TEST_MEMORY:-0}"
         environment:
           DD_FAST_BUILD: "1"
           CMAKE_BUILD_PARALLEL_LEVEL: "12"


### PR DESCRIPTION
## Description

Without this `scripts/run-tests` fails

```
WARN[0000] The "DD_TEST_CPUS" variable is not set. Defaulting to a blank string.
error while interpolating services.testrunner.cpus: failed to cast to expected type: strconv.ParseFloat: parsing "": invalid syntax
❌ Python 3.10 failed with exit code 1

❌ Suite 'conftest' failed. Stopping execution.
```

https://docs.docker.com/reference/compose-file/services/#cpus
The documentation doesn't seem to explicitly say that 0 is accepted as unlimited for `mem_limit` but seems to be working?

```
❯ scripts/ddtest
bits@ip-10-126-86-78:~/project$ cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "cgroup v2 or no limit"
max
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
