### PR TITLE
chore(ci_visibility): allow overriding agentless URL for all backend API clients for CI visibility

### DIFF
--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -159,7 +159,7 @@ class BackendConnectorAgentlessSetup(BackendConnectorSetup):
         self.api_key = api_key
 
     def get_connector_for_subdomain(self, subdomain: Subdomain) -> BackendConnector:
-        if subdomain == Subdomain.CITESTCYCLE and (agentless_url := os.environ.get("DD_CIVISIBILITY_AGENTLESS_URL")):
+        if agentless_url := os.environ.get("DD_CIVISIBILITY_AGENTLESS_URL"):
             url = agentless_url
         else:
             url = f"https://{subdomain.value}.{self.site}"

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -435,7 +435,10 @@ class TestBackendConnectorSetup:
         assert connector.use_gzip is True
         assert connector.default_headers["dd-api-key"] == "the-key"
 
-    def test_detect_agentless_setup_with_citestcycle_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize("subdomain", list(Subdomain))
+    def test_detect_agentless_setup_with_url_override_for_all_subdomains(
+        self, monkeypatch: pytest.MonkeyPatch, subdomain: Subdomain
+    ) -> None:
         monkeypatch.setattr(
             os,
             "environ",
@@ -449,14 +452,7 @@ class TestBackendConnectorSetup:
         connector_setup = BackendConnectorSetup.detect_setup()
         assert isinstance(connector_setup, BackendConnectorAgentlessSetup)
 
-        connector = connector_setup.get_connector_for_subdomain(Subdomain.API)
-        assert isinstance(connector.conn, http.client.HTTPSConnection)
-        assert connector.conn.host == "api.datadoghq.com"
-        assert connector.conn.port == 443
-        assert connector.use_gzip is True
-        assert connector.default_headers["dd-api-key"] == "the-key"
-
-        connector = connector_setup.get_connector_for_subdomain(Subdomain.CITESTCYCLE)
+        connector = connector_setup.get_connector_for_subdomain(subdomain)
         assert isinstance(connector.conn, http.client.HTTPSConnection)
         assert connector.conn.host == "localhost"
         assert connector.conn.port == 33333


### PR DESCRIPTION
## Description

This change makes `DD_CIVISIBILITY_AGENTLESS_URL` override apply to **all** CI Visibility backend subdomains, not just `CITESTCYCLE`.

Previously, only `Subdomain.CITESTCYCLE` used the explicit agentless URL while other subdomains still used the default `https://<subdomain>.<site>` format. With this update, when `DD_CIVISIBILITY_AGENTLESS_URL` is set, every subdomain connector uses that override consistently.

## Testing

- Updated `tests/testing/internal/test_http.py`:
  - Renamed and expanded the override test to cover all subdomains.
  - Parametrized with `list(Subdomain)` to validate behavior for each enum value.
  - Asserted that connector host/port resolve to the override URL (`localhost:33333`) for every case.

## Risks

- **Low risk**: behavior changes only when `DD_CIVISIBILITY_AGENTLESS_URL` is set (used only for testing)
- Default behavior (site-based subdomain URL construction) is unchanged when override is not provided.

## Additional Notes

- No public API changes.
