### PR TITLE
chore: remove multiple_os_tests hatch venv

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -168,37 +168,6 @@ test = [
 [[envs.profiling_pytorch.matrix]]
 python = ["3.12"]
 
-## Multiple OS tests
-
-[envs.multiple_os_tests]
-dependencies = [
-    "pytest",
-    "pytest-cov",
-    "requests",
-    "hypothesis",
-    "flask",
-    "asgiref",
-    "botocore",
-    "dnspython",
-]
-
-[envs.multiple_os_tests.env-vars]
-DD_IAST_ENABLED = "false"
-DD_REMOTE_CONFIGURATION_ENABLED = "false"
-CMAKE_BUILD_PARALLEL_LEVEL="6"
-CARGO_BUILD_JOBS = "6"
-
-[envs.multiple_os_tests.scripts]
-test = [
-    "uname -a",
-    "pip freeze",
-    "python -m pytest tests/internal/service_name/test_extra_services_names.py -v -s",
-    "python -m pytest tests/appsec/architectures/test_appsec_loading_modules.py -v -s",
-]
-
-[[envs.multiple_os_tests.matrix]]
-python = ["3.14", "3.12", "3.10"]
-
 [envs.snapshot_viewer]
 dev-mode = false
 detached = true


### PR DESCRIPTION
## Description

No longer used after we migrated it to run in GitLab #15608. It uses uv instead.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
