### PR TITLE
fix(appsec): pass lowercase downstream request headers to libddwaf

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c35863e8e9f5872e27e5f6cf0be8fae82288a4ff'
+          ref: 'e1cd85f960c713cf6a7e9caa61094b5914d0e386'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c35863e8e9f5872e27e5f6cf0be8fae82288a4ff'
+          ref: 'e1cd85f960c713cf6a7e9caa61094b5914d0e386'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -323,7 +323,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c35863e8e9f5872e27e5f6cf0be8fae82288a4ff'
+          ref: 'e1cd85f960c713cf6a7e9caa61094b5914d0e386'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -381,7 +381,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@c35863e8e9f5872e27e5f6cf0be8fae82288a4ff
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@e1cd85f960c713cf6a7e9caa61094b5914d0e386
     secrets: inherit
     permissions:
       contents: read
@@ -412,7 +412,7 @@ jobs:
   integration-frameworks-system-tests:
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@c35863e8e9f5872e27e5f6cf0be8fae82288a4ff
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@e1cd85f960c713cf6a7e9caa61094b5914d0e386
     secrets: inherit
     permissions:
       contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "c35863e8e9f5872e27e5f6cf0be8fae82288a4ff"
+  SYSTEM_TESTS_REF: "e1cd85f960c713cf6a7e9caa61094b5914d0e386"
 
 default:
   interruptible: true

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -259,6 +259,10 @@ class WAF_DATA_NAMES(metaclass=Constant_Class):
     DOWN_RES_HEADERS: Literal["server.io.net.response.headers"] = "server.io.net.response.headers"
     DOWN_RES_BODY: Literal["server.io.net.response.body"] = "server.io.net.response.body"
 
+    HEADER_ADDRESSES = frozenset(
+        (DOWN_REQ_HEADERS, DOWN_RES_HEADERS, REQUEST_HEADERS_NO_COOKIES, RESPONSE_HEADERS_NO_COOKIES)
+    )
+
 
 class SPAN_DATA_NAMES(metaclass=Constant_Class):
     """string names used by the library for tagging data from requests in context or span"""

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -67,6 +67,12 @@ def _transform_headers(data: Union[Dict[str, str], List[Tuple[str, str]]]) -> Di
     return normalized
 
 
+def _serialize_address_values(waf_name: str, value: Any) -> Any:
+    if waf_name in WAF_DATA_NAMES.HEADER_ADDRESSES:
+        return _transform_headers(value)
+    return value
+
+
 def get_rules() -> str:
     return asm_config._asm_static_rule_file or DEFAULT.RULES
 
@@ -281,8 +287,8 @@ class AppSecSpanProcessor(SpanProcessor):
                 continue
             # ensure ephemeral addresses are sent, event when value is None
             if waf_name not in WAF_DATA_NAMES.PERSISTENT_ADDRESSES and custom_data:
-                if key in custom_data:
-                    ephemeral_data[waf_name] = custom_data[key]
+                if value := custom_data.get(key):
+                    ephemeral_data[waf_name] = _serialize_address_values(waf_name, value)
 
             elif self._is_needed(waf_name) or force_keys:
                 value = None
@@ -292,7 +298,7 @@ class AppSecSpanProcessor(SpanProcessor):
                     value = _asm_request_context.get_value("waf_addresses", SPAN_DATA_NAMES[key])
                 # if value is a callable, it's a lazy value for api security that should not be sent now
                 if value is not None and not hasattr(value, "__call__"):
-                    data[waf_name] = _transform_headers(value) if key.endswith("HEADERS_NO_COOKIES") else value
+                    data[waf_name] = _serialize_address_values(waf_name, value)
                     if waf_name in WAF_DATA_NAMES.PERSISTENT_ADDRESSES:
                         data_already_sent.add(key)
                     log.debug("[action] WAF got value %s", WAF_DATA_NAMES.get(key, key))

--- a/releasenotes/notes/aap-fix-api10-headers-23aa445139713469.yaml
+++ b/releasenotes/notes/aap-fix-api10-headers-23aa445139713469.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    AAP: This fix resolves an issue where some downstream request analysis rules were not matched because HTTP header names were compared case-sensitively; header names are now normalized so rules match correctly.

--- a/tests/appsec/appsec/rules-rasp.json
+++ b/tests/appsec/appsec/rules-rasp.json
@@ -260,13 +260,13 @@
               {
                 "address": "server.io.net.request.headers",
                 "key_path": [
-                  "Host"
+                  "host"
                 ]
               },
               {
                 "address": "server.io.net.request.headers",
                 "key_path": [
-                  "TagHost"
+                  "taghost"
                 ]
               }
             ],


### PR DESCRIPTION
## Description

Normalize headers to be always lowercase in the context of API 10 for correct rule evaluation in libddwaf.


## Testing

- updated test RASP ruleset

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

