### PR TITLE
test(profiling): revert 'unflake test_uwsgi_threads_processes_no_primary_lazy_apps'

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -71,10 +71,6 @@ class Profiler(object):
 
         if stop_on_exit:
             atexit.register(self.stop)
-            # Also register for SIGTERM/SIGINT to flush profiles before exit.
-            # This is important for environments like uWSGI with --skip-atexit
-            # where Python's atexit handlers are not called.
-            atexit.register_on_exit_signal(self.stop)
 
         if profile_children:
             forksafe.register(self._restart_on_fork)

--- a/releasenotes/notes/profiling-flush-profile-on-exit-signal-abfa7c1e9d7ae893.yaml
+++ b/releasenotes/notes/profiling-flush-profile-on-exit-signal-abfa7c1e9d7ae893.yaml
@@ -1,4 +1,0 @@
-fixes:
-  - |
-    profiling: Profiles are now flushed before exit when an exit signal is received. This addresses an issue where the
-    last profile was not flushed when the process exited using uWSGI with ``--skip-atexit``.


### PR DESCRIPTION
## Description

Reverts #15983. It results in flushing profiles twice for frameworks like `uvicorn`. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
