### PR TITLE
test(profiling): fix flaky RLock Profiler test [backport 4.0]

### DIFF
--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -11,6 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from typing import cast
 import uuid
 
 import mock
@@ -20,6 +21,7 @@ from ddtrace import ext
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingLockCollector
 from ddtrace.profiling.collector.threading import ThreadingRLockCollector
 from tests.profiling.collector import pprof_utils
@@ -462,7 +464,15 @@ class BaseThreadingLockCollectorTest:
         )  # pyright: ignore[reportCallIssue]
         ddup.start()
 
-    def teardown_method(self, method: Callable[..., None]) -> None:
+        # Clear any accumulated samples that have been created by other unrelated tests
+        # and that may interfere with our tests.
+        ddup.upload()
+
+    def teardown_method(self) -> None:
+        # Clear any accumulated samples that have not been uploaded and may interfere
+        # with subsequent tests.
+        ddup.upload()
+
         # might be unnecessary but this will ensure that the file is removed
         # after each successful test, and when a test fails it's easier to
         # pinpoint and debug.
@@ -1163,9 +1173,10 @@ class BaseThreadingLockCollectorTest:
         # Allow up to 50x overhead since lock operations are extremely fast (microseconds)
         # and wrapper overhead is constant per call
         overhead_multiplier: float = profiled_time_zero / regular_time if regular_time > 0 else 1
-        assert (
-            overhead_multiplier < 50
-        ), f"Overhead too high: {overhead_multiplier}x (regular: {regular_time:.6f}s, profiled: {profiled_time_zero:.6f}s)"  # noqa: E501
+        assert overhead_multiplier < 50, (
+            f"Overhead too high: {overhead_multiplier}x (regular: {regular_time:.6f}s, "
+            f"profiled: {profiled_time_zero:.6f}s)"
+        )
 
     def test_release_not_sampled_when_acquire_not_sampled(self) -> None:
         """Test that lock release events are NOT sampled if their corresponding acquire was not sampled."""
@@ -1175,6 +1186,7 @@ class BaseThreadingLockCollectorTest:
             # Do multiple acquire/release cycles
             for _ in range(10):
                 lock.acquire()
+                assert cast(_ProfiledLock, lock).acquired_time is None
                 time.sleep(0.001)
                 lock.release()
 


### PR DESCRIPTION
## Description

Backport of #15655. This is currently our top most flaky test in `4.0` (see [here](https://app.datadoghq.com/notebook/13705222/dd-trace-py-profiling-tests?refresh_mode=sliding&tpl_var_branch%5B0%5D=4.0&tpl_var_ignored_tests%5B0%5D=%2Agunicorn%2A&from_ts=1767856688326&to_ts=1767943088326)).

This PR fixes flakiness in
`test_release_not_sampled_when_acquire_not_sampled` by calling `ddup.upload` in `teardown` and `setup`. As we use the data sent by `ddup` to check whether the Profiler created any Samples, any remaining state/Samples from previous tests (that wouldn't have uploaded because they didn't need to for testing what they test) could pollute our assumption.

Note that we're calling `upload` both in setup and teardown, and not only in teardown, to hedge us against other completely unrelated tests that may have pushed some state into `ddup` and not cleaned up.
