### PR TITLE
fix(profiling): link libatomic statically [backport 3.19]

### DIFF
--- a/releasenotes/notes/profiling-link-libatomic-e65bdf29199ff1f7.yaml
+++ b/releasenotes/notes/profiling-link-libatomic-e65bdf29199ff1f7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where memory profiler module fails
+    to load when the system doesn't have libatomic installed.
+

--- a/setup.py
+++ b/setup.py
@@ -1172,7 +1172,7 @@ if not IS_PYSTON:
                     "ddtrace/internal/datadog/profiling/dd_wrapper/include",
                 ],
                 extra_link_args=(
-                    ["-Wl,-rpath,$ORIGIN/../../internal/datadog/profiling", "-latomic"]
+                    ["-Wl,-rpath,$ORIGIN/../../internal/datadog/profiling", "-Wl,-Bstatic", "-latomic", "-Wl,-Bdynamic"]
                     if CURRENT_OS == "Linux"
                     else ["-Wl,-rpath,@loader_path/../../internal/datadog/profiling"]
                     if CURRENT_OS == "Darwin"


### PR DESCRIPTION
## Description

https://app.datadoghq.com/notebook/13639339/postmortem-ir-47431-python-memory-profiler-not-loading-due-to-a-missing-dep

Cherry-picked commit 884c38af31446e1ccee06ed0c923578405e2a517 from #15744

Some of the images don't come with `libatomic` installed, one can check that by running
`dpkg -l | grep atomic`.

On `python:3.13`, we get

```
root@ac566ce59903:/# dpkg -l | grep atomic
ii  libatomic1:amd64                   14.2.0-19                            amd64        support library providing __atomic built-in functions
```

On `python:3.13-slim` we get empty output
```
❯ docker run -it python:3.13-slim /bin/bash
root@b4d68d736e25:/# dpkg -l | grep atomic
```

On `python:3.13-slim` image using `ddtrace==3.19.3`, 

```
root@b7eb327380a7:/# python
Python 3.13.11 (main, Dec 30 2025, 00:42:11) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from ddtrace.profiling.collector import _memalloc
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from ddtrace.profiling.collector import _memalloc
  File "/usr/local/lib/python3.13/site-packages/ddtrace/internal/module.py", line 252, in _create_module
    return self.loader.create_module(spec)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
ImportError: libatomic.so.1: cannot open shared object file: No such file or directory
```

On same image using prebuilt wheel from this branch, [wheels-cp313-manylinux_x86_64](https://github.com/DataDog/dd-trace-py/actions/runs/20729190757/artifacts/5029687926)

```
root@12858feb4d06:/# python -c "from ddtrace.profiling.collector import _memalloc; print('import success')"
import success
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
