### PR TITLE
chore(tests): fix flaky fast api tests

### DIFF
--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -742,7 +742,17 @@ def _run_websocket_context_propagation_test():
         fastapi_unpatch()
 
 
-@pytest.mark.subprocess(env=dict(DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true"))
+def _is_known_fastapi_websocket_teardown_stderr(stderr):
+    if stderr == "":
+        return True
+
+    return "Exception ignored in: <function BaseEventLoop.__del__" in stderr and "Invalid file descriptor: -1" in stderr
+
+
+@pytest.mark.subprocess(
+    env=dict(DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true"),
+    err=_is_known_fastapi_websocket_teardown_stderr,
+)
 @snapshot(ignores=["meta._dd.span_links", "metrics.websocket.message.length"])
 def test_websocket_context_propagation(snapshot_app):
     """Test trace context propagation."""


### PR DESCRIPTION
There is a fastAPI test which is super flaky on 3.10, see here: https://gitlab.ddbuild.io/datadog/apm-reliability/dd-trace-py/builds/1459351983. 

The error is not due to the test, thus ignored.