### PR TITLE
chore(appsec): remove unused emails from payment events waf  addresses

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -460,7 +460,6 @@ def _on_checkout_session_create(session):
             "amount_total": session.amount_total,
             "client_reference_id": session.client_reference_id,
             "currency": session.currency,
-            "customer_email": session.customer_email,
             "discounts.coupon": discounts_coupon,
             "discounts.promotion_code": discounts_promotion_code,
             "livemode": session.livemode,
@@ -486,7 +485,6 @@ def _on_payment_intent_create(payment_intent):
             "currency": payment_intent.currency,
             "livemode": payment_intent.livemode,
             "payment_method": payment_method,
-            "receipt_email": payment_intent.receipt_email,
         }
 
         call_waf_callback({"PAYMENT_CREATION": payment_creation_data})
@@ -510,9 +508,6 @@ def _on_payment_intent_event(event):
                 "last_payment_error.code": event.data.object.last_payment_error.code,
                 "last_payment_error.decline_code": event.data.object.last_payment_error.decline_code,
                 "last_payment_error.payment_method.id": event.data.object.last_payment_error.payment_method.id,
-                "last_payment_error.payment_method.billing_details.email": (
-                    event.data.object.last_payment_error.payment_method.billing_details.email
-                ),
                 "last_payment_error.payment_method.type": event.data.object.last_payment_error.payment_method.type,
             }
         elif event.type == "payment_intent.canceled":
@@ -520,7 +515,6 @@ def _on_payment_intent_event(event):
 
             payment_intent_webhook_data = {
                 "cancellation_reason": event.data.object.cancellation_reason,
-                "receipt_email": event.data.object.receipt_email,
             }
         else:
             return

--- a/tests/appsec/integrations/stripe_tests/rules-stripe.json
+++ b/tests/appsec/integrations/stripe_tests/rules-stripe.json
@@ -61,12 +61,6 @@
               "currency"
             ]
           },
-          "appsec.events.payments.create.customer_email": {
-            "address": "server.business_logic.payment.creation",
-            "key_path": [
-              "customer_email"
-            ]
-          },
           "appsec.events.payments.create.discounts.coupon": {
             "address": "server.business_logic.payment.creation",
             "key_path": [
@@ -107,12 +101,6 @@
             "address": "server.business_logic.payment.creation",
             "key_path": [
               "payment_method"
-            ]
-          },
-          "appsec.events.payments.create.receipt_email": {
-            "address": "server.business_logic.payment.creation",
-            "key_path": [
-              "receipt_email"
             ]
           }
         }
@@ -229,12 +217,6 @@
               "last_payment_error.payment_method.id"
             ]
           },
-          "appsec.events.payments.failure.last_payment_error.payment_method.billing_details.email": {
-            "address": "server.business_logic.payment.failure",
-            "key_path": [
-              "last_payment_error.payment_method.billing_details.email"
-            ]
-          },
           "appsec.events.payments.failure.last_payment_error.payment_method.type": {
             "address": "server.business_logic.payment.failure",
             "key_path": [
@@ -275,12 +257,6 @@
             "address": "server.business_logic.payment.cancellation",
             "key_path": [
               "livemode"
-            ]
-          },
-          "appsec.events.payments.cancellation.receipt_email": {
-            "address": "server.business_logic.payment.cancellation",
-            "key_path": [
-              "receipt_email"
             ]
           }
         }

--- a/tests/appsec/integrations/stripe_tests/test_stripe.py
+++ b/tests/appsec/integrations/stripe_tests/test_stripe.py
@@ -151,7 +151,6 @@ def test_stripe_checkout_session_create(
         "appsec.events.payments.create.id": session.id,
         "appsec.events.payments.create.currency": session.currency,
         "appsec.events.payments.create.client_reference_id": "order_123",
-        "appsec.events.payments.create.customer_email": "customer@example.com",
     }
 
     for tag, expected_value in expected_tags.items():
@@ -282,7 +281,6 @@ def test_stripe_payment_intent_create(
         "appsec.events.payments.create.id": session.id,
         "appsec.events.payments.create.currency": session.currency,
         "appsec.events.payments.create.payment_method": stripe_payment_method.id,
-        "appsec.events.payments.create.receipt_email": "customer@example.com",
     }
 
     for tag, expected_value in expected_tags.items():
@@ -340,9 +338,6 @@ def include_webhook(path: str) -> Dict[str, Any]:
                 "appsec.events.payments.failure.last_payment_error.payment_method.id": (
                     payment_intent["last_payment_error"]["payment_method"]["id"]
                 ),
-                "appsec.events.payments.failure.last_payment_error.payment_method.billing_details.email": (
-                    payment_intent["last_payment_error"]["payment_method"]["billing_details"]["email"]
-                ),
                 "appsec.events.payments.failure.last_payment_error.payment_method.type": (
                     payment_intent["last_payment_error"]["payment_method"]["type"]
                 ),
@@ -359,7 +354,6 @@ def include_webhook(path: str) -> Dict[str, Any]:
                 "appsec.events.payments.cancellation.id": payment_intent["id"],
                 "appsec.events.payments.cancellation.currency": payment_intent["currency"],
                 "appsec.events.payments.cancellation.cancellation_reason": payment_intent["cancellation_reason"],
-                "appsec.events.payments.cancellation.receipt_email": payment_intent["receipt_email"],
             },
             lambda payment_intent: {
                 "appsec.events.payments.cancellation.amount": payment_intent["amount"],


### PR DESCRIPTION
## Description

Due to PII concerns, emails have been removed from the scope of the stripe monitoring initiative.
Note no rules targeting emails have been published and thus there is no risk of PII. But as a measure of precaution, we remove them from the instrumentation.

## Testing

- updated tests

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

- Note: this removal needs to be backported to all impacted releases (4.2 and 4.3)
