### PR TITLE
Increase RSA key size in IAST test

### DIFF
--- a/tests/appsec/iast_packages/packages/pkg_rsa.py
+++ b/tests/appsec/iast_packages/packages/pkg_rsa.py
@@ -20,7 +20,7 @@ def pkg_rsa_view():
     response = ResultResponse(request.args.get("package_param"))
 
     try:
-        (public_key, private_key) = rsa.newkeys(512)
+        (public_key, private_key) = rsa.newkeys(2048)
 
         message = response.package_param
         encrypted_message = rsa.encrypt(message.encode(), public_key)
@@ -45,7 +45,7 @@ def pkg_rsa_propagation_view():
         return response.json()
 
     try:
-        (public_key, private_key) = rsa.newkeys(512)
+        (public_key, private_key) = rsa.newkeys(2048)
 
         message = response.package_param
         encrypted_message = rsa.encrypt(message.encode(), public_key)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fa82d2e0-6078-4f6e-ab9a-09a1527e57af","source":"chat","resourceId":"41c3cef2-50a5-4558-9bf8-23fc22116eda","workflowId":"f6d78f29-8034-4f6a-a079-9b0cfac47a13","codeChangeId":"f6d78f29-8034-4f6a-a079-9b0cfac47a13","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/41c3cef2-50a5-4558-9bf8-23fc22116eda)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Description

- Update RSA test fixture to use 2048-bit keys to address VULN-15708 weak key alert.

## Testing

- Not run (formatting command failed: hatch not available in environment).

## Risks

- Low: test-only change to key size may increase runtime cost in fixture.

## Additional Notes

- Security ticket: VULN-15708.