### PR TITLE
ci(pytest): break up pytest test suite CI jobs

### DIFF
--- a/tests/ci_visibility/suitespec.yml
+++ b/tests/ci_visibility/suitespec.yml
@@ -46,7 +46,26 @@ suites:
     runner: riot
     snapshot: true
   pytest:
-    venvs_per_job: 1
+    venvs_per_job: 2
+    paths:
+      - '@bootstrap'
+      - '@core'
+      - '@contrib'
+      - '@tracing'
+      - '@pytest'
+      - '@ci_visibility'
+      - '@coverage'
+      - '@coverage_utils'
+      - '@codeowners'
+      - '@testing'
+      - tests/contrib/pytest/*
+      - tests/contrib/internal/coverage/*
+      - tests/snapshots/tests.contrib.pytest.*
+    runner: riot
+    snapshot: true
+    pattern: 'pytest$'
+  pytest_benchmark:
+    venvs_per_job: 3
     paths:
       - '@bootstrap'
       - '@core'
@@ -60,12 +79,49 @@ suites:
       - '@testing'
       - tests/contrib/pytest/*
       - tests/contrib/pytest_benchmark/*
+      - tests/contrib/internal/coverage/*
+      - tests/snapshots/tests.contrib.pytest.*
+    runner: riot
+    snapshot: true
+  pytest_bdd:
+    venvs_per_job: 3
+    paths:
+      - '@bootstrap'
+      - '@core'
+      - '@contrib'
+      - '@tracing'
+      - '@pytest'
+      - '@ci_visibility'
+      - '@coverage'
+      - '@coverage_utils'
+      - '@codeowners'
+      - '@testing'
+      - tests/contrib/pytest/*
       - tests/contrib/pytest_bdd/*
+      - tests/contrib/internal/coverage/*
+      - tests/snapshots/tests.contrib.pytest.*
+    runner: riot
+    snapshot: true
+  pytest_flaky:
+    venvs_per_job: 3
+    paths:
+      - '@bootstrap'
+      - '@core'
+      - '@contrib'
+      - '@tracing'
+      - '@pytest'
+      - '@ci_visibility'
+      - '@coverage'
+      - '@coverage_utils'
+      - '@codeowners'
+      - '@testing'
+      - tests/contrib/pytest/*
       - tests/contrib/pytest_flaky/*
       - tests/contrib/internal/coverage/*
       - tests/snapshots/tests.contrib.pytest.*
     runner: riot
     snapshot: true
+    pattern: 'pytest:flaky'
   testing:
     venvs_per_job: 1
     paths:


### PR DESCRIPTION
## Description

Right now we run all `pytest*` test suites in the same set of CI jobs.

This PR breaks up the `pytest$`, `pytest_benchmark`, `pytest_bdd`, `pytest:flaky` riot test suites into different GitLab test suites.

This will allow us to have better control over job level parallelism for the individual test suites.

`riot list --hash-only pytest | wc -l` is 34 venvs, this is a lot, but if we break up by actual test test suites we get:

- pytest: 15
- pytest_benchmark: 6
- pytest_bdd: 7
- pytest:flaky: 6


<img width="321" height="173" alt="image" src="https://github.com/user-attachments/assets/1d0a6259-3ffe-4c85-ab29-c82686d34c94" />


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
