### PR TITLE
chore(llm): fix service naming docs

### DIFF
--- a/ddtrace/contrib/internal/anthropic/__init__.py
+++ b/ddtrace/contrib/internal/anthropic/__init__.py
@@ -31,8 +31,5 @@ Configuration
 
    The service name reported by default for Anthropic requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_ANTHROPIC_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_ANTHROPIC_SERVICE`` environment variable.
 """  # noqa: E501

--- a/ddtrace/contrib/internal/crewai/__init__.py
+++ b/ddtrace/contrib/internal/crewai/__init__.py
@@ -24,8 +24,5 @@ Configuration
 
    The service name reported by default for CrewAI requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_CREWAI_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_CREWAI_SERVICE`` environment variable.
 """  # noqa: E501

--- a/ddtrace/contrib/internal/google_adk/__init__.py
+++ b/ddtrace/contrib/internal/google_adk/__init__.py
@@ -21,9 +21,6 @@ Configuration
 
    The service name reported by default for Google ADK requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_GOOGLE_ADK_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Set this option with the ``DD_GOOGLE_ADK_SERVICE`` environment variable.
 
 """

--- a/ddtrace/contrib/internal/google_genai/__init__.py
+++ b/ddtrace/contrib/internal/google_genai/__init__.py
@@ -28,8 +28,5 @@ Configuration
 
    The service name reported by default for Google GenAI requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_GOOGLE_GENAI_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_GOOGLE_GENAI_SERVICE`` environment variable.
 """

--- a/ddtrace/contrib/internal/langchain/__init__.py
+++ b/ddtrace/contrib/internal/langchain/__init__.py
@@ -59,10 +59,6 @@ Configuration
 
    The service name reported by default for LangChain requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_LANGCHAIN_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
-
+   Alternatively, set this option with the ``DD_LANGCHAIN_SERVICE`` environment variable.
 
 """  # noqa: E501

--- a/ddtrace/contrib/internal/langgraph/__init__.py
+++ b/ddtrace/contrib/internal/langgraph/__init__.py
@@ -20,7 +20,5 @@ Configuration
 
 .. py:data:: ddtrace.config.langgraph["service"]
    The service name reported by default for LangGraph requests.
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_LANGGRAPH_SERVICE`` environment
-   variables.
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_LANGGRAPH_SERVICE`` environment variable.
 """

--- a/ddtrace/contrib/internal/litellm/__init__.py
+++ b/ddtrace/contrib/internal/litellm/__init__.py
@@ -28,8 +28,5 @@ Configuration
 
    The service name reported by default for LiteLLM requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_LITELLM_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_LITELLM_SERVICE`` environment variable.
 """  # noqa: E501

--- a/ddtrace/contrib/internal/mcp/__init__.py
+++ b/ddtrace/contrib/internal/mcp/__init__.py
@@ -21,9 +21,7 @@ Configuration
 
 .. py:data:: ddtrace.config.mcp["service"]
    The service name reported by default for MCP requests.
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_MCP_SERVICE`` environment
-   variables.
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_MCP_SERVICE`` environment variable.
 
 .. py:data:: ddtrace.config.mcp["distributed_tracing"]
    Whether or not to enable distributed tracing for MCP requests.

--- a/ddtrace/contrib/internal/openai/__init__.py
+++ b/ddtrace/contrib/internal/openai/__init__.py
@@ -56,8 +56,5 @@ Configuration
 
    The service name reported by default for OpenAI requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_OPENAI_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_OPENAI_SERVICE`` environment variable.
 """  # noqa: E501

--- a/ddtrace/contrib/internal/openai_agents/__init__.py
+++ b/ddtrace/contrib/internal/openai_agents/__init__.py
@@ -24,8 +24,5 @@ Configuration
 
    The service name reported by default for OpenAI Agents requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_OPENAI_AGENTS_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_OPENAI_AGENTS_SERVICE`` environment variable.
 """  # noqa: E501

--- a/ddtrace/contrib/internal/pydantic_ai/__init__.py
+++ b/ddtrace/contrib/internal/pydantic_ai/__init__.py
@@ -26,8 +26,5 @@ Configuration
 
    The service name reported by default for PydanticAI requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_PYDANTIC_AI_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_PYDANTIC_AI_SERVICE`` environment variable.
 """  # noqa: E501

--- a/ddtrace/contrib/internal/vertexai/__init__.py
+++ b/ddtrace/contrib/internal/vertexai/__init__.py
@@ -28,8 +28,5 @@ Configuration
 
    The service name reported by default for Vertex AI requests.
 
-   Alternatively, you can set this option with the ``DD_SERVICE`` or ``DD_VERTEXAI_SERVICE`` environment
-   variables.
-
-   Default: ``DD_SERVICE``
+   Alternatively, set this option with the ``DD_VERTEXAI_SERVICE`` environment variable.
 """  # noqa: E501


### PR DESCRIPTION
## Description

Update LLM integration service name configuration documentation to use `DD_<integration>_SERVICE` environment variables.

**Context:** Some customers have service names remapped in the Datadog UI, where `DD_SERVICE` is the resolved service name but the integration-specific service name (`DD_<integration>_SERVICE`) is what's actually encoded in spans. We also have `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` which is poorly documented.

This PR updates documentation to reflect the actual span data sent by ddtrace, ensuring it matches what customers see in their raw trace data.

## Testing

- Documentation changes only, no code logic modified

## Risks

**Low risk** - Documentation only. No code changes.

## Additional Notes

None
