### PR TITLE
ci(codeowners): fix tests/tracer/ codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,6 @@ tests/internal                      @DataDog/apm-core-python
 tests/lib-injection                 @DataDog/apm-core-python
 tests/opentelemetry                 @DataDog/apm-core-python
 tests/opentracer                    @DataDog/apm-core-python
-tests/tracer                        @DataDog/apm-core-python
 
 # Test Visibility and related
 ddtrace/contrib/internal/coverage                     @DataDog/ci-app-libraries
@@ -246,7 +245,7 @@ tests/runtime/                                     @DataDog/apm-sdk-capabilities
 tests/test_sampling.py                             @DataDog/apm-sdk-capabilities-python
 tests/test_tracemethods.py                         @DataDog/apm-sdk-capabilities-python
 tests/opentelemetry/                               @DataDog/apm-sdk-capabilities-python
-tests/tracer/                                      @DataDog/apm-sdk-capabilities-python
+tests/tracer/                                      @DataDog/apm-sdk-capabilities-python @DataDog/apm-core-python
 # Override because order matters
 tests/tracer/test_ci.py                            @DataDog/ci-app-libraries
 


### PR DESCRIPTION
## Description

The `tests/tracer/` entry was duplicated in `CODEOWNERS`, the hierarchy is last entry matching wins so the sdk entry was overwriting the core entry.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
