### PR TITLE
fix(internal): only release GIL if it was acquired

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -226,8 +226,8 @@ download_dependency_wheels:
     .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_SHA}"
     .gitlab/scripts/upload-wheels-to-s3.sh "${CI_PIPELINE_ID}"
 
-    # Upload to branch path (only for main/release branches)
-    if [ "${CI_COMMIT_BRANCH:-}" = "main" ] || [[ "${CI_COMMIT_BRANCH:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    # Upload to branch path (all branches)
+    if [ -n "${CI_COMMIT_BRANCH:-}" ]; then
       .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_BRANCH}"
     fi
 


### PR DESCRIPTION
## Description

This changes `GILGuard` and `AllowThreads` to only release the GIL / restore Thread if it was acquired/saved in the first place (which doesn't happen when Python is finalising). 

```
Stack Trace (Datadog Crashtracker 1.0)

#0  _PyObject_GC_NewVar
    ip=0x7f1781bd001e  sp=0x7f177e6fe340  symbol=0x7f1781bcfe80

#1  _PyEval_EvalFrameDefault
    ip=0x7f1781be7f4e  sp=0x7f177e6fe390  symbol=0x7f1781be2dd0

#2  PyObject_CallOneArg
    ip=0x7f1781c04f0e  sp=0x7f177e6fe510  symbol=0x7f1781c04eb0

#3  _PyObject_GenericGetAttrWithDict
    ip=0x7f1781bf4f4e  sp=0x7f177e6fe550  symbol=0x7f1781bf4d50

#4  PyObject_GetAttr
    ip=0x7f1781bdd299  sp=0x7f177e6fe5c0  symbol=0x7f1781bdd250

#5  _PyEval_EvalFrameDefault
    ip=0x7f1781be3ca1  sp=0x7f177e6fe5e0  symbol=0x7f1781be2dd0

#6  _PyObject_FastCallDictTstate
    ip=0x7f1781bdd8fd  sp=0x7f177e6fe760  symbol=0x7f1781bdd860

#7  _PyObject_MakeTpCall
    ip=0x7f1781bdaa13  sp=0x7f177e6fe870  symbol=0x7f1781bda9a0

#8  _PyEval_EvalFrameDefault
    ip=0x7f1781be33eb  sp=0x7f177e6fe8c0  symbol=0x7f1781be2dd0

#9  __pyx_pw_ddtrace_internal_datadog_profiling_ddup_upload
    ip=0x7f177d5f4169  sp=0x7f177e6fea40
    mangled=_ZL68__pyx_pw_7ddtrace_8internal_7datadog_9profiling_4ddup_5_ddup_7uploadP7_objectPKS0_lS0_

#10 PyObject_Vectorcall
    ip=0x7f1781beed47  sp=0x7f177e6febd0  symbol=0x7f1781beed10

#11 _PyEval_EvalFrameDefault
    ip=0x7f1781be33eb  sp=0x7f177e6febf0  symbol=0x7f1781be2dd0

#12 std::thread::_State_impl<...>::_M_run
    ip=0x7f177fa625ad  sp=0x7f177e6fee30  symbol=0x7f177fa623b0

#13 execute_native_thread_routine
    ip=0x7f177fa62990  sp=0x7f177e6feec0  symbol=0x7f177fa62980
```