### PR TITLE
ci: use codeql-config.yml file in codeql job

### DIFF
--- a/scripts/codeql_scan.sh
+++ b/scripts/codeql_scan.sh
@@ -13,7 +13,7 @@ git clone https://github.com/DataDog/codescanning.git --depth 1 --single-branch 
 dd-octo-sts debug --scope DataDog/dd-trace-py --policy codeql || true
 
 # Create CodeQL databases.
-$CODEQL database create "$CODEQL_DB" $DB_CONFIGS
+$CODEQL database create "$CODEQL_DB" $DB_CONFIGS --codescanning-config=.github/codeql-config.yml
 
 # Run queries for each supported ecosystem and save results to intermediate SARIF files.
 $CODEQL database analyze "$CODEQL_DB" "$PYTHON_CUSTOM_QLPACK" $SCAN_CONFIGS --sarif-category="python" --output="/tmp/python.sarif"


### PR DESCRIPTION
## Description

Following the migration of the codeql job to gitlab-ci (https://github.com/DataDog/dd-trace-py/pull/15757), the `.github/codeql-config.yml` file is not used anymore.

This triggers false positives in directories that were previously silenced. 

## Testing

From the [codeql](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1408683279#L130) job on this PR:

```log
[2026-02-09 09:11:29] [build-stdout] Calling python3 -S /usr/local/codeql/python/tools/python_tracer.py --verbosity 2 -z all -c /tmp/dd-trace-py.codeql/working/trap_cache -R /go/src/github.com/DataDog/apm-reliability/dd-trace-py --filter exclude:tests/appsec/iast_packages/packages/ --filter exclude:tests/appsec/contrib_appsec/
```

## Risks

None: the skipped directories are appsec test folders that contain intentionally vulnerable code

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
