### PR TITLE
chore(tracer): migrate Span.span_type to native SpanData

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -117,7 +117,6 @@ class Span(SpanData):
         "context",
         "_metrics",
         "_store",
-        "span_type",
         "start_ns",
         "duration_ns",
         # Internal attributes
@@ -182,7 +181,6 @@ class Span(SpanData):
                 raise TypeError("parent_id must be an integer")
             return
 
-        self.span_type = span_type
         self._span_api = span_api
 
         self._meta: Dict[str, str] = {}

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -518,12 +518,14 @@ class SpanData:
     name: str
     service: Optional[str]
     resource: str
+    span_type: Optional[str]
 
     def __new__(
         cls: Type[_SpanDataT],
         name: str,
         service: Optional[str] = None,
         resource: Optional[str] = None,
+        span_type: Optional[str] = None,
     ) -> _SpanDataT: ...
 
 class SpanEventData:

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -954,9 +954,9 @@ def _value():
         # {"service": True},  # Now handled gracefully by Rust (converts to None)
         # {"resource": 50},  # Now handled gracefully by Rust (falls back to name or "")
         # {"name": [1, 2, 3]},  # Now handled gracefully by Rust (converts to "")
+        # {"span_type": 100},  # Now handled gracefully by Rust (converts to None)
         {"start_ns": []},
         {"duration_ns": {}},
-        {"span_type": 100},
     ],
 )
 def test_encoding_invalid_data_raises(data):
@@ -990,18 +990,22 @@ def test_encoding_invalid_data_raises(data):
         ("resource", 50, "", "test"),  # Invalid resource type -> "" (empty string)
         ("resource", [1, 2, 3], "", "test"),  # Invalid resource type -> "" (empty string)
         ("resource", {"dict": "value"}, "", "my-name"),  # Invalid resource type -> "" (empty string)
+        ("span_type", 100, None, "test"),  # Invalid span_type -> None
+        ("span_type", True, None, "test"),  # Invalid span_type -> None
+        ("span_type", {"dict": "value"}, None, "test"),  # Invalid span_type -> None
     ],
 )
-def test_encoding_invalid_name_service_handled_gracefully(field, invalid_value, expected_value, span_name):
-    """Test that invalid data types for name/service/resource are handled gracefully.
+def test_encoding_invalid_rust_string_fields_handled_gracefully(field, invalid_value, expected_value, span_name):
+    """Test that invalid data types for Rust-backed string fields are handled gracefully.
 
-    Since name, service, and resource are now backed by Rust PyBackedString, invalid types
+    Since name, service, resource, and span_type are now backed by Rust PyBackedString, invalid types
     are converted at setter time rather than raising during encoding.
 
     - Invalid name types -> "" (empty string)
     - Invalid service types -> None (allows inheritance from parent/config)
     - Invalid resource types -> "" (empty string)
       Note: fallback to name only happens when resource=None in __new__, not on setter
+    - Invalid span_type types -> None
     """
     encoder = MsgpackEncoderV04(1 << 20, 1 << 20)
 

--- a/tests/tracer/test_span_data.py
+++ b/tests/tracer/test_span_data.py
@@ -66,7 +66,7 @@ SPECIAL_CHARACTER_STRINGS = [
 
 # Property categories for parameterized tests
 REQUIRED_STRING_PROPERTIES = ["name", "resource"]
-OPTIONAL_STRING_PROPERTIES = ["service"]
+OPTIONAL_STRING_PROPERTIES = ["service", "span_type"]
 ALL_STRING_PROPERTIES = REQUIRED_STRING_PROPERTIES + OPTIONAL_STRING_PROPERTIES
 
 
@@ -82,6 +82,7 @@ def test_basic_creation():
     assert span.service is None
     # resource defaults to name when not provided
     assert span.resource == "test.span"
+    assert span.span_type is None
 
 
 def test_creation_accepts_extra_kwargs():
@@ -89,7 +90,7 @@ def test_creation_accepts_extra_kwargs():
 
     Since SpanData.__new__ accepts *args/**kwargs, subclasses (like Span) can pass
     additional parameters without needing to override __new__. SpanData only uses
-    'name', 'service', and 'resource'; other parameters are ignored but don't raise errors.
+    'name', 'service', 'resource', and 'span_type'; other parameters are ignored but don't raise errors.
     """
     span = SpanData(
         name="test.span",
@@ -106,6 +107,7 @@ def test_creation_accepts_extra_kwargs():
     assert span.name == "test.span"
     assert span.service == "test-service"
     assert span.resource == "test-resource"
+    assert span.span_type == "web"
 
 
 # =============================================================================


### PR DESCRIPTION
## Description

Continuing our Span -> SpanData migration, this PR migrates the Span.span_type property to the native SpanData class.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
