### PR TITLE
test(debugger): add missing flush method in exploration testing

### DIFF
--- a/tests/debugging/exploration/debugger.py
+++ b/tests/debugging/exploration/debugger.py
@@ -108,6 +108,9 @@ class NoopProbeStatusLogger:
     def __init__(self, *args, **kwargs):
         pass
 
+    def flush(self, *args, **kwargs):
+        pass
+
     def received(self, *args, **kwargs):
         pass
 


### PR DESCRIPTION
We add the missing no-on flush method to the no-op status logger used in debugger exploration tests.