### PR TITLE
perf(profiling): stop reversing frames from stack sampler

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -95,8 +95,7 @@ class Sample
     std::vector<int64_t> values = {};
 
     // Additional metadata
-    int64_t endtime_ns = 0;         // end of the event
-    bool reverse_locations = false; // whether to reverse locations when exporting/flushing
+    int64_t endtime_ns = 0; // end of the event
 
     // Backing memory for string copies
     internal::StringArena string_storage{};
@@ -156,9 +155,6 @@ class Sample
     // call returns. Frames obtained internally via PyFrame_GetBack() are
     // released by this function.
     void push_pyframes(PyFrameObject* frame);
-
-    // Set whether to reverse locations when exporting/flushing
-    void set_reverse_locations(bool reverse) { reverse_locations = reverse; }
 
     // Flushes the current buffer, clearing it
     bool flush_sample();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -320,7 +320,6 @@ Datadog::Sample::clear_buffers()
     locations.clear();
     dropped_frames = 0;
     has_dropped_frames_indicator = false;
-    reverse_locations = false;
     string_storage.reset();
 }
 
@@ -344,11 +343,6 @@ Datadog::Sample::export_sample()
           "<" + std::to_string(dropped_frames) + " frame" + (1 == dropped_frames ? "" : "s") + " omitted>";
         Sample::push_frame_impl(name, "", 0, 0);
         has_dropped_frames_indicator = true;
-    }
-
-    if (reverse_locations) {
-        std::reverse(locations.begin(), locations.end());
-        reverse_locations = false; // Reset after reversing
     }
 
     const ddog_prof_Sample2 sample = {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
@@ -9,7 +9,7 @@ void
 FrameStack::render(EchionSampler& echion)
 {
     auto& renderer = echion.renderer();
-    for (auto it = this->rbegin(); it != this->rend(); ++it) {
+    for (auto it = this->begin(); it != this->end(); ++it) {
 #if PY_VERSION_HEX >= 0x030c0000
         if ((*it).get().is_entry)
             // This is a shim frame so we skip it.

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -236,7 +236,6 @@ StackRenderer::render_stack_end()
         return;
     }
 
-    sample->set_reverse_locations(true);
     sample->flush_sample();
     SampleManager::drop_sample(sample);
     sample = nullptr;


### PR DESCRIPTION
## Description

`FrameStack::render` iterated frames in reverse order to support Echion standalone's `MojoRenderer`. No need to do this, and reverse frames again in `export_sample()`. 

This should lower cpu overhead for exporting a sample from stack sampler. And keeps the behavior in sync with lock/memory samplers, pushing frames from leaf to root, and truncating around the root of the frames. 

## Testing

[test_stack_locations](https://github.com/DataDog/dd-trace-py/blob/8f7b888e94d7693f3c5f035a08c37d5f1eca77a9/tests/profiling/collector/test_stack.py#L93) tests that we output frames in correct order. 


## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
