### PR TITLE
ci: update system-tests version [4.2]

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c35863e8e9f5872e27e5f6cf0be8fae82288a4ff'
+          ref: '8a9c1ebe35573fafb6d47af1f9b239a608c3748b'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c35863e8e9f5872e27e5f6cf0be8fae82288a4ff'
+          ref: '8a9c1ebe35573fafb6d47af1f9b239a608c3748b'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -323,7 +323,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c35863e8e9f5872e27e5f6cf0be8fae82288a4ff'
+          ref: '8a9c1ebe35573fafb6d47af1f9b239a608c3748b'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -381,7 +381,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@c35863e8e9f5872e27e5f6cf0be8fae82288a4ff
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@8a9c1ebe35573fafb6d47af1f9b239a608c3748b
     secrets: inherit
     permissions:
       contents: read
@@ -412,7 +412,7 @@ jobs:
   integration-frameworks-system-tests:
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@c35863e8e9f5872e27e5f6cf0be8fae82288a4ff
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@8a9c1ebe35573fafb6d47af1f9b239a608c3748b
     secrets: inherit
     permissions:
       contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "c35863e8e9f5872e27e5f6cf0be8fae82288a4ff"
+  SYSTEM_TESTS_REF: "8a9c1ebe35573fafb6d47af1f9b239a608c3748b"
 
 default:
   interruptible: true


### PR DESCRIPTION
## Description

Update system tests because they fail in 4.2 at the moment (see this: https://github.com/DataDog/dd-trace-py/pull/15981).

<img width="1032" height="253" alt="image" src="https://github.com/user-attachments/assets/0e007246-c376-4dbd-b85e-ec706ba73c72" />
