### PR TITLE
ci: pin test agent in hatch.toml [backport #16652 to 4.5]

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -13,7 +13,7 @@ dependencies = [
     "types-protobuf==3.20.4.5",
     "types-PyYAML==6.0.12.2",
     "types-setuptools==65.6.0.0",
-    "ddapm-test-agent>=1.2.0",
+    "ddapm-test-agent==1.42.0",
     "packaging==23.1",
     "pygments==2.16.1",
     "riot==0.21.0",


### PR DESCRIPTION
Backport a6dfd8e95b524942bd9f1835d87ccb84881a6267 from #16652 to 4.5.

## Description

Pin test agent to version `1.42.0` to avoid the breaking change introduced in https://github.com/DataDog/dd-apm-test-agent/pull/279

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

The CI actually uses `1.36.0` but it adds `wrapt` as a transitive depdency that breaks the current type checking.

<!-- Any other information that would be helpful for reviewers -->
