### PR TITLE
Correct type signature on Span.set_tag

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -316,7 +316,7 @@ class Span(SpanData):
         self.context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] = value
         return value
 
-    def set_tag(self, key: str, value: Optional[str] = None) -> None:
+    def set_tag(self, key: str, value: Optional[str | NumericType] = None) -> None:
         """Set a tag key/value pair on the span.
 
         Keys must be strings, values must be ``str``-able.


### PR DESCRIPTION
The docstring says anything str-able. The code clearly handles cases where the value is an int or float. Restricting this to just str causes type checkers to mark previously fine code as a problem:

```py
span.set_tag('num_things', 123)  # used to be fine
```

The alternative is to update every place in my code that calls set_tag with a numeric value and have it use `set_metric` or `set_tag(key, str(value))` instead. Either are annoying IMO because this is sort of a silly detail to force people to remember when they have a million other things to think about.
