### PR TITLE
test(profiling): remove xfail mark on test_asyncio_context_manager

### DIFF
--- a/tests/profiling/collector/test_asyncio_context_manager.py
+++ b/tests/profiling/collector/test_asyncio_context_manager.py
@@ -1,11 +1,6 @@
-from sys import version_info as PYVERSION
-
 import pytest
 
 
-@pytest.mark.xfail(
-    condition=PYVERSION >= (3, 13), reason="Sampling async context manager stacks does not work on >=3.13"
-)
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_context_manager",


### PR DESCRIPTION
## Description

Noticed that this passes locally on 3.13 and 3.14. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
