### PR TITLE
perf(profiling): reduce redundant operations

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -51,7 +51,7 @@ unwind_frame(PyObject* frame_addr, FrameStack& stack)
 
     PyObject* current_frame_addr = frame_addr;
     while (current_frame_addr != NULL && stack.size() < max_frames) {
-        if (seen_frames.find(current_frame_addr) != seen_frames.end())
+        if (seen_frames.contains(current_frame_addr))
             break;
 
         seen_frames.insert(current_frame_addr);

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -296,7 +296,7 @@ ThreadInfo::unwind_tasks(PyThreadState* tstate)
         for (auto key : to_remove) {
             // Only remove the link if the Child Task previously existed; otherwise it's a Task that
             // has just been created and that wasn't in all_tasks when we took the snapshot.
-            if (previous_task_objects.find(key) != previous_task_objects.end()) {
+            if (auto it = previous_task_objects.find(key); it != previous_task_objects.end()) {
                 task_link_map.erase(key);
             }
         }
@@ -366,8 +366,8 @@ ThreadInfo::unwind_tasks(PyThreadState* tstate)
 
             // Get the next task in the chain
             PyObject* task_origin = task.origin;
-            if (waitee_map.find(task_origin) != waitee_map.end()) {
-                current_task = waitee_map.find(task_origin)->second;
+            if (auto maybe_waitee = waitee_map.find(task_origin); maybe_waitee != waitee_map.end()) {
+                current_task = maybe_waitee->second;
                 continue;
             }
 
@@ -375,10 +375,11 @@ ThreadInfo::unwind_tasks(PyThreadState* tstate)
                 // Check for, e.g., gather links
                 std::lock_guard<std::mutex> lock(task_link_map_lock);
 
-                if (task_link_map.find(task_origin) != task_link_map.end() &&
-                    origin_map.find(task_link_map[task_origin]) != origin_map.end()) {
-                    current_task = origin_map.find(task_link_map[task_origin])->second;
-                    continue;
+                if (auto maybe_parent = task_link_map.find(task_origin); maybe_parent != task_link_map.end()) {
+                    if (auto maybe_origin = origin_map.find(maybe_parent->second); maybe_origin != origin_map.end()) {
+                        current_task = maybe_origin->second;
+                        continue;
+                    }
                 }
             }
 
@@ -659,7 +660,7 @@ ThreadInfo::unwind_greenlets(PyThreadState* tstate, unsigned long cur_native_id)
         auto greenlet_id = greenlet_info.first;
         auto& greenlet = greenlet_info.second;
 
-        if (parent_greenlets.find(greenlet_id) != parent_greenlets.end())
+        if (parent_greenlets.contains(greenlet_id))
             continue;
 
         auto frame = greenlet->frame;

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -335,9 +335,8 @@ Sampler::track_asyncio_loop(uintptr_t thread_id, PyObject* loop)
 {
     // Holds echion's global lock
     std::lock_guard<std::mutex> guard(thread_info_map_lock);
-    if (thread_info_map.find(thread_id) != thread_info_map.end()) {
-        thread_info_map.find(thread_id)->second->asyncio_loop =
-          (loop != Py_None) ? reinterpret_cast<uintptr_t>(loop) : 0;
+    if (auto it = thread_info_map.find(thread_id); it != thread_info_map.end()) {
+        it->second->asyncio_loop = (loop != Py_None) ? reinterpret_cast<uintptr_t>(loop) : 0;
     }
 }
 


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13089

This slightly improves readability (and maybe performance, marginally) by
- Using `contains()` over `find() != end()`
- Reusing the result of `find()` to `erase()` things instead of erasing by key