### PR TITLE
chore(runtime): improve relaibility of runtime metrics

### DIFF
--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -1,3 +1,5 @@
+import mock
+
 from ddtrace.internal.runtime.constants import CPU_PERCENT
 from ddtrace.internal.runtime.constants import GC_COUNT_GEN0
 from ddtrace.internal.runtime.constants import GC_RUNTIME_METRICS
@@ -7,6 +9,7 @@ from ddtrace.internal.runtime.constants import THREAD_COUNT
 from ddtrace.internal.runtime.metric_collectors import GCRuntimeMetricCollector
 from ddtrace.internal.runtime.metric_collectors import PSUtilRuntimeMetricCollector
 from ddtrace.internal.runtime.metric_collectors import RuntimeMetricCollector
+from ddtrace.vendor import psutil
 from tests.utils import BaseTestCase
 
 
@@ -33,96 +36,48 @@ class TestPSUtilRuntimeMetricCollector(BaseTestCase):
             self.assertRegex(metric_name, r"^runtime.python\..*")
 
     def test_static_metrics(self):
-        import os
-        import threading
-        import time
+        """Verify that PSUtilRuntimeMetricCollector captures mocked psutil values in runtime metrics."""
+        # Mock values for psutil methods
+        mock_cpu_percent = 50.0
+        mock_memory_rss = 1024 * 1024 * 100  # 100 MB
+        mock_thread_count = 5
 
-        from ddtrace.vendor import psutil
+        # Create a mock memory_info object that returns rss
+        mock_memory_info = mock.Mock()
+        mock_memory_info.rss = mock_memory_rss
 
-        # Something to bump CPU utilization
-        def busy_wait(duration_ms):
-            end_time = time.time() + (duration_ms / 1000.0)
-            while time.time() < end_time:
-                pass
-
-        def get_metrics():
-            # need to waste a reading of psutil because some of its reading have
-            # memory and need a previous state
+        # Mock psutil Process methods globally
+        with (
+            mock.patch.object(psutil.Process, "cpu_percent", return_value=mock_cpu_percent),
+            mock.patch.object(psutil.Process, "memory_info", return_value=mock_memory_info),
+            mock.patch.object(psutil.Process, "num_threads", return_value=mock_thread_count),
+        ):
+            # Initialize collector - it will create a Process instance that uses our mocked methods
             collector = PSUtilRuntimeMetricCollector()
-            collector.collect_fn(None)  # wasted
-            proc = psutil.Process(os.getpid())
-            proc.cpu_percent()  # wasted
-
-            # Create some load.  If the duration is too low, then it can cause
-            # wildly different values between readings.
-            busy_wait(50)
-
+            # Get metrics from collector
             runtime_metrics = dict(collector.collect_fn(None))
 
-            with proc.oneshot():
-                psutil_metrics = {
-                    CPU_PERCENT: proc.cpu_percent(),
-                    MEM_RSS: proc.memory_info().rss,
-                    THREAD_COUNT: proc.num_threads(),
-                }
-            return runtime_metrics, psutil_metrics
+        # Assert that ddtrace adds the mocked values to the runtime metrics dict
+        self.assertIn(THREAD_COUNT, runtime_metrics)
+        self.assertEqual(
+            runtime_metrics[THREAD_COUNT],
+            mock_thread_count,
+            "Thread count should match mocked value",
+        )
 
-        def check_metrics(runtime_metrics, psutil_metrics):
-            def within_threshold(a, b, epsilon):
-                return abs(a - b) <= epsilon * max(abs(a), abs(b))
+        self.assertIn(MEM_RSS, runtime_metrics)
+        self.assertEqual(
+            runtime_metrics[MEM_RSS],
+            mock_memory_rss,
+            "Memory RSS should match mocked value",
+        )
 
