### PR TITLE
ci(benchmarks): fix baseline build wheel downloading

### DIFF
--- a/.gitlab/benchmarks/steps/build-baseline.sh
+++ b/.gitlab/benchmarks/steps/build-baseline.sh
@@ -12,7 +12,7 @@ else
   S3_INDEX_URL="https://${S3_BUCKET}.s3.amazonaws.com/${BASELINE_COMMIT_SHA}/index.html"
 
   echo "Attempting to download wheel from S3 index: ${S3_INDEX_URL}"
-  if python3.9 -m pip download --no-deps --index-url "${S3_INDEX_URL}" ddtrace 2>/dev/null; then
+  if python3.9 -m pip download --no-index --no-deps --find-links "${S3_INDEX_URL}" --pre ddtrace 2>/dev/null; then
     echo "Successfully downloaded wheel from S3"
   else
     echo "Failed to download from S3, building wheel from scratch..."


### PR DESCRIPTION
## Description

If we don't provide `--no-index`, then `pip download` will look at our S3 bucket **and** at PyPI, and then grab the highest version between the two.

This means we might be comparing against the version in PyPI instead of the specific commit we are targeting.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
