### PR TITLE
ci: don't run CodeQL on release tag pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,6 +204,10 @@ codeql-scan:
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
+  rules:
+    - if: !reference [.is_release]
+      when: never
+    - when: on_success
   variables:
     AWS_REGION: us-east-1
     BASE_REF: main


### PR DESCRIPTION
## Description

We don't have all the necessary variables needed when running on a release tag. We can skip this case, especially since we will run CodeQL for the commit on the push anyways.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
