### PR TITLE
feat(profiling): support more `asyncio` utils

### DIFF
--- a/releasenotes/notes/profiling-new-asyncio-utils-0da63b888136e5d1.yaml
+++ b/releasenotes/notes/profiling-new-asyncio-utils-0da63b888136e5d1.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    profiling: the Profiler now properly stacks flame graphs for Tasks awaiting and awaited through ``asyncio.shield``.

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -407,10 +407,19 @@ def assert_profile_has_sample(
             if DEBUG_TEST:
                 print(e)
 
-    if not found and print_samples_on_failure:
-        print_all_samples(profile)
+    error_description = "Expected samples not found in profile "
+    if not found:
+        error_description += str(expected_sample.locations)
+        if expected_sample.task_name:
+            error_description += ", task name " + expected_sample.task_name
 
-    assert found, "Expected samples not found in profile " + str(expected_sample.locations)
+        if expected_sample.thread_name:
+            error_description += ", thread name " + expected_sample.thread_name
+
+        if print_samples_on_failure:
+            print_all_samples(profile)
+
+    assert found, error_description
 
 
 def print_all_samples(profile: pprof_pb2.Profile) -> None:

--- a/tests/profiling/collector/test_asyncio_shield.py
+++ b/tests/profiling/collector/test_asyncio_shield.py
@@ -1,0 +1,102 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_shield",
+    ),
+    err=None,
+)
+# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+def test_asyncio_shield() -> None:
+    import asyncio
+    import os
+
+    from ddtrace.internal.datadog.profiling import stack
+    from ddtrace.profiling import profiler
+    from tests.profiling.collector import pprof_utils
+
+    assert stack.is_available, stack.failure_msg
+
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
+
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
+
+    async def main() -> None:
+        # Create tasks and shield them
+        tasks = [asyncio.create_task(wait_and_return_delay(float(i) / 10)) for i in range(2, 7)]
+
+        # Shield each task
+        shielded_tasks = [asyncio.shield(task) for task in tasks]
+
+        # Wait for all shielded tasks to complete
+        results = await asyncio.gather(*shielded_tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+
+    p = profiler.Profiler()
+    p.start()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
+
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
+
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_shield.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_shield.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_shield.py",
+            line_no=main.__code__.co_firstlineno + 8,
+        ),
+    ]
+
+    # Check that we have seen samples for the shielded tasks (Task-2 .. Task-6)
+    seen_task_names: set[str] = set()
+    exceptions: list[AssertionError] = []
+    for i in range(2, 7):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+            seen_task_names.add(f"Task-{i}")
+        except AssertionError as e:
+            exceptions.append(e)
+
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for e in exceptions:
+            print(e)
+
+        raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout.py
+++ b/tests/profiling/collector/test_asyncio_timeout.py
@@ -1,0 +1,111 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_timeout",
+    ),
+    err=None,
+    pytest_args=["-k", "test_asyncio_timeout"],
+)
+# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.skipif(
+    __import__("sys").version_info < (3, 11),
+    reason="asyncio.timeout requires Python 3.11+",
+)
+def test_asyncio_timeout() -> None:
+    import asyncio
+    import os
+
+    from ddtrace.internal.datadog.profiling import stack
+    from ddtrace.profiling import profiler
+    from tests.profiling.collector import pprof_utils
+
+    assert stack.is_available, stack.failure_msg
+
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
+
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
+
+    async def task_with_timeout(delay: float) -> float:
+        async with asyncio.timeout(10.0):  # Long timeout, won't trigger
+            return await wait_and_return_delay(delay)
+
+    async def main() -> None:
+        # Create tasks that will run within timeout contexts
+        tasks = [asyncio.create_task(task_with_timeout(float(i) / 10)) for i in range(2, 7)]
+
+        # Wait for all tasks to complete
+        results = await asyncio.gather(*tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+
+    p = profiler.Profiler()
+    p.start()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
+
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
+
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_timeout.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_timeout.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="task_with_timeout",
+            filename="test_asyncio_timeout.py",
+            line_no=task_with_timeout.__code__.co_firstlineno + 2,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_timeout.py",
+            line_no=main.__code__.co_firstlineno + 5,
+        ),
+    ]
+
+    # Check that we have seen samples for the tasks (Task-2 .. Task-6)
+    exceptions: list[AssertionError] = []
+    for i in range(2, 7):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+        except AssertionError as e:
+            exceptions.append(e)
+
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for e in exceptions:
+            print(e)
+
+        raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout_at.py
+++ b/tests/profiling/collector/test_asyncio_timeout_at.py
@@ -1,0 +1,114 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_timeout_at",
+    ),
+    err=None,
+    pytest_args=["-k", "test_asyncio_timeout_at"],
+)
+# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.skipif(
+    __import__("sys").version_info < (3, 11),
+    reason="asyncio.timeout_at requires Python 3.11+",
+)
+def test_asyncio_timeout_at() -> None:
+    import asyncio
+    import os
+    import time
+
+    from ddtrace.internal.datadog.profiling import stack
+    from ddtrace.profiling import profiler
+    from tests.profiling.collector import pprof_utils
+
+    assert stack.is_available, stack.failure_msg
+
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
+
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
+
+    async def task_with_timeout_at(delay: float) -> float:
+        # Set timeout far in the future
+        when = time.time() + 10.0
+        async with asyncio.timeout_at(when):
+            return await wait_and_return_delay(delay)
+
+    async def main() -> None:
+        # Create tasks that will run within timeout_at contexts
+        tasks = [asyncio.create_task(task_with_timeout_at(float(i) / 10)) for i in range(2, 7)]
+
+        # Wait for all tasks to complete
+        results = await asyncio.gather(*tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+
+    p = profiler.Profiler()
+    p.start()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
+
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
+
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_timeout_at.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_timeout_at.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="task_with_timeout_at",
+            filename="test_asyncio_timeout_at.py",
+            line_no=task_with_timeout_at.__code__.co_firstlineno + 4,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_timeout_at.py",
+            line_no=main.__code__.co_firstlineno + 5,
+        ),
+    ]
+
+    # Check that we have seen samples for the tasks (Task-2 .. Task-6)
+    exceptions: list[AssertionError] = []
+    for i in range(2, 7):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+        except AssertionError as e:
+            exceptions.append(e)
+
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for e in exceptions:
+            print(e)
+
+        raise exceptions[0]


### PR DESCRIPTION
## Description

This PR adds support for `asyncio.shield` (and adds a test for it). Additionally, it ensures (through a test) that we properly support `asyncio.timeout` and `asyncio.timeout_at` (we do not need special code for them, as they don't wrap the Tasks we use with them, but we do want to make sure we do the proper unwinding when they're used and that we can still do it in future versions of Python). 

Related
- Dependency: https://github.com/DataDog/dd-trace-py/pull/15813
- Dependent: https://github.com/DataDog/dd-trace-py/pull/15820