### PR TITLE
ci(langgraph): set venvs per job to 4

### DIFF
--- a/tests/llmobs/suitespec.yml
+++ b/tests/llmobs/suitespec.yml
@@ -162,7 +162,6 @@ suites:
     runner: riot
     snapshot: true
   langgraph:
-    parallelism: 2
     paths:
       - '@bootstrap'
       - '@core'
@@ -174,6 +173,7 @@ suites:
       - tests/contrib/langgraph/*
     runner: riot
     snapshot: true
+    venvs_per_job: 4
   crewai:
     parallelism: 3
     paths:


### PR DESCRIPTION
## Description

Current median duration of langgraph is 14m with p95 of 20m.

There are 24 venvs, so this change will result in us going from 2 jobs to 6, which should help reduce total duration a bit.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
