### PR TITLE
ci(debugging): skip botocore exploration tests

### DIFF
--- a/.gitlab/templates/debugging/exploration.yml
+++ b/.gitlab/templates/debugging/exploration.yml
@@ -28,7 +28,7 @@
     git clone --depth 1 --branch ${{BOTO3_TAG}} https://github.com/boto/boto3.git
     cd boto3
     python${{PYTHON_VERSION}} scripts/ci/install
-    python${{PYTHON_VERSION}} scripts/ci/run-tests --test-runner 'pytest -svv -W error -W "ignore::dateutil.parser._parser.UnknownTimezoneWarning" -W "ignore::DeprecationWarning"'
+    python${{PYTHON_VERSION}} scripts/ci/run-tests --test-runner 'pytest -svv -W error -W "ignore::dateutil.parser._parser.UnknownTimezoneWarning" -W "ignore::DeprecationWarning" -k "not test_documentation"'
   after_script:
     - cat ${{DD_DEBUGGER_EXPL_OUTPUT_FILE}}
   artifacts:


### PR DESCRIPTION
## Description

We'll skip botocore for now since those are the ones which tend to hang.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
