### PR TITLE
ci(appsec): enable auto inject tests for appsec

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '72aa528751120288e30c45f81c7f988935f984cf'
+          ref: '107798bd55a6d4ca247b88d01a1316549b8bafe9'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -133,7 +133,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '72aa528751120288e30c45f81c7f988935f984cf'
+          ref: '107798bd55a6d4ca247b88d01a1316549b8bafe9'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -338,7 +338,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '72aa528751120288e30c45f81c7f988935f984cf'
+          ref: '107798bd55a6d4ca247b88d01a1316549b8bafe9'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -396,7 +396,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72aa528751120288e30c45f81c7f988935f984cf
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@107798bd55a6d4ca247b88d01a1316549b8bafe9
     secrets: inherit
     permissions:
       contents: read
@@ -427,7 +427,7 @@ jobs:
   integration-frameworks-system-tests:
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72aa528751120288e30c45f81c7f988935f984cf
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@107798bd55a6d4ca247b88d01a1316549b8bafe9
     secrets: inherit
     permissions:
       contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "72aa528751120288e30c45f81c7f988935f984cf"
+  SYSTEM_TESTS_REF: "107798bd55a6d4ca247b88d01a1316549b8bafe9"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v90830366-2b17cbb-profiling_native"


### PR DESCRIPTION
Update ST commit hash. We want to enable `SIMPLE_AUTO_INJECTION_APPSEC` scenario:
https://github.com/DataDog/system-tests/pull/6197

with that, now the test aren't skipped:

```
collected 2205 items / 2204 deselected / 1 selected
tests/auto_inject/test_auto_inject_install.py .                          [100%]
- generated xml file: /go/src/github.com/DataDog/apm-reliability/dd-trace-py/system-tests/logs_simple_auto_injection_appsec/reportJunit.xml -
===================== 1 passed, 2204 deselected in 50.92s ======================
```