### PR TITLE
fix(llmobs): support upstream propagated hex parent IDs

### DIFF
--- a/releasenotes/notes/fix-llmobs-hex-ids-8300c16dc4b21c29.yaml
+++ b/releasenotes/notes/fix-llmobs-hex-ids-8300c16dc4b21c29.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where upstream hexadecimal LLMObs parent IDs were not propagated correctly in ``LLMObs.activate_distributed_headers()``.


### PR DESCRIPTION
## Description
This PR does 2 things:
1. Support hexadecimal parent IDs in distributed request headers. We neglected upstream Go services that might store parent IDs as direct hex strings instead of int which is how Python does it.
2. Simplify our `_activate_llmobs_distributed_context` method to return immediately (no-op) if we detect either missing/invalid llmobs trace/parent IDs. We don't need to activate any new llmobs context in this case because this implies that there's no valid upstream llmobs span/trace to propagate, we'll just start a new llmobs context when we start a new llmobs span in the new service. APM contexts are activated/propagated separately so we can exit early in these cases.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
