### PR TITLE
ci: increase frequency of lock update PRs

### DIFF
--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -1,13 +1,13 @@
-name: Generate Package Versions
+name: Update riot lockfiles
 
 on:
   workflow_dispatch: # can be triggered manually
   schedule:
-    - cron: "0 0 * * 0" # weekly on Sunday at midnight
+    - cron: "0 0 * * *" # daily at midnight
 
 jobs:
-  generate-package-versions:
-    name: Generate package versions
+  update-riot-lockfiles:
+    name: Update riot lockfiles
     runs-on: ubuntu-22.04
     permissions:
       actions: read


### PR DESCRIPTION
This change updates the "generate package versions" job to run daily instead of weekly. This helps keep the "latest" specifiers in the riotfile a bit more up to date with the OSS world. This change also renames the job to something more aligned with how we talk about it.