### PR TITLE
refactor(profiling): add explicit casts to avoid narrowing conversions

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -54,7 +54,7 @@ Datadog::Uploader::export_to_file(ddog_prof_EncodedProfile& encoded, std::string
         ddog_Error_drop(&bytes_res.err);
         return false;
     }
-    out.write(reinterpret_cast<const char*>(bytes_res.ok.ptr), bytes_res.ok.len);
+    out.write(reinterpret_cast<const char*>(bytes_res.ok.ptr), static_cast<std::streamsize>(bytes_res.ok.len));
     if (out.fail()) {
         std::cerr << "Error writing to output file " << pprof_filename << ": " << strerror(errno) << std::endl;
         return false;

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -141,10 +141,10 @@ safe_memcpy(void* dst, const void* src, size_t n)
 
     // Copy in page-bounded chunks (at most one fault per bad page).
     while (rem) {
-        safe_memcpy_return_t to_src_pg =
-          page_size - (static_cast<uintptr_t>(reinterpret_cast<uintptr_t>(s)) & (page_size - 1));
-        safe_memcpy_return_t to_dst_pg =
-          page_size - (static_cast<uintptr_t>(reinterpret_cast<uintptr_t>(d)) & (page_size - 1));
+        safe_memcpy_return_t to_src_pg = static_cast<safe_memcpy_return_t>(
+          page_size - (static_cast<uintptr_t>(reinterpret_cast<uintptr_t>(s)) & (page_size - 1)));
+        safe_memcpy_return_t to_dst_pg = static_cast<safe_memcpy_return_t>(
+          page_size - (static_cast<uintptr_t>(reinterpret_cast<uintptr_t>(d)) & (page_size - 1)));
         safe_memcpy_return_t chunk = std::min(rem, std::min(to_src_pg, to_dst_pg));
 
         // Optional early probe to fault before entering large memcpy

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -269,7 +269,7 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
       (static_cast<int>(
         (frame_addr->instr_ptr - 1 -
          reinterpret_cast<_Py_CODEUNIT*>((reinterpret_cast<PyCodeObject*>(frame_addr->f_executable)))))) -
-      offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+      static_cast<int>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT));
     auto maybe_frame = Frame::get(echion, reinterpret_cast<PyCodeObject*>(frame_addr->f_executable), lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
@@ -30,6 +30,6 @@ GreenletInfo::unwind(EchionSampler& echion, PyObject* cur_frame, PyThreadState* 
 
     stack.push_back(Frame::get(echion, name));
 
-    return count + 1; // We add an extra count for the frame with the greenlet
-                      // name.
+    return static_cast<int>(count) + 1; // We add an extra count for the frame with the greenlet
+                                        // name.
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
@@ -10,7 +10,7 @@ MirrorSet::create(PyObject* set_addr)
     }
 
     auto size = set.mask + 1;
-    ssize_t table_size = size * sizeof(setentry);
+    ssize_t table_size = static_cast<ssize_t>(size * sizeof(setentry));
     if (table_size < 0 || table_size > MAX_MIRROR_SIZE) {
         return ErrorKind::MirrorError;
     }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
@@ -55,7 +55,7 @@ VmReader::create(size_t sz)
         unlink(tmpfile.data());
 
         // Make sure we have enough size
-        if (ftruncate(fd, sz) == -1) {
+        if (ftruncate(fd, static_cast<off_t>(sz)) == -1) {
             continue;
         }
 
@@ -109,7 +109,7 @@ VmReader::safe_copy(pid_t process_id,
 
     // Check to see if we need to resize the buffer
     if (remote_iov[0].iov_len > sz) {
-        if (ftruncate(fd, remote_iov[0].iov_len) == -1) {
+        if (ftruncate(fd, static_cast<off_t>(remote_iov[0].iov_len)) == -1) {
             return 0;
         } else {
             void* tmp = mremap(buffer, sz, remote_iov[0].iov_len, MREMAP_MAYMOVE);
@@ -121,7 +121,7 @@ VmReader::safe_copy(pid_t process_id,
         }
     }
 
-    ssize_t ret = pwritev(fd, remote_iov, riovcnt, 0);
+    ssize_t ret = pwritev(fd, remote_iov, static_cast<int>(riovcnt), 0);
     if (ret == -1) {
         return ret;
     }
@@ -211,7 +211,7 @@ copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void* buf)
 
     // Early exit on zero page
     if (reinterpret_cast<uintptr_t>(addr) < 4096) {
-        return result;
+        return static_cast<int>(result);
     }
 
 #if defined PL_LINUX

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -114,7 +114,8 @@ Sampler::adapt_sampling_interval()
                             info.system_time.seconds * 1e6 + info.system_time.microseconds);
 #endif
     auto sampler_thread_delta = static_cast<double>(new_sampler_thread_count - sampler_thread_count);
-    auto process_delta = static_cast<double>(new_process_count - process_count - sampler_thread_delta);
+    auto process_delta =
+      static_cast<double>(new_process_count) - static_cast<double>(process_count) - sampler_thread_delta;
     if (process_delta <= 0) {
         process_delta = 1; // Avoid division by zero or negative values
     }

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -55,7 +55,7 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
 
     // Finalize the thread information we have
     sample->push_threadinfo(static_cast<int64_t>(thread_id), static_cast<int64_t>(native_id), name);
-    sample->push_walltime(thread_state.wall_time_ns, 1);
+    sample->push_walltime(static_cast<int64_t>(thread_state.wall_time_ns), 1);
 
     const std::optional<Span> active_span = ThreadSpanLinks::get_instance().get_active_span_from_thread_id(thread_id);
     if (active_span) {
@@ -87,11 +87,11 @@ StackRenderer::render_task_begin(const std::string& task_name, bool on_cpu)
         // Add the thread context into the sample
         sample->push_threadinfo(
           static_cast<int64_t>(thread_state.id), static_cast<int64_t>(thread_state.native_id), thread_state.name);
-        sample->push_walltime(thread_state.wall_time_ns, 1);
+        sample->push_walltime(static_cast<int64_t>(thread_state.wall_time_ns), 1);
 
         if (on_cpu) {
             // initialized to 0, so possibly a no-op
-            sample->push_cputime(thread_state.cpu_time_ns, 1);
+            sample->push_cputime(static_cast<int64_t>(thread_state.cpu_time_ns), 1);
         }
 
         sample->push_monotonic_ns(thread_state.now_time_ns);
@@ -225,7 +225,7 @@ StackRenderer::render_cpu_time(uint64_t cpu_time_us)
     // TODO - it's absolutely false that thread-level CPU time is task time.  This needs to be normalized
     // to the task level, but for now just keep it because this is how the v1 sampler works
     thread_state.cpu_time_ns = 1000LL * cpu_time_us;
-    sample->push_cputime(thread_state.cpu_time_ns, 1);
+    sample->push_cputime(static_cast<int64_t>(thread_state.cpu_time_ns), 1);
 }
 
 void


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13775

Use explicit static_cast where implicit narrowing conversions occur:
- danger.cc: Cast page calculations to safe_memcpy_return_t
- mirrors.cc: Cast table_size calculation to ssize_t
- greenlets.cc: Cast count to int before adding
- stack_renderer.cpp: Cast microsecond_t to int64_t for push_* calls
- vm.cc: Cast size_t to off_t for ftruncate, riovcnt to int for pwritev
- uploader.cpp: Cast len to std::streamsize for write()
- frame.cc: Cast offsetof result to int
- sampler.cpp: Cast uint64_t to double before subtraction

Fixes clang-tidy bugprone-narrowing-conversions warnings.

