### PR TITLE
fix(mcp): set span_kind upfront

### DIFF
--- a/ddtrace/contrib/internal/mcp/patch.py
+++ b/ddtrace/contrib/internal/mcp/patch.py
@@ -234,11 +234,15 @@ def traced_request_responder_enter(mcp, pin: Pin, func, instance, args: tuple, k
         SERVER_TOOL_CALL_OPERATION_NAME if isinstance(request_root, CallToolRequest) else SERVER_REQUEST_OPERATION_NAME
     )
 
+    # Span kind must be set upon span creation or else it cannot be updated
+    span_kind = "tool" if isinstance(request_root, CallToolRequest) else "task"
+
     span = integration.trace(
         pin,
         operation_name,
         submit_to_llmobs=True,
         span_name="mcp.{}".format(_get_attr(request_root, "method", "unknown")),
+        kind=span_kind,
     )
     setattr(instance, "_dd_span", span)
 

--- a/ddtrace/llmobs/_integrations/mcp.py
+++ b/ddtrace/llmobs/_integrations/mcp.py
@@ -90,6 +90,10 @@ class MCPIntegration(BaseLLMIntegration):
         if mcp_span_type:
             span._set_ctx_item(MCP_SPAN_TYPE, mcp_span_type)
 
+        span_kind = kwargs.get("kind", "None")
+        if span_kind:
+            span._set_ctx_item(SPAN_KIND, span_kind)
+
         return span
 
     # Inject intent capture properties into inputSchemas on the response

--- a/releasenotes/notes/set-missing-span-kind-on-mcp-server-spans-5fe93ca89b2dfe14.yaml
+++ b/releasenotes/notes/set-missing-span-kind-on-mcp-server-spans-5fe93ca89b2dfe14.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes an error when attempting to modify an in-progress MCP server span, due to the span being created without a "kind."


### PR DESCRIPTION
In the previous PR we did a refactor to do all span tagging in the respond method, as opposed to setting some things on enter and some in respond.

Unfortunately it cropped up in testing that it was impossible for the user to add custom tags to the span (e.g. user_id). When I tried it gave an error than a span without span_kind set could not be updated.