### PR TITLE
chore(ci_visibility): early exit for retry mechanisms

### DIFF
--- a/ddtrace/testing/internal/retry_handlers.py
+++ b/ddtrace/testing/internal/retry_handlers.py
@@ -77,6 +77,9 @@ class AutoTestRetriesHandler(RetryHandler):
         return self.max_tests_to_retry_per_session > 0
 
     def should_retry(self, test: Test) -> bool:
+        if test.has_passed():
+            return False
+
         retries_so_far = len(test.test_runs) - 1  # Initial attempt does not count.
         return test.last_test_run.get_status() == TestStatus.FAIL and retries_so_far < self.max_retries_per_test
 
@@ -127,6 +130,9 @@ class EarlyFlakeDetectionHandler(RetryHandler):
             test.set_early_flake_detection_abort_reason("slow")
             return False
 
+        if test.has_passed() and test.has_failed():
+            return False
+
         target_number_of_retries = self._target_number_of_retries(test)
         retries_so_far = len(test.test_runs) - 1  # Initial attempt does not count.
         return retries_so_far < target_number_of_retries
@@ -169,6 +175,9 @@ class AttemptToFixHandler(RetryHandler):
         return test.is_attempt_to_fix()
 
     def should_retry(self, test: Test) -> bool:
+        if test.has_failed():
+            return False
+
         retries_so_far = len(test.test_runs) - 1  # Initial attempt does not count.
         return retries_so_far < self.session_manager.settings.test_management.attempt_to_fix_retries
 

--- a/ddtrace/testing/internal/test_data.py
+++ b/ddtrace/testing/internal/test_data.py
@@ -171,6 +171,13 @@ class TestRun(TestItem["Test", t.NoReturn]):
         self.set_tags(context.get_tags())
         self.set_metrics(context.get_metrics())
 
+    def set_status(self, status: TestStatus) -> None:
+        super().set_status(status)
+        if status == TestStatus.PASS:
+            self.test._has_passed = True
+        elif status == TestStatus.FAIL:
+            self.test._has_failed = True
+
     def is_retry(self) -> bool:
         return self.attempt_number > 0
 
@@ -215,6 +222,8 @@ class Test(TestItem["TestSuite", "TestRun"]):
         self.session = self.module.parent
 
         self._is_flaky_run = False
+        self._has_passed = False
+        self._has_failed = False
 
     def __str__(self) -> str:
         return f"{self.parent.parent.name}/{self.parent.name}::{self.name}"
@@ -312,6 +321,12 @@ class Test(TestItem["TestSuite", "TestRun"]):
 
     def is_flaky_run(self) -> bool:
         return self._is_flaky_run
+
+    def has_passed(self) -> bool:
+        return self._has_passed
+
+    def has_failed(self) -> bool:
+        return self._has_failed
 
 
 class TestSuite(TestItem["TestModule", "Test"]):


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9032caab-c746-4633-b7f0-795150fa1f15","source":"chat","resourceId":"273f85b3-3e18-4a96-abfd-615bc7d9adad","workflowId":"7d518267-669d-4d1e-b753-e7c701b64e6d","codeChangeId":"7d518267-669d-4d1e-b753-e7c701b64e6d","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/273f85b3-3e18-4a96-abfd-615bc7d9adad)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Description

Implements early exit logic for retry mechanisms to reduce unnecessary overhead on customer CI. This change prevents scheduling further test retries once the purpose of each retry mechanism has been fulfilled:

- **Auto Test Retries**: Stop retrying after the first successful test execution
- **Early Flake Detection**: Stop retrying once there has been at least one failed and one successful execution
- **Attempt to Fix**: Stop retrying after the first failed execution

The implementation adds state tracking to the `Test` class to record whether it has passed or failed at any point, then uses these flags in each retry handler's `should_retry()` method to determine early exit conditions.

## Testing

Updated test expectations in `test_pytest_efd.py` to reflect the reduced number of retries:
- EFD flaky test case now expects 2 test runs instead of 11
- EFD skip-then-fail case now expects 3 test runs instead of 11
- All event counts and output assertions updated accordingly
- Tests verify that retries stop as soon as early exit conditions are met

## Risks

Low risk. The changes are additive and only add early exit conditions without modifying existing retry logic. Behavior is only affected when early exit conditions are met, which improves efficiency without changing correctness.

## Additional Notes

The implementation leverages the existing `set_status()` method on `TestRun` to track test outcomes, ensuring state is updated whenever a test status is recorded. This approach maintains a single source of truth for test status information.