### PR TITLE
temp(profiling): always push cpu time

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -683,8 +683,7 @@ ThreadInfo::update_cpu_time()
 bool
 ThreadInfo::is_running()
 {
-    // Running state is computed in update_cpu_time by taking two back-to-back measurements of the CPU time.
-    return this->running_;
+    return true;
 }
 
 void


### PR DESCRIPTION
More context on https://app.datadoghq.com/notebook/13794809/python-ddtrace-profile-quality-down?refresh_mode=sliding&from_ts=1769508606596&to_ts=1769509565991.

Superseded by https://github.com/DataDog/dd-trace-py/pull/16273