### PR TITLE
ci(crashtracker): fix flaky crash tracker tests

### DIFF
--- a/tests/internal/crashtracker/test_crashtracker.py
+++ b/tests/internal/crashtracker/test_crashtracker.py
@@ -129,7 +129,7 @@ def test_crashtracker_receiver_not_in_path():
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore:.*fork.*:DeprecationWarning::"})
 def test_crashtracker_simple():
     # This test does the following
     # 1. Finds a random port in the range 10000-20000 it can bind to (5 retries)
@@ -680,7 +680,7 @@ def test_crashtracker_process_tags():
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore:.*fork.*:DeprecationWarning::"})
 def test_crashtracker_echild_hang():
     """
     It's possible for user code and services to harvest child processes by doing a `waitpid()` until errno is ECHILD.


### PR DESCRIPTION
## Description

Similar to https://github.com/DataDog/dd-trace-py/pull/16028 a few other tests which need to ignore this warning.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes flaky tests: DD_M5IC1R DD_TP99W6
