### PR TITLE
fix(llmobs): prevent duplicate LLM spans with OpenAI agents SDK

### DIFF
--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -64,10 +64,17 @@ class OpenAIIntegration(BaseLLMIntegration):
         if operation_id in traced_operations:
             submit_to_llmobs = True
         # When the OpenAI agents SDK integration is active, it handles LLM span creation
-        # for responses API calls via its own trace processor. Skip submitting these operations
+        # for responses and chat completion API calls via its own trace processor. Skip submitting these operations
         # to LLMObs from the OpenAI integration to avoid duplicate spans.
-        if operation_id in ("createResponse", "parseResponse") and self._is_agents_sdk_active():
+        if (
+            operation_id in ("createResponse", "parseResponse", "createChatCompletion", "parseChatCompletion")
+            and self._is_agents_sdk_active()
+        ):
             submit_to_llmobs = False
+            log.debug(
+                "Found OpenAI Agents integration active. Skipping submission of LLM span for OpenAI operation: %s. ",
+                operation_id,
+            )
         log.debug("Creating LLM span for openai operation: %s", operation_id)
         return super().trace(pin, operation_id, submit_to_llmobs, **kwargs)
 

--- a/releasenotes/notes/fix-duplicate-llm-spans-openai-agents-sdk-cff4d702228c788a.yaml
+++ b/releasenotes/notes/fix-duplicate-llm-spans-openai-agents-sdk-cff4d702228c788a.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     LLM Observability: This fix resolves an issue where duplicate LLM spans were created when using the
-    OpenAI agents SDK with the responses API. When both the OpenAI and OpenAI agents SDK integrations
+    OpenAI agents SDK with the responses API and chat completion API. When both the OpenAI and OpenAI agents SDK integrations
     are active, the OpenAI integration now defers to the agents SDK integration for handling response
     API spans, preventing duplicate spans from being submitted to LLM Observability.


### PR DESCRIPTION
When both the OpenAI and OpenAI agents SDK integrations are active, duplicate LLM spans were being created for responses API calls. The OpenAI integration now checks if the agents SDK integration is active and defers to it for handling response API spans.

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
