### PR TITLE
fix(profiling): correctly enable with injection

### DIFF
--- a/releasenotes/notes/profiling-fix-lib-injection-d75227d656d74e48.yaml
+++ b/releasenotes/notes/profiling-fix-lib-injection-d75227d656d74e48.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    A bug which could prevent Profiling from being enabled when the library is installed through
+    Single Step Instrumentation was fixed.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13821

This PR fixes an edge case where Profiling could fail to be enabled with lib injection if the `DD_PROFILING_ENABLED` environment variable was not present. The problem came from the fact `envier` does not parse a configuration item if its associated variable is not in the environment. In our case, this meant that we would not run the "injection-based enablement" logic if the `DD_PROFILING_ENABLED` variable wasn't there.   

To fix this, I moved the injection-based configuration parsing to the `__init__` method of the Profiling configuration class. 