### PR TITLE
ci: fix nightly macrobenchmark trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,9 @@ macrobenchmarks:
     # Allow failures if explicitly asked
     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
       allow_failure: true
-    # Always run on tagged releases
+    # Always run on tagged releases and release branches
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+      when: always
     - if: !reference [.is_release]
       when: always
     # Otherwise, run manually


### PR DESCRIPTION
## Description

We now trigger nightly jobs with API calls, so we need to update the rules for macrobenchmarks to run when triggered via the API.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
