### PR TITLE
ci(appsec): terminate server subprocess more reliably

### DIFF
--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -1,6 +1,7 @@
 """This Flask application is imported on tests.appsec.appsec_utils.gunicorn_flask_server"""
 
 import os
+import sys
 
 
 if os.getenv("_USE_DDTRACE_COMMAND", False) not in ("1", "true", "True"):
@@ -308,8 +309,8 @@ def iast_code_injection_vulnerability():
 
 @app.route("/shutdown", methods=["GET"])
 def shutdown_view():
-    tracer.shutdown()
-    return "OK"
+    tracer.shutdown(timeout=10)
+    sys.exit(0)
 
 
 @app.route("/iast-stacktrace-leak-vulnerability", methods=["GET"])


### PR DESCRIPTION
## Description

This PR introduces some additional resiliency to possible server shutdown deadlocking which could occur during the appsec test suite.

I am not sure if this change is at all related to the deadlocking we've seen in the appsec test suites, but it is different from the other server subprocess tests in the repo, so I figured easy to try and align them.

1. `/shutdown` calls `tracer.shutdown()` with a timeout now
2. `/shutdown` does an explicit `sys.exit(0)`
    1. I don't really like this, but the other test suites do it, so figured might as well align them?
3. Adding a timeout to the `server_process.wait()` call with a fallback to SIGKILL the process if it does not exit in a timely manner

While this doesn't address any underlying deadlocking related issues, it does help prevent the test suite from deadlocking and timing out (which the timeout is set to 50m).

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
