### PR TITLE
ci: fix possible crash at debugger test shutdown

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -479,7 +479,14 @@ PeriodicThread_start(PeriodicThread* self, PyObject* Py_UNUSED(args))
             }
         }
 
-        PyDict_DelItem(_periodic_threads, self->ident);
+        // Don't attempt dictionary operations during interpreter finalization
+#if PY_VERSION_HEX >= 0x030d0000
+        if (!Py_IsFinalizing()) {
+#else
+        if (!_Py_IsFinalizing()) {
+#endif
+            PyDict_DelItem(_periodic_threads, self->ident);
+        }
 
         // Notify the join method that the thread has stopped
         self->_stopped->set();


### PR DESCRIPTION
## Description

There is a possible race condition when we stop tracking a periodic thread and when Python enters finalization.

Crash Sequence

1. Main thread (PID 4770): Py_Finalize() → PyGC_Collect() → clears freelists
2. Background thread (PID 4899): Still running in PeriodicThread lambda
3. Thread reaches line 482: PyDict_DelItem(_periodic_threads, self->ident)
4. Dictionary operation fails, tries to raise KeyError
5. _PyErr_SetKeyError() → PyTuple_Pack() → tuple_alloc()
6. tuple_alloc() calls _Py_object_freelists_GET()
7. SEGFAULT: Freelists already freed by main thread

Stack Trace

0.  _Py_object_freelists_GET()          - Accessing freed memory
1.  maybe_freelist_pop()                 - Tuple freelist
2.  tuple_alloc()                        - Allocating tuple
3.  PyTuple_Pack()                       - Packing exception args
4.  _PyErr_SetKeyError()                 - Setting KeyError
5.  delitem_knownhash_lock_held()       - Dictionary deletion
6.  _PyDict_DelItem_KnownHash()         - Public dict API
7.  [ddtrace._threads.so @ 0x2acac1]   - Line 482 in _threads.cpp

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
