### PR TITLE
ci: fix flaky test_native_logs test

### DIFF
--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -881,6 +881,7 @@ def test_native_logs(tmp_path):
     flare.prepare("DEBUG")
 
     native_logger.log("debug", "debug log")
+    native_logger.disable("file")  # Flush the non-blocking writer
 
     native_flare_file_path = tmp_path / f"tracer_native_{os.getpid()}.log"
     assert os.path.exists(native_flare_file_path)


### PR DESCRIPTION
## Description

The native log writer writes asynchronously in a background thread, the only way to be sure that the writer flushes properly before trying to read the file is to shut it down.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes flaky tests: DD_AXPEPP DD_2WWQZ7 DD_SUS1W7 DD_DS9D2P DD_WDDCWQ DD_XLJY29
