### PR TITLE
fix(llmobs): Fix experiment interruption detection for asyncio.CancelledError

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1228,6 +1228,9 @@ class Experiment:
                     convert_tags_dict_to_list(self._tags),
                 )
                 self._run_results.append(run_result)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            self._interrupted = True
+            raise
         except BaseException:
             self._interrupted = True
             raise

--- a/releasenotes/notes/llmobs-experiment-cancelled-error-interruption-fc5b31d6b65d4b29.yaml
+++ b/releasenotes/notes/llmobs-experiment-cancelled-error-interruption-fc5b31d6b65d4b29.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes experiment interruption detection to handle ``asyncio.CancelledError``
+    in addition to ``KeyboardInterrupt``. Previously, a SIGINT during async experiment execution
+    was converted to ``CancelledError`` by the event loop and not recognized as an interruption.


### PR DESCRIPTION
## Summary
- Handle `asyncio.CancelledError` alongside `KeyboardInterrupt` as an experiment interruption
- When SIGINT arrives during async execution, the event loop converts `KeyboardInterrupt` to `CancelledError`, which was previously not recognized as an interruption
- Only set `_interrupted = True` for actual interruptions, not for other exceptions

## Test plan
- [x] Manual testing with SIGINT during experiment execution
- [x] Verified `_interrupted` flag is correctly set for CancelledError
- [x] Verified non-interrupt exceptions (e.g. RuntimeError with raise_errors=True) don't set `_interrupted`