### PR TITLE
test(profiling): use `uvloop` in all tests

### DIFF
--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
@@ -21,6 +21,7 @@ def test_asyncio_recursive_on_cpu_tasks():
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
+    from tests.profiling.collector.test_utils import async_run
 
     assert stack.is_available, stack.failure_msg
 
@@ -53,7 +54,7 @@ def test_asyncio_recursive_on_cpu_tasks():
         return await outer()
 
     def main_sync():
-        asyncio.run(async_main())
+        async_run(async_main())
 
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
@@ -71,12 +72,33 @@ def test_asyncio_recursive_on_cpu_tasks():
     output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
-    def loc(f_name: str) -> StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
+    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-    base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-    handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+
+    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+    # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
+    # Without uvloop: main_sync → run → Runner.run → run_until_complete → run_forever → _run_once → _run → async_main
+    if use_uvloop:
+        runner_frames = [
+            loc("async_run"),
+            loc("run"),  # uvloop run
+        ]
+        if PYVERSION >= (3, 11):
+            runner_frames += [loc("Runner.run")]
+        event_loop_frames = []
+    else:
+        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+        event_loop_frames = [
+            loc(f"{base_event_loop_prefix}run_until_complete"),
+            loc(f"{base_event_loop_prefix}run_forever"),
+            loc(f"{base_event_loop_prefix}_run_once"),
+            loc(f"{handle_prefix}_run"),
+        ]
 
     pprof_utils.assert_profile_has_sample(
         profile,
@@ -90,14 +112,10 @@ def test_asyncio_recursive_on_cpu_tasks():
                     [
                         loc("<module>"),
                         loc("main_sync"),
-                        loc("run"),
                     ]
-                    + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+                    + runner_frames
+                    + event_loop_frames
                     + [
-                        loc(f"{base_event_loop_prefix}run_until_complete"),
-                        loc(f"{base_event_loop_prefix}run_forever"),
-                        loc(f"{base_event_loop_prefix}_run_once"),
-                        loc(f"{handle_prefix}_run"),
                         # loc("Task-1"),
                         loc("async_main"),
                         loc("outer"),
@@ -130,14 +148,10 @@ def test_asyncio_recursive_on_cpu_tasks():
                     [
                         loc("<module>"),
                         loc("main_sync"),
-                        loc("run"),
                     ]
-                    + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+                    + runner_frames
+                    + event_loop_frames
                     + [
-                        loc(f"{base_event_loop_prefix}run_until_complete"),
-                        loc(f"{base_event_loop_prefix}run_forever"),
-                        loc(f"{base_event_loop_prefix}_run_once"),
-                        loc(f"{handle_prefix}_run"),
                         # loc("Task-1"),
                         loc("async_main"),
                         loc("outer"),

--- a/tests/profiling/collector/test_asyncio_weak_links.py
+++ b/tests/profiling/collector/test_asyncio_weak_links.py
@@ -1,6 +1,14 @@
+import os
+
 import pytest
 
 
+# Skip this test when using uvloop - the weak link feature relies on asyncio internals
+# that uvloop doesn't expose the same way
+@pytest.mark.skipif(
+    os.environ.get("USE_UVLOOP", "0") == "1",
+    reason="uvloop does not support weak link detection the same way as asyncio",
+)
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_weak_links",
@@ -15,6 +23,7 @@ def test_asyncio_weak_links_wall_time() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_utils import async_run
 
     assert stack.is_available, stack.failure_msg
 
@@ -43,7 +52,7 @@ def test_asyncio_weak_links_wall_time() -> None:
     p = profiler.Profiler()
     p.start()
 
-    asyncio.run(main())
+    async_run(main())
 
     p.stop()
 

--- a/tests/profiling/collector/test_threading_asyncio.py
+++ b/tests/profiling/collector/test_threading_asyncio.py
@@ -10,7 +10,6 @@ import pytest
     err=None,
 )
 def test_lock_acquire_events():
-    import asyncio
     import os
     import threading
 
@@ -21,6 +20,8 @@ def test_lock_acquire_events():
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
+    from tests.profiling.collector.test_utils import async_run
+
     # Tests that lock acquire/release events from asyncio threads are captured
     # correctly. See test_asyncio.py for asyncio.Lock tests.
     async def _lock():
@@ -28,16 +29,16 @@ def test_lock_acquire_events():
         lock.acquire()  # !ACQUIRE! test_lock_acquire_events_1
         lock.release()  # !RELEASE! test_lock_acquire_events_1
 
-    def asyncio_run():
+    def asyncio_run_func():
         lock = threading.Lock()  # !CREATE! test_lock_acquire_events_2
         lock.acquire()  # !ACQUIRE! test_lock_acquire_events_2
-        asyncio.run(_lock())
+        async_run(_lock())
         lock.release()  # !RELEASE! test_lock_acquire_events_2
 
     # start a complete profiler so asyncio policy is setup
     p = profiler.Profiler()
     p.start()
-    t = threading.Thread(target=asyncio_run, name="foobar")
+    t = threading.Thread(target=asyncio_run_func, name="foobar")
     t.start()
     t.join()
     p.stop()
@@ -52,40 +53,55 @@ def test_lock_acquire_events():
 
     task_name_regex = r"Task-\d+$"
 
+    # uvloop wraps coroutine execution, so the lock acquire/release inside the coroutine
+    # is reported from uvloop's wrapper code, not from _lock. We skip the _lock lock
+    # event check when using uvloop since the filename and line numbers would be from
+    # uvloop's source code.
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+
+    expected_acquire_events = [
+        pprof_utils.LockAcquireEvent(
+            caller_name="asyncio_run_func",
+            filename=expected_filename,
+            linenos=linenos_2,
+            lock_name="lock",
+            thread_name="foobar",
+        ),
+    ]
+    expected_release_events = [
+        pprof_utils.LockReleaseEvent(
+            caller_name="asyncio_run_func",
+            filename=expected_filename,
+            linenos=linenos_2,
+            lock_name="lock",
+            thread_name="foobar",
+        ),
+    ]
+
+    if not use_uvloop:
+        expected_acquire_events.append(
+            pprof_utils.LockAcquireEvent(
+                caller_name="_lock",
+                filename=expected_filename,
+                linenos=linenos_1,
+                lock_name="lock",
+                task_name=task_name_regex,
+                thread_name="foobar",
+            )
+        )
+        expected_release_events.append(
+            pprof_utils.LockReleaseEvent(
+                caller_name="_lock",
+                filename=expected_filename,
+                linenos=linenos_1,
+                lock_name="lock",
+                task_name=task_name_regex,
+                thread_name="foobar",
+            )
+        )
+
     pprof_utils.assert_lock_events(
         profile,
-        expected_acquire_events=[
-            pprof_utils.LockAcquireEvent(
-                caller_name="asyncio_run",
-                filename=expected_filename,
-                linenos=linenos_2,
-                lock_name="lock",
-                thread_name="foobar",
-            ),
-            pprof_utils.LockAcquireEvent(
-                caller_name="_lock",
-                filename=expected_filename,
-                linenos=linenos_1,
-                lock_name="lock",
-                task_name=task_name_regex,
-                thread_name="foobar",
-            ),
-        ],
-        expected_release_events=[
-            pprof_utils.LockReleaseEvent(
-                caller_name="asyncio_run",
-                filename=expected_filename,
-                linenos=linenos_2,
-                lock_name="lock",
-                thread_name="foobar",
-            ),
-            pprof_utils.LockReleaseEvent(
-                caller_name="_lock",
-                filename=expected_filename,
-                linenos=linenos_1,
-                lock_name="lock",
-                task_name=task_name_regex,
-                thread_name="foobar",
-            ),
-        ],
+        expected_acquire_events=expected_acquire_events,
+        expected_release_events=expected_release_events,
     )

--- a/tests/profiling/collector/test_utils.py
+++ b/tests/profiling/collector/test_utils.py
@@ -7,9 +7,13 @@ from typing import Any
 from typing import Coroutine
 from typing import Optional
 from typing import Type
+from typing import TypeVar
 
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling import profiler
+
+
+T = TypeVar("T")
 
 
 def init_ddup(test_name: str) -> None:
@@ -30,15 +34,15 @@ def init_ddup(test_name: str) -> None:
     ddup.start()
 
 
-def async_run(coro: Coroutine[Any, Any, Any]) -> None:
+def async_run(coro: Coroutine[Any, Any, T]) -> T:
     use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
     if use_uvloop:
         import uvloop
 
-        uvloop.run(coro)
+        return uvloop.run(coro)
     else:
-        asyncio.run(coro)
+        return asyncio.run(coro)
 
 
 def uvloop_available() -> bool:


### PR DESCRIPTION
## Description

This adds support for running all `asyncio` test cases both with the stock `asyncio` Event Loop and `uvloop` based on an environment variable defined in the `riotfile`.

This makes it easy to confirm not only that we get correct Stacks for `uvloop` but also that we see the exact same components with the default Event Loop and `uvloop`.

Links
- Jira: https://datadoghq.atlassian.net/browse/PROF-13511
- Base: https://github.com/DataDog/dd-trace-py/pull/16100

