### PR TITLE
test(profiling): unflake some tests

### DIFF
--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -60,7 +60,7 @@ def test_call_script_pprof_output(tmp_path: Path) -> None:
 
     stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
     _, pid = list(s.strip() for s in stdout.strip().split("\n"))
-    profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}")
+    profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}", allow_penultimate=True)
     samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
     assert len(samples) > 0
 
@@ -77,7 +77,7 @@ def test_fork(tmp_path: Path) -> None:
     assert exitcode == 0
     stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
     child_pid = stdout.strip()
-    profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}")
+    profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}", allow_penultimate=True)
     parent_expected_acquire_events = [
         pprof_utils.LockAcquireEvent(
             caller_name="<module>",
@@ -99,7 +99,7 @@ def test_fork(tmp_path: Path) -> None:
         expected_acquire_events=parent_expected_acquire_events,
         expected_release_events=parent_expected_release_events,
     )
-    child_profile = pprof_utils.parse_newest_profile(filename + "." + str(child_pid))
+    child_profile = pprof_utils.parse_newest_profile(f"{filename}.{child_pid}")
     # We expect the child profile to not have lock events from the parent process
     # Note that assert_lock_events function only checks that the given events
     # exists, and doesn't assert that other events don't exist.


### PR DESCRIPTION
## Description

This makes some tests less flaky. Previously, we would sometimes parse an empty Profile (0 samples in it) and make the test fail. The fix is to, when this happens, ignore the failure and parse/use the previous Profile instead (which we expect to ALWAYS be non-empty).   

- [See in Flaky Management](https://app.datadoghq.com/ci/test/flaky?query=%40test.codeowners%3A%2Aprofiling-python%2A%20flaky_test_state%3Aquarantined%20%40test.suite%3Atest_main.py&sort=-pipelines_failed&viewMode=flaky)
- [See failures on this branch](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.codeowners%3A%2Aprofiling-python%2A%20%40test.suite%3Atest_main.py%20status%3Aerror%20%40git.branch%3Akowalski%2Ftest-profiling-unflake-some-tests&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1766388450558&end=1766993250558&paused=false)

Related
- https://github.com/DataDog/dd-trace-py/pull/15796