### PR TITLE
refactor(profiling): use two-time upload api in libdatadog

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -122,7 +122,15 @@ Datadog::Uploader::upload_unlocked()
         .len = static_cast<uintptr_t>(to_compress_files.size()),
     };
 
-    bool ret = true;
+    // Build and send the request in one call
+    auto init_runtime_res = ddog_prof_Exporter_init_runtime(&ddog_exporter);
+    if (init_runtime_res.tag != DDOG_VOID_RESULT_OK) {
+        std::cerr << "Error initializing runtime: " << err_to_msg(&init_runtime_res.err, "Error initializing runtime")
+                  << std::endl;
+        ddog_Error_drop(&init_runtime_res.err);
+        return false;
+    }
+
     // Before starting a new upload, we need to cancel the current one (if it exists).
     // To do that, we exchange the current cancellation token with a new one (which will be used for our own upload)
     // If the current cancellation token was not null, then we use it to cancel the ongoing upload, then drop it.
@@ -138,16 +146,16 @@ Datadog::Uploader::upload_unlocked()
         ddog_CancellationToken_drop(&current_cancel);
     }
 
-    // Build and send the request in one call
-    ddog_prof_Result_HttpStatus res = ddog_prof_Exporter_send_blocking(&ddog_exporter,
-                                                                       &encoded_profile,
-                                                                       files_to_compress,
-                                                                       nullptr, // optional_additional_tags
-                                                                       optional_process_tags_ptr,
-                                                                       &internal_metadata_json_slice,
-                                                                       nullptr, // optional_info_json
-                                                                       &new_cancel_clone_for_request);
+    auto res = ddog_prof_Exporter_send_blocking(&ddog_exporter,
+                                                &encoded_profile,
+                                                files_to_compress,
+                                                nullptr, // optional_additional_tags
+                                                optional_process_tags_ptr,
+                                                &internal_metadata_json_slice,
+                                                nullptr, // optional_info_json
+                                                &new_cancel_clone_for_request);
 
