### PR TITLE
chore(appsec): update default waf rules version

### DIFF
--- a/ddtrace/appsec/rules.json
+++ b/ddtrace/appsec/rules.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.14.2"
+    "rules_version": "1.16.1"
   },
   "rules": [
     {
@@ -2985,7 +2985,7 @@
                 "address": "graphql.server.resolver"
               }
             ],
-            "regex": "\\b(?:(?:l(?:(?:utimes|chmod)(?:Sync)?|(?:stat|ink)Sync)|w(?:rite(?:(?:File|v)(?:Sync)?|Sync)|atchFile)|u(?:n(?:watchFile|linkSync)|times(?:Sync)?)|s(?:(?:ymlink|tat)Sync|pawn(?:File|Sync))|ex(?:ec(?:File(?:Sync)?|Sync)|istsSync)|a(?:ppendFile|ccess)(?:Sync)?|(?:Caveat|Inode)s|open(?:dir)?Sync|new\\s+Function|Availability|\\beval)\\s*\\(|m(?:ain(?:Module\\s*(?:\\W*\\s*(?:constructor|require)|\\[)|\\s*(?:\\W*\\s*(?:constructor|require)|\\[))|kd(?:temp(?:Sync)?|irSync)\\s*\\(|odule\\.exports\\s*=)|c(?:(?:(?:h(?:mod|own)|lose)Sync|reate(?:Write|Read)Stream|p(?:Sync)?)\\s*\\(|o(?:nstructor\\s*(?:\\W*\\s*_load|\\[)|pyFile(?:Sync)?\\s*\\())|f(?:(?:(?:s(?:(?:yncS)?|tatS)|datas(?:yncS)?)ync|ch(?:mod|own)(?:Sync)?)\\s*\\(|u(?:nction\\s*\\(\\s*\\)\\s*{|times(?:Sync)?\\s*\\())|r(?:e(?:(?:ad(?:(?:File|link|dir)?Sync|v(?:Sync)?)|nameSync)\\s*\\(|quire\\s*(?:\\W*\\s*main|\\[))|m(?:Sync)?\\s*\\()|process\\s*(?:\\W*\\s*(?:mainModule|binding)|\\[)|t(?:his\\.constructor|runcateSync\\s*\\()|_(?:\\$\\$ND_FUNC\\$\\$_|_js_function)|global\\s*(?:\\W*\\s*process|\\[)|String\\s*\\.\\s*fromCharCode|binding\\s*\\[)",
+            "regex": "\\b(?:(?:l(?:(?:utimes|chmod)(?:Sync)?|(?:stat|ink)Sync)|w(?:rite(?:(?:File|v)(?:Sync)?|Sync)|atchFile)|u(?:n(?:watchFile|linkSync)|times(?:Sync)?)|s(?:(?:ymlink|tat)Sync|pawn(?:File|Sync))|ex(?:ec(?:File(?:Sync)?|Sync)|istsSync)|a(?:ppendFile|ccess)(?:Sync)?|(?:Caveat|Inode)s|open(?:dir)?Sync|new\\s+Function|Availability|\\beval)\\s*\\(|m(?:ain(?:Module\\s*(?:\\W*\\s*(?:constructor|require)|\\[)|\\s*(?:\\W*\\s*(?:constructor|require)|\\[))|kd(?:temp(?:Sync)?|irSync)\\s*\\(|odule\\.exports\\s*=)|c(?:(?:(?:h(?:mod|own)|lose)Sync|reate(?:Write|Read)Stream|p(?:Sync)?)\\s*\\(|o(?:nstructor\\s*(?:\\W*\\s*_load|\\[)|pyFile(?:Sync)?\\s*\\())|f(?:(?:(?:s(?:(?:yncS)?|tatS)|datas(?:yncS)?)ync|ch(?:mod|own)(?:Sync)?)\\s*\\(|u(?:nction\\s*\\(\\s*\\)\\s*{|times(?:Sync)?\\s*\\())|r(?:e(?:(?:ad(?:(?:File|link|dir)?Sync|v(?:Sync)?)|nameSync)\\s*\\(|quire\\s*(?:\\W*\\s*main\\b|\\[))|m(?:Sync)?\\s*\\()|process\\s*(?:\\W*\\s*(?:mainModule|binding)|\\[)|t(?:his\\.constructor|runcateSync\\s*\\()|_(?:\\$\\$ND_FUNC\\$\\$_|_js_function)|global\\s*(?:\\W*\\s*process|\\[)|String\\s*\\.\\s*fromCharCode|binding\\s*\\[)",
             "options": {
               "case_sensitive": true,
               "min_length": 3
@@ -4376,7 +4376,7 @@
                 "address": "graphql.server.resolver"
               }
             ],
