### PR TITLE
refactor(profiling): move `StringTable` to `EchionSampler`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <echion/strings.h>
 #include <echion/threads.h>
 
 class EchionSampler
@@ -31,6 +32,9 @@ class EchionSampler
     // Task unwinding state
     std::optional<Frame::Key> frame_cache_key_;
     std::unordered_set<PyObject*> previous_task_objects_;
+
+    // Caches
+    StringTable string_table_;
 
   public:
     EchionSampler() = default;
@@ -60,12 +64,19 @@ class EchionSampler
     std::optional<Frame::Key>& frame_cache_key() { return frame_cache_key_; }
     std::unordered_set<PyObject*>& previous_task_objects() { return previous_task_objects_; }
 
+    // Accessor for StringTable operations
+    StringTable& string_table() { return string_table_; }
+    const StringTable& string_table() const { return string_table_; }
+
     void postfork_child()
     {
         // Re-init mutexes (placement new to avoid UB)
         new (&thread_info_map_lock_) std::mutex;
         new (&task_link_map_lock_) std::mutex;
         new (&greenlet_info_map_lock_) std::mutex;
+
+        // Reset string_table mutex
+        string_table_.postfork_child();
 
         // Clear stale entries from parent process.
         // No lock needed: only one thread exists in child immediately after fork.

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
@@ -34,6 +34,9 @@
 #include <echion/strings.h>
 #include <echion/vm.h>
 
+// Forward declaration
+class EchionSampler;
+
 // ----------------------------------------------------------------------------
 class Frame
 {
@@ -67,16 +70,21 @@ class Frame
     }
     Frame(StringTable::Key name)
       : name(name) {};
-    [[nodiscard]] static Result<Frame::Ptr> create(PyCodeObject* code, int lasti);
+    [[nodiscard]] static Result<Frame::Ptr> create(EchionSampler& echion, PyCodeObject* code, int lasti);
 
 #if PY_VERSION_HEX >= 0x030b0000
-    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(_PyInterpreterFrame* frame_addr,
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(EchionSampler& echion,
+                                                                    _PyInterpreterFrame* frame_addr,
                                                                     _PyInterpreterFrame** prev_addr);
 #else
-    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(PyObject* frame_addr, PyObject** prev_addr);
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(EchionSampler& echion,
+                                                                    PyObject* frame_addr,
+                                                                    PyObject** prev_addr);
 #endif
 
-    [[nodiscard]] static Result<std::reference_wrapper<Frame>> get(PyCodeObject* code_addr, int lasti);
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> get(EchionSampler& echion,
+                                                                   PyCodeObject* code_addr,
+                                                                   int lasti);
     static Frame& get(StringTable::Key name);
 
   private:

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h
@@ -16,6 +16,8 @@
 
 #define FRAME_NOT_SET Py_False // Sentinel for frame cell
 
+class EchionSampler;
+
 class GreenletInfo
 {
   public:
@@ -34,5 +36,5 @@ class GreenletInfo
     {
     }
 
-    int unwind(PyObject*, PyThreadState*, FrameStack&);
+    int unwind(EchionSampler& echion, PyObject*, PyThreadState*, FrameStack&);
 };

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -36,13 +36,16 @@ class FrameStack : public std::deque<Frame::Ref>
     }
 };
 
+// Forward declaration
+class EchionSampler;
+
 // ----------------------------------------------------------------------------
 size_t
-unwind_frame(PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
+unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
 
 // ----------------------------------------------------------------------------
 void
-unwind_python_stack(PyThreadState* tstate, FrameStack& stack);
+unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack);
 
 // ----------------------------------------------------------------------------
 class StackInfo

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
@@ -94,8 +94,3 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
   private:
     mutable std::mutex table_lock;
 };
