### PR TITLE
ci(profiling): disable native tests temporarily

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -407,6 +407,7 @@ profiling_native:
   stage: tests
   tags: [ "arch:amd64" ]
   image: registry.ddbuild.io/images/mirror/ubuntu:25.04
+  allow_failure: true
   parallel:
     matrix:
       - PYTHON: ["3.9.24", "3.10.19", "3.11.14", "3.12.12", "3.13.11", "3.14.2"]


### PR DESCRIPTION
## Description

This temporarily disables the `profiling_native` jobs in the CI as they have been flaking (or even failing consistently) since we've moved them to GitLab. 

I am working on a fix in parallel, but we should not stop work from getting done in the meantime (discussed on Slack). 