### PR TITLE
fix(dsm): dsm integration events were not registered

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -150,6 +150,9 @@ class Tracer(object):
             partial_flush_min_spans=config._partial_flush_min_spans,
             dd_processors=[PeerServiceProcessor(_ps_config), BaseServiceProcessor()],
         )
+        if config._data_streams_enabled:
+            # Import the datastreams package to register event handlers for kafka, botocore, etc.
+            import ddtrace.internal.datastreams  # noqa: F401
 
         # Ensure that tracer exit hooks are registered and unregistered once per instance
         forksafe.register_before_fork(self._sample_before_fork)

--- a/releasenotes/notes/fix-dsm-showing-no-data-7ac4b2b30c86cf00.yaml
+++ b/releasenotes/notes/fix-dsm-showing-no-data-7ac4b2b30c86cf00.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    data_streams: This fix resolves an issue where no data was shown in DSM.


### PR DESCRIPTION
Since 4.3.0, no data is shown when instrumenting DSM apps.

This was due to the fact that the module registering the DSM integration events was not imported anymore