-            "regex": "java\\.lang\\.(?:runtime|processbuilder)",
+            "regex": "\\bjava\\.lang\\.(?:runtime|processbuilder)\\b",
             "options": {
               "case_sensitive": true,
               "min_length": 17
@@ -5539,6 +5539,7 @@
         "confidence": "0",
         "module": "waf"
       },
+      "max_version": "1.24.9",
       "conditions": [
         {
           "parameters": {
@@ -5649,6 +5650,52 @@
             "options": {
               "case_sensitive": true,
               "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-932-110",
+      "name": "Python: Subprocess-based command injection",
+      "tags": {
+        "type": "command_injection",
+        "category": "attack_attempt",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "(?s)\\bsubprocess\\b.*\\b(?:check_output|run|Popen|call|check_call)\\b",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 14
             }
           },
           "operator": "match_regex"
@@ -6625,7 +6672,10 @@
               {
                 "address": "graphql.server.resolver"
               }
-            ]
+            ],
+            "options": {
+              "path-inspection": true
+            }
           },
           "operator": "ssrf_detector"
         }
@@ -8870,6 +8920,498 @@
       "transformers": []
     }
   ],
+  "rules_compat": [
+    {
+      "id": "api-001-100",
+      "name": "JWT: No expiry is present",
+      "tags": {
+        "type": "jwt",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.jwt",
+                "key_path": [
+                  "payload",
+                  "exp"
+                ]
+              }
+            ]
+          },
+          "operator": "!exists"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "_dd.appsec.api.jwt.no_expiry": {
+            "value": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "api-001-110",
+      "name": "JWT: Collect algorithm used",
+      "tags": {
+        "type": "jwt",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.jwt",
+                "key_path": [
+                  "header",
+                  "alg"
+                ]
+              }
+            ]
+          },
+          "operator": "exists"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "api.security.jwt.alg": {
+            "address": "server.request.jwt",
+            "key_path": [
+              "header",
+              "alg"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "api-001-120",
+      "name": "JWT: No audience is specified",
+      "tags": {
+        "type": "jwt",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.jwt",
+                "key_path": [
+                  "payload",
+                  "aud"
+                ]
+              }
+            ]
+          },
+          "operator": "!exists"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "_dd.appsec.api.jwt.no_audience": {
+            "value": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "api-001-130",
+      "name": "JWT: None algorithm used",
+      "tags": {
+        "type": "jwt",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.jwt",
+                "key_path": [
+                  "header",
+                  "alg"
+                ]
+              }
+            ],
+            "list": [
+              "none",
+              "nonE",
+              "noNe",
+              "noNE",
+              "nOne",
+              "nOnE",
+              "nONe",
+              "nONE",
+              "None",
+              "NonE",
+              "NoNe",
+              "NoNE",
+              "NOne",
+              "NOnE",
+              "NONe",
+              "NONE"
+            ]
+          },
+          "operator": "exact_match"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": true,
+        "attributes": {
+          "_dd.appsec.api.jwt.none_alg": {
+            "value": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "api-010-100",
+      "name": "Monitor redirections to GET targets",
+      "tags": {
+        "type": "api10",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.response.status"
+              }
+            ],
+            "list": [
+              "301",
+              "302"
+            ]
+          },
+          "operator": "exact_match"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "api.security.redirection.move_target": {
+            "address": "server.io.net.response.headers",
+            "key_path": [
+              "Location"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "api-010-110",
+      "name": "Monitor redirections to POST targets",
+      "tags": {
+        "type": "api10",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.response.status"
+              }
+            ],
+            "list": [
+              "307",
+              "308"
+            ]
+          },
+          "operator": "exact_match"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "api.security.redirection.redirect_target": {
+            "address": "server.io.net.response.headers",
+            "key_path": [
+              "Location"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "api-010-200",
+      "name": "Large response bodies in downstream network calls",
+      "tags": {
+        "type": "api10",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.response.headers",
+                "key_path": [
+                  "content-length"
+                ]
+              }
+            ],
+            "regex": "\\d{7,}",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 7
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "api.security.large_response.length": {
+            "address": "server.io.net.response.headers",
+            "key_path": [
+              "content-length"
+            ]
+          },
+          "api.security.large_response.url": {
+            "address": "server.io.net.url"
+          }
+        }
+      }
+    },
+    {
+      "id": "api-010-300",
+      "name": "Secrets transmitted in downstream URL parameters",
+      "tags": {
+        "type": "api10",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "regex": "[?&](?:(?:api|access)?(_)?(?:key|secret|token|password|passwd|pwd))=",
+            "options": {
+              "case_sensitive": false
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "api.security.secret.disclosed_in_url_params": {
+            "value": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "api-010-400",
+      "name": "Unauthenticated MCP access",
+      "tags": {
+        "type": "api10",
+        "category": "api_security",
+        "confidence": "0",
+        "module": "business-logic"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "regex": "/mcp/(?:tools|resources)/",
+            "options": {
+              "case_sensitive": false
+            }
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.request.headers",
+                "key_path": [
+                  "authorization"
+                ]
+              }
+            ]
+          },
+          "operator": "!exists"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.response.status"
+              }
+            ],
+            "list": [
+              "401"
+            ]
+          },
+          "operator": "!exact_match"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "api.security.mcp.broken_auth": {
+            "value": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "ua0-600-551",
+      "name": "Datadog test scanner - scalar trace-tagging version: user-agent",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "tool_name": "Datadog Canary Test",
+        "confidence": "1",
+        "module": "waf"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              },
+              {
+                "address": "grpc.server.request.metadata",
+                "key_path": [
+                  "dd-canary"
+                ]
+              }
+            ],
+            "regex": "^dd-test-scanner-tag-scalar(?:$|/|\\s)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "attributes": {
+          "_dd.appsec.test.scanner.scalar": {
+            "value": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "ua0-600-552",
+      "name": "Datadog test scanner - reference trace-tagging version: user-agent",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "tool_name": "Datadog Canary Test",
+        "confidence": "1",
+        "module": "waf"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              },
+              {
+                "address": "grpc.server.request.metadata",
+                "key_path": [
+                  "dd-canary"
+                ]
+              }
+            ],
+            "regex": "^dd-test-scanner-tag-ref(?:$|/|\\s)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "attributes": {
+          "_dd.appsec.test.scanner.reference": {
+            "address": "server.request.headers.no_cookies",
+            "key_path": [
+              "user-agent"
+            ]
+          }
+        }
+      }
+    }
+  ],
   "processors": [
     {
       "id": "http-endpoint-fingerprint",
@@ -9073,6 +9615,28 @@
       },
       "evaluate": true,
       "output": true
+    },
+    {
+      "id": "decode-auth-jwt",
+      "generator": "jwt_decode",
+      "min_version": "1.25.0",
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "authorization"
+                ]
+              }
+            ],
+            "output": "server.request.jwt"
+          }
+        ]
+      },
+      "evaluate": true,
+      "output": false
     },
     {
       "id": "http-network-fingerprint",
@@ -9916,6 +10480,24 @@
         "type": "card",
         "card_type": "mastercard",
         "category": "payment"
+      }
+    },
+    {
+      "id": "c542c147-3883-43d6-a067-178e4a7bd65d",
+      "name": "Password",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bpass(?:[_-]?word|wd)?\\b|\\bpwd\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "tags": {
+        "type": "password",
+        "category": "credentials"
       }
     },
     {

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -7,30 +7,34 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.14.2",
-      "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
+      "_dd.appsec.event_rules.version": "1.16.1",
+      "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
+      "_dd.appsec.fp.http.network": "net-0-0000000000",
+      "_dd.appsec.rc_products": "[] u:0 r:1",
       "_dd.appsec.waf.version": "1.30.1",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
+      "_dd.p.tid": "699dd65400000000",
       "_dd.p.ts": "02",
       "_dd.runtime_family": "python",
       "appsec.event": "true",
       "http.status_code": "404",
       "language": "python",
-      "runtime-id": "b7a5cef93fb04f94b309dd02d0467745"
+      "runtime-id": "3a46ead67f3f49e39073d61d171bae9c"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,
-      "_dd.appsec.event_rules.error_count": 0,
-      "_dd.appsec.event_rules.loaded": 166,
-      "_dd.appsec.waf.duration": 204.672,
-      "_dd.appsec.waf.duration_ext": 280.3802490234375,
-      "_dd.top_level": 1,
+      "_dd.appsec.event_rules.error_count": 0.0,
+      "_dd.appsec.event_rules.loaded": 166.0,
+      "_dd.appsec.waf.duration": 284.75,
+      "_dd.appsec.waf.duration_ext": 375.8749990083743,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 2,
-      "process_id": 416619
+      "_sampling_priority_v1": 2.0,
+      "process_id": 12318.0
     },
