### PR TITLE
ci: use pull_request instead of pull_request_target for validate-backport

### DIFF
--- a/.github/workflows/backport-validate.yml
+++ b/.github/workflows/backport-validate.yml
@@ -1,6 +1,6 @@
 name: Validate Backport
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
 


### PR DESCRIPTION
In the validate-backport github action, `pull_request_target` was used as a security measure instead of `pull_request`, to avoid running untrusted code in github actions. On reflection, this is inappropriate for backport validation, which requires checking out the PR branch and attempting to merge it. The use of `pull_request_target` leads to confusing validation messages like [this one](https://github.com/DataDog/dd-trace-py/pull/16193#issuecomment-3807163560), which shows an evaluation of a merge commit from the base branch instead of the HEAD branch.