### PR TITLE
fix(profiling): use C APIs to collect thread id/native id (#16396) [backport 4.4]

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -158,11 +158,6 @@ memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
         return nullptr;
     }
 
-    if (!traceback_t::init_invokes_cpython()) {
-        PyErr_SetString(PyExc_RuntimeError, "failed to initialize traceback module");
-        return nullptr;
-    }
-
     if (!memalloc_heap_tracker_init_no_cpython((uint32_t)heap_sample_size)) {
         PyErr_SetString(PyExc_RuntimeError, "failed to initialize heap tracker");
         return nullptr;
@@ -209,9 +204,6 @@ memalloc_stop(PyObject* Py_UNUSED(module), PyObject* Py_UNUSED(args))
     PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &global_memalloc_ctx.pymem_allocator_obj);
 
     memalloc_heap_tracker_deinit_no_cpython();
-
-    /* Finally, we know in-progress sampling won't use the buffer pool, so clear it out */
-    traceback_t::deinit_invokes_cpython();
 
     memalloc_enabled = false;
 

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -1,7 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <frameobject.h>
-#include <string>
 #include <string_view>
 
 #include "_pymacro.h"
@@ -9,143 +8,6 @@
 #include "_memalloc_debug.h"
 #include "_memalloc_reentrant.h"
 #include "_memalloc_tb.h"
