### PR TITLE
fix(profiling): fix use-after-free on Cancellation Token

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
@@ -27,6 +27,7 @@ class Uploader
     std::string process_tags;
 
     bool export_to_file(ddog_prof_EncodedProfile& encoded, std::string_view internal_metadata_json);
+    static void cancel_inflight_locked();
 
   public:
     bool upload();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -223,4 +223,8 @@ Datadog::Uploader::postfork_child()
 {
     // NB placement-new to re-init and leak the mutex because doing anything else is UB
     new (&upload_lock) std::mutex();
+
+    // Do not call into Rust in the child after fork. Just reset our view of the
+    // global cancellation token state.
+    cancel = { .inner = nullptr };
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_api.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_api.cpp
@@ -31,6 +31,31 @@ TEST(UploadDeathTest, SingleSample)
 }
 
 void
+double_upload_single_sample()
+{
+    configure("my_test_service", "my_test_env", "0.0.1", "https://127.0.0.1:9126", "cpython", "3.10.6", "3.100", 256);
+
+    // Collect and flush one sample
+    auto h = ddup_start_sample();
+    ddup_push_walltime(h, 1.0, 1);
+    ddup_flush_sample(h);
+    ddup_drop_sample(h);
+    h = nullptr;
+
+    // Upload twice. The second call used to be able to hit a stale/dropped
+    // cancellation token in the uploader glue.
+    ddup_upload();
+    ddup_upload();
+
+    std::exit(0);
+}
+
+TEST(UploadDeathTest, DoubleUploadSingleSample)
+{
+    EXPECT_EXIT(double_upload_single_sample(), ::testing::ExitedWithCode(0), "");
+}
+
+void
 single_oneframe_sample()
 {
     configure("my_test_service", "my_test_env", "0.0.1", "https://127.0.0.1:9126", "cpython", "3.10.6", "3.100", 256);

--- a/releasenotes/notes/profiling-fix-cancellation-token-use-after-free-9ab3bca3b7d878e5.yaml
+++ b/releasenotes/notes/profiling-fix-cancellation-token-use-after-free-9ab3bca3b7d878e5.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: A rare crash caused by a memory corruption in the profile upload logic has been fixed.


### PR DESCRIPTION
## Description

This PR fixes a use-after-free that we have witnessed both in internal and customer services. 

```
thread '<unnamed>' ([15-42]) panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-util-0.7.16/src/sync/cancellation_token/tree_node.rs:254:5: assertion failed: locked_node.num_handles > 0 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace fatal runtime error: failed to initiate panic, error [1215143760-2418262048], aborting
```
 
([this in the source code](https://github.com/tokio-rs/tokio/blob/tokio-util-0.7.x/tokio-util/src/sync/cancellation_token/tree_node.rs#L254-L263))

From what I can tell, this crash was probably caused by trying to use a Cancellation Token that had already been freed previously. Looking at the code, it seems like we have a somewhat weird behaviour where `~Uploader` cancels upload (`ddog_CancellationToken_cancel(&cancel)`) then frees the Cancellation Token (`ddog_CancellationToken_drop(&cancel)`) despite `&cancel` being a global / static. As a result, if more than one `~Uploader` instance exists, it's very likely we end up freeing that `cancel` more than one.

### The fix

The fix I propose is to not drop the Cancellation Token in the destructor, but rather at the end of uploading.  
First, a seemingly simpler fix would be to make `cancel` a field of the `Uploader` class. This however does not work, as we need to be able to call `cancel_inflight` from anywhere, meaning `cancel` needs to be easily findable ⇒ having a `static` here makes sense as a solution.

The way the upload function in `libdatadog` works is pretty simple but somewhat confusing because it's asynchronous, and we use it a synchronous way. The details are that while the upload routine itself is asynchronous, it is an implementation detail of `Exporter::send`, which is the one we use and that is blocking [there is no simple way to expose asynchronicity from Rust to the outside world]. However, this doesn't mean having a Cancellation Token is nonsensical: whereas the thread uploading the Profile will never be able to cancel its request (as sending the Profile will block it), other threads will be able to see `cancel` and use it to tell `libdatadog` to stop uploading. 

Note that doing this is thread-safe because `cancel` is only ever written to/read from with `upload_lock` held. 

### Open questions
- Are we allowed to use Cancellation Token from another thread than the one that created it? Yes, it seems.