### PR TITLE
fix(profiling): always use leaf Task name [backport 4.1]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -75,6 +75,7 @@ StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
     if (failed) {
         return;
     }
+
     if (sample == nullptr) {
         // The very first task on a thread will already have a sample, since there's no way to deduce whether
         // a thread has tasks without checking, and checking before populating the sample would make the state
@@ -89,10 +90,13 @@ StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
         // Add the thread context into the sample
         sample->push_threadinfo(
           static_cast<int64_t>(thread_state.id), static_cast<int64_t>(thread_state.native_id), thread_state.name);
-        sample->push_task_name(task_name);
         sample->push_walltime(thread_state.wall_time_ns, 1);
-        if (on_cpu)
-            sample->push_cputime(thread_state.cpu_time_ns, 1); // initialized to 0, so possibly a no-op
+
+        if (on_cpu) {
+            // initialized to 0, so possibly a no-op
+            sample->push_cputime(thread_state.cpu_time_ns, 1);
+        }
+
         sample->push_monotonic_ns(thread_state.now_time_ns);
 
         // We also want to make sure the tid -> span_id mapping is present in the sample for the task
@@ -103,9 +107,10 @@ StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
             sample->push_local_root_span_id(active_span->local_root_span_id);
             sample->push_trace_type(std::string_view(active_span->span_type));
         }
-
-        pushed_task_name = true;
     }
+
+    sample->push_task_name(task_name);
+    pushed_task_name = true;
 }
 
 void

--- a/releasenotes/notes/profiling-always-use-leaf-task-name-46bf36ed9f1d723b.yaml
+++ b/releasenotes/notes/profiling-always-use-leaf-task-name-46bf36ed9f1d723b.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: the Profiler now always uses the name of leaf tasks for the "Task name" label. Previously, one of the
+    Stacks would be labelled with the parent task's name, which would lead to inconsistent behaviour across runs.

--- a/tests/profiling/collector/test_asyncio_gather_tasks.py
+++ b/tests/profiling/collector/test_asyncio_gather_tasks.py
@@ -8,7 +8,7 @@ import pytest
     err=None,
 )
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
-def test_asyncio_gather_wall_time() -> None:
+def test_asyncio_gather_tasks() -> None:
     import asyncio
     import os
 
@@ -62,42 +62,21 @@ def test_asyncio_gather_wall_time() -> None:
             line_no=-1,
         )
 
-    # One of the two Tasks gets included under the Main Task randomly, we have to try both.
-    try:
-        for f, t in (("f4_0", "Task-1"), ("f4_1", "F4_1")):
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    task_name=t,
-                    locations=[
-                        fn_location("sleep"),
-                        fn_location("f5"),
-                        fn_location(f),
-                        fn_location("f3"),
-                        fn_location("f2"),
-                        fn_location("f1"),
-                        fn_location("main"),
-                    ],
-                ),
-            )
-    except AssertionError:
-        for f, t in (("f4_0", "F4_0"), ("f4_1", "Task-1")):
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    task_name=t,
-                    locations=[
-                        fn_location("sleep"),
-                        fn_location("f5"),
-                        fn_location(f),
-                        fn_location("f3"),
-                        fn_location("f2"),
-                        fn_location("f1"),
-                        fn_location("main"),
-                    ],
-                ),
-            )
+    for f, t in (("f4_0", "F4_0"), ("f4_1", "F4_1")):
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t,
+                locations=[
+                    fn_location("sleep"),
+                    fn_location("f5"),
+                    fn_location(f),
+                    fn_location("f3"),
+                    fn_location("f2"),
+                    fn_location("f1"),
+                    fn_location("main"),
+                ],
+            ),
+        )

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
@@ -114,9 +114,9 @@ def test_asyncio_recursive_on_cpu_tasks():
         print_samples_on_failure=True,
     )
 
-    # Same test, but with a specific task_name ("Task-1")``
-    # Ideally, we should be able to report the Task-2 specific part in its own
-    # Stack, but at the moment we are not. This will be fixed in the future.
+    # Same test, but with a specific task_name - "Task-2".
+    # Task-1 is the "root"/parent Task, Task-2 is the one created by inner1.
+    # Since we label Samples with the Leaf Task's name, we want to see "Task-2".
     pprof_utils.assert_profile_has_sample(
         profile,
         list(profile.sample),
@@ -124,7 +124,7 @@ def test_asyncio_recursive_on_cpu_tasks():
             thread_name="MainThread",
             span_id=span_id,
             local_root_span_id=local_root_span_id,
-            task_name="Task-1",
+            task_name="Task-2",
             locations=list(
                 reversed(
                     [

--- a/tests/profiling/collector/test_asyncio_wait.py
+++ b/tests/profiling/collector/test_asyncio_wait.py
@@ -63,99 +63,50 @@ def test_asyncio_wait() -> None:
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
 
-    # Note: there currently is a bug somewhere that makes one of the Tasks show up under the parent Task and the
-    # other Tasks be under their own Task name. We need to fix this.
-    # For the time being, though, which Task is "independent" is non-deterministic which means we must
-    # test both possibilities ("inner 2" is part of "outer" or "inner 1" is part of "outer").
-    try:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="outer",  # TODO: This is a bug and we need to fix it, it should be "inner 1"
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner1",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner1.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 1",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner1",
+                    filename="test_asyncio_wait.py",
+                    line_no=inner1.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_wait.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 2",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner2",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner2.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
-    except AssertionError:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="outer",  # TODO: This is a bug and we need to fix it, it should be "inner 1"
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner2",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner2.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 1",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner1",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner1.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 2",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner2",
+                    filename="test_asyncio_wait.py",
+                    line_no=inner2.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_wait.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )


### PR DESCRIPTION
## Description

Backport of https://github.com/DataDog/dd-trace-py/pull/15813.