### PR TITLE
fix(profiling): fix crash with uvloop and subprocess

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -168,6 +168,8 @@ static PyMemberDef PeriodicThread_members[] = {
       0,
       "whether to ignore the thread for profiling" },
 
+    { "_is_after_fork", T_BOOL, offsetof(PeriodicThread, _after_fork), READONLY, "whether the thread is after fork" },
+
     { NULL } /* Sentinel */
 };
 
@@ -247,6 +249,14 @@ PeriodicThread__on_shutdown(PeriodicThread* self)
 static PyObject*
 PeriodicThread_start(PeriodicThread* self, PyObject* args)
 {
+    // After fork, the child process should not restart threads that were running in the parent
+    // until properly reinitialized through forksafe handlers. This prevents crashes when
+    // pthread_create is called before threading state is safe (e.g., in uvloop's _after_fork).
+    // Check this first because after fork, self->_thread is non-null but the thread doesn't exist.
+    if (self->_after_fork) {
+        Py_RETURN_NONE;
+    }
+
     if (self->_thread != nullptr) {
         PyErr_SetString(PyExc_RuntimeError, "Thread already started");
         return NULL;

--- a/ddtrace/internal/_threads.pyi
+++ b/ddtrace/internal/_threads.pyi
@@ -1,6 +1,7 @@
 import typing as t
 
 class PeriodicThread:
+    _is_after_fork: bool
     name: str
     ident: int
     interval: float

--- a/releasenotes/notes/profiling-fix-uvloop-crashes-097aea980e59ce36.yaml
+++ b/releasenotes/notes/profiling-fix-uvloop-crashes-097aea980e59ce36.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: a bug causing crashes when using ``uvloop`` and forking has been resolved.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13112

This is an attempt to address the following crash. There seems to be a case (that I wasn't able to reproduce in a Docker image, but maybe my "code environment" didn't match the customer's exactly) where using `uvloop` results in a crash caused by `PeriodicThread_start` after  `uvloop` tries to restart Threads after a fork.

```
#0   0x00007f9a7acdbefa cfree 
#1   0x00007f9a7accc6b5 pthread_create 
#2   0x00007f9a7a63aaa5 std::thread::_M_start_thread 
#3   0x00007f9a7a639d18 PeriodicThread_start 
#4   0x00007f9a2e71d565 __pyx_f_6uvloop_4loop_9UVProcess__after_fork (uvloop/loop.c:120214:3)
#5   0x00007f9a2e6369a8 __pyx_f_6uvloop_4loop___get_fork_handler (uvloop/loop.c:163075:24)
#6   0x00007f9a7ad17073 __fork 
#7   0x00007f9a2e732d62 uv__spawn_and_init_child_fork (src/unix/process.c:831:10)
#8   0x00007f9a2e732d62 uv__spawn_and_init_child (src/unix/process.c:919:9)
#9   0x00007f9a2e732d62 uv_spawn (src/unix/process.c:1013:18)
#10  0x00007f9a2e71fb87 __pyx_f_6uvloop_4loop_9UVProcess__init (uvloop/loop.c:119056:19)
#11  0x00007f9a2e711bf7 __pyx_f_6uvloop_4loop_18UVProcessTransport_new (uvloop/loop.c:126866:16)
#12  0x00007f9a2e712aa7 __pyx_gb_6uvloop_4loop_4Loop_116generator16 (uvloop/loop.c:54030:28)
#13  0x00007f9a2e631419 __Pyx_Coroutine_SendEx (uvloop/loop.c:196315:14)
#14  0x00007f9a2e699f8a __Pyx_Coroutine_AmSend (uvloop/loop.c:196492:18)
#15  0x00007f9a2e69a052 __Pyx_Coroutine_Yield_From_Coroutine (uvloop/loop.c:197380:14)
#16  0x00007f9a2e69b0e5 __Pyx_Coroutine_Yield_From (uvloop/loop.c:197408:16)
#17  0x00007f9a2e69b0e5 __pyx_gb_6uvloop_4loop_4Loop_122generator18 (uvloop/loop.c:55002:15)
#18  0x00007f9a2e631419 __Pyx_Coroutine_SendEx (uvloop/loop.c:196315:14)
#19  0x00007f9a2e69bb86 __Pyx_Generator_Next (uvloop/loop.c:196581:18)
#20  0x00007f9a2e6398eb __Pyx_PyObject_Call (uvloop/loop.c:191431:15)
#21  0x00007f9a2e6398eb __Pyx_PyObject_FastCallDict (uvloop/loop.c:191552:16)
#22  0x00007f9a2e715a69 __pyx_f_6uvloop_4loop_6Handle__run (uvloop/loop.c:66873:27)
#23  0x00007f9a2e71996b __pyx_f_6uvloop_4loop_4Loop__on_idle (uvloop/loop.c:17975:25)
#24  0x00007f9a2e713e52 __pyx_f_6uvloop_4loop_6Handle__run (uvloop/loop.c:66927:24)
#25  0x00007f9a2e715c88 __pyx_f_6uvloop_4loop_cb_idle_callback (uvloop/loop.c:87335:19)
#26  0x00007f9a2e731311 uv__run_idle (unix/loop-watcher.c:68:1)
#27  0x00007f9a2e72e647 uv_run (src/unix/core.c:439:5)
#28  0x00007f9a2e64fdb5 __pyx_f_6uvloop_4loop_4Loop__Loop__run (uvloop/loop.c:18458:23)
#29  0x00007f9a2e6b7e50 __pyx_f_6uvloop_4loop_4Loop__run (uvloop/loop.c:18876:18)
#30  0x00007f9a2e6c8cf0 __pyx_pf_6uvloop_4loop_4Loop_24run_forever (uvloop/loop.c:31528:18)
#31  0x00007f9a2e6c8cf0 __pyx_pw_6uvloop_4loop_4Loop_25run_forever (uvloop/loop.c:31331:13)
#32  0x00007f9a7b065c25 PyObject_VectorcallMethod 
#33  0x00007f9a2e6ccd60 __pyx_pf_6uvloop_4loop_4Loop_44run_until_complete (uvloop/loop.c:33768:23)
#34  0x00007f9a2e6ce591 __pyx_pw_6uvloop_4loop_4Loop_45run_until_complete (uvloop/loop.c:33318:13)
#35  0x00007f9a7b039358 PyObject_Vectorcall 
```

## Fix

The `_after_fork` boolean field marks that this thread object is in a "post-fork zombie state." When the flag is set to true, Thread methods (e.g. `join`) become no-ops because the threads do not exist anymore so we should not try to do something with them. By checking that same flag, we can tell that we are trying to start a Thread that doesn't really exist and so we shouldn't try to do it. 