-
-// Cached reference to threading module and current_thread function
-static PyObject* threading_module = NULL;
-static PyObject* threading_current_thread = NULL;
-
-bool
-traceback_t::init_invokes_cpython()
-{
-    // Initialize threading module structure references
-    // Note: MemoryCollector.start() ensures _threading is imported before calling
-    // _memalloc.start(), so this should normally succeed. If it fails, we return false
-    // and the error will be handled up the stack.
-    if (threading_module == NULL) {
-        // Import the threading module (or use ddtrace's unpatched version)
-        PyObject* sys_modules = PyImport_GetModuleDict();
-        if (sys_modules == NULL) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to get sys.modules");
-            return false;
-        }
-
-        // Try to get threading module from sys.modules (don't force import)
-        PyObject* threading_mod_name = PyUnicode_FromString("threading");
-        if (threading_mod_name == NULL) {
-            return false;
-        }
-        threading_module = PyDict_GetItem(sys_modules, threading_mod_name);
-        Py_DECREF(threading_mod_name);
-
-        // If threading not in sys.modules, try ddtrace.internal._unpatched._threading
-        if (threading_module == NULL) {
-            PyObject* mod_path = PyUnicode_DecodeFSDefault("ddtrace.internal._unpatched._threading");
-            threading_module = PyImport_Import(mod_path);
-            Py_XDECREF(mod_path);
-            if (threading_module == NULL) {
-                // Error is already set by PyImport_Import
-                return false;
-            }
-        } else {
-            Py_INCREF(threading_module); // PyDict_GetItem returns borrowed reference
-        }
-
-        // Get threading.current_thread function
-        threading_current_thread = PyObject_GetAttrString(threading_module, "current_thread");
-        if (threading_current_thread == NULL || !PyCallable_Check(threading_current_thread)) {
-            Py_XDECREF(threading_module);
-            threading_module = NULL;
-            Py_XDECREF(threading_current_thread);
-            threading_current_thread = NULL;
-            PyErr_SetString(PyExc_RuntimeError, "Failed to get threading.current_thread");
-            return false;
-        }
-        // PyObject_GetAttrString returns new reference, keep it
-    }
-    return true;
-}
-
-/* RAII helper to save and restore Python error state */
-class PythonErrorRestorer
-{
-  public:
-    PythonErrorRestorer()
-    {
-#ifdef _PY312_AND_LATER
-        // Python 3.12+: Use the new API that returns a single exception object
-        saved_exception = PyErr_GetRaisedException();
-#else
-        // Python < 3.12: Use the old API with separate type, value, traceback
-        PyErr_Fetch(&saved_exc_type, &saved_exc_value, &saved_exc_traceback);
-#endif
-    }
-
-    ~PythonErrorRestorer()
-    {
-#ifdef _PY312_AND_LATER
-        // Python 3.12+: Restore using the new API if there was an exception
-        if (saved_exception != NULL) {
-            PyErr_SetRaisedException(saved_exception);
-        }
-#else
-        // Python < 3.12: Restore using the old API if there was an exception
-        if (saved_exc_type != NULL || saved_exc_value != NULL || saved_exc_traceback != NULL) {
-            PyErr_Restore(saved_exc_type, saved_exc_value, saved_exc_traceback);
-        }
-#endif
-    }
-
-    // Non-copyable, non-movable
-    PythonErrorRestorer(const PythonErrorRestorer&) = delete;
-    PythonErrorRestorer& operator=(const PythonErrorRestorer&) = delete;
-    PythonErrorRestorer(PythonErrorRestorer&&) = delete;
-    PythonErrorRestorer& operator=(PythonErrorRestorer&&) = delete;
-
-  private:
-#ifdef _PY312_AND_LATER
-    PyObject* saved_exception;
-#else
-    PyObject* saved_exc_type;
-    PyObject* saved_exc_value;
-    PyObject* saved_exc_traceback;
-#endif
-};
-
-void
-traceback_t::deinit_invokes_cpython()
-{
-    // Check if Python is finalizing. If so, skip cleanup to avoid segfaults.
-    // During finalization, Python objects may be in an invalid state.
-#ifdef _PY313_AND_LATER
-    if (Py_IsFinalizing()) {
-#else
-    if (_Py_IsFinalizing()) {
-#endif
-        // Just clear the pointers without decrementing references
-        threading_current_thread = NULL;
-        threading_module = NULL;
-        return;
-    }
-
-    // Save exception state before cleanup, then restore it afterward.
-    // This is important because deinit() may be called during exception handling
-    // (e.g., when MemoryCollector.__exit__ is called with an exception), and
-    // we need to preserve the exception for pytest.raises() and similar mechanisms.
-    // We temporarily clear it during cleanup to avoid issues with Py_DECREF().
-    PythonErrorRestorer error_restorer;
-
-    // Use Py_XDECREF for all cleanup to safely handle NULL pointers.
-    // During exception handling, objects may have been invalidated or set to NULL.
-    PyObject* old_threading_current_thread = threading_current_thread;
-    threading_current_thread = NULL;
-    Py_XDECREF(old_threading_current_thread);
-
-    PyObject* old_threading_module = threading_module;
-    threading_module = NULL;
-    Py_XDECREF(old_threading_module);
-
-    // Error will be restored automatically by error_restorer destructor
-}
 
 /* Helper function to convert PyUnicode object to string_view
  * Returns the string_view pointing to internal UTF-8 representation, or fallback if conversion fails
@@ -162,85 +24,39 @@ unicode_to_string_view(PyObject* unicode_obj, std::string_view fallback = "<unkn
     if (ptr) {
         return std::string_view(ptr, len);
     }
+    // PyUnicode_AsUTF8AndSize always sets an error on failure (TypeError if not a
+    // unicode object, MemoryError if UTF-8 cache allocation fails). Clear it since
+    // we're inside the allocator hook and must not leave stale errors for the caller.
+    PyErr_Clear();
     return fallback;
 }
 
-/* Helper function to get thread native_id and name from Python's threading module
- * and push threadinfo to the sample.
+/* Helper function to get thread info using C-level APIs and push to sample.
  *
- * NOTE: This is called during traceback construction, which happens during allocation
- * tracking. We're already inside a reentrancy guard and GC is disabled, so it's safe
- * to call Python functions here (similar to how we call PyUnicode_AsUTF8AndSize for frames).
+ * Uses only PyThread_get_thread_ident() and PyThread_get_thread_native_id(),
+ * which are C-level calls that never re-enter the Python interpreter.
+ * This is critical because this function is called from inside CPython's
+ * PYMEM_DOMAIN_OBJ allocation path. Calling Python-level code (e.g.,
+ * threading.current_thread()) from here can release the GIL via the eval
+ * loop's periodic check, allowing other threads to observe partially-constructed
+ * CPython internal state and causing crashes.
+ *
+ * Thread names are not available from C-level APIs; push_threadinfo falls back
+ * to str(thread_id) when name is empty. The stack profiler provides thread names
+ * via stack.register_thread() at safe points.
  */
 static void
 push_threadinfo_to_sample(Datadog::Sample& sample)
 {
-    // Save any existing error state to avoid masking errors
-    PythonErrorRestorer error_restorer;
-
-    // Use threading.current_thread() to get the current thread object
-    if (threading_current_thread == NULL) {
-        // threading.current_thread not available, don't push anything
-        // Error will be restored automatically by error_restorer destructor
-        return;
-    }
-
-    // Call threading.current_thread() - equivalent to threading.current_thread()
-    PyObject* thread = PyObject_CallObject(threading_current_thread, NULL);
-    if (thread == NULL) {
-        PyErr_Clear();
-        // Failed to get thread, don't push anything
-        // Error will be restored automatically by error_restorer destructor
-        return;
-    }
-
-    // Get thread.ident attribute (thread ID)
-    // If thread.ident is None (can happen before thread starts), fall back to PyThread_get_thread_ident()
-    int64_t thread_id = 0;
-    PyObject* ident_obj = PyObject_GetAttrString(thread, "ident");
-    if (ident_obj != NULL && ident_obj != Py_None && PyLong_Check(ident_obj)) {
-        thread_id = PyLong_AsLongLong(ident_obj);
-    } else {
-        // Fallback to PyThread_get_thread_ident() if thread.ident is None
-        thread_id = (int64_t)PyThread_get_thread_ident();
-    }
-    Py_XDECREF(ident_obj);
-
-    // If we still don't have a valid thread_id, don't push anything
+    int64_t thread_id = (int64_t)PyThread_get_thread_ident();
     if (thread_id == 0) {
-        Py_DECREF(thread);
         return;
     }
-    // Initialize native_id to thread_id as fallback; will be overwritten below if thread.native_id is available
-    int64_t thread_native_id = thread_id;
 
-    // Get thread.name attribute and keep it alive until we use it
-    PyObject* name_obj = PyObject_GetAttrString(thread, "name");
-    std::string_view thread_name = "";
-    if (name_obj && name_obj != Py_None && PyUnicode_Check(name_obj)) {
-        thread_name = unicode_to_string_view(name_obj, "");
-    }
+    int64_t thread_native_id = (int64_t)PyThread_get_thread_native_id();
 
-    // Get thread.native_id attribute
-    PyObject* native_id_obj = PyObject_GetAttrString(thread, "native_id");
-    if (native_id_obj != NULL) {
-        if (PyLong_Check(native_id_obj)) {
-            thread_native_id = PyLong_AsLongLong(native_id_obj);
-        }
-        Py_DECREF(native_id_obj);
-    } else {
-        PyErr_Clear();
-    }
-
-    Py_DECREF(thread);
-
-    // Push threadinfo to sample with all data (name_obj must still be alive here)
-    sample.push_threadinfo(thread_id, thread_native_id, thread_name);
-
-    // Now safe to release name_obj since push_threadinfo has copied the string
-    Py_XDECREF(name_obj);
-
-    // Error will be restored automatically by error_restorer destructor
+    // Pass empty name; push_threadinfo will fall back to str(thread_id)
+    sample.push_threadinfo(thread_id, thread_native_id, "");
 }
 
 /* Helper function to extract frame info from PyFrameObject and push to sample */
@@ -329,9 +145,6 @@ push_stacktrace_to_sample_invokes_cpython(Datadog::Sample& sample)
 void
 traceback_t::init_sample_invokes_cpython(size_t size, size_t weighted_size)
 {
-    // Save any existing error state to avoid masking errors during traceback construction/reset
-    PythonErrorRestorer error_restorer;
-
     // Size 0 allocations are legal and we can hypothetically sample them,
     // e.g. if an allocation during sampling pushes us over the next sampling threshold,
     // but we can't sample it, so we sample the next allocation which happens to be 0
@@ -344,7 +157,7 @@ traceback_t::init_sample_invokes_cpython(size_t size, size_t weighted_size)
     // Note: profile_state is initialized in memalloc_start() before any traceback_t objects are created
     sample.push_alloc(weighted_size, count);
 
-    // Get thread native_id and name from Python's threading module and push to sample
+    // Get thread id and native_id using C-level APIs and push to sample
     push_threadinfo_to_sample(sample);
 
     // Collect frames from the Python frame chain and push to Sample

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -25,14 +25,6 @@ class traceback_t
      * _invokes_cpython suffix: calls CPython APIs which may release the GIL during frame collection */
     void init_sample_invokes_cpython(size_t size, size_t weighted_size);
 
-    /* Initialize traceback module (creates interned strings)
-     * Returns true on success, false otherwise
-     * NOTE: Invokes CPython APIs */
-    [[nodiscard]] static bool init_invokes_cpython();
-    /* Deinitialize traceback module
-     * NOTE: Invokes CPython APIs */
-    static void deinit_invokes_cpython();
-
     // Non-copyable, non-movable
     traceback_t(const traceback_t&) = delete;
     traceback_t& operator=(const traceback_t&) = delete;

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -52,13 +52,6 @@ class MemoryCollector:
         if _memalloc is None:
             raise collector.CollectorUnavailable
 
-        # Ensure threading module structures are available before starting memalloc
-        # The C++ code directly accesses threading._active, threading._limbo, and
-        # ddtrace.internal._threads.periodic_threads dictionaries to get thread info.
-        # The threading module is already imported at the top of this file.
-        # We import _threads here to ensure periodic_threads dict exists.
-        import ddtrace.internal._threads  # noqa: F401
-
         try:
             _memalloc.start(self.max_nframe, self.heap_sample_size)
         except RuntimeError:

--- a/releasenotes/notes/profiling-fix-memalloc-crash-threading-current-thread-31902df842d7e205.yaml
+++ b/releasenotes/notes/profiling-fix-memalloc-crash-threading-current-thread-31902df842d7e205.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Fixes crashes in the memory profiler caused by re-entering the
+    Python interpreter from inside CPython's allocator hook.

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -119,7 +119,11 @@ def test_memory_collector(tmp_path: Path) -> None:
         profile,
         samples,
         expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
+            # Memory profiler uses Python C APIs to get thread id and there's
+            # no Python C API to get thread name. We can consider using Echion's
+            # ThreadInfoMap to get thread_name. DataDog::Sample::push_threadinfo()
+            # uses thread_id as a fallback for thread_name.
+            thread_name=str(threading.main_thread().ident),
             thread_id=threading.main_thread().ident,
             locations=[
                 pprof_utils.StackLocation(
@@ -1060,7 +1064,12 @@ def test_memory_collector_stack_order(tmp_path: Path) -> None:
         profile,
         samples,
         expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
+            # Memory profiler uses Python C APIs to get thread id and there's
+            # no Python C API to get thread name. We can consider using Echion's
+            # ThreadInfoMap to get thread_name. DataDog::Sample::push_threadinfo()
+            # uses thread_id as a fallback for thread_name.
+            thread_name=str(threading.main_thread().ident),
+            thread_id=threading.main_thread().ident,
             locations=[
                 loc("inner_frame"),
                 loc("middle_frame"),


### PR DESCRIPTION
## Description

Manual backport of #16396 to 4.4

In [incident-49169](https://app.datadoghq.com/incidents/49169), we investigated an issue following a ddtrace upgrade. Services started to show drop in requests, and error tracking showed multiple different types of crashes referring to Python internal frames.

The investigation showed that memory profiler's call to `PyObject_CallObject(threading_current_thread, NULL)` can lead to Python eval loop, releasing GIL. When the GIL is released other threads can observe partially-constructed CPython internal state, causing crashes in `dictresize`, `PyObject_GetAttr`, `PyObject_RichCompare`, `PyLong_AsUnsignedLong`, and similar functions. The re-entered eval loop can also trigger GC that traverses partially constructed objects on the same thread.

https://app.datadoghq.com/notebook/13862979/ir-49169-memory-profiler-crash-analysis

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

(cherry picked from commit 38fa7f4ceb3b6b408a7d786196f49c32b788c4b2)

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
