### PR TITLE
chore(mcp): update mcp latest version to 1.26.0

### DIFF
--- a/ddtrace/contrib/integration_registry/registry.yaml
+++ b/ddtrace/contrib/integration_registry/registry.yaml
@@ -571,7 +571,7 @@ integrations:
   tested_versions_by_dependency:
     mcp:
       min: 1.10.1
-      max: 1.16.0
+      max: 1.26.0
 
 - integration_name: molten
   is_external_package: true

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -439,7 +439,7 @@
         "dependency": "mcp",
         "integration": "mcp",
         "minimum_tracer_supported": "1.10.1",
-        "max_tracer_supported": "1.16.0",
+        "max_tracer_supported": "1.26.0",
         "auto-instrumented": true
     },
     {

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -60,7 +60,7 @@ logbook,logbook,1.0.0,1.8.2,True
 loguru,loguru,0.4.1,0.7.3,True
 mako,mako,1.0.14,1.3.10,True
 mariadb,mariadb,1.0.11,1.1.13,True
-mcp,mcp,1.10.1,1.16.0,True
+mcp,mcp,1.10.1,1.26.0,True
 molten,molten,1.0.2,1.0.2,True
 mysql-connector-python,mysql,8.0.5,9.4.0,True
 mysqlclient,mysqldb,2.2.1,2.2.6,True


### PR DESCRIPTION
Duplicate of https://github.com/DataDog/dd-trace-py/pull/16198

I fixed the CI issue but my changes were nuked by github for no reason so I open a clean PR here.