### PR TITLE
fix: do not clone pathlib

### DIFF
--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -80,6 +80,7 @@ def cleanup_loaded_modules() -> None:
             "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
             "wrapt",
             "bytecode",  # needed by before-fork hooks
+            "pathlib",  # used in singledispatch
         ]
     )
     for m in list(_ for _ in sys.modules if _ not in ddtrace.LOADED_MODULES):

--- a/releasenotes/notes/fix-pathlib-no-clone-1704ffa623aa27fd.yaml
+++ b/releasenotes/notes/fix-pathlib-no-clone-1704ffa623aa27fd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    exception replay: fix a gevent support issue that could cause an exception
+    when Exception Replay tries to figure out if a frame belongs to user code
+    for capturing. 


### PR DESCRIPTION
## Description

We add `pathlib` to the list of modues that are not to be cloned when gevent is detected. This library is used internally and can cause incompatibilities for single dispatch functions when other ddtrace modules are loaded lazily at runtime.

## Testing

The issue could not be reproduced easily. However the symptoms reported in #15969 suggest that the a clone of pathlib makes internal `singledispatch` functions fail on instance checks. Problems of this nature have already been reported and fixed in a similar way.