### PR TITLE
ci: fix verify_package_version job

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -243,13 +243,16 @@ publish-wheels-to-s3:
         echo "S3 index (branch):   ${BRANCH_INDEX_URL}"
       fi
 
-
 # Fail if the downloaded package versions do not match the git tag version
 verify_package_version:
   image: registry.ddbuild.io/images/mirror/python:3.14.0
   tags: [ "arch:amd64" ]
   stage: package
-  needs: [ download_ddtrace_artifacts ]
+  needs:
+    - "build linux"
+    - "build macos"
+    - "build sdist"
+    - "download_ddtrace_artifacts"
   only:
     # v2.10.0
     # v2.10.1


### PR DESCRIPTION
## Description

We were only depending on the download artifacts job, which only has the windows builds.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
