### PR TITLE
ci(profiling): compare changes against main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -448,11 +448,13 @@ profiling_native:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "main"
     - changes:
-        - .gitlab-ci.yml
-        - ddtrace/internal/datadog/profiling/**/*
-        - ddtrace/profiling/**/*
-        - src/native/**/*
-        - tests/profiling/**/*
+        compare_to: "refs/heads/main"
+        paths:
+          - .gitlab-ci.yml
+          - ddtrace/internal/datadog/profiling/**/*
+          - ddtrace/profiling/**/*
+          - src/native/**/*
+          - tests/profiling/**/*
   parallel:
     matrix:
       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]


### PR DESCRIPTION
## Description

Currently, it happens that `profiling_native` jobs aren't run in case of a force push because GitLab is unable to compute a meaningful before/after for the branch ⇒ no clear paths for the diff. 

Adding this tells GitLab to always compare the current branch to `main`.  
It has a downside: if I push e.g. a release note on top of a commit that did change native code, it will run `profiling_native` jobs even though they're not relevant (for release note changes).  
I think though it's worth the extra work if it can avoid us from missing a bug. 