### PR TITLE
fix(tracer): reset context provider and wrap executor on shutdown

### DIFF
--- a/releasenotes/notes/fix-shutdown-wrap-and-context-a25f3fbefb0d77a9.yaml
+++ b/releasenotes/notes/fix-shutdown-wrap-and-context-a25f3fbefb0d77a9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracer: Removes wrap executor and context provider after tracer shutdown.


### PR DESCRIPTION
## Description

Fixes an issue where ``Tracer._wrap_executor`` was not reset during tracer reinitialization. When the tracer was shut down and reinitialized between test runs, the ``_wrap_executor`` property persisted from the previous instance.

Also fixes an issue where the active span was not unset on tracer shutdown, causing trace context to leak between test runs.

This change ensures that the wrap executor and context provider are properly removed during tracer shutdown.

## Testing

- Fixed flaky tests in ``test_tracer.py``

## Risks

None

## Additional Notes

None