### PR TITLE
chore(ci): disable useless scenarios

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -107,12 +107,16 @@ jobs:
     strategy:
       matrix:
         weblog-variant: [flask-poc, uwsgi-poc , django-poc, fastapi, python3.12, django-py3.13]
-        scenario: [remote-config, appsec, appsec-1, other, debugger-1, debugger-2]
-        exclude:
-          - scenario: debugger-1
-            weblog-variant: [django-poc, python3.12, django-py3.13, fastapi]
-          - scenario: debugger-2
-            weblog-variant: [django-poc, python3.12, django-py3.13, fastapi]
+        scenario: [remote-config, appsec, appsec-1, other]
+        include:
+          - weblog-variant: flask-poc
+            scenario: debugger-1
+          - weblog-variant: flask-poc
+            scenario: debugger-2
+          - weblog-variant: uwsgi-poc
+            scenario: debugger-1
+          - weblog-variant: uwsgi-poc
+            scenario: debugger-2
       fail-fast: false
     env:
       TEST_LIBRARY: python


### PR DESCRIPTION
## Description

several debugger system tests scenarios are taking a lots of time just to run only xfail tests.
This disable those tests and restrict debugger system tests to flask-poc and uwsgi-poc
