### PR TITLE
ci(logger): fix flaky logger tests

### DIFF
--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -108,6 +108,9 @@ class LoggerTestCase(BaseTestCase):
         log.setLevel(logging.INFO)
         ddtrace.internal.logger._rate_limit = 0
 
+        # Clear buckets in case any were created during logger setup
+        ddtrace.internal.logger._buckets.clear()
+
         # Log a bunch of times very quickly (this is fast)
         for _ in range(1000):
             log.info("test")
@@ -115,7 +118,7 @@ class LoggerTestCase(BaseTestCase):
         # Assert that we did not perform any rate limiting
         self.assertEqual(call_handlers.call_count, 1000)
 
-        # Our buckets are empty
+        # Our buckets are empty (no rate limit means no buckets should be created)
         self.assertEqual(ddtrace.internal.logger._buckets, dict())
 
     @mock.patch("logging.Logger.callHandlers")
@@ -125,14 +128,14 @@ class LoggerTestCase(BaseTestCase):
             When effective level is DEBUG
                 Always calls the base `Logger.handle`
         """
-        # Our buckets are empty
-        self.assertEqual(ddtrace.internal.logger._buckets, dict())
-
         # Configure an INFO logger with no rate limit
         log = get_logger("test.logger")
         log.setLevel(logging.DEBUG)
         assert log.getEffectiveLevel() == logging.DEBUG
         assert ddtrace.internal.logger._rate_limit > 0
+
+        # Clear buckets in case any were created during logger setup
+        ddtrace.internal.logger._buckets.clear()
 
         # Log a bunch of times very quickly (this is fast)
         for level in ALL_LEVEL_NAMES:
@@ -141,10 +144,9 @@ class LoggerTestCase(BaseTestCase):
                 log_fn("test")
 
         # Assert that we did not perform any rate limiting
-        total = 1000 * len(ALL_LEVEL_NAMES)
-        self.assertTrue(total <= call_handlers.call_count <= total + 1)
+        self.assertEqual(call_handlers.call_count, 1000 * len(ALL_LEVEL_NAMES))
 
-        # Our buckets are empty
+        # Our buckets are empty (DEBUG level logging should not create buckets)
         self.assertEqual(ddtrace.internal.logger._buckets, dict())
 
     @mock.patch("logging.Logger.callHandlers")


### PR DESCRIPTION
## Description

Fixes flaky bucket assertions in logger tests. The tests ``test_logger_handle_debug`` and ``test_logger_handle_no_limit`` were asserting that buckets were empty before clearing any buckets that may have been created during logger setup or by other code.

The fix clears buckets after logger setup and before logging, ensuring the tests only verify that the test's own logging doesn't create buckets.

## Testing

- Fixed flaky assertions in ``test_logger_handle_debug`` and ``test_logger_handle_no_limit``

## Risks

None

## Additional Notes

None
