### PR TITLE
chore: remove obsolete `ref_protected` from STS trust policies

### DIFF
--- a/.github/chainguard/codeql.sts.yaml
+++ b/.github/chainguard/codeql.sts.yaml
@@ -5,7 +5,6 @@ claim_pattern:
   ref_type: "branch"
   ref: ".+"
   ref_path: "refs/heads/.+"
-  ref_protected: "true"
   pipeline_source: "(web|schedule|push|tag)"
   ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py//.gitlab-ci.yml@refs/heads/.+"
 permissions:

--- a/.github/chainguard/self.generate-package-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.generate-package-versions.create-pr.sts.yaml
@@ -5,7 +5,6 @@ subject: repo:DataDog/dd-trace-py:ref:refs/heads/main
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/generate-package-versions\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.generate-supported-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.generate-supported-versions.create-pr.sts.yaml
@@ -5,7 +5,6 @@ subject: repo:DataDog/dd-trace-py:ref:refs/heads/main
 claim_pattern:
   event_name: workflow_dispatch
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/generate-supported-versions\.yml@refs/heads/main
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `ref_protected: "true"` from dd-octo-sts trust policy claim patterns

The `ref_protected` OIDC claim is now obsolete in the DataDog org:

- **GitHub**: The org-level "incompatible file paths on windows" push ruleset causes ALL branches to report `ref_protected: true` in OIDC tokens, making it useless as a security signal
- **GitLab**: All branches on `gitlab.ddbuild.io` report `ref_protected: true` due to org-level `pushAccessLevels: 40` config

Since the claim is universally `true`, it provides no actual filtering — only a false sense of security. Removing it has zero functional impact on policy enforcement.

All other constraints (subject, ref, job_workflow_ref, project_path, pipeline_source, etc.) remain unchanged and continue to provide the real security boundaries.

Ticket: https://datadoghq.atlassian.net/browse/SINT-4732

## Test plan

- [ ] Verify that the remaining policy constraints are sufficient (ref, job_workflow_ref, etc. are unchanged)
- [ ] No functional change expected since ref_protected was already always true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
