### PR TITLE
refactor(profiling): remove `MirrorDict` and `TaskInfo::current`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/mirrors.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/mirrors.h
@@ -68,23 +68,6 @@ class MirrorObject
 };
 
 // ----------------------------------------------------------------------------
-class MirrorDict : public MirrorObject
-{
-  public:
-    [[nodiscard]] static Result<MirrorDict> create(PyObject* dict_addr);
-
-    [[nodiscard]] PyObject* get_item(PyObject* key) { return PyDict_GetItem(reinterpret_cast<PyObject*>(&dict), key); }
-
-  private:
-    MirrorDict(PyDictObject dict, std::unique_ptr<char[]> data)
-      : MirrorObject(std::move(data))
-      , dict(dict)
-    {
-    }
-    PyDictObject dict;
-};
-
-// ----------------------------------------------------------------------------
 class MirrorSet : public MirrorObject
 {
   public:

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
@@ -137,7 +137,6 @@ class TaskInfo
     {
     }
 
-    [[nodiscard]] static Result<TaskInfo::Ptr> current(PyObject*);
     size_t unwind(FrameStack&);
 };
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
@@ -1,57 +1,5 @@
 #include <echion/mirrors.h>
 
-[[nodiscard]] Result<MirrorDict>
-MirrorDict::create(PyObject* dict_addr)
-{
-    PyDictObject dict;
-
-    if (copy_type(dict_addr, dict)) {
-        return ErrorKind::MirrorError;
-    }
-
-    PyDictKeysObject keys;
-    if (copy_type(dict.ma_keys, keys)) {
-        return ErrorKind::MirrorError;
-    }
-
-    // Compute the full dictionary data size
-#if PY_VERSION_HEX >= 0x030b0000
-    size_t entry_size = keys.dk_kind == DICT_KEYS_UNICODE ? sizeof(PyDictUnicodeEntry) : sizeof(PyDictKeyEntry);
-    size_t keys_size = sizeof(PyDictKeysObject) + (1 << keys.dk_log2_index_bytes) + (keys.dk_nentries * entry_size);
-#else
-    size_t entry_size = sizeof(PyDictKeyEntry);
-    size_t keys_size = sizeof(PyDictKeysObject) + (keys.dk_size * sizeof(Py_ssize_t)) + (keys.dk_nentries * entry_size);
-#endif
-    size_t values_size = dict.ma_values != NULL ? keys.dk_nentries * sizeof(PyObject*) : 0;
-
-    // Allocate the buffer
-    ssize_t data_size = keys_size + (keys.dk_nentries * entry_size) + values_size;
-    if (data_size < 0 || data_size > MAX_MIRROR_SIZE) {
-        return ErrorKind::MirrorError;
-    }
-
-    auto data = std::make_unique<char[]>(data_size);
-
-    // Copy the key data and update the pointer
-    if (copy_generic(dict.ma_keys, data.get(), keys_size)) {
-        return ErrorKind::MirrorError;
-    }
-
-    dict.ma_keys = reinterpret_cast<PyDictKeysObject*>(data.get());
-
-    if (dict.ma_values != NULL) {
-        // Copy the value data and update the pointer
-        char* values_addr = data.get() + keys_size;
-        if (copy_generic(dict.ma_values, keys_size, values_size)) {
-            return ErrorKind::MirrorError;
-        }
-
-        dict.ma_values = reinterpret_cast<PyDictValues*>(values_addr);
-    }
-
-    return MirrorDict(dict, std::move(data));
-}
-
 [[nodiscard]] Result<MirrorSet>
 MirrorSet::create(PyObject* set_addr)
 {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -129,28 +129,6 @@ TaskInfo::create(TaskObj* task_addr)
       reinterpret_cast<PyObject*>(task_addr), loop, std::move(*maybe_coro), name, std::move(waiter));
 }
 
-// ----------------------------------------------------------------------------
-Result<TaskInfo::Ptr>
-TaskInfo::current(PyObject* loop)
-{
-    if (loop == NULL) {
-        return ErrorKind::TaskInfoError;
-    }
-
-    auto maybe_current_tasks_dict = MirrorDict::create(asyncio_current_tasks);
-    if (!maybe_current_tasks_dict) {
-        return ErrorKind::TaskInfoError;
-    }
-
-    auto current_tasks_dict = std::move(*maybe_current_tasks_dict);
-    PyObject* task = current_tasks_dict.get_item(loop);
-    if (task == NULL) {
-        return ErrorKind::TaskInfoError;
-    }
-
-    return TaskInfo::create(reinterpret_cast<TaskObj*>(task));
-}
-
 size_t
 TaskInfo::unwind(FrameStack& stack)
 {


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-12843

This PR removes dead code. Although dead code doesn't hurt, it's always easier to have less code than more, and if we need it back we can always restore it from history. 