### PR TITLE
ci: fix flaky crash tracker zombie tests

### DIFF
--- a/tests/internal/crashtracker/test_crashtracker.py
+++ b/tests/internal/crashtracker/test_crashtracker.py
@@ -737,18 +737,18 @@ def test_crashtracker_echild_hang():
             else:
                 children.append(pid)
 
-        # Wait for all children to exit.  It shouldn't take more than 1s, so fail if it does.
-        timeout = 1  # seconds
+        # Wait for all children to exit.  It shouldn't take more than 5s, so fail if it does.
+        timeout = 5  # seconds
         end_time = time.time() + timeout
         while True:
             if time.time() > end_time:
-                pytest.fail("Timed out waiting for children to exit")
+                raise AssertionError("Timed out waiting for children to exit")
             try:
-                _, __ = os.waitpid(-1, os.WNOHANG)
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+                if pid == 0:
+                    time.sleep(0.01)  # Avoid busy-wait when no child exited
             except ChildProcessError:
                 break
-            except Exception as e:
-                pytest.fail("Unexpected exception: %s" % e)
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
@@ -806,18 +806,18 @@ def test_crashtracker_no_zombies():
             else:
                 children.append(pid)
 
-        # Wait for all children to exit.  It shouldn't take more than 1s, so fail if it does.
-        timeout = 1  # seconds
+        # Wait for all children to exit.  It shouldn't take more than 5s, so fail if it does.
+        timeout = 5  # seconds
         end_time = time.time() + timeout
         while True:
             if time.time() > end_time:
-                pytest.fail("Timed out waiting for children to exit")
+                raise AssertionError("Timed out waiting for children to exit")
             try:
-                _, __ = os.waitpid(-1, os.WNOHANG)
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+                if pid == 0:
+                    time.sleep(0.01)  # Avoid busy-wait when no child exited
             except ChildProcessError:
                 break
-            except Exception as e:
-                pytest.fail("Unexpected exception: %s" % e)
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")


### PR DESCRIPTION
## Description

There are three main changes to these tests:

- `pytest.fail` doesn't work in a subprocess test, we just need to raise an exception
- increase total timeout for checking child processes to 5 seconds (just in case)
- add a `time.sleep(0.01)` to avoid over starvation of the CPU when the test is running

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes flaky test: DD_V8XB1A
