### PR TITLE
refactor(profiling): use smaller base types for enums

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -52,12 +53,12 @@ namespace Datadog {
 #define X_ENUM(a, b) a,
 #define X_STR(a, b) b,
 
-enum class ExportTagKey
+enum class ExportTagKey : std::uint8_t
 {
     EXPORTER_TAGS(X_ENUM) Length_
 };
 
-enum class ExportLabelKey
+enum class ExportLabelKey : std::uint8_t
 {
     EXPORTER_LABELS(X_ENUM) Length_
 };

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/types.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/types.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Datadog {
-enum SampleType : unsigned int
+enum SampleType : std::uint16_t
 {
     Invalid = 0,
     CPU = 1 << 0,

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -12,7 +13,7 @@
 
 namespace Datadog {
 
-enum class MetricType
+enum class MetricType : std::uint8_t
 {
     Time,
     Memory


### PR DESCRIPTION
## Description

Specify explicit base types for enums to reduce memory footprint:
- `ExportTagKey`: use `std::uint8_t` (14 values)
- `ExportLabelKey`: use `std::uint8_t` (12 values)
- `SampleType`: use `std::uint16_t` (bit flags up to `1<<9`)
- `MetricType`: use `std::uint8_t` (2 values)

Fixes clang-tidy [`performance-enum-size`](https://clang.llvm.org/extra/clang-tidy/checks/performance/enum-size.html) warnings.