### PR TITLE
chore(appsec): remove redundant ddwaf_object_free(diagnostics) calls in update_rules()

### DIFF
--- a/releasenotes/notes/fix-ddwaf-diagnostics-double-free-48639b49863fae36.yaml
+++ b/releasenotes/notes/fix-ddwaf-diagnostics-double-free-48639b49863fae36.yaml
@@ -1,4 +1,0 @@
----
-other:
-  - |
-    ASM: Remove redundant ``ddwaf_object_free(diagnostics)`` calls in ``DDWaf.update_rules()``.


### PR DESCRIPTION
## Description

Remove two double-free calls on `diagnostics` in `DDWaf.update_rules()`.

[`_set_info()`](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/appsec/_ddwaf/waf.py#L111) already calls `ddwaf_object_free(diagnostics)` at the end of its body:

```python
def _set_info(self, diagnostics: ddwaf_object, action: str) -> None:
    info_struct: dict[str, Any] = diagnostics.struct or {}
    # ... extracts info from diagnostics ...
    self._info = DDWaf_info(...)
    ddwaf_object_free(diagnostics)  # ← frees diagnostics here
```

But `update_rules()` was calling `ddwaf_object_free(diagnostics)` again after `_set_info()` returned, in two places:

```python
# Location 1 (updates loop):
self._set_info(diagnostics, "update")    # frees diagnostics inside
ddwaf_object_free(ruleset_object)
ddwaf_object_free(diagnostics)           # ← double-free (removed)

# Location 2 (default ruleset re-add):
self._set_info(diagnostics, "update")    # frees diagnostics inside
ddwaf_object_free(diagnostics)           # ← double-free (removed)
```

**Why it's safe today:** `ddwaf_object_free` calls `ddwaf_object_invalid()` which zeroes the struct after freeing, so the second call is a no-op. But it's still a latent bug — if the allocator reuses that memory between the two calls, the second free corrupts the heap.

Found during crash analysis of dd-trace-py 4.5.0 (libddwaf 1.30.1). ~198 WAF-related crashes over 3 days, mostly heap corruption in `ddwaf_object_free` tree walks. The double-free isn't the primary crash cause (that's external heap corruption), but it should be fixed as defensive hygiene. See the [full crash analysis report](https://github.com/DataDog/crash-analysis/blob/main/reports/2026-03-03-tracer-4.5.0-crash-analysis.md) (Family 4 section).

## Testing

The change is a pure deletion of redundant `ddwaf_object_free()` calls. Existing appsec WAF tests cover `update_rules()` behavior and will validate no regressions.

## Risks

None — the removed calls were already no-ops in practice (the struct is zeroed after the first free). Removing them eliminates a latent heap corruption risk.

## Additional Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)