### PR TITLE
ci: backport PRs have commits signed

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,12 +6,11 @@ on:
       - labeled
 
 jobs:
-  backport:
-    name: Backport
+  collect-backport-targets:
+    name: Collect Backport Targets
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
+    outputs:
+      target_branches_json: ${{ steps.collect-targets.outputs.target_branches_json }}
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
@@ -27,17 +26,6 @@ jobs:
         )
       )
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/dd-trace-py
-          policy: self.backport.create-pr
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
       - name: Collect Backport Labels (Labeled Event)
         if: github.event.action == 'labeled'
         env:
@@ -63,79 +51,113 @@ jobs:
             exit 1
           fi
 
+      - name: Collect Target Branches
+        id: collect-targets
+        run: |
+          TARGET_BRANCHES_JSON=$(awk '{ print $NF }' /tmp/backport-labels.sorted.txt | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "target_branches_json=${TARGET_BRANCHES_JSON}" >> "$GITHUB_OUTPUT"
+
+  backport:
+    name: Backport (${{ matrix.target_branch }})
+    needs: collect-backport-targets
+    if: needs.collect-backport-targets.outputs.target_branches_json != '' && needs.collect-backport-targets.outputs.target_branches_json != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target_branch: ${{ fromJSON(needs.collect-backport-targets.outputs.target_branches_json || '[]') }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.backport.create-pr
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
       - name: Execute Backport
+        id: create-commit
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          TARGET_BRANCH: ${{ matrix.target_branch }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
           MERGE_COMMIT=$(git rev-parse HEAD)
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          WORKTREE=".worktrees/backport-${TARGET_BRANCH}"
+          BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${TARGET_BRANCH}"
 
-          FAILURES=()
-          while IFS= read -r BACKPORT_LABEL; do
-            TARGET_BRANCH=$(echo "${BACKPORT_LABEL}" | awk '{ print $NF }')
-            WORKTREE=".worktrees/backport-${TARGET_BRANCH}"
-            BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${TARGET_BRANCH}"
+          echo "Backporting ${MERGE_COMMIT} to ${TARGET_BRANCH}"
+          git worktree add ${WORKTREE} ${TARGET_BRANCH}
+          cd ${WORKTREE}
+          git branch -D ${BACKPORT_BRANCH} || true
+          git switch --create ${BACKPORT_BRANCH}
 
-            echo "Backporting ${MERGE_COMMIT} to ${TARGET_BRANCH}"
-            git worktree add ${WORKTREE} ${TARGET_BRANCH}
-            cd ${WORKTREE}
-            git branch -D ${BACKPORT_BRANCH} || true
-            git switch --create ${BACKPORT_BRANCH}
-
-            set +e
-            CHERRYPICK_OUT=$(git cherry-pick -x --mainline 1 ${MERGE_COMMIT} 2>&1)
-            CHERRYPICK_STATUS=$?
-            set -e
-            if [ "${CHERRYPICK_STATUS}" -ne 0 ]; then
-              echo "Cherry-pick failed for ${TARGET_BRANCH}:"
-              echo "${CHERRYPICK_OUT}"
-              git cherry-pick --abort || true
-              FAILURES+=("${TARGET_BRANCH}")
-              cd "${GITHUB_WORKSPACE}"
-              git worktree remove -f ${WORKTREE}
-              continue
-            fi
-
-            git push --force origin ${BACKPORT_BRANCH}
+          set +e
+          CHERRYPICK_OUT=$(git cherry-pick -x --mainline 1 ${MERGE_COMMIT} 2>&1)
+          CHERRYPICK_STATUS=$?
+          set -e
+          if [ "${CHERRYPICK_STATUS}" -ne 0 ]; then
+            echo "Cherry-pick failed for ${TARGET_BRANCH}:"
+            echo "${CHERRYPICK_OUT}"
+            git cherry-pick --abort || true
             cd "${GITHUB_WORKSPACE}"
             git worktree remove -f ${WORKTREE}
-
-            set +e
-            EXISTING_PR=$(gh pr list --state open --base ${TARGET_BRANCH} --head ${BACKPORT_BRANCH} --json number --jq '.[0].number' 2>&1)
-            GH_PR_LIST_STATUS=$?
-            set -e
-            if [ "${GH_PR_LIST_STATUS}" -ne 0 ]; then
-              echo "Failed to query existing backport PR for ${TARGET_BRANCH}:"
-              echo "${EXISTING_PR}"
-              FAILURES+=("${TARGET_BRANCH}")
-              continue
-            fi
-            if [ -z "${EXISTING_PR}" ]; then
-              set +e
-              CREATE_OUT=$(gh pr create \
-                --title "${PR_TITLE} [backport ${TARGET_BRANCH}]" \
-                --body "Backport #${PR_NUMBER} to ${TARGET_BRANCH}" \
-                --base ${TARGET_BRANCH} \
-                --head ${BACKPORT_BRANCH} 2>&1)
-              GH_PR_CREATE_STATUS=$?
-              set -e
-              if [ "${GH_PR_CREATE_STATUS}" -ne 0 ]; then
-                echo "Failed to create backport PR for ${TARGET_BRANCH}:"
-                echo "${CREATE_OUT}"
-                FAILURES+=("${TARGET_BRANCH}")
-                continue
-              fi
-            else
-              echo "Backport PR already exists for ${TARGET_BRANCH}: #${EXISTING_PR}"
-            fi
-          done < /tmp/backport-labels.sorted.txt
-
-          if [ ${#FAILURES[@]} -gt 0 ]; then
-            echo "Backport failed for: ${FAILURES[*]}"
             exit 1
+          fi
+
+          echo "branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "branch-from=$(git rev-parse ${TARGET_BRANCH})" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "target-branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Push Commit
+        uses: DataDog/commit-headless@action/v2.0.3
+        with:
+          branch: ${{ steps.create-commit.outputs.branch }}
+          branch-from: ${{ steps.create-commit.outputs.branch-from }}
+          command: push
+          commits: ${{ steps.create-commit.outputs.commit }}
+          force: true
+
+      - name: Create PR
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_BRANCH: ${{ steps.create-commit.outputs.target-branch }}
+          BACKPORT_BRANCH: ${{ steps.create-commit.outputs.branch }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          set +e
+          EXISTING_PR=$(gh pr list --state open --base ${TARGET_BRANCH} --head ${BACKPORT_BRANCH} --json number --jq '.[0].number' 2>&1)
+          GH_PR_LIST_STATUS=$?
+          set -e
+          if [ "${GH_PR_LIST_STATUS}" -ne 0 ]; then
+            echo "Failed to query existing backport PR for ${TARGET_BRANCH}:"
+            echo "${EXISTING_PR}"
+            exit 1
+          fi
+          if [ -z "${EXISTING_PR}" ]; then
+            set +e
+            CREATE_OUT=$(gh pr create \
+              --title "${PR_TITLE} [backport ${TARGET_BRANCH}]" \
+              --body "Backport #${PR_NUMBER} to ${TARGET_BRANCH}" \
+              --base ${TARGET_BRANCH} \
+              --head ${BACKPORT_BRANCH} 2>&1)
+            GH_PR_CREATE_STATUS=$?
+            set -e
+            if [ "${GH_PR_CREATE_STATUS}" -ne 0 ]; then
+              echo "Failed to create backport PR for ${TARGET_BRANCH}:"
+              echo "${CREATE_OUT}"
+              exit 1
+            fi
+          else
+            echo "Backport PR already exists for ${TARGET_BRANCH}: #${EXISTING_PR}"
           fi


### PR DESCRIPTION
## Description

  - Refactor the backport workflow from a sequential loop into parallel matrix jobs, so each target branch is backported independently
  - Use DataDog/commit-headless to sign backport commits
  - Simplify error handling by letting each matrix job fail independently instead of accumulating failures

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
