### PR TITLE
ci: start serverless lambda tests sooner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,8 +107,7 @@ serverless lambda tests:
     project: DataDog/datadog-lambda-python
     strategy: depend
     branch: main
-  needs:
-    - job: "upload all"
+  needs: []
   variables:
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
     UPSTREAM_PROJECT_URL: $CI_PROJECT_URL


### PR DESCRIPTION
## Description

Thew downstream pipeline doesn't consume any artifacts at all during building, so there is no reason to block and wait for all wheels to be built and published.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
