### PR TITLE
ci: add upload serverless package job

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -151,7 +151,7 @@ variables:
             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
           - ARCH_TAG: "arm64"
             PYTHON_TAG: "cp311-cp311"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_aarch64"
+            IMAGE_TAG: "v85383414-751efc0-manylinux2014_aarch64"
     - job: "package version"
   script:
     - .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_SHA}" serverless


### PR DESCRIPTION
## Description

Right now the serverless benchmarks requires waiting for all wheels to be built and uploaded first.

This PR adds a job to upload only the wheels necessary for serverless so we can start the serverless benchmarks job faster.

In a future step we'll update the serverless-tools scripts to use this new `index.serverless.html` file and update the dependency of the serverless benchmark job.


The impact should be faster CI times, since serverless benchmarks is one of the last jobs that can start.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
