### PR TITLE
fix(profiling): link libatomic statically

### DIFF
--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -105,8 +105,9 @@ if(APPLE)
                    INSTALL_RPATH "@loader_path/../../internal/datadog/profiling"
                    LINK_FLAGS "-undefined dynamic_lookup")
 elseif(UNIX)
-    # Linux specific
-    target_link_libraries(${FULL_EXTENSION_NAME} PRIVATE atomic)
+    # Linux specific - statically link libatomic to avoid runtime dependency Use linker flags to statically link
+    # libatomic while keeping other libraries dynamic
+    target_link_options(${FULL_EXTENSION_NAME} PRIVATE "-Wl,-Bstatic" "-latomic" "-Wl,-Bdynamic")
     set_target_properties(${FULL_EXTENSION_NAME} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                                             INSTALL_RPATH "$ORIGIN/../../internal/datadog/profiling")
 endif()

--- a/releasenotes/notes/profiling-link-libatomic-e65bdf29199ff1f7.yaml
+++ b/releasenotes/notes/profiling-link-libatomic-e65bdf29199ff1f7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where memory profiler module fails
+    to load when the system doesn't have libatomic installed.
+


### PR DESCRIPTION
## Description

Similar to 3.19 and 4.0 fix PRs 
- https://github.com/DataDog/dd-trace-py/pull/15744
- https://github.com/DataDog/dd-trace-py/pull/15850

On `python:3.14-slim` image using `ddtrace==4.1.2`, we get 

```
root@8a55e06cad23:~# python -c "try:
    from ddtrace.profiling.collector import _memalloc
except ImportError as e:
    print(e)"
libatomic.so.1: cannot open shared object file: No such file or directory
```

Also on the latest head commit d18e59ecf2f12cc407eb4dd4e1d647dee3276533, we get the same error.

With this PR, we no longer get that `ImportError`. 

Tested with the built-wheel from this specific build python run https://github.com/DataDog/dd-trace-py/actions/runs/20731234476?pr=15851

```
❯ gh run download 20731234476 -n wheels-cp314-manylinux_x86_64 --repo DataDog/dd-trace-py
❯ docker run -v $(pwd):/workspace -it python:3.14-slim /bin/bash
root@26cdc8c52a23:/# pip install /workspace/ddtrace*.whl
root@26cdc8c52a23:/# python -c "from ddtrace.profiling.collector import _memalloc; print('import success')"
import success
```


<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
