### PR TITLE
chore: Revert "fix(profiling): clear Sample before returning to Pool (#16186)"

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
@@ -35,10 +35,6 @@ StaticSamplePool::take_sample()
 std::optional<Sample*>
 StaticSamplePool::return_sample(Sample* sample)
 {
-    // Clear any data pushed to this sample before returning it to the pool.
-    // This prevents stale data (like span_id) from leaking to the next user.
-    sample->clear_buffers();
-
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* expected = nullptr;
         if (pool[i].compare_exchange_strong(expected, sample, std::memory_order_acq_rel, std::memory_order_relaxed)) {

--- a/releasenotes/notes/fix-profiling-sample-pool-stale-data-2fc2c1345d6e6f43.yaml
+++ b/releasenotes/notes/fix-profiling-sample-pool-stale-data-2fc2c1345d6e6f43.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    profiling: A bug where non-pushed samples could leak data to subsequent samples has been fixed.


### PR DESCRIPTION
This reverts commit a3067d6c43ddc0fab222d8e2452b96ff29d1fa91, which was the first in a continuous series of commits to main with broken `linux build` steps.
