### PR TITLE
fix(lib-injection): use `append` instead of `index(-1, ...)`

### DIFF
--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -484,7 +484,7 @@ def _inject():
             return
 
         # Add the custom site-packages directory to the Python path to load the ddtrace package.
-        sys.path.insert(-1, site_pkgs_path)
+        sys.path.append(site_pkgs_path)
         _log("sys.path %s" % sys.path, level="debug")
         # Used to track whether the ddtrace package was successfully injected. Must be set before importing ddtrace
         os.environ["_DD_PY_SSI_INJECT"] = "1"
@@ -533,7 +533,7 @@ def _inject():
                     for entry in os.getenv("PYTHONPATH", "").split(os.pathsep)
                     if not any(path in entry for path in path_segments_indicating_removal)
                 ]
-                python_path.insert(-1, site_pkgs_path)
+                python_path.append(site_pkgs_path)
                 python_path.insert(0, bootstrap_dir)
                 python_path = os.pathsep.join(python_path)
                 os.environ["PYTHONPATH"] = python_path

--- a/releasenotes/notes/fix-injection-append-eafc95df39034f63.yaml
+++ b/releasenotes/notes/fix-injection-append-eafc95df39034f63.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    lib injection: the injected ``site-packages`` directory is now added as the last entry in the ``PYTHONPATH``
+    environment variable (it previously was added before the last entry).


### PR DESCRIPTION
## Description

This updates the `sitecustomize` logic for SSI to add our `site-packages` at the end of the Python path instead of at the penultimate position.  The problem was that `inserts(n, ...)` inserts the item _before_ position `n` and not _at_ position `n`.

We suspect this caused bugs with imports where the version of libraries we shipped were imported instead of the version shipped by the customer in their environment.