### PR TITLE
fix(profiling): enable GC guard for Python 3.12+ to prevent reentrancy crashes

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -383,8 +383,14 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
        increase in memory usage during sampling. But it is overall cheap (mostly
        just toggling a boolean) and the alternative is hard-to-diagnose crashes.
 
+       UPDATE: We've observed intermittent crashes in Python 3.12 (particularly in
+       CI environments) that suggest reentrancy or corruption issues. While Python
+       3.12 defers GC, the profiler still calls Python APIs (threading.current_thread(),
+       PyUnicode_AsUTF8AndSize, frame access) during allocation hooks, which can
+       trigger issues. Re-enabling the GC guard for 3.12 as a conservative measure.
+
        RAII guard automatically re-enables GC when it goes out of scope. */
-#if defined(_PY310_AND_LATER) && !defined(_PY312_AND_LATER)
+#if defined(_PY310_AND_LATER)
     pygc_temp_disable_guard_t gc_guard;
 #endif
 

--- a/releasenotes/notes/profiling-py312-gc-guard-fix-2b917c349b76c597.yaml
+++ b/releasenotes/notes/profiling-py312-gc-guard-fix-2b917c349b76c597.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where intermittent segmentation faults
+    occurred when running the memory profiler on Python 3.12. The crashes were
+    caused by garbage collection running during memory allocation tracking, which
+    could corrupt internal state and lead to failures.


### PR DESCRIPTION
Python 3.12 defers GC to eval breaker points rather than running during allocations. However, the memory profiler still calls Python C APIs (threading.current_thread(), PyUnicode_AsUTF8AndSize, frame access) during allocation hooks, which can cause reentrancy issues and memory corruption leading to intermittent segfaults.

Re-enabling the GC guard for 3.12+ prevents these crashes by ensuring GC doesn't run during traceback collection, even though this causes a small temporary increase in memory usage during sampling.

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
