### PR TITLE
perf(profiling): remove one redundant syscall

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -52,6 +52,7 @@ class ThreadInfo
     mach_port_t mach_port;
 #endif
     microsecond_t cpu_time;
+    bool running_ = false;
 
     uintptr_t asyncio_loop = 0;
     uintptr_t tstate_addr = 0; // Remote address of PyThreadState for accessing asyncio_tasks_head

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -624,18 +624,29 @@ Result<void>
 ThreadInfo::update_cpu_time()
 {
 #if defined PL_LINUX
-    struct timespec ts;
-    if (clock_gettime(cpu_clock_id, &ts)) {
+    struct timespec ts1;
+    if (clock_gettime(cpu_clock_id, &ts1)) {
         // If the clock is invalid, we skip updating the CPU time.
         // This can happen if we try to compute CPU time for a thread that has exited.
         if (errno == EINVAL) {
+            this->running_ = false;
             return Result<void>::ok();
         }
 
         return ErrorKind::CpuTimeError;
     }
 
-    this->cpu_time = TS_TO_MICROSECOND(ts);
+    this->cpu_time = TS_TO_MICROSECOND(ts1);
+
+    // Determine if running by checking if CPU time advances between two back-to-back
+    // measurements. This is done here to avoid a separate is_running() call with
+    // its own syscalls (reduces 3 syscalls per thread to 2).
+    struct timespec ts2;
+    if (clock_gettime(cpu_clock_id, &ts2) != 0) {
+        this->running_ = false;
+    } else {
+        this->running_ = (ts1.tv_sec != ts2.tv_sec || ts1.tv_nsec != ts2.tv_nsec);
+    }
 #elif defined PL_DARWIN
     thread_basic_info_data_t info;
     mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
@@ -646,6 +657,7 @@ ThreadInfo::update_cpu_time()
         // If the thread is invalid, we skip updating the CPU time.
         // This can happen if we try to compute CPU time for a thread that has exited.
         if (kr == KERN_INVALID_ARGUMENT) {
+            this->running_ = false;
             return Result<void>::ok();
         }
 
@@ -653,10 +665,13 @@ ThreadInfo::update_cpu_time()
     }
 
     if (info.flags & TH_FLAGS_IDLE) {
+        this->running_ = false;
         return Result<void>::ok();
     }
 
     this->cpu_time = TV_TO_MICROSECOND(info.user_time) + TV_TO_MICROSECOND(info.system_time);
+    // On macOS, thread_info already gives us run_state, so no need to check if the clock is advancing
+    this->running_ = (info.run_state == TH_STATE_RUNNING);
 #endif
 
     return Result<void>::ok();
@@ -665,30 +680,8 @@ ThreadInfo::update_cpu_time()
 bool
 ThreadInfo::is_running()
 {
-#if defined PL_LINUX
-    struct timespec ts1, ts2;
-
-    // Get two back-to-back times
-    if (clock_gettime(cpu_clock_id, &ts1) != 0)
-        return false;
-    if (clock_gettime(cpu_clock_id, &ts2) != 0)
-        return false;
-
-    // If the CPU time has advanced, the thread is running
-    return (ts1.tv_sec != ts2.tv_sec || ts1.tv_nsec != ts2.tv_nsec);
-
-#elif defined PL_DARWIN
-    thread_basic_info_data_t info;
-    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
-    kern_return_t kr = thread_info(
-      static_cast<thread_act_t>(this->mach_port), THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&info), &count);
-
-    if (kr != KERN_SUCCESS)
-        return false;
-
-    return info.run_state == TH_STATE_RUNNING;
-
-#endif
+    // Running state is computed in update_cpu_time by taking two back-to-back measurements of the CPU time.
+    return this->running_;
 }
 
 void

--- a/releasenotes/notes/perf-profiling-reduce-syscall-overhead-5efb5d1d4115105e.yaml
+++ b/releasenotes/notes/perf-profiling-reduce-syscall-overhead-5efb5d1d4115105e.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    profiling: A redundant syscall per thread during stack sampling was eliminated by caching the thread running state
+    when updating CPU time, reducing syscall overhead from 3 to 2 calls per thread on Linux.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13513

This PR removes one redundant syscall per thread during stack sampling on Linux.

Previously, `is_running()` performed its own `clock_gettime()` calls (2 syscalls) separately from `update_cpu_time()` (which did 1 syscall). By moving the "is running" check into `update_cpu_time()`, we reduce the total syscalls from 3 to 2 per thread per sample.

On Linux, we determine if a thread is running by checking if its CPU time advances between two back-to-back `clock_gettime()` calls. On macOS, `thread_info()` already provides the run state, so no extra syscall was needed there – we now just cache that result.

## Testing

Existing tests. No behaviour change.

## Risks

None as far as I can tell – this is purely an internal optimisation with no observable change in functionality.