-    "duration": 291118,
-    "start": 1698579016662570325
+    "duration": 9729000,
+    "start": 1771951700103792000
   }]]

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -7,30 +7,35 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.14.2",
-      "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
+      "_dd.appsec.event_rules.version": "1.16.1",
+      "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
+      "_dd.appsec.fp.http.network": "net-0-0000000000",
+      "_dd.appsec.fp.session": "ssn--3fd6b904-1f57cef4-",
+      "_dd.appsec.rc_products": "[] u:0 r:1",
       "_dd.appsec.waf.version": "1.30.1",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
+      "_dd.p.tid": "699dd65400000000",
       "_dd.p.ts": "02",
       "_dd.runtime_family": "python",
       "appsec.event": "true",
       "http.status_code": "404",
       "language": "python",
-      "runtime-id": "b7a5cef93fb04f94b309dd02d0467745"
+      "runtime-id": "3a46ead67f3f49e39073d61d171bae9c"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,
-      "_dd.appsec.event_rules.error_count": 0,
-      "_dd.appsec.event_rules.loaded": 166,
-      "_dd.appsec.waf.duration": 103.238,
-      "_dd.appsec.waf.duration_ext": 174.04556274414062,
-      "_dd.top_level": 1,
+      "_dd.appsec.event_rules.error_count": 0.0,
+      "_dd.appsec.event_rules.loaded": 166.0,
+      "_dd.appsec.waf.duration": 91.0,
+      "_dd.appsec.waf.duration_ext": 162.74999870802276,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 2,
-      "process_id": 416619
+      "_sampling_priority_v1": 2.0,
+      "process_id": 12318.0
     },
