### PR TITLE
ci(internal): increase parallelism for GitLab jobs

### DIFF
--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -196,7 +196,7 @@ suites:
       - ddtrace/contrib/integration_registry/*
     runner: riot
   internal:
-    parallelism: 2
+    venvs_per_job: 3
     paths:
       - '@core'
       - '@remoteconfig'


### PR DESCRIPTION
## Description

Runtime right now can be 15+ minutes. There are 12 venvs, so this should give us 4 jobs instead of 2 and should get the runtime down under 10 minutes.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
