### PR TITLE
ci: fix serverless system-tests build layer

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -384,7 +384,7 @@ jobs:
       - name: Build datadog_lambda layer
         run: |
           wheel_path=$(find ./artifacts -name "*.whl" | head -n 1)
-          sed -i 's|^ddtrace =.*$|ddtrace = { file = "'"$wheel_path"'" }|' pyproject.toml
+          sed -zEi 's|(ddtrace = )\[[^]]*]|\1{ file = "'"$wheel_path"'" }|g' pyproject.toml
           ARCH=amd64 PYTHON_VERSION=3.13 ./scripts/build_layers.sh
 
       - name: Upload layer artifact


### PR DESCRIPTION
## Description

A recent change in datadog-lambda-python changes the way the `ddtrace` dependency is defined.
https://github.com/DataDog/datadog-lambda-python/blob/74fb90be64e357d0b2d8e7573b6787d0735aabd9/pyproject.toml#L32-L35

This requires modifying the sed command.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Note: this sed command is brittle and will probably break again on a future change. We should try to think of a better solution, but let's unblock CI first.
