### PR TITLE
ci(profiling): use `profiling_native` image for `clang-tidy`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   SYSTEM_TESTS_REF: "b8d5e051fb307f031a9ce32c894c388f4501d7dc"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
-  PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v90830366-2b17cbb-profiling_native"
+  PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v96371602-f288245-profiling_native"
   # Repository URL for CI Visibility
   DD_GIT_REPOSITORY_URL: "https://github.com/DataDog/dd-trace-py.git"
 

--- a/.gitlab/native.yml
+++ b/.gitlab/native.yml
@@ -24,22 +24,16 @@ include:
 
 "clang-tidy profiling":
   stage: tests
-  image: registry.ddbuild.io/images/mirror/ubuntu:25.04
+  image: registry.ddbuild.io/dd-trace-py:v96371602-f288245-profiling_native
   tags: ["arch:amd64"]
   timeout: 20m
   needs: []
   before_script:
-    - apt-get update && apt-get install -y clang clang-tidy clang-tools cmake bc python3 python3-pip python3-venv curl jq
-    - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
-    - source "$HOME/.cargo/env"
-    - python3 -m venv /tmp/venv
-    - source /tmp/venv/bin/activate
-    - python3 -m pip install setuptools wheel cmake setuptools_rust cython pybind11  # ci-deps: allow-no-version
+    - pyenv global 3.12
   script:
     - |
       echo -e "\e[0Ksection_start:`date +%s`:clang_tidy_build[collapsed=true]\r\e[0Kclang-tidy on profiling C++ code"
       export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
-      source /tmp/venv/bin/activate
       # Run clang-tidy on profiling C++ code (builds only profiling, skips pip install of full package)
       ddtrace/internal/datadog/profiling/run_clang_tidy.sh
       echo -e "\e[0Ksection_end:`date +%s`:clang_tidy_build\r\e[0K"

--- a/tests/profiling/collector/test_asyncio_import_order.py
+++ b/tests/profiling/collector/test_asyncio_import_order.py
@@ -81,6 +81,7 @@ def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
         EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
     else:
         EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+
     EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
     EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
@@ -106,6 +107,7 @@ def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
         EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
     else:
         EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+
     EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
     pprof_utils.assert_profile_has_sample(


### PR DESCRIPTION
## Description

This PR updates the `clang-tidy profiling` job to use the `profiling_native` image (which comes with `clang-tidy` preinstalled, among others) to make execution faster and less wasteful.

<!-- [Image build](https://gitlab.ddbuild.io/DataDog/images/-/jobs/1424644477) -->

Related  PRs:
-  https://github.com/DataDog/images/pull/8737
- https://github.com/DataDog/dd-trace-py/pull/15725

