### PR TITLE
fix(internal): resolve race condition in application shutdown on Python 3.14+

### DIFF
--- a/releasenotes/notes/fix-period-thread-shutdown-race-35244eeb6fc444bd.yaml
+++ b/releasenotes/notes/fix-period-thread-shutdown-race-35244eeb6fc444bd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: This fix resolves an issue where a race condition during PeriodicThread shutdown caused random crashes on Python 3.14+ during application finalization.


### PR DESCRIPTION
## Description

Resolution for random SIGSEGV crashes during pytest shutdown on Python 3.14+ in tests that heavily use PeriodicThread (internal, profiling suites).

PyRef destructor was calling `Py_DECREF` after the thread signaled completion, creating a race where `join()` could return while the background thread was still executing Python refcounting operations. Python 3.14's new recursion check in `_Py_Dealloc` dereferences `tstate` immediately, causing crashes if finalization has set it to NULL.

The solution is to add a `Py_IsFinalizing` check to the destructor.

We've only see this issue in our CI suite so far, which may be related to the total number of PeriodicThreads created which then need to be cleaned up during the process atexit hook handler to shutdown threads before process exit.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
