### PR TITLE
ci: change backport action to use internal code [APMLP-586]

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
     # the first || is only for testing
     if: >
       github.event.pull_request.merged
-      || (
+      && (
         github.event.action == 'closed'
         || (
           github.event.action == 'labeled'


### PR DESCRIPTION
## Description

This change updates the backport github action to sign its commits, removing a manual step involved in backporting.

## Testing

https://github.com/DataDog/dd-trace-py/pull/16233