### PR TITLE
chore(tests): fix flaky tests from mock import

### DIFF
--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from ddtrace.internal.runtime.constants import CPU_PERCENT
 from ddtrace.internal.runtime.constants import GC_COUNT_GEN0


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

- Fix flaky tracer wrap tests that started failing after #15952
- I think there was an import error at the module level that was causing test discovery and import order issues that made the tests flaky, particularly the generator wrapping test. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
