### PR TITLE
ci: run backport on label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - closed
+      - labeled
 
 jobs:
   backport:
@@ -13,7 +14,6 @@ jobs:
       id-token: write
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
-    # the first || is only for testing
     if: >
       github.event.pull_request.merged
       && (


### PR DESCRIPTION
This change fixes an issue where the backport action doesn't run when labels are applied to closed pull requests. I had removed this functionality thinking that it was only for testing purposes, but now realize that it's necessary in main.