### PR TITLE
refactor(profiling): rename reserved identifiers

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -172,19 +172,19 @@ landing:
 #if defined PL_LINUX
 ssize_t
 safe_memcpy_wrapper(pid_t,
-                    const struct iovec* __dstvec,
-                    unsigned long int __dstiovcnt,
-                    const struct iovec* __srcvec,
-                    unsigned long int __srciovcnt,
+                    const struct iovec* dstvec,
+                    unsigned long int dstiovcnt,
+                    const struct iovec* srcvec,
+                    unsigned long int srciovcnt,
                     unsigned long int)
 {
-    (void)__dstiovcnt;
-    (void)__srciovcnt;
-    assert(__dstiovcnt == 1);
-    assert(__srciovcnt == 1);
+    (void)dstiovcnt;
+    (void)srciovcnt;
+    assert(dstiovcnt == 1);
+    assert(srciovcnt == 1);
 
-    size_t to_copy = std::min(__dstvec->iov_len, __srcvec->iov_len);
-    return safe_memcpy(__dstvec->iov_base, __srcvec->iov_base, to_copy);
+    size_t to_copy = std::min(dstvec->iov_len, srcvec->iov_len);
+    return safe_memcpy(dstvec->iov_base, srcvec->iov_base, to_copy);
 }
 #elif defined PL_DARWIN
 kern_return_t

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -17,7 +17,7 @@
 // ----------------------------------------------------------------------------
 #if PY_VERSION_HEX >= 0x030b0000
 static inline int
-_read_varint(unsigned char* table, ssize_t size, ssize_t* i)
+read_varint(unsigned char* table, ssize_t size, ssize_t* i)
 {
     ssize_t guard = size - 1;
     if (*i >= guard)
@@ -34,9 +34,9 @@ _read_varint(unsigned char* table, ssize_t size, ssize_t* i)
 
 // ----------------------------------------------------------------------------
 static inline int
-_read_signed_varint(unsigned char* table, ssize_t size, ssize_t* i)
+read_signed_varint(unsigned char* table, ssize_t size, ssize_t* i)
 {
-    int val = _read_varint(table, size, i);
+    int val = read_varint(table, size, i);
     return (val & 1) ? -(val >> 1) : (val >> 1);
 }
 #endif
@@ -93,17 +93,17 @@ Frame::infer_location(PyCodeObject* code_obj, int lasti)
                 break;
 
             case 14: // Long form
-                lineno += _read_signed_varint(table_data, len, &i);
+                lineno += read_signed_varint(table_data, len, &i);
 
                 this->location.line = lineno;
-                this->location.line_end = lineno + _read_varint(table_data, len, &i);
-                this->location.column = _read_varint(table_data, len, &i);
-                this->location.column_end = _read_varint(table_data, len, &i);
+                this->location.line_end = lineno + read_varint(table_data, len, &i);
+                this->location.column = read_varint(table_data, len, &i);
+                this->location.column_end = read_varint(table_data, len, &i);
 
                 break;
 
             case 13: // No column data
-                lineno += _read_signed_varint(table_data, len, &i);
+                lineno += read_signed_varint(table_data, len, &i);
 
                 this->location.line = lineno;
                 this->location.line_end = lineno;

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -317,7 +317,7 @@ _stack_atfork_child()
 }
 
 __attribute__((constructor)) void
-_stack_init()
+stack_init()
 {
     // At just do start-of-process cleanup (e.g., set PID)
     _stack_postfork_cleanup();

--- a/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
@@ -8,7 +8,7 @@
 using namespace Datadog;
 
 static PyObject*
-_stack_start(PyObject* self, PyObject* args, PyObject* kwargs)
+stack_start_impl(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     (void)self;
     static const char* const_kwlist[] = { "min_interval", NULL };
@@ -27,7 +27,7 @@ _stack_start(PyObject* self, PyObject* args, PyObject* kwargs)
 }
 
 // Bypasses the old-style cast warning with an unchecked helper function
-PyCFunction stack_start = cast_to_pycfunction(_stack_start);
+PyCFunction stack_start = cast_to_pycfunction(stack_start_impl);
 
 static PyObject*
 stack_stop(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
@@ -100,7 +100,7 @@ stack_thread_unregister(PyObject* self, PyObject* args)
 }
 
 static PyObject*
-_stack_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
+stack_link_span_impl(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     (void)self;
     uint64_t thread_id;
@@ -136,7 +136,7 @@ _stack_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
     Py_RETURN_NONE;
 }
 
-PyCFunction stack_link_span = cast_to_pycfunction(_stack_link_span);
+PyCFunction stack_link_span = cast_to_pycfunction(stack_link_span_impl);
 
 static PyObject*
 stack_track_asyncio_loop(PyObject* self, PyObject* args)
@@ -307,7 +307,7 @@ update_greenlet_frame(PyObject* Py_UNUSED(m), PyObject* args)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef _stack_methods[] = {
+static PyMethodDef stack_methods[] = {
     { "start", reinterpret_cast<PyCFunction>(stack_start), METH_VARARGS | METH_KEYWORDS, "Start the sampler" },
     { "stop", stack_stop, METH_VARARGS, "Stop the sampler" },
     { "register_thread", stack_thread_register, METH_VARARGS, "Register a thread" },
@@ -334,11 +334,11 @@ static PyMethodDef _stack_methods[] = {
 };
 
 PyMODINIT_FUNC
-PyInit__stack(void)
+PyInit__stack(void) // NOLINT(bugprone-reserved-identifier)
 {
     PyObject* m;
     static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT, "_stack", NULL, -1, _stack_methods, NULL, NULL, NULL, NULL
+        PyModuleDef_HEAD_INIT, "_stack", NULL, -1, stack_methods, NULL, NULL, NULL, NULL
     };
 
     m = PyModule_Create(&moduledef);


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13775

In Python, we're used to prefixing "private" symbols with an underscore; it's not really a thing in C/C++ (believe it or not it's actually undefined behaviour!).

Rename identifiers that start with underscore (reserved in C++):
- `danger.cc`: `__dstvec`, `__dstiovcnt`, `__srcvec`, `__srciovcnt` -> remove double underscore
- `stack.cpp`: `_stack_start` -> `stack_start_impl`, `_stack_link_span` -> `stack_link_span_impl`,
  `_stack_methods` -> `stack_methods`
- `sampler.cpp`: `_stack_atfork_child` -> `stack_atfork_child`, `_stack_init` -> `stack_init`
- `frame.cc`: `_read_varint` -> `read_varint`, `_read_signed_varint` -> `read_signed_varint`

Note: `PyInit__stack` cannot be renamed as it follows Python C API conventions for a module named `_stack`, so a NOLINT comment was added.

Fixes clang-tidy `bugprone-reserved-identifier` warnings.