### PR TITLE
ci(tracer): fix flaky test_ctx

### DIFF
--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1333,7 +1333,8 @@ def test_ctx(tracer, test_spans):
     assert s3.parent_id == s2.span_id
     assert s4.parent_id == s1.span_id
     assert s1.trace_id == s2.trace_id == s3.trace_id == s4.trace_id
-    assert s1.get_metric(_SAMPLING_PRIORITY_KEY) == 1
+    # Agent based sampling may set the sampling priority to either 0 or 1.
+    assert s1.get_metric(_SAMPLING_PRIORITY_KEY) in (AUTO_KEEP, AUTO_REJECT)
     assert s2.get_metric(_SAMPLING_PRIORITY_KEY) is None
     assert _ORIGIN_KEY not in s1.get_tags()
 


### PR DESCRIPTION
## Description

Fixes flaky test failures in the tracer test suite where sampling priority assertions were non-deterministic.

The tracer test suite submits spans to a real Datadog Agent with priority sampling enabled. The sampling priority is not deterministic in test runs as it depends on the number of spans received by the test agent in a period of time. The agent can apply a sampling priority of either 0 or 1 on a span, causing assertion failures when tests expect a specific value.

## Testing

- Ensures ``test_ctx`` is no longer flaky

## Risks

None

## Additional Notes

None
