### PR TITLE
chore(profiling): remove dead store assignment

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
@@ -44,7 +44,6 @@ VmReader::create(size_t sz)
     for (auto& tmp_dir : tmp_dirs) {
         // Reset the file descriptor, just in case
         close(fd);
-        fd = -1;
 
         // Create the temporary file
         std::string tmpfile = tmp_dir + tmp_suffix;


### PR DESCRIPTION

## Description

Remove redundant `fd = -1` assignment that is never read before being
overwritten by `mkstemp()`.

Fixes clang-tidy clang-analyzer-deadcode.DeadStores warning.
