### PR TITLE
refactor(profiling): pass large objects by const reference

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -43,8 +43,17 @@ extern "C"
     void ddup_cleanup();
     void ddup_set_runtime_id(std::string_view runtime_id);
     void ddup_set_process_id();
+
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    // Pass by value is intentional: the map may be modified concurrently by other threads,
+    // so we take a copy to avoid data races while iterating.
     void ddup_profile_set_endpoints(std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints);
+
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    // Pass by value is intentional: the map may be modified concurrently by other threads,
+    // so we take a copy to avoid data races while iterating.
     void ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts);
+
     bool ddup_upload();
 
     // Proxy functions to the underlying sample

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -482,6 +482,9 @@ ddup_upload() // cppcheck-suppress unusedFunction
     return result;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+// Pass by value is intentional: the map may be modified concurrently by other threads,
+// so we take a copy to avoid data races while iterating.
 void
 ddup_profile_set_endpoints(
   std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints) // cppcheck-suppress unusedFunction
@@ -504,6 +507,9 @@ ddup_profile_set_endpoints(
     }
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+// Pass by value is intentional: the map may be modified concurrently by other threads,
+// so we take a copy to avoid data races while iterating.
 void
 ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts)
 {

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/interp.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/interp.h
@@ -30,4 +30,4 @@ class InterpreterInfo
 };
 
 void
-for_each_interp(_PyRuntimeState* runtime, std::function<void(InterpreterInfo& interp)> callback);
+for_each_interp(_PyRuntimeState* runtime, const std::function<void(InterpreterInfo& interp)>& callback);

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -131,4 +131,4 @@ class ThreadInfo
 using PyThreadStateCallback = std::function<void(PyThreadState*, ThreadInfo&)>;
 
 void
-for_each_thread(EchionSampler& echion, InterpreterInfo& interp, PyThreadStateCallback callback);
+for_each_thread(EchionSampler& echion, InterpreterInfo& interp, const PyThreadStateCallback& callback);

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -83,7 +83,7 @@ class StackRenderer
                              microsecond_t wall_time_us,
                              uintptr_t thread_id,
                              unsigned long native_id);
-    void render_task_begin(std::string task_name, bool on_cpu);
+    void render_task_begin(const std::string& task_name, bool on_cpu);
     void render_stack_begin();
     void render_frame(Frame& frame);
     void render_cpu_time(uint64_t cpu_time_us);

--- a/ddtrace/internal/datadog/profiling/stack/include/thread_span_links.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/thread_span_links.hpp
@@ -18,7 +18,7 @@ struct Span
     Span(uint64_t _span_id, uint64_t _local_root_span_id, std::string _span_type)
       : span_id(_span_id)
       , local_root_span_id(_local_root_span_id)
-      , span_type(_span_type)
+      , span_type(std::move(_span_type))
     {
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/interp.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/interp.cc
@@ -1,7 +1,7 @@
 #include <echion/interp.h>
 
 void
-for_each_interp(_PyRuntimeState* runtime, std::function<void(InterpreterInfo& interp)> callback)
+for_each_interp(_PyRuntimeState* runtime, const std::function<void(InterpreterInfo& interp)>& callback)
 {
     InterpreterInfo interpreter_info = { 0 };
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -718,7 +718,7 @@ ThreadInfo::update_cpu_time()
 }
 
 void
-for_each_thread(EchionSampler& echion, InterpreterInfo& interp, PyThreadStateCallback callback)
+for_each_thread(EchionSampler& echion, InterpreterInfo& interp, const PyThreadStateCallback& callback)
 {
     std::unordered_set<PyThreadState*> threads;
     std::unordered_set<PyThreadState*> seen_threads;

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -66,7 +66,7 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
 }
 
 void
-StackRenderer::render_task_begin(std::string task_name, bool on_cpu)
+StackRenderer::render_task_begin(const std::string& task_name, bool on_cpu)
 {
     static bool failed = false;
     if (failed) {


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13775

Change function parameters from pass-by-value to pass-by-const-reference for large objects (`std::function`, `std::string`) to avoid unnecessary copies. For `thread_span_links.hpp`, use `std::move` on the value parameter since it's copied only once. 

The `map` case is special because we need to copy it for concurrency safety reasons.

Fixes clang-tidy `performance-unnecessary-value-param` warnings.
