### PR TITLE
chore(profiling): update typing in memalloc.pyi

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.pyi
+++ b/ddtrace/profiling/collector/_memalloc.pyi
@@ -1,14 +1,3 @@
-import typing
-
-from .. import event
-
-# (filename, line number, function name)
-FrameType = event.DDFrame
-StackType = event.StackTraceType
-
-# (stack, thread_id)
-TracebackType = typing.Tuple[StackType, int]
-
 def start(max_nframe: int, heap_sample_interval: int) -> None: ...
 def stop() -> None: ...
-def heap() -> typing.List[typing.Tuple[TracebackType, int, int, int]]: ...
+def heap() -> None: ...

--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -1,6 +1,4 @@
 from collections import namedtuple
-import typing
 
 
 DDFrame = namedtuple("DDFrame", ["file_name", "lineno", "function_name"])
-StackTraceType = typing.List[DDFrame]


### PR DESCRIPTION
## Description

`_memalloc.heap()` returns `None`, update it in `_memalloc.pyi` and remove type defs that are not needed anymore.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
