### PR TITLE
fix(profiling): prevent unbounded loop in interpreter iteration

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/interp.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/interp.cc
@@ -5,21 +5,45 @@ for_each_interp(_PyRuntimeState* runtime, std::function<void(InterpreterInfo& in
 {
     InterpreterInfo interpreter_info = { 0 };
 
-    for (char* interp_addr = reinterpret_cast<char*>(runtime->interpreters.head); interp_addr != NULL;
-         interp_addr = reinterpret_cast<char*>(interpreter_info.next)) {
-        if (copy_type(interp_addr + offsetof(PyInterpreterState, id), interpreter_info.id))
+    // Limit interpreter iteration to prevent infinite loops from cycles or corrupted memory.
+    // This limit is based on CPython's tachyon profiler (256) and should be more than
+    // enough for realistic use cases (most applications use 1 interpreter).
+    const size_t MAX_INTERPRETERS = 256;
+
+    char* interp_addr = reinterpret_cast<char*>(runtime->interpreters.head);
+    char* prev_interp_addr = nullptr;
+
+    // Safety: prevent infinite loops from cycles or corrupted interpreter linked lists
+    for (size_t iteration_count = 0; iteration_count < MAX_INTERPRETERS && interp_addr != NULL; ++iteration_count) {
+
+        // Cycle detection: if we didn't advance from previous iteration, we're stuck
+        if (prev_interp_addr != nullptr && interp_addr == prev_interp_addr) {
+            break; // Cycle detected or failed to advance
+        }
+        prev_interp_addr = interp_addr;
+
+        // Always read next pointer first - we need it to advance
+        if (copy_type(interp_addr + offsetof(PyInterpreterState, next), interpreter_info.next))
+            break; // Can't read next, can't advance - stop iteration
+
+        if (copy_type(interp_addr + offsetof(PyInterpreterState, id), interpreter_info.id)) {
+            interp_addr = reinterpret_cast<char*>(interpreter_info.next);
             continue;
+        }
 
 #if PY_VERSION_HEX >= 0x030b0000
         if (copy_type(interp_addr + offsetof(PyInterpreterState, threads.head), interpreter_info.tstate_head))
 #else
         if (copy_type(interp_addr + offsetof(PyInterpreterState, tstate_head), interpreter_info.tstate_head))
 #endif
+        {
+            interp_addr = reinterpret_cast<char*>(interpreter_info.next);
             continue;
-
-        if (copy_type(interp_addr + offsetof(PyInterpreterState, next), interpreter_info.next))
-            continue;
+        }
 
         callback(interpreter_info);
-    };
+
+        // Move to next interpreter
+        interp_addr = reinterpret_cast<char*>(interpreter_info.next);
+    }
 }

--- a/releasenotes/notes/profiling-interpreter-loop-45f5a6d7bab9bbd6.yaml
+++ b/releasenotes/notes/profiling-interpreter-loop-45f5a6d7bab9bbd6.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where the stack profiler could loop
+    infinitely when iterating through Python interpreter states. This could have
+    occurred if the interpreter linked list became corrupted or contained a cycle,
+    potentially causing the profiler to hang. The fix adds both cycle detection
+    and an iteration limit (256 interpreters) to prevent unbounded loops.


### PR DESCRIPTION
## Description

Since most applications use single Python interpreter, this would rarely happen, but in theory can loop infinitely. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->

https://datadoghq.atlassian.net/browse/PROF-13436