### PR TITLE
chore(profiling): 'profiling_native' jobs for native-only changes TEST [DO NOT MERGE]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -487,7 +487,9 @@ lib_injection_tests:
     - if [ "${SANITIZER}" == "safety" ]; then export ASAN_OPTIONS=detect_leaks=0; fi
     - ./ddtrace/internal/datadog/profiling/build_standalone.sh --${SANITIZER} RelWithDebInfo stack_test
 
-# Run on every PR (only if profiling files changed)
+# Run on every PR (only if native profiling files changed)
+# Scoped to C/C++, Cython, Rust, and build config — pure Python profiling
+# files (e.g. _lock.py, threading.py) do NOT need native sanitizer/valgrind runs.
 profiling_native:
   extends: .profiling_native_base
   rules:
@@ -496,9 +498,14 @@ profiling_native:
     - changes:
         - .gitlab-ci.yml
         - ddtrace/internal/datadog/profiling/**/*
-        - ddtrace/profiling/**/*
+        - ddtrace/profiling/collector/_memalloc*
+        - ddtrace/profiling/collector/_task.pyx
+        - ddtrace/profiling/collector/_pymacro.h
+        - ddtrace/profiling/collector/CMakeLists.txt
+        - ddtrace/profiling/_threading.pyx
         - src/native/**/*
-        - tests/profiling/**/*
+        - setup.py
+        - pyproject.toml
   parallel:
     matrix:
       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -498,7 +498,7 @@ profiling_native:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "main"
     - changes:
-        - .gitlab-ci.yml
+        # - .gitlab-ci.yml
         # Native source files by extension (C, C++, Cython, CMake modules)
         - ddtrace/internal/datadog/profiling/**/*.cpp
         - ddtrace/internal/datadog/profiling/**/*.cc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -487,11 +487,11 @@ lib_injection_tests:
     - if [ "${SANITIZER}" == "safety" ]; then export ASAN_OPTIONS=detect_leaks=0; fi
     - ./ddtrace/internal/datadog/profiling/build_standalone.sh --${SANITIZER} RelWithDebInfo stack_test
 
-# Run on every PR (only if native profiling files changed)
-# Uses extension-based patterns so new native files are automatically covered
-# and new Python files are automatically excluded — no directory-level tribal
-# knowledge required. Non-extension build files (CMakeLists.txt, .sh, .supp)
-# are listed separately.
+# Run on PRs where files in the C++ build graph changed.
+# This job builds C++ tests via CMake (build_standalone.sh), so only C/C++,
+# Cython, and CMake files should trigger it. Extension-based patterns keep Python,
+# Rust, and docs out automatically; non-extension build files (CMakeLists.txt,
+# .sh, .supp) are listed separately.
 profiling_native:
   extends: .profiling_native_base
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -488,8 +488,10 @@ lib_injection_tests:
     - ./ddtrace/internal/datadog/profiling/build_standalone.sh --${SANITIZER} RelWithDebInfo stack_test
 
 # Run on every PR (only if native profiling files changed)
-# Scoped to C/C++, Cython, Rust, and build config — pure Python profiling
-# files (e.g. _lock.py, threading.py) do NOT need native sanitizer/valgrind runs.
+# Uses extension-based patterns so new native files are automatically covered
+# and new Python files are automatically excluded — no directory-level tribal
+# knowledge required. Non-extension build files (CMakeLists.txt, .sh, .supp)
+# are listed separately.
 profiling_native:
   extends: .profiling_native_base
   rules:
@@ -497,13 +499,24 @@ profiling_native:
     - if: $CI_COMMIT_REF_NAME == "main"
     - changes:
         - .gitlab-ci.yml
-        - ddtrace/internal/datadog/profiling/**/*
-        - ddtrace/profiling/collector/_memalloc*
-        - ddtrace/profiling/collector/_task.pyx
-        - ddtrace/profiling/collector/_pymacro.h
-        - ddtrace/profiling/collector/CMakeLists.txt
-        - ddtrace/profiling/_threading.pyx
-        - src/native/**/*
+        # Native source files by extension (C, C++, Cython, CMake modules)
+        - ddtrace/internal/datadog/profiling/**/*.cpp
+        - ddtrace/internal/datadog/profiling/**/*.cc
+        - ddtrace/internal/datadog/profiling/**/*.h
+        - ddtrace/internal/datadog/profiling/**/*.hpp
+        - ddtrace/internal/datadog/profiling/**/*.pyx
+        - ddtrace/internal/datadog/profiling/**/*.cmake
+        - ddtrace/profiling/**/*.cpp
+        - ddtrace/profiling/**/*.cc
+        - ddtrace/profiling/**/*.h
+        - ddtrace/profiling/**/*.hpp
+        - ddtrace/profiling/**/*.pyx
+        # Build/test config files (not matchable by extension alone)
+        - ddtrace/internal/datadog/profiling/**/CMakeLists.txt
+        - ddtrace/internal/datadog/profiling/**/*.sh
+        - ddtrace/internal/datadog/profiling/**/*.supp
+        - ddtrace/profiling/**/CMakeLists.txt
+        # Top-level build config
         - setup.py
         - pyproject.toml
   parallel:

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -30,7 +30,7 @@ CALLER_FRAME_INDEX: int = 3
 
 
 def _current_thread() -> tuple[int, str]:
-    thread_id: int = _thread.get_ident()
+    thread_id: int = _thread.get_ident() + 2  # second push: only this file changed
     return thread_id, _threading.get_thread_name(thread_id)
 
 


### PR DESCRIPTION
## Description

**Test PR — DO NOT MERGE**

Live demonstration that the extension-based `profiling_native` trigger rules from [PR #16501](https://github.com/DataDog/dd-trace-py/pull/16501) correctly skip Python-only changes.

### Why two commits?

GitLab `rules:changes` on branch pipelines evaluates files changed **between pushes** (not the full branch diff). On a first push to a new branch, there's no previous SHA to compare against, so `changes` evaluates to **always-true** and all jobs run regardless of patterns.

To get a real evaluation, we need a **second push** where the only changed file is a Python profiling file:

| Commit | Changes | Purpose |
|--------|---------|---------|
| `2d1fb07` | `.gitlab-ci.yml` only | Comments out `- .gitlab-ci.yml` from the trigger list so the CI config diff doesn't self-trigger. Establishes the `before_sha`. |
| `dabe128` | `_lock.py` only | Test payload — a Python file under `ddtrace/profiling/` that matched the **old** `ddtrace/profiling/**/*` glob but does **not** match any `**/*.cpp`, `**/*.pyx`, etc. pattern. |

The second push (`2d1fb07 → dabe128`) gives GitLab a clean diff containing only `_lock.py`. If `profiling_native` is **absent** from the resulting pipeline, the extension-based rules work as intended.

## Testing
* Check the latest pipeline: **no** `profiling_native` jobs ran
* All `dd-gitlab/profiling/profile K/20` job are expected to fail (due to the dummy `_lock.py` change)