### PR TITLE
chore(profiling): clang-tidy fixes

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -122,7 +122,7 @@ class Sample
     bool push_absolute_ns(int64_t timestamp_ns);
 
     // Interacts with static Sample state
-    bool is_timeline_enabled() const;
+    static bool is_timeline_enabled();
     static void set_timeline(bool enabled);
 
     // Pytorch GPU metadata

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -27,12 +27,12 @@ Datadog::internal::StringArena::reset()
 std::string_view
 Datadog::internal::StringArena::insert(std::string_view s)
 {
-    auto chunk = &chunks.back();
+    auto* chunk = &chunks.back();
     if ((chunk->capacity() - chunk->size()) < s.size()) {
         chunk = &chunks.emplace_back();
         chunk->reserve(std::max(s.size(), Datadog::internal::StringArena::DEFAULT_SIZE));
     }
-    int base = chunk->size();
+    auto base = chunk->size();
     chunk->insert(chunk->end(), s.begin(), s.end());
     return std::string_view(chunk->data() + base, s.size());
 }
@@ -532,7 +532,7 @@ Datadog::Sample::push_monotonic_ns(int64_t _monotonic_ns)
 
         // Get the current monotonic time.  Use clock_gettime directly because the standard underspecifies
         // which clock is actually used in std::chrono
-        timespec ts;
+        timespec ts{ 0, 0 };
         clock_gettime(CLOCK_MONOTONIC, &ts);
         auto monotonic_ns = static_cast<int64_t>(ts.tv_sec) * 1'000'000'000LL + ts.tv_nsec;
 
@@ -555,7 +555,7 @@ Datadog::Sample::set_timeline(bool enabled)
 }
 
 bool
