### PR TITLE
docs: simpler backport documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -47,7 +47,7 @@ When submitting a pull request, ensure the following requirements are met:
 * **All changes are related to the pull request's stated goal** - Keep changes focused and avoid scope creep.
 * **The change includes tests OR the PR description describes a testing strategy** - All code changes should be tested appropriately.
 * **The change includes or references documentation updates if necessary** - Update user-facing documentation when adding new features or changing behavior.
-* **Backport labels are set if applicable** - Apply appropriate backport labels for fixes and CI changes as described in the `Backporting`_ section.
+* **Backport labels are set if applicable** - Apply appropriate backport labels for critical fixes as described in the `Backporting`_ section.
 * **Avoids breaking API changes** - Follow the :doc:`versioning policy <versioning>` to maintain backward compatibility.
 * **The PR description includes an overview of the change** - Clearly describe what the change does and why it's needed.
 * **The PR description articulates the motivation for the change** - Explain the problem being solved or the improvement being made.
@@ -81,12 +81,11 @@ Backporting
 
 Each minor version has its own branch.
 
-* **Fix PRs** are backported to all maintained release branches.
-* **CI PRs** are backported to the maintained release branches.
+* **Fix PRs** are backported to the most recent release branch only when they are critically important.
 * **New features** (``feat`` PRs) are not backported.
 * **Chore, documentation, and other PRs** are not backported.
 
-If your pull request is a ``fix`` or ``ci`` change, apply the backport labels corresponding to the minor
+If your pull request is a critical ``fix`` change, apply the backport labels corresponding to the minor
 versions that need the change.
 
 Tests


### PR DESCRIPTION
This change updates the documentation about backporting to align with the latest practice on the Python guild.