-
-// We make this a reference to a heap-allocated object so that we can avoid
-// the destruction on exit. We are in charge of cleaning up the object. Note
-// that the object will leak, but this is not a problem.
-inline StringTable& string_table = *(new StringTable());

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h
@@ -126,7 +126,7 @@ class TaskInfo
     // only if it is awaiting another Task.
     TaskInfo::Ptr waiter = nullptr;
 
-    [[nodiscard]] static Result<TaskInfo::Ptr> create(TaskObj*);
+    [[nodiscard]] static Result<TaskInfo::Ptr> create(EchionSampler& echion, TaskObj*);
     TaskInfo(PyObject* origin, PyObject* loop, GenInfo::Ptr coro, StringTable::Key name, TaskInfo::Ptr waiter)
       : origin(origin)
       , loop(loop)
@@ -137,5 +137,5 @@ class TaskInfo
     {
     }
 
-    size_t unwind(FrameStack&);
+    size_t unwind(EchionSampler& echion, FrameStack&);
 };

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -115,10 +115,14 @@ class ThreadInfo
     void unwind_greenlets(EchionSampler&, PyThreadState*, unsigned long);
     [[nodiscard]] Result<std::vector<TaskInfo::Ptr>> get_all_tasks(EchionSampler&, PyThreadState* tstate);
 #if PY_VERSION_HEX >= 0x030e0000
-    [[nodiscard]] Result<void> get_tasks_from_thread_linked_list(std::vector<TaskInfo::Ptr>& tasks);
-    [[nodiscard]] Result<void> get_tasks_from_interpreter_linked_list(PyThreadState* tstate,
+    [[nodiscard]] Result<void> get_tasks_from_thread_linked_list(EchionSampler& echion,
+                                                                 std::vector<TaskInfo::Ptr>& tasks);
+    [[nodiscard]] Result<void> get_tasks_from_interpreter_linked_list(EchionSampler& echion,
+                                                                      PyThreadState* tstate,
                                                                       std::vector<TaskInfo::Ptr>& tasks);
-    [[nodiscard]] Result<void> get_tasks_from_linked_list(uintptr_t head_addr, std::vector<TaskInfo::Ptr>& tasks);
+    [[nodiscard]] Result<void> get_tasks_from_linked_list(EchionSampler& echion,
+                                                          uintptr_t head_addr,
+                                                          std::vector<TaskInfo::Ptr>& tasks);
 #endif
 };
 

--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -51,6 +51,10 @@ class Sampler
   public:
     // Singleton instance
     static Sampler& get();
+
+    // Accessor for EchionSampler
+    EchionSampler& get_echion() { return *echion; }
+
     bool start();
     void stop();
     void register_thread(uint64_t id, uint64_t native_id, const char* name);

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -1,5 +1,6 @@
 #include <echion/frame.h>
 
+#include <echion/echion_sampler.h>
 #include <echion/errors.h>
 #include <echion/render.h>
 
@@ -58,17 +59,17 @@ reset_frame_cache()
 
 // ------------------------------------------------------------------------
 Result<Frame::Ptr>
