### PR TITLE
chore: set SYS_PTRACE and SYS_ADMIN for testrunner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,9 @@ services:
         # Set DD_TEST_CPUS (e.g., "4") and DD_TEST_MEMORY (e.g., "8g") to apply limits
         cpus: "${DD_TEST_CPUS:-0}"
         mem_limit: "${DD_TEST_MEMORY:-0}"
+        cap_add:
+          - SYS_PTRACE
+          - SYS_ADMIN
         environment:
           DD_FAST_BUILD: "1"
           CMAKE_BUILD_PARALLEL_LEVEL: "12"


### PR DESCRIPTION
## Description

So that we can easily run gdb and native profilers like ddprof in testrunner. 


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
