### PR TITLE
ci(mcp): use 5 venvs per gitlab job

### DIFF
--- a/tests/llmobs/suitespec.yml
+++ b/tests/llmobs/suitespec.yml
@@ -134,7 +134,6 @@ suites:
     snapshot: true
     venvs_per_job: 1
   mcp:
-    parallelism: 1
     paths:
       - '@bootstrap'
       - '@core'
@@ -146,6 +145,7 @@ suites:
       - tests/snapshots/tests.contrib.mcp.*
     runner: riot
     snapshot: true
+    venvs_per_job: 5
   openai:
     venvs_per_job: 1
     paths:


### PR DESCRIPTION
## Description

Right now median duration is about 10m and p95 is 16m.

There are 10 venvs for the mcp suite, so this will move from 1 GitLab job to 2, and should drop the runtime in about half.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
