### PR TITLE
refactor(profiling): attempt to remove one global

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+
+#include <unordered_map>
+
+#include <echion/threads.h>
+
+class EchionSampler
+{
+    // Thread Info map (Thread ID -> ThreadInfo)
+    std::unordered_map<uintptr_t, ThreadInfo::Ptr> thread_info_map_;
+    std::mutex thread_info_map_lock_;
+
+    // Task Link map (Task -> Task relationships)
+    // std::unordered_map<PyObject*, PyObject*> task_link_map_;
+    // std::mutex task_link_map_lock_;
+
+  public:
+    EchionSampler() = default;
+    ~EchionSampler() = default;
+
+    std::unordered_map<uintptr_t, ThreadInfo::Ptr>& thread_info_map() { return thread_info_map_; }
+    std::mutex& thread_info_map_lock() { return thread_info_map_lock_; }
+
+    // std::unordered_map<PyObject*, PyObject*>& task_link_map() { return task_link_map_; }
+    // std::mutex& task_link_map_lock() { return task_link_map_lock_; }
+
+    void postfork_child()
+    {
+        new (&thread_info_map_lock_) std::mutex;
+        // new (&task_link_map_lock_) std::mutex;
+    }
+};

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -33,6 +33,8 @@
 #include <echion/tasks.h>
 #include <echion/timing.h>
 
