### PR TITLE
chore(profiling): avoid implicit widening of multiplication result

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -39,7 +39,8 @@ struct StringArena
     // allocate) that is bigger than any actual sample string size seen over a
     // random selection of a few hundred Python profiles at Datadog. So ideally
     // we only need one chunk, which we can reuse between samples
-    static constexpr size_t DEFAULT_SIZE = 16 * 1024;
+    static constexpr size_t KB = 1024;
+    static constexpr size_t DEFAULT_SIZE = 16 * KB;
     // Strings are backed by fixed-size Chunks. The Chunks can't grow, or
     // they'll move and invalidate pointers into the arena. At the same time,
     // they must be dynamically sized at creation because we get arbitrary

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
@@ -73,11 +73,16 @@ VmReader::create(size_t sz)
     return new VmReader(sz, ret, fd);
 }
 
+namespace {
+constexpr size_t KB = 1024;
+constexpr size_t MB = KB * KB;
+} // namespace
+
 VmReader*
 VmReader::get_instance()
 {
     if (instance == nullptr) {
-        instance = VmReader::create(1024 * 1024); // A megabyte?
+        instance = VmReader::create(MB);
         if (!instance) {
             std::cerr << "Failed to initialize VmReader with buffer size " << instance->sz << std::endl;
             return nullptr;


### PR DESCRIPTION
## Description

Use explicit static_cast<size_t> to avoid implicit widening
conversion when multiplying int literals assigned to size_t.

Fixes clang-tidy [bugprone-implicit-widening-of-multiplication-result](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.html#bugprone-implicit-widening-of-multiplication-result) warnings.
