### PR TITLE
refactor(profiling): avoid integer to pointer cast in comparisons

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -495,7 +495,7 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState*)
 
         auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_wr.wr_object));
         if (maybe_task_info) {
-            if ((*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
+            if (reinterpret_cast<uintptr_t>((*maybe_task_info)->loop) == this->asyncio_loop) {
                 tasks.push_back(std::move(*maybe_task_info));
             }
         }
@@ -519,7 +519,7 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState*)
         for (auto task_addr : eager_tasks) {
             auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
             if (maybe_task_info) {
-                if ((*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
+                if (reinterpret_cast<uintptr_t>((*maybe_task_info)->loop) == this->asyncio_loop) {
                     tasks.push_back(std::move(*maybe_task_info));
                 }
             }


### PR DESCRIPTION
## Description

Compare by casting the pointer to uintptr_t instead of casting the
integer to a pointer. This preserves pointer provenance information
for the compiler's optimization passes.

Fixes clang-tidy [performance-no-int-to-ptr](https://clang.llvm.org/extra/clang-tidy/checks/performance/no-int-to-ptr.html) warnings.

## Why?

_According to ChatGPT..._ Converting an integer to a pointer:

- Breaks alias analysis
- Prevents optimization
- May inhibit vectorization or other memory-related optimizations
- Often signals low-level or unsafe code

Modern compilers rely heavily on pointer provenance and strict aliasing rules to optimize aggressively. When you construct pointers from integers, the compiler:

- Cannot reliably track the memory object the pointer refers to
- Must assume conservative aliasing
- May disable important optimizations

So the check exists because these casts often degrade optimization quality.