### PR TITLE
refactor(profiling): move `stack_chunk` to `EchionSampler`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -33,6 +33,11 @@ class EchionSampler
     std::optional<Frame::Key> frame_cache_key_;
     std::unordered_set<PyObject*> previous_task_objects_;
 
+    // Stack chunk for Python 3.11+ frame unwinding
+#if PY_VERSION_HEX >= 0x030b0000
+    std::unique_ptr<StackChunk> stack_chunk_ = nullptr;
+#endif
+
   public:
     EchionSampler() = default;
     ~EchionSampler() = default;
@@ -61,6 +66,10 @@ class EchionSampler
 
     std::optional<Frame::Key>& frame_cache_key() { return frame_cache_key_; }
     std::unordered_set<PyObject*>& previous_task_objects() { return previous_task_objects_; }
+
+#if PY_VERSION_HEX >= 0x030b0000
+    std::unique_ptr<StackChunk>& stack_chunk() { return stack_chunk_; }
+#endif
 
     void postfork_child()
     {

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
@@ -70,7 +70,8 @@ class Frame
     [[nodiscard]] static Result<Frame::Ptr> create(PyCodeObject* code, int lasti);
 
 #if PY_VERSION_HEX >= 0x030b0000
-    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(_PyInterpreterFrame* frame_addr,
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(StackChunk* stack_chunk,
+                                                                    _PyInterpreterFrame* frame_addr,
                                                                     _PyInterpreterFrame** prev_addr);
 #else
     [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(PyObject* frame_addr, PyObject** prev_addr);

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h
@@ -34,5 +34,9 @@ class GreenletInfo
     {
     }
 
+#if PY_VERSION_HEX >= 0x030b0000
+    int unwind(StackChunk* stack_chunk, PyObject*, PyThreadState*, FrameStack&);
+#else
     int unwind(PyObject*, PyThreadState*, FrameStack&);
+#endif
 };

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stack_chunk.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stack_chunk.h
@@ -41,8 +41,4 @@ class StackChunk
     std::unique_ptr<StackChunk> previous = nullptr;
 };
 
-// ----------------------------------------------------------------------------
-
-inline std::unique_ptr<StackChunk> stack_chunk = nullptr;
-
 #endif // PY_VERSION_HEX >= 0x030b0000

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -37,12 +37,19 @@ class FrameStack : public std::deque<Frame::Ref>
 };
 
 // ----------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x030b0000
+size_t
+unwind_frame(StackChunk* stack_chunk, PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
+#else
 size_t
 unwind_frame(PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
+#endif
 
 // ----------------------------------------------------------------------------
+class EchionSampler; // forward declaration
+
 void
-unwind_python_stack(PyThreadState* tstate, FrameStack& stack);
+unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack);
 
 // ----------------------------------------------------------------------------
 class StackInfo

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
@@ -137,5 +137,9 @@ class TaskInfo
     {
     }
 
+#if PY_VERSION_HEX >= 0x030b0000
+    size_t unwind(StackChunk* stack_chunk, FrameStack&);
+#else
     size_t unwind(FrameStack&);
+#endif
 };

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -221,7 +221,7 @@ Frame::key(PyCodeObject* code, int lasti)
 // ------------------------------------------------------------------------
 #if PY_VERSION_HEX >= 0x030b0000
 Result<std::reference_wrapper<Frame>>
-Frame::read(_PyInterpreterFrame* frame_addr, _PyInterpreterFrame** prev_addr)
+Frame::read(StackChunk* stack_chunk, _PyInterpreterFrame* frame_addr, _PyInterpreterFrame** prev_addr)
 #else
 Result<std::reference_wrapper<Frame>>
 Frame::read(PyObject* frame_addr, PyObject** prev_addr)

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
@@ -1,7 +1,12 @@
 #include <echion/greenlets.h>
 
+#if PY_VERSION_HEX >= 0x030b0000
+int
+GreenletInfo::unwind(StackChunk* stack_chunk, PyObject* cur_frame, PyThreadState* tstate, FrameStack& stack)
+#else
 int
 GreenletInfo::unwind(PyObject* cur_frame, PyThreadState* tstate, FrameStack& stack)
+#endif
 {
     PyObject* frame_addr = NULL;
 #if PY_VERSION_HEX >= 0x030d0000
@@ -24,7 +29,11 @@ GreenletInfo::unwind(PyObject* cur_frame, PyThreadState* tstate, FrameStack& sta
 #else // Python < 3.11
     frame_addr = cur_frame == Py_None ? reinterpret_cast<PyObject*>(tstate->frame) : cur_frame;
 #endif
+#if PY_VERSION_HEX >= 0x030b0000
+    auto count = unwind_frame(stack_chunk, frame_addr, stack);
+#else
     auto count = unwind_frame(frame_addr, stack);
+#endif
 
     stack.push_back(Frame::get(name));
 


### PR DESCRIPTION
## Description

**Links**
- Based on https://github.com/DataDog/dd-trace-py/pull/16180/s
- https://datadoghq.atlassian.net/browse/PROF-13364

This removes some more global / static state from the Python Profiler code base.  
This PR should be a functional no-op; the only changes are moving symbols to the `EchionSampler` class, then passing that state around.

**Note** Please don't auto-merge this PR as it doesn't target `main`!
