### PR TITLE
fix(ffe): fix exposure logging according to requirements (#15686)

### DIFF
--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -4,6 +4,9 @@ Feature Flagging and Experimentation (FFE) product module.
 This module handles Feature Flag configuration rules from Remote Configuration
 and forwards the raw bytes to the native FFE processor.
 """
+
+from collections import OrderedDict
+from collections.abc import MutableMapping
 from importlib.metadata import version
 import typing
 
@@ -40,7 +43,42 @@ else:
 
 
 T = typing.TypeVar("T", covariant=True)
+K = typing.TypeVar("K")
+V = typing.TypeVar("V")
 logger = get_logger(__name__)
+
+
+class LRUCache(MutableMapping, typing.Generic[K, V]):
+    """LRU cache implementation using OrderedDict that implements the Mapping interface."""
+
+    def __init__(self, maxsize: int = 128):
+        self._cache: typing.OrderedDict[K, V] = OrderedDict()
+        self._maxsize = maxsize
+
+    def __getitem__(self, key: K) -> V:
+        """Get value from cache, moving it to end (most recently used)."""
+        self._cache.move_to_end(key)
+        return self._cache[key]
+
+    def __setitem__(self, key: K, value: V) -> None:
+        """Put value in cache, evicting least recently used if at capacity."""
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = value
+        if len(self._cache) > self._maxsize:
+            self._cache.popitem(last=False)  # Remove least recently used (first item)
+
+    def __delitem__(self, key: K) -> None:
+        """Delete key from cache."""
+        del self._cache[key]
+
+    def __iter__(self) -> typing.Iterator[K]:
+        """Iterate over cache keys."""
+        return iter(self._cache)
+
+    def __len__(self) -> int:
+        """Return number of items in cache."""
+        return len(self._cache)
 
 
 class DataDogProvider(AbstractProvider):
@@ -58,8 +96,11 @@ class DataDogProvider(AbstractProvider):
         self._config_received = False
 
         # Cache for reported exposures to prevent duplicates
-        # Stores tuples of (flag_key, variant_key, allocation_key)
-        self._exposure_cache: typing.Set[typing.Tuple[str, typing.Optional[str], typing.Optional[str]]] = set()
+        # Stores mapping of (flag_key, subject_id) -> (allocation_key, variant_key)
+        # Using LRU cache with maxsize of 65536 to prevent unbounded memory growth
+        self._exposure_cache: LRUCache[
+            typing.Tuple[str, str], typing.Tuple[typing.Optional[str], typing.Optional[str]]
+        ] = LRUCache(maxsize=65536)
 
         # Check if experimental flagging provider is enabled
         self._enabled = ffe_config.experimental_flagging_provider_enabled
@@ -209,13 +250,8 @@ class DataDogProvider(AbstractProvider):
             )
 
             # No configuration available - return default
+            # Note: No exposure logging when configuration is missing
             if details is None:
-                self._report_exposure(
-                    flag_key=flag_key,
-                    variant_key=None,
-                    allocation_key=None,
-                    evaluation_context=evaluation_context,
-                )
                 return FlagResolutionDetails(
                     value=default_value,
                     reason=Reason.DEFAULT,
@@ -229,12 +265,14 @@ class DataDogProvider(AbstractProvider):
 
                 # Flag not found - return default with DEFAULT reason
                 if details.error_code == ffe.ErrorCode.FlagNotFound:
-                    self._report_exposure(
-                        flag_key=flag_key,
-                        variant_key=None,
-                        allocation_key=None,
-                        evaluation_context=evaluation_context,
-                    )
+                    # Only report exposure if do_log is explicitly True
+                    if details.do_log:
+                        self._report_exposure(
+                            flag_key=flag_key,
+                            variant_key=None,
+                            allocation_key=None,
+                            evaluation_context=evaluation_context,
+                        )
                     return FlagResolutionDetails(
                         value=default_value,
                         reason=Reason.DEFAULT,
@@ -252,13 +290,14 @@ class DataDogProvider(AbstractProvider):
             # Map native ffe.Reason to OpenFeature Reason
             reason = self._map_reason_to_openfeature(details.reason)
 
-            # Report exposure event
-            self._report_exposure(
-                flag_key=flag_key,
-                variant_key=details.variant,
-                allocation_key=details.allocation_key,
-                evaluation_context=evaluation_context,
-            )
+            # Report exposure event only if do_log flag is True
+            if details.do_log:
+                self._report_exposure(
+                    flag_key=flag_key,
+                    variant_key=details.variant,
+                    allocation_key=details.allocation_key,
+                    evaluation_context=evaluation_context,
+                )
 
             # Check if variant is None/empty to determine if we should use default value.
             # For JSON flags, value can be null which is valid, so we check variant instead.
@@ -297,27 +336,41 @@ class DataDogProvider(AbstractProvider):
         Report a feature flag exposure event to the EVP proxy intake.
 
         Uses caching to prevent duplicate exposure events for the same
-        (flag_key, variant_key, allocation_key) combination.
+        (flag_key, subject_id, variant_key, allocation_key) combination.
+
+        Note: This method should only be called when exposure logging is enabled.
+        Callers must check the do_log flag before invoking this method.
+
+        Args:
+            flag_key: The feature flag key
+            variant_key: The variant key returned by evaluation
+            allocation_key: The allocation key
+            evaluation_context: The evaluation context with subject information
         """
         try:
-            # Check cache to prevent duplicate exposure events
-            cache_key = (flag_key, variant_key, allocation_key)
-            if cache_key in self._exposure_cache:
-                logger.debug("Skipping duplicate exposure event for %s", cache_key)
-                return
-
             exposure_event = build_exposure_event(
                 flag_key=flag_key,
                 variant_key=variant_key,
                 allocation_key=allocation_key,
                 evaluation_context=evaluation_context,
             )
+            if not exposure_event:
+                return
 
-            if exposure_event:
-                writer = get_exposure_writer()
-                writer.enqueue(exposure_event)
-                # Add to cache only after successful enqueue
-                self._exposure_cache.add(cache_key)
+            # Check cache to prevent duplicate exposure events
+            key = (flag_key, exposure_event["subject"]["id"])
+            value = (allocation_key, variant_key)
+
+            cached_value = self._exposure_cache.get(key, None)
+            if cached_value and cached_value == value:
+                logger.debug("Skipping duplicate exposure event for %s->%s", key, value)
+                return
+
+            writer = get_exposure_writer()
+            writer.enqueue(exposure_event)
+
+            # Add to cache only after successful enqueue
+            self._exposure_cache[key] = value
         except Exception as e:
             logger.debug("Failed to report exposure event: %s", e, exc_info=True)
 

--- a/releasenotes/notes/fix-ffe-exposure-logging-8fff59857ff54540.yaml
+++ b/releasenotes/notes/fix-ffe-exposure-logging-8fff59857ff54540.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    openfeature: Fix exposure event deduplication to use (flag_key, subject_id) as cache key
+    instead of (flag_key, variant_key, allocation_key). This ensures different users each
+    receive their own exposure event while still deduplicating repeated evaluations for the
+    same user. Also adds LRU eviction to prevent unbounded memory growth and respects the
+    do_log flag from flag metadata.

--- a/tests/openfeature/test_exposure.py
+++ b/tests/openfeature/test_exposure.py
@@ -4,7 +4,6 @@ Tests for exposure event building.
 
 from openfeature.evaluation_context import EvaluationContext
 
-from ddtrace.internal.openfeature._exposure import _build_subject
 from ddtrace.internal.openfeature._exposure import build_exposure_event
 
 
@@ -29,11 +28,12 @@ class TestBuildExposureEvent:
         assert event["variant"]["key"] == "variant-a"
         assert event["allocation"]["key"] == "allocation-1"
         assert event["subject"]["id"] == "user-123"
+        assert event["subject"]["attributes"] == {"tier": "premium", "email": "test@example.com"}
         assert "timestamp" in event
         assert isinstance(event["timestamp"], int)
 
-    def test_build_exposure_event_without_allocation_key(self):
-        """Test that variant_key is used as allocation_key if not provided."""
+    def test_build_exposure_event_missing_allocation_key(self):
+        """Test that None is returned when allocation_key is not provided."""
         context = EvaluationContext(targeting_key="user-456")
 
         event = build_exposure_event(
@@ -43,9 +43,7 @@ class TestBuildExposureEvent:
             evaluation_context=context,
         )
 
-        assert event is not None
-        assert event["allocation"]["key"] == "variant-b"
-        assert event["variant"]["key"] == "variant-b"
+        assert event is None
 
     def test_build_exposure_event_missing_flag_key(self):
         """Test that None is returned when flag_key is missing."""
@@ -71,12 +69,10 @@ class TestBuildExposureEvent:
             evaluation_context=context,
         )
 
