### PR TITLE
fix(profiling): always use leaf Task name

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -75,6 +75,7 @@ StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
     if (failed) {
         return;
     }
+
     if (sample == nullptr) {
         // The very first task on a thread will already have a sample, since there's no way to deduce whether
         // a thread has tasks without checking, and checking before populating the sample would make the state
@@ -89,11 +90,13 @@ StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
         // Add the thread context into the sample
         sample->push_threadinfo(
           static_cast<int64_t>(thread_state.id), static_cast<int64_t>(thread_state.native_id), thread_state.name);
-        sample->push_task_name(task_name);
         sample->push_walltime(thread_state.wall_time_ns, 1);
 
-        if (on_cpu)
-            sample->push_cputime(thread_state.cpu_time_ns, 1); // initialized to 0, so possibly a no-op
+        if (on_cpu) {
+            // initialized to 0, so possibly a no-op
+            sample->push_cputime(thread_state.cpu_time_ns, 1);
+        }
+
         sample->push_monotonic_ns(thread_state.now_time_ns);
 
         // We also want to make sure the tid -> span_id mapping is present in the sample for the task
@@ -104,9 +107,10 @@ StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
             sample->push_local_root_span_id(active_span->local_root_span_id);
             sample->push_trace_type(std::string_view(active_span->span_type));
         }
-
-        pushed_task_name = true;
     }
+
+    sample->push_task_name(task_name);
+    pushed_task_name = true;
 }
 
 void

--- a/releasenotes/notes/profiling-always-use-leaf-task-name-46bf36ed9f1d723b.yaml
+++ b/releasenotes/notes/profiling-always-use-leaf-task-name-46bf36ed9f1d723b.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: the Profiler now always uses the name of leaf tasks for the "Task name" label. Previously, one of the
+    Stacks would be labelled with the parent task's name, which would lead to inconsistent behaviour across runs.

--- a/tests/profiling/collector/test_asyncio_gather_tasks.py
+++ b/tests/profiling/collector/test_asyncio_gather_tasks.py
@@ -8,7 +8,7 @@ import pytest
     err=None,
 )
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
-def test_asyncio_gather_wall_time() -> None:
+def test_asyncio_gather_tasks() -> None:
     import asyncio
     import os
 
@@ -62,42 +62,21 @@ def test_asyncio_gather_wall_time() -> None:
             line_no=-1,
         )
 
-    # One of the two Tasks gets included under the Main Task randomly, we have to try both.
-    try:
-        for f, t in (("f4_0", "Task-1"), ("f4_1", "F4_1")):
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    task_name=t,
-                    locations=[
-                        fn_location("sleep"),
-                        fn_location("f5"),
-                        fn_location(f),
-                        fn_location("f3"),
-                        fn_location("f2"),
-                        fn_location("f1"),
-                        fn_location("main"),
-                    ],
-                ),
-            )
-    except AssertionError:
-        for f, t in (("f4_0", "F4_0"), ("f4_1", "Task-1")):
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    task_name=t,
-                    locations=[
-                        fn_location("sleep"),
-                        fn_location("f5"),
-                        fn_location(f),
-                        fn_location("f3"),
-                        fn_location("f2"),
-                        fn_location("f1"),
-                        fn_location("main"),
-                    ],
-                ),
-            )
+    for f, t in (("f4_0", "F4_0"), ("f4_1", "F4_1")):
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t,
+                locations=[
+                    fn_location("sleep"),
+                    fn_location("f5"),
+                    fn_location(f),
+                    fn_location("f3"),
+                    fn_location("f2"),
+                    fn_location("f1"),
+                    fn_location("main"),
+                ],
+            ),
+        )

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
@@ -114,9 +114,9 @@ def test_asyncio_recursive_on_cpu_tasks():
         print_samples_on_failure=True,
     )
 
