### PR TITLE
fix(litellm): resolve model_provider for Router spans with aliased model names

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -119,6 +119,8 @@ DISPATCH_ON_OPENAI_AGENT_SPAN_FINISH = "on_openai_agent_span_finish"
 OAI_HANDOFF_TOOL_ARG = "{}"
 
 LITELLM_ROUTER_INSTANCE_KEY = "_dd.router_instance"
+LITELLM_STREAM_MODEL_KEY = "_dd.litellm_model"
+LITELLM_STREAM_PROVIDER_KEY = "_dd.litellm_provider"
 
 PROXY_REQUEST = "llmobs.proxy_request"
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -414,6 +414,10 @@ class LLMObs(Service):
         if span_kind in ("llm", "embedding") and span._get_ctx_item(MODEL_NAME) is not None:
             meta["model_name"] = span._get_ctx_item(MODEL_NAME) or ""
             meta["model_provider"] = (span._get_ctx_item(MODEL_PROVIDER) or "custom").lower()
+        elif span_kind == "workflow" and span._get_ctx_item(MODEL_PROVIDER):
+            # emit model info on router/proxy workflow spans when available
+            meta["model_name"] = span._get_ctx_item(MODEL_NAME) or ""
+            meta["model_provider"] = span._get_ctx_item(MODEL_PROVIDER).lower()
         metadata = span._get_ctx_item(METADATA) or {}
         if span_kind == "agent" and span._get_ctx_item(AGENT_MANIFEST) is not None:
             metadata["agent_manifest"] = span._get_ctx_item(AGENT_MANIFEST)

--- a/tests/contrib/litellm/conftest.py
+++ b/tests/contrib/litellm/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from ddtrace.contrib.internal.litellm.patch import patch
 from ddtrace.contrib.internal.litellm.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
+from tests.contrib.litellm.utils import aliased_model_list
 from tests.contrib.litellm.utils import get_request_vcr
 from tests.contrib.litellm.utils import model_list
 from tests.llmobs._utils import TestLLMObsSpanWriter
@@ -73,3 +74,10 @@ def router():
     from litellm import Router
 
     yield Router(model_list=model_list)
+
+
+@pytest.fixture
+def aliased_router():
+    from litellm import Router
+
+    yield Router(model_list=aliased_model_list)

--- a/tests/contrib/litellm/utils.py
+++ b/tests/contrib/litellm/utils.py
@@ -209,6 +209,35 @@ tools = [
     }
 ]
 
+# model_list with aliases that differ from the underlying litellm model.
+# Reproduces the bug where Router aliases cause _model_map lookup misses.
+aliased_model_list = [
+    {
+        "model_name": "my-gpt",
+        "litellm_params": {
+            "model": "gpt-3.5-turbo",
+            "api_key": "<not-a-real-key>",
+        },
+    },
+]
+
+expected_aliased_router_settings = {
+    "router_general_settings": RouterGeneralSettings(async_only_mode=False, pass_through_all_models=False),
+    "routing_strategy": "simple-shuffle",
+    "routing_strategy_args": {},
+    "provider_budget_config": None,
+    "retry_policy": None,
+    "enable_tag_filtering": False,
+    "model_list": [
+        {
+            "model_name": "my-gpt",
+            "litellm_params": {
+                "model": "gpt-3.5-turbo",
+            },
+        },
+    ],
+}
+
 expected_router_settings = {
     "router_general_settings": RouterGeneralSettings(async_only_mode=False, pass_through_all_models=False),
     "routing_strategy": "simple-shuffle",


### PR DESCRIPTION
## Summary

Resolves #16647.

When using LiteLLM's `Router` with aliased model names (where `model_name` differs from `litellm_params.model`), `model_provider` and `model_name` are missing from LLM Observability span events. This is because `_model_map` is keyed by the resolved model name (e.g., `vertex_ai/gemini-3-flash-preview`) while the Router span passes the alias (e.g., `gemini`), causing a lookup miss.

**Changes:**
- **`ddtrace/llmobs/_integrations/litellm.py`**: When `_model_map` lookup misses, fall back to `response._hidden_params["custom_llm_provider"]` for `model_provider` and `response.model` for `model_name` (non-streamed). For streamed responses, fall back to model info stashed in `kwargs` during stream setup.
- **`ddtrace/contrib/internal/litellm/patch.py`**: Extract `custom_llm_provider` and `model` from the raw stream object in `_handle_router_stream_response` before wrapping, and stash in `kwargs` for later use by `_llmobs_set_tags`.
- **`ddtrace/llmobs/_constants.py`**: Add `LITELLM_STREAM_MODEL_KEY` and `LITELLM_STREAM_PROVIDER_KEY` constants for the stashed kwargs keys.
- **`ddtrace/llmobs/_llmobs.py`**: Emit `model_name` and `model_provider` on `workflow` spans when available, since Router operations produce workflow spans rather than LLM spans.

## Testing

- Added `test_router_completion_aliased_model` and `test_router_acompletion_aliased_model` using a Router configured with aliased model names (`model_name: "my-gpt"` → `litellm_params.model: "gpt-3.5-turbo"`).
- Tests are parametrized over `stream` (True/False), covering both the response-attribute fallback and the kwargs fallback paths.
- Tests verify both the inner LLM span and the outer Router workflow span contain the correct `model_provider` and `model_name`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

🤖 Generated with [Claude Code](https://claude.com/claude-code)