-    "duration": 262812,
-    "start": 1698579016632697894
+    "duration": 9651000,
+    "start": 1771951700074596000
   }]]

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -7,32 +7,36 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.14.2",
-      "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
+      "_dd.appsec.event_rules.version": "1.16.1",
+      "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
+      "_dd.appsec.fp.http.network": "net-0-0000000000",
+      "_dd.appsec.rc_products": "[] u:0 r:1",
       "_dd.appsec.waf.version": "1.30.1",
       "_dd.base_service": "tests.appsec.appsec",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
+      "_dd.p.tid": "699dd65400000000",
       "_dd.p.ts": "02",
       "_dd.runtime_family": "python",
       "appsec.event": "true",
       "http.status_code": "404",
       "http.url": "http://example.com/.git",
       "language": "python",
-      "runtime-id": "b7a5cef93fb04f94b309dd02d0467745"
+      "runtime-id": "3a46ead67f3f49e39073d61d171bae9c"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,
-      "_dd.appsec.event_rules.error_count": 0,
-      "_dd.appsec.event_rules.loaded": 166,
-      "_dd.appsec.waf.duration": 126.022,
-      "_dd.appsec.waf.duration_ext": 203.3710479736328,
-      "_dd.top_level": 1,
+      "_dd.appsec.event_rules.error_count": 0.0,
+      "_dd.appsec.event_rules.loaded": 166.0,
+      "_dd.appsec.waf.duration": 90.666,
+      "_dd.appsec.waf.duration_ext": 154.29199993377551,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 2,
-      "process_id": 416619
+      "_sampling_priority_v1": 2.0,
+      "process_id": 12318.0
     },
-    "duration": 379587,
-    "start": 1698579016777341606
+    "duration": 9667000,
+    "start": 1771951700192252000
   }]]

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -7,13 +7,17 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.14.2",
+      "_dd.appsec.event_rules.version": "1.16.1",
+      "_dd.appsec.fp.http.endpoint": "http-get-8a5edab2--",
+      "_dd.appsec.fp.http.header": "hdr-0110000010-bcea973b-1-4740ae63",
+      "_dd.appsec.fp.http.network": "net-0-0000000000",
+      "_dd.appsec.fp.session": "ssn----",
+      "_dd.appsec.rc_products": "[] u:0 r:2",
       "_dd.appsec.waf.version": "1.30.1",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "699dd78200000000",
       "_dd.runtime_family": "python",
       "asgi.version": "3.0",
       "component": "django",
@@ -26,33 +30,33 @@
       "http.request.headers.accept": "*/*",
       "http.request.headers.accept-encoding": "gzip, deflate",
       "http.request.headers.host": "localhost:8000",
-      "http.request.headers.user-agent": "python-requests/2.31.0",
+      "http.request.headers.user-agent": "python-requests/2.32.3",
       "http.response.headers.content-length": "16",
       "http.response.headers.content-type": "text/html; charset=utf-8",
       "http.route": "^$",
       "http.status_code": "200",
       "http.url": "http://localhost:8000/",
-      "http.useragent": "python-requests/2.28.2",
+      "http.useragent": "python-requests/2.32.3",
       "http.version": "1.1",
       "language": "python",
       "network.client.ip": "127.0.0.1",