-        assert event is not None
-        assert event["variant"]["key"] == ""
-        assert event["allocation"]["key"] == "allocation-1"
+        assert event is None
 
-    def test_build_exposure_event_missing_subject(self):
-        """Test that None is returned when subject cannot be built."""
+    def test_build_exposure_event_none_context(self):
+        """Test that exposure event is built with empty targeting_key when context is None."""
         event = build_exposure_event(
             flag_key="test-flag",
             variant_key="variant-a",
@@ -84,68 +80,36 @@ class TestBuildExposureEvent:
             evaluation_context=None,
         )
 
-        assert event is None
+        assert event is not None
+        assert event["subject"]["id"] == ""
+        assert event["subject"]["attributes"] == {}
 
-
-class TestBuildSubject:
-    """Test subject building from evaluation context."""
-
-    def test_build_subject_with_targeting_key(self):
-        """Test building subject with targeting_key."""
-        context = EvaluationContext(targeting_key="user-123")
-
-        subject = _build_subject(context)
-
-        assert subject is not None
-        assert subject["id"] == "user-123"
-
-    def test_build_subject_with_attributes(self):
-        """Test building subject with attributes."""
-        context = EvaluationContext(targeting_key="user-123", attributes={"tier": "premium", "region": "us-east"})
-
-        subject = _build_subject(context)
-
-        assert subject is not None
-        assert subject["id"] == "user-123"
-        assert subject["attributes"]["tier"] == "premium"
-        assert subject["attributes"]["region"] == "us-east"
-
-    def test_build_subject_with_type(self):
-        """Test building subject with explicit subject_type."""
-        context = EvaluationContext(
-            targeting_key="org-456", attributes={"subject_type": "organization", "name": "ACME Corp"}
-        )
-
-        subject = _build_subject(context)
-
-        assert subject is not None
-        assert subject["id"] == "org-456"
-        assert subject["type"] == "organization"
-        assert subject["attributes"]["name"] == "ACME Corp"
-        # subject_type should not appear in attributes
-        assert "subject_type" not in subject["attributes"]
-
-    def test_build_subject_missing_targeting_key(self):
-        """Test that None is returned when targeting_key is missing."""
+    def test_build_exposure_event_missing_targeting_key(self):
+        """Test that exposure event uses empty string when targeting_key is missing."""
         context = EvaluationContext(targeting_key=None, attributes={"tier": "premium"})
 
