### PR TITLE
test(profiling): improve message in `test_uwsgi_threads_processes_no_primary_lazy_apps`

### DIFF
--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -153,7 +153,7 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(uwsgi, tmp_path, monkeypat
     worker_pids = _get_worker_pids(proc.stdout, 2, 2)
     assert len(worker_pids) == 2
 
-    # Wait for profiles with samples to be generated
+    # Wait for profiles with wall-time samples to be generated
     # The upload interval is 1s, but we need to wait for at least one full
     # profiling cycle plus buffer for slow CI environments
     max_wait = 10
@@ -163,19 +163,22 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(uwsgi, tmp_path, monkeypat
     while waited < max_wait:
         time.sleep(wait_interval)
         waited += wait_interval
-        # Check if profiles with samples exist for all workers
+        # Check if profiles with wall-time samples exist for all workers
         try:
             all_have_samples = all(
-                pprof_utils.parse_newest_profile("%s.%d" % (filename, pid), assert_samples=False).sample
+                pprof_utils.get_samples_with_value_type(
+                    pprof_utils.parse_newest_profile("%s.%d" % (filename, pid), assert_samples=False),
+                    "wall-time",
+                )
                 for pid in worker_pids
             )
             if all_have_samples:
                 break
-        except (IndexError, FileNotFoundError):
-            # Profile files don't exist yet
+        except (IndexError, FileNotFoundError, StopIteration):
+            # Profile files don't exist yet or don't have wall-time sample type
             pass
 
-    assert all_have_samples, f"Timed out waiting for profiles with samples after {max_wait}s"
+    assert all_have_samples, f"Timed out waiting for profiles with wall-time samples after {max_wait}s"
 
     # Kill master process
     parent_pid: int = worker_pids[0]


### PR DESCRIPTION
## What does this PR do?

Improve log and assertion messages for a flaky test so we can better understand what's going on...


- [test(profiling): unflake a flaky test](https://github.com/DataDog/dd-trace-py/pull/15746)
- [See test runs on the branch](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3Atest_uwsgi_threads_processes_no_primary_lazy_apps%2A%20%40test.status%3Afail%20%40git.branch%3Akowalski%2Ftest-profiling-improve-message-in-test_uwsgi_threads_processes_no_primary_lazy_apps&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1765988278194&end=1766593078194&paused=false)