-    # Same test, but with a specific task_name ("Task-1")``
-    # Ideally, we should be able to report the Task-2 specific part in its own
-    # Stack, but at the moment we are not. This will be fixed in the future.
+    # Same test, but with a specific task_name - "Task-2".
+    # Task-1 is the "root"/parent Task, Task-2 is the one created by inner1.
+    # Since we label Samples with the Leaf Task's name, we want to see "Task-2".
     pprof_utils.assert_profile_has_sample(
         profile,
         list(profile.sample),
@@ -124,7 +124,7 @@ def test_asyncio_recursive_on_cpu_tasks():
             thread_name="MainThread",
             span_id=span_id,
             local_root_span_id=local_root_span_id,
-            task_name="Task-1",
+            task_name="Task-2",
             locations=list(
                 reversed(
                     [

--- a/tests/profiling/collector/test_asyncio_wait.py
+++ b/tests/profiling/collector/test_asyncio_wait.py
@@ -63,99 +63,50 @@ def test_asyncio_wait() -> None:
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
 
-    # Note: there currently is a bug somewhere that makes one of the Tasks show up under the parent Task and the
-    # other Tasks be under their own Task name. We need to fix this.
-    # For the time being, though, which Task is "independent" is non-deterministic which means we must
-    # test both possibilities ("inner 2" is part of "outer" or "inner 1" is part of "outer").
-    try:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="outer",  # TODO: This is a bug and we need to fix it, it should be "inner 1"
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner1",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner1.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 1",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner1",
+                    filename="test_asyncio_wait.py",
+                    line_no=inner1.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_wait.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 2",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner2",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner2.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
-    except AssertionError:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="outer",  # TODO: This is a bug and we need to fix it, it should be "inner 1"
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner2",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner2.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 1",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner1",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner1.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 2",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner2",
+                    filename="test_asyncio_wait.py",
+                    line_no=inner2.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_wait.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )


### PR DESCRIPTION
## What does this PR do? 

Related bugs
- [One of the child Tasks (in gather/wait) appears as part of the parent Task](https://datadoghq.atlassian.net/browse/PROF-13090)
- [Parent (awaiting) Tasks are never pushed with render_task_begin](https://datadoghq.atlassian.net/browse/PROF-13154)
- [Filtering the Flame Graph by Task name doesn't work](https://datadoghq.atlassian.net/browse/PROF-13260)

This updates the Profiler code to always use the name of the Leaf Task when unwinding `asyncio` Tasks. Previously, one of the Tasks (in practice random, determined by which Task was the first item of the  `asyncio` `current_tasks` set) would not be "tagged" with its own Task Name, but with that of its (outmost) Parent Task.  
The reason for this behaviour is that we had a different code path for `render_task_begin`: the first Task would already have an ongoing `Sample`, in which case we would do nothing; subsequent Tasks would need a new `Sample`, in which case we would push some data (including, but not limited to, the Task Name).  

Now, if we didn't push the Task Name, how come did we have the Parent Task's name? We have another mechanism for pushing Task Names. There is a `pushed_task_name` flag in the Stack Renderer that determines whether we have pushed the name of the current Task.  If we later saw a "dummy Frame" (pushed by Echion at the border of two related Tasks), we would _not_ push the Frame itself, but we would use its contents (function name, in practice Task name) to populate the current Task's name. 
For the first Task [which already had a non-null `Sample`], this flag would not be flipped. As a result, we would use the "Task name fallback". And since the Stack is rendered top-to-bottom, the first Task name we would see would be the outmost (Parent-most) Task's.


Note that this also fixes (at least partially) the bug where filtering by Task name in the Flame Graph doesn't actually filter by Task name. 

<img width="874" height="192" alt="image" src="https://github.com/user-attachments/assets/6446000e-8377-404b-ad7b-ce1aea2fad8f" />


## What is the fix?

The fix is to _always_ push the Task name in `render_task_begin`, even if `Sample != nullptr`.  
We might need to push other information as well for the first Sample (wall time, CPU time, etc.) as we do for subsequent Samples, but I actually believe we don't [as we push them already once for the Thread]. 

## Important notes 

Note that this fix is not 100% correct!  
Since we push the Task name once for the whole Stack, it means both the Frames that belong to the Leaf Task and those of the Parent Task [as well as the Frames of any other Tasks in between] will have their Task Name label set to that of the Leaf Task.

We will need to find a solution to that, but it is not exactly straightforward – I think we need to tag part of the Stack with more than one Task name and I'm unsure how to do this since _the whole Sample/Stack_ (and not just a Frame) is tagged in the Profile.  So this needs to be discussed and thought through. 

Note that the state after this PR is better, still, because
- Previously, the results would be inconsistent (random) across runs, which is bad for obvious reasons
- ... it also made testing harder 
- I would argue the new logic is slightly more correct than the previous one – since we consider the whole Stack as "belonging" in a way to the Leaf Task, it is "correct" to say that all Frames should be tagged with the Leaf Task's name. On the other hand, it was definitely incorrect to have some Frames of the Leaf Task being tagged with the Parent Task's name. 
