### PR TITLE
refactor(profiling): make `python_stack` local and non static

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -39,10 +39,6 @@ class FrameStack : public std::deque<Frame::Ref>
 };
 
 // ----------------------------------------------------------------------------
-
-inline FrameStack python_stack;
-
-// ----------------------------------------------------------------------------
 static size_t
 unwind_frame(PyObject* frame_addr, FrameStack& stack)
 {
@@ -106,13 +102,6 @@ unwind_python_stack(PyThreadState* tstate, FrameStack& stack)
     PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->frame);
 #endif
     unwind_frame(frame_addr, stack);
-}
-
-// ----------------------------------------------------------------------------
-static void
-unwind_python_stack(PyThreadState* tstate)
-{
-    unwind_python_stack(tstate, python_stack);
 }
 
 // ----------------------------------------------------------------------------

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -15,7 +15,6 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
-#include <optional>
 #include <unordered_map>
 
 #if defined PL_LINUX
@@ -40,6 +39,7 @@ class ThreadInfo
 
     uintptr_t thread_id;
     unsigned long native_id;
+    FrameStack python_stack;
 
     std::string name;
 
@@ -201,7 +201,7 @@ inline std::mutex thread_info_map_lock;
 inline void
 ThreadInfo::unwind(PyThreadState* tstate)
 {
-    unwind_python_stack(tstate);
+    unwind_python_stack(tstate, python_stack);
 
     if (asyncio_loop) {
         // unwind_tasks returns a [[nodiscard]] Result<void>.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13364

This PR makes the `python_stack` variable non global (and non static) so that its lifetime is easier to understand and to reason about.  This change is trivial as `python_stack` is already at the moment used exactly like a local variable would be.  
Since it is used by many parts of the Thread unwinding logic, I have made it part of the `ThreadInfo` fields, so that each `ThreadInfo` method can easily use it. Methods outside `ThreadInfo` access it using a reference argument.

_This is part of a broader effort to get rid of statics and globals in the Python Profiler._
- https://github.com/DataDog/dd-trace-py/pull/15801
- https://github.com/DataDog/dd-trace-py/pull/15805
- https://github.com/DataDog/dd-trace-py/pull/15806

## Performance

Running the Profiler with those changes under the Full Host Profiler shows no noticeable CPU time change (which could have happened, at least marginally, since we have changed the semantics around and lifetime of  `FrameStack` objects).