-      "runtime-id": "b2c7ce6a4c114a098e6aa511fb939d25",
+      "runtime-id": "eda1cae1186a40c1b3f643d7bda2b98b",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,
-      "_dd.appsec.event_rules.error_count": 0,
-      "_dd.appsec.event_rules.loaded": 166,
-      "_dd.appsec.waf.duration": 96.626,
-      "_dd.appsec.waf.duration_ext": 147.81951904296875,
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.appsec.event_rules.error_count": 0.0,
+      "_dd.appsec.event_rules.loaded": 166.0,
+      "_dd.appsec.waf.duration": 113.0,
+      "_dd.appsec.waf.duration_ext": 226.54200074612163,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 20221
+      "_sampling_priority_v1": 1.0,
+      "process_id": 15127.0
     },
-    "duration": 2914917,
-    "start": 1692647408949458722
+    "duration": 3278000,
+    "start": 1771952002633779000
   },
      {
        "name": "django.middleware",
@@ -61,15 +65,12 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
-         "_dd.p.tid": "654a694400000000",
          "component": "django"
        },
-       "duration": 1699417,
-       "start": 1692647408950162097
+       "duration": 1744000,
+       "start": 1771952002634761000
      },
         {
           "name": "django.middleware",
@@ -78,15 +79,12 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
-            "_dd.p.tid": "654a694400000000",
             "component": "django"
           },
-          "duration": 34625,
-          "start": 1692647408950207805
+          "duration": 33000,
+          "start": 1771952002634816000
         },
         {
           "name": "django.middleware",
@@ -95,15 +93,12 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
-            "_dd.p.tid": "654a694400000000",
             "component": "django"
           },
-          "duration": 1566291,
-          "start": 1692647408950263889
+          "duration": 1573000,
+          "start": 1771952002634881000
         },
            {
              "name": "django.middleware",
@@ -112,15 +107,12 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
-               "_dd.p.tid": "654a694400000000",
                "component": "django"
              },
-             "duration": 28375,
-             "start": 1692647408950281930
+             "duration": 31000,
+             "start": 1771952002634914000
            },
            {
              "name": "django.middleware",
@@ -129,15 +121,12 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
-               "_dd.p.tid": "654a694400000000",
                "component": "django"
              },
-             "duration": 1474875,
-             "start": 1692647408950323972
+             "duration": 1437000,
+             "start": 1771952002634970000
            },
               {
                 "name": "django.middleware",
@@ -146,15 +135,12 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
-                  "_dd.p.tid": "654a694400000000",
                   "component": "django"
                 },
-                "duration": 13125,
-                "start": 1692647408950340055
+                "duration": 24000,
+                "start": 1771952002635004000
               },
               {
                 "name": "django.middleware",
@@ -163,15 +149,12 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
-                  "_dd.p.tid": "654a694400000000",
                   "component": "django"
                 },
-                "duration": 1398792,
-                "start": 1692647408950373180
+                "duration": 1311000,
+                "start": 1771952002635052000
               },
                  {
                    "name": "django.middleware",
@@ -180,15 +163,12 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
-                     "_dd.p.tid": "654a694400000000",
                      "component": "django"
                    },
-                   "duration": 13125,
-                   "start": 1692647408950388180
+                   "duration": 53000,
+                   "start": 1771952002635082000
                  },
                  {
                    "name": "django.middleware",
@@ -197,15 +177,12 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
-                     "_dd.p.tid": "654a694400000000",
                      "component": "django"
                    },
-                   "duration": 1353125,
-                   "start": 1692647408950412430
+                   "duration": 1195000,
+                   "start": 1771952002635158000
                  },
                     {
                       "name": "django.middleware",
@@ -214,15 +191,12 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
-                        "_dd.p.tid": "654a694400000000",
                         "component": "django"
                       },
-                      "duration": 36334,
-                      "start": 1692647408950426805
+                      "duration": 35000,
+                      "start": 1771952002635187000
                     },
                     {
                       "name": "django.middleware",
@@ -231,15 +205,12 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
-                        "_dd.p.tid": "654a694400000000",
                         "component": "django"
                       },
-                      "duration": 1260125,
-                      "start": 1692647408950475847
+                      "duration": 1059000,
+                      "start": 1771952002635244000
                     },
                        {
                          "name": "django.middleware",
@@ -248,15 +219,12 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
-                           "_dd.p.tid": "654a694400000000",
                            "component": "django"
                          },
-                         "duration": 1204917,
-                         "start": 1692647408950492847
+                         "duration": 980000,
+                         "start": 1771952002635272000
                        },
                           {
                             "name": "django.middleware",
@@ -265,15 +233,12 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
-                              "_dd.p.tid": "654a694400000000",
                               "component": "django"
                             },
