### PR TITLE
ci: don't run codeql jobs on nightly builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,7 +158,7 @@ macrobenchmarks:
   allow_failure: false
   rules:
     # Always run on nightly schedule or API triggered pipelines
-    - if: $NIGHTLY_BUILD == "true" || $CI_PIPELINE_SOURCE == "api"
+    - if: $NIGHTLY_BUILD == "true"
       when: always
     # Allow failures if explicitly asked
     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"


### PR DESCRIPTION
This change skips codeql CI jobs in the nightly build because they are [currently failing](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1345313292) and the other contexts where they run are enough to remain in compliance.