-Frame::create(PyCodeObject* code, int lasti)
+Frame::create(EchionSampler& echion, PyCodeObject* code, int lasti)
 {
-    auto maybe_filename = string_table.key(code->co_filename, StringTag::FileName);
+    auto maybe_filename = echion.string_table().key(code->co_filename, StringTag::FileName);
     if (!maybe_filename) {
         return ErrorKind::FrameError;
     }
 
 #if PY_VERSION_HEX >= 0x030b0000
-    auto maybe_name = string_table.key(code->co_qualname, StringTag::FuncName);
+    auto maybe_name = echion.string_table().key(code->co_qualname, StringTag::FuncName);
 #else
-    auto maybe_name = string_table.key(code->co_name, StringTag::FuncName);
+    auto maybe_name = echion.string_table().key(code->co_name, StringTag::FuncName);
 #endif
 
     if (!maybe_name) {
@@ -221,10 +222,10 @@ Frame::key(PyCodeObject* code, int lasti)
 // ------------------------------------------------------------------------
 #if PY_VERSION_HEX >= 0x030b0000
 Result<std::reference_wrapper<Frame>>
-Frame::read(_PyInterpreterFrame* frame_addr, _PyInterpreterFrame** prev_addr)
+Frame::read(EchionSampler& echion, _PyInterpreterFrame* frame_addr, _PyInterpreterFrame** prev_addr)
 #else
 Result<std::reference_wrapper<Frame>>
-Frame::read(PyObject* frame_addr, PyObject** prev_addr)
+Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
 #endif
 {
 #if PY_VERSION_HEX >= 0x030b0000
@@ -273,7 +274,7 @@ Frame::read(PyObject* frame_addr, PyObject** prev_addr)
     int instr_offset = static_cast<int>(frame_addr->instr_ptr - 1 - code_units);
     int code_offset = offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
     const int lasti = instr_offset - code_offset;
-    auto maybe_frame = Frame::get(code_obj, lasti);
+    auto maybe_frame = Frame::get(echion, code_obj, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
     }
@@ -285,7 +286,7 @@ Frame::read(PyObject* frame_addr, PyObject** prev_addr)
         (frame_addr->instr_ptr - 1 -
          reinterpret_cast<_Py_CODEUNIT*>((reinterpret_cast<PyCodeObject*>(frame_addr->f_executable)))))) -
       offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto maybe_frame = Frame::get(reinterpret_cast<PyCodeObject*>(frame_addr->f_executable), lasti);
+    auto maybe_frame = Frame::get(echion, reinterpret_cast<PyCodeObject*>(frame_addr->f_executable), lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
     }
@@ -295,7 +296,7 @@ Frame::read(PyObject* frame_addr, PyObject** prev_addr)
     const int lasti =
       (static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code))))) -
       offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto maybe_frame = Frame::get(frame_addr->f_code, lasti);
+    auto maybe_frame = Frame::get(echion, frame_addr->f_code, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
     }
@@ -320,7 +321,7 @@ Frame::read(PyObject* frame_addr, PyObject** prev_addr)
         return ErrorKind::FrameError;
     }
 
-    auto maybe_frame = Frame::get(py_frame.f_code, py_frame.f_lasti);
+    auto maybe_frame = Frame::get(echion, py_frame.f_code, py_frame.f_lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
     }
@@ -334,7 +335,7 @@ Frame::read(PyObject* frame_addr, PyObject** prev_addr)
 
 // ----------------------------------------------------------------------------
 Result<std::reference_wrapper<Frame>>
-Frame::get(PyCodeObject* code_addr, int lasti)
+Frame::get(EchionSampler& echion, PyCodeObject* code_addr, int lasti)
 {
     auto frame_key = Frame::key(code_addr, lasti);
 
@@ -348,7 +349,7 @@ Frame::get(PyCodeObject* code_addr, int lasti)
         return std::ref(INVALID_FRAME);
     }
 
-    auto maybe_new_frame = Frame::create(&code, lasti);
+    auto maybe_new_frame = Frame::create(echion, &code, lasti);
     if (!maybe_new_frame) {
         return std::ref(INVALID_FRAME);
     }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
@@ -1,7 +1,9 @@
 #include <echion/greenlets.h>
 
+#include <echion/echion_sampler.h>
+
 int
