### PR TITLE
fix(profiling): patched gevent.joinall return

### DIFF
--- a/releasenotes/notes/fix-profiling-gevent-joinall-return-593d22628a25fd99.yaml
+++ b/releasenotes/notes/fix-profiling-gevent-joinall-return-593d22628a25fd99.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: fixed an issue that causes greenlets to misbehave when
+    ``gevent.joinall`` is called.


### PR DESCRIPTION
## Description

We fix the patched version of gevent.joinall used by the profiler to track greenlets to return the result of the original wrapped function (a list of greenlets) instead of returning None.