### PR TITLE
refactor(llmobs): use anyOf for categorical structured output

### DIFF
--- a/ddtrace/llmobs/_evaluators/llm_judge.py
+++ b/ddtrace/llmobs/_evaluators/llm_judge.py
@@ -116,11 +116,11 @@ class ScoreStructuredOutput(BaseStructuredOutput):
 class CategoricalStructuredOutput(BaseStructuredOutput):
     """Categorical structured output selecting from predefined categories.
 
+    Categories are provided as a dict mapping category values to their descriptions.
     Use ``pass_values`` to define which categories count as passing.
     """
 
-    description: str
-    categories: List[str]
+    categories: Dict[str, str]
     reasoning: bool = False
     reasoning_description: Optional[str] = None
     pass_values: Optional[List[str]] = None
@@ -130,7 +130,8 @@ class CategoricalStructuredOutput(BaseStructuredOutput):
         return "categorical_eval"
 
     def to_json_schema(self) -> Dict[str, Any]:
-        return self._build_schema({"type": "string", "description": self.description, "enum": self.categories})
+        any_of = [{"const": value, "description": desc} for value, desc in self.categories.items()]
+        return self._build_schema({"type": "string", "anyOf": any_of})
 
 
 StructuredOutput = Union[
@@ -214,16 +215,21 @@ def _create_anthropic_client(client_options: Optional[Dict[str, Any]] = None) ->
         if system:
             kwargs["system"] = system
         if json_schema:
-            # Anthropic doesn't support minimum/maximum for number properties in json schema.
-            # The range should be described in the description instead.
             schema_copy = json.loads(json.dumps(json_schema))
             for prop_val in schema_copy.get("properties", {}).values():
-                if isinstance(prop_val, dict) and prop_val.get("type") == "number":
+                if not isinstance(prop_val, dict):
+                    continue
+                # Anthropic doesn't support minimum/maximum for number properties in json schema.
+                # The range should be described in the description instead.
+                if prop_val.get("type") == "number":
                     min_val = prop_val.pop("minimum", None)
                     max_val = prop_val.pop("maximum", None)
                     if min_val is not None or max_val is not None:
                         range_str = f" (range: {min_val} to {max_val})"
                         prop_val["description"] = prop_val.get("description", "") + range_str
+                # Anthropic doesn't support 'type' on properties that use 'anyOf'.
+                if "anyOf" in prop_val:
+                    prop_val.pop("type", None)
             # Use beta API for structured outputs
             kwargs["extra_headers"] = {"anthropic-beta": "structured-outputs-2025-11-13"}
             kwargs["extra_body"] = {"output_format": {"type": "json_schema", "schema": schema_copy}}
@@ -334,8 +340,11 @@ class LLMJudge(BaseEvaluator):
                     model="gpt-5-mini",
                     user_prompt="Classify the sentiment: {{output_data}}",
                     structured_output=CategoricalStructuredOutput(
-                        description="Sentiment classification",
-                        categories=["positive", "neutral", "negative"],
+                        categories={
+                            "positive": "The response has a positive sentiment",
+                            "neutral": "The response has a neutral sentiment",
+                            "negative": "The response has a negative sentiment",
+                        },
                         pass_values=["positive", "neutral"],
                     ),
                 )

--- a/tests/llmobs/test_llm_judge.py
+++ b/tests/llmobs/test_llm_judge.py
@@ -28,10 +28,13 @@ class TestStructuredOutputTypes:
         assert schema["properties"]["score_eval"]["maximum"] == 1.0
 
     def test_categorical_output_schema(self):
-        output = CategoricalStructuredOutput("Sentiment", categories=["pos", "neg"])
+        output = CategoricalStructuredOutput(categories={"pos": "Positive sentiment", "neg": "Negative sentiment"})
         schema = output.to_json_schema()
         assert output.label == "categorical_eval"
-        assert schema["properties"]["categorical_eval"]["enum"] == ["pos", "neg"]
+        assert schema["properties"]["categorical_eval"]["anyOf"] == [
+            {"const": "pos", "description": "Positive sentiment"},
+            {"const": "neg", "description": "Negative sentiment"},
+        ]
 
 
 class TestLLMJudge:
@@ -115,7 +118,8 @@ class TestLLMJudge:
             model="test-model",
             user_prompt="Classify: {{output_data}}",
             structured_output=CategoricalStructuredOutput(
-                "Sentiment", categories=["positive", "negative"], pass_values=["positive"]
+                categories={"positive": "Positive sentiment", "negative": "Negative sentiment"},
+                pass_values=["positive"],
             ),
         )
         result = judge.evaluate(EvaluatorContext(input_data={}, output_data="Great!"))


### PR DESCRIPTION
## Description

- In order to align with the UI, this PR updates the categorical structured output to use `anyOf` instead of `enum`

## Testing

- Tests in `tests/llmobs/test_llm_judge.py`

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
