### PR TITLE
ci(iast): fix flaky test

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/_iast/taint_sinks/_base.py
@@ -144,7 +144,6 @@ class VulnerabilityBase:
         # If the path contains site-packages anywhere, return 'site-packages/<rest>'
         # Normalize separators to forward slashes for consistency
         if (idx := file_name_norm.find("/site-packages/")) != -1:
-            print(f"file_name_norm({idx}): {file_name_norm}")
             return file_name_norm[idx:]
         return ""
 

--- a/tests/appsec/integrations/fastapi_tests/app.py
+++ b/tests/appsec/integrations/fastapi_tests/app.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 import time
 from urllib.parse import parse_qs
+from urllib.parse import urlparse
 
 from fastapi import FastAPI
 from fastapi import Form
@@ -107,17 +108,15 @@ def get_app():
 
     @app.post("/iast/ssrf/test_secure", response_class=PlainTextResponse)
     async def view_iast_ssrf_secure(url: str = Form(...)):
-        from urllib.parse import urlparse
-
         # Validate the URL and enforce whitelist
         allowed_domains = ["example.com", "api.example.com", "www.datadoghq.com", "localhost"]
-        if type(url) == bytes:
+        if isinstance(url, bytes):
             url = url.decode("utf-8")
         parsed_url = urlparse(url)
         if parsed_url.hostname not in allowed_domains:
             return PlainTextResponse("Forbidden", status_code=403)
         try:
-            requests.get(parsed_url.geturl())
+            requests.get(url)
         except Exception:
             pass
 


### PR DESCRIPTION
The urlparse function was imported inside the async function view_iast_ssrf_secure, which caused a race condition in multiprocess mode where:                                                                            
  - The IAST validator wrapper for urlparse is set up at module startup                                                                                                                                                             
  - But importing inside a function can bypass or inconsistently apply the wrapper                                                                                                                                                  
  - This caused the secure mark to not be applied reliably, leading to false SSRF vulnerability reports                 

Flaky tests IDs: DD_1PGYGI DD_ONKXDT DD_U2V880 DD_954GJO DD_O236KS                                                                                                            
                                                                                               