### PR TITLE
chore(profiling): remove _PY39_AND_LATER macro

### DIFF
--- a/ddtrace/profiling/collector/_pymacro.h
+++ b/ddtrace/profiling/collector/_pymacro.h
@@ -17,15 +17,3 @@
 #if PY_VERSION_HEX >= 0x030a0000
 #define _PY310_AND_LATER
 #endif
-
-#if PY_VERSION_HEX >= 0x03090000
-#define _PY39_AND_LATER
-#endif
-
-#if PY_VERSION_HEX >= 0x03080000
-#define _PY38_AND_LATER
-#endif
-
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 8
-#define _PY38
-#endif


### PR DESCRIPTION
## Description

We support Python versions 3.9-3.14, so _PY39_AND_LATER is always set. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
