### PR TITLE
ci: allow codeql uploads on tag builds

### DIFF
--- a/.github/chainguard/codeql.sts.yaml
+++ b/.github/chainguard/codeql.sts.yaml
@@ -6,7 +6,7 @@ claim_pattern:
   ref: ".+"
   ref_path: "refs/heads/.+"
   ref_protected: "true"
-  pipeline_source: "(web|schedule|push)"
+  pipeline_source: "(web|schedule|push|tag)"
   ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py//.gitlab-ci.yml@refs/heads/.+"
 permissions:
   security_events: write


### PR DESCRIPTION
## Description

This change fixes errors like [this one](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1334805080) by allowing codeql sarif uploads on tag builds.