### PR TITLE
chore(tracer): remove setting self._span_api on Span

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -174,8 +174,6 @@ class Span(SpanData):
                 raise TypeError("parent_id must be an integer")
             return
 
-        self._span_api = span_api
-
         self._meta: dict[str, str] = {}
         self._metrics: dict[str, NumericType] = {}
 


### PR DESCRIPTION
## Description

https://github.com/DataDog/dd-trace-py/pull/16445 reintroduced setting `self._span_api` in `Span.__init__` which was removed by #16415 

This is causing some issues: https://github.com/DataDog/dd-trace-py/pull/16442/changes#r2804395683

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
