### PR TITLE
fix(llmobs): subsequent context handling with annotations (#15764)

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1112,6 +1112,12 @@ class LLMObs(Service):
             # restored after exiting the annotation_context block
             if state["created_context"] is not None:
                 state["created_context"]._reactivate = False
+                # DEV: Deactivate the context we created so subsequent annotation_contexts
+                # don't see the stale context with the old ANNOTATIONS_CONTEXT_ID.
+                # Only deactivate if this context is still the active one (not a Span).
+                current_active = cls._instance.tracer.context_provider.active()
+                if current_active is state["created_context"]:
+                    cls._instance.tracer.context_provider.activate(None)
 
         return AnnotationContext(register_annotation, deregister_annotation)
 

--- a/releasenotes/notes/llmobs_context_fix-692c453a633b4742.yaml
+++ b/releasenotes/notes/llmobs_context_fix-692c453a633b4742.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where using multiple sequential ``annotation_context`` blocks 
+    caused annotations to fail after the first operation in subsequent contexts. Previously, the trace context 
+    created by the first ``annotation_context`` remained active after exiting, causing the second context to 
+    reuse a stale context ID. This resulted in annotations not being applied to spans after the first batch 
+    call in the second ``annotation_context`` block.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -1437,6 +1437,47 @@ def test_annotation_context_not_reactivated_after_exit(llmobs):
         assert span2._get_ctx_item(TAGS) is None
 
 
+def test_annotation_context_sequential_contexts_work_independently(llmobs):
+    """
+    Regression test: Verifies that multiple sequential annotation_contexts work correctly.
+    This tests the specific customer issue where using annotation_context multiple times
+    (e.g., with LangChain's structured outputs and batch()) would cause the second context's
+    annotations to fail after the first batch call.
+
+    The bug occurred because:
+    1. First annotation_context creates a Context with ANNOTATIONS_CONTEXT_ID=X
+    2. First annotation_context exits, but the Context remains active (with _reactivate=False)
+    3. Second annotation_context enters and reuses the stale Context's ANNOTATIONS_CONTEXT_ID=X
+    4. After first span finishes in second context, the Context is not reactivated
+    5. Subsequent spans don't have ANNOTATIONS_CONTEXT_ID, so annotations fail
+    """
+    # First annotation context
+    with llmobs.annotation_context(tags={"context": "first"}):
+        with llmobs.workflow(name="first_ctx_op1") as span1:
+            assert span1._get_ctx_item(TAGS) == {"context": "first"}
+        with llmobs.workflow(name="first_ctx_op2") as span2:
+            assert span2._get_ctx_item(TAGS) == {"context": "first"}
+
+    # Second annotation context - this is where the bug manifested
+    with llmobs.annotation_context(tags={"context": "second"}):
+        # First operation works (reused old context ID)
+        with llmobs.workflow(name="second_ctx_op1") as span3:
+            assert span3._get_ctx_item(TAGS) == {"context": "second"}
+        # Second operation failed before the fix (context not reactivated)
+        with llmobs.workflow(name="second_ctx_op2") as span4:
+            assert span4._get_ctx_item(TAGS) == {"context": "second"}
+        # Third operation to verify it continues to work
+        with llmobs.agent(name="second_ctx_op3") as span5:
+            assert span5._get_ctx_item(TAGS) == {"context": "second"}
+
+    # Third annotation context - verify it still works
+    with llmobs.annotation_context(tags={"context": "third"}):
+        with llmobs.workflow(name="third_ctx_op1") as span6:
+            assert span6._get_ctx_item(TAGS) == {"context": "third"}
+        with llmobs.workflow(name="third_ctx_op2") as span7:
+            assert span7._get_ctx_item(TAGS) == {"context": "third"}
+
+
 def test_annotation_context_only_applies_to_local_context(llmobs):
     """
     tests that annotation contexts only apply to spans belonging to the same


### PR DESCRIPTION
Backports https://github.com/DataDog/dd-trace-py/pull/15764


## Description

**Fixes customer issue with sequential `annotation_context` blocks**

When using `LLMObs.annotation_context()` multiple times sequentially (e.g., with LangChain's `with_structured_output()` and `batch()`), only the first batch call in the second annotation context would be annotated. Subsequent calls would fail to receive annotations.

### Root Cause

The previous fix in #15571 addressed annotation context persistence *within* a single `annotation_context` block by setting `_reactivate=True` on the Context. However, it didn't handle **multiple sequential `annotation_context` blocks**.

The bug flow was:
1. First `annotation_context` creates a Context with `ANNOTATIONS_CONTEXT_ID=X` and `_reactivate=True`
2. First `annotation_context` exits, sets `_reactivate=False` **but the Context remains active**
3. Second `annotation_context` enters, sees the stale Context, and reuses its `ANNOTATIONS_CONTEXT_ID=X`
4. First span in second context works (inherits the old Context)
5. Span finishes, but `_reactivate=False` so Context is NOT reactivated
6. Subsequent spans don't have `ANNOTATIONS_CONTEXT_ID`, so **annotations fail**

### The Fix

In `deregister_annotation()`, after setting `_reactivate=False`, we now also **deactivate the context we created** if it's still the active context. This ensures subsequent `annotation_context` blocks start fresh with their own Context.

## Testing

- Added `test_annotation_context_sequential_contexts_work_independently` which specifically tests the customer's scenario
- I tested the customers example code manually

## Risks

Context is confusing, but all the tests still pass so I think we should be alright.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
