### PR TITLE
fix(llmobs): add missing return in activate distributed context (backport to 4.0)

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1852,11 +1852,15 @@ class LLMObs(Service):
                 return
             parent_llmobs_trace_id = context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
             if parent_llmobs_trace_id is None:
-                log.debug("Failed to extract LLMObs trace ID from request headers. Expected string, got None.")
+                log.debug(
+                    "Failed to extract LLMObs trace ID from request headers. Expected string, got None. "
+                    "Defaulting to the corresponding APM trace ID."
+                )
                 llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
                 llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(context.trace_id)
                 cls._instance._llmobs_context_provider.activate(llmobs_context)
                 error = "missing_parent_llmobs_trace_id"
+                return
             llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
             llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(parent_llmobs_trace_id)
             cls._instance._llmobs_context_provider.activate(llmobs_context)

--- a/releasenotes/notes/fix-llmobs-activate-distributed-headers-432abd8e9efdf3bc.yaml
+++ b/releasenotes/notes/fix-llmobs-activate-distributed-headers-432abd8e9efdf3bc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue in ``activate_distributed_headers()`` where distributed requests missing a LLM Observability trace ID would be incorrectly propagated twice.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -25,6 +25,7 @@ from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_DOCUMENTS
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import OUTPUT_VALUE
+from ddtrace.llmobs._constants import PROPAGATED_LLMOBS_TRACE_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import SESSION_ID
@@ -1052,6 +1053,22 @@ def test_activate_distributed_headers_no_llmobs_parent_id_does_nothing(llmobs, m
         mock_extract.return_value = dummy_context
         llmobs.activate_distributed_headers({})
         mock_llmobs_logs.debug.assert_called_once_with("Failed to extract LLMObs parent ID from request headers.")
+
+
+def test_activate_distributed_headers_no_llmobs_trace_id_starts_new_context(llmobs, mock_llmobs_logs):
+    with mock.patch("ddtrace.llmobs._llmobs.HTTPPropagator.extract") as mock_extract:
+        dummy_context = Context(
+            trace_id=123, span_id=456, meta={PROPAGATED_PARENT_ID_KEY: "123", PROPAGATED_LLMOBS_TRACE_ID_KEY: None}
+        )
+        mock_extract.return_value = dummy_context
+        with mock.patch("ddtrace.llmobs.LLMObs._instance.tracer.context_provider.activate") as mock_activate:
+            llmobs.activate_distributed_headers({})
+            assert mock_extract.call_count == 1
+            mock_llmobs_logs.debug.assert_called_once_with(
+                "Failed to extract LLMObs trace ID from request headers. Expected string, got None. "
+                "Defaulting to the corresponding APM trace ID."
+            )
+            mock_activate.assert_called_once_with(dummy_context)
 
 
 def test_activate_distributed_headers_activates_context(llmobs):


### PR DESCRIPTION
<!-- Provide an overview of the change and motivation for the change --> We were missing a return during the 4.0 migration in `LLMObs._activate_distributed_context()`. We were previously activating two contexts in a row (and one with an incorrect "None" LLMObs trace ID) instead of returning after the first error case was handled.

<!-- Describe your testing strategy or note what tests are included -->

<!-- Note any risks associated with this change, or "None" if no risks -->

<!-- Any other information that would be helpful for reviewers -->

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
