### PR TITLE
fix(debugging): prevent capturing errors

### DIFF
--- a/ddtrace/debugging/_safety.py
+++ b/ddtrace/debugging/_safety.py
@@ -16,11 +16,10 @@ GetSetDescriptor = type(type.__dict__["__dict__"])  # type: ignore[index]  # noq
 
 def get_args(frame: FrameType) -> Iterator[Tuple[str, Any]]:
     code = frame.f_code
+    _locals = frame.f_locals
     nargs = code.co_argcount + bool(code.co_flags & CO_VARARGS) + bool(code.co_flags & CO_VARKEYWORDS)
     arg_names = code.co_varnames[:nargs]
-    arg_values = (frame.f_locals[name] for name in arg_names)
-
-    return zip(arg_names, arg_values)
+    return ((name, _locals.get(name)) for name in arg_names)
 
 
 def get_locals(frame: FrameType) -> Iterator[Tuple[str, Any]]:

--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -348,7 +348,7 @@ def capture_value(
             if not redact(n)
             else redacted_value(v)
         )
-        for n, v in takewhile(lambda _: not cond(_), islice(fields.items(), maxfields))
+        for n, v in takewhile(lambda _: not cond(_), islice(fields.copy().items(), maxfields))
     }
     data = {
         "type": qualname(_type),

--- a/releasenotes/notes/fix-debugging-prevent-capturing-errors-dea3449207fcc193.yaml
+++ b/releasenotes/notes/fix-debugging-prevent-capturing-errors-dea3449207fcc193.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    exception replay: fix for errors while capturing exception replay snapshots.


### PR DESCRIPTION
## Description

We fix a couple of places in the capturing logic that are likely to cause errors when taking snapshots.

## Additional Notes

These errors have been spotted through telemetry data.