-            # Number of threads should be precise
-            if psutil_metrics[THREAD_COUNT] != runtime_metrics[THREAD_COUNT]:
-                return False
-
-            # CPU and RAM should be approximate.  These tests are checking that the category of
-            # the value is correct, rather than the specific value itself.
-            epsilon = 0.25
-            if not within_threshold(psutil_metrics[CPU_PERCENT], runtime_metrics[CPU_PERCENT], epsilon):
-                return False
-
-            if not within_threshold(psutil_metrics[MEM_RSS], runtime_metrics[MEM_RSS], epsilon):
-                return False
-
-            return True
-
-        # Sanity-check that the num_threads comparison works
-        rt_metrics, pu_metrics = get_metrics()
-        pu_metrics[THREAD_COUNT] += 1
-        self.assertFalse(check_metrics(rt_metrics, pu_metrics))
-
-        # Check that the CPU comparison works
-        rt_metrics, pu_metrics = get_metrics()
-        pu_metrics[CPU_PERCENT] *= 2
-        self.assertFalse(check_metrics(rt_metrics, pu_metrics))
-
-        # Check that the memory comparison works
-        rt_metrics, pu_metrics = get_metrics()
-        pu_metrics[MEM_RSS] *= 2
-        self.assertFalse(check_metrics(rt_metrics, pu_metrics))
-
-        # Baseline check
-        self.assertTrue(check_metrics(*get_metrics()))
-
-        # Check for threads.  Rather than using a sleep() which might be brittle in CI, use an explicit
-        # semaphore as a stop condition per thread.
-        def thread_stopper(stop_event):
-            stop_event.wait()
-
-        stop_event = threading.Event()
-        threads = [threading.Thread(target=thread_stopper, args=(stop_event,)) for _ in range(10)]
-        _ = [thread.start() for thread in threads]
-        self.assertTrue(check_metrics(*get_metrics()))
-        stop_event.set()
-        _ = [thread.join() for thread in threads]
-
-        # FIXME: this assertion is prone to failure
-        """
-        # Check for RSS
-        wasted_memory = [" "] * 16 * 1024**2  # 16 megs
-        self.assertTrue(check_metrics(*get_metrics()))
-        del wasted_memory
-        """
+        self.assertIn(CPU_PERCENT, runtime_metrics)
+        self.assertEqual(
+            runtime_metrics[CPU_PERCENT],
+            mock_cpu_percent,
+            "CPU percent should match mocked value",
+        )
 
 
 class TestGCRuntimeMetricCollector(BaseTestCase):


### PR DESCRIPTION
## Description

Improves reliability of `test_static_metrics` by replacing timing-dependent assertions with mocked psutil methods. The test now verifies that `PSUtilRuntimeMetricCollector` correctly captures psutil values in the runtime metrics dictionary (sample [failures](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.status%3Afail%20%40git.branch%3A%28main%20OR%20master%29%20%40git.repository.id_v2%3A%2Add-trace%2A%20%40git.repository.id_v2%3A%2Add-trace-py%2A%20-%40test.is_retry%3A%2A%20%40test.codeowners%3A%40DataDog%2Fapm-sdk-capabilities-python&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZuaPqP6hBHdoAAAABhBWnVhUHFZOEFBQlRMVDlEWmNlLWl3R3oAAAAkZjE5YjlhM2YtYTE1Zi00NWY2LTk5YmYtNDgwMWE5ZmU2OThjAABX0g&fromUser=false&index=citest&panel=%7B%22queryString%22%3A%22%40test.name%3A%5C%22TestPSUtilRuntimeMetricCollector%3A%3Atest_static_metrics%5Bpy3.9%5D%5C%22%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22test.name%22%2C%22value%22%3A%22TestPSUtilRuntimeMetricCollector%3A%3Atest_static_metrics%5Bpy3.9%5D%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1760123496000%2C%22to%22%3A1767899496000%2C%22live%22%3Atrue%7D%7D&testId=AwAAAZuaPqP6hBHdoAAAABhBWnVhUHFZOEFBQlRMVDlEWmNlLWl3R3oAAAAkZjE5YjlhM2YtYTE1Zi00NWY2LTk5YmYtNDgwMWE5ZmU2OThjAABX0g&top_n=50&top_o=top&trace=AwAAAZuaPqP6hBHdoAAAABhBWnVhUHFZOEFBQlRMVDlEWmNlLWl3R3oAAAAkZjE5YjlhM2YtYTE1Zi00NWY2LTk5YmYtNDgwMWE5ZmU2OThjAABX0g&viz=toplist&x_missing=true&start=1760125511642&end=1767901511642&paused=true)).

## Testing

- Mock `cpu_percent()`, `memory_info()`, and `num_threads()` globally for `psutil.Process`
- Assert that mocked values are correctly added to the runtime metrics dict

## Risks

None - Only modifies test code to improve reliability.
