### PR TITLE
perf(profiling): unwind only one Frame per Task

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -39,11 +39,14 @@ class FrameStack : public std::deque<Frame::Ref>
 };
 
 // ----------------------------------------------------------------------------
+// Unwind Python frames starting from frame_addr and push them onto stack.
+// @param max_depth: Maximum number of frames to unwind. Defaults to max_frames.
+// @return: Number of frames added to the stack.
 static size_t
-unwind_frame(PyObject* frame_addr, FrameStack& stack)
+unwind_frame(PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames)
 {
     std::unordered_set<PyObject*> seen_frames; // Used to detect cycles in the stack
-    int count = 0;
+    size_t count = 0;
 
     PyObject* current_frame_addr = frame_addr;
     while (current_frame_addr != NULL && stack.size() < max_frames) {
@@ -68,6 +71,10 @@ unwind_frame(PyObject* frame_addr, FrameStack& stack)
 
         stack.push_back(*maybe_frame);
         count++;
+
+        if (count >= max_depth) {
+            break;
+        }
     }
 
     return count;


### PR DESCRIPTION
## Description

This is a small (but still worth it) performance improvement in the context of `asyncio` Task unwinding. Previously, we would use the `unwind_frame` to get the current Frame for an `asyncio` Task. In the case of a running Task, this would also yield all the Python  `asyncio` runtime Frames that were "on top" of that Task Frame (and that we would later have to remove from the Stack). 

Building that Python Stack that we don't care about takes some time (because we need to walk the Frame chain) – we should only do it if we need to. Here, we clearly don't need to, as we only care about the Task Frame, so I added a new argument to `unwind_frame` that allows to early exit after a certain Stack depth has been reached (and I set it to `1` when unwinding a Task Frame).