### PR TITLE
chore(ci): use pre-built alpine_build image for test sdist job

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -1,6 +1,7 @@
 variables:
   IMAGE_BASE_URL: "registry.ddbuild.io/dd-trace-py"
   MANYLINUX_AMD64_IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+  ALPINE_BUILD_IMAGE_TAG: "v99952233-e6a3deb-alpine_build"
 
 .PYTHON_VERSIONS: &PYTHON_VERSIONS
   - "3.9"
@@ -162,7 +163,7 @@ variables:
     - .gitlab/scripts/upload-wheels-to-s3.sh "${CI_PIPELINE_ID}" serverless
 
 "test sdist":
-  image: registry.ddbuild.io/images/mirror/python:3.9.6-alpine3.14
+  image: "${IMAGE_BASE_URL}:${ALPINE_BUILD_IMAGE_TAG}"
   tags: [ "arch:arm64" ]
   stage: package
   variables:
@@ -178,11 +179,6 @@ variables:
   script:
     - SDIST_FILE=$(ls ${CI_PROJECT_DIR}/pywheels/*.tar.gz | head -n 1)
     - TMP_DIR=$(mktemp -d) && cd $TMP_DIR
-    - |
-      apk add curl git gcc g++ musl-dev libffi-dev openssl-dev bash cargo make cmake patchelf
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      export PATH="$HOME/.cargo/bin:$PATH"
-      pip install 'twine>=5.0,<7' 'readme-renderer[md]>=44.0,<45' 'cmarkgfm>=2024,<2025.10.20'  # ci-deps: allow
     - twine check ${SDIST_FILE}
     - pip install ${SDIST_FILE}
     - python ${CI_PROJECT_DIR}/tests/smoke_test.py


### PR DESCRIPTION
## Description

Replace per-run Rust/toolchain installation with a pre-built Alpine image that has Rust, build tools, and Python packages pre-installed. This eliminates recurring rustup downloads that can cause timeouts.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->
Maintaining several images with different lifecycles.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
Requires following PR first: https://github.com/DataDog/images/pull/8964
