### PR TITLE
ci: refactor upload jobs, add manylinux2014 upload

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -279,7 +279,7 @@ download_dependency_wheels:
   extends: .upload_wheels_base
   needs: [ "ddtrace package", "package version" ]
   script:
-    - !reference[.upload_wheels_base, script]
+    - !reference [.upload_wheels_base, script]
     - |
       set -euo pipefail
 


### PR DESCRIPTION
## Description

There are two main changes in this PR:

1. Refactor the upload jobs to be a little more generic/less lines copy-pasted
2. Add an `upload manylinux2014` job
    1. Right now we have an `upload manylinux2014_x86_64` which is used by benchmarks, but we have other pipelines which also need the aarch64 wheels


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
