### PR TITLE
chore(llmobs): reduce dataset batch update threshold from 5MB to 500KB

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -643,7 +643,7 @@ class Dataset:
     _updated_record_ids_to_new_fields: dict[str, UpdatableDatasetRecord]
     _deleted_record_ids: list[str]
 
-    BATCH_UPDATE_THRESHOLD = 5 * 1024 * 1024  # 5MB
+    BATCH_UPDATE_THRESHOLD = 500 * 1024  # 500kb
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

- Reduces `Dataset.BATCH_UPDATE_THRESHOLD` from 5MB to 500KB

In local testing against staging, the 5MB threshold was causing timeouts during dataset push operations. Dropping to 500KB resolves the timeouts.

## Test plan

- [ ] Local testing against staging confirmed no timeouts with 500KB threshold