### PR TITLE
chore(profiling): remove unused `StringTable::key_unsafe()` function

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h
@@ -66,8 +66,6 @@ class StringTable : public std::unordered_map<uintptr_t, std::string>
     // Python string object
     [[nodiscard]] Result<Key> key(PyObject* s, StringTag tag = StringTag::Unknown);
 
-    [[nodiscard]] Key key_unsafe(PyObject* s, StringTag tag = StringTag::Unknown);
-
     [[nodiscard]] Result<std::reference_wrapper<const std::string>> lookup(Key key) const;
 
     [[nodiscard]] inline size_t size() const

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/strings.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/strings.cc
@@ -84,28 +84,6 @@ StringTable::key(PyObject* s, StringTag tag)
     return Result<Key>(k);
 };
 
-// Python string object
-[[nodiscard]] StringTable::Key
-StringTable::key_unsafe(PyObject* s, StringTag tag)
-{
-    const std::lock_guard<std::mutex> lock(table_lock);
-
-    auto k = make_tagged_key(reinterpret_cast<uintptr_t>(s), tag);
-
-    if (this->find(k) == this->end()) {
-#if PY_VERSION_HEX >= 0x030c0000
-        // The task name might hold a PyLong for deferred task name formatting.
-        auto str =
-          (PyLong_CheckExact(s)) ? "Task-" + std::to_string(PyLong_AsLong(s)) : std::string(PyUnicode_AsUTF8(s));
-#else
-        auto str = std::string(PyUnicode_AsUTF8(s));
-#endif
-        this->emplace(k, str);
-    }
-
-    return k;
-};
-
 [[nodiscard]] Result<std::reference_wrapper<const std::string>>
 StringTable::lookup(StringTable::Key key) const
 {


### PR DESCRIPTION
## Description

`StringTable::key_unsafe` is no longer used. Removing it. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
