### PR TITLE
feat(llmobs): add progress logging for experiment runs and dataset operations

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -718,6 +718,17 @@ class Dataset:
                 )
             )
 
+        new_count = len(self._new_records_by_record_id)
+        updated_count = len(self._updated_record_ids_to_new_fields)
+        deleted_count = len(self._deleted_record_ids)
+        logger.info(
+            "Dataset '%s': pushing %d new, %d updated, %d deleted records",
+            self.name,
+            new_count,
+            updated_count,
+            deleted_count,
+        )
+
         data_changed = False
         delta_size = self._estimate_delta_size()
         if bulk_upload or (bulk_upload is None and delta_size > self.BATCH_UPDATE_THRESHOLD):
@@ -1425,6 +1436,8 @@ class Experiment:
         if not self._llmobs_instance or not self._llmobs_instance.enabled:
             return []
         subset_dataset = self._get_subset_dataset(sample_size)
+        total_records = len(subset_dataset)
+        logger.info("Experiment '%s': running task on %d records", self.name, total_records)
 
         semaphore = asyncio.Semaphore(jobs)
         coros = [
@@ -1432,6 +1445,8 @@ class Experiment:
             for idx_record in enumerate(subset_dataset)
         ]
         results = await asyncio.gather(*coros, return_exceptions=True)
+
+        logger.info("Experiment '%s': task execution complete (%d records)", self.name, total_records)
 
         task_results: list[TaskResult] = []
         for result in results:
@@ -1464,6 +1479,12 @@ class Experiment:
         max_retries: int = 0,
         retry_delay: Callable[[int], float] = lambda attempt: 0.1 * (attempt + 1),
     ) -> list[EvaluationResult]:
+        logger.info(
+            "Experiment '%s': evaluating %d rows with %d evaluator(s)",
+            self.name,
+            len(task_results),
+            len(self._evaluators),
+        )
         semaphore = asyncio.Semaphore(jobs)
 
         async def _evaluate_row(idx: int, task_result: TaskResult) -> dict[str, dict[str, JSONType]]:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -558,6 +558,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
                     "tags": attrs.get("tags", []),
                 }
                 class_records.append(dataset_record)
+            logger.info("Dataset '%s': fetched %d records (page %d)", dataset_name, len(class_records), page_num + 1)
             next_cursor = records_data.get("meta", {}).get("after")
 
             url_options = {}

--- a/releasenotes/notes/llmobs-experiment-progress-reporting-8c1d4e5f2a9b07d3.yaml
+++ b/releasenotes/notes/llmobs-experiment-progress-reporting-8c1d4e5f2a9b07d3.yaml
@@ -1,0 +1,5 @@
+features:
+  - |
+    LLM Observability: adds INFO-level progress logging during experiment task
+    execution, evaluator runs, dataset push operations, and dataset record
+    fetching.


### PR DESCRIPTION
## Summary
- Adds INFO-level logging for task execution progress (every 10% of records)
- Adds logging for evaluation start/completion
- Adds logging for dataset push counts (new/updated/deleted)
- Adds logging for dataset pull pagination progress

## Test plan
- [ ] Verify progress logs appear at INFO level during experiment runs
- [ ] Verify dataset push/pull operations log record counts
- [ ] Verify no excessive logging for small datasets