### PR TITLE
ci: don't use mergequeue labels

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -7,6 +7,7 @@ merge_method: squash
 gitlab_check_enable: true
 gitlab_jobs_retry_enable: false
 gitlab_fail_fast: false
+skip_labels: true
 
 ---
 schema-version: v1


### PR DESCRIPTION
## Description

There is a race condition with the mergequeue where it adds/changes a label, and then our Validate Changelog job runs, and if the mergequeue checks the mergeable status before this job has completed it'll show as unmergeable.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
