### PR TITLE
test(profiling): make `memalloc` test less flaky

### DIFF
--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -94,7 +94,7 @@ class MemoryCollector:
             # DEV: This can happen if either _memalloc has not been started or has been stopped.
             LOG.debug("Unable to collect heap events from process %d", os.getpid(), exc_info=True)
 
-    def snapshot_and_parse_pprof(self, output_filename: str) -> Any:
+    def snapshot_and_parse_pprof(self, output_filename: str, assert_samples: bool = True) -> Any:
         """Export samples to profile, upload, and parse the pprof profile.
 
         This is similar to test_snapshot() but exports to the profile and returns
@@ -102,6 +102,7 @@ class MemoryCollector:
 
         Args:
             output_filename: The pprof output filename prefix (without .pid.counter suffix)
+            assert_samples: Whether to assert that the profile contains samples
 
         Returns:
             Parsed pprof profile object (pprof_pb2.Profile)
@@ -123,4 +124,4 @@ class MemoryCollector:
                 "pprof_utils is not available. snapshot_and_parse_pprof() is only available in test environment."
             )
 
-        return pprof_utils.parse_newest_profile(output_filename)
+        return pprof_utils.parse_newest_profile(output_filename, assert_samples=assert_samples)

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -626,8 +626,8 @@ def test_memory_collector_python_interface_with_allocation_tracking_no_deletion(
     mc = memalloc.MemoryCollector(heap_sample_size=32)
 
     with mc:
-        # Take initial snapshot to reset allocation tracking
-        mc.snapshot_and_parse_pprof(output_filename)
+        # Take initial snapshot to reset allocation tracking (may have no samples)
+        mc.snapshot_and_parse_pprof(output_filename, assert_samples=False)
 
         first_batch = []
         for i in range(20):


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13361

This makes the `memalloc` test less flaky by reducing the sampling interval. Currently, `memalloc` is our top flaky test. 

<img width="1198" height="587" alt="image" src="https://github.com/user-attachments/assets/a29a5d58-e1a4-4da3-aa74-101387aeed2b" />

The fix is:
- Making `heap_sample_size` lower to maximise the number of Samples we take (`heap_sample_size` really should be `heap_sample_interval`, since that's literally what it's named internally in the Collector, but that's an another-day-problem)
- More importantly, adding an `assert_samples` parameter to `snapshot_and_parse_pprof` to allow the caller _not_ to do it. The reason is that we call `snapshot_and_parse_pprof` once just to reset the Sampler's state, so it's very possible that we didn't have Samples in the state at that moment (and it's completely OK if it happens). We only want to assert we have Samples when we want to... look at the Samples.

Links
- [See test runs in Datadog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.pipeline.name%3ADataDog%2Fapm-reliability%2Fdd-trace-py%20status%3Aerror%20%40git.commit.sha%3A%288884ac9d847f8e5f2e12bc2a3e211aa3247d32c4%20OR%20f773331ca863676197efc18d472efbe4c7a0d8d4%29%20%40git.branch%3Akowalski%2Ftest-profiling-make-memalloc-test-less-flaky%20%40test.name%3A%2Amem%2A&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=30&top_o=top&viz=timeseries&x_missing=true&start=1766484843412&end=1766499243412&paused=false) for the current branch
- [See test runs in Datadog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.pipeline.name%3ADataDog%2Fapm-reliability%2Fdd-trace-py%20status%3Aerror%20%40test.name%3Atest_memory_collector_python_interface_with_allocation_tracking_no_deletion%2A&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22warm%22%2Cnull%2Cnull%2C%22value%22%5D&currentTab=overview&eventStack=&fromUser=true&index=citest&top_n=30&top_o=top&viz=timeseries&x_missing=true&start=1765909864308&end=1766514664308&paused=false) for the faulty test (should go down after merge)