### PR TITLE
fix(profiling): upload Profiles on exit signals

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -71,6 +71,10 @@ class Profiler(object):
 
         if stop_on_exit:
             atexit.register(self.stop)
+            # Also register for SIGTERM/SIGINT to flush profiles before exit.
+            # This is important for environments like uWSGI with --skip-atexit
+            # where Python's atexit handlers are not called.
+            atexit.register_on_exit_signal(self.stop)
 
         if profile_children:
             forksafe.register(self._restart_on_fork)

--- a/releasenotes/notes/profiling-flush-profile-on-exit-signal-abfa7c1e9d7ae893.yaml
+++ b/releasenotes/notes/profiling-flush-profile-on-exit-signal-abfa7c1e9d7ae893.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: Profiles are now flushed before exit when an exit signal is received. This addresses an issue where the
+    last profile was not flushed when the process exited using uWSGI with ``--skip-atexit``.


### PR DESCRIPTION
## Description

This updates the Python Profiler to register itself for callback on "exit signals" (e.g. `SIGTERM`). This is important in cases like uWSGI with `--skip-atexit` which terminates processes without calling exit handlers, because failing to do so would cause empty Profiles.

```
builtins.AssertionError: No samples found in profile
```

This bug was detected while trying to fix flakiness for `test_uwsgi_threads_processes_no_primary_lazy_apps`. It apparently has been flaking since `Nov 30, 2025, 1:27 am` (but I think we may just not have data from before then).

[See test runs](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3A%2Add-trace-py%20%40ci.job.name%3A%2Aprofil%2A%20%40test.suite%3Atest_uwsgi.py%20status%3Aerror%20%40git.branch%3Akowalski%2Ffix-profiling-upload-profiles-on-exit-signals%20-%28%40git.commit.sha%3Aaf66cfddf3053c4b4d3b0444c851bc27f8793aa5%20OR%20%22this%20commit%20was%20removed%20from%20the%20branch%22%29&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22warm%22%2Cnull%2Cnull%2C%22value%22%5D&currentTab=overview&eventStack=&fromUser=true&index=citest&mode=sliding&top_n=100&top_o=top&viz=timeseries&x_missing=true&start=1767695904000&end=1767955104000&paused=true)