### PR TITLE
fix(profiling): always report CPU time regardless of Thread running state

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -54,13 +54,11 @@ class ThreadInfo
     mach_port_t mach_port;
 #endif
     microsecond_t cpu_time;
-    bool running_ = false;
 
     uintptr_t asyncio_loop = 0;
     uintptr_t tstate_addr = 0; // Remote address of PyThreadState for accessing asyncio_tasks_head
 
     [[nodiscard]] Result<void> update_cpu_time();
-    bool is_running();
 
     [[nodiscard]] Result<void> sample(EchionSampler&, int64_t, PyThreadState*, microsecond_t);
     void unwind(EchionSampler&, PyThreadState*);

--- a/releasenotes/notes/profiling-always-report-cpu-time-5f9aa07e648801fc.yaml
+++ b/releasenotes/notes/profiling-always-report-cpu-time-5f9aa07e648801fc.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: The Profiler now always reports CPU time for threads, regardless of whether they are running when
+    the sample is captured.


### PR DESCRIPTION
## Description

This PR updates the Python Profiler logic to always report CPU Time for sampled Threads, regardless of whether they were running when we computed their spent CPU time.

### Why?

In [Incident 48491](https://app.datadoghq.com/incidents/48491), we investigated an issue where following a `ddtrace` upgrade, one of our Python services suddenly started reporting near zero CPU Time and no Frames at all/empty flame graphs.  

The investigation showed that this changed if we removed the check on `is_running` and always reported CPU Time for each sampled Thread.  
Originally, this check was introduced to avoid reporting CPU Time on Stacks that were in fact idle states; however it also means it the Thread runs between two Samples but then does not run when we "check whether it is running", then we are blind to what it did during that time.  
On top of that, there is no reliable way to check whether a Thread is running – checking this is by definition racy, and although there are potential ways around it, we could never guarantee that the running state we determined matched the one that the Thread was in when we captured its Stack, meaning we could have discrepancies anyway.  
Finally, several other Datadog Profilers have this bias and accept it, so we should probably match that behaviour. 

**Note** the performance difference will probably be negligible, but this change may actually slightly improve our CPU usage as we will now make one less system call.