### PR TITLE
ci: disable vllm jobs temporarily (#16220) [backport 4.3]

### DIFF
--- a/tests/llmobs/suitespec.yml
+++ b/tests/llmobs/suitespec.yml
@@ -213,4 +213,4 @@ suites:
     runner: riot
     gpu: true
     snapshot: true
-
+    skip: true  # Temporarily disabled


### PR DESCRIPTION
## Description

Manual backport of 8d1678b3623d92e53a790258859e3d558d3a034d from #16220 to 4.3

Needed for #16245

Disable vllm jobs temporarily as they are failing to start 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
