### PR TITLE
chore(DSM): fix test flake for dsm processor shutdown

### DIFF
--- a/tests/contrib/aiokafka/test_aiokafka_dsm.py
+++ b/tests/contrib/aiokafka/test_aiokafka_dsm.py
@@ -9,6 +9,7 @@ from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsCtx
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.native import DDSketch
+from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.service import ServiceStatusError
 from tests.utils import DummyTracer
 from tests.utils import override_global_tracer
@@ -54,7 +55,7 @@ def dsm_processor(tracer):
             processor.shutdown(timeout=5)
         except ServiceStatusError as e:
             # Expected: processor already stopped by tracer shutdown during test teardown
-            if "already in status stopped" not in str(e):
+            if e.current_status == ServiceStatus.RUNNING:
                 raise
 
 

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -11,6 +11,7 @@ from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsCtx
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.native import DDSketch
+from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.service import ServiceStatusError
 from tests.datastreams.test_public_api import MockedTracer
 
@@ -40,7 +41,7 @@ def dsm_processor(tracer):
             processor.shutdown(timeout=5)
         except ServiceStatusError as e:
             # Expected: processor already stopped by tracer shutdown during test teardown
-            if "already in status stopped" not in str(e):
+            if e.current_status == ServiceStatus.RUNNING:
                 raise
 
 


### PR DESCRIPTION
## Description

This is just a smaller version of https://github.com/DataDog/dd-trace-py/pull/15758, so that we can merge the root fix now without interfering with any changes that would come from this PR: https://github.com/DataDog/dd-trace-py/pull/15715.

Tests were flaky due to:
Race during teardown where processor.shutdown() could be called twice (once by the test fixture and once by global tracer teardown), causing a ServiceStatusError; the new try/except ignores that expected case.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
