### PR TITLE
feat(llmobs): add experiment result export and pull from backend

### DIFF
--- a/ddtrace/llmobs/__init__.py
+++ b/ddtrace/llmobs/__init__.py
@@ -15,6 +15,8 @@ from ddtrace.llmobs._evaluators import SummaryEvaluatorContext
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 from ddtrace.llmobs._experiment import EvaluatorResult
+from ddtrace.llmobs._experiment import experiment_result_as_dataframe
+from ddtrace.llmobs._experiment import experiment_result_to_csv
 from ddtrace.llmobs._llmobs import LLMObs
 from ddtrace.llmobs._llmobs import LLMObsSpan
 from ddtrace.llmobs.types import Prompt
@@ -33,4 +35,6 @@ __all__ = [
     "EvaluatorContext",
     "EvaluatorResult",
     "SummaryEvaluatorContext",
+    "experiment_result_as_dataframe",
+    "experiment_result_to_csv",
 ]

--- a/releasenotes/notes/llmobs-experiment-results-export-f3d9e7a20b614c85.yaml
+++ b/releasenotes/notes/llmobs-experiment-results-export-f3d9e7a20b614c85.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    LLM Observability: adds ``experiment_result_as_dataframe()`` and
+    ``experiment_result_to_csv()`` for exporting experiment results. Adds
+    ``Experiment.result`` property to retrieve the last run's result. Adds
+    ``LLMObs.pull_experiment_results()`` to fetch results from the backend.


### PR DESCRIPTION
## Summary
- Adds `experiment_result_as_dataframe()` and `experiment_result_to_csv()` for exporting results
- Stores last result on experiment instance via `.result` property
- Adds `LLMObs.pull_experiment_results(experiment_id)` to fetch results from backend via `GET /api/v2/llm-obs/v3/experiments/{id}/events`
- Paginated fetching with conversion of spans + eval metrics into `ExperimentResult` format

## Test plan
- [ ] Verify `experiment_result_as_dataframe()` produces correct DataFrame columns
- [ ] Verify `experiment_result_to_csv()` writes valid CSV
- [ ] Verify `.result` property returns last run result
- [ ] Verify `pull_experiment_results()` fetches and parses backend response correctly