### PR TITLE
fix(profiling): fix memory profiling in `>=4.1`

### DIFF
--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -114,11 +114,13 @@ endif()
 # Link with libdd_wrapper if NATIVE_EXTENSION_LOCATION is defined
 if(DEFINED NATIVE_EXTENSION_LOCATION)
     # Find the libdd_wrapper shared library
+    # NATIVE_EXTENSION_LOCATION is ddtrace/internal/native, so ../datadog/profiling
+    # gets us to ddtrace/internal/datadog/profiling where libdd_wrapper is located
     find_library(
         DD_WRAPPER_LIB
         NAMES libdd_wrapper${EXTENSION_SUFFIX}
         PATHS ${CMAKE_CURRENT_SOURCE_DIR}/../../internal/datadog/profiling
-              ${NATIVE_EXTENSION_LOCATION}/../../datadog/profiling
+              ${NATIVE_EXTENSION_LOCATION}/../datadog/profiling
         NO_DEFAULT_PATH)
 
     if(DD_WRAPPER_LIB)

--- a/releasenotes/notes/profiling-use-correct-native-extension-location-7eaf7cd1c727b91e.yaml
+++ b/releasenotes/notes/profiling-use-correct-native-extension-location-7eaf7cd1c727b91e.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: the build now uses the correct location for the native extension module. Previously, linking would
+    work correctly in tests, but published wheels failed to import the memory profiler extension.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13371

This PR fixes the following error happening when trying to use the Memory Profiler on 4.1+

```
...
Registering hook '<function _ at 0xffff98802ca0>' on module 'asyncio'
Calling hook '<function _ at 0xffff98802ca0>' on already imported module 'asyncio'
failed to import memalloc
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/ddtrace/profiling/collector/memalloc.py", line 14, in <module>
    from ddtrace.profiling.collector import _memalloc
  File "/usr/local/lib/python3.11/site-packages/ddtrace/internal/module.py", line 252, in _create_module
    return self.loader.create_module(spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: /usr/local/lib/python3.11/site-packages/ddtrace/profiling/collector/_memalloc.cpython-311-aarch64-linux-gnu.so: undefined symbol: _ZN7Datadog6Sample9push_heapEl
...
```

This PR fixes the CMake build scripts which incorrectly referred to `${NATIVE_EXTENSION_LOCATION}/../../datadog/profiling` for `libdd_wrapper`, where it should have had one less `../` 🫠 

The bug was probably introduced by https://github.com/DataDog/dd-trace-py/pull/15424 (which created `ddtrace/profiling/collector/CMakeLists.txt`) and very probably not detected because the bug only occurs on wheels/"release builds" (and not in-tree builds, which we use for testing).

## Testing

I tested the fix using an S3 wheel with a `prof-correctness` image (see this PR: https://github.com/DataDog/prof-correctness/pull/77). The issue is gone when using the fixed version.

## Follow-ups

As a follow-up, we should probably 
- Add Memory Profiling checks to `prof-correctness` (to ensure at least that the Memory Profiler _runs_!)
- Add some kind of checks – possibly also as part of `prof-correctness` – to smoke-test new `ddtrace` release candidates and spot those regressions before they happen. 
