### PR TITLE
fix(contrib): missing traces with pymongo >=4.12 (#13684)

### DIFF
--- a/ddtrace/contrib/internal/pymongo/patch.py
+++ b/ddtrace/contrib/internal/pymongo/patch.py
@@ -88,7 +88,10 @@ def unpatch():
 
 
 def patch_pymongo_module():
-    _w(pymongo.MongoClient.__init__, _trace_mongo_client_init)
+    if _VERSION >= (4, 12):
+        _w(pymongo.MongoClient._init_background, _trace_mongo_client_init)
+    else:
+        _w(pymongo.MongoClient.__init__, _trace_mongo_client_init)
     _w(Topology.select_server, _trace_topology_select_server)
     if _VERSION >= (3, 12):
         _w(Server.run_operation, _trace_server_run_operation_and_with_response)


### PR DESCRIPTION
## Description

Fix patching of `pymongo>=4.12`.  (#13684)

This version initialize Topology instance lazily, so patch should be applied on method that creates Topology instance instead of client constructor.

## Testing

Tested with pymongo `4.15.`

## Risks

We keep the behavior for `pymongo<4.12`, so risk is very low.

## Additional Notes
