### PR TITLE
test(profiling): fix flaky RLock Profiler test [backport 3.19]

### DIFF
--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -11,6 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from typing import cast
 import uuid
 
 import mock
@@ -21,6 +22,7 @@ from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
+from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingLockCollector
 from ddtrace.profiling.collector.threading import ThreadingRLockCollector
 from tests.profiling.collector import pprof_utils
@@ -461,7 +463,15 @@ class BaseThreadingLockCollectorTest:
         )  # pyright: ignore[reportCallIssue]
         ddup.start()
 
-    def teardown_method(self, method: Callable[..., None]) -> None:
+        # Clear any accumulated samples that have been created by other unrelated tests
+        # and that may interfere with our tests.
+        ddup.upload()
+
+    def teardown_method(self) -> None:
+        # Clear any accumulated samples that have not been uploaded and may interfere
+        # with subsequent tests.
+        ddup.upload()
+
         # might be unnecessary but this will ensure that the file is removed
         # after each successful test, and when a test fails it's easier to
         # pinpoint and debug.
@@ -1162,9 +1172,10 @@ class BaseThreadingLockCollectorTest:
         # Allow up to 50x overhead since lock operations are extremely fast (microseconds)
         # and wrapper overhead is constant per call
         overhead_multiplier: float = profiled_time_zero / regular_time if regular_time > 0 else 1
-        assert (
-            overhead_multiplier < 50
-        ), f"Overhead too high: {overhead_multiplier}x (regular: {regular_time:.6f}s, profiled: {profiled_time_zero:.6f}s)"  # noqa: E501
+        assert overhead_multiplier < 50, (
+            f"Overhead too high: {overhead_multiplier}x (regular: {regular_time:.6f}s, "
+            f"profiled: {profiled_time_zero:.6f}s)"
+        )
 
     def test_release_not_sampled_when_acquire_not_sampled(self) -> None:
         """Test that lock release events are NOT sampled if their corresponding acquire was not sampled."""
@@ -1174,6 +1185,7 @@ class BaseThreadingLockCollectorTest:
             # Do multiple acquire/release cycles
             for _ in range(10):
                 lock.acquire()
+                assert cast(_ProfiledLock, lock).acquired_time is None
                 time.sleep(0.001)
                 lock.release()
 


### PR DESCRIPTION
## Description

This is a backport of #15655 to 3.19.