### PR TITLE
fix(profiling): don't link with libatomic [backport 4.0]

### DIFF
--- a/releasenotes/notes/profiling-link-libatomic-e65bdf29199ff1f7.yaml
+++ b/releasenotes/notes/profiling-link-libatomic-e65bdf29199ff1f7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where memory profiler module fails
+    to load when the system doesn't have libatomic installed.
+

--- a/setup.py
+++ b/setup.py
@@ -1172,7 +1172,7 @@ if not IS_PYSTON:
                     "ddtrace/internal/datadog/profiling/dd_wrapper/include",
                 ],
                 extra_link_args=(
-                    ["-Wl,-rpath,$ORIGIN/../../internal/datadog/profiling", "-latomic"]
+                    ["-Wl,-rpath,$ORIGIN/../../internal/datadog/profiling"]
                     if CURRENT_OS == "Linux"
                     else ["-Wl,-rpath,@loader_path/../../internal/datadog/profiling"]
                     if CURRENT_OS == "Darwin"


### PR DESCRIPTION
## Description

On `python:3.13-slim` image with `ddtrace==4.0.2`

```
root@b09e95ea2b98:/# python
Python 3.13.11 (main, Dec 30 2025, 00:42:11) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from ddtrace.profiling.collector import _memalloc
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from ddtrace.profiling.collector import _memalloc
  File "/usr/local/lib/python3.13/site-packages/ddtrace/internal/module.py", line 252, in _create_module
    return self.loader.create_module(spec)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
ImportError: libatomic.so.1: cannot open shared object file: No such file or directory
```

On same image, using prebuilt wheel from this branch https://github.com/DataDog/dd-trace-py/actions/runs/20755076539?pr=15869, `from ddtrace.profiling.collector import _memalloc` works without any problem. 


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
