### PR TITLE
chore: reorganize serverless `CODEOWNERS` by cloud provider teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -249,27 +249,31 @@ tests/tracer/                                      @DataDog/apm-sdk-capabilities
 # Override because order matters
 tests/tracer/test_ci.py                            @DataDog/ci-app-libraries
 
-# Serverless (mixed)
-tests/internal/test_serverless.py                         @DataDog/apm-serverless @DataDog/asm-python @DataDog/serverless-aws @DataDog/serverless-azure-and-gcp
-
-# Serverless: AWS
+# AWS Lambda
 ddtrace/contrib/internal/aws_lambda                       @DataDog/apm-serverless @DataDog/serverless-aws
-ddtrace/ext/aws.py                                        @DataDog/apm-serverless @DataDog/serverless-aws
 tests/contrib/aws_lambda                                  @DataDog/apm-serverless @DataDog/serverless-aws
 tests/snapshots/tests.contrib.aws_lambda.*                @DataDog/apm-serverless @DataDog/serverless-aws
 
-# Serverless: Azure and GCP
+# AWS SDK
+ddtrace/ext/aws.py                                        @DataDog/apm-serverless @DataDog/serverless-aws @DataDog/apm-idm-python
+
+# Azure Functions
 ddtrace/contrib/internal/azure_eventhubs                  @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 ddtrace/contrib/internal/azure_functions                  @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 ddtrace/contrib/internal/azure_servicebus                 @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-ddtrace/ext/azure_eventhubs.py                            @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-ddtrace/ext/azure_servicebus.py                           @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-tests/contrib/azure_eventhubs                             @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 tests/contrib/azure_functions*                            @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-tests/contrib/azure_servicebus                            @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-tests/snapshots/tests.contrib.azure_eventhubs.*           @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 tests/snapshots/tests.contrib.azure_functions*            @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-tests/snapshots/tests.contrib.azure_servicebus.*          @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+
+# Azure SDK
+ddtrace/ext/azure_eventhubs.py                            @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp @DataDog/apm-idm-python
+ddtrace/ext/azure_servicebus.py                           @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp @DataDog/apm-idm-python
+tests/contrib/azure_eventhubs                             @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp @DataDog/apm-idm-python
+tests/contrib/azure_servicebus                            @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp @DataDog/apm-idm-python
+tests/snapshots/tests.contrib.azure_eventhubs.*           @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp @DataDog/apm-idm-python
+tests/snapshots/tests.contrib.azure_servicebus.*          @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp @DataDog/apm-idm-python
+
+# Serverless (mixed)
+tests/internal/test_serverless.py                         @DataDog/apm-serverless @DataDog/asm-python @DataDog/serverless-aws @DataDog/serverless-azure-and-gcp
 
 # Data Streams Monitoring
 ddtrace/data_streams.py                                   @DataDog/data-streams-monitoring


### PR DESCRIPTION
## Description

Reorganizes the serverless section of `CODEOWNERS` to better reflect team ownership by cloud provider:

- Replace `@DataDog/serverless` with
  - `@DataDog/serverless-aws` for AWS
  - `@DataDog/serverless-azure-and-gcp` for Azure and GCP
- Maintain `@DataDog/apm-serverless` as co-owner on all serverless components
- Groups entries by cloud provider (AWS, Azure/GCP) for better readability
- Consolidates some patterns using wildcards

## Testing

No functional changes

## Risks

none?

## Additional Notes

none