### PR TITLE
fix(profiling): enable serialization of wrapped lock objects in Python Lock profiler [backport 3.19]

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -38,6 +38,33 @@ def _current_thread() -> Tuple[int, str]:
     return thread_id, _threading.get_thread_name(thread_id)
 
 
+def _get_original_lock_class(module_name: str, class_name: str) -> Callable[..., Any]:
+    """Reconstruct the original lock class when unpickling. Since this is a module-level function, it can be pickled."""
+    import importlib
+
+    module: ModuleType = importlib.import_module(module_name)
+    obj: _LockAllocatorWrapper | Callable[..., Any] = getattr(module, class_name)
+
+    # If the object is still wrapped (profiling active in this process), unwrap it. Else, return the original object.
+    if isinstance(obj, _LockAllocatorWrapper) and obj._original_class:
+        return obj._original_class
+
+    return obj
+
+
+def _create_original_lock_instance(module_name: str, class_name: str) -> Any:
+    """Create an instance of the original lock class when unpickling a _ProfiledLock."""
+    # Map internal _thread types to their threading module counterparts, as they're not directly accessible.
+    if module_name == "_thread":
+        if class_name == "lock":
+            module_name, class_name = "threading", "Lock"
+        elif class_name == "RLock":
+            module_name, class_name = "threading", "RLock"
+
+    lock_class = _get_original_lock_class(module_name, class_name)
+    return lock_class()
+
+
 class _ProfiledLock:
     """
     Lightweight lock wrapper that profiles lock acquire/release operations.
@@ -88,6 +115,18 @@ class _ProfiledLock:
 
     def __repr__(self) -> str:
         return f"<_ProfiledLock({self.__wrapped__!r}) at {self.init_location}>"
+
+    def __reduce__(self) -> Tuple[Callable[[str, str], Any], Tuple[str, str]]:
+        """Support pickling by returning the wrapped lock.
+
+        In the context of multiprocessing, the child process will get the unwrapped lock class, which will be re-wrapped
+        if profiling is enabled there.
+        """
+        wrapped_type = type(self.__wrapped__)
+        return (
+            _create_original_lock_instance,
+            (wrapped_type.__module__, wrapped_type.__qualname__),
+        )
 
     ### Regular methods ###
 
@@ -256,6 +295,15 @@ class _LockAllocatorWrapper:
         # Prevent automatic method binding (e.g., Foo.lock_class = threading.Lock)
         return self
 
+    def __getattr__(self, name: str) -> Any:
+        # Delegate attribute access to the original class.
+        # This is needed for Semaphore/BoundedSemaphore inheritance where code accesses
+        # Semaphore.__init__ c-tor through our wrapper.
+        original_class: Optional[Type[Any]] = object.__getattribute__(self, "_original_class")
+        if original_class is not None:
+            return getattr(original_class, name)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
     def __mro_entries__(self, bases: Tuple[Any, ...]) -> Tuple[Type[Any], ...]:
         """Support subclassing the wrapped lock type (PEP 560).
 
@@ -266,6 +314,20 @@ class _LockAllocatorWrapper:
         This method returns the actual lock type to be used as the base class.
         """
         return (self._original_class,)  # type: ignore[return-value]
+
+    def __reduce__(self) -> Tuple[Callable[[str, str], Callable[..., Any]], Tuple[str, str]]:
+        """Support pickling by returning the original class.
+
+        In the context of multiprocessing, the child process will get the unwrapped lock class, which will be re-wrapped
+        if profiling is enabled there.
+        """
+        if self._original_class is None:
+            raise TypeError("Cannot pickle uninitialized _LockAllocatorWrapper")
+
+        return (
+            _get_original_lock_class,
+            (self._original_class.__module__, self._original_class.__qualname__),
+        )
 
 
 class LockCollector(collector.CaptureSamplerCollector):

--- a/releasenotes/notes/profiling-fix-lock-pickle-serialization-c112813a9f3a3baf.yaml
+++ b/releasenotes/notes/profiling-fix-lock-pickle-serialization-c112813a9f3a3baf.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    profiling: Fixes a ``PicklingError`` when using ``multiprocessing.Manager()`` with lock profiling
+    enabled on Python 3.14+. Python 3.14 changed the default multiprocessing start method from
+    ``fork`` to ``forkserver``, which requires all objects to be pickleable. The lock profiler's
+    wrappers now properly support pickle serialization.
+

--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import _thread
 import glob
 import os
+import pickle
 import sys
 import threading
 import time
@@ -39,6 +40,9 @@ CollectorClassType = Union[Type[ThreadingLockCollector], Type[ThreadingRLockColl
 # threading.Lock and threading.RLock are factory functions that return _thread types.
 # We reference the underlying _thread types directly to avoid creating instances at import time.
 LockClassInst = Union[_thread.LockType, _thread.RLock]
+# Type aliases for pickle tests
+LockTypeInst = Union[_thread.LockType, _thread.RLock]
+LockTypeClass = Type[LockTypeInst]
 
 # Module-level globals for testing global lock profiling
 _test_global_lock: LockClassInst
@@ -497,6 +501,23 @@ class BaseThreadingLockCollectorTest:
 
             # Try this way too
             Foobar(self.lock_class)
+
+    def _assert_pickle_roundtrip(self, obj: object, wrapped_type: type) -> Union[LockTypeClass, LockTypeInst]:
+        """Helper to verify an object can be pickled and unwraps correctly."""
+        assert isinstance(obj, wrapped_type)
+        unpickled = pickle.loads(pickle.dumps(obj))
+        assert not isinstance(unpickled, wrapped_type)
+        return unpickled
+
+    def test_lock_class_pickle(self) -> None:
+        """Test that the wrapped lock class can be pickled (Python 3.14+ forkserver compat)."""
+        with self.collector_class(capture_pct=100):
+            self._assert_pickle_roundtrip(self.lock_class, LockAllocatorWrapper)
+
+    def test_lock_instance_pickle(self) -> None:
+        """Test that profiled lock instances can be pickled (Python 3.14+ forkserver compat)."""
+        with self.collector_class(capture_pct=100):
+            self._assert_pickle_roundtrip(self.lock_class(), _ProfiledLock)
 
     def test_lock_events(self):
         # The first argument is the recorder.Recorder which is used for the


### PR DESCRIPTION
## Description
This PR back-ports a bug fix (#15899) to v3.19.

## Testing
* CI