### PR TITLE
ci: explicitly name benchmark results baseline and candidate

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -62,13 +62,13 @@ Run scenario
 
 The scenario can be run using the built image to compare two versions of the library and save the results in a local artifacts folder::
 
-  scripts/perf-run-scenario <scenario> <version> <version> --artifacts <artifacts>
+  scripts/perf-run-scenario <scenario> <baseline-version> <candidate-version> --artifacts <artifacts>
 
 The version specifiers can reference published versions on PyPI, git repositories, or `.` for your local version.
 
 To run benchmarks against a single version without comparison, pass an empty string ``""`` as the second version::
 
-  scripts/perf-run-scenario <scenario> <version> "" --artifacts <artifacts>
+  scripts/perf-run-scenario <scenario> <baseline-version> "" --artifacts <artifacts>
 
 Example::
 

--- a/benchmarks/base/benchmark
+++ b/benchmarks/base/benchmark
@@ -7,14 +7,14 @@ fi
 
 ARTIFACTS=/artifacts/${RUN_ID}/${SCENARIO}
 
-OUTPUT_V1=${ARTIFACTS}/${DDTRACE_V1}/
+OUTPUT_V1=${ARTIFACTS}/baseline/
 mkdir -p ${OUTPUT_V1}
 source ${VENV_DDTRACE_V1}/bin/activate
 python run.py ${OUTPUT_V1}
 deactivate
 
 if [ "${DDTRACE_V2}" != "" ]; then
-  OUTPUT_V2=${ARTIFACTS}/${DDTRACE_V2}/
+  OUTPUT_V2=${ARTIFACTS}/candidate/
   mkdir -p ${OUTPUT_V2}
   source ${VENV_DDTRACE_V2}/bin/activate
   python run.py ${OUTPUT_V2}


### PR DESCRIPTION
## Description

Now that we use static versions we might have an artifacts naming conflict. So instead now we use static naming "baseline" and "candidate" to refer to the first and second versions provided to `perf-run-scenario`

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
