### PR TITLE
fix(profiling): salt `StringTable` keys with tag

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
@@ -29,21 +29,45 @@ Result<std::string>
 pyunicode_to_utf8(PyObject* str_addr);
 
 // ----------------------------------------------------------------------------
+// NOTE: StringTag is used to salt the upper bits of string table keys.
+// This prevents collisions when Python reuses memory addresses for different
+// types of strings (e.g., a Task name getting deallocated and the same address
+// being reused for a code object's name). Without tags, we'd return stale
+// cached values for the wrong string type.
+enum class StringTag : uint8_t
+{
+    Unknown = 0,     // Default/untagged (for backwards compatibility)
+    FileName = 1,    // co_filename from code objects
+    FuncName = 2,    // co_name / co_qualname from code objects
+    TaskName = 3,    // asyncio Task names
+    GreenletName = 4 // greenlet names
+};
 
 class StringTable : public std::unordered_map<uintptr_t, std::string>
 {
   public:
     using Key = uintptr_t;
 
+    // Tag is stored in the upper 8 bits of the key (bits 56-63).
+    // On x86_64, only 48 bits are used for virtual addresses, so this is safe.
+    // On other architectures with larger address spaces, collisions are still
+    // unlikely and the worst case is just a cache miss (re-read the string).
+    static constexpr int TAG_SHIFT = 56;
+    static constexpr Key TAG_MASK = static_cast<Key>(0xFF) << TAG_SHIFT;
+
+    [[nodiscard]] static constexpr Key make_tagged_key(uintptr_t addr, StringTag tag)
+    {
+        return (addr & ~TAG_MASK) | (static_cast<Key>(tag) << TAG_SHIFT);
+    }
+
     static constexpr Key INVALID = 1;
     static constexpr Key UNKNOWN = 2;
     static constexpr Key C_FRAME = 3;
 
     // Python string object
-    [[nodiscard]] Result<Key> key(PyObject* s);
+    [[nodiscard]] Result<Key> key(PyObject* s, StringTag tag = StringTag::Unknown);
 
-    // Python string object
-    [[nodiscard]] Key key_unsafe(PyObject* s);
+    [[nodiscard]] Key key_unsafe(PyObject* s, StringTag tag = StringTag::Unknown);
 
     [[nodiscard]] Result<std::reference_wrapper<const std::string>> lookup(Key key) const;
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -60,15 +60,15 @@ reset_frame_cache()
 Result<Frame::Ptr>
 Frame::create(PyCodeObject* code, int lasti)
 {
-    auto maybe_filename = string_table.key(code->co_filename);
+    auto maybe_filename = string_table.key(code->co_filename, StringTag::FileName);
     if (!maybe_filename) {
         return ErrorKind::FrameError;
     }
 
 #if PY_VERSION_HEX >= 0x030b0000
-    auto maybe_name = string_table.key(code->co_qualname);
+    auto maybe_name = string_table.key(code->co_qualname, StringTag::FuncName);
 #else
-    auto maybe_name = string_table.key(code->co_name);
+    auto maybe_name = string_table.key(code->co_name, StringTag::FuncName);
 #endif
 
     if (!maybe_name) {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -107,7 +107,7 @@ TaskInfo::create(TaskObj* task_addr)
         return ErrorKind::TaskInfoGeneratorError;
     }
 
-    auto maybe_name = string_table.key(task.task_name);
+    auto maybe_name = string_table.key(task.task_name, StringTag::TaskName);
     if (!maybe_name) {
         recursion_depth--;
         return ErrorKind::TaskInfoError;

--- a/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
@@ -210,7 +210,7 @@ track_greenlet(PyObject* Py_UNUSED(m), PyObject* args)
     if (!PyArg_ParseTuple(args, "lOO", &greenlet_id, &name, &frame))
         return NULL;
 
-    auto maybe_greenlet_name = string_table.key(name);
+    auto maybe_greenlet_name = string_table.key(name, StringTag::GreenletName);
     if (!maybe_greenlet_name) {
         // We failed to get this task but we keep going
         PyErr_SetString(PyExc_RuntimeError, "Failed to get greenlet name from the string table");

--- a/releasenotes/notes/profiling-salt-string-table-keys-3c42c34b842f8c48.yaml
+++ b/releasenotes/notes/profiling-salt-string-table-keys-3c42c34b842f8c48.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: An issue where a duplicate key in a cache could lead to inconsistent profiles has been fixed.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13207

This PR addresses a bug where keys in the `StringTable` could collide even for unrelated objects, leading to very surprising bugs (e.g. Task names like `<module>`). The root cause, in short, is that `StringTable` keys are just the address (`uintptr_t`) of what the string represents (e.g. a Task name, a function name, a file name, etc.). Some assumptions that hold for functions (they never get freed in normal circumstances) do not for Tasks (Tasks can be garbage collected, and Task objects can be reused for subsequent Tasks). More details available on Jira.

**Note** This will not help with the same address being reused to store the name of two different Tasks (which I don’t expect to happen very often anyway), but it’d be a step in the right direction for almost free.