### PR TITLE
chore: add FFE team as sole CODEOWNER for native code and releasenotes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -212,7 +212,10 @@ tests/internal/remoteconfig         @DataDog/remote-config @DataDog/apm-core-pyt
 ddtrace/openfeature/                      @DataDog/feature-flagging-and-experimentation-sdk
 ddtrace/internal/openfeature/             @DataDog/feature-flagging-and-experimentation-sdk
 ddtrace/internal/settings/openfeature.py  @DataDog/feature-flagging-and-experimentation-sdk
+src/native/ffe.rs                         @DataDog/feature-flagging-and-experimentation-sdk
 tests/openfeature/                        @DataDog/feature-flagging-and-experimentation-sdk
+releasenotes/notes/*openfeature*          @DataDog/feature-flagging-and-experimentation-sdk
+releasenotes/notes/*ffe*                  @DataDog/feature-flagging-and-experimentation-sdk
 
 # API SDK
 ddtrace/trace/                                     @DataDog/apm-sdk-capabilities-python


### PR DESCRIPTION
## Motivation

The FFE team owns all Python OpenFeature code, but two paths were falling through to catch-all owners:

- `src/native/ffe.rs` (Rust FFE evaluation engine) -> was `apm-core-python` via `*` catch-all
- FFE release notes -> were `apm-python` via `releasenotes/` rule

## Changes

Add 3 CODEOWNERS entries for `@DataDog/feature-flagging-and-experimentation-sdk`:

- `src/native/ffe.rs`
- `releasenotes/notes/*openfeature*`
- `releasenotes/notes/*ffe*`

## Decisions

- Glob patterns for releasenotes so future FFE notes are automatically covered.
- Only `ffe.rs`, not broader `src/native/`, to avoid claiming shared native infrastructure.