### PR TITLE
ci: update system-tests [backport 4.2]

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '8910f640050543eeb7b1d70d29943f8cbf1d3396'
+          ref: 'b70045d150ad433df14decedb8426bc8f3869826'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '8910f640050543eeb7b1d70d29943f8cbf1d3396'
+          ref: 'b70045d150ad433df14decedb8426bc8f3869826'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -323,7 +323,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '8910f640050543eeb7b1d70d29943f8cbf1d3396'
+          ref: 'b70045d150ad433df14decedb8426bc8f3869826'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -381,7 +381,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@8910f640050543eeb7b1d70d29943f8cbf1d3396
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@b70045d150ad433df14decedb8426bc8f3869826
     secrets: inherit
     permissions:
       contents: read
@@ -412,7 +412,7 @@ jobs:
   integration-frameworks-system-tests:
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@8910f640050543eeb7b1d70d29943f8cbf1d3396
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@b70045d150ad433df14decedb8426bc8f3869826
     secrets: inherit
     permissions:
       contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "8910f640050543eeb7b1d70d29943f8cbf1d3396"
+  SYSTEM_TESTS_REF: "b70045d150ad433df14decedb8426bc8f3869826"
 
 default:
   interruptible: true


### PR DESCRIPTION
## Description

Backport of https://github.com/DataDog/dd-trace-py/pull/15940. 