### PR TITLE
refactor(profiling): remove `reported` field from `traceback_t`

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -154,8 +154,8 @@ heap_tracker_t::pool_get_with_alloc_data_invokes_cpython(size_t size, size_t wei
     if (!pool.empty()) {
         auto tb = std::move(pool.back());
         pool.pop_back();
-        /* Reset it with the new allocation data */
-        tb->reset_invokes_cpython(size, weighted_size);
+        /* Initialize it with the new allocation data */
+        tb->init_sample_invokes_cpython(size, weighted_size);
         return tb;
     }
 

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -364,9 +364,3 @@ traceback_t::traceback_t(size_t size, size_t weighted_size, uint16_t max_nframe)
 
     init_sample_invokes_cpython(size, weighted_size);
 }
-
-void
-traceback_t::reset_invokes_cpython(size_t size, size_t weighted_size)
-{
-    init_sample_invokes_cpython(size, weighted_size);
-}

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -20,10 +20,10 @@ class traceback_t
 
     ~traceback_t() = default;
 
-    /* Reset/clear this traceback for reuse with a new allocation
-     * Clears all sample data and re-collects frames from the current Python frame chain
-     * NOTE: Invokes CPython APIs which may release the GIL during frame collection */
-    void reset_invokes_cpython(size_t size, size_t weighted_size);
+    /* Initialize/populate this traceback with allocation data and collect frames
+     * Assumes sample buffers are already clean (cleared when returned to pool)
+     * _invokes_cpython suffix: calls CPython APIs which may release the GIL during frame collection */
+    void init_sample_invokes_cpython(size_t size, size_t weighted_size);
 
     /* Initialize traceback module (creates interned strings)
      * Returns true on success, false otherwise
@@ -38,11 +38,6 @@ class traceback_t
     traceback_t& operator=(const traceback_t&) = delete;
     traceback_t(traceback_t&&) = delete;
     traceback_t& operator=(traceback_t&&) = delete;
-
-  private:
-    /* Common initialization logic shared by constructor and reset
-     * _invokes_cpython suffix: calls CPython APIs which may release the GIL during frame collection */
-    void init_sample_invokes_cpython(size_t size, size_t weighted_size);
 };
 
 /* The maximum number of frames we can collect for a traceback


### PR DESCRIPTION
## Description

Refactor memory profiler to remove `reported` field in `traceback_t`. Its main purpose was to avoid double reporting allocation samples. With this change, we export the allocation sample right away when we decide to sample, reset allocation sample, and keep only heap data. 

The plan is to split allocation/heap sampling logic so that we can have a separate tunable heap sampling logic to lower the overhead of heap profiling. Most of the overhead comes from the fact that we call 
https://github.com/DataDog/dd-trace-py/blob/8ba9355b4a03f5e4d2cd261fa27db06b50c341fa/ddtrace/profiling/collector/_memalloc_heap.cpp#L209
for every `free()` on Python object. 


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