-Datadog::Sample::is_timeline_enabled() const
+Datadog::Sample::is_timeline_enabled()
 {
     return timeline_enabled;
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
@@ -24,9 +24,9 @@ std::optional<Sample*>
 StaticSamplePool::take_sample()
 {
     for (std::size_t i = 0; i < CAPACITY; ++i) {
-        Sample* s = pool[i].exchange(nullptr, std::memory_order_acq_rel);
-        if (s != nullptr) {
-            return s;
+        Sample* string = pool[i].exchange(nullptr, std::memory_order_acq_rel);
+        if (string != nullptr) {
+            return string;
         }
     }
     return std::nullopt;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -20,7 +20,7 @@ Datadog::Uploader::Uploader(std::string_view _output_filename,
   : output_filename{ _output_filename }
   , ddog_exporter{ _ddog_exporter }
   , encoded_profile{ _encoded_profile }
-  , profiler_stats{ std::move(_stats) }
+  , profiler_stats{ _stats }
 {
     // Increment the upload sequence number every time we build an uploader.
     // Uploaders are use-once-and-destroy.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -190,7 +190,7 @@ Datadog::UploaderBuilder::build()
         return errmsg;
     }
 
-    auto ddog_exporter = &res.ok;
+    auto* ddog_exporter = &res.ok;
 
     auto set_timeout_result = ddog_prof_Exporter_set_timeout(ddog_exporter, max_timeout_ms);
     if (set_timeout_result.tag == DDOG_VOID_RESULT_ERR) {
@@ -235,6 +235,6 @@ Datadog::UploaderBuilder::build()
     // This was necessary to avoid double-free from calling ddog_prof_Exporter_drop()
     // in the destructor of Uploader. See comments in uploader.hpp for more details.
     return std::variant<Datadog::Uploader, std::string>{
-        std::in_place_type<Datadog::Uploader>, output_filename, *ddog_exporter, encoded.ok, std::move(stats)
+        std::in_place_type<Datadog::Uploader>, output_filename, *ddog_exporter, encoded.ok, stats
     };
 }

--- a/ddtrace/internal/datadog/profiling/stack/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/CMakeLists.txt
@@ -39,6 +39,7 @@ set_target_properties(
 include(FetchContent)
 include(AnalysisFunc)
 include(FindCppcheck)
+include(FindClangtidy)
 
 find_package(Python3 COMPONENTS Interpreter Development)
 
@@ -70,6 +71,9 @@ add_cppcheck_target(
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Static analysis
+add_clangtidy_target(${EXTENSION_NAME})
 
 # Never build with native unwinding, since this is not currently used
 target_compile_definitions(${EXTENSION_NAME} PRIVATE UNWIND_NATIVE_DISABLE)

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
@@ -49,10 +49,10 @@ class Frame
 
     struct _location
     {
-        int line = 0;
-        int line_end = 0;
-        int column = 0;
-        int column_end = 0;
+        unsigned line = 0;
+        unsigned line_end = 0;
+        unsigned column = 0;
+        unsigned column_end = 0;
     } location;
 
 #if PY_VERSION_HEX >= 0x030b0000

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/render.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/render.h
@@ -34,8 +34,13 @@ class RendererInterface
 
     // If a renderer has its own caching mechanism for frames, this can be used
     // to store frame information.
-    virtual void
-    frame(uintptr_t key, uintptr_t filename, uintptr_t name, int line, int line_end, int column, int column_end) = 0;
+    virtual void frame(uintptr_t key,
+                       uintptr_t filename,
+                       uintptr_t name,
+                       unsigned line,
+                       unsigned line_end,
+                       unsigned column,
+                       unsigned column_end) = 0;
 
     // Refers to the frame stored using the renderer's frame function
     virtual void frame_ref(uintptr_t key) = 0;
@@ -94,7 +99,7 @@ class NullRenderer : public RendererInterface
     bool is_valid() override { return true; }
     void header() override {}
     void metadata(const std::string&, const std::string&) override {}
-    void frame(uintptr_t, uintptr_t, uintptr_t, int, int, int, int) override {}
+    void frame(uintptr_t, uintptr_t, uintptr_t, unsigned, unsigned, unsigned, unsigned) override {}
     void frame_ref(uintptr_t) override {}
     void frame_kernel(const std::string&) override {}
 
@@ -150,7 +155,13 @@ class Renderer
 
     void string(uintptr_t key, const std::string& value) { getActiveRenderer()->string(key, value); }
 
-    void frame(uintptr_t key, uintptr_t filename, uintptr_t name, int line, int line_end, int column, int column_end)
+    void frame(uintptr_t key,
+               uintptr_t filename,
+               uintptr_t name,
+               unsigned line,
+               unsigned line_end,
+               unsigned column,
+               unsigned column_end)
     {
         getActiveRenderer()->frame(key, filename, name, line, line_end, column, column_end);
     }

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -39,7 +39,7 @@ class StackRenderer : public RendererInterface
     void close() override {}
     void header() override {}
     void metadata(const std::string&, const std::string&) override {}
-    void frame(uintptr_t, uintptr_t, uintptr_t, int, int, int, int) override {};
+    void frame(uintptr_t, uintptr_t, uintptr_t, unsigned, unsigned, unsigned, unsigned) override {};
     void frame_ref(uintptr_t) override{};
     void frame_kernel(const std::string&) override {};
     void string(uintptr_t, const std::string&) override {};

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -148,7 +148,7 @@ safe_memcpy(void* dst, const void* src, size_t n)
         safe_memcpy_return_t chunk = std::min(rem, std::min(to_src_pg, to_dst_pg));
 
         // Optional early probe to fault before entering large memcpy
-        (void)*reinterpret_cast<volatile const uint8_t*>(s);
+        (void)*static_cast<volatile const uint8_t*>(s);
 
         // If this faults, we'll siglongjmp back to the sigsetjmp above.
         (void)memcpy(d, s, static_cast<size_t>(chunk));


### PR DESCRIPTION
## Description

This resolves some issues reported by `clang-tidy`. Long term, I plan to get rid of all the errors it reports (either by fixing them or properly tagging them as excluded) and to add a CI check. This is the first step :) 