### PR TITLE
test(profiling): try to unflake `test_resource_not_collected`

### DIFF
--- a/tests/profiling/collector/test_asyncio_weak_links.py
+++ b/tests/profiling/collector/test_asyncio_weak_links.py
@@ -78,6 +78,7 @@ def test_asyncio_weak_links_wall_time() -> None:
                 # loc("Task-1"),
             ],
         ),
+        print_samples_on_failure=True,
     )
 
     # We should see a stack for Task-1 / parent / Task-awaited / awaited / sleep
@@ -96,4 +97,5 @@ def test_asyncio_weak_links_wall_time() -> None:
                 # loc("Task-1"),
             ],
         ),
+        print_samples_on_failure=True,
     )

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -828,10 +828,13 @@ def test_resource_not_collected(tmp_path: Path, tracer: Tracer) -> None:
     ddup.upload()
 
     with stack.StackCollector(tracer=tracer):
+        # Give the Profiler some time to start
+        time.sleep(0.1)
+
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
         with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
-            _fib(28)
+            _fib(35)
 
     ddup.upload(tracer=tracer)
 
@@ -847,7 +850,7 @@ def test_resource_not_collected(tmp_path: Path, tracer: Tracer) -> None:
                 pprof_utils.StackLocation(
                     filename=os.path.basename(__file__),
                     function_name=test_name,
-                    line_no=test_resource_not_collected.__code__.co_firstlineno + 14,
+                    line_no=test_resource_not_collected.__code__.co_firstlineno + 17,
                 )
             ],
         ),


### PR DESCRIPTION
## Description

This is an attempt at making a test less flaky (not sure why it's flaky to be honest, so hard to fix for real).

Also, drive-by change to make a test print samples on failure for future debugging/unflaking.