### PR TITLE
ci: attempt another pattern on backport validate chainguard [APMLP-586]

### DIFF
--- a/.github/chainguard/self.backportvalidate.create-pr.sts.yaml
+++ b/.github/chainguard/self.backportvalidate.create-pr.sts.yaml
@@ -1,10 +1,12 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/dd-trace-py:pull_request
+subject_pattern: "repo:DataDog/dd-trace-py:ref:.*"
 
 claim_pattern:
-  event_name: (pull_request_target|pull_request)
-  ref: refs/heads/main
+  event_name: "(pull_request_target|pull_request)"
+  ref_type: "branch"
+  ref: ".+"
+  ref_path: "refs/heads/.+"
   ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/backport-validate\.yml@refs/heads/main
 


### PR DESCRIPTION
This change attempts another approach with the backport validation chainguard file. I'm guessing a bit here and don't know of a better way to debug this than merging to main and retrying from the dependent PR https://github.com/DataDog/dd-trace-py/pull/16109