### PR TITLE
test(profiling): unflake `test_uwsgi_threads_processes_no_primary_lazy_apps`

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -71,10 +71,6 @@ class Profiler(object):
 
         if stop_on_exit:
             atexit.register(self.stop)
-            # Also register for SIGTERM/SIGINT to flush profiles before exit.
-            # This is important for environments like uWSGI with --skip-atexit
-            # where Python's atexit handlers are not called.
-            atexit.register_on_exit_signal(self.stop)
 
         if profile_children:
             forksafe.register(self._restart_on_fork)

--- a/releasenotes/notes/profiling-flush-profile-on-exit-signal-abfa7c1e9d7ae893.yaml
+++ b/releasenotes/notes/profiling-flush-profile-on-exit-signal-abfa7c1e9d7ae893.yaml
@@ -1,4 +1,0 @@
-fixes:
-  - |
-    profiling: Profiles are now flushed before exit when an exit signal is received. This addresses an issue where the
-    last profile was not flushed when the process exited using uWSGI with ``--skip-atexit``.


### PR DESCRIPTION
## Description

This reverts PR #16038/ commit ed1afe37461986f0a54d3324625b5a1bbb962e99 and readds #15983 without the problematic part.

Note that this also means the test will probably not be 100% non flaky (with just this change, I was still seeing some flakes – more rarely, but sometimes still). We may need to look more into it in the future.