### PR TITLE
Revert "fix(psycopg): fix psycopg3 closed connection patching error"

### DIFF
--- a/ddtrace/contrib/internal/psycopg/connection.py
+++ b/ddtrace/contrib/internal/psycopg/connection.py
@@ -53,11 +53,6 @@ class Psycopg2TracedConnection(dbapi.TracedConnection):
 
 def patch_conn(conn, traced_conn_cls, pin=None):
     """Wrap will patch the instance so that its queries are traced."""
-
-    # Return the plain connection if it has already been closed
-    if hasattr(conn, "closed") and conn.closed:
-        return conn
-
     # ensure we've patched extensions (this is idempotent) in
     # case we're only tracing some connections.
     _config = None
@@ -69,33 +64,21 @@ def patch_conn(conn, traced_conn_cls, pin=None):
 
     c = traced_conn_cls(conn)
 
+    # if the connection has an info attr, we are using psycopg3
+    if hasattr(conn, "dsn"):
+        dsn = sql.parse_pg_dsn(conn.dsn)
+    else:
+        dsn = sql.parse_pg_dsn(conn.info.dsn)
+
     tags = {
+        net.TARGET_HOST: dsn.get("host"),
+        net.TARGET_PORT: dsn.get("port", 5432),
+        net.SERVER_ADDRESS: dsn.get("host"),
+        db.NAME: dsn.get("dbname"),
+        db.USER: dsn.get("user"),
+        "db.application": dsn.get("application_name"),
         db.SYSTEM: "postgresql",
     }
-
-    try:
-        # if the connection has an info attr, we are using psycopg3
-        if hasattr(conn, "dsn"):
-            dsn = sql.parse_pg_dsn(conn.dsn)
-        else:
-            dsn = sql.parse_pg_dsn(conn.info.dsn)
-    except Exception:
-        # If for any reason we fail to parse the dsn, use an empty placeholder
-        dsn = {}
-
-    if dsn:
-        # Only add the dsn related tags if available
-        tags.update(
-            {
-                net.TARGET_HOST: dsn.get("host"),
-                net.TARGET_PORT: dsn.get("port", 5432),
-                net.SERVER_ADDRESS: dsn.get("host"),
-                db.NAME: dsn.get("dbname"),
-                db.USER: dsn.get("user"),
-                "db.application": dsn.get("application_name"),
-            }
-        )
-
     Pin(tags=tags, _config=_config).onto(c)
     return c
 

--- a/releasenotes/notes/fix-psycopg3-patched-connection-bug-ecdf7204467b0848.yaml
+++ b/releasenotes/notes/fix-psycopg3-patched-connection-bug-ecdf7204467b0848.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    tracing(psycopg): Fixes an OperationalError that occurred when patching a closed psycopg3 connection.

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -158,25 +158,6 @@ class PsycopgCore(TracerTestCase):
             dict(name="postgres.query"),
         )
 
-    def test_patch_closed_connection(self):
-        """
-        Patching a closed connection should not throw an OperationalError.
-        """
-        from ddtrace.contrib.internal.psycopg.connection import Psycopg3TracedConnection
-        from ddtrace.contrib.internal.psycopg.connection import patch_conn
-
-        # The normal closed connection has no errors
-        conn = psycopg.connect(**POSTGRES_CONFIG)
-        conn.close()
-
-        try:
-            patched_connection = patch_conn(conn, traced_conn_cls=Psycopg3TracedConnection)
-        except psycopg.OperationalError as e:
-            self.fail(f"patched_connection has ran into an OperationalError: {e}")
-
-        # When the connection is closed, we return the plain connection
-        self.assertIs(patched_connection, conn)
-
     def test_disabled_execute(self):
         conn = self._get_conn()
         self.tracer.enabled = False

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -165,25 +165,6 @@ class PsycopgCore(TracerTestCase):
             dict(name="postgres.query"),
         )
 
-    def test_patch_closed_connection(self):
-        """
-        Patching a closed connection should not throw an error.
-        (psycopg2 handles this gracefully)
-        """
-        from ddtrace.contrib.internal.psycopg.connection import Psycopg2TracedConnection
-        from ddtrace.contrib.internal.psycopg.connection import patch_conn
-
-        conn = psycopg2.connect(**POSTGRES_CONFIG)
-        conn.close()
-
-        try:
-            patched_connection = patch_conn(conn, traced_conn_cls=Psycopg2TracedConnection)
-        except psycopg2.OperationalError as e:
-            self.fail(f"patched_connection has ran into an OperationalError: {e}")
-
-        # When the connection is closed, we return the plain connection
-        self.assertIs(patched_connection, conn)
-
     def test_disabled_execute(self):
         conn = self._get_conn()
         self.tracer.enabled = False


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#15695 - I'll bring it back in a future patch release. The main goal is to limit the changes in the next patch release.