### PR TITLE
ci: add push event to codeql chainguard

### DIFF
--- a/.github/chainguard/codeql.sts.yaml
+++ b/.github/chainguard/codeql.sts.yaml
@@ -6,7 +6,7 @@ claim_pattern:
   ref: ".+"
   ref_path: "refs/heads/.+"
   ref_protected: "true"
-  pipeline_source: "(web|schedule)"
+  pipeline_source: "(web|schedule|push)"
   ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py//.gitlab-ci.yml@refs/heads/.+"
 permissions:
   security_events: write


### PR DESCRIPTION
Enables codeql runs triggered on github push events