### PR TITLE
runtime only check deepeval

### DIFF
--- a/tests/llmobs/test_deep_eval_evaluators.py
+++ b/tests/llmobs/test_deep_eval_evaluators.py
@@ -25,7 +25,7 @@ class SimpleDeepEvalMetric(BaseMetric):
         passed = test_case.actual_output == test_case.expected_output
         self.score = 1.0 if passed else 0.0
         self.reason = "Match" if passed else "Mismatch"
-        self.success = "pass" if passed else "fail"
+        self.success = passed
         return self.score
 
 
@@ -52,7 +52,7 @@ class TestDeepEvalEvaluatorMeasure:
         metric.measure(tc)
         assert metric.score == 1.0
         assert metric.reason == "Match"
-        assert metric.success == "pass"
+        assert metric.success is True
 
     def test_measure_sets_score_fail(self):
         metric = SimpleDeepEvalMetric()
@@ -60,7 +60,7 @@ class TestDeepEvalEvaluatorMeasure:
         metric.measure(tc)
         assert metric.score == 0.0
         assert metric.reason == "Mismatch"
-        assert metric.success == "fail"
+        assert metric.success is False
 
 
 class TestDeepEvalEvaluatorInExperiment:


### PR DESCRIPTION
exploring alternative approach where deepeval is only lazily imported (type hint of evaluators arg doesn't reference deepeval types)
