### PR TITLE
chore(llmobs): migrate integrations to use meta_struct

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -1,30 +1,7 @@
-SPAN_KIND = "_ml_obs.meta.span.kind"
-SESSION_ID = "_ml_obs.session_id"
-METADATA = "_ml_obs.meta.metadata"
-METRICS = "_ml_obs.metrics"
-ML_APP = "_ml_obs.meta.ml_app"
+# Propagation keys stored on Context for distributed requests
 PROPAGATED_PARENT_ID_KEY = "_dd.p.llmobs_parent_id"
 PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
-PARENT_ID_KEY = "_ml_obs.llmobs_parent_id"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
-LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"
-TAGS = "_ml_obs.tags"
-AGENT_MANIFEST = "_ml_obs.meta.agent_manifest"
-
-MODEL_NAME = "_ml_obs.meta.model_name"
-MODEL_PROVIDER = "_ml_obs.meta.model_provider"
-
-INPUT_DOCUMENTS = "_ml_obs.meta.input.documents"
-INPUT_MESSAGES = "_ml_obs.meta.input.messages"
-INPUT_VALUE = "_ml_obs.meta.input.value"
-INPUT_PROMPT = "_ml_obs.meta.input.prompt"
-TOOL_DEFINITIONS = "_ml_obs.meta.tool_definitions"
-
-OUTPUT_DOCUMENTS = "_ml_obs.meta.output.documents"
-OUTPUT_MESSAGES = "_ml_obs.meta.output.messages"
-OUTPUT_VALUE = "_ml_obs.meta.output.value"
-
-MCP_TOOL_CALL_INTENT = "_ml_obs.meta.intent"
 
 SPAN_START_WHILE_DISABLED_WARNING = (
     "Span started with LLMObs disabled."
@@ -79,10 +56,6 @@ ROOT_PARENT_ID = "undefined"
 # Used to differentiate traces of Datadog-run operations vs user-application operations.
 RUNNER_IS_INTEGRATION_SPAN_TAG = "runner.integration"
 
-# All ragas traces have this context item set so we can differentiate
-# spans generated from the ragas integration vs user application spans.
-IS_EVALUATION_SPAN = "_ml_obs.evaluation_span"
-
 ANNOTATIONS_CONTEXT_ID = "annotations_context_id"
 INTERNAL_CONTEXT_VARIABLE_KEYS = "_dd_context_variable_keys"
 INTERNAL_QUERY_VARIABLE_KEYS = "_dd_query_variable_keys"
@@ -90,9 +63,6 @@ INTERNAL_QUERY_VARIABLE_KEYS = "_dd_query_variable_keys"
 FAITHFULNESS_DISAGREEMENTS_METADATA = "_dd.faithfulness_disagreements"
 EVALUATION_KIND_METADATA = "_dd.evaluation_kind"
 EVALUATION_SPAN_METADATA = "_dd.evaluation_span"
-
-SPAN_LINKS = "_ml_obs.span_links"
-NAME = "_ml_obs.name"
 
 # Prompt constants
 DEFAULT_PROMPT_NAME = "unnamed-prompt"
@@ -102,9 +72,6 @@ PROMPT_TRACKING_INSTRUMENTATION_METHOD = "prompt_tracking_instrumentation_method
 PROMPT_MULTIMODAL = "prompt_multimodal"
 INSTRUMENTATION_METHOD_AUTO = "auto"
 INSTRUMENTATION_METHOD_ANNOTATED = "annotated"
-
-DECORATOR = "_ml_obs.decorator"
-INTEGRATION = "_ml_obs.integration"
 
 DISPATCH_ON_TOOL_CALL_OUTPUT_USED = "on_tool_call_output_used"
 DISPATCH_ON_LLM_TOOL_CHOICE = "on_llm_tool_choice"
@@ -131,12 +98,6 @@ EXPERIMENT_PROJECT_ID_KEY = "_ml_obs.experiment_project_id"
 EXPERIMENT_DATASET_NAME_KEY = "_ml_obs.experiment_dataset_name"
 EXPERIMENT_NAME_KEY = "_ml_obs.experiment_name"
 
-# experiment context keys
-EXPERIMENT_CONFIG = "_ml_obs.config"
-EXPERIMENT_RECORD_METADATA = "_ml_obs.meta.metadata"
-EXPERIMENT_EXPECTED_OUTPUT = "_ml_obs.meta.input.expected_output"
-EXPERIMENTS_INPUT = "_ml_obs.meta.input"
-EXPERIMENTS_OUTPUT = "_ml_obs.meta.output"
 DEFAULT_PROJECT_NAME = "default-project"
 
 # Fallback markers for prompt tracking when OpenAI strips values
@@ -147,13 +108,6 @@ FILE_FALLBACK_MARKER = "[file]"
 INPUT_TYPE_IMAGE = "input_image"
 INPUT_TYPE_FILE = "input_file"
 INPUT_TYPE_TEXT = "input_text"
-
-# Managed Prompts Cache and Timeout defaults
-DEFAULT_PROMPTS_CACHE_TTL = 60  # seconds before stale
-DEFAULT_PROMPTS_TIMEOUT = 5.0  # seconds for all prompt fetch operations
-
-# Managed Prompts API
-PROMPTS_ENDPOINT = "/api/unstable/llm-obs/v1/prompts"
 
 
 class LLMOBS_STRUCT:
@@ -188,3 +142,11 @@ class LLMOBS_STRUCT:
     MODEL_PROVIDER = "model_provider"
     INTENT = "intent"
     CONFIG = "config"
+
+
+# Managed Prompts Cache and Timeout defaults
+DEFAULT_PROMPTS_CACHE_TTL = 60  # seconds before stale
+DEFAULT_PROMPTS_TIMEOUT = 5.0  # seconds for all prompt fetch operations
+
+# Managed Prompts API
+PROMPTS_ENDPOINT = "/api/unstable/llm-obs/v1/prompts"

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -9,9 +9,9 @@ from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.integration import IntegrationConfig
-from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import PROXY_REQUEST
 from ddtrace.llmobs._llmobs import LLMObs
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.trace import Span
 from ddtrace.trace import tracer
 
@@ -71,7 +71,7 @@ class BaseLLMIntegration:
         span.set_metric(_SPAN_MEASURED_KEY, 1)
         self._set_base_span_tags(span, **kwargs)
         if self.llmobs_enabled:
-            span._set_ctx_item(INTEGRATION, self._integration_name)
+            _annotate_llmobs_span_data(span, tags={"integration": self._integration_name})
         return span
 
     def llmobs_set_tags(

--- a/ddtrace/llmobs/_integrations/bedrock_agents.py
+++ b/ddtrace/llmobs/_integrations/bedrock_agents.py
@@ -9,8 +9,8 @@ from ddtrace._trace.span import Span
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import generate_128bit_trace_id
 from ddtrace.internal.utils.formats import format_trace_id
-from ddtrace.llmobs._constants import LLMOBS_TRACE_ID
 from ddtrace.llmobs._integrations.bedrock_utils import parse_model_id
+from ddtrace.llmobs._utils import _get_llmobs_trace_id
 from ddtrace.llmobs._utils import _get_ml_app
 from ddtrace.llmobs._utils import _get_session_id
 from ddtrace.llmobs._utils import safe_json
@@ -58,9 +58,8 @@ def _build_span_event(
     if span_id is None:
         span_id = generate_128bit_trace_id()
     apm_trace_id = format_trace_id(root_span.trace_id)
-    llmobs_trace_id = root_span._get_ctx_item(LLMOBS_TRACE_ID)
-    if llmobs_trace_id is None:
-        llmobs_trace_id = root_span.trace_id
+    llmobs_trace_id_str = _get_llmobs_trace_id(root_span)
+    llmobs_trace_id = int(llmobs_trace_id_str) if llmobs_trace_id_str else root_span.trace_id
     session_id = _get_session_id(root_span)
     ml_app = _get_ml_app(root_span)
     tags = [f"ml_app:{ml_app}", f"session_id:{session_id}", "integration:bedrock_agents"]

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -3,19 +3,13 @@ from typing import Optional
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.llmobs._constants import AGENT_MANIFEST
 from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import METADATA
-from ddtrace.llmobs._constants import METRICS
-from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import OUTPUT_VALUE
-from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import Message
@@ -50,13 +44,12 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
         tool_output = kwargs.get("tool_output", "")
         tool_id = kwargs.get("tool_id", "")
 
-        span._set_ctx_items(
-            {
-                SPAN_KIND: "tool",
-                INPUT_VALUE: tool_input,
-                OUTPUT_VALUE: tool_output,
-                METADATA: {"tool_id": tool_id},
-            }
+        _annotate_llmobs_span_data(
+            span,
+            kind="tool",
+            input_value=tool_input,
+            output_value=tool_output,
+            metadata={"tool_id": tool_id},
         )
 
     def _llmobs_set_agent_tags(
@@ -81,16 +74,15 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
 
         agent_manifest = self._build_agent_manifest(model, metadata, init_system_message)
 
-        span._set_ctx_items(
-            {
-                SPAN_KIND: "agent",
-                MODEL_NAME: model or "",
-                INPUT_VALUE: input_messages,
-                METADATA: metadata,
-                OUTPUT_VALUE: output_messages,
-                METRICS: metrics,
-                AGENT_MANIFEST: agent_manifest,
-            }
+        _annotate_llmobs_span_data(
+            span,
+            kind="agent",
+            model_name=model or "",
+            input_value=input_messages,
+            output_value=output_messages,
+            metadata=metadata,
+            metrics=metrics,
+            agent_manifest=agent_manifest,
         )
 
     def _build_agent_manifest(

--- a/ddtrace/llmobs/_integrations/crewai.py
+++ b/ddtrace/llmobs/_integrations/crewai.py
@@ -8,17 +8,13 @@ from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import format_trace_id
-from ddtrace.llmobs._constants import AGENT_MANIFEST
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
-from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import METADATA
-from ddtrace.llmobs._constants import NAME
-from ddtrace.llmobs._constants import OUTPUT_VALUE
-from ddtrace.llmobs._constants import PARENT_ID_KEY
+from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
-from ddtrace.llmobs._constants import SPAN_KIND
-from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import _SpanLink
@@ -99,7 +95,7 @@ class CrewAIIntegration(BaseLLMIntegration):
         response: Optional[Any] = None,
         operation: str = "",
     ) -> None:
-        span._set_ctx_item(SPAN_KIND, OP_NAMES_TO_SPAN_KIND.get(operation, "task"))
+        _annotate_llmobs_span_data(span, kind=OP_NAMES_TO_SPAN_KIND.get(operation, "task"))
         if operation == "crew":
             crew_id = _get_crew_id(span, "crew")
             self._llmobs_set_tags_crew(span, args, kwargs, response)
@@ -122,6 +118,8 @@ class CrewAIIntegration(BaseLLMIntegration):
         crew_instance = kwargs.pop("_dd.instance", None)
         crew_id = _get_crew_id(span, "crew")
         task_span_ids = self._crews_to_task_span_ids.get(crew_id, [])
+        llmobs_data = _get_llmobs_data_metastruct(span)
+        curr_span_links = llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
         if task_span_ids:
             last_task_span_id = task_span_ids[-1]
             span_link = _SpanLink(
@@ -129,8 +127,8 @@ class CrewAIIntegration(BaseLLMIntegration):
                 trace_id=format_trace_id(span.trace_id),
                 attributes={"from": "output", "to": "output"},
             )
-            curr_span_links = span._get_ctx_item(SPAN_LINKS) or []
-            span._set_ctx_item(SPAN_LINKS, curr_span_links + [span_link])
+            llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = curr_span_links + [span_link]
+            span._set_struct_tag(LLMOBS_STRUCT.KEY, llmobs_data)
         metadata = {
             "process": getattr(crew_instance, "process", ""),
             "planning": getattr(crew_instance, "planning", ""),
@@ -139,10 +137,10 @@ class CrewAIIntegration(BaseLLMIntegration):
             "memory": getattr(crew_instance, "memory", ""),
         }
         inputs = get_argument_value(args, kwargs, 0, "inputs", optional=True) or ""
-        span._set_ctx_items({INPUT_VALUE: inputs, NAME: "CrewAI Crew", METADATA: metadata})
+        _annotate_llmobs_span_data(span, input_value=inputs, name="CrewAI Crew", metadata=metadata)
         if span.error:
             return
-        span._set_ctx_item(OUTPUT_VALUE, getattr(response, "raw", ""))
+        _annotate_llmobs_span_data(span, output_value=getattr(response, "raw", ""))
 
     def _llmobs_set_tags_task(self, span, args, kwargs, response):
         crew_id = _get_crew_id(span, "task")
@@ -167,14 +165,19 @@ class CrewAIIntegration(BaseLLMIntegration):
                     attributes={"from": "input", "to": "input"},
                 )
                 span_links.append(span_link)
-            curr_span_links = span._get_ctx_item(SPAN_LINKS) or []
-            span._set_ctx_item(SPAN_LINKS, curr_span_links + span_links)
-        span._set_ctx_items(
-            {NAME: task_name if task_name else "CrewAI Task", METADATA: metadata, INPUT_VALUE: task_description}
+            llmobs_data = _get_llmobs_data_metastruct(span)
+            curr_span_links = llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
+            llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = curr_span_links + span_links
+            span._set_struct_tag(LLMOBS_STRUCT.KEY, llmobs_data)
+        _annotate_llmobs_span_data(
+            span,
+            name=task_name if task_name else "CrewAI Task",
+            metadata=metadata,
+            input_value=task_description,
         )
         if span.error:
             return
-        span._set_ctx_item(OUTPUT_VALUE, getattr(response, "raw", ""))
+        _annotate_llmobs_span_data(span, output_value=getattr(response, "raw", ""))
 
     def _llmobs_set_tags_agent(self, span, args, kwargs, response):
         """Set span links and metadata for agent spans.
@@ -192,40 +195,44 @@ class CrewAIIntegration(BaseLLMIntegration):
             trace_id=format_trace_id(span.trace_id),
             attributes={"from": "output", "to": "output"},
         )
-        curr_span_links = parent_span._get_ctx_item(SPAN_LINKS) or []
-        parent_span._set_ctx_item(SPAN_LINKS, curr_span_links + [parent_span_link])
+        parent_llmobs_data = _get_llmobs_data_metastruct(parent_span)
+        parent_curr_span_links = parent_llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
+        parent_llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = parent_curr_span_links + [parent_span_link]
+        parent_span._set_struct_tag(LLMOBS_STRUCT.KEY, parent_llmobs_data)
+
         span_link = _SpanLink(
             span_id=str(parent_span.span_id),
             trace_id=format_trace_id(span.trace_id),
             attributes={"from": "input", "to": "input"},
         )
-        curr_span_links = span._get_ctx_item(SPAN_LINKS) or []
-        span._set_ctx_items(
-            {
-                NAME: agent_role if agent_role else "CrewAI Agent",
-                INPUT_VALUE: {"context": context, "input": task_description},
-                SPAN_LINKS: curr_span_links + [span_link],
-            }
+        llmobs_data = _get_llmobs_data_metastruct(span)
+        curr_span_links = llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
+        llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = curr_span_links + [span_link]
+        span._set_struct_tag(LLMOBS_STRUCT.KEY, llmobs_data)
+
+        _annotate_llmobs_span_data(
+            span,
+            name=agent_role if agent_role else "CrewAI Agent",
+            input_value={"context": context, "input": task_description},
         )
         if span.error:
             return
-        span._set_ctx_item(OUTPUT_VALUE, response)
+        _annotate_llmobs_span_data(span, output_value=response)
 
     def _llmobs_set_tags_tool(self, span, args, kwargs, response):
         tool_instance = kwargs.pop("_dd.instance", None)
         tool_name = getattr(tool_instance, "name", "")
         description = _extract_tool_description_field(getattr(tool_instance, "description", ""))
         tool_input = kwargs.get("input", "")
-        span._set_ctx_items(
-            {
-                NAME: tool_name if tool_name else "CrewAI Tool",
-                METADATA: {"description": description},
-                INPUT_VALUE: tool_input,
-            }
+        _annotate_llmobs_span_data(
+            span,
+            name=tool_name if tool_name else "CrewAI Tool",
+            metadata={"description": description},
+            input_value=tool_input,
         )
         if span.error:
             return
-        span._set_ctx_item(OUTPUT_VALUE, response)
+        _annotate_llmobs_span_data(span, output_value=response)
 
         try:
             if isinstance(tool_input, str):
@@ -274,7 +281,7 @@ class CrewAIIntegration(BaseLLMIntegration):
         if hasattr(agent, "tools"):
             manifest["tools"] = self._get_agent_tools(agent.tools)
 
-        span._set_ctx_item(AGENT_MANIFEST, manifest)
+        _annotate_llmobs_span_data(span, agent_manifest=manifest)
 
     def _get_agent_tools(self, tools):
         if not tools or not isinstance(tools, list):
@@ -291,7 +298,12 @@ class CrewAIIntegration(BaseLLMIntegration):
 
     def _llmobs_set_tags_flow(self, span, args, kwargs, response):
         inputs = get_argument_value(args, kwargs, 0, "inputs", optional=True) or {}
-        span._set_ctx_items({NAME: span.name or "CrewAI Flow", INPUT_VALUE: inputs, OUTPUT_VALUE: str(response)})
+        _annotate_llmobs_span_data(
+            span,
+            name=span.name or "CrewAI Flow",
+            input_value=inputs,
+            output_value=str(response),
+        )
         return
 
     def _llmobs_set_tags_flow_method(self, span, args, kwargs, response):
@@ -320,13 +332,15 @@ class CrewAIIntegration(BaseLLMIntegration):
             span_dict = self._flow_span_to_method_to_span_dict.get(span._parent, {}).setdefault(str(response), {})
             span_dict.update({"span_id": str(span.span_id), "trace_id": format_trace_id(span.trace_id)})
 
-        span._set_ctx_items(
-            {
-                NAME: span.name or "Flow Method",
-                INPUT_VALUE: input_dict,
-                OUTPUT_VALUE: str(response),
-                SPAN_LINKS: span_links,
-            }
+        llmobs_data = _get_llmobs_data_metastruct(span)
+        llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = span_links
+        span._set_struct_tag(LLMOBS_STRUCT.KEY, llmobs_data)
+
+        _annotate_llmobs_span_data(
+            span,
+            name=span.name or "Flow Method",
+            input_value=input_dict,
+            output_value=str(response),
         )
         return
 
@@ -391,15 +405,18 @@ class CrewAIIntegration(BaseLLMIntegration):
                         attributes={"from": "output", "to": "input"},
                     )
                 )
-                flow_span_span_links = flow_span._get_ctx_item(SPAN_LINKS) or []
+                flow_llmobs_data = _get_llmobs_data_metastruct(flow_span)
+                flow_span_span_links = flow_llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
                 # Remove temporary output->output link since the AND has been triggered
                 span_links_minus_tmp_output_links = [
                     link for link in flow_span_span_links if link["span_id"] != str(method_span_dict["span_id"])
                 ]
-                flow_span._set_ctx_item(SPAN_LINKS, span_links_minus_tmp_output_links)
+                flow_llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = span_links_minus_tmp_output_links
+                flow_span._set_struct_tag(LLMOBS_STRUCT.KEY, flow_llmobs_data)
 
         if triggered is False:
-            flow_span_span_links = flow_span._get_ctx_item(SPAN_LINKS) or []
+            flow_llmobs_data = _get_llmobs_data_metastruct(flow_span)
+            flow_span_span_links = flow_llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
             flow_span_span_links.append(
                 _SpanLink(
                     span_id=str(trigger_span_dict["span_id"]),
@@ -407,7 +424,8 @@ class CrewAIIntegration(BaseLLMIntegration):
                     attributes={"from": "output", "to": "output"},
                 )
             )
-            flow_span._set_ctx_item(SPAN_LINKS, flow_span_span_links)
+            flow_llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = flow_span_span_links
+            flow_span._set_struct_tag(LLMOBS_STRUCT.KEY, flow_llmobs_data)
         return
 
     def _llmobs_set_span_link_on_task(self, span: Optional[Span], args: Any, kwargs: Any) -> None:
@@ -510,6 +528,6 @@ def _get_crew_id(span, operation):
     if operation == "crew":
         return f"crew_{span.trace_id}_{span.span_id}"
     if operation == "task":
-        parent_id = span._get_ctx_item(PARENT_ID_KEY) or span.parent_id
+        parent_id = _get_llmobs_parent_id(span) or span.parent_id
         return f"crew_{span.trace_id}_{parent_id}"
     return f"{span.trace_id}"

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -9,19 +9,17 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs import LLMObs
-from ddtrace.llmobs._constants import AGENT_MANIFEST
-from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import NAME
-from ddtrace.llmobs._constants import OUTPUT_VALUE
-from ddtrace.llmobs._constants import PARENT_ID_KEY
+from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
-from ddtrace.llmobs._constants import SPAN_KIND
-from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.constants import LANGGRAPH_ASTREAM_OUTPUT
 from ddtrace.llmobs._integrations.utils import format_langchain_io
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
+from ddtrace.llmobs._utils import get_span_links
 from ddtrace.llmobs.types import _SpanLink
 from ddtrace.trace import Span
 
@@ -92,28 +90,30 @@ class LangGraphIntegration(BaseLLMIntegration):
         invoked_node_span_links: list[_SpanLink] = invoked_node.get("span_links") or []
         if invoked_node_span_links:
             span_links = invoked_node_span_links
-        current_span_links: list[_SpanLink] = span._get_ctx_item(SPAN_LINKS) or []
+        current_span_links = get_span_links(span)
+        _annotate_llmobs_span_data(span, span_links=current_span_links + span_links)
 
         def maybe_format_langchain_io(messages):
             if messages is None:
                 return None
             return format_langchain_io(messages)
 
-        span._set_ctx_items(
-            {
-                SPAN_KIND: "agent" if operation == "graph" else "task",
-                INPUT_VALUE: format_langchain_io(inputs),
-                OUTPUT_VALUE: maybe_format_langchain_io(response)
-                or maybe_format_langchain_io(span._get_ctx_item(LANGGRAPH_ASTREAM_OUTPUT)),
-                NAME: invoked_node.get("name") or kwargs.get("name", span.name),
-                SPAN_LINKS: current_span_links + span_links,
-            }
+        # Get output value, checking for astream output if response is None
+        astream_output = span._get_ctx_item(LANGGRAPH_ASTREAM_OUTPUT)
+        output_value = maybe_format_langchain_io(response) or maybe_format_langchain_io(astream_output)
+
+        _annotate_llmobs_span_data(
+            span,
+            kind="agent" if operation == "graph" else "task",
+            input_value=format_langchain_io(inputs),
+            output_value=output_value,
+            name=invoked_node.get("name") or kwargs.get("name", span.name),
         )
 
         if operation == "graph":
             agent = self._graph_spans_to_graph_instances[span]
             agent_manifest = self._get_agent_manifest(agent, args, config)
-            span._set_ctx_item(AGENT_MANIFEST, agent_manifest)
+            _annotate_llmobs_span_data(span, agent_manifest=agent_manifest)
 
     def _get_agent_manifest(self, agent, args, config: dict[str, Any]) -> Optional[dict[str, Any]]:
         """Gets the agent manifest for a given agent at the end of its execution."""
@@ -233,10 +233,13 @@ class LangGraphIntegration(BaseLLMIntegration):
             )
             for task_id in finished_tasks.keys()
         ]
-        graph_span_span_links: list[_SpanLink] = graph_span._get_ctx_item(SPAN_LINKS) or []
-        graph_span._set_ctx_item(SPAN_LINKS, graph_span_span_links + output_span_links)
+        graph_span_llmobs_data = _get_llmobs_data_metastruct(graph_span)
+        graph_span_span_links: list[_SpanLink] = graph_span_llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
+        graph_span_llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = graph_span_span_links + output_span_links
+        graph_span._set_struct_tag(LLMOBS_STRUCT.KEY, graph_span_llmobs_data)
         if graph_caller_span is not None and not is_subgraph_node:
-            graph_caller_span_links: list[_SpanLink] = graph_caller_span._get_ctx_item(SPAN_LINKS) or []
+            caller_llmobs_data = _get_llmobs_data_metastruct(graph_caller_span)
+            graph_caller_span_links: list[_SpanLink] = caller_llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
             span_links: list[_SpanLink] = [
                 _SpanLink(
                     span_id=str(graph_span.span_id) or "undefined",
@@ -244,7 +247,8 @@ class LangGraphIntegration(BaseLLMIntegration):
                     attributes={"from": "output", "to": "output"},
                 )
             ]
-            graph_caller_span._set_ctx_item(SPAN_LINKS, graph_caller_span_links + span_links)
+            caller_llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = graph_caller_span_links + span_links
+            graph_caller_span._set_struct_tag(LLMOBS_STRUCT.KEY, caller_llmobs_data)
 
         return
 
@@ -307,7 +311,8 @@ class LangGraphIntegration(BaseLLMIntegration):
         Default handler that links any finished tasks not used as triggers for queued tasks to the outer graph span.
         """
         standalone_terminal_task_ids = set(finished_tasks.keys()) - used_finished_tasks_ids
-        graph_span_links: list[_SpanLink] = graph_span._get_ctx_item(SPAN_LINKS) or []
+        llmobs_data = _get_llmobs_data_metastruct(graph_span)
+        graph_span_links: list[_SpanLink] = llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
         for finished_task_id in standalone_terminal_task_ids:
             node = self._graph_nodes_for_graph_by_task_id.get(graph_span, {}).get(finished_task_id)
             if node is None:
@@ -324,7 +329,8 @@ class LangGraphIntegration(BaseLLMIntegration):
                     attributes={"from": "output", "to": "output"},
                 )
             )
-        graph_span._set_ctx_item(SPAN_LINKS, graph_span_links)
+        llmobs_data[LLMOBS_STRUCT.SPAN_LINKS] = graph_span_links
+        graph_span._set_struct_tag(LLMOBS_STRUCT.KEY, llmobs_data)
 
 
 def _get_model_info(model) -> tuple[Optional[str], Optional[str], dict[str, Any]]:
@@ -540,7 +546,7 @@ def _default_span_link(span: Span) -> _SpanLink:
     the span is linked to its parent's input.
     """
     return _SpanLink(
-        span_id=span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID,
+        span_id=_get_llmobs_parent_id(span) or ROOT_PARENT_ID,
         trace_id=format_trace_id(span.trace_id),
         attributes={"from": "input", "to": "input"},
     )

--- a/ddtrace/llmobs/_integrations/mcp.py
+++ b/ddtrace/llmobs/_integrations/mcp.py
@@ -13,14 +13,11 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import MCP_TOOL_CALL_INTENT
-from ddtrace.llmobs._constants import NAME
-from ddtrace.llmobs._constants import OUTPUT_VALUE
-from ddtrace.llmobs._constants import SPAN_KIND
-from ddtrace.llmobs._constants import TAGS
+from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.trace import Span
 
@@ -70,11 +67,10 @@ def _find_client_session_root(span: Optional[Span]) -> Optional[Span]:
 
 
 def _set_or_update_tags(span: Span, tags: dict[str, str]) -> None:
-    existing_tags: Optional[dict[str, str]] = span._get_ctx_item(TAGS)
-    if existing_tags is not None:
-        existing_tags.update(tags)
-    else:
-        span._set_ctx_item(TAGS, tags)
+    llmobs_data = _get_llmobs_data_metastruct(span)
+    existing_tags = llmobs_data.get(LLMOBS_STRUCT.TAGS) or {}
+    existing_tags.update(tags)
+    _annotate_llmobs_span_data(span, tags=existing_tags)
 
 
 class MCPIntegration(BaseLLMIntegration):
@@ -148,17 +144,17 @@ class MCPIntegration(BaseLLMIntegration):
         tool_name = args[0] if len(args) > 0 else kwargs.get("name", "unknown_tool")
         span_name = "MCP Client Tool Call: {}".format(tool_name)
 
-        span._set_ctx_items(
-            {
-                SPAN_KIND: "tool",
-                NAME: span_name,
-                INPUT_VALUE: tool_arguments,
-            }
+        _annotate_llmobs_span_data(
+            span,
+            kind="tool",
+            name=span_name,
+            input_value=tool_arguments,
         )
 
         client_session_root = _find_client_session_root(span)
         if client_session_root:
-            client_session_root_tags = client_session_root._get_ctx_item(TAGS) or {}
+            client_session_root_llmobs_data = _get_llmobs_data_metastruct(client_session_root)
+            client_session_root_tags = client_session_root_llmobs_data.get(LLMOBS_STRUCT.TAGS) or {}
             _set_or_update_tags(
                 span,
                 {
@@ -180,15 +176,14 @@ class MCPIntegration(BaseLLMIntegration):
                 self._parse_mcp_text_content(item) for item in content if _get_attr(item, "type", None) == "text"
             ]
         output_value = {"content": processed_content, "isError": is_error}
-        span._set_ctx_item(OUTPUT_VALUE, output_value)
+        _annotate_llmobs_span_data(span, output_value=output_value)
 
     def _llmobs_set_tags_initialize(self, span: Span, args: list[Any], kwargs: dict[str, Any], response: Any) -> None:
-        span._set_ctx_items(
-            {
-                NAME: "MCP Client Initialize",
-                SPAN_KIND: "task",
-                OUTPUT_VALUE: safe_json(response),
-            }
+        _annotate_llmobs_span_data(
+            span,
+            name="MCP Client Initialize",
+            kind="task",
+            output_value=safe_json(response),
         )
 
         server_info = getattr(response, "serverInfo", None)
@@ -240,7 +235,7 @@ class MCPIntegration(BaseLLMIntegration):
             span.set_tag(ERROR_TYPE, "ToolError")
             span.set_tag(ERROR_MSG, "tool resulted in an error")
         _set_or_update_tags(span, override_tags)
-        span._set_ctx_items({NAME: tool_name, SPAN_KIND: "tool"})
+        _annotate_llmobs_span_data(span, name=tool_name, kind="tool")
 
     def process_telemetry_argument(self, span: Span, request: "CallToolRequest") -> None:
         """Process and remove telemetry argument from requests
@@ -255,7 +250,7 @@ class MCPIntegration(BaseLLMIntegration):
         if isinstance(arguments, dict) and telemetry:
             intent = _get_attr(telemetry, INTENT_KEY, None)
             if intent:
-                span._set_ctx_item(MCP_TOOL_CALL_INTENT, intent)
+                _annotate_llmobs_span_data(span, intent=intent)
 
             # The argument is removed before recording the input and calling the tool
             del arguments[TELEMETRY_KEY]
@@ -300,13 +295,12 @@ class MCPIntegration(BaseLLMIntegration):
             input_obj = request_root
 
         # Set defaults. Type-specific methods below may override.
-        span._set_ctx_items(
-            {
-                SPAN_KIND: "task",
-                INPUT_VALUE: safe_json(input_obj),
-                OUTPUT_VALUE: safe_json(response_root),
-                TAGS: common_tags,
-            }
+        _annotate_llmobs_span_data(
+            span,
+            kind="task",
+            input_value=safe_json(input_obj),
+            output_value=safe_json(response_root),
+            tags=common_tags,
         )
 
         if InitializeRequest and request_root and isinstance(request_root, InitializeRequest):
@@ -317,23 +311,21 @@ class MCPIntegration(BaseLLMIntegration):
     def _llmobs_set_tags_list_tools(self, span: Span, args: list[Any], kwargs: dict[str, Any], response: Any) -> None:
         cursor = get_argument_value(args, kwargs, 0, "cursor", optional=True)
 
-        span._set_ctx_items(
-            {
-                NAME: "MCP Client list Tools",
-                SPAN_KIND: "task",
-                INPUT_VALUE: safe_json({"cursor": cursor}),
-                OUTPUT_VALUE: safe_json(response),
-            }
+        _annotate_llmobs_span_data(
+            span,
+            name="MCP Client list Tools",
+            kind="task",
+            input_value=safe_json({"cursor": cursor}),
+            output_value=safe_json(response),
         )
 
     def _llmobs_set_tags_session(self, span: Span, args: list[Any], kwargs: dict[str, Any], response: Any) -> None:
         read_stream = kwargs.get("read_stream", None)
         write_stream = kwargs.get("write_stream", None)
 
-        span._set_ctx_items(
-            {
-                NAME: "MCP Client Session",
-                SPAN_KIND: "workflow",
-                INPUT_VALUE: safe_json({"read_stream": read_stream, "write_stream": write_stream}),
-            }
+        _annotate_llmobs_span_data(
+            span,
+            name="MCP Client Session",
+            kind="workflow",
+            input_value=safe_json({"read_stream": read_stream, "write_stream": write_stream}),
         )

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -5,19 +5,10 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import INPUT_DOCUMENTS
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import METADATA
-from ddtrace.llmobs._constants import METRICS
-from ddtrace.llmobs._constants import MODEL_NAME
-from ddtrace.llmobs._constants import MODEL_PROVIDER
-from ddtrace.llmobs._constants import NAME
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import OUTPUT_VALUE
 from ddtrace.llmobs._constants import PROXY_REQUEST
 from ddtrace.llmobs._constants import REASONING_OUTPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import _compute_completion_tokens
@@ -26,6 +17,7 @@ from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_completion
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_response
 from ddtrace.llmobs._integrations.utils import update_proxy_workflow_input_output_value
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import Document
@@ -120,8 +112,12 @@ class OpenAIIntegration(BaseLLMIntegration):
             self._llmobs_set_tags_from_tool(span, kwargs, response)
         update_proxy_workflow_input_output_value(span, span_kind)
         metrics = self._extract_llmobs_metrics_tags(span, response, span_kind, kwargs)
-        span._set_ctx_items(
-            {SPAN_KIND: span_kind, MODEL_NAME: model_name, MODEL_PROVIDER: model_provider, METRICS: metrics}
+        _annotate_llmobs_span_data(
+            span,
+            kind=span_kind,
+            model_name=model_name,
+            model_provider=model_provider,
+            metrics=metrics,
         )
 
     @staticmethod
@@ -138,16 +134,16 @@ class OpenAIIntegration(BaseLLMIntegration):
         input_documents: list[Document] = []
         for doc in embedding_inputs:
             input_documents.append(Document(text=str(doc)))
-        span._set_ctx_items({METADATA: metadata, INPUT_DOCUMENTS: input_documents})
+        _annotate_llmobs_span_data(span, metadata=metadata, input_documents=input_documents)
         if span.error or not resp:
             return
         if encoding_format == "float":
             embedding_dim = len(resp.data[0].embedding)
-            span._set_ctx_item(
-                OUTPUT_VALUE, "[{} embedding(s) returned with size {}]".format(len(resp.data), embedding_dim)
-            )
+            output_value = "[{} embedding(s) returned with size {}]".format(len(resp.data), embedding_dim)
+            _annotate_llmobs_span_data(span, output_value=output_value)
             return
-        span._set_ctx_item(OUTPUT_VALUE, "[{} embedding(s) returned]".format(len(resp.data)))
+        output_value = "[{} embedding(s) returned]".format(len(resp.data))
+        _annotate_llmobs_span_data(span, output_value=output_value)
 
     @staticmethod
     def _llmobs_set_tags_from_tool(span: Span, kwargs: dict[str, Any], response: Any) -> None:
@@ -160,14 +156,13 @@ class OpenAIIntegration(BaseLLMIntegration):
         span_name = "MCP Client Tool Call: {}".format(tool_name)
         span.name = span_name
 
-        span._set_ctx_items(
-            {
-                SPAN_KIND: "tool",
-                NAME: span_name,
-                INPUT_VALUE: safe_json(tool_arguments) if tool_arguments is not None else "",
-                OUTPUT_VALUE: safe_json(tool_output) if tool_output is not None else "",
-                METADATA: {"tool_id": tool_id},
-            }
+        _annotate_llmobs_span_data(
+            span,
+            name=span_name,
+            kind="tool",
+            input_value=safe_json(tool_arguments) if tool_arguments is not None else "",
+            output_value=safe_json(tool_output) if tool_output is not None else "",
+            metadata={"tool_id": tool_id},
         )
 
     @staticmethod

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -8,29 +8,18 @@ from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import format_trace_id
-from ddtrace.llmobs._constants import AGENT_MANIFEST
 from ddtrace.llmobs._constants import DISPATCH_ON_GUARDRAIL_SPAN_START
 from ddtrace.llmobs._constants import DISPATCH_ON_LLM_TOOL_CHOICE
 from ddtrace.llmobs._constants import DISPATCH_ON_OPENAI_AGENT_SPAN_FINISH
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
-from ddtrace.llmobs._constants import INPUT_MESSAGES
-from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import METADATA
-from ddtrace.llmobs._constants import METRICS
-from ddtrace.llmobs._constants import MODEL_NAME
-from ddtrace.llmobs._constants import MODEL_PROVIDER
-from ddtrace.llmobs._constants import NAME
 from ddtrace.llmobs._constants import OAI_HANDOFF_TOOL_ARG
-from ddtrace.llmobs._constants import OUTPUT_MESSAGES
-from ddtrace.llmobs._constants import OUTPUT_VALUE
-from ddtrace.llmobs._constants import PARENT_ID_KEY
-from ddtrace.llmobs._constants import SESSION_ID
-from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import LLMObsTraceInfo
 from ddtrace.llmobs._integrations.utils import OaiSpanAdapter
 from ddtrace.llmobs._integrations.utils import OaiTraceAdapter
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
+from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_span_name
 from ddtrace.llmobs._utils import load_data_value
@@ -107,7 +96,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
 
         span_type = oai_span.span_type
         span_kind = oai_span.llmobs_span_kind
-        span._set_ctx_item(SPAN_KIND, span_kind)
+        _annotate_llmobs_span_data(span, kind=span_kind)
 
         if oai_span.error:
             error_msg = oai_span.get_error_message()
@@ -137,7 +126,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         elif span_type == "custom":
             custom_data = oai_span.formatted_custom_data
             if custom_data:
-                span._set_ctx_item(METADATA, custom_data)
+                _annotate_llmobs_span_data(span, metadata=custom_data)
 
     def _llmobs_update_trace_info_input(self, oai_span: OaiSpanAdapter, llmobs_span: Span) -> None:
         """
@@ -148,12 +137,12 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         trace_info = self._llmobs_get_trace_info(oai_span)
         if not trace_info:
             return
-        if oai_span.span_type == "agent" and llmobs_span._get_ctx_item(PARENT_ID_KEY) == trace_info.span_id:
+        if oai_span.span_type == "agent" and _get_llmobs_parent_id(llmobs_span) == trace_info.span_id:
             trace_info.current_top_level_agent_span_id = str(llmobs_span.span_id)
         if (
             oai_span.span_type == "response"
             and not trace_info.input_oai_span
-            and llmobs_span._get_ctx_item(PARENT_ID_KEY) == trace_info.current_top_level_agent_span_id
+            and _get_llmobs_parent_id(llmobs_span) == trace_info.current_top_level_agent_span_id
         ):
             trace_info.input_oai_span = oai_span
 
@@ -172,10 +161,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             return
 
         current_top_level_agent_span_id = trace_info.current_top_level_agent_span_id
-        if (
-            current_top_level_agent_span_id
-            and llmobs_span._get_ctx_item(PARENT_ID_KEY) == current_top_level_agent_span_id
-        ):
+        if current_top_level_agent_span_id and _get_llmobs_parent_id(llmobs_span) == current_top_level_agent_span_id:
             trace_info.output_oai_span = oai_span
 
     def _llmobs_set_trace_attributes(self, span: Span, oai_trace: OaiTraceAdapter) -> None:
@@ -185,23 +171,19 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
 
         group_id = oai_trace.group_id
         if group_id:
-            span._set_ctx_item(SESSION_ID, group_id)
+            _annotate_llmobs_span_data(span, session_id=group_id)
 
-        span._set_ctx_item(SPAN_KIND, "workflow")
-
-        if trace_info.input_oai_span:
-            input_value = trace_info.input_oai_span.llmobs_trace_input()
-            if input_value:
-                span._set_ctx_item(INPUT_VALUE, input_value)
-
-        if trace_info.output_oai_span:
-            output_value = trace_info.output_oai_span.response_output_text
-            if output_value:
-                span._set_ctx_item(OUTPUT_VALUE, output_value)
-
+        input_value = trace_info.input_oai_span.llmobs_trace_input() if trace_info.input_oai_span else None
+        output_value = trace_info.output_oai_span.response_output_text if trace_info.output_oai_span else None
         metadata = oai_trace.metadata
-        if metadata:
-            span._set_ctx_item(METADATA, metadata)
+
+        _annotate_llmobs_span_data(
+            span,
+            kind="workflow",
+            input_value=input_value if input_value else None,
+            output_value=output_value if output_value else None,
+            metadata=metadata if metadata else None,
+        )
 
     def _llmobs_set_response_attributes(self, span: Span, oai_span: OaiSpanAdapter) -> None:
         """Sets attributes for response type spans."""
@@ -210,24 +192,23 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
 
         parent = _get_nearest_llmobs_ancestor(span)
         trace_info = self._llmobs_get_trace_info(oai_span)
-        if parent and trace_info and span._get_ctx_item(PARENT_ID_KEY) == trace_info.current_top_level_agent_span_id:
-            span._set_ctx_item(NAME, _get_span_name(parent) + " (LLM)")
+        span_name = None
+        if parent and trace_info and _get_llmobs_parent_id(span) == trace_info.current_top_level_agent_span_id:
+            span_name = _get_span_name(parent) + " (LLM)"
 
-        if oai_span.llmobs_model_name:
-            span._set_ctx_item(MODEL_NAME, oai_span.llmobs_model_name)
-            span._set_ctx_item(MODEL_PROVIDER, "openai")
+        model_name = oai_span.llmobs_model_name if oai_span.llmobs_model_name else None
+        model_provider = "openai" if oai_span.llmobs_model_name else None
 
+        input_messages = None
         if oai_span.input:
             messages, tool_call_ids = oai_span.llmobs_input_messages()
-
             for tool_call_id in tool_call_ids:
                 core.dispatch(DISPATCH_ON_TOOL_CALL_OUTPUT_USED, (tool_call_id, span))
+            input_messages = messages
 
-            span._set_ctx_item(INPUT_MESSAGES, messages)
-
+        output_messages = None
         if oai_span.response and oai_span.response.output:
             messages, tool_call_outputs, _ = oai_span.llmobs_output_messages()
-
             for tool_call_output in tool_call_outputs:
                 core.dispatch(
                     DISPATCH_ON_LLM_TOOL_CHOICE,
@@ -241,20 +222,25 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
                         },
                     ),
                 )
+            output_messages = messages
 
-            span._set_ctx_item(OUTPUT_MESSAGES, messages)
-
-        metadata = oai_span.llmobs_metadata
-        if metadata:
-            span._set_ctx_item(METADATA, metadata)
-
-        metrics = oai_span.llmobs_metrics
-        if metrics:
-            span._set_ctx_item(METRICS, metrics)
+        _annotate_llmobs_span_data(
+            span,
+            name=span_name,
+            model_name=model_name,
+            model_provider=model_provider,
+            input_messages=input_messages,
+            output_messages=output_messages,
+            metadata=oai_span.llmobs_metadata if oai_span.llmobs_metadata else None,
+            metrics=oai_span.llmobs_metrics if oai_span.llmobs_metrics else None,
+        )
 
     def _llmobs_set_tool_attributes(self, span: Span, oai_span: OaiSpanAdapter) -> None:
-        span._set_ctx_item(INPUT_VALUE, oai_span.input or "")
-        span._set_ctx_item(OUTPUT_VALUE, oai_span.output or "")
+        _annotate_llmobs_span_data(
+            span,
+            input_value=oai_span.input or "",
+            output_value=oai_span.output or "",
+        )
         core.dispatch(
             DISPATCH_ON_TOOL_CALL,
             (oai_span.name, oai_span.input, "function", span),
@@ -263,8 +249,11 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
     def _llmobs_set_handoff_attributes(self, span: Span, oai_span: OaiSpanAdapter) -> None:
         handoff_tool_name = "transfer_to_{}".format("_".join(oai_span.to_agent.split(" ")).lower())
         span.name = handoff_tool_name
-        span._set_ctx_item("input_value", oai_span.from_agent or "")
-        span._set_ctx_item("output_value", oai_span.to_agent or "")
+        _annotate_llmobs_span_data(
+            span,
+            input_value=oai_span.from_agent or "",
+            output_value=oai_span.to_agent or "",
+        )
         core.dispatch(
             DISPATCH_ON_TOOL_CALL,
             (handoff_tool_name, OAI_HANDOFF_TOOL_ARG, "handoff", span),
@@ -272,7 +261,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
 
     def _llmobs_set_agent_attributes(self, span: Span, oai_span: OaiSpanAdapter) -> None:
         if oai_span.llmobs_metadata:
-            span._set_ctx_item(METADATA, oai_span.llmobs_metadata)
+            _annotate_llmobs_span_data(span, metadata=oai_span.llmobs_metadata)
 
     def _llmobs_get_trace_info(
         self, oai_trace_or_span: Union[OaiSpanAdapter, OaiTraceAdapter]
@@ -336,7 +325,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         if guardrails:
             manifest["guardrails"] = guardrails
 
-        span._set_ctx_item(AGENT_MANIFEST, manifest)
+        _annotate_llmobs_span_data(span, agent_manifest=manifest)
 
     def _extract_model_settings_from_agent(self, agent):
         if not hasattr(agent, "model_settings"):

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -14,25 +14,19 @@ from ddtrace.llmobs._constants import DISPATCH_ON_LLM_TOOL_CHOICE
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
 from ddtrace.llmobs._constants import FILE_FALLBACK_MARKER
 from ddtrace.llmobs._constants import IMAGE_FALLBACK_MARKER
-from ddtrace.llmobs._constants import INPUT_MESSAGES
-from ddtrace.llmobs._constants import INPUT_PROMPT
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_TYPE_FILE
 from ddtrace.llmobs._constants import INPUT_TYPE_IMAGE
 from ddtrace.llmobs._constants import INPUT_TYPE_TEXT
-from ddtrace.llmobs._constants import INPUT_VALUE
 from ddtrace.llmobs._constants import INSTRUMENTATION_METHOD_AUTO
-from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import OAI_HANDOFF_TOOL_ARG
-from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import OUTPUT_VALUE
 from ddtrace.llmobs._constants import PROMPT_MULTIMODAL
 from ddtrace.llmobs._constants import PROMPT_TRACKING_INSTRUMENTATION_METHOD
-from ddtrace.llmobs._constants import TAGS
-from ddtrace.llmobs._constants import TOOL_DEFINITIONS
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import _validate_prompt
 from ddtrace.llmobs._utils import load_data_value
 from ddtrace.llmobs._utils import safe_json
@@ -312,12 +306,12 @@ def openai_set_meta_tags_from_completion(
     if not span.error and completions:
         choices = getattr(completions, "choices", completions)
         output_messages = [Message(content=str(_get_attr(choice, "text", ""))) for choice in choices]
-    span._set_ctx_items(
-        {
-            INPUT_MESSAGES: [Message(content=p) for p in prompt],
-            METADATA: parameters,
-            OUTPUT_MESSAGES: output_messages,
-        }
+    input_messages = [Message(content=p) for p in prompt]
+    _annotate_llmobs_span_data(
+        span,
+        input_messages=input_messages,
+        metadata=parameters,
+        output_messages=output_messages,
     )
 
 
@@ -347,16 +341,19 @@ def openai_set_meta_tags_from_chat(
             processed_message["content"] = ""  # reset content to empty string if tool results present
         input_messages.append(processed_message)
     parameters = get_metadata_from_kwargs(kwargs, integration_name, "chat")
-    span._set_ctx_items({INPUT_MESSAGES: input_messages, METADATA: parameters})
-
+    tools = None
     if kwargs.get("tools") or kwargs.get("functions"):
         tools = _openai_get_tool_definitions(kwargs.get("tools") or [])
         tools.extend(_openai_get_tool_definitions(kwargs.get("functions") or []))
-        if tools:
-            span._set_ctx_item(TOOL_DEFINITIONS, tools)
+    _annotate_llmobs_span_data(
+        span,
+        input_messages=input_messages,
+        metadata=parameters,
+        tool_definitions=tools if tools else None,
+    )
 
     if span.error or not messages:
-        span._set_ctx_item(OUTPUT_MESSAGES, [Message(content="")])
+        _annotate_llmobs_span_data(span, output_messages=[Message(content="")])
         return
     if isinstance(messages, list):  # streamed response
         role = ""
@@ -375,7 +372,7 @@ def openai_set_meta_tags_from_chat(
             if extracted_tool_calls:
                 message["tool_calls"] = extracted_tool_calls
             output_messages.append(message)
-        span._set_ctx_item(OUTPUT_MESSAGES, output_messages)
+        _annotate_llmobs_span_data(span, output_messages=output_messages)
         return
     choices = _get_attr(messages, "choices", [])
     output_messages = []
@@ -396,7 +393,7 @@ def openai_set_meta_tags_from_chat(
             message["tool_results"] = extracted_tool_results
             message["content"] = ""  # set content empty to avoid duplication
         output_messages.append(message)
-    span._set_ctx_item(OUTPUT_MESSAGES, output_messages)
+    _annotate_llmobs_span_data(span, output_messages=output_messages)
 
 
 def _openai_extract_tool_calls_and_results_chat(
@@ -903,11 +900,7 @@ def set_prompt_tracking_tags(span: Span, *, is_multimodal: bool = False) -> None
     if is_multimodal:
         new_tags[PROMPT_MULTIMODAL] = "true"
 
-    existing_tags = span._get_ctx_item(TAGS)
-    if existing_tags:
-        existing_tags.update(new_tags)
-    else:
-        span._set_ctx_item(TAGS, new_tags)
+    _annotate_llmobs_span_data(span, tags=new_tags)
 
 
 def openai_set_meta_tags_from_response(
@@ -927,11 +920,10 @@ def openai_set_meta_tags_from_response(
     if "instructions" in kwargs:
         input_messages.insert(0, Message(content=str(kwargs["instructions"]), role="system"))
 
-    span._set_ctx_items(
-        {
-            INPUT_MESSAGES: input_messages,
-            METADATA: openai_get_metadata_from_response(response, kwargs),
-        }
+    _annotate_llmobs_span_data(
+        span,
+        input_messages=input_messages,
+        metadata=openai_get_metadata_from_response(response, kwargs),
     )
 
     prompt_data = kwargs.get("prompt")
@@ -952,25 +944,29 @@ def openai_set_meta_tags_from_response(
                         prompt_data["variables"] = normalized_variables
 
             validated_prompt = _validate_prompt(prompt_data, strict_validation=False)
-            span._set_ctx_item(INPUT_PROMPT, validated_prompt)
+            _annotate_llmobs_span_data(span, prompt=validated_prompt)
 
             set_prompt_tracking_tags(span, is_multimodal=has_multimodal)
         except (TypeError, ValueError, AttributeError) as e:
             logger.debug("Failed to validate prompt for OpenAI response: %s", e)
 
     if span.error or not response:
-        span._set_ctx_item(OUTPUT_MESSAGES, [Message(content="")])
+        _annotate_llmobs_span_data(span, output_messages=[Message(content="")])
         return
 
     # The response potentially contains enriched metadata (ex. tool calls) not in the original request
-    metadata = span._get_ctx_item(METADATA) or {}
-    metadata.update(openai_get_metadata_from_response(response))
-    span._set_ctx_item(METADATA, metadata)
+    llmobs_data = _get_llmobs_data_metastruct(span)
+    existing_metadata = llmobs_data.get("meta", {}).get("metadata", {})
+    existing_metadata.update(openai_get_metadata_from_response(response))
     output_messages, mcp_tool_definitions = openai_get_output_messages_from_response(response, integration)
-    span._set_ctx_item(OUTPUT_MESSAGES, output_messages)
     tools = _openai_get_tool_definitions(kwargs.get("tools") or [])
-    if mcp_tool_definitions or tools:
-        span._set_ctx_item(TOOL_DEFINITIONS, tools + mcp_tool_definitions)
+    all_tools = (tools + mcp_tool_definitions) if (mcp_tool_definitions or tools) else None
+    _annotate_llmobs_span_data(
+        span,
+        metadata=existing_metadata,
+        output_messages=output_messages,
+        tool_definitions=all_tools,
+    )
 
 
 def _openai_get_tool_definitions(tools: list[Any]) -> list[ToolDefinition]:
@@ -1099,12 +1095,16 @@ def update_proxy_workflow_input_output_value(span: Span, span_kind: str = ""):
     """Helper to update the input and output value for workflow spans."""
     if span_kind != "workflow":
         return
-    input_messages = span._get_ctx_item(INPUT_MESSAGES)
-    output_messages = span._get_ctx_item(OUTPUT_MESSAGES)
+    llmobs_data = _get_llmobs_data_metastruct(span)
+    llmobs_meta = llmobs_data.get("meta", {})
+    llmobs_input = llmobs_meta.get("input", {})
+    llmobs_output = llmobs_meta.get("output", {})
+    input_messages = llmobs_input.get("messages") if isinstance(llmobs_input, dict) else None
+    output_messages = llmobs_output.get("messages") if isinstance(llmobs_output, dict) else None
     if input_messages:
-        span._set_ctx_item(INPUT_VALUE, input_messages)
+        _annotate_llmobs_span_data(span, input_value=safe_json(input_messages))
     if output_messages:
-        span._set_ctx_item(OUTPUT_VALUE, output_messages)
+        _annotate_llmobs_span_data(span, output_value=safe_json(output_messages))
 
 
 class OaiSpanAdapter:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -18,16 +18,11 @@ from ddtrace.llmobs._constants import DEFAULT_PROMPT_NAME
 from ddtrace.llmobs._constants import GEMINI_APM_SPAN_NAME
 from ddtrace.llmobs._constants import INTERNAL_CONTEXT_VARIABLE_KEYS
 from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
-from ddtrace.llmobs._constants import IS_EVALUATION_SPAN
 from ddtrace.llmobs._constants import LANGCHAIN_APM_SPAN_NAME
 from ddtrace.llmobs._constants import LITELLM_APM_SPAN_NAME
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
-from ddtrace.llmobs._constants import ML_APP
-from ddtrace.llmobs._constants import NAME
 from ddtrace.llmobs._constants import OPENAI_APM_SPAN_NAME
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
-from ddtrace.llmobs._constants import SESSION_ID
-from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._constants import VERTEXAI_APM_SPAN_NAME
 from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import Message
@@ -208,7 +203,7 @@ def _get_span_name(span: Span) -> str:
         client_name = span.get_tag("openai.request.provider") or "OpenAI"
         return "{}.{}".format(client_name, span.resource)
     llmobs_data = _get_llmobs_data_metastruct(span)
-    return llmobs_data.get(LLMOBS_STRUCT.NAME) or span._get_ctx_item(NAME) or span.name
+    return llmobs_data.get(LLMOBS_STRUCT.NAME) or span.name
 
 
 def _is_evaluation_span(span: Span) -> bool:
@@ -217,15 +212,13 @@ def _is_evaluation_span(span: Span) -> bool:
     nearest LLMObs span ancestor. Default to 'False'
     """
     llmobs_data = _get_llmobs_data_metastruct(span)
-    is_evaluation_span = llmobs_data.get(LLMOBS_STRUCT.IS_EVALUATION_SPAN) or span._get_ctx_item(IS_EVALUATION_SPAN)
+    is_evaluation_span = llmobs_data.get(LLMOBS_STRUCT.IS_EVALUATION_SPAN)
     if is_evaluation_span:
         return is_evaluation_span
     llmobs_parent = _get_nearest_llmobs_ancestor(span)
     while llmobs_parent:
         parent_llmobs_data = _get_llmobs_data_metastruct(llmobs_parent)
-        is_evaluation_span = parent_llmobs_data.get(LLMOBS_STRUCT.IS_EVALUATION_SPAN) or llmobs_parent._get_ctx_item(
-            IS_EVALUATION_SPAN
-        )
+        is_evaluation_span = parent_llmobs_data.get(LLMOBS_STRUCT.IS_EVALUATION_SPAN)
         if is_evaluation_span:
             return is_evaluation_span
         llmobs_parent = _get_nearest_llmobs_ancestor(llmobs_parent)
@@ -238,13 +231,13 @@ def _get_ml_app(span: Span) -> Optional[str]:
     Default to the global config LLMObs ML app name otherwise.
     """
     llmobs_data = _get_llmobs_data_metastruct(span)
-    ml_app = llmobs_data.get(LLMOBS_STRUCT.ML_APP) or span._get_ctx_item(ML_APP)
+    ml_app = llmobs_data.get(LLMOBS_STRUCT.ML_APP)
     if ml_app:
         return ml_app
     llmobs_parent = _get_nearest_llmobs_ancestor(span)
     while llmobs_parent:
         parent_llmobs_data = _get_llmobs_data_metastruct(llmobs_parent)
-        ml_app = parent_llmobs_data.get(LLMOBS_STRUCT.ML_APP) or llmobs_parent._get_ctx_item(ML_APP)
+        ml_app = parent_llmobs_data.get(LLMOBS_STRUCT.ML_APP)
         if ml_app is not None:
             return ml_app
         llmobs_parent = _get_nearest_llmobs_ancestor(llmobs_parent)
@@ -254,13 +247,13 @@ def _get_ml_app(span: Span) -> Optional[str]:
 def _get_session_id(span: Span) -> Optional[str]:
     """Return the session ID for a given span, by checking the span's nearest LLMObs span ancestor."""
     llmobs_data = _get_llmobs_data_metastruct(span)
-    session_id = llmobs_data.get(LLMOBS_STRUCT.SESSION_ID) or span._get_ctx_item(SESSION_ID)
+    session_id = llmobs_data.get(LLMOBS_STRUCT.SESSION_ID)
     if session_id:
         return session_id
     llmobs_parent = _get_nearest_llmobs_ancestor(span)
     while llmobs_parent:
         parent_llmobs_data = _get_llmobs_data_metastruct(llmobs_parent)
-        session_id = parent_llmobs_data.get(LLMOBS_STRUCT.SESSION_ID) or llmobs_parent._get_ctx_item(SESSION_ID)
+        session_id = parent_llmobs_data.get(LLMOBS_STRUCT.SESSION_ID)
         if session_id is not None:
             return session_id
         llmobs_parent = _get_nearest_llmobs_ancestor(llmobs_parent)
@@ -344,9 +337,7 @@ def add_span_link(span: Span, span_id: str, trace_id: str, from_io: str, to_io: 
 
 def get_span_links(span: Span) -> list[_SpanLink]:
     llmobs_data = _get_llmobs_data_metastruct(span)
-    current_span_links: list[_SpanLink] = (
-        llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or span._get_ctx_item(SPAN_LINKS) or []
-    )
+    current_span_links: list[_SpanLink] = llmobs_data.get(LLMOBS_STRUCT.SPAN_LINKS) or []
     return current_span_links
 
 


### PR DESCRIPTION
Update all LLMObs integrations to use span._meta_struct instead of span context items:

- All _integrations/*.py files now use _annotate_llmobs_span_data() instead of span._set_ctx_item() / span._set_ctx_items()
- _utils.py: Remove backward-compat fallbacks to ctx_item since all code now uses meta_struct exclusively
- _constants.py: Remove unused old constants (SPAN_KIND, SESSION_ID, METADATA, METRICS, ML_APP, PARENT_ID_KEY, LLMOBS_TRACE_ID, TAGS, AGENT_MANIFEST, MODEL_NAME, MODEL_PROVIDER, INPUT_*, OUTPUT_*, IS_EVALUATION_SPAN, SPAN_LINKS, NAME, DECORATOR, INTEGRATION, EXPERIMENT_CONFIG, EXPERIMENT_RECORD_METADATA, etc.)

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
