### PR TITLE
chore(profiling): add `StringTable` size in internal payload

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -25,6 +25,9 @@ class ProfilerStats
     // The latest sampling interval (in microseconds) as determined by adaptive sampling
     std::optional<size_t> sampling_interval_us;
 
+    // Number of entries in the echion StringTable
+    std::optional<size_t> string_table_count;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -37,6 +40,9 @@ class ProfilerStats
 
     void set_sampling_interval_us(size_t interval_us);
     std::optional<size_t> get_sampling_interval_us();
+
+    void set_string_table_count(size_t count);
+    std::optional<size_t> get_string_table_count();
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -44,6 +44,7 @@ Datadog::ProfilerStats::reset_state()
     sample_count = 0;
     sampling_event_count = 0;
     sampling_interval_us = std::nullopt;
+    string_table_count = std::nullopt;
 }
 
 void
@@ -58,6 +59,18 @@ Datadog::ProfilerStats::get_sampling_interval_us()
     return sampling_interval_us;
 }
 
+void
+Datadog::ProfilerStats::set_string_table_count(size_t count)
+{
+    string_table_count = count;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_string_table_count()
+{
+    return string_table_count;
+}
+
 std::string
 Datadog::ProfilerStats::get_internal_metadata_json()
 {
@@ -70,6 +83,13 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_sampling_interval) {
         internal_metadata_json += R"("sampling_interval_us": )";
         append_to_string(internal_metadata_json, *maybe_sampling_interval);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_string_table_count = get_string_table_count();
+    if (maybe_string_table_count) {
+        internal_metadata_json += R"("string_table_count": )";
+        append_to_string(internal_metadata_json, *maybe_string_table_count);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
@@ -150,6 +150,12 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
         return std::ref(it->second);
     };
 
+    [[nodiscard]] inline size_t size() const
+    {
+        const std::lock_guard<std::mutex> lock(table_lock);
+        return std::unordered_map<uintptr_t, std::string>::size();
+    };
+
     StringTable()
       : std::unordered_map<uintptr_t, std::string>()
     {

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -7,6 +7,7 @@
 #include "echion/errors.h"
 #include "echion/greenlets.h"
 #include "echion/interp.h"
+#include "echion/strings.h"
 #include "echion/tasks.h"
 #include "echion/threads.h"
 #include "echion/vm.h"
@@ -182,6 +183,7 @@ Sampler::sampling_thread(const uint64_t seq_num)
         });
 
         Sample::profile_borrow().stats().increment_sampling_event_count();
+        Sample::profile_borrow().stats().set_string_table_count(string_table.size());
 
         if (do_adaptive_sampling) {
             // Adjust the sampling interval at most every second


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13207 

This PR adds a new `string_table_count` field to the internal payload for Profiles. This will allow us to debug potential memory leaks caused by the String Table (and more specifically not cleaning it up).   

This may actually actually be useful very soon to debug [this customer ticket](https://datadoghq.atlassian.net/browse/SCP-1046).

[Example Events UI query](https://ddstaging.datadoghq.com/internal/events-ui/queries?agg=min~%2540internal.string_table_count&group_by=&interval=15000&query_string=language%3Apython%20version%3A2026-01-13-14-24%20&query_type=timeseries&timerange=1768309931543-1768310831543l&track=profile)

Example result (the script I have produces a lot of Task names ⇒ lots of strings in the String Table)

<img width="1894" height="685" alt="image" src="https://github.com/user-attachments/assets/3aefa074-eb47-4943-b3d2-3e9e3dc25da8" />

and on a longer time range...

<img width="878" height="682" alt="image" src="https://github.com/user-attachments/assets/1986183c-1d6e-40f9-8db4-52480a5e5d07" />

Note that here with ~20k items in the cache in our case, it'd be 20k * (20 bytes (overhead) + say 30 bytes (contents)) so about 1000k/1M, which isn't... that much by any modern standards. So not sure if that would be a problem in real life.