### PR TITLE
fix(profiling): race condition in `StackChunk`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stack_chunk.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stack_chunk.h
@@ -41,6 +41,11 @@ class StackChunk
     void* origin = NULL;
     std::vector<char> data;
     size_t data_capacity = 0;
+
+    // copied_size stores the actual number of bytes copied by StackChunk::update.
+    // This MUST be used for bounds checking in StackChunk::resolve, NOT chunk->size from the copied data,
+    // because a race condition can cause chunk->size to be larger than what was actually copied.
+    size_t copied_size = 0;
     std::unique_ptr<StackChunk> previous = nullptr;
 };
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/stack_chunk.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/stack_chunk.cc
@@ -42,6 +42,11 @@ StackChunk::update_with_depth(_PyStackChunk* chunk_addr, size_t depth)
         return ErrorKind::StackChunkError;
     }
 
+    // Store the size we actually copied. This is critical for bounds checking in StackChunk::resolve.
+    // We must NOT read chunk->size from the copied data because a race condition can cause
+    // it to be larger than what was actually copied, leading to out-of-bounds access.
+    copied_size = chunk.size;
+
     if (chunk.previous != NULL) {
         if (chunk.previous == chunk_addr) {
             previous = nullptr;
@@ -68,11 +73,12 @@ StackChunk::resolve(void* address)
         return address;
     }
 
-    _PyStackChunk* chunk = reinterpret_cast<_PyStackChunk*>(data.data());
-
-    // Check if this chunk contains the address
-    if (address >= origin && address < reinterpret_cast<char*>(origin) + chunk->size)
-        return reinterpret_cast<char*>(chunk) + (reinterpret_cast<char*>(address) - reinterpret_cast<char*>(origin));
+    // Use copied_size for bounds checking, NOT chunk->size from the copied data.
+    // A race condition during copying can cause the header's size field to be larger
+    // than what was actually copied, leading to out-of-bounds access and SEGV.
+    if (address >= origin && address < reinterpret_cast<char*>(origin) + copied_size) {
+        return data.data() + (reinterpret_cast<char*>(address) - reinterpret_cast<char*>(origin));
+    }
 
     if (previous)
         return previous->resolve(address);
@@ -84,8 +90,8 @@ StackChunk::resolve(void* address)
 bool
 StackChunk::is_valid() const
 {
-    return data_capacity > 0 && data.size() > 0 && data.size() >= sizeof(_PyStackChunk) && data.data() != nullptr &&
-           origin != nullptr;
+    return data_capacity > 0 && copied_size > 0 && copied_size >= sizeof(_PyStackChunk) && data.size() >= copied_size &&
+           data.data() != nullptr && origin != nullptr;
 }
 
 #endif // PY_VERSION_HEX >= 0x030b0000

--- a/releasenotes/notes/profiling-race-condition-stack-chunk-b3efd548e57b1b8b.yaml
+++ b/releasenotes/notes/profiling-race-condition-stack-chunk-b3efd548e57b1b8b.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: A race condition that could lead to out-of-bounds access in the Profiler was fixed.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13774

This fixes a rare (but real, found in Crash Logs) race condition where we would see segmentation faults in `Frame::read`. After analysis, it seems this comes from a race condition where the number of bytes copied in the `StackChunk` did not match (was less than) the number of bytes in the `StackChunk` according to the header, if the `StackChunk` was updated by Python as we were reading it. When this happens, we would try to read from an invalid pointer (we would "believe" our copy of the `StackChunk` had more bytes than it actually did).

---

**Example crash stack**

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x00007fcde855cfc6 Frame::read 
#1   0x00007fcde855d114 unwind_frame 
#2   0x00007fcde855ec68 ThreadInfo::unwind 
#3   0x00007fcde855eda2 ThreadInfo::sample 
#4   0x00007fcde855f02e std::_Function_handler<void (_ts*, ThreadInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}::operator()(InterpreterInfo&) const::{lambda(_ts*, ThreadInfo&)#1}>::_M_invoke 
#5   0x00007fcde855f2c0 for_each_thread 
#6   0x00007fcde855f382 std::_Function_handler<void (InterpreterInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}>::_M_invoke 
#7   0x00007fcde855c2f9 for_each_interp 
#8   0x00007fcde855f6e7 Datadog::Sampler::sampling_thread 
#9   0x00007fcde855f853 call_sampling_thread 
```