### PR TITLE
chore: increment version to 4.4.0rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.4.0rc2"
+version = "4.4.0rc3"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
This change increments the version string to represent the next version that would be tagged from main according to the release process guidelines.