### PR TITLE
test(profiling): fix flaky RLock Profiler test [backport 4.0]

### DIFF
--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -43,8 +43,7 @@ LockClassInst = Union[_thread.LockType, _thread.RLock]
 _test_global_lock: LockClassInst
 
 
-class TestBar:
-    ...
+class TestBar: ...
 
 
 _test_global_bar_instance: TestBar


### PR DESCRIPTION
## Description

This is a backport of #15655 to 4.0.