### PR TITLE
chore(profiling): fix flaky `test_sample_count`

### DIFF
--- a/tests/profiling/collector/test_sample_count.py
+++ b/tests/profiling/collector/test_sample_count.py
@@ -52,13 +52,14 @@ def test_sample_count():
     files = glob.glob(output_filename + ".*.internal_metadata.json")
 
     found_at_least_one_with_more_samples_than_sampling_events = False
-    for f in files:
+    for i, f in enumerate(files):
         with open(f, "r") as fp:
             internal_metadata = json.load(fp)
 
-            assert internal_metadata is not None
-            assert "sample_count" in internal_metadata
-            assert internal_metadata["sample_count"] > 0
+            if i < len(files) - 1:
+                assert internal_metadata is not None
+                assert "sample_count" in internal_metadata
+                assert internal_metadata["sample_count"] > 0
 
             assert "sampling_event_count" in internal_metadata
             assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13361

This fixes `test_sample_count` which used to be flaky due to us pushing whatever data we have left before exiting the process, in which case we could have a 0 sample count. The fix is to only `assert` for non-last items.

[See test runs](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.branch%3Akowalski%2Fchore-profiling-fix-flaky-test_sample_count%20%40test.name%3Atest_sample_count%2A&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1766167311983&end=1766772111983&paused=false)

We're now all green! 🚀 

<img width="622" height="885" alt="image" src="https://github.com/user-attachments/assets/4998b6ca-6621-464b-8614-62b7ef657d1b" />