-        subject = _build_subject(context)
+        event = build_exposure_event(
+            flag_key="test-flag",
+            variant_key="variant-a",
+            allocation_key="allocation-1",
+            evaluation_context=context,
+        )
 
-        assert subject is None
+        assert event is not None
+        assert event["subject"]["id"] == ""
+        assert event["subject"]["attributes"] == {"tier": "premium"}
 
-    def test_build_subject_none_context(self):
-        """Test that None is returned when context is None."""
-        subject = _build_subject(None)
-
-        assert subject is None
-
-    def test_build_subject_empty_attributes(self):
-        """Test building subject with no attributes."""
+    def test_build_exposure_event_empty_attributes(self):
+        """Test building exposure event with no attributes in context."""
         context = EvaluationContext(targeting_key="user-789")
 
-        subject = _build_subject(context)
+        event = build_exposure_event(
+            flag_key="test-flag",
+            variant_key="variant-a",
+            allocation_key="allocation-1",
+            evaluation_context=context,
+        )
 
-        assert subject is not None
-        assert subject["id"] == "user-789"
-        assert "attributes" not in subject
-        assert "type" not in subject
+        assert event is not None
+        assert event["subject"]["id"] == "user-789"
+        assert event["subject"]["attributes"] == {}


### PR DESCRIPTION
<!-- Provide an overview of the change and motivation for the change --> This fixes feature flags exposure logging according to [requirements](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/5906009399/FFE+SDK+requirements) and [new system
tests](https://github.com/DataDog/system-tests/pull/5868).

<!-- Describe your testing strategy or note what tests are included --> Updated python tests but haven't tested with system tests.

<!-- Note any risks associated with this change, or "None" if no risks -->
I guess none

<!-- Any other information that would be helpful for reviewers -->

---------


(cherry picked from commit 1dcf5d173bed8c337af4ec797fa3dfa841b352c5)

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
