### PR TITLE
ci: pre-merge backport conflict checks [APMLP-586]

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -271,6 +271,7 @@ push_pyframe_to_sample(Datadog::Sample& sample, PyFrameObject* frame)
         filename_sv = unicode_to_string_view(code->co_filename);
     }
 
+    // Push frame to Sample (leaf to root order)
     // push_frame copies the strings immediately into its StringArena
     sample.push_frame(name_sv, filename_sv, 0, lineno_val);
 


### PR DESCRIPTION
## Description

This change adds a github action that is triggered by the addition of a "backport x.y" label to a pull request. When this label is added, the action applies the PR's changeset to the minor version branch indicated by the label, and shares the resulting error via a PR comment.

This makes the backporting process easier, because developers can make adjustments to their pull requests prior to merge to make them easier to integrate with the backport target branches instead of needing to make such changes post-merge.

## Testing

[This comment](https://github.com/DataDog/dd-trace-py/pull/16109#issuecomment-3787017881) and the one immediate after it were generated by the code on this pull request. At that point in the history, this PR included an intentionally conflicting change for testing purposes.

## Risks

None
