### PR TITLE
fix(crashtracking): receiver binary is outdated in dogweb; use rust embedding as a temp workaround

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -81,7 +81,8 @@ def _get_tags(additional_tags: Optional[Dict[str, str]]) -> Dict[str, str]:
 
 
 def _get_args(additional_tags: Optional[Dict[str, str]]):
-    dd_crashtracker_receiver = shutil.which("_dd_crashtracker_receiver")
+    # dd_crashtracker_receiver = shutil.which("_dd_crashtracker_receiver")
+    dd_crashtracker_receiver = None
 
     # If not found in PATH, try ddtrace installation directory. This can happen
     # in an injected environment


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
