### PR TITLE
fix(profiling): clear Sample before returning to Pool

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
@@ -35,6 +35,10 @@ StaticSamplePool::take_sample()
 std::optional<Sample*>
 StaticSamplePool::return_sample(Sample* sample)
 {
+    // Clear any data pushed to this sample before returning it to the pool.
+    // This prevents stale data (like span_id) from leaking to the next user.
+    sample->clear_buffers();
+
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* expected = nullptr;
         if (pool[i].compare_exchange_strong(expected, sample, std::memory_order_acq_rel, std::memory_order_relaxed)) {

--- a/releasenotes/notes/fix-profiling-sample-pool-stale-data-2fc2c1345d6e6f43.yaml
+++ b/releasenotes/notes/fix-profiling-sample-pool-stale-data-2fc2c1345d6e6f43.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: A bug where non-pushed samples could leak data to subsequent samples has been fixed.


### PR DESCRIPTION
## Description

Fix flaky `test_lock_events_tracer_non_web` tests caused by stale data in the Profiling Sample pool.

When a `Sample` is dropped (not flushed) via `SampleManager::drop_sample`, it was being returned to the `StaticSamplePool` without clearing its buffers. If a previous user of the sample had pushed data (e.g. `span_id`), that data would persist and leak to the next user of the pooled Sample.

This was causing flaky test failures where `span_id=12345` (from `test_ddup.py`) would appear in subsequent lock profiling tests instead of the expected span ID.

1. `test_ddup.py` creates a `SampleHandle` and pushes `span_id=12345` but never flushes
2. When the handle is deallocated, `drop_sample` returns the sample to the pool with stale data
3. Lock collector tests get this pooled sample and inherit the stale `span_id`

The fix calls `clear_buffers` on the sample before returning it to the pool.

## Testing

Existing profiling tests should now pass consistently. The flaky `test_lock_events_tracer_non_web` tests should no longer fail with stale span IDs.