-                            "duration": 10541,
-                            "start": 1692647408950507389
+                            "duration": 15000,
+                            "start": 1771952002635300000
                           },
                           {
                             "name": "django.middleware",
@@ -282,15 +247,12 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
-                              "_dd.p.tid": "654a694400000000",
                               "component": "django"
                             },
-                            "duration": 1116875,
-                            "start": 1692647408950530764
+                            "duration": 856000,
+                            "start": 1771952002635336000
                           },
                              {
                                "name": "django.middleware",
@@ -299,15 +261,12 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
-                                 "_dd.p.tid": "654a694400000000",
                                  "component": "django"
                                },
-                               "duration": 1096458,
-                               "start": 1692647408950543597
+                               "duration": 821000,
+                               "start": 1771952002635359000
                              },
                                 {
                                   "name": "django.middleware",
@@ -316,15 +275,12 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
-                                    "_dd.p.tid": "654a694400000000",
                                     "component": "django"
                                   },
-                                  "duration": 1066208,
-                                  "start": 1692647408950558847
+                                  "duration": 778000,
+                                  "start": 1771952002635383000
                                 },
                                    {
                                      "name": "django.middleware",
@@ -333,15 +289,12 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
-                                       "_dd.p.tid": "654a694400000000",
                                        "component": "django"
                                      },
-                                     "duration": 59292,
-                                     "start": 1692647408950980305
+                                     "duration": 29000,
+                                     "start": 1771952002635615000
                                    },
                                    {
                                      "name": "django.middleware",
@@ -350,15 +303,12 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
-                                       "_dd.p.tid": "654a694400000000",
                                        "component": "django"
                                      },
-                                     "duration": 20250,
-                                     "start": 1692647408951188680
+                                     "duration": 22000,
+                                     "start": 1771952002635792000
                                    },
                                    {
                                      "name": "django.view",
@@ -367,15 +317,12 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
-                                       "_dd.p.tid": "654a694400000000",
                                        "component": "django"
                                      },
-                                     "duration": 42292,
-                                     "start": 1692647408951354680
+                                     "duration": 41000,
+                                     "start": 1771952002635983000
                                    },
                           {
                             "name": "django.middleware",
@@ -384,15 +331,12 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
-                              "_dd.p.tid": "654a694400000000",
                               "component": "django"
                             },
-                            "duration": 26708,
-                            "start": 1692647408951662889
+                            "duration": 27000,
+                            "start": 1771952002636214000
                           },
                        {
                          "name": "django.middleware",
@@ -401,15 +345,12 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
-                           "_dd.p.tid": "654a694400000000",
                            "component": "django"
                          },
-                         "duration": 16500,
-                         "start": 1692647408951712305
+                         "duration": 20000,
+                         "start": 1771952002636272000
                        },
                     {
                       "name": "django.middleware",
@@ -418,15 +359,12 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
-                        "_dd.p.tid": "654a694400000000",
                         "component": "django"
                       },
-                      "duration": 12125,
-                      "start": 1692647408951746472
+                      "duration": 18000,
+                      "start": 1771952002636324000
                     },
               {
                 "name": "django.middleware",
@@ -435,15 +373,12 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
-                  "_dd.p.tid": "654a694400000000",
                   "component": "django"
                 },
-                "duration": 10208,
-                "start": 1692647408951781847
+                "duration": 15000,
+                "start": 1771952002636382000
               },
            {
              "name": "django.middleware",
@@ -452,15 +387,12 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
-               "_dd.p.tid": "654a694400000000",
                "component": "django"
              },
-             "duration": 14167,
-             "start": 1692647408951808805
+             "duration": 18000,
+             "start": 1771952002636426000
            },
         {
           "name": "django.middleware",
@@ -469,13 +401,10 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
-            "_dd.p.tid": "654a694400000000",
             "component": "django"
           },
