### PR TITLE
chore(tests): fix flaky tracer test

### DIFF
--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -480,8 +480,10 @@ class TraceMiddleware:
                 raise
             finally:
                 core.dispatch("web.request.final_tags", (span,))
-                if span in scope["datadog"]["request_spans"]:
-                    scope["datadog"]["request_spans"].remove(span)
+                # missing datadog scope should not crash request teardown.
+                request_spans = scope.get("datadog", {}).get("request_spans")
+                if request_spans and span in request_spans:
+                    request_spans.remove(span)
 
                 # Safety mechanism: finish any remaining receive spans to ensure no spans are unfinished
                 if scope["type"] == "websocket" and "datadog" in scope:


### PR DESCRIPTION
 A tracer test (`test_span_links_set_on_root_span_not_child`) has been very flaky recently, making it longer to merge PRs, here is an example of failure: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1458071973.
 
 This was due to the fact that, in `ddtrace/contrib/internal/asgi/middleware.py` , request teardown assumed scope["datadog"]["request_spans"] always exists
 
 This PR fixes the flakiness !