### PR TITLE
ci(fix): refactor serverless-system-tests-build-layer

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -383,6 +383,7 @@ jobs:
 
       - name: Build datadog_lambda layer
         run: |
+          wheel_path=$(find ./artifacts -name "*.whl" | head -n 1)
           ARCH=amd64 PYTHON_VERSION=3.13 DD_TRACE_WHEEL=$wheel_path ./scripts/build_layers.sh
 
       - name: Upload layer artifact


### PR DESCRIPTION
## Description
The definition of the ddtrace dependency in datadog-lambda-python is being modified and the build_layers.sh script in that repo is being refactored to deduplicate the use of the sed command injecting the ddtrace wheel in different repos [PR](https://github.com/DataDog/datadog-lambda-python/pull/720). This PR brings dd-trace-py into compatibility with those changes. 
<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
