### PR TITLE
fix(profiling): clear `thread_info_map` after fork

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -45,6 +45,9 @@ class Sampler
     bool do_adaptive_sampling = true;
     void adapt_sampling_interval();
 
+    void atfork_child();
+    friend void _stack_atfork_child();
+
   public:
     // Singleton instance
     static Sampler& get();

--- a/releasenotes/notes/profiling-reset-threadinfo-fork-1ad07e470a06bcfa.yaml
+++ b/releasenotes/notes/profiling-reset-threadinfo-fork-1ad07e470a06bcfa.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: The stack Profiler now correctly resets thread, task, and greenlet information
+    after a fork, preventing stale data from the parent process from affecting profiling in
+    child processes.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13089

This PR updates the Profiling code to clear the `thread_info_map` container when the process forks. We now also clear the `task_link_map` and `greenlet_info_map` as they probably also contain outdated information.

**Why do we need this?**

The goal of this PR is to fix a bug illustrated in https://github.com/DataDog/dd-trace-py/pull/16078. For some reason, which is still unclear to me, we would previously get samples (for CPU Time / Wall Time) for Threads (= labelled with Thread names) that only exist in the parent process in the profiles created by the child process. This is completely wrong and we should not have that –  existing Threads  continue to exist in the parent process, but are not replicated as part of the fork in the child process. 

This should not happen, as far as we know, since `for_each_thread` doesn't use `thread_info_map` to iterate over Threads –  it uses the Python Interpreter object and its linked list of Python Threads. We expect this data should be valid / consistent post-fork.  (However, the behaviour of multi-threaded code in processes that fork is mostly undefined behaviour, so we may be hitting a rough edge case here, and maybe "Python itself" knows that it doesn't work, but... it's UB.)

For some reason – that I do not know either –  clearing the `thread_info_map` in the fork handler makes the problem go away [the profiles do not refer to Threads from the parent process at all].  
If I had to guess, I'd say it's probably because the Sampler still "sees" the Threads in the Python Interpreter State, but because they're not in its Thread Info Map, it just skips them, making the bug we see disappear (although it does not technically _fix_ the root cause).