### PR TITLE
docs: update instructions for creating release branches

### DIFF
--- a/docs/contributing-release.rst
+++ b/docs/contributing-release.rst
@@ -57,9 +57,10 @@ Ensure you have followed the prerequisite steps above.
 
 .. code-block:: bash
 
-    $ git checkout main
+    $ git checkout A.B  # previous release branch
     $ git pull
-    $ git checkout -b X.Y
+    $ git checkout -b X.Y  # new release branch
+    $ git merge main -Xtheirs
     $ git push -u origin X.Y
 
 2. If you're releasing an X.Y.0 version, update the ``version`` attribute in ``pyproject.toml`` to the ``dev``


### PR DESCRIPTION
This change updates the release procedure to work around an issue I discovered that led to duplicated release notes between versions 4.1 and 4.2. The root of the issue was that, because releases are tagged on release branches, the main branch doesn't include the release tags. Thus when reno specifies main or a release branch created from main as the branch to scan, it doesn't see the tags. The fix is to base the new release branch on the previous one and then merge main into it. When we adjust the process to do all of this on main as opposed to on release branches, this issue will go away.