+    bool ret = true;
     if (res.tag == DDOG_PROF_RESULT_HTTP_STATUS_ERR_HTTP_STATUS) { // NOLINT (cppcoreguidelines-pro-type-union-access)
         auto err = res.err;                                        // NOLINT (cppcoreguidelines-pro-type-union-access)
         errmsg = err_to_msg(&err, "Error uploading");


### PR DESCRIPTION
## What does this PR do?

This PR changes the Profiler codebase to use the new two-time upload API (1. create the `tokio` runtime; 2. actually start the upload) to avoid a race condition often reported by TSan the `profiling_native` job  -- see https://github.com/DataDog/libdatadog/pull/1733. pr

```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ForkDeathTest
[ RUN      ] ForkDeathTest.SampleInThreadsAndForkMany
/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:137: Failure
Death test: sample_in_threads_and_fork(16, 10e3)
    Result: died but not with expected exit code:
            Exited with exit status 66
Actual msg:
[  DEATH   ] ==================
[  DEATH   ] WARNING: ThreadSanitizer: data race (pid=10692)
[  DEATH   ]   Read of size 8 at 0x72b0000100e0 by main thread:
[  DEATH   ]     #0 write <null> (libclang_rt.tsan-x86_64.so+0x82976) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ]     #1 std::sys::fd::unix::FileDesc::write::h03a0f593da82637a /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/fd/unix.rs:346:13 (_native.cpython-314-x86_64-linux-gnu.so+0x67810b) (BuildId: 46434a56828b14a5896a23eb3c80b267e178a68c)
[  DEATH   ]     #2 std::sys::fs::unix::File::write::hf489ad007e4249a9 /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/fs/unix.rs:1570:16 (_native.cpython-314-x86_64-linux-gnu.so+0x67810b)
[  DEATH   ]     #3 _$LT$$RF$std..fs..File$u20$as$u20$std..io..Write$GT$::write::hddaf57c9e49ca7b2 /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/fs.rs:1364:20 (_native.cpython-314-x86_64-linux-gnu.so+0x67810b)
[  DEATH   ]     #4 Datadog::Uploader::prefork() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp:197:9 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x13856) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #5 ddup_prefork() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp:124:5 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x9904) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #6 __run_prefork_handlers posix/register-atfork.c:141:11 (libc.so.6+0xf834e) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)
[  DEATH   ]     #7 sample_in_threads_and_fork(unsigned int, unsigned int) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:112:17 (test_forking+0xd0e0) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #8 ForkDeathTest_SampleInThreadsAndForkMany_Test::TestBody() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:137:5 (test_forking+0xdb3c) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #9 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/build/dd_wrapper/_deps/googletest-src/googletest/src/gtest.cc:2638:10 (test_forking+0x47478) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #10 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/build/dd_wrapper/_deps/googletest-src/googletest/src/gtest.cc:2674:14 (test_forking+0x47478)
[  DEATH   ]     #11 __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16 (libc.so.6+0x29ca7) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)
[  DEATH   ] 
[  DEATH   ]   Previous write of size 8 at 0x72b0000100e0 by thread T1 (mutexes: write M0):
[  DEATH   ]     #0 eventfd <null> (libclang_rt.tsan-x86_64.so+0x79e84) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ]     #1 new_unregistered /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/sys/unix/mod.rs:8:28 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad) (BuildId: 46434a56828b14a5896a23eb3c80b267e178a68c)
[  DEATH   ]     #2 new /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/sys/unix/waker/eventfd.rs:27:21 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #3 new /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/waker.rs:87:9 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #4 new /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/io/driver.rs:120:21 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #5 create_io_stack /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/driver.rs:144:42 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #6 tokio::runtime::driver::Driver::new::h35527ab9443fd0a3 /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/driver.rs:47:52 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #7 ddup_upload /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp:480:28 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0xa636) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #8 upload_in_thread(void*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:12:5 (test_forking+0xcbd4) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #9 <null> <null> (libclang_rt.tsan-x86_64.so+0x7495b) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ] 
[  DEATH   ]   As if synchronized via sleep:
[  DEATH   ]     #0 nanosleep <null> (libclang_rt.tsan-x86_64.so+0x71c34) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ]     #1 void std::this_thread::sleep_for<long, std::ratio<1l, 1000000l>>(std::chrono::duration<long, std::ratio<1l, 1000000l>> const&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/this_thread_sleep.h:80:9 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x13879) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #2 Datadog::Uploader::prefork() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp:198:9 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x13879)
[  DEATH   ]     #3 ddup_prefork() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp:124:5 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x9904) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #4 __run_prefork_handlers posix/register-atfork.c:141:11 (libc.so.6+0xf834e) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)
[  DEATH   ]     #5 sample_in_threads_and_fork(unsigned int, unsigned int) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:112:17 (test_forking+0xd0e0) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #6 ForkDeathTest_SampleInThreadsAndForkMany_Test::TestBody() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:137:5 (test_forking+0xdb3c) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #7 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/build/dd_wrapper/_deps/googletest-src/googletest/src/gtest.cc:2638:10 (test_forking+0x47478) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #8 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/build/dd_wrapper/_deps/googletest-src/googletest/src/gtest.cc:2674:14 (test_forking+0x47478)
[  DEATH   ]     #9 __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16 (libc.so.6+0x29ca7) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)
[  DEATH   ] 
[  DEATH   ]   Location is file descriptor 7 created by thread T1 at:
[  DEATH   ]     #0 eventfd <null> (libclang_rt.tsan-x86_64.so+0x79e84) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ]     #1 new_unregistered /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/sys/unix/mod.rs:8:28 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad) (BuildId: 46434a56828b14a5896a23eb3c80b267e178a68c)
[  DEATH   ]     #2 new /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/sys/unix/waker/eventfd.rs:27:21 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #3 new /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/waker.rs:87:9 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #4 new /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/io/driver.rs:120:21 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #5 create_io_stack /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/driver.rs:144:42 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #6 tokio::runtime::driver::Driver::new::h35527ab9443fd0a3 /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/driver.rs:47:52 (_native.cpython-314-x86_64-linux-gnu.so+0x6957ad)
[  DEATH   ]     #7 ddup_upload /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp:480:28 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0xa636) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #8 upload_in_thread(void*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:12:5 (test_forking+0xcbd4) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #9 <null> <null> (libclang_rt.tsan-x86_64.so+0x7495b) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ] 
[  DEATH   ]   Mutex M0 (0x7ffff6b117e8) created at:
[  DEATH   ]     #0 pthread_mutex_lock <null> (libclang_rt.tsan-x86_64.so+0x76782) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ]     #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/x86_64-linux-gnu/c++/14/bits/gthr-default.h:762:12 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x13766) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #2 std::mutex::lock() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_mutex.h:113:17 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x13766)
[  DEATH   ]     #3 Datadog::Uploader::lock() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp:160:17 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0x13766)
[  DEATH   ]     #4 ddup_upload /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp:455:5 (libdd_wrapper.cpython-314-x86_64-linux-gnu.so+0xa4d2) (BuildId: d897612444f657ca175c65879a25c92ca5723dd7)
[  DEATH   ]     #5 upload_in_thread(void*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:12:5 (test_forking+0xcbd4) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #6 <null> <null> (libclang_rt.tsan-x86_64.so+0x7495b) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ] 
[  DEATH   ]   Thread T1 (tid=10744, running) created by main thread at:
[  DEATH   ]     #0 pthread_create <null> (libclang_rt.tsan-x86_64.so+0x74a05) (BuildId: 229b67347f9d16547489a41e6cdd38bf904a70b2)
[  DEATH   ]     #1 sample_in_threads_and_fork(unsigned int, unsigned int) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:98:9 (test_forking+0xd082) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #2 ForkDeathTest_SampleInThreadsAndForkMany_Test::TestBody() /go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_forking.cpp:137:5 (test_forking+0xdb3c) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #3 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/build/dd_wrapper/_deps/googletest-src/googletest/src/gtest.cc:2638:10 (test_forking+0x47478) (BuildId: 8619e3219ddfb766594b8d595ec0c44feb82c6b0)
[  DEATH   ]     #4 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /go/src/github.com/DataDog/apm-reliability/dd-trace-py/build/dd_wrapper/_deps/googletest-src/googletest/src/gtest.cc:2674:14 (test_forking+0x47478)
[  DEATH   ]     #5 __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16 (libc.so.6+0x29ca7) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)
[  DEATH   ] 
[  DEATH   ] SUMMARY: ThreadSanitizer: data race /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/fd/unix.rs:346:13 in std::sys::fd::unix::FileDesc::write::h03a0f593da82637a
[  DEATH   ] ==================
[  DEATH   ] Error uploading (ddog_prof_Exporter_send_blocking failed: Failed to send HTTP request: error sending request for url (https://127.0.0.1:9126/profiling/v1/input): client error (Connect): tcp connect error: Connection refused (os error 111))
[  DEATH   ] Error uploading (ddog_prof_Exporter_send_blocking failed: Failed to send HTTP request: error sending request for url (https://127.0.0.1:9126/profiling/v1/input): client error (Connect): tcp connect error: Connection refused (os error 111))
[  DEATH   ] ThreadSanitizer: reported 1 warnings
[  DEATH   ] Error uploading (ddog_prof_Exporter_send_blocking failed: Failed to send HTTP request: error sending request for url (https://127.0.0.1:9126/profiling/v1/input): client error (Connect): tcp connect error: Connection refused (os error 111))
[  DEATH   ] ThreadSanitizer: reported 1 warnings
[  DEATH   ] 
[  FAILED  ] ForkDeathTest.SampleInThreadsAndForkMany (1759 ms)
[----------] 1 test from ForkDeathTest (1759 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1762 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ForkDeathTest.SampleInThreadsAndForkMany
```

The problem was that in some cases, we could have a thread trying to use a cancellation token to cancel an ongoing upload before the associated `tokio` runtime had finished initialising, leading to that race condition.  
This same race condition was also responsible for some crashes reported by Crash Tracking. 

**Note** this PR currently points to a specific commit SHA in `libdatadog` -- before merging it we'll have to update that SHA and upgrade `libdatadog` in `dd-trace-py` to be able to use that new API.