### PR TITLE
refactor(profiling): make `current_tasks` and `current_greenlets` non global

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h
@@ -89,7 +89,3 @@ inline std::unordered_map<uintptr_t, GreenletInfo::ID>& greenlet_thread_map =
 inline std::mutex greenlet_info_map_lock;
 
 // ----------------------------------------------------------------------------
-
-inline std::vector<std::unique_ptr<StackInfo>> current_greenlets;
-
-// ----------------------------------------------------------------------------

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
@@ -295,10 +295,6 @@ TaskInfo::current(PyObject* loop)
 
 // ----------------------------------------------------------------------------
 
-inline std::vector<std::unique_ptr<StackInfo>> current_tasks;
-
-// ----------------------------------------------------------------------------
-
 inline size_t
 TaskInfo::unwind(FrameStack& stack, size_t& upper_python_stack_size)
 {

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -40,6 +40,8 @@ class ThreadInfo
     uintptr_t thread_id;
     unsigned long native_id;
     FrameStack python_stack;
+    std::vector<std::unique_ptr<StackInfo>> current_tasks;
+    std::vector<std::unique_ptr<StackInfo>> current_greenlets;
 
     std::string name;
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/timing.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/timing.h
@@ -15,8 +15,6 @@ inline clock_serv_t cclock;
 
 typedef unsigned long microsecond_t;
 
-inline microsecond_t last_time = 0;
-
 #define TS_TO_MICROSECOND(ts) ((ts).tv_sec * 1e6 + (ts).tv_nsec / 1e3)
 #define TV_TO_MICROSECOND(tv) ((tv).seconds * 1e6 + (tv).microseconds)
 


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13364

_This is part of a broader effort to get rid of statics and globals in the Python Profiler._
- https://github.com/DataDog/dd-trace-py/pull/15801
- https://github.com/DataDog/dd-trace-py/pull/15805
- https://github.com/DataDog/dd-trace-py/pull/15806