### PR TITLE
chore(profiling): add reflection tests for the Python Lock profiler

### DIFF
--- a/tests/profiling/collector/test_lock_reflection.py
+++ b/tests/profiling/collector/test_lock_reflection.py
@@ -152,5 +152,6 @@ def test_dunders_accessible(lock_class: Type[object], collector_class: Type[obje
 def test_known_gaps_limit() -> None:
     """Meta-test: ensure KNOWN_COVERAGE_GAPS doesn't grow too large."""
     assert len(KNOWN_COVERAGE_GAPS) <= MAX_ALLOWED_GAPS, (
-        f"Too many known gaps: {len(KNOWN_COVERAGE_GAPS)} (max is {MAX_ALLOWED_GAPS}). Consider fixing some: {KNOWN_COVERAGE_GAPS}"
+        f"Too many known gaps: {len(KNOWN_COVERAGE_GAPS)} (max is {MAX_ALLOWED_GAPS}). "
+        f"Consider fixing some: {KNOWN_COVERAGE_GAPS}"
     )


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-13443

## Description

Adds reflection-based tests for Lock Profiler wrapper interface completeness. These tests use Python introspection to automatically verify that wrapped lock types (`_ProfiledLock`, `_LockAllocatorWrapper`) expose the same methods and dunders as their original counterparts.

## Testing

### What Reflection Tests **Cannot** Catch
- **PR #15899 (`__reduce__`)** - Original lock types inherit this from `object`, so no gap detected
- **PR #15604 (`__mro_entries__`)** - Original lock types inherit this from type system, so no gap detected

These bugs require **behavioral tests** (actually pickle, actually subclass) which already exist in `test_threading.py`

### What Reflection Tests **Can** Catch
Any method or dunder that:
- The **original lock type explicitly defines** (visible in `dir()`)
- But the **wrapper doesn't expose** (missing or inaccessible)

#### Example 1: Missing dunder `__enter__`

```
# Commented out _ProfiledLock.__enter__ (line 154-155)

$ python -m pytest tests/profiling/collector/test_lock_reflection.py::TestWrapperInterfaceCompleteness::test_dunders_accessible -v
...
FAILED test_dunders_accessible[Lock] - AssertionError: Wrapped Lock missing dunders: {'__enter__'}
FAILED test_dunders_accessible[RLock] - AssertionError: Wrapped RLock missing dunders: {'__enter__'}
FAILED test_dunders_accessible[Semaphore] - AssertionError: Wrapped Semaphore missing dunders: {'__enter__'}
FAILED test_dunders_accessible[BoundedSemaphore] - AssertionError: Wrapped BoundedSemaphore missing dunders: {'__enter__'}
FAILED test_dunders_accessible[Condition] - AssertionError: Wrapped Condition missing dunders: {'__enter__'}
```

#### Example 2: Missing public method `locked()`

```
# Commented out _ProfiledLock.locked() (line 147-149)

$ python -m pytest tests/profiling/collector/test_lock_reflection.py::TestWrapperInterfaceCompleteness::test_public_methods_accessible -v
...
FAILED test_public_methods_accessible[Lock] - AssertionError: Wrapped Lock missing public methods: {'locked'}
FAILED test_public_methods_accessible[RLock] - AssertionError: Wrapped RLock missing public methods: {'locked'}
```
