### PR TITLE
chore(codeowner): make profiling settings pyi file owned by profiling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,13 +130,14 @@ scripts/iast/*                      @DataDog/asm-python
 
 
 # Profiling
-ddtrace/profiling                   @DataDog/profiling-python
+ddtrace/profiling                            @DataDog/profiling-python
 ddtrace/internal/settings/profiling.py       @DataDog/profiling-python
-ddtrace/internal/datadog/profiling  @DataDog/profiling-python
-tests/profiling                     @DataDog/profiling-python
+ddtrace/internal/settings/profiling.pyi      @DataDog/profiling-python
+ddtrace/internal/datadog/profiling           @DataDog/profiling-python
+tests/profiling                              @DataDog/profiling-python
 .github/workflows/profiling-native.yml       @DataDog/profiling-python
-.gitlab/tests/profiling.yml         @DataDog/profiling-python
-.github/workflows/pytorch_gpu_tests.yml @DataDog/profiling-python
+.gitlab/tests/profiling.yml                  @DataDog/profiling-python
+.github/workflows/pytorch_gpu_tests.yml      @DataDog/profiling-python
 
 # Crashtracker
 ddtrace/internal/core/crashtracking.py       @DataDog/profiling-python @DataDog/apm-core-python


### PR DESCRIPTION
## Description

To streamline future review process. Profling owns `ddtrace/internal/settings/profiling.pyi` file. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
