### PR TITLE
fix(debugging): avoid iterating over mutating __dict__

### DIFF
--- a/ddtrace/debugging/_safety.py
+++ b/ddtrace/debugging/_safety.py
@@ -65,9 +65,8 @@ def safe_getitem(obj, index):
 
 def _safe_dict(o: Any) -> Dict[str, Any]:
     try:
-        __dict__ = object.__getattribute__(o, "__dict__")
-        if type(__dict__) is dict:
-            return __dict__
+        if type(__dict__ := object.__getattribute__(o, "__dict__")) is dict:
+            return __dict__.copy()
     except Exception:
         pass  # nosec
 

--- a/releasenotes/notes/fix-debugging-safe-dict-no-iter-mutation-cff876c3dce4bc50.yaml
+++ b/releasenotes/notes/fix-debugging-safe-dict-no-iter-mutation-cff876c3dce4bc50.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    exception replay: avoid ``RuntimeError`` caused by capturing the 
+    ``__dict__`` attribute of an object that mutates during iteration.


### PR DESCRIPTION
## Description

We prevent iterations over the bare ``__dict__`` attribute of an object that can mutate while the values are captured by returning a shallow copy of the dictionary.

## Additional Notes

Addresses reports in #15182.