### PR TITLE
chore(llmobs): add integration tag to bedrock llm spans

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -142,6 +142,7 @@ class BedrockIntegration(BaseLLMIntegration):
                 METADATA: metadata,
                 METRICS: usage_metrics if span_kind != "workflow" else {},
                 OUTPUT_MESSAGES: output_messages,
+                INTEGRATION: self._integration_name,
             }
         )
 


### PR DESCRIPTION
## Description
Adds missing integration tag to bedrock LLMObs spans. This isn't a big user-facing change (adds a tag to LLM spans), rather it's meant to populate the bedrock integration tag for our telemetry metrics.
<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
