### PR TITLE
ci: export core.* files for easier crash analysis

### DIFF
--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -16,8 +16,12 @@ variables:
     - export _CI_DD_AGENT_URL=http://${HOST_IP}:8126/
   retry: 2
   artifacts:
+    when: always
+    paths:
+      - core.*
     reports:
       junit: test-results/junit*.xml
+    expire_in: 1 week
 
 .testrunner_gpu:
   extends: .testrunner


### PR DESCRIPTION
## Description

Export core.* files as artifacts from testrunner jobs. One can load that core file in gdb in local testrunner image on workspace (**x86_64**) to do an analysis. 

And also download the .so files from the CI for debug symbols. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
