### PR TITLE
chore(ray): increase ray parallelism as it often times out

### DIFF
--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -1042,7 +1042,7 @@ suites:
     runner: riot
     snapshot: true
   ray:
-    parallelism: 1
+    parallelism: 3
     paths:
       - '@bootstrap'
       - '@core'


### PR DESCRIPTION
As the commit says, increase ray parallelism to make the CI jobs faster