### PR TITLE
fix(lib-injection): don't set py-limited-api for psutil

### DIFF
--- a/ddtrace/vendor/psutil/setup.py
+++ b/ddtrace/vendor/psutil/setup.py
@@ -597,10 +597,6 @@ def get_extensions():
             extra_link_args=getattr(original_ext, "extra_link_args", []),
         )
 
-        # Copy py_limited_api if it exists
-        if hasattr(original_ext, "py_limited_api"):
-            adapted.py_limited_api = original_ext.py_limited_api
-
         return adapted
 
     # Get the platform-specific extension name
@@ -645,9 +641,6 @@ def get_extensions():
             define_macros=macros,
             libraries=[],
         )
-        # Copy py_limited_api from the main extension for consistency
-        if hasattr(ext, "py_limited_api"):
-            posix_ext.py_limited_api = ext.py_limited_api
 
         # Add platform-specific libraries for posix extension
         if SUNOS:

--- a/releasenotes/notes/limited-api-0c9b84268ca779d3.yaml
+++ b/releasenotes/notes/limited-api-0c9b84268ca779d3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    SSI: This fixes an issue where ddtrace fails to find _psutil_linux.abi3.so
+    file in an injected environment.


### PR DESCRIPTION
## Description

auto_inject CI was broken with the following message

```
Unable to get total memory available, using default value of 1024 KB

Traceback (most recent call last):
  File "/opt/datadog-packages/datadog-apm-library-python/4.1.2/sitecustomize.py", line 343, in _inject
    raise ModuleNotFoundError("ddtrace")
ModuleNotFoundError: ddtrace

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/datadog-packages/datadog-apm-library-python/4.1.2/ddtrace_pkgs/site-packages-ddtrace-py3.13-manylinux2014/ddtrace/internal/settings/profiling.py", line 39, in _derive_default_heap_sample_size
    from ddtrace.vendor import psutil
  File "/opt/datadog-packages/datadog-apm-library-python/4.1.2/ddtrace_pkgs/site-packages-ddtrace-py3.13-manylinux2014/ddtrace/vendor/psutil/__init__.py", line 93, in <module>
    from . import _pslinux as _psplatform
  File "/opt/datadog-packages/datadog-apm-library-python/4.1.2/ddtrace_pkgs/site-packages-ddtrace-py3.13-manylinux2014/ddtrace/vendor/psutil/_pslinux.py", line 26, in <module>
    from . import _psutil_linux as cext
  File "/opt/datadog-packages/datadog-apm-library-python/4.1.2/ddtrace_pkgs/site-packages-ddtrace-py3.13-manylinux2014/ddtrace/internal/module.py", line 252, in _create_module
    return self.loader.create_module(spec)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
ImportError:
  /opt/datadog-packages/datadog-apm-library-python/4.1.2/
  ddtrace_pkgs/site-packages-ddtrace-py3.13-manylinux2014/
  ddtrace/vendor/psutil/_psutil_linux.abi3.so:
  cannot open shared object file: No such file or directory

AssertionError:
  '' == ''
```

It looks like we have recently set `py_limited_api` for both `_psutil_linux*.so` and `_psutil_posix*.so`, and ended up having `_psutil_linux.abi3.so` and `_psutil_posix.abi3.so`. And it somehow ended up not having the right .so file for the target architecture in the lib injection image. We try to avoid it by not setting `py_limited_api` and explicitly have python version and architecture specifiers in the .so files. 

Relevant previous PRs
- https://github.com/DataDog/dd-trace-py/pull/15414
- https://github.com/DataDog/dd-trace-py/pull/15549

Affected release lines
- 4.1.x
- 4.2.x

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
