### PR TITLE
chore(profiling): remove unused method on `StackRenderer`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -84,7 +84,6 @@ class StackRenderer
                              uintptr_t thread_id,
                              unsigned long native_id);
     void render_task_begin(const std::string& task_name, bool on_cpu);
-    void render_stack_begin();
     void render_frame(Frame& frame);
     void render_cpu_time(uint64_t cpu_time_us);
     void render_stack_end();

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -645,7 +645,6 @@ ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t d
 
             const auto& task_name = maybe_task_name->get();
             renderer.render_task_begin(task_name, task_stack_info->on_cpu);
-            renderer.render_stack_begin();
 
             task_stack_info->stack.render(echion);
 
@@ -662,7 +661,6 @@ ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t d
 
             const auto& task_name = maybe_task_name->get();
             renderer.render_task_begin(task_name, greenlet_stack->on_cpu);
-            renderer.render_stack_begin();
 
             auto& stack = greenlet_stack->stack;
             stack.render(echion);
@@ -672,7 +670,6 @@ ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t d
 
         current_greenlets.clear();
     } else {
-        renderer.render_stack_begin();
         python_stack.render(echion);
         renderer.render_stack_end();
     }

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -111,12 +111,6 @@ StackRenderer::render_task_begin(const std::string& task_name, bool on_cpu)
 }
 
 void
-StackRenderer::render_stack_begin()
-{
-    // This function is part of the necessary API, but it is unused by the Datadog profiler for now.
-}
-
-void
 StackRenderer::render_frame(Frame& frame)
 {
     if (sample == nullptr) {


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13291

As title says, this is a remnant of standalone Echion that we don't use in `dd-trace-py`.