### PR TITLE
ci(native): fix logger race condition

### DIFF
--- a/tests/tracer/test_native_logger.py
+++ b/tests/tracer/test_native_logger.py
@@ -104,6 +104,8 @@ def test_logger_subprocess(
     env["_DD_NATIVE_LOGGING_BACKEND"] = backend
     env["_DD_NATIVE_LOGGING_FILE_PATH"] = log_path_abs
     env["_DD_NATIVE_LOGGING_LOG_LEVEL"] = configured_level
+    # Suppress UserWarning (e.g., pkg_resources deprecation warnings) in subprocess
+    env["PYTHONWARNINGS"] = "ignore::UserWarning"
 
     message = f"msg_{uuid.uuid4().hex}"
     code = """


### PR DESCRIPTION
## Description

Fix intermittent test failures in `test_logger_subprocess` by:
- Using absolute paths for log files to avoid subprocess working directory issues
- Suppressing UserWarning messages (e.g., pkg_resources deprecation warnings) in subprocess output

The test was failing ~0.5% of the time in CI with file not found errors and UserWarning messages causing assertion failures.

## Testing

Existing test `test_logger_subprocess` should now be more reliable. 

Fixes: DD_9XDHGB DD_4YRJF5 DD_8CTVV8 DD_821ARX

Samples Errors:

```
assert b'/go/src/git...ule(module)\n' == b''
  
  Full diff:
  - b''
  + (b'/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/modu'
  +  b'le.py:313: UserWarning: pkg_resources is deprecated as an API. See https://s'
  +  b'etuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is'
  +  b' slated for removal as early as 2025-11-30. Refrain from using this package '
  +  b'or pin to Setuptools<81.\n  self.loader.exec_module(module)\n')
```

```
builtins.FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pytest-of-bits/pytest-0/test_logger_subprocess_trace_i1/file_trace_info.log'
```

## Risks

None - test-only change.

## Additional Notes

None