+class EchionSampler;
+
 class ThreadInfo
 {
   public:
@@ -123,17 +125,7 @@ class ThreadInfo
 
 // ----------------------------------------------------------------------------
 
-// We make this a reference to a heap-allocated object so that we can avoid
-// the destruction on exit. We are in charge of cleaning up the object. Note
-// that the object will leak, but this is not a problem.
-inline std::unordered_map<uintptr_t, ThreadInfo::Ptr>& thread_info_map =
-  *(new std::unordered_map<uintptr_t, ThreadInfo::Ptr>()); // indexed by thread_id
-
-inline std::mutex thread_info_map_lock;
-
-// ----------------------------------------------------------------------------
-
 using PyThreadStateCallback = std::function<void(PyThreadState*, ThreadInfo&)>;
 
 void
-for_each_thread(InterpreterInfo& interp, PyThreadStateCallback callback);
+for_each_thread(EchionSampler& echion, InterpreterInfo& interp, PyThreadStateCallback callback);

--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -1,10 +1,13 @@
 #pragma once
+
+#include <atomic>
+
 #include "constants.hpp"
 #include "stack_renderer.hpp"
 
 #include "echion/strings.h"
 
-#include <atomic>
+class EchionSampler;
 
 namespace Datadog {
 
@@ -13,6 +16,8 @@ class Sampler
     // This class manages the initialization of echion as well as the sampling thread.
     // The underlying echion instance it manages keeps much of its state globally, so this class is a singleton in order
     // to keep it aligned with the echion state.
+    std::unique_ptr<EchionSampler> echion;
+
   private:
     std::shared_ptr<StackRenderer> renderer_ptr;
 

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -4,6 +4,7 @@
 #include "thread_span_links.hpp"
 
 #include "echion/danger.h"
+#include "echion/echion_sampler.h"
 #include "echion/errors.h"
 #include "echion/greenlets.h"
 #include "echion/interp.h"
@@ -174,7 +175,7 @@ Sampler::sampling_thread(const uint64_t seq_num)
 
         // Perform the sample
         for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
-            for_each_thread(interp, [&](PyThreadState* tstate, ThreadInfo& thread) {
+            for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& thread) {
                 auto success = thread.sample(interp.id, tstate, wall_time_us);
                 if (success) {
                     Sample::profile_borrow().stats().increment_sample_count();
@@ -215,7 +216,8 @@ Sampler::set_interval(double new_interval_s)
 }
 
 Sampler::Sampler()
-  : renderer_ptr{ std::make_shared<StackRenderer>() }
+  : echion{ std::make_unique<EchionSampler>() }
+  , renderer_ptr{ std::make_shared<StackRenderer>() }
 {
 }
 
@@ -233,6 +235,9 @@ Sampler::postfork_child()
     if (renderer_ptr) {
         renderer_ptr->postfork_child();
     }
+    if (echion) {
+        echion->postfork_child();
+    }
 }
 
 void
@@ -246,9 +251,8 @@ _stack_atfork_child()
     // Clear renderer caches to avoid using stale interned IDs
     Sampler::get().postfork_child();
 
-    // `thread_info_map_lock` and `task_link_map_lock` are global locks held in echion
+    // `task_link_map_lock` is a global lock held in echion
     // NB placement-new to re-init and leak the mutex because doing anything else is UB
-    new (&thread_info_map_lock) std::mutex;
     new (&task_link_map_lock) std::mutex;
     new (&greenlet_info_map_lock) std::mutex;
 
@@ -280,14 +284,14 @@ void
 Sampler::register_thread(uint64_t id, uint64_t native_id, const char* name)
 {
     // Registering threads requires coordinating with one of echion's global locks, which we take here.
-    const std::lock_guard<std::mutex> thread_info_guard{ thread_info_map_lock };
+    const std::lock_guard<std::mutex> thread_info_guard{ echion->thread_info_map_lock() };
 
     static bool has_errored = false;
-    auto it = thread_info_map.find(id);
-    if (it == thread_info_map.end()) {
+    auto it = echion->thread_info_map().find(id);
+    if (it == echion->thread_info_map().end()) {
         auto maybe_thread_info = ThreadInfo::create(id, native_id, name);
         if (maybe_thread_info) {
-            thread_info_map.emplace(id, std::move(*maybe_thread_info));
+            echion->thread_info_map().emplace(id, std::move(*maybe_thread_info));
         } else {
             if (!has_errored) {
                 has_errored = true;
@@ -313,8 +317,8 @@ void
 Sampler::unregister_thread(uint64_t id)
 {
     // unregistering threads requires coordinating with one of echion's global locks, which we take here.
-    const std::lock_guard<std::mutex> thread_info_guard{ thread_info_map_lock };
-    thread_info_map.erase(id);
+    const std::lock_guard<std::mutex> thread_info_guard{ echion->thread_info_map_lock() };
+    echion->thread_info_map().erase(id);
 }
 
 bool
@@ -356,8 +360,8 @@ void
 Sampler::track_asyncio_loop(uintptr_t thread_id, PyObject* loop)
 {
     // Holds echion's global lock
-    std::lock_guard<std::mutex> guard(thread_info_map_lock);
-    if (auto it = thread_info_map.find(thread_id); it != thread_info_map.end()) {
+    std::lock_guard<std::mutex> guard(echion->thread_info_map_lock());
+    if (auto it = echion->thread_info_map().find(thread_id); it != echion->thread_info_map().end()) {
         it->second->asyncio_loop = (loop != Py_None) ? reinterpret_cast<uintptr_t>(loop) : 0;
     }
 }


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13364

This is the first PR of a series where I will remove static and global state from the Python Stack Sampler. This PR lays ground for future related changes, and proposes an approach I'd like to get feedback on before I generalise it.

The way I did it here is pretty conventional/straightforward	–  I was looking to remove global/statics `thread_info_map_` and `thread_info_map_lock_` and move them to a place where we better understand and manage their lifetime, as well as limit who can "see" and access them.

To do this, I created a new class `EchionSampler` (where I plan to move other globals/statics as well in the future). The Sampling Thread has an instance of that class and all the Echion state lives there.  
Anything that needs to access this state thus needs to access that `EchionSampler` object (e.g. by taking it as a parameter) and read from it. Currently, I have previously-global variables as `private` attributes exposed through methods returning references (or `const` references if it makes sense). 

What I'd like to get people's opinion on:
- Passing the `EchionSampler` around everywhere (because it's going to be accessed almost everywhere eventually I think...) is a bit ugly and feels vert C-y. I guess a more C++-friendly version would be to make everything that needs to access data from `EchionSampler` be a method on `EchionSampler` but I am not sure I like that a lot either. 
- Accessing things through getter methods is a bit verbose because (1) we need to add `echion_sampler.` before every access and (2) because we need to add `()` after what we access since we're now calling a function. It's not the end of the world, but it's also not great in my opinion. I'm open to any options if anyone has an idea. 

~One open question I still have: certain Python-exposed functions (like `register_thread`) need to be able to access the `EchionSampler` state, but they don't hold a reference to it nor to the current Sampling Thread. I'm not sure how we can handle this without making `EchionSampler` itself a static/singleton...~ I just double-checked and it turns out `Sampler` is already a singleton that has a single `static` instance so this isn't a problem.