### PR TITLE
feat(llmobs): add ml_app field to annotation_context prompts

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -127,6 +127,8 @@ def _validate_prompt(prompt: Union[Dict[str, Any], Prompt], strict_validation: b
     validated_prompt: ValidatedPromptDict = {}
     if final_prompt_id:
         validated_prompt["id"] = final_prompt_id
+    if ml_app:
+        validated_prompt["ml_app"] = ml_app
     if version:
         validated_prompt["version"] = version
     if variables:

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -413,6 +413,7 @@ def test_llmobs_chain(langchain_core, langchain_openai, openai_url, llmobs_event
         metadata={"max_tokens": 256, "temperature": 0.7},
         prompt={
             "id": "test_langchain_llmobs.prompt",
+            "ml_app": "langchain_test",
             "chat_template": [
                 {"content": "You are world class technical documentation writer.", "role": "system"},
                 {"content": "{input}", "role": "user"},
@@ -465,6 +466,7 @@ def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, llmob
         span_links=True,
         prompt={
             "id": "langchain.unknown_prompt_template",
+            "ml_app": "langchain_test",
             "chat_template": [{"content": "what is the city {person} is from?", "role": "user"}],
             "variables": {"person": "Spongebob Squarepants", "language": "Spanish"},
             "_dd_context_variable_keys": ["context"],
@@ -477,6 +479,7 @@ def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, llmob
         span_links=True,
         prompt={
             "id": "test_langchain_llmobs.prompt2",
+            "ml_app": "langchain_test",
             "chat_template": [{"content": "what country is the city {city} in? respond in {language}", "role": "user"}],
             "variables": {"city": mock.ANY, "language": "Spanish"},
             "_dd_context_variable_keys": ["context"],
@@ -512,6 +515,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, llmobs_events, tra
             span_links=True,
             prompt={
                 "id": "langchain.unknown_prompt_template",
+                "ml_app": "langchain_test",
                 "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
                 "variables": {"topic": "chickens"},
                 "_dd_context_variable_keys": ["context"],
@@ -525,6 +529,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, llmobs_events, tra
             span_links=True,
             prompt={
                 "id": "langchain.unknown_prompt_template",
+                "ml_app": "langchain_test",
                 "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
                 "variables": {"topic": "pigs"},
                 "_dd_context_variable_keys": ["context"],
@@ -539,6 +544,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, llmobs_events, tra
             span_links=True,
             prompt={
                 "id": "langchain.unknown_prompt_template",
+                "ml_app": "langchain_test",
                 "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
                 "variables": {"topic": "chickens"},
                 "_dd_context_variable_keys": ["context"],
@@ -552,6 +558,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, llmobs_events, tra
             span_links=True,
             prompt={
                 "id": "langchain.unknown_prompt_template",
+                "ml_app": "langchain_test",
                 "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
                 "variables": {"topic": "pigs"},
                 "_dd_context_variable_keys": ["context"],

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -466,6 +466,7 @@ def test_structured_prompt_data(llmobs, llmobs_backend):
     assert len(events) == 1
     assert events[0][0]["spans"][0]["meta"]["input"]["prompt"] == {
         "id": "unnamed-ml-app_unnamed-prompt",
+        "ml_app": "unnamed-ml-app",
         "template": "test {{value}}",
         "_dd_context_variable_keys": ["context"],
         "_dd_query_variable_keys": ["question"],
@@ -491,6 +492,7 @@ def test_structured_prompt_data_v2(llmobs, llmobs_backend):
     assert events[0][0]["spans"][0]["meta"]["input"] == {
         "prompt": {
             "id": "test",
+            "ml_app": "unnamed-ml-app",
             "chat_template": [{"role": "user", "content": "test {{value}}"}],
             "variables": {"value": "test", "context": "test", "question": "test"},
             "tags": {"env": "prod", "llm": "openai"},

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -780,6 +780,7 @@ def test_annotate_prompt_dict(llmobs):
             "variables": {"var1": "var1", "var2": "var3"},
             "version": "1.0.0",
             "id": "test_prompt",
+            "ml_app": "unnamed-ml-app",
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
         }
@@ -804,6 +805,7 @@ def test_annotate_prompt_dict_with_context_var_keys(llmobs):
             "variables": {"var1": "var1", "var2": "var3"},
             "version": "1.0.0",
             "id": "test_prompt",
+            "ml_app": "unnamed-ml-app",
             "_dd_context_variable_keys": ["var1", "var2"],
             "_dd_query_variable_keys": ["user_input"],
         }
@@ -828,6 +830,7 @@ def test_annotate_prompt_typed_dict(llmobs):
             "variables": {"var1": "var1", "var2": "var3"},
             "version": "1.0.0",
             "id": "test_prompt",
+            "ml_app": "unnamed-ml-app",
             "_dd_context_variable_keys": ["var1", "var2"],
             "_dd_query_variable_keys": ["user_input"],
         }
@@ -1337,11 +1340,19 @@ def test_annotation_context_modifies_prompt(llmobs):
         with llmobs.llm(name="test_agent", model_name="test") as span:
             assert span._get_ctx_item(INPUT_PROMPT) == {
                 "id": "unnamed-ml-app_unnamed-prompt",
+                "ml_app": "unnamed-ml-app",
                 "template": "test_template",
                 "_dd_context_variable_keys": ["context"],
                 "_dd_query_variable_keys": ["question"],
             }
             assert span._get_ctx_item(TAGS) == {PROMPT_TRACKING_INSTRUMENTATION_METHOD: "annotated"}
+
+
+def test_annotation_context_prompt_includes_ml_app(llmobs):
+    prompt = {"template": "test_template"}
+    with llmobs.annotation_context(prompt=prompt):
+        with llmobs.llm(name="test_agent", model_name="test") as span:
+            assert span._get_ctx_item(INPUT_PROMPT).get("ml_app") == "unnamed-ml-app"
 
 
 def test_annotation_context_modifies_name(llmobs):
@@ -1574,6 +1585,7 @@ async def test_annotation_context_async_modifies_prompt(llmobs):
         with llmobs.llm(name="test_agent", model_name="test") as span:
             assert span._get_ctx_item(INPUT_PROMPT) == {
                 "id": "unnamed-ml-app_unnamed-prompt",
+                "ml_app": "unnamed-ml-app",
                 "template": "test_template",
                 "_dd_context_variable_keys": ["context"],
                 "_dd_query_variable_keys": ["question"],


### PR DESCRIPTION
## Description

Automatically include the ml_app field from config in prompts passed to LLMObs.annotation_context().

## Testing

- Added test_annotation_context_prompt_includes_ml_app test
- Updated existing test_annotation_context_modifies_prompt to include ml_app in expected dict

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
