### PR TITLE
chore(ci): tolerate BaseEventLoop.__del__ stderr in fastapi websocket subprocess tests

### DIFF
--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -625,11 +625,18 @@ def _run_websocket_send_only_test():
         fastapi_unpatch()
 
 
+def _is_websocket_teardown_stderr(stderr):
+    """Allow stderr caused by BaseEventLoop.__del__ closing an invalid file descriptor during teardown."""
+    if not stderr:
+        return True
+    return "BaseEventLoop.__del__" in stderr and "Invalid file descriptor: -1" in stderr
+
+
 @pytest.mark.subprocess(
     env=dict(
         DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true",
     ),
-    err=None,
+    err=_is_websocket_teardown_stderr,
 )
 @snapshot(ignores=["meta._dd.span_links", "metrics.websocket.message.length"])
 def test_traced_websocket(test_spans, snapshot_app):
@@ -642,7 +649,7 @@ def test_traced_websocket(test_spans, snapshot_app):
     env=dict(
         DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true",
     ),
-    err=None,
+    err=_is_websocket_teardown_stderr,
 )
 @snapshot(ignores=["meta._dd.span_links", "metrics.websocket.message.length"])
 def test_websocket_only_sends(test_spans, snapshot_app):
@@ -656,7 +663,7 @@ def test_websocket_only_sends(test_spans, snapshot_app):
         DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true",
         DD_TRACE_WEBSOCKET_MESSAGES_INHERIT_SAMPLING="false",
     ),
-    err=None,
+    err=_is_websocket_teardown_stderr,
 )
 @snapshot(ignores=["meta._dd.span_links", "metrics.websocket.message.length", "meta._dd.p.dm"])
 def test_websocket_tracing_sampling_not_inherited(test_spans, snapshot_app):
@@ -670,7 +677,7 @@ def test_websocket_tracing_sampling_not_inherited(test_spans, snapshot_app):
         DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true",
         DD_TRACE_WEBSOCKET_MESSAGES_SEPARATE_TRACES="false",
     ),
-    err=None,
+    err=_is_websocket_teardown_stderr,
 )
 @snapshot(ignores=["meta._dd.span_links", "metrics.websocket.message.length"])
 def test_websocket_tracing_not_separate_traces(test_spans, snapshot_app):
@@ -746,7 +753,7 @@ def _run_websocket_context_propagation_test():
         fastapi_unpatch()
 
 
-@pytest.mark.subprocess(env=dict(DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true"), err=None)
+@pytest.mark.subprocess(env=dict(DD_TRACE_WEBSOCKET_MESSAGES_ENABLED="true"), err=_is_websocket_teardown_stderr)
 @snapshot(ignores=["meta._dd.span_links", "metrics.websocket.message.length"])
 def test_websocket_context_propagation(snapshot_app):
     """Test trace context propagation."""


### PR DESCRIPTION
## Summary
- FastAPI websocket subprocess tests (`test_traced_websocket`, `test_websocket_only_sends`, `test_websocket_tracing_sampling_not_inherited`, `test_websocket_tracing_not_separate_traces`, `test_websocket_context_propagation`) intermittently fail in CI with `ValueError: Invalid file descriptor: -1` from `BaseEventLoop.__del__` during asyncio event loop cleanup
- This is a harmless CPython race condition in asyncio teardown that occurs more frequently under CI resource constraints (particularly Python 3.9, fastapi 1/7 runner)
- Adds an `err=` callback to all 5 websocket subprocess test markers that accepts this known warning while still rejecting genuinely unexpected stderr

## Root Cause
The `@pytest.mark.subprocess` marker defaults to `err=""`, requiring stderr to be exactly empty. During websocket test subprocess cleanup, `BaseEventLoop.__del__` sometimes tries to close an already-closed file descriptor (-1), writing a warning to stderr. This causes the subprocess test framework to fail the test even though the actual test logic succeeded.

## Test plan
- [x] Verified fix function correctly accepts empty stderr, the known CI warning, and rejects unrelated errors
- [x] All 5 affected websocket tests pass locally on Python 3.9 with latest fastapi
- [ ] CI should validate the fix resolves the flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)