### PR TITLE
chore(ci): enable sccache with S3 backend for Rust/C++ compilation caching

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -34,6 +34,8 @@ variables:
     CMAKE_ARGS: "-DNATIVE_TESTING=OFF"
     # DEV: Hack to make ASM CMake able to find the Python3 library
     CIBW_BUILD: "1"
+    # Enable sccache for Rust/C/C++ compilation caching
+    DD_USE_SCCACHE: "1"
     # job resource requests
     KUBERNETES_CPU_REQUEST: "6"
     KUBERNETES_MEMORY_REQUEST: "10Gi"
@@ -67,6 +69,10 @@ variables:
     PYTHON_TAG: "cp314-cp314"
     UV_PYTHON: "/opt/python/cp314-cp314/bin/python"
     IMAGE_TAG: "${MANYLINUX_AMD64_IMAGE_TAG}"
+    # S3-backed sccache
+    SCCACHE_BUCKET: "dd-trace-py-builds"
+    SCCACHE_S3_KEY_PREFIX: "sccache"
+    SCCACHE_REGION: "us-east-1"
   script:
     - .gitlab/scripts/build-sdist.sh
 
@@ -74,6 +80,11 @@ variables:
   extends: .build_base
   image: ${IMAGE_BASE_URL}:${IMAGE_TAG}
   tags: [ "arch:$ARCH_TAG" ]
+  variables:
+    # S3-backed sccache for Linux builds
+    SCCACHE_BUCKET: "dd-trace-py-builds"
+    SCCACHE_S3_KEY_PREFIX: "sccache"
+    SCCACHE_REGION: "us-east-1"
   parallel:
     matrix:
       - ARCH_TAG: "amd64"

--- a/.gitlab/scripts/build-wheel.sh
+++ b/.gitlab/scripts/build-wheel.sh
@@ -9,3 +9,8 @@ build_wheel
 repair_wheel
 finalize
 test_wheel
+
+# Show sccache stats if available
+if command -v sccache &> /dev/null; then
+  sccache --show-stats || true
+fi


### PR DESCRIPTION
## Description

Configure sccache to use the dd-trace-py-builds S3 bucket as a shared compilation cache. This avoids recompiling Rust and C++ from scratch on every CI run — subsequent builds get cache hits for unchanged compilation units.

- Add SCCACHE_BUCKET, SCCACHE_S3_KEY_PREFIX, SCCACHE_REGION to build_base (wheel builds) and build_base_venvs (test setup)
- Add sccache stats output to build-wheel.sh for visibility

sccache is already installed in the manylinux images and the testrunner. setup.py already handles RUSTC_WRAPPER when DD_USE_SCCACHE=1.

## Testing

<!-- Describe your testing strategy or note what tests are included -->
[first run populating caches](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/pipelines/99974959)
[link to a re-run
](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1470475504)

```
Cache hits rate                    98.86 %
Cache hits rate (C/C++)           100.00 %
Cache hits rate (Rust)             95.98 %
```

On manual tests, this seems to be faster (~40% on wheel builds). However I would prefer to merge this to get actual stats.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->
We depend on s3 and can get build failures when s3 is not available.
@brettlangdon mentioned that we are exposing s3 build artifacts in a public repository. We agreed that this was acceptable as we do not expect anything to leak out of these.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
Macos runners are not getting the s3 config, however with the local cache, we are getting relevant hit rates.