### PR TITLE
Revert "ci: allow failures on datadog-lambda-python pipeline"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,6 @@ serverless lambda tests:
     UPSTREAM_GITLAB_USER_LOGIN: $GITLAB_USER_LOGIN
     UPSTREAM_GITLAB_USER_EMAIL: $GITLAB_USER_EMAIL
     SKIP_E2E_TESTS: "true"
-  allow_failure: true
 
 # Validate the ast-grep rule's test suite in .sg/tests
 "ast-grep rules":


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#15717