-          "duration": 14417,
-          "start": 1692647408951840180
+          "duration": 22000,
+          "start": 1771952002636473000
         }]]

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -8,7 +8,7 @@
     "parent_id": 0,
     "type": "web",
     "meta": {
-      "_dd.appsec.event_rules.version": "1.14.2",
+      "_dd.appsec.event_rules.version": "1.16.1",
       "_dd.appsec.fp.http.endpoint": "http-get-b8b6a5d3--",
       "_dd.appsec.fp.http.header": "hdr-0110000010-bcea973b-1-4740ae63",
       "_dd.appsec.fp.http.network": "net-0-0000000000",
@@ -18,7 +18,7 @@
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
-      "_dd.p.tid": "689a0aeb00000000",
+      "_dd.p.tid": "699dd78000000000",
       "_dd.p.ts": "02",
       "_dd.runtime_family": "python",
       "actor.ip": "127.0.0.1",
@@ -42,25 +42,25 @@
       "http.version": "1.1",
       "language": "python",
       "network.client.ip": "127.0.0.1",
-      "runtime-id": "1d43ccc33a8c4a7faa54516b35801d61",
+      "runtime-id": "7e4190511986495aa510dfd07af9e5eb",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,
-      "_dd.appsec.event_rules.error_count": 0,
-      "_dd.appsec.event_rules.loaded": 166,
-      "_dd.appsec.rasp.duration": 82.667,
-      "_dd.appsec.rasp.duration_ext": 168.750062584877,
+      "_dd.appsec.event_rules.error_count": 0.0,
+      "_dd.appsec.event_rules.loaded": 166.0,
+      "_dd.appsec.rasp.duration": 32.166,
+      "_dd.appsec.rasp.duration_ext": 103.75099736847915,
       "_dd.appsec.rasp.rule.eval": 3.0,
-      "_dd.appsec.waf.duration": 181.166,
-      "_dd.appsec.waf.duration_ext": 298.54197055101395,
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.appsec.waf.duration": 139.042,
+      "_dd.appsec.waf.duration_ext": 268.41600265470333,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 2,
-      "process_id": 14593
+      "_sampling_priority_v1": 2.0,
+      "process_id": 15113.0
     },
-    "duration": 13881625,
+    "duration": 9295000,
     "meta_struct": {
       "appsec": {
         "triggers": [
@@ -108,12 +108,12 @@
                 ]
               }
             ],
-            "span_id": 12543500013006596850
+            "span_id": 5559825017041716331
           }
         ]
       }
     },
-    "start": 1754925803971905344
+    "start": 1771952000583343000
   },
      {
        "name": "django.middleware",
@@ -126,8 +126,8 @@
          "_dd.base_service": "",
          "component": "django"
        },
-       "duration": 12236167,
-       "start": 1754925803972655052
+       "duration": 7559000,
+       "start": 1771952000584171000
      },
         {
           "name": "django.middleware",
@@ -140,8 +140,8 @@
             "_dd.base_service": "",
             "component": "django"
           },
-          "duration": 20417,
-          "start": 1754925803972689594
+          "duration": 29000,
+          "start": 1771952000584218000
         },
         {
           "name": "django.middleware",
@@ -154,8 +154,8 @@
             "_dd.base_service": "",
             "component": "django"
           },
-          "duration": 12118875,
-          "start": 1754925803972729886
+          "duration": 7395000,
+          "start": 1771952000584277000
         },
            {
              "name": "django.middleware",
@@ -168,8 +168,8 @@
                "_dd.base_service": "",
                "component": "django"
              },
-             "duration": 19792,
-             "start": 1754925803972748177
+             "duration": 30000,
+             "start": 1771952000584311000
            },
            {
              "name": "django.middleware",
@@ -182,8 +182,8 @@
                "_dd.base_service": "",
                "component": "django"
              },
-             "duration": 11954958,
-             "start": 1754925803972784094
+             "duration": 7193000,
+             "start": 1771952000584366000
            },
               {
                 "name": "django.middleware",
@@ -196,8 +196,8 @@
                   "_dd.base_service": "",
                   "component": "django"
                 },
-                "duration": 10250,
-                "start": 1754925803972801594
+                "duration": 19000,
+                "start": 1771952000584402000
               },
               {
                 "name": "django.middleware",
@@ -210,8 +210,8 @@
                   "_dd.base_service": "",
                   "component": "django"
                 },
-                "duration": 11868292,
-                "start": 1754925803972827094
+                "duration": 7064000,
+                "start": 1771952000584445000
               },
                  {
                    "name": "django.middleware",
@@ -224,8 +224,8 @@
                      "_dd.base_service": "",
                      "component": "django"
                    },
-                   "duration": 41208,
-                   "start": 1754925803972848594
+                   "duration": 55000,
+                   "start": 1771952000584477000
                  },
                  {
                    "name": "django.middleware",
@@ -238,8 +238,8 @@
                      "_dd.base_service": "",
                      "component": "django"
                    },
-                   "duration": 11781583,
-                   "start": 1754925803972906594
+                   "duration": 6942000,
+                   "start": 1771952000584556000
                  },
                     {
                       "name": "django.middleware",
@@ -252,8 +252,8 @@
                         "_dd.base_service": "",
                         "component": "django"
                       },
-                      "duration": 25834,
-                      "start": 1754925803972924427
+                      "duration": 35000,
+                      "start": 1771952000584587000
                     },
                     {
                       "name": "django.middleware",
@@ -266,8 +266,8 @@
                         "_dd.base_service": "",
                         "component": "django"
                       },
-                      "duration": 11681500,
-                      "start": 1754925803972968261
+                      "duration": 6800000,
+                      "start": 1771952000584647000
                     },
                        {
                          "name": "django.middleware",
@@ -280,8 +280,8 @@
                            "_dd.base_service": "",
                            "component": "django"
                          },
-                         "duration": 11622875,
-                         "start": 1754925803972988844
+                         "duration": 6710000,
+                         "start": 1771952000584678000
                        },
                           {
                             "name": "django.middleware",
@@ -294,8 +294,8 @@
                               "_dd.base_service": "",
                               "component": "django"
                             },
-                            "duration": 15125,
-                            "start": 1754925803973050386
+                            "duration": 19000,
+                            "start": 1771952000584707000
                           },
                           {
                             "name": "django.middleware",
@@ -308,8 +308,8 @@
                               "_dd.base_service": "",
                               "component": "django"
                             },
-                            "duration": 11472333,
-                            "start": 1754925803973086636
+                            "duration": 6573000,
+                            "start": 1771952000584749000
                           },
                              {
                                "name": "django.middleware",
@@ -322,8 +322,8 @@
                                  "_dd.base_service": "",
                                  "component": "django"
                                },
-                               "duration": 11447084,
-                               "start": 1754925803973103052
+                               "duration": 6534000,
+                               "start": 1771952000584776000
                              },
                                 {
                                   "name": "django.middleware",
@@ -336,8 +336,8 @@
                                     "_dd.base_service": "",
                                     "component": "django"
                                   },
-                                  "duration": 11410500,
-                                  "start": 1754925803973121719
+                                  "duration": 6493000,
+                                  "start": 1771952000584803000
                                 },
                                    {
                                      "name": "django.middleware",
@@ -350,8 +350,8 @@
                                        "_dd.base_service": "",
                                        "component": "django"
                                      },
-                                     "duration": 38666,
-                                     "start": 1754925803975188011
+                                     "duration": 26000,
+                                     "start": 1771952000586368000
                                    },
                                    {
                                      "name": "django.middleware",
@@ -364,8 +364,8 @@
                                        "_dd.base_service": "",
                                        "component": "django"
                                      },
-                                     "duration": 13208,
-                                     "start": 1754925803975252719
+                                     "duration": 19000,
+                                     "start": 1771952000586419000
                                    },
                                    {
                                      "name": "django.middleware",
@@ -378,8 +378,8 @@
                                        "_dd.base_service": "",
                                        "component": "django"
                                      },
-                                     "duration": 14167,
-                                     "start": 1754925803984377052
+                                     "duration": 24000,
+                                     "start": 1771952000591151000
                                    },
                           {
                             "name": "django.middleware",
@@ -392,8 +392,8 @@
                               "_dd.base_service": "",
                               "component": "django"
                             },
-                            "duration": 22875,
-                            "start": 1754925803984581677
+                            "duration": 30000,
+                            "start": 1771952000591346000
                           },
                        {
                          "name": "django.middleware",
@@ -406,8 +406,8 @@
                            "_dd.base_service": "",
                            "component": "django"
                          },
-                         "duration": 14708,
-                         "start": 1754925803984628636
+                         "duration": 24000,
+                         "start": 1771952000591410000
                        },
                     {
                       "name": "django.middleware",
@@ -420,8 +420,8 @@
                         "_dd.base_service": "",
                         "component": "django"
                       },
-                      "duration": 13833,
-                      "start": 1754925803984666761
+                      "duration": 18000,
+                      "start": 1771952000591468000
                     },
               {
                 "name": "django.middleware",
@@ -434,8 +434,8 @@
                   "_dd.base_service": "",
                   "component": "django"
                 },
-                "duration": 11833,
-                "start": 1754925803984719511
+                "duration": 17000,
+                "start": 1771952000591530000
               },
            {
              "name": "django.middleware",
@@ -448,8 +448,8 @@
                "_dd.base_service": "",
                "component": "django"
              },
-             "duration": 82792,
-             "start": 1754925803984756219
+             "duration": 80000,
+             "start": 1771952000591579000
            },
         {
           "name": "django.middleware",
@@ -462,6 +462,6 @@
             "_dd.base_service": "",
             "component": "django"
           },
-          "duration": 17667,
-          "start": 1754925803984867344
+          "duration": 25000,
+          "start": 1771952000591693000
         }]]


### PR DESCRIPTION
## Description

Update default WAF rules from v1.14.2 to v1.16.1

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Had to update the ddapm-trace-agent to the version used in `docker-compose.yml` in `hatch.toml` to avoid a formatting mismatch.
