### PR TITLE
ci: fix backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -105,13 +105,31 @@ jobs:
             cd "${GITHUB_WORKSPACE}"
             git worktree remove -f ${WORKTREE}
 
-            EXISTING_PR=$(gh pr list --state open --base ${TARGET_BRANCH} --head ${BACKPORT_BRANCH} --json number --jq '.[0].number')
+            set +e
+            EXISTING_PR=$(gh pr list --state open --base ${TARGET_BRANCH} --head ${BACKPORT_BRANCH} --json number --jq '.[0].number' 2>&1)
+            GH_PR_LIST_STATUS=$?
+            set -e
+            if [ "${GH_PR_LIST_STATUS}" -ne 0 ]; then
+              echo "Failed to query existing backport PR for ${TARGET_BRANCH}:"
+              echo "${EXISTING_PR}"
+              FAILURES+=("${TARGET_BRANCH}")
+              continue
+            fi
             if [ -z "${EXISTING_PR}" ]; then
-              gh pr create \
+              set +e
+              CREATE_OUT=$(gh pr create \
                 --title "${PR_TITLE} [backport ${TARGET_BRANCH}]" \
                 --body "Backport #${PR_NUMBER} to ${TARGET_BRANCH}" \
                 --base ${TARGET_BRANCH} \
-                --head ${BACKPORT_BRANCH}
+                --head ${BACKPORT_BRANCH} 2>&1)
+              GH_PR_CREATE_STATUS=$?
+              set -e
+              if [ "${GH_PR_CREATE_STATUS}" -ne 0 ]; then
+                echo "Failed to create backport PR for ${TARGET_BRANCH}:"
+                echo "${CREATE_OUT}"
+                FAILURES+=("${TARGET_BRANCH}")
+                continue
+              fi
             else
               echo "Backport PR already exists for ${TARGET_BRANCH}: #${EXISTING_PR}"
             fi


### PR DESCRIPTION
## Description

  Refactor the backport GitHub Action to correctly handle multiple backport labels and improve robustness.

  Label collection is now split into explicit, event-specific steps:
  - labeled event: validates and processes only the single event label
  - closed event: collects all backport x.y labels from the merged PR

  A shared execution step iterates over the collected labels, creating backport branches and PRs for each.

  Other improvements:
  - Cherry-pick failures no longer abort remaining backports — failures are collected and reported at the end
  - Added guard against processing non-backport labels on the closed event (contains(..., 'backport '))
  - Added existing PR check to avoid creating duplicate backport PRs
  - Replaced DataDog/commit-headless push action with inline git push
  - Passed PR_TITLE via env: instead of ${{ }} interpolation to prevent script injection
  - Removed unused PR_BRANCH environment variable

  Why

  The previous implementation used github.event.label.name for both event types, which is only populated on the labeled action. This meant merging a PR with multiple backport labels could miss targets.

  This refactor makes the two supported workflows explicit in the Actions logs and easier to reason about:
  - PR merged with existing backport labels → one run processes all labels
  - Backport label added after merge → one run processes that single label

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
