### PR TITLE
ci: add policy for backport validation action [APMLP-586]

### DIFF
--- a/.github/chainguard/self.backportvalidate.create-pr.sts.yaml
+++ b/.github/chainguard/self.backportvalidate.create-pr.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-py:pull_request
+
+claim_pattern:
+  event_name: (pull_request_target|pull_request)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/backport-validate\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write
+


### PR DESCRIPTION
This change supports https://github.com/DataDog/dd-trace-py/pull/16109 by adding a chainguard for the backport-validate GHA workflow. I'm not totally sure about the permissions it needs - what I want that job to do is put the output of `git merge <backport target>` into a comment on an existing pull request. I'm getting "please tell me who you are" when I try that without octo ([example](https://github.com/DataDog/dd-trace-py/actions/runs/21223138120/job/61062897675)), and this chainguard with relatively open permissions is my attempt to get around that issue.