### PR TITLE
ci(dsm): fix dsm kafka test flake

### DIFF
--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -239,11 +239,11 @@ def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consume
 
     # Auto commit is enabled so we want to wait for the commit event to fire
     first_offset = _wait_for_auto_commit_and_fetch_offset()
-    if first_offset is not None:
-        assert (
-            list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)]
-            == first_offset
-        )
+    assert first_offset is not None, "Auto-commit did not complete within 5 seconds"
+    assert (
+        list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)]
+        == first_offset
+    )
 
 
 def test_data_streams_kafka_produce_api_compatibility(dsm_processor, consumer, producer, empty_kafka_topic):


### PR DESCRIPTION
## Description
Fix test flake in a kafka auto commit test. We previously just assumed that an auto commit will happen within a second. This will sleep and periodically check until it has the commit for up to 5 seconds.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Test failure example: [here](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fapm-reliability%2Fdd-trace-py%22%20%40test.suite%3A%22test_kafka_dsm.py%22%20%40test.module%3A%22tests.contrib.kafka%22&sort=-pipelines_failed&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%228ceb536cd045bdda%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D&viewMode=flaky)
<!-- Any other information that would be helpful for reviewers -->
