### PR TITLE
ci: publish artifacts to branch paths

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -233,6 +233,16 @@ publish-wheels-to-s3:
       echo "S3 index (commit):   ${COMMIT_INDEX_URL}"
       echo "S3 index (pipeline): ${PIPE_INDEX_URL}"
 
+      # Also publish to branch path if on main or a release branch
+      if [ "$CI_COMMIT_BRANCH" == "main" ] || [[ "$CI_COMMIT_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        echo "Publishing to ${CI_COMMIT_BRANCH}/ path"
+        aws s3 cp --recursive --exclude "*" --include "*.whl" pywheels "s3://${BUCKET}/${CI_COMMIT_BRANCH}/"
+        generate_index_html "index.branch.html"
+        aws s3 cp "index.branch.html" "s3://${BUCKET}/${CI_COMMIT_BRANCH}/index.html" --content-type text/html
+        BRANCH_INDEX_URL="https://${BUCKET}.s3.amazonaws.com/${CI_COMMIT_BRANCH}/index.html"
+        echo "S3 index (branch):   ${BRANCH_INDEX_URL}"
+      fi
+
 
 # Fail if the downloaded package versions do not match the git tag version
 verify_package_version:


### PR DESCRIPTION
## Description

Allows accessing wheels/artifacts uploaded to the public s3 bucket by the branch name, if the branch is `main` or a release branch (e.g. `4.1`, `4.2`, etc).

This is useful for system-tests which wants to download the most recent artifacts for "main", and doesn't want to have to lookup the latest commit sha or handle when the latest commit sha hasn't published an artifact yet (or failed).

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

This implementation uses a "last-write-wins" model where files are continuously published to the same S3 folder (main/ or release branch folders) on each commit. The index.html is always updated to reflect the current files, so tools like pip install --find-links will grab the latest artifacts. However, be aware that bulk copying the S3 folder may include older versions until the bucket's TTL policies clean them up.
