### PR TITLE
chore: set version to 4.6.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.5.0rc4"
+version = "4.6.0rc1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
4.5.0 has been released, so the version on main is set to the upcoming candidate version.