### PR TITLE
fix(ray): metadata can be none during job submission

### DIFF
--- a/releasenotes/notes/fix-ray-none-metadata-af38b39b38d918b4.yaml
+++ b/releasenotes/notes/fix-ray-none-metadata-af38b39b38d918b4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ray: This fix resolves an issue where ``None`` metadata in Ray job submission caused a crash.


### PR DESCRIPTION
The integration was assuming metadata was always at least an empty array (true during testing).

It happened to cause a crash in staging/prod. This PR fixes the issue by handling `None` case