### PR TITLE
test(profiling): unflake `test_multiprocessing` (#15990) [backport 4.1]

### DIFF
--- a/tests/profiling/_test_multiprocessing.py
+++ b/tests/profiling/_test_multiprocessing.py
@@ -1,15 +1,17 @@
 import multiprocessing
 import os
 import sys
-import time
 
 
 def f():
     import ddtrace.profiling.bootstrap
 
-    profiler = ddtrace.profiling.bootstrap.profiler
-    for _ in range(50):
-        time.sleep(0.1)
+    profiler = ddtrace.profiling.bootstrap.profiler  # pyright: ignore[reportAttributeAccessIssue]
+    # Do some CPU work to ensure we get samples
+    total = 0
+    for i in range(5_000_000):
+        total += i
+
     # Manually stop the profiler: atexit hooks are not called in subprocesses launched by multiprocessing and we want to
     # be sure the profile are flushed out
     profiler.stop()

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -158,7 +158,7 @@ def test_multiprocessing(method: str, tmp_path: Path) -> None:
     env = os.environ.copy()
     env["DD_PROFILING_OUTPUT_PPROF"] = filename
     env["DD_PROFILING_ENABLED"] = "1"
-    env["DD_PROFILING_CAPTURE_PCT"] = "1"
+    env["DD_PROFILING_CAPTURE_PCT"] = "100"
     stdout, stderr, exitcode, _ = call_program(
         "ddtrace-run",
         sys.executable,


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13361

Backport of https://github.com/DataDog/dd-trace-py/pull/15990.