### PR TITLE
ci: allow any ref in backport chainguard

### DIFF
--- a/.github/chainguard/self.backport.create-pr.sts.yaml
+++ b/.github/chainguard/self.backport.create-pr.sts.yaml
@@ -5,7 +5,7 @@ subject: repo:DataDog/dd-trace-py:pull_request
 claim_pattern:
   event_name: (pull_request_target|pull_request)
   ref: ".+"
-  job_workflow_ref: "DataDog/dd-trace-py/\.github/workflows/backport\.yml@.+"
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/backport\.yml@.+
 
 permissions:
   contents: write


### PR DESCRIPTION
This change fixes errors like [this one](https://github.com/DataDog/dd-trace-py/actions/runs/21371174970/job/61515820654?pr=16193) caused by a mismatch between `job_workflow_ref` and the chainguard file on backport job runs.