### PR TITLE
refactor(profiling): use different table for ephemeral entities

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -28,6 +28,9 @@ class ProfilerStats
     // Number of entries in the echion StringTable
     std::optional<size_t> string_table_count;
 
+    // Number of ephemeral entries in the echion StringTable
+    std::optional<size_t> string_table_ephemeral_count;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -43,6 +46,9 @@ class ProfilerStats
 
     void set_string_table_count(size_t count);
     std::optional<size_t> get_string_table_count();
+
+    void set_string_table_ephemeral_count(size_t count);
+    std::optional<size_t> get_string_table_ephemeral_count();
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -45,6 +45,7 @@ Datadog::ProfilerStats::reset_state()
     sampling_event_count = 0;
     sampling_interval_us = std::nullopt;
     string_table_count = std::nullopt;
+    string_table_ephemeral_count = std::nullopt;
 }
 
 void
@@ -71,6 +72,18 @@ Datadog::ProfilerStats::get_string_table_count()
     return string_table_count;
 }
 
+void
+Datadog::ProfilerStats::set_string_table_ephemeral_count(size_t count)
+{
+    string_table_ephemeral_count = count;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_string_table_ephemeral_count()
+{
+    return string_table_ephemeral_count;
+}
+
 std::string
 Datadog::ProfilerStats::get_internal_metadata_json()
 {
@@ -90,6 +103,13 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_string_table_count) {
         internal_metadata_json += R"("string_table_count": )";
         append_to_string(internal_metadata_json, *maybe_string_table_count);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_string_table_ephemeral_count = get_string_table_ephemeral_count();
+    if (maybe_string_table_ephemeral_count) {
+        internal_metadata_json += R"("string_table_ephemeral_count": )";
+        append_to_string(internal_metadata_json, *maybe_string_table_ephemeral_count);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/strings.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/strings.cc
@@ -53,8 +53,9 @@ StringTable::key(PyObject* s, StringTag tag)
     const std::lock_guard<std::mutex> lock(table_lock);
 
     auto k = make_tagged_key(reinterpret_cast<uintptr_t>(s), tag);
+    auto& table = table_for(tag);
 
-    if (this->find(k) == this->end()) {
+    if (table.find(k) == table.end()) {
 #if PY_VERSION_HEX >= 0x030c0000
         // The task name might hold a PyLong for deferred task name formatting.
         std::string str = "Task-";
@@ -78,20 +79,21 @@ StringTable::key(PyObject* s, StringTag tag)
 
         std::string str = std::move(*maybe_unicode);
 #endif
-        this->emplace(k, str);
+        table.emplace(k, str);
     }
 
     return Result<Key>(k);
-};
+}
 
 [[nodiscard]] Result<std::reference_wrapper<const std::string>>
 StringTable::lookup(StringTable::Key key) const
 {
     const std::lock_guard<std::mutex> lock(table_lock);
 
-    const auto it = this->find(key);
-    if (it == this->cend())
+    const auto& table = table_for_key(key);
+    const auto it = table.find(key);
+    if (it == table.cend())
         return ErrorKind::LookupError;
 
     return std::ref(it->second);
-};
+}

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -189,6 +189,7 @@ Sampler::sampling_thread(const uint64_t seq_num)
 
         Sample::profile_borrow().stats().increment_sampling_event_count();
         Sample::profile_borrow().stats().set_string_table_count(echion->string_table().size());
+        Sample::profile_borrow().stats().set_string_table_ephemeral_count(echion->string_table().ephemeral_size());
 
         if (do_adaptive_sampling) {
             // Adjust the sampling interval at most every second


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13291

This refactors the `StringTable` class to have two underlying tables. One is used for storing entities we see as living forever (function names, file names, etc.) and the other for storing ephemeral entities (e.g. Task names).  


For now, this is the only change. However, I plan to make it so that the table for ephemeral entities is cleared every once in a while to avoid memory leaks (in a different PR).

**Note** I could have used two different `StringTable` objects instead of changing what the `StringTable` is, but I think it's cleaner to have an interface that says "this is everything you need for interning-related business".