### PR TITLE
ci(celery): try to avoid potential deadlock in beat test

### DIFF
--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -816,8 +816,6 @@ class CeleryDistributedTracingIntegrationTask(CeleryBaseTestCase):
             )
             sleep(5)
             celery_proc.terminate()
-            celery_proc.wait(timeout=10)
-
-            output = celery_proc.stdout.read()
+            output, _ = celery_proc.communicate(timeout=10)
             # Check for panics in the output
             assert b"panic" not in output.lower(), f"Found panic in celery beat output:\n{output}"


### PR DESCRIPTION
## Description

There is a deadlocking job in celery CI. I _think_ it is the beat job, but I cannot confirm 100% or reproduce locally (we don't have pytest -v in ci so I had to count the dots and guess which test). Since I cannot reproduce locally, this is my best guess at what could be a problem, we are deadlocking trying to read the stdout of the subprocess while it is writing to it during SIGTERM shutdown. Regardless, this change is fairly harmless, so might not make it better, but shouldn't make anything worse.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