-GreenletInfo::unwind(PyObject* cur_frame, PyThreadState* tstate, FrameStack& stack)
+GreenletInfo::unwind(EchionSampler& echion, PyObject* cur_frame, PyThreadState* tstate, FrameStack& stack)
 {
     PyObject* frame_addr = NULL;
 #if PY_VERSION_HEX >= 0x030d0000
@@ -24,7 +26,7 @@ GreenletInfo::unwind(PyObject* cur_frame, PyThreadState* tstate, FrameStack& sta
 #else // Python < 3.11
     frame_addr = cur_frame == Py_None ? reinterpret_cast<PyObject*>(tstate->frame) : cur_frame;
 #endif
-    auto count = unwind_frame(frame_addr, stack);
+    auto count = unwind_frame(echion, frame_addr, stack);
 
     stack.push_back(Frame::get(name));
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
@@ -1,12 +1,13 @@
 #include <echion/stacks.h>
 
+#include <echion/echion_sampler.h>
 #include <unordered_set>
 
 // Unwind Python frames starting from frame_addr and push them onto stack.
 // @param max_depth: Maximum number of frames to unwind. Defaults to max_frames.
 // @return: Number of frames added to the stack.
 size_t
-unwind_frame(PyObject* frame_addr, FrameStack& stack, size_t max_depth)
+unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth)
 {
     std::unordered_set<PyObject*> seen_frames; // Used to detect cycles in the stack
     size_t count = 0;
@@ -19,10 +20,11 @@ unwind_frame(PyObject* frame_addr, FrameStack& stack, size_t max_depth)
         seen_frames.insert(current_frame_addr);
 
 #if PY_VERSION_HEX >= 0x030b0000
-        auto maybe_frame = Frame::read(reinterpret_cast<_PyInterpreterFrame*>(current_frame_addr),
+        auto maybe_frame = Frame::read(echion,
+                                       reinterpret_cast<_PyInterpreterFrame*>(current_frame_addr),
                                        reinterpret_cast<_PyInterpreterFrame**>(&current_frame_addr));
 #else
-        auto maybe_frame = Frame::read(current_frame_addr, &current_frame_addr);
+        auto maybe_frame = Frame::read(echion, current_frame_addr, &current_frame_addr);
 #endif
         if (!maybe_frame) {
             break;
@@ -44,7 +46,7 @@ unwind_frame(PyObject* frame_addr, FrameStack& stack, size_t max_depth)
 }
 
 void
-unwind_python_stack(PyThreadState* tstate, FrameStack& stack)
+unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack)
 {
     stack.clear();
 #if PY_VERSION_HEX >= 0x030b0000
@@ -70,5 +72,5 @@ unwind_python_stack(PyThreadState* tstate, FrameStack& stack)
 #else // Python < 3.11
     PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->frame);
 #endif
-    unwind_frame(frame_addr, stack);
+    unwind_frame(echion, frame_addr, stack);
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -1,5 +1,7 @@
 #include <echion/tasks.h>
 
+#include <echion/echion_sampler.h>
+
 #include <stack>
 
 Result<GenInfo::Ptr>
@@ -85,7 +87,7 @@ GenInfo::create(PyObject* gen_addr)
 
 // ----------------------------------------------------------------------------
 Result<TaskInfo::Ptr>
-TaskInfo::create(TaskObj* task_addr)
+TaskInfo::create(EchionSampler& echion, TaskObj* task_addr)
 {
     static thread_local size_t recursion_depth = 0;
     recursion_depth++;
@@ -107,7 +109,7 @@ TaskInfo::create(TaskObj* task_addr)
         return ErrorKind::TaskInfoGeneratorError;
     }
 
-    auto maybe_name = string_table.key(task.task_name, StringTag::TaskName);
+    auto maybe_name = echion.string_table().key(task.task_name, StringTag::TaskName);
     if (!maybe_name) {
         recursion_depth--;
         return ErrorKind::TaskInfoError;
@@ -118,7 +120,8 @@ TaskInfo::create(TaskObj* task_addr)
 
     TaskInfo::Ptr waiter = nullptr;
     if (task.task_fut_waiter) {
-        auto maybe_waiter = TaskInfo::create(reinterpret_cast<TaskObj*>(task.task_fut_waiter)); // TODO: Make lazy?
+        auto maybe_waiter =
+          TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task.task_fut_waiter)); // TODO: Make lazy?
         if (maybe_waiter) {
             waiter = std::move(*maybe_waiter);
         }
@@ -130,7 +133,7 @@ TaskInfo::create(TaskObj* task_addr)
 }
 
 size_t
-TaskInfo::unwind(FrameStack& stack)
+TaskInfo::unwind(EchionSampler& echion, FrameStack& stack)
 {
     // TODO: Check for running task.
 
@@ -156,7 +159,7 @@ TaskInfo::unwind(FrameStack& stack)
         // For a running Task, unwind_frame would also yield the asyncio runtime frames "on top"
         // of the Task frame, but we would discard those anyway. Limiting to 1 frame avoids walking
         // the Frame chain unnecessarily.
-        auto new_frames = unwind_frame(frame, stack, 1);
+        auto new_frames = unwind_frame(echion, frame, stack, 1);
         assert(new_frames <= 1 && "expected exactly 1 frame to be unwound (or 0 in case of an error)");
 
         // If we failed to unwind the Frame, stop unwinding the coroutine chain; otherwise we could

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -8,7 +8,7 @@
 void
 ThreadInfo::unwind(EchionSampler& echion, PyThreadState* tstate)
 {
-    unwind_python_stack(tstate, python_stack);
+    unwind_python_stack(echion, tstate, python_stack);
 
     if (asyncio_loop) {
         // unwind_tasks returns a [[nodiscard]] Result<void>.
@@ -37,7 +37,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
     if (!frame_cache_key) {
         for (size_t i = 0; i < python_stack.size(); i++) {
             const auto& frame = python_stack[i].get();
-            const auto& frame_name = string_table.lookup(frame.name)->get();
+            const auto& frame_name = echion.string_table().lookup(frame.name)->get();
 
 #if PY_VERSION_HEX >= 0x030b0000
             // After Python 3.11, function names in Frames are qualified with e.g. the class name, so we
@@ -49,7 +49,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
             // can use the filename to identify the "_run" Frame.
             constexpr std::string_view asyncio_runners_py = "asyncio/events.py";
             constexpr std::string_view _run = "_run";
-            auto filename = string_table.lookup(frame.filename)->get();
+            auto filename = echion.string_table().lookup(frame.filename)->get();
             auto is_asyncio = filename.rfind(asyncio_runners_py) == filename.size() - asyncio_runners_py.size();
             auto is_run_frame = is_asyncio && (frame_name.rfind(_run) == frame_name.size() - _run.size());
 #endif
@@ -183,7 +183,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
         for (auto current_task = leaf_task;;) {
             auto& task = current_task.get();
 
-            auto task_stack_size = task.unwind(stack);
+            auto task_stack_size = task.unwind(echion, stack);
             if (task.is_on_cpu) {
                 // Get the "bottom" part of the Python synchronous Stack, that is to say the
                 // synchronous functions and coroutines called by the Task's outermost coroutine
@@ -264,7 +264,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
 // ----------------------------------------------------------------------------
 #if PY_VERSION_HEX >= 0x030e0000
 Result<void>
-ThreadInfo::get_tasks_from_thread_linked_list(std::vector<TaskInfo::Ptr>& tasks)
+ThreadInfo::get_tasks_from_thread_linked_list(EchionSampler& echion, std::vector<TaskInfo::Ptr>& tasks)
 {
     if (this->tstate_addr == 0 || this->asyncio_loop == 0) {
         return ErrorKind::TaskInfoError;
@@ -279,11 +279,13 @@ ThreadInfo::get_tasks_from_thread_linked_list(std::vector<TaskInfo::Ptr>& tasks)
     constexpr size_t asyncio_tasks_head_offset = offsetof(_PyThreadStateImpl, asyncio_tasks_head);
     uintptr_t head_addr = this->tstate_addr + asyncio_tasks_head_offset;
 
-    return get_tasks_from_linked_list(head_addr, tasks);
+    return get_tasks_from_linked_list(echion, head_addr, tasks);
 }
 
 Result<void>
-ThreadInfo::get_tasks_from_interpreter_linked_list(PyThreadState* tstate, std::vector<TaskInfo::Ptr>& tasks)
+ThreadInfo::get_tasks_from_interpreter_linked_list(EchionSampler& echion,
+                                                   PyThreadState* tstate,
+                                                   std::vector<TaskInfo::Ptr>& tasks)
 {
     if (tstate == nullptr || tstate->interp == nullptr || this->asyncio_loop == 0) {
         return ErrorKind::TaskInfoError;
@@ -292,11 +294,11 @@ ThreadInfo::get_tasks_from_interpreter_linked_list(PyThreadState* tstate, std::v
     constexpr size_t asyncio_tasks_head_offset = offsetof(PyInterpreterState, asyncio_tasks_head);
     uintptr_t head_addr = reinterpret_cast<uintptr_t>(tstate->interp) + asyncio_tasks_head_offset;
 
-    return get_tasks_from_linked_list(head_addr, tasks);
+    return get_tasks_from_linked_list(echion, head_addr, tasks);
 }
 
 Result<void>
-ThreadInfo::get_tasks_from_linked_list(uintptr_t head_addr, std::vector<TaskInfo::Ptr>& tasks)
+ThreadInfo::get_tasks_from_linked_list(EchionSampler& echion, uintptr_t head_addr, std::vector<TaskInfo::Ptr>& tasks)
 {
     if (head_addr == 0 || this->asyncio_loop == 0) {
         return ErrorKind::TaskInfoError;
@@ -341,7 +343,7 @@ ThreadInfo::get_tasks_from_linked_list(uintptr_t head_addr, std::vector<TaskInfo
         uintptr_t task_addr_uint = next_node_addr - task_node_offset_val;
 
         // Create TaskInfo for the task
-        auto maybe_task_info = TaskInfo::create(reinterpret_cast<TaskObj*>(task_addr_uint));
+        auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr_uint));
         if (maybe_task_info) {
             auto& task_info = *maybe_task_info;
             if (task_info->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
@@ -372,10 +374,10 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState* tstate)
     // First, get tasks from this thread's linked-list (if tstate_addr is set)
     // Note: We continue processing even if one source fails to maximize partial results
     if (tstate != nullptr && this->tstate_addr != 0) {
-        (void)get_tasks_from_thread_linked_list(tasks);
+        (void)get_tasks_from_thread_linked_list(echion, tasks);
 
         // Second, get tasks from interpreter's linked-list (lingering tasks)
-        (void)get_tasks_from_interpreter_linked_list(tstate, tasks);
+        (void)get_tasks_from_interpreter_linked_list(echion, tstate, tasks);
     }
 
     // Handle third-party tasks from Python _scheduled_tasks WeakSet
@@ -391,7 +393,7 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState* tstate)
                 auto scheduled_tasks = std::move(*maybe_scheduled_tasks);
                 for (auto task_addr : scheduled_tasks) {
                     // In WeakSet.data (set), elements are the Task objects themselves
-                    auto maybe_task_info = TaskInfo::create(reinterpret_cast<TaskObj*>(task_addr));
+                    auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
                     if (maybe_task_info &&
                         (*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
                         tasks.push_back(std::move(*maybe_task_info));
@@ -417,7 +419,7 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState* tstate)
 
         auto eager_tasks = std::move(*maybe_eager_tasks);
         for (auto task_addr : eager_tasks) {
-            auto maybe_task_info = TaskInfo::create(reinterpret_cast<TaskObj*>(task_addr));
+            auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
             if (maybe_task_info) {
                 if ((*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
                     tasks.push_back(std::move(*maybe_task_info));
@@ -455,7 +457,7 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState*)
         if (copy_type(task_wr_addr, task_wr))
             continue;
 
-        auto maybe_task_info = TaskInfo::create(reinterpret_cast<TaskObj*>(task_wr.wr_object));
+        auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_wr.wr_object));
         if (maybe_task_info) {
             if ((*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
                 tasks.push_back(std::move(*maybe_task_info));
@@ -479,7 +481,7 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState*)
 
         auto eager_tasks = std::move(*maybe_eager_tasks);
         for (auto task_addr : eager_tasks) {
-            auto maybe_task_info = TaskInfo::create(reinterpret_cast<TaskObj*>(task_addr));
+            auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
             if (maybe_task_info) {
                 if ((*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
                     tasks.push_back(std::move(*maybe_task_info));
@@ -532,7 +534,7 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
         auto stack_info = std::make_unique<StackInfo>(greenlet->name, on_cpu);
         auto& stack = stack_info->stack;
 
-        greenlet->unwind(frame, tstate, stack);
+        greenlet->unwind(echion, frame, tstate, stack);
 
         std::unordered_set<GreenletInfo::ID> visited;
 
@@ -562,7 +564,7 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
             if (parent_frame == FRAME_NOT_SET || parent_frame == Py_None)
                 break;
 
-            parent_greenlet->second->unwind(parent_frame, tstate, stack);
+            parent_greenlet->second->unwind(echion, parent_frame, tstate, stack);
 
             // Move up the greenlet chain
             greenlet_id = parent_greenlet_id;
@@ -594,7 +596,7 @@ ThreadInfo::sample(EchionSampler& echion, int64_t iid, PyThreadState* tstate, mi
     // 3. The normal thread stack (if no asyncio tasks or greenlets)
     if (!current_tasks.empty()) {
         for (auto& task_stack_info : current_tasks) {
-            auto maybe_task_name = string_table.lookup(task_stack_info->task_name);
+            auto maybe_task_name = echion.string_table().lookup(task_stack_info->task_name);
             if (!maybe_task_name) {
                 return ErrorKind::ThreadInfoError;
             }
@@ -611,7 +613,7 @@ ThreadInfo::sample(EchionSampler& echion, int64_t iid, PyThreadState* tstate, mi
         current_tasks.clear();
     } else if (!current_greenlets.empty()) {
         for (auto& greenlet_stack : current_greenlets) {
-            auto maybe_task_name = string_table.lookup(greenlet_stack->task_name);
+            auto maybe_task_name = echion.string_table().lookup(greenlet_stack->task_name);
             if (!maybe_task_name) {
                 return ErrorKind::ThreadInfoError;
             }

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -184,7 +184,7 @@ Sampler::sampling_thread(const uint64_t seq_num)
         });
 
         Sample::profile_borrow().stats().increment_sampling_event_count();
-        Sample::profile_borrow().stats().set_string_table_count(string_table.size());
+        Sample::profile_borrow().stats().set_string_table_count(echion->string_table().size());
 
         if (do_adaptive_sampling) {
             // Adjust the sampling interval at most every second
@@ -280,10 +280,6 @@ _stack_atfork_child()
 
     // Clear renderer caches to avoid using stale interned IDs
     Sampler::get().postfork_child();
-
-    // Reset the string_table mutex to avoid deadlock if fork happened while it was held
-    // Note: task_link_map_lock and greenlet_info_map_lock are handled in EchionSampler::postfork_child
-    string_table.postfork_child();
 }
 
 __attribute__((constructor)) void

--- a/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
@@ -3,6 +3,8 @@
 #include "sampler.hpp"
 #include "thread_span_links.hpp"
 
+#include "echion/echion_sampler.h"
+
 using namespace Datadog;
 
 static PyObject*
@@ -226,7 +228,8 @@ track_greenlet(PyObject* Py_UNUSED(m), PyObject* args)
     if (!PyArg_ParseTuple(args, "lOO", &greenlet_id, &name, &frame))
         return NULL;
 
-    auto maybe_greenlet_name = string_table.key(name, StringTag::GreenletName);
+    auto& sampler = Sampler::get();
+    auto maybe_greenlet_name = sampler.get_echion().string_table().key(name, StringTag::GreenletName);
     if (!maybe_greenlet_name) {
         // We failed to get this task but we keep going
         PyErr_SetString(PyExc_RuntimeError, "Failed to get greenlet name from the string table");
@@ -236,7 +239,7 @@ track_greenlet(PyObject* Py_UNUSED(m), PyObject* args)
     auto greenlet_name = *maybe_greenlet_name;
 
     Py_BEGIN_ALLOW_THREADS;
-    Sampler::get().track_greenlet(greenlet_id, greenlet_name, frame);
+    sampler.track_greenlet(greenlet_id, greenlet_name, frame);
     Py_END_ALLOW_THREADS;
 
     Py_RETURN_NONE;

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -1,10 +1,11 @@
 #include "stack_renderer.hpp"
 
+#include "sampler.hpp"
 #include "thread_span_links.hpp"
 
 #include "dd_wrapper/include/sample_manager.hpp"
 
-#include "echion/strings.h"
+#include "echion/echion_sampler.h"
 
 using namespace Datadog;
 
@@ -138,7 +139,7 @@ StackRenderer::render_frame(Frame& frame)
     auto line = frame.location.line;
 
     std::string_view name_str;
-    auto maybe_name_str = string_table.lookup(frame.name);
+    auto maybe_name_str = Sampler::get().get_echion().string_table().lookup(frame.name);
     if (maybe_name_str) {
         name_str = maybe_name_str->get();
     } else {
@@ -158,7 +159,7 @@ StackRenderer::render_frame(Frame& frame)
     }
 
     std::string_view filename_str;
-    auto maybe_filename_str = string_table.lookup(frame.filename);
+    auto maybe_filename_str = Sampler::get().get_echion().string_table().lookup(frame.filename);
     if (maybe_filename_str) {
         filename_str = maybe_filename_str->get();
     } else {


### PR DESCRIPTION
## Motivation

https://datadoghq.atlassian.net/browse/PROF-13364

The `StringTable` used for string interning in the profiler stack sampler was a global variable. This made it harder to reason about thread-safety and state management, particularly around fork handling. Moving it into `EchionSampler` encapsulates the state better and ensures proper lifecycle management.

## Safety 

This should be a no-op regarding lifetimes and safety more generally. 

* **Lifetime** The `StringTable` used to be a global  ('`static auto& string_table = *(new StringTable())`); it is now a member of `EchionSampler`. Although this lifetime is "shorter", the `EchionSampler` is a member of the `Sampler` object, which has `static` lifetime itself. This means the "new" `StringTable` also has `static` lifetime and this should be fine, as long as we weren't previously relying on an implicit `static` construction order.
* **Threading** Access to `StringTable` was guarded by a mutex (this was needed because both the Sampling Thread (for pushing Frames, etc.) and "Python Threads" (for pushing Greenlet names, etc.) accessed it. This hasn't changed.
* **Fork safety** We used to call `string_table.postfork_child` as part of `_stack_atfork_child`. We now do it in `EchionSampler::postfork_child`, which itself is called as part of `_stack_atfork_child`. Semantics here are unchanged as well. 

## Changes

### State encapsulation
- Removed the global `string_table` variable from `strings.h`
- Added `StringTable string_table_` as a member of `EchionSampler`
- Added `string_table` accessor method to `EchionSampler`

### API updates
Updated the following functions to receive `EchionSampler&` as a parameter instead of accessing the global:
- `Frame::create`, `Frame::read`, `Frame::get`
- `unwind_frame`, `unwind_python_stack`
- `TaskInfo::create`, `TaskInfo::unwind`
- `GreenletInfo::unwind`
- `ThreadInfo::get_tasks_from_thread_linked_list`, `ThreadInfo::get_tasks_from_interpreter_linked_list`, `ThreadInfo::get_tasks_from_linked_list`

### Fork handling
- Updated `EchionSampler::postfork_child` to call `string_table_.postfork_child` to properly reset the mutex after fork

### Other
- Added `get_echion` accessor to `Sampler` class for accessing the underlying `EchionSampler`

## Testing

Existing test suites cover this refactoring.

