### PR TITLE
chore(profiling): ci speed up cache installs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,7 @@ lib_injection_tests:
     - if [ "${MEMCPY_MODE}" == "fast" ]; then export ECHION_USE_FAST_COPY_MEMORY=1; else export ECHION_USE_FAST_COPY_MEMORY=0; fi
     - ./ddtrace/internal/datadog/profiling/build_standalone.sh --${SANITIZER} RelWithDebInfo stack_test
 
-# Run on every PR with default memcpy mode (only if profiling files changed)
+# Run on every PR (only if profiling files changed)
 profiling_native:
   extends: .profiling_native_base
   rules:
@@ -441,25 +441,19 @@ profiling_native:
         - ddtrace/internal/datadog/profiling/**/*
         - ddtrace/profiling/**/*
         - src/native/**/*
+        - tests/profiling/**/*
   parallel:
     matrix:
       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         MEMCPY_MODE: ["default"]
-        SANITIZER: ["safety", "thread"]
+        SANITIZER: ["safety", "thread", ""]
+      # Valgrind on subset only: ASAN/LSAN (in "safety") already cover leaks, buffer overflows,
+      # and use-after-free. Valgrind's main added value is detecting uninitialized memory usage,
+      # which is worth checking on a few versions without the slowdown on all runs.
+      # If needed, please add more versions to the list.
       - PYTHON_VERSION: ["3.12", "3.14"]
         MEMCPY_MODE: ["default"]
         SANITIZER: ["valgrind"]
-
-# Fast memcpy mode: nightly/schedule only
-profiling_native_fast_memcpy:
-  extends: .profiling_native_base
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "main"
-    - when: manual
-      allow_failure: true
-  parallel:
-    matrix:
       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         MEMCPY_MODE: ["fast"]
         SANITIZER: ["safety", "thread"]


### PR DESCRIPTION
## Description
<!-- Provide an overview of the change and motivation for the change -->
- Non profiling runs:
Looking at runs on [main](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1350528466), we can find many (36) runs of 14+ minute, that end up doing nothinging. We eventually bail out when we check whether this is profiling or not.

- Profiling runs:
Profiling runs actually do some testing. I can see some of the jobs [failing](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1351783639) in 32 minutes.

Overall we can see that we reinstall dependencies on every CI run. We are down to ~5 minutes on profiling runs (which will still require improvement, though a nice first step).

This PR
- Avoid installing dependencies in every CI RUN
This is done by exposing a profiling native image in images. 

- Adjust the rules to run profiling tests.
This might need a little more tuning, though it should already be more robust than the previous check.

- Runs the tests without a sanitizer configuration

## Testing

<!-- Describe your testing strategy or note what tests are included -->
Refer to CI runs.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->
This will require updating images in a separate repository.

## Additional Notes

Associated internal [PR](https://github.com/DataDog/images/pull/8478) (private Datadog repository).

<!-- Any other information that would be helpful for reviewers -->

