### PR TITLE
ci(tracer): fix flaky tracer flare tests

### DIFF
--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -41,6 +41,9 @@ class TracerFlareTests(TestCase):
     mock_config_dict = {}
 
     def setUp(self):
+        # Defensive cleanup: remove any pre-existing tracer flare handlers
+        self._remove_handlers()
+
         self.setUpPyfakefs()
         self.shared_dir = self.fs.create_dir("tracer_flare_test")
         self.flare = Flare(
@@ -197,29 +200,29 @@ class TracerFlareTests(TestCase):
                 )
                 logs.append(data)
 
-        assert len(logs) == 5, f"Expected 4 log lines, got {len(logs)}"
+        # Verify the routing message exists
+        routing_logs = [log for log in logs if log["message"].startswith("ddtrace logs will be routed to")]
+        assert len(routing_logs) == 1, "Expected exactly one routing message log"
+        assert routing_logs[0]["logger"] == "ddtrace"
+        assert routing_logs[0]["level"] == "DEBUG"
 
-        assert logs[0]["logger"] == "ddtrace"
-        assert logs[0]["level"] == "DEBUG"
-        assert logs[0]["message"].startswith("ddtrace logs will be routed to")
+        # Filter to only logs from our test logger
+        test_logs = [log for log in logs if log["logger"] == "ddtrace.flare.test.module"]
+        assert len(test_logs) == 4, f"Expected 4 test logs, got {len(test_logs)}"
 
-        assert logs[1]["logger"] == "ddtrace.flare.test.module"
-        assert logs[1]["level"] == "DEBUG"
-        assert logs[1]["message"] == "this is a test log"
+        assert test_logs[0]["level"] == "DEBUG"
+        assert test_logs[0]["message"] == "this is a test log"
 
-        assert logs[2]["logger"] == "ddtrace.flare.test.module"
-        assert logs[2]["level"] == "INFO"
-        assert logs[2]["message"] == "this is another test log with a number: 1234"
+        assert test_logs[1]["level"] == "INFO"
+        assert test_logs[1]["message"] == "this is another test log with a number: 1234"
 
-        assert logs[3]["logger"] == "ddtrace.flare.test.module"
-        assert logs[3]["level"] == "WARNING"
-        assert logs[3]["message"] == "this is a warning with a float: 12.34"
+        assert test_logs[2]["level"] == "WARNING"
+        assert test_logs[2]["message"] == "this is a warning with a float: 12.34"
 
-        assert logs[4]["logger"] == "ddtrace.flare.test.module"
-        assert logs[4]["level"] == "ERROR"
-        assert logs[4]["message"] == "this is an exception log"
-        assert logs[4]["exception"].startswith("Traceback (most recent call last):")
-        assert "ZeroDivisionError" in logs[4]["exception"]
+        assert test_logs[3]["level"] == "ERROR"
+        assert test_logs[3]["message"] == "this is an exception log"
+        assert test_logs[3]["exception"].startswith("Traceback (most recent call last):")
+        assert "ZeroDivisionError" in test_logs[3]["exception"]
 
         self.flare.clean_up_files()
         self.flare.revert_configs()
@@ -871,24 +874,31 @@ def test_native_logs(tmp_path):
     from ddtrace import config
     from ddtrace.internal.native._native import logger as native_logger
 
-    config._trace_writer_native = True
-    flare = Flare(
-        trace_agent_url=TRACE_AGENT_URL,
-        flare_dir=tmp_path,
-        ddconfig={"config": "testconfig"},
-    )
+    original_trace_writer_native = config._trace_writer_native
+    flare = None
+    try:
+        config._trace_writer_native = True
+        flare = Flare(
+            trace_agent_url=TRACE_AGENT_URL,
+            flare_dir=tmp_path,
+            ddconfig={"config": "testconfig"},
+        )
 
-    flare.prepare("DEBUG")
+        flare.prepare("DEBUG")
 
-    native_logger.log("debug", "debug log")
-    native_logger.disable("file")  # Flush the non-blocking writer
+        native_logger.log("debug", "debug log")
+        native_logger.disable("file")  # Flush the non-blocking writer
 
-    native_flare_file_path = tmp_path / f"tracer_native_{os.getpid()}.log"
-    assert os.path.exists(native_flare_file_path)
+        native_flare_file_path = tmp_path / f"tracer_native_{os.getpid()}.log"
+        assert os.path.exists(native_flare_file_path)
 
-    with open(native_flare_file_path, "r") as file:
-        assert "debug log" in file.readline()
+        with open(native_flare_file_path, "r") as file:
+            assert "debug log" in file.readline()
 
-    # Sends request to testagent
-    # This just validates the request params
-    flare.send(MOCK_FLARE_SEND_REQUEST)
+        # Sends request to testagent
+        # This just validates the request params
+        flare.send(MOCK_FLARE_SEND_REQUEST)
+    finally:
+        config._trace_writer_native = original_trace_writer_native
+        if flare is not None:
+            flare.revert_configs()


### PR DESCRIPTION
## Description

These are the two common issues found.

```
Expected 4 log lines, got 7
assert 7 == 5
 +  where 7 = len([{'filename': '_logger.py', 'funcName': '_add_file_handler', 'level': 'DEBUG', 'lineno': 98, ...}, {'filename': 'test_tracer_flare.py', 'funcName': 'test_json_logs', 'level': 'DEBUG', 'lineno': 150, ...}, {'filename': 'test_tracer_flare.py', 'funcName': 'test_json_logs', 'level': 'INFO', 'lineno': 151, ...}, {'filename': 'test_tracer_flare.py', 'funcName': 'test_json_logs', 'level': 'WARNING', 'lineno': 152, ...}, {'exception': 'Traceback (most recent call last):\n  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/tests/internal/test_tracer_flare.py", line 154, in test_json_logs\n    1 / 0\n    ~~^~~\nZeroDivisionError: division by zero', 'filename': 'test_tracer_flare.py', 'funcName': 'test_json_logs', 'level': 'ERROR', ...}, {'filename': 'writer.py', 'funcName': '_put', 'level': 'DEBUG', 'lineno': 280, ...}, ...])
```

and

```
File handler was not removed
assert <RotatingFileHandler /tmp/pytest-of-bits/pytest-6/test_native_logs_py3_12_0/tracer_python_16840.log (DEBUG)> is None
 +  where <RotatingFileHandler /tmp/pytest-of-bits/pytest-6/test_native_logs_py3_12_0/tracer_python_16840.log (DEBUG)> = _get_handler()
 +    where _get_handler = <tests.internal.test_tracer_flare.TracerFlareTests testMethod=test_json_logs>._get_handler
```


The solution is to:

1. Filter/scope the logs that we assert against to only the ones we care about (avoiding non-deterministic logs from the writer for example)
2. Add some better log handler cleanup logic to prevent leaks between tests

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes flaky tests: DD_LH6Z2D DD_0CQ77U DD_710Z26 DD_70TKFD DD_8V85Q7 DD_R28439
