### PR TITLE
chore(profiling): slight improvement to `build_standalone.sh`

### DIFF
--- a/ddtrace/internal/datadog/profiling/build_standalone.sh
+++ b/ddtrace/internal/datadog/profiling/build_standalone.sh
@@ -21,6 +21,12 @@ if [[ $OSTYPE == 'darwin'* ]]; then
   export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 fi
 
+# Make sure bc is installed
+if ! command -v bc &> /dev/null; then
+  echo "Error: bc not found. Please install bc."
+  exit 1
+fi
+
 # Function to find the highest version of compilers
 # Note that the product of this check is ignored if the user passes CC/CXX
 find_highest_compiler_version() {

--- a/ddtrace/internal/datadog/profiling/cmake/FindLibNative.cmake
+++ b/ddtrace/internal/datadog/profiling/cmake/FindLibNative.cmake
@@ -5,7 +5,7 @@ if(DEFINED NATIVE_EXTENSION_LOCATION)
 else()
     message(
         FATAL_ERROR
-            "NATIVE_EXTENSION_LOCATION is not set. Use `python setup.py` or ddtrace/internal/datadog/profiling/build_standalone.sh"
+            "NATIVE_EXTENSION_LOCATION is not set. Use `python setup.py` or ddtrace/internal/datadog/profiling/build_standalone.sh "
             "to build profiling native extensions.")
 endif()
 
@@ -14,7 +14,7 @@ if(DEFINED EXTENSION_SUFFIX)
 else()
     message(
         FATAL_ERROR
-            "EXTENSION_SUFFIX is not set. Use `python setup.py` or ddtrace/internal/datadog/profiling/build_standalone.sh"
+            "EXTENSION_SUFFIX is not set. Use `python setup.py` or ddtrace/internal/datadog/profiling/build_standalone.sh "
             "to build profiling native extensions.")
 endif()
 


### PR DESCRIPTION
## Description

This adds a check for the `bc` command since we heavily used it and it doesn't come installed out of the box on most, if not all, distributions.