### PR TITLE
chore(profiling): ensure fork safety for `StringTable`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
@@ -164,6 +164,12 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
         this->emplace(UNKNOWN, "<unknown>");
     };
 
+    void postfork_child()
+    {
+        // NB placement-new to re-init and leak the mutex because doing anything else is UB
+        new (&table_lock) std::mutex();
+    }
+
   private:
     mutable std::mutex table_lock;
 };

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -239,6 +239,9 @@ _stack_atfork_child()
     new (&thread_info_map_lock) std::mutex;
     new (&task_link_map_lock) std::mutex;
     new (&greenlet_info_map_lock) std::mutex;
+
+    // Reset the string_table mutex to avoid deadlock if fork happened while it was held
+    string_table.postfork_child();
 }
 
 __attribute__((constructor)) void


### PR DESCRIPTION
## Description

Follow-up to @taegyunkim 's comment on https://github.com/DataDog/dd-trace-py/pull/16015. 