### PR TITLE
ci(tracer): resolve flakiness in tests that fork

### DIFF
--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -11,7 +11,7 @@ def test_get_runtime_id():
     assert runtime_id == runtime.get_runtime_id()
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_get_runtime_id_fork():
     import os
 
@@ -40,7 +40,7 @@ def test_get_runtime_id_fork():
     assert exit_code == 42
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_get_runtime_id_double_fork():
     import os
 
@@ -73,7 +73,7 @@ def test_get_runtime_id_double_fork():
     assert exit_code == 42
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_ancestor_runtime_id():
     """
     Check that the ancestor runtime ID is set after a fork, and that it remains

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -61,7 +61,7 @@ def test_rand128bit():
     assert t1 <= unix_time2 <= t2
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_fork_no_pid_check():
     import os
 
@@ -93,7 +93,7 @@ def test_fork_no_pid_check():
             os._exit(0)
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_fork_pid_check():
     import os
 
@@ -203,7 +203,7 @@ def test_threadsafe():
     assert len(ids) > 0
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_tracer_usage_fork():
     from itertools import chain
     import os
@@ -280,7 +280,7 @@ def test_tracer_usage_multiprocess():
         ids = ids | child_ids  # accumulate the ids
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_span_api_fork():
     from itertools import chain
     import os

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -751,7 +751,7 @@ def test_tracer_shutdown():
 
 
 @pytest.mark.skip(reason="Fails to Pickle RateLimiter in the Tracer")
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_tracer_fork():
     import contextlib
     import multiprocessing
@@ -1024,7 +1024,7 @@ def _test_tracer_runtime_tags_fork_task(tracer, q):
 
 
 @pytest.mark.skip(reason="Fails to Pickle RateLimiter in the Tracer")
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_tracer_runtime_tags_fork():
     import multiprocessing
 
@@ -1126,7 +1126,7 @@ def test_runtime_id_parent_only(tracer):
     PYTHON_VERSION_INFO >= (3, 12),
     reason="This test runs in a multithreaded process, using os.fork() may cause deadlocks in child processes",
 )
-@pytest.mark.subprocess
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_runtime_id_fork():
     import os
 
@@ -1711,7 +1711,7 @@ def test_closing_other_context_spans_multi_spans(tracer, test_spans):
     assert len(spans) == 2
 
 
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess(err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_fork_manual_span_same_context():
     import ddtrace.auto  # noqa
 
@@ -1741,7 +1741,7 @@ def test_fork_manual_span_same_context():
     assert exit_code == 12
 
 
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess(err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_fork_manual_span_different_contexts():
     import ddtrace.auto  # noqa
 
@@ -1766,7 +1766,7 @@ def test_fork_manual_span_different_contexts():
     assert exit_code == 12
 
 
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess(err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_fork_pid():
     import ddtrace.auto  # noqa
 


### PR DESCRIPTION
## Description

Calling `os.fork` in py3.14 raises the following warning which causes subprocess tests to fail: `STDERR: Expected [] got [b'tests/tracer/test_rand.py:104: DeprecationWarning: This process (pid=3042) is multi-threaded, use of fork() may lead to deadlocks in the child.\n  pid = os.fork()\n']`

## Testing

Fixes: DD_PP0QBW DD_RFPFF3 DD_OVZO4Q DD_Q54J5M by disabling warnings in test. We will address this warning in a future release. 