### PR TITLE
feat(ai_guard): honor in-app blocking settings by default

### DIFF
--- a/ddtrace/appsec/ai_guard/_api_client.py
+++ b/ddtrace/appsec/ai_guard/_api_client.py
@@ -65,6 +65,13 @@ class Evaluation(TypedDict):
 
 
 class Options(TypedDict, total=False):
+    """Optional evaluation behavior.
+
+    Attributes:
+        block: Controls whether non-ALLOW decisions raise ``AIGuardAbortError``. Defaults to
+            following the AI Guard response ``is_blocking_enabled`` setting when omitted.
+    """
+
     block: bool
 
 
@@ -201,16 +208,20 @@ class AIGuardClient:
 
     @staticmethod
     def _is_blocking_enabled(options: Optional[Options], remote_enabled: bool) -> bool:
-        if not remote_enabled or not options:
+        if not remote_enabled:
             return False
-        return options.get("block", False)
+        if not options:
+            return True
+        return options.get("block", True)
 
     def evaluate(self, messages: list[Message], options: Optional[Options] = None) -> Evaluation:
         """Evaluate if the list of messages are safe to execute.
 
         Args:
             messages: list of messages to evaluate
-            options: Optional configuration with 'block' parameter (defaults to False)
+            options: Optional configuration with 'block' parameter. By default, block follows
+                the AI Guard response is_blocking_enabled setting; set block=False to force
+                non-blocking behavior.
 
         Returns:
             EvaluationResult containing action and reason

--- a/releasenotes/notes/ai-guard-default-block-ui-37ad8475fdc6ac27.yaml
+++ b/releasenotes/notes/ai-guard-default-block-ui-37ad8475fdc6ac27.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    ai_guard: Calls to evaluate now block if blocking was enabled for the service in the AI Guard UI.
+    This behavior can be disabled by passing the parameter `block=False`, which now defaults to `block=True`.

--- a/tests/appsec/ai_guard/api/test_api_client.py
+++ b/tests/appsec/ai_guard/api/test_api_client.py
@@ -50,7 +50,11 @@ PROMPT = [
             ContentPart(
                 type="input_image",
                 image_url=ImageURL(
-                    url="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+                    url=(
+                        "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/"
+                        "Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-"
+                        "Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+                    )
                 ),
             ),
         ],
@@ -151,6 +155,28 @@ def test_evaluate_method(
     assert_mock_execute_request_call(
         mock_execute_request, ai_guard_client, messages, endpoint="https://api.example.com/ai-guard"
     )
+
+
+@pytest.mark.parametrize(
+    "options,should_block",
+    [
+        pytest.param(None, True, id="options omitted follows remote blocking"),
+        pytest.param(Options(), True, id="block omitted follows remote blocking"),
+        pytest.param(Options(block=False), False, id="explicit block false disables blocking"),
+    ],
+)
+@patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+def test_evaluate_block_defaults_to_remote_is_blocking_enabled(
+    mock_execute_request, ai_guard_client, options, should_block
+):
+    mock_execute_request.return_value = mock_evaluate_response("DENY", "Nope", ["deny_everything"], True)
+
+    if should_block:
+        with pytest.raises(AIGuardAbortError):
+            ai_guard_client.evaluate(TOOL_CALL, options)
+    else:
+        result = ai_guard_client.evaluate(TOOL_CALL, options)
+        assert result["action"] == "DENY"
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer._namespace")


### PR DESCRIPTION
## Description

Set `block=True` by default on AI Guard's `evaluate`. This makes the AI Guard SDK block requests if blocking is enabled for the service in-app. To override the in-app settings programatically, `block=False` can be set.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

[APPSEC-61436](https://datadoghq.atlassian.net/browse/APPSEC-61436)


[APPSEC-61436]: https://datadoghq.atlassian.net/browse/APPSEC-61436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