### PR TITLE
fix(tracer): resolve issue with not flushing during SIGTERM and SIGINT (#16342)

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -6,7 +6,7 @@ from itertools import chain
 import logging
 import os
 from os import getpid
-from threading import RLock
+from threading import Lock
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -154,9 +154,10 @@ class Tracer(object):
         # Ensure that tracer exit hooks are registered and unregistered once per instance
         forksafe.register_before_fork(self._sample_before_fork)
         atexit.register(self._atexit)
+        atexit.register_on_exit_signal(self._atexit)
         forksafe.register(self._child_after_fork)
 
-        self._shutdown_lock = RLock()
+        self._shutdown_lock = Lock()
 
         self._new_process = False
 
@@ -875,8 +876,10 @@ class Tracer(object):
             before exiting or :obj:`None` to block until flushing has successfully completed (default: :obj:`None`)
         :type timeout: :obj:`int` | :obj:`float` | :obj:`None`
         """
-        with self._shutdown_lock:
-            # Thread safety: Ensures tracer is shutdown synchronously
+        if not self._shutdown_lock.acquire(blocking=False):
+            # Already shutting down from this or another thread — skip re-entrant call
+            return
+        try:
             for processor in chain(self._span_processors, SpanProcessor.__processors__, [self._span_aggregator]):
                 if processor:
                     processor.shutdown(timeout)
@@ -889,3 +892,5 @@ class Tracer(object):
                 atexit.unregister(self._atexit)
                 forksafe.unregister(self._child_after_fork)
                 self.start_span = self._start_span_after_shutdown  # type: ignore[method-assign]
+        finally:
+            self._shutdown_lock.release()

--- a/ddtrace/internal/utils/signals.py
+++ b/ddtrace/internal/utils/signals.py
@@ -1,6 +1,25 @@
 import signal
 
 
+# Track which signals have had the base exit handler installed
+_exit_handlers_installed = set()
+
+
+def _raise_default(signum, frame):
+    signal.signal(signum, signal.SIG_DFL)
+    signal.raise_signal(signum)
+
+
+def _install_exit_handler(sig):
+    """Install a base handler that exits the process after all other handlers complete."""
+    if sig in _exit_handlers_installed:
+        return
+
+    # Install the exit handler as the base (will run last due to wrapping order)
+    signal.signal(sig, _raise_default)
+    _exit_handlers_installed.add(sig)
+
+
 def handle_signal(sig, f):
     """
     Returns a signal of type `sig` with function `f`, if there are
@@ -8,13 +27,24 @@ def handle_signal(sig, f):
 
     Else, wraps the given signal with the previously defined one,
     so no signals are overridden.
+
+    For SIGTERM and SIGINT, automatically ensures the process exits after
+    all handlers complete by installing a base exit handler on first use.
     """
     old_signal = signal.getsignal(sig)
 
+    # For termination signals, ensure we have a base handler that will exit the process
+    if sig in (signal.SIGTERM, signal.SIGINT) and not callable(old_signal):
+        _install_exit_handler(sig)
+        old_signal = signal.getsignal(sig)
+
     def wrap_signals(*args, **kwargs):
+        # Execute new handler first, then old handler.
+        # This ensures handlers registered later run before handlers registered earlier,
+        # so the base exit handler (registered first) runs last (after all cleanup).
+        f(*args, **kwargs)
         if old_signal is not None:
             old_signal(*args, **kwargs)
-        f(*args, **kwargs)
 
     # Return the incoming signal if any of the following cases happens:
     # - old signal does not exist,

--- a/releasenotes/notes/signal-shutdown-flush-42aa1273cbe5e39e.yaml
+++ b/releasenotes/notes/signal-shutdown-flush-42aa1273cbe5e39e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where traces may not be flushed during the handling of ``SIGTERM`` or ``SIGINT`` signals.

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -214,17 +214,12 @@ impl TraceExporterPy {
     }
 
     fn shutdown(&mut self, timeout_ns: u64) -> PyResult<()> {
-        match self
-            .inner
-            .take()
-            .ok_or(PyValueError::new_err(
-                "TraceExporter has already been consumed",
-            ))?
-            .shutdown(Some(Duration::from_nanos(timeout_ns)))
-        {
-            Ok(_) => Ok(()),
-            Err(e) => Err(TraceExporterErrorPy::from(e).into()),
+        if let Some(exporter) = self.inner.take() {
+            exporter
+                .shutdown(Some(Duration::from_nanos(timeout_ns)))
+                .map_err(TraceExporterErrorPy::from)?;
         }
+        Ok(())
     }
 
     fn drop(&mut self) -> PyResult<()> {

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import itertools
 import os
-import signal
 import sys
 
-import mock
 import pytest
 
-from ddtrace.internal.atexit import register_on_exit_signal
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
 from tests.integration.utils import parametrize_with_all_encodings
 from tests.integration.utils import skip_if_native_writer
@@ -16,21 +13,6 @@ from tests.utils import call_program
 
 
 FOUR_KB = 1 << 12
-
-
-@mock.patch("signal.signal")
-@mock.patch("signal.getsignal")
-def test_shutdown_on_exit_signal(mock_get_signal, mock_signal, tracer):
-    mock_get_signal.return_value = None
-    register_on_exit_signal(tracer._atexit)
-    assert mock_signal.call_count == 2
-    assert mock_signal.call_args_list[0][0][0] == signal.SIGTERM
-    assert mock_signal.call_args_list[1][0][0] == signal.SIGINT
-    original_shutdown = tracer.shutdown
-    tracer.shutdown = mock.Mock()
-    mock_signal.call_args_list[0][0][1]("", "")
-    assert tracer.shutdown.call_count == 1
-    tracer.shutdown = original_shutdown
 
 
 def test_import_ddtrace_generates_no_output_by_default(ddtrace_run_python_code_in_subprocess):

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_signal_shutdown_flushes_traces_nostats.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_signal_shutdown_flushes_traces_nostats.json
@@ -1,0 +1,26 @@
+[[
+  {
+    "name": "signal-shutdown-test",
+    "service": "signal-test-svc",
+    "resource": "signal-shutdown-test",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "test_signal_shutdown_flushes_t0",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6982365b00000000",
+      "language": "python",
+      "runtime-id": "bb7fe00f98c14549bad565c99ccf088c"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 626
+    },
+    "duration": 406875,
+    "start": 1770141275809623386
+  }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_signal_shutdown_flushes_traces_stats.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_signal_shutdown_flushes_traces_stats.json
@@ -1,0 +1,24 @@
+[[
+  {
+    "name": "signal-shutdown-test",
+    "service": "signal-test-svc",
+    "resource": "signal-shutdown-test",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.base_service": "test_signal_shutdown_flushes_t0",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6982362f00000000",
+      "language": "python",
+      "runtime-id": "78e48d852d1746998dc68682b13851f8"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 626.0
+    },
+    "duration": 1642667,
+    "start": 1770141231735705171
+  }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_signal_shutdown_flushes_traces_stats_tracestats.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_signal_shutdown_flushes_traces_stats_tracestats.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Start": 0,
+    "Duration": 10000000000,
+    "Stats": [
+      {
+        "Name": "signal-shutdown-test",
+        "Resource": "signal-shutdown-test",
+        "Service": "signal-test-svc",
+        "Type": "",
+        "HTTPStatusCode": 0,
+        "Synthetics": false,
+        "Hits": 1,
+        "TopLevelHits": 1,
+        "Duration": 1642667,
+        "Errors": 0,
+        "OkSummary": 37,
+        "ErrorSummary": 24
+      }
+    ]
+  }
+]

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -661,6 +661,21 @@ class NativeWriterTests(AgentWriterTests):
             for trace in payload:
                 assert 0.6 == trace[0]["metrics"].get(_KEEP_SPANS_RATE_KEY, -1)
 
+    def test_on_shutdown_idempotent(self):
+        """Test that NativeWriter.on_shutdown() can be called multiple times without raising ValueError."""
+        writer = NativeWriter("http://dne:1234")
+        writer.start()
+        # First call should succeed
+        writer.on_shutdown()
+        # Second call should also succeed (idempotent)
+        writer.on_shutdown()
+
+    def test_on_shutdown_before_start(self):
+        """Test that NativeWriter.on_shutdown() can be called before start() without raising ValueError."""
+        writer = NativeWriter("http://dne:1234")
+        # Call shutdown without ever calling start()
+        writer.on_shutdown()
+
     # Http related metrics are sent by the native code
     def test_drop_reason_bad_endpoint(self):
         pytest.skip()


### PR DESCRIPTION
## Description

Backport of #16342 to 4.4

Currently we do not properly register SIGTERM and SIGINT handlers for Tracer._atexit. This means any buffered traces or stats payloads may be lost during SIGTERM or SIGINT.

The impact on traces is up to 1 seconds worth of traces could be lost. For stats it is up to 10 seconds of stats which could be lost.

There are three changes here:

1. Properly registering the `atexit.register_on_exit_signal` for `Tracer._atexit`
2. Ensure our SIGTERM/SIGINT handlers restore and call the default Python behavior after our hooks have been called. a. Or call whatever custom/user signals were registered before ours, defaulting to the default handlers if none were.
3. Change the order of the signal handlers being called a. from first -> last, to last -> first so we can ensure the default signal handling behavior happens after all of our signals are called

## Testing

Regression test added to ensure that all trace/stats writer configurations properly flush on exit.

We set a really high writer flush interval for traces to ensure we maintain the traces in the buffer while we trigger a SIGTERM/SIGINT.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


(cherry picked from commit aa0794c9b1c9e965d943c70f6415b06e1a3e9a0b)

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
