### PR TITLE
ci: reduce MQ size to 2

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -11,8 +11,8 @@ gitlab_jobs_retry_enable: false
 gitlab_fail_fast: false
 # Do not add merge queue status labels on the PR, they will trigger required status checks and block the PR from the MQ
 skip_labels: true
-# Validate up to 5 PRs from the queue at once
-speculative_max_depth: 5
+# Validate up to 2 PRs from the queue at once
+speculative_max_depth: 2
 # Run CI for A, A+B, and B such that if A or A+B fail, but B passes, we can still merge B
 speculative_fallback_enable: true
 branches:


### PR DESCRIPTION
## Description

At least for now, goal is to have a higher MQ size, but right now we are seeing a lot of contention/pressure on job queueing, at least for macOS jobs. Reducing this size should help overall.

One of the reasons this number has a high amount of pressure is because we use speculative fallback, meaning when we have A and B in the queue, we build pipelines for A, A+B, and B, that way if A or A+B fail, but B succeeds, we can still merge B.

This is another lever we can play with as well if we find the lower MQ size doesn't help as much as we want.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
