### PR TITLE
perf(profiling): disable lock profiler by default

### DIFF
--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -276,7 +276,7 @@ class ProfilingConfigLock(DDConfig):
     enabled = DDConfig.v(
         bool,
         "enabled",
-        default=True,
+        default=False,
         help_type="Boolean",
         help="Whether to enable the lock profiler",
     )

--- a/releasenotes/notes/profiling-disable-lock-by-default-a1b2c3d4e5f6g7h8.yaml
+++ b/releasenotes/notes/profiling-disable-lock-by-default-a1b2c3d4e5f6g7h8.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    profiling: The lock profiler is now disabled by default due to its high overhead.
+    To re-enable it, set the environment variable ``DD_PROFILING_LOCK_ENABLED=true``.
+


### PR DESCRIPTION

## Description

<!-- Provide an overview of the change and motivation for the change -->
The lock profiler has high overhead and should not be enabled by default. Users can re-enable it by setting: 
```
DD_PROFILING_LOCK_ENABLED=true.
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->
I was working on doe benchmarks to validate the overhead impact of the profiler on uvloop applications with recent changes to the instrumentation. I noticed that the overhead was high. 
The following command can be used to reproduce (with the matching branch on dd-trace-doe.

```
go run ./cmd/doe run \
  language=python framework=fastapi runtime_version=3.12 archetype=throughput loops_cpu=0.2 off_cpu=0.01 duration=100 clients=10 timeout=30 tracing=true \
  library_version=5903bd072959d53153195871892f34e4124abc45 profiling=true \
  env=,DD_PROFILING_LOCK_ENABLED=false \
  -n 10 -f
```
I will post the results in slack.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->
Customers will no longer see lock profiling by default.
If we get the feedback from multiple customers that this is an important feature, we should work to reduce the latency overhead.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
NA