### PR TITLE
chore(aap): properly count httpx redirect requests

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -550,7 +550,6 @@ def _on_httpx_request_started(ctx: ExecutionContext) -> None:
         return
 
     analyze_body = should_analyze_body_response(asm_context)
-    asm_context.downstream_requests += 1
     ctx.set_item(APPSEC_SSRF_ANALYZE_BODY_KEY, analyze_body)
 
 
@@ -584,6 +583,7 @@ def _on_httpx_client_send_single_request_started(ctx: ExecutionContext) -> None:
         addresses,
         rule_type=EXPLOIT_PREVENTION.TYPE.SSRF_REQ,
     )
+    asm_context.downstream_requests += 1
     if blocking_config := get_blocked():
         raise BlockingException(blocking_config, EXPLOIT_PREVENTION.BLOCKING, EXPLOIT_PREVENTION.TYPE.SSRF, raw_url)
 


### PR DESCRIPTION
## Description

Properly count redirect requests in AppSec's httpx integration

## Testing

This is only tested in the system-tests for now.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
