### PR TITLE
chore(dbm): propagated hash is propagated in _meta as a string

### DIFF
--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -136,7 +136,7 @@ class _DBM_Propagator(object):
             dbm_tags[DBM_TRACE_PARENT_KEY] = db_span.context._traceparent
 
         if dbm_config.inject_sql_basehash and (base_hash := process_tags.base_hash):
-            dbm_tags[DBM_SERVICE_HASH] = base_hash
+            dbm_tags[DBM_SERVICE_HASH] = str(base_hash)
 
         sql_comment = self.comment_generator(**dbm_tags)
         if sql_comment:

--- a/tests/internal/test_database_monitoring.py
+++ b/tests/internal/test_database_monitoring.py
@@ -149,6 +149,7 @@ def test_dbm_not_propagating_base_hash_when_deactivated():
         injected_sql = modified_args[0]
 
         assert "ddsh" not in injected_sql
+        assert PROPAGATED_HASH not in dbspan._metrics
         assert PROPAGATED_HASH not in dbspan._meta
 
 
@@ -163,6 +164,8 @@ def test_dbm_not_propagating_base_hash_when_deactivated():
     )
 )
 def test_dbm_propagating_base_hash_when_activated():
+    import re
+
     from ddtrace.internal import process_tags
     from ddtrace.internal.constants import PROPAGATED_HASH
     from ddtrace.propagation import _database_monitoring
@@ -179,10 +182,17 @@ def test_dbm_propagating_base_hash_when_activated():
         modified_args, _ = dbm_propagator.inject(dbspan, args, kwargs)
 
         injected_sql = modified_args[0]
+        ddsh_value = None
 
-        assert "ddsh" in injected_sql
         assert PROPAGATED_HASH in dbspan._meta
+        assert "ddsh" in injected_sql
+
+        match = re.search(r"ddsh='(\d+)'", injected_sql)
+        if match:
+            ddsh_value = match.group(1)
+
         assert dbspan._meta[PROPAGATED_HASH] == str(process_tags.base_hash)
+        assert ddsh_value == dbspan._meta[PROPAGATED_HASH]
 
 
 @pytest.mark.subprocess(


### PR DESCRIPTION
Propagated hash was currently sent as a number in the metrics.

It should instead sent as a string in the tags ! This PR is fixing that.