### PR TITLE
ci(internal): fix flaky forksafe awakeable test

### DIFF
--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -124,13 +124,16 @@ def test_awakeable_periodic_service():
 
 def test_forksafe_awakeable_periodic_service():
     queue = [None]
+    periodic_ran = Event()
 
     class AwakeMe(periodic.ForksafeAwakeablePeriodicService):
         def reset(self):
             queue.clear()
+            periodic_ran.clear()
 
         def periodic(self):
             queue.append(len(queue))
+            periodic_ran.set()
 
     awake_me = AwakeMe(1)
     awake_me.start()
@@ -143,6 +146,7 @@ def test_forksafe_awakeable_periodic_service():
         # reset
         assert not queue
         awake_me.awake()
+        periodic_ran.wait(timeout=5)  # Wait for periodic() to complete
         assert queue
         os._exit(42)
 


### PR DESCRIPTION
## Description

Periodic thread `awake()` doesn't block waiting for periodic to run, it only short circuits the periodic interval.

This change adds an event to fix coordination/race conditions in the test case.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes flaky tests: DD_JLE17C DD_ZLGCVU DD_IXM2OK DD_E3PIV4 DD_NXYY6G
