### PR TITLE
refactor(profiling): stop parsing column numbers from linetable

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/frame.h
@@ -50,13 +50,7 @@ class Frame
     StringTable::Key filename = 0;
     StringTable::Key name = 0;
 
-    struct _location
-    {
-        unsigned line = 0;
-        unsigned line_end = 0;
-        unsigned column = 0;
-        unsigned column_end = 0;
-    } location;
+    unsigned line = 0;
 
 #if PY_VERSION_HEX >= 0x030b0000
     bool is_entry = false;

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -128,7 +128,7 @@ StackRenderer::render_frame(Frame& frame)
 
     const auto& string_table = Sampler::get().get_echion().string_table();
 
-    auto line = frame.location.line;
+    auto line = frame.line;
 
     string_id name_id;
     auto maybe_name_id = string_id_cache.find(frame.name);


### PR DESCRIPTION
## Description

Given that we don't export columns (we did from MojoRenderer from standalone echion, but that's now gone) we don't need to parse those from linetables. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
