### PR TITLE
perf(profiling): clear sample when returning it to the pool

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -168,6 +168,9 @@ heap_tracker_t::pool_put_no_cpython(std::unique_ptr<traceback_t> tb)
         return;
     }
 
+    /* Clear buffers before returning to pool to prevent memory leaks */
+    tb->sample.clear_buffers();
+
     /* Try to return the traceback to the pool */
     if (pool.size() < POOL_CAPACITY) {
         pool.push_back(std::move(tb));

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -372,7 +372,6 @@ traceback_t::traceback_t(size_t size, size_t weighted_size, uint16_t max_nframe)
 void
 traceback_t::reset_invokes_cpython(size_t size, size_t weighted_size)
 {
-    sample.clear_buffers();
     reported = false;
     init_sample_invokes_cpython(size, weighted_size);
 }


### PR DESCRIPTION
## Description

When traceback is returned to the pool, we didn't clear Sample object buffers. And cleared only when they are returned from the pool. This PR clears the Sample object when it's returned to the pool, slightly decreasing the memory usage from memory profiler. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
