### PR TITLE
perf(profiling): compute each Task's Stack exactly once

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -197,6 +197,17 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
         }
     }
 
+    // Pre-compute per-task coroutine stacks so that each task's coroutine chain is walked exactly once.
+    // Without this, a parent task's coroutine chain would be walked once for each child task that
+    // references it in its task chain (e.g. 10 children from asyncio.gather = 10 redundant unwinds
+    // of the parent's coroutine chain).
+    std::unordered_map<PyObject*, FrameStack> task_coro_stacks;
+    for (auto& task : all_tasks) {
+        FrameStack task_stack;
+        task->unwind(echion, task_stack, using_uvloop);
+        task_coro_stacks.emplace(task->origin, std::move(task_stack));
+    }
+
     // Make sure the on CPU task is first
     for (size_t i = 0; i < leaf_tasks.size(); i++) {
         if (leaf_tasks[i].get().is_on_cpu) {
@@ -219,7 +230,17 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
             }
             auto& task = current_task.get();
 
-            auto task_stack_size = task.unwind(echion, stack, using_uvloop);
+            // Look up the pre-computed coroutine stack for this task
+            size_t task_stack_size = 0;
+            if (auto it = task_coro_stacks.find(task.origin); it != task_coro_stacks.end()) {
+                task_stack_size = it->second.size();
+                for (const auto& frame_ref : it->second) {
+                    if (stack.size() >= max_frames) {
+                        break;
+                    }
+                    stack.push_back(frame_ref);
+                }
+            }
             if (task.is_on_cpu) {
                 // Get the "bottom" part of the Python synchronous Stack, that is to say the
                 // synchronous functions and coroutines called by the Task's outermost coroutine


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13613

This PR updates the Task unwinding logic in the Profiler to unwind each Task (its coroutine chain) exactly once. The results are cached in a hash map (keyed by Task address) and re-used to generate the "stacked Stacks" for each child Task.

I ran some performance tests with highly-concurrent workloads (lots of Tasks running at the same time) and highly hierarchical workloads (mix of parent, child, grand child, grand-grand-child Tasks) and the performance improvement really was marginal, especially when using `ECHION_USE_FAST_COPY_MEMORY=1`. 

Time to execute `unwind_tasks` for a Thread, before changes...
* `process_vm_readv`: ~800us (it's a lot!)
* `memcpy`:           ~150us (it's much better)

... and after changes:
- `process_vm_readv`: ~700us (it's 12% better!)
- `memcpy`:           ~130us-150us (on average, feels a bit better, high variance)

However, this is the right thing to do, so it is probably worth checking it in anyway. 