### PR TITLE
test(profiling): unflake `test_gunicorn`, again [backport 4.1]

### DIFF
--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -134,7 +134,7 @@ def _test_gunicorn(
         # when run on GitLab CI. We need to match either of these two.
         filename_regex = r"^(?:__init__\.py|gunicorn-app\.py)$"
 
-        expected_location = pprof_utils.StackLocation(function_name="fib", filename=filename_regex, line_no=12)
+        expected_location = pprof_utils.StackLocation(function_name="fib", filename=filename_regex, line_no=8)
 
         pprof_utils.assert_profile_has_sample(
             profile,


### PR DESCRIPTION
## Description

I think I may have been a little bit too quick with this one (https://github.com/DataDog/dd-trace-py/pull/15864)... this should unflake again. 

[See test runs](https://app.datadoghq.com/ci/test/runs?agg_m_a=count&agg_m_b=count&agg_m_source_a=base&agg_m_source_b=base&agg_q_a=%40test.name&agg_q_b=%40test.name&agg_q_source_a=base&agg_q_source_b=base&agg_t_a=count&agg_t_b=count&currentTab=overview&eventStack=&ff_display=a&formula_f1=-b&fromUser=true&index=citest&mode=sliding&query_a=test_level%3Atest%20%40ci.pipeline.name%3ADataDog%2Fapm-reliability%2Fdd-trace-py%20%40git.branch%3Akowalski%2Ftest-profiling-unflake-test_gunicorn-again%20status%3Aerror%20%40ci.job.name%3A%2Aprofile%2A%20%40test.name%3A%2Agunicorn%2A&query_b=test_level%3Atest%20%40ci.pipeline.name%3ADataDog%2Fapm-reliability%2Fdd-trace-py%20%40git.branch%3Amain%20%40ci.job.name%3A%2Aprofile%2A%20-%40test.name%3A%2Agunicorn%2A%20-status%3Aerror&top_n_a=100&top_n_b=100&top_o_a=top&top_o_b=top&viz=timeseries&x_missing_a=true&x_missing_b=true&start=1767874271253&end=1767885071253&paused=false)