### PR TITLE
fix(pylibmc): ensure global tracer is set by default

### DIFF
--- a/ddtrace/contrib/internal/pylibmc/client.py
+++ b/ddtrace/contrib/internal/pylibmc/client.py
@@ -51,7 +51,8 @@ class TracedClient(ObjectProxy):
 
         schematized_service = schematize_service_name(service)
         pin = Pin(service=schematized_service)
-        pin._tracer = tracer
+        if tracer is not None:
+            pin._tracer = tracer
         pin.onto(self)
 
         # attempt to collect the pool of urls this client talks to

--- a/releasenotes/notes/pylibmc-fix-pin-632e1601923e0259.yaml
+++ b/releasenotes/notes/pylibmc-fix-pin-632e1601923e0259.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    pylibmc: Fixes an issue where initializing a TracedClient without a tracer disables tracing. The global tracer is now used when ``tracer=None``.


### PR DESCRIPTION
## Description

Fixes an issue where initializing a `TracedClient` without a tracer disabled tracing. When `tracer=None`, the code was setting `pin._tracer = None`, which overrode Pin's default `ddtrace.tracer` and prevented spans from being created.

The fix only sets `pin._tracer` when a tracer is explicitly provided, allowing Pin to use its default `ddtrace.tracer` when `tracer=None`.

## Testing

- All existing pylibmc tests pass
- Removed unnecessary manual Pin overrides from tests that were workarounds for this bug

## Risks

Low risk. This restores expected behavior and maintains backward compatibility when a tracer is explicitly provided.

## Additional Notes

- Aligns pylibmc integration with the pattern used by other integrations
- Simplifies test suite by removing manual Pin overrides
