### PR TITLE
fix(profiling): [2/n] fix a bug silently dropping all Lock samples with 'gevent' + 'ddtrace-run'

### DIFF
--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -18,6 +18,7 @@ from typing import Union
 from typing import cast
 
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.settings.profiling import config
 from ddtrace.profiling import collector
 from ddtrace.trace import Tracer
@@ -465,6 +466,7 @@ class LockCollector(collector.CaptureSamplerCollector):
         super().__init__(*args, **kwargs)
         self.tracer: Optional[Tracer] = tracer
         self._original_lock: Optional[Callable[..., Any]] = None
+        self._reimport_hook: Optional[Callable[[ModuleType], None]] = None
 
     def _get_patch_target(self) -> Callable[..., Any]:
         return cast(Callable[..., Any], getattr(self.MODULE, self.PATCHED_LOCK_NAME))
@@ -476,12 +478,36 @@ class LockCollector(collector.CaptureSamplerCollector):
         """Start collecting lock usage."""
         _c_initialize_gevent_support()
         self.patch()
+
+        # AIDEV-NOTE: Register a hook to re-apply patches if the target module is
+        # re-imported after cleanup_loaded_modules() discards it from sys.modules.
+        # Without this, ddtrace-run + gevent installed = lock profiling silently broken.
+        module_name = self.MODULE.__name__
+        patched_module_id = id(self.MODULE)
+
+        def _on_module_reimport(new_module: ModuleType) -> None:
+            nonlocal patched_module_id
+            if id(new_module) == patched_module_id:
+                return
+            self.MODULE = new_module
+            self.patch()
+            patched_module_id = id(new_module)
+
+        self._reimport_hook = _on_module_reimport
+        ModuleWatchdog.register_module_hook(module_name, self._reimport_hook)
+
         super(LockCollector, self)._start_service()  # type: ignore[safe-super]
 
     def _stop_service(self) -> None:
         """Stop collecting lock usage."""
         super(LockCollector, self)._stop_service()  # type: ignore[safe-super]
         self.unpatch()
+        if self._reimport_hook is not None:
+            try:
+                ModuleWatchdog.unregister_module_hook(self.MODULE.__name__, self._reimport_hook)
+            except Exception:
+                pass
+            self._reimport_hook = None
 
     def patch(self) -> None:
         """Patch the module for tracking lock allocation."""

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -126,11 +126,11 @@ class _ProfiledLock:
     # _owner/_RLock__owner; without this property, non-RLock wrappers (e.g. Lock) fail
     # the check, causing AssertionError("Found unknown lock implementation").
     @property
-    def _owner(self) -> Any:
+    def _owner(self) -> int | None:
         return getattr(self.__wrapped__, "_owner", None)
 
     @_owner.setter
-    def _owner(self, value: Any) -> None:
+    def _owner(self, value: int) -> None:
         try:
             self.__wrapped__._owner = value
         except (AttributeError, TypeError):
@@ -503,8 +503,8 @@ class LockCollector(collector.CaptureSamplerCollector):
         # Register a hook to re-apply patches if the target module is
         # re-imported after cleanup_loaded_modules() discards it from sys.modules.
         # Without this, ddtrace-run + gevent installed = lock profiling silently broken.
-        module_name = self.MODULE.__name__
-        patched_module_id = id(self.MODULE)
+        module_name: str = self.MODULE.__name__
+        patched_module_id: int = id(self.MODULE)
 
         def _on_module_reimport(new_module: ModuleType) -> None:
             nonlocal patched_module_id

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -4,6 +4,7 @@
 # would cause Cython compilation errors since they aren't valid C types.
 
 import _thread
+import logging
 import os.path
 import sys
 import time
@@ -26,6 +27,9 @@ from ddtrace.trace import Tracer
 from ddtrace.profiling._threading import get_thread_name, get_thread_native_id
 from ddtrace.profiling.collector._sampler cimport CaptureSampler
 from ddtrace.profiling.collector._task cimport get_task as _c_get_task, initialize_gevent_support as _c_initialize_gevent_support
+
+
+LOG = logging.getLogger(__name__)
 
 
 ACQUIRE_RELEASE_CO_NAMES: frozenset[str] = frozenset(["_acquire", "_release"])
@@ -479,7 +483,7 @@ class LockCollector(collector.CaptureSamplerCollector):
         _c_initialize_gevent_support()
         self.patch()
 
-        # AIDEV-NOTE: Register a hook to re-apply patches if the target module is
+        # Register a hook to re-apply patches if the target module is
         # re-imported after cleanup_loaded_modules() discards it from sys.modules.
         # Without this, ddtrace-run + gevent installed = lock profiling silently broken.
         module_name = self.MODULE.__name__
@@ -489,6 +493,16 @@ class LockCollector(collector.CaptureSamplerCollector):
             nonlocal patched_module_id
             if id(new_module) == patched_module_id:
                 return
+            LOG.warning(
+                "%s: target module %r was re-imported (id %#x -> %#x); "
+                "re-applying lock profiling patches. "
+                "This typically happens when gevent is installed and cleanup_loaded_modules() "
+                "discards the previously-patched module from sys.modules.",
+                type(self).__name__,
+                module_name,
+                patched_module_id,
+                id(new_module),
+            )
             self.unpatch()
             self.MODULE = new_module
             self.patch()
@@ -514,6 +528,12 @@ class LockCollector(collector.CaptureSamplerCollector):
         """Patch the module for tracking lock allocation."""
         original_lock: Callable[..., Any] = self._get_patch_target()
         if isinstance(original_lock, _LockAllocatorWrapper):
+            LOG.debug(
+                "%s: %s.%s is already patched, skipping to avoid double-wrapping.",
+                type(self).__name__,
+                self.MODULE.__name__,
+                self.PATCHED_LOCK_NAME,
+            )
             return
         self._original_lock = original_lock
 

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -119,6 +119,23 @@ class _ProfiledLock:
         # and should not generate profile samples to avoid double-counting
         self.is_internal: bool = is_internal
 
+    # gevent compatibility — gevent's _patch_existing_locks() calls
+    # type(threading.RLock()) to determine the RLock type, then scans gc.get_objects()
+    # for instances of that type. When our wrapper is on threading.RLock, the type is
+    # _ProfiledLock, so ALL profiled lock instances match. gevent then checks each for
+    # _owner/_RLock__owner; without this property, non-RLock wrappers (e.g. Lock) fail
+    # the check, causing AssertionError("Found unknown lock implementation").
+    @property
+    def _owner(self) -> Any:
+        return getattr(self.__wrapped__, "_owner", None)
+
+    @_owner.setter
+    def _owner(self, value: Any) -> None:
+        try:
+            self.__wrapped__._owner = value
+        except (AttributeError, TypeError):
+            pass
+
     # DUNDER methods
 
     def __eq__(self, other: object) -> bool:

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -506,7 +506,7 @@ class LockCollector(collector.CaptureSamplerCollector):
         if self._reimport_hook is not None:
             try:
                 ModuleWatchdog.unregister_module_hook(self.MODULE.__name__, self._reimport_hook)
-            except Exception:
+            except Exception:  # nosec B110
                 pass
             self._reimport_hook = None
 

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -553,6 +553,9 @@ class LockCollector(collector.CaptureSamplerCollector):
                 self.MODULE.__name__,
                 self.PATCHED_LOCK_NAME,
             )
+
+            # preserve for unpatch()
+            self._original_lock = original_lock._original_class
             return
         self._original_lock = original_lock
 

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -4,7 +4,6 @@
 # would cause Cython compilation errors since they aren't valid C types.
 
 import _thread
-import logging
 import os.path
 import sys
 import time
@@ -26,10 +25,14 @@ from ddtrace.trace import Tracer
 
 from ddtrace.profiling._threading import get_thread_name, get_thread_native_id
 from ddtrace.profiling.collector._sampler cimport CaptureSampler
-from ddtrace.profiling.collector._task cimport get_task as _c_get_task, initialize_gevent_support as _c_initialize_gevent_support
+from ddtrace.profiling.collector._task cimport (
+    get_task as _c_get_task,
+    initialize_gevent_support as _c_initialize_gevent_support,
+)
+from ddtrace.internal.logger import get_logger
 
 
-LOG = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 ACQUIRE_RELEASE_CO_NAMES: frozenset[str] = frozenset(["_acquire", "_release"])
@@ -119,7 +122,7 @@ class _ProfiledLock:
         # and should not generate profile samples to avoid double-counting
         self.is_internal: bool = is_internal
 
-    # gevent compatibility — gevent's _patch_existing_locks() calls
+    # gevent compatibility — gevent's _patch_existing_locks calls
     # type(threading.RLock()) to determine the RLock type, then scans gc.get_objects()
     # for instances of that type. When our wrapper is on threading.RLock, the type is
     # _ProfiledLock, so ALL profiled lock instances match. gevent then checks each for
@@ -510,11 +513,13 @@ class LockCollector(collector.CaptureSamplerCollector):
             nonlocal patched_module_id
             if id(new_module) == patched_module_id:
                 return
-            LOG.warning(
-                "%s: target module %r was re-imported (id %#x -> %#x); "
-                "re-applying lock profiling patches. "
-                "This typically happens when gevent is installed and cleanup_loaded_modules() "
-                "discards the previously-patched module from sys.modules.",
+            log.warning(
+                (
+                    "%s: target module %r was re-imported (id %#x -> %#x); "
+                    "re-applying lock profiling patches. "
+                    "This typically happens when gevent is installed and cleanup_loaded_modules() "
+                    "discards the previously-patched module from sys.modules."
+                ),
                 type(self).__name__,
                 module_name,
                 patched_module_id,
@@ -535,17 +540,14 @@ class LockCollector(collector.CaptureSamplerCollector):
         super(LockCollector, self)._stop_service()  # type: ignore[safe-super]
         self.unpatch()
         if self._reimport_hook is not None:
-            try:
-                ModuleWatchdog.unregister_module_hook(self.MODULE.__name__, self._reimport_hook)
-            except Exception:  # nosec B110
-                pass
+            ModuleWatchdog.unregister_module_hook(self.MODULE.__name__, self._reimport_hook)
             self._reimport_hook = None
 
     def patch(self) -> None:
         """Patch the module for tracking lock allocation."""
         original_lock: Callable[..., Any] = self._get_patch_target()
         if isinstance(original_lock, _LockAllocatorWrapper):
-            LOG.debug(
+            log.debug(
                 "%s: %s.%s is already patched, skipping to avoid double-wrapping.",
                 type(self).__name__,
                 self.MODULE.__name__,

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -489,6 +489,7 @@ class LockCollector(collector.CaptureSamplerCollector):
             nonlocal patched_module_id
             if id(new_module) == patched_module_id:
                 return
+            self.unpatch()
             self.MODULE = new_module
             self.patch()
             patched_module_id = id(new_module)
@@ -512,6 +513,8 @@ class LockCollector(collector.CaptureSamplerCollector):
     def patch(self) -> None:
         """Patch the module for tracking lock allocation."""
         original_lock: Callable[..., Any] = self._get_patch_target()
+        if isinstance(original_lock, _LockAllocatorWrapper):
+            return
         self._original_lock = original_lock
 
         # Determine which module file to check for internal lock detection

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -220,8 +220,10 @@ class _ProfilerInstance(service.Service):
         if self._lock_collector_enabled:
             # These collectors require the import of modules, so we create them
             # if their import is detected at runtime.
-            def start_collector(collector_class: type[collector.Collector]) -> None:
+            def start_lock_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
+                    if any(type(c) is collector_class for c in self._collectors):
+                        return
                     col = collector_class(tracer=self.tracer)
 
                     if self.status == service.ServiceStatus.RUNNING:
@@ -255,8 +257,10 @@ class _ProfilerInstance(service.Service):
 
         if self._pytorch_collector_enabled:
 
-            def start_collector(collector_class: type[collector.Collector]) -> None:
+            def start_pytorch_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
+                    if any(type(c) is collector_class for c in self._collectors):
+                        return
                     col = collector_class()
 
                     if self.status == service.ServiceStatus.RUNNING:
@@ -273,17 +277,16 @@ class _ProfilerInstance(service.Service):
 
                     self._collectors.append(col)
 
+            if self._collectors_on_import is None:
+                self._collectors_on_import = []
+
             torch_hooks: list[tuple[str, Callable[[Any], None]]] = [
-                ("torch", lambda _: start_collector(pytorch.TorchProfilerCollector)),
+                ("torch", lambda _: start_pytorch_collector(pytorch.TorchProfilerCollector)),
             ]
+            self._collectors_on_import.extend(torch_hooks)
 
             for module, hook in torch_hooks:
                 ModuleWatchdog.register_module_hook(module, hook)
-
-            if self._collectors_on_import is None:
-                self._collectors_on_import = torch_hooks
-            else:
-                self._collectors_on_import = self._collectors_on_import + torch_hooks
 
         if self._memory_collector_enabled:
             self._collectors.append(memalloc.MemoryCollector())
@@ -346,8 +349,9 @@ class _ProfilerInstance(service.Service):
             for module, hook in self._collectors_on_import:
                 try:
                     ModuleWatchdog.unregister_module_hook(module, hook)
-                except ValueError:
+                except (ValueError, Exception):
                     pass
+            self._collectors_on_import = None
 
         if self._scheduler is not None:
             self._scheduler.stop()

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -220,7 +220,7 @@ class _ProfilerInstance(service.Service):
         if self._lock_collector_enabled:
             # These collectors require the import of modules, so we create them
             # if their import is detected at runtime.
-            def start_lock_collector(collector_class: type[collector.Collector]) -> None:
+            def start_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
                     if any(type(c) is collector_class for c in self._collectors):
                         return
@@ -257,7 +257,7 @@ class _ProfilerInstance(service.Service):
 
         if self._pytorch_collector_enabled:
 
-            def start_pytorch_collector(collector_class: type[collector.Collector]) -> None:
+            def start_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
                     if any(type(c) is collector_class for c in self._collectors):
                         return
@@ -281,7 +281,7 @@ class _ProfilerInstance(service.Service):
                 self._collectors_on_import = []
 
             torch_hooks: list[tuple[str, Callable[[Any], None]]] = [
-                ("torch", lambda _: start_pytorch_collector(pytorch.TorchProfilerCollector)),
+                ("torch", lambda _: start_collector(pytorch.TorchProfilerCollector)),
             ]
             self._collectors_on_import.extend(torch_hooks)
 
@@ -347,10 +347,7 @@ class _ProfilerInstance(service.Service):
         # Prevent doing more initialisation now that we are shutting down.
         if self._collectors_on_import:
             for module, hook in self._collectors_on_import:
-                try:
-                    ModuleWatchdog.unregister_module_hook(module, hook)
-                except (ValueError, Exception):
-                    pass
+                ModuleWatchdog.unregister_module_hook(module, hook)
             self._collectors_on_import = None
 
         if self._scheduler is not None:

--- a/releasenotes/notes/fix-lock-profiler-module-cloning-4c524e7d7d5c5967.yaml
+++ b/releasenotes/notes/fix-lock-profiler-module-cloning-4c524e7d7d5c5967.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    profiling: Fixes an issue where the lock profiler silently stopped capturing
+    lock events when running under ``ddtrace-run`` with gevent installed. The
+    module cloning mechanism discarded the patched ``threading`` and ``asyncio``
+    modules, causing user code to import fresh, unpatched modules. The lock
+    profiler now re-applies patches automatically when target modules are
+    re-imported.

--- a/releasenotes/notes/fix-lock-profiler-module-cloning-4c524e7d7d5c5967.yaml
+++ b/releasenotes/notes/fix-lock-profiler-module-cloning-4c524e7d7d5c5967.yaml
@@ -2,8 +2,4 @@
 fixes:
   - |
     profiling: Fixes an issue where the lock profiler silently stopped capturing
-    lock events when running under ``ddtrace-run`` with gevent installed. The
-    module cloning mechanism discarded the patched ``threading`` and ``asyncio``
-    modules, causing user code to import fresh, unpatched modules. The lock
-    profiler now re-applies patches automatically when target modules are
-    re-imported.
+    lock events when running under ``ddtrace-run`` with `gevent` installed.

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -193,6 +193,99 @@ def test_patch():
     assert collector._original_lock == threading.Lock
 
 
+def test_lock_patching_survives_module_reimport():
+    """Test that lock patches are re-applied when threading is re-imported.
+
+    This simulates what cleanup_loaded_modules() does when gevent is installed:
+    it removes 'threading' from sys.modules, causing the next import to load a
+    fresh, unpatched module. Without the fix, user code would get native locks.
+    """
+    import importlib
+
+    collector = ThreadingLockCollector()
+    collector.start()
+
+    # Verify patching works on the current module
+    assert isinstance(threading.Lock, LockAllocatorWrapper)
+
+    # Simulate cleanup_loaded_modules(): remove threading from sys.modules
+    old_threading = sys.modules.pop("threading")
+    try:
+        # Re-import threading — this is what user code does after cloning
+        new_threading = importlib.import_module("threading")
+        assert new_threading is not old_threading, "Should be a different module object"
+
+        # The fix: patches should have been re-applied to the new module
+        assert isinstance(new_threading.Lock, LockAllocatorWrapper), (
+            "Lock on re-imported threading module should be patched. "
+            "This fails without the ModuleWatchdog re-import hook fix."
+        )
+
+        # User-created locks from the new module should be profiled
+        lock = new_threading.Lock()
+        assert isinstance(lock, _ProfiledLock), "Locks created from re-imported threading should be profiled"
+    finally:
+        # Restore original module to not break other tests
+        sys.modules["threading"] = old_threading
+        collector.stop()
+
+
+def test_lock_unpatch_after_module_reimport():
+    """Test that stop/unpatch works correctly after module has been swapped."""
+    import importlib
+
+    collector = ThreadingLockCollector()
+    collector.start()
+    assert isinstance(threading.Lock, LockAllocatorWrapper)
+
+    # Simulate module swap
+    old_threading = sys.modules.pop("threading")
+    try:
+        new_threading = importlib.import_module("threading")
+        assert isinstance(new_threading.Lock, LockAllocatorWrapper)
+
+        # Stop should unpatch the current (new) module
+        collector.stop()
+        assert not isinstance(new_threading.Lock, LockAllocatorWrapper), (
+            "After stop, the new threading module should be unpatched"
+        )
+    finally:
+        sys.modules["threading"] = old_threading
+
+
+@pytest.mark.parametrize(
+    "collector_class,lock_name",
+    [
+        (ThreadingLockCollector, "Lock"),
+        (ThreadingRLockCollector, "RLock"),
+        (ThreadingSemaphoreCollector, "Semaphore"),
+        (ThreadingBoundedSemaphoreCollector, "BoundedSemaphore"),
+        (ThreadingConditionCollector, "Condition"),
+    ],
+)
+def test_all_threading_collectors_survive_module_reimport(
+    collector_class: CollectorTypeClass,
+    lock_name: str,
+) -> None:
+    """Test that all threading lock collector types re-patch after module re-import."""
+    import importlib
+
+    collector_inst = collector_class()
+    collector_inst.start()
+
+    assert isinstance(getattr(threading, lock_name), LockAllocatorWrapper)
+
+    old_threading = sys.modules.pop("threading")
+    try:
+        new_threading = importlib.import_module("threading")
+        assert isinstance(getattr(new_threading, lock_name), LockAllocatorWrapper), (
+            f"{collector_class.__name__} should re-patch {lock_name} on the re-imported module"
+        )
+    finally:
+        sys.modules["threading"] = old_threading
+        collector_inst.stop()
+
+
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="only works on linux")
 @pytest.mark.subprocess(err=None)
 # For macOS: Could print 'Error uploading' but okay to ignore since we are checking if native_id is set

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -193,6 +193,9 @@ def test_patch():
     assert collector._original_lock == threading.Lock
 
 
+# Run in a subprocess: pops threading from sys.modules to simulate gevent's
+# cleanup_loaded_modules(), which would corrupt ModuleWatchdog state in-process.
+@pytest.mark.subprocess()
 def test_lock_patching_survives_module_reimport():
     """Test that lock patches are re-applied when threading is re-imported.
 
@@ -201,56 +204,63 @@ def test_lock_patching_survives_module_reimport():
     fresh, unpatched module. Without the fix, user code would get native locks.
     """
     import importlib
+    import sys
+    import threading
+
+    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
     collector = ThreadingLockCollector()
     collector.start()
 
-    # Verify patching works on the current module
     assert isinstance(threading.Lock, LockAllocatorWrapper)
 
     # Simulate cleanup_loaded_modules(): remove threading from sys.modules
     old_threading = sys.modules.pop("threading")
-    try:
-        # Re-import threading — this is what user code does after cloning
-        new_threading = importlib.import_module("threading")
-        assert new_threading is not old_threading, "Should be a different module object"
+    # Re-import threading — this is what user code does after cloning
+    new_threading = importlib.import_module("threading")
+    assert new_threading is not old_threading, "Should be a different module object"
 
-        # The fix: patches should have been re-applied to the new module
-        assert isinstance(new_threading.Lock, LockAllocatorWrapper), (
-            "Lock on re-imported threading module should be patched. "
-            "This fails without the ModuleWatchdog re-import hook fix."
-        )
+    # The fix: patches should have been re-applied to the new module
+    assert isinstance(new_threading.Lock, LockAllocatorWrapper), (
+        "Lock on re-imported threading module should be patched. "
+        "This fails without the ModuleWatchdog re-import hook fix."
+    )
 
-        # User-created locks from the new module should be profiled
-        lock = new_threading.Lock()
-        assert isinstance(lock, _ProfiledLock), "Locks created from re-imported threading should be profiled"
-    finally:
-        # Restore original module to not break other tests
-        sys.modules["threading"] = old_threading
-        collector.stop()
+    # User-created locks from the new module should be profiled
+    lock = new_threading.Lock()
+    assert isinstance(lock, _ProfiledLock), "Locks created from re-imported threading should be profiled"
+
+    collector.stop()
 
 
+# Run in a subprocess: pops threading from sys.modules to simulate gevent's
+# cleanup_loaded_modules(), which would corrupt ModuleWatchdog state in-process.
+@pytest.mark.subprocess()
 def test_lock_unpatch_after_module_reimport():
     """Test that stop/unpatch works correctly after module has been swapped."""
     import importlib
+    import sys
+    import threading
+
+    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
     collector = ThreadingLockCollector()
     collector.start()
     assert isinstance(threading.Lock, LockAllocatorWrapper)
 
     # Simulate module swap
-    old_threading = sys.modules.pop("threading")
-    try:
-        new_threading = importlib.import_module("threading")
-        assert isinstance(new_threading.Lock, LockAllocatorWrapper)
+    sys.modules.pop("threading")
+    new_threading = importlib.import_module("threading")
+    assert isinstance(new_threading.Lock, LockAllocatorWrapper)
 
-        # Stop should unpatch the current (new) module
-        collector.stop()
-        assert not isinstance(new_threading.Lock, LockAllocatorWrapper), (
-            "After stop, the new threading module should be unpatched"
-        )
-    finally:
-        sys.modules["threading"] = old_threading
+    # Stop should unpatch the current (new) module
+    collector.stop()
+    assert not isinstance(new_threading.Lock, LockAllocatorWrapper), (
+        "After stop, the new threading module should be unpatched"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -195,7 +195,7 @@ def test_patch():
 
 # Run in a subprocess: pops threading from sys.modules to simulate gevent's
 # cleanup_loaded_modules(), which would corrupt ModuleWatchdog state in-process.
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(err=b"re-applying lock profiling patches")
 def test_lock_patching_survives_module_reimport():
     """Test that lock patches are re-applied when threading is re-imported.
 
@@ -237,7 +237,7 @@ def test_lock_patching_survives_module_reimport():
 
 # Run in a subprocess: pops threading from sys.modules to simulate gevent's
 # cleanup_loaded_modules(), which would corrupt ModuleWatchdog state in-process.
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(err=b"re-applying lock profiling patches")
 def test_lock_unpatch_after_module_reimport():
     """Test that stop/unpatch works correctly after module has been swapped."""
     import importlib

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -195,7 +195,7 @@ def test_patch():
 
 # Run in a subprocess: pops threading from sys.modules to simulate gevent's
 # cleanup_loaded_modules(), which would corrupt ModuleWatchdog state in-process.
-@pytest.mark.subprocess(err=b"re-applying lock profiling patches")
+@pytest.mark.subprocess(err=lambda s: "re-applying lock profiling patches" in s)
 def test_lock_patching_survives_module_reimport():
     """Test that lock patches are re-applied when threading is re-imported.
 
@@ -237,7 +237,7 @@ def test_lock_patching_survives_module_reimport():
 
 # Run in a subprocess: pops threading from sys.modules to simulate gevent's
 # cleanup_loaded_modules(), which would corrupt ModuleWatchdog state in-process.
-@pytest.mark.subprocess(err=b"re-applying lock profiling patches")
+@pytest.mark.subprocess(err=lambda s: "re-applying lock profiling patches" in s)
 def test_lock_unpatch_after_module_reimport():
     """Test that stop/unpatch works correctly after module has been swapped."""
     import importlib

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -207,7 +207,7 @@ def test_lock_patching_survives_module_reimport():
     import sys
     import threading
 
-    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
     from ddtrace.profiling.collector._lock import _ProfiledLock
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
@@ -244,7 +244,7 @@ def test_lock_unpatch_after_module_reimport():
     import sys
     import threading
 
-    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
     collector = ThreadingLockCollector()


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/16922) | [Next PR >](https://github.com/DataDog/dd-trace-py/pull/17902)

## Summary

Fix a bug where the lock profiler is silently non-functional under `ddtrace-run` when gevent is installed.

`cleanup_loaded_modules()` removes `threading` (and `asyncio`) from `sys.modules` **after** the lock profiler has already patched them. When user code later does `import threading`, Python loads a fresh, unpatched module — so `threading.Lock()` returns a native lock, not a profiled one. The collector's `MODULE` class attribute still points to the old (discarded) module object, so `ThreadingLockCollector.status == RUNNING` but the patching has no effect on user code.

**Trigger condition:** gevent is *installed* (not necessarily used). This affects any deployment using `gunicorn[gevent]`, which is extremely common, even if the app runs with gthread workers or uvicorn.

### Verified broken vs fixed (manual comparison)
#### main branch
* [URL](https://app.datadoghq.com/profiling/explorer?query=service%3Alock-demo%20env%3Averify-main&fromUser=true&my_code=enabled&profile_type=wall-time&profiling-timeline__stack_order=top-down&profiling-timeline__summary_tab=breakdown&profiling-timeline__tb=1773413357015000000&profiling-timeline__tf_f_0=0&profiling-timeline__tf_f_1=35225000000&profiling-timeline__tf_us_0=0&profiling-timeline__tf_us_1=35225000000&refresh_mode=paused&viz=flame_graph&from_ts=1773345336340&to_ts=1773431736340&live=false)

_**No lock samples captured**_
<img width="1530" height="870" alt="Screenshot 2026-03-13 at 3 56 29 PM" src="https://github.com/user-attachments/assets/b33b6864-c785-4198-aa7a-092343453453" />

**_No lock names_**
<img width="1560" height="835" alt="Screenshot 2026-03-13 at 3 59 36 PM" src="https://github.com/user-attachments/assets/e780a95a-bba9-4ecc-9bd7-0d94541dc835" />


#### THIS branch
* [URL](https://app.datadoghq.com/profiling/explorer?query=service%3Alock-demo%20env%3Averify-vlad_lockprof-fix-threading-mod-cloning-bug&fromUser=true&my_code=enabled&overview_facet=log_prof_python_lock_hold_time&profile_type=lock-acquire-time&profiling-timeline__stack_order=top-down&profiling-timeline__summary_tab=breakdown&profiling-timeline__tb=1773413394235000000&profiling-timeline__tf_f_0=0&profiling-timeline__tf_f_1=35235000000&profiling-timeline__tf_us_0=0&profiling-timeline__tf_us_1=35235000000&refresh_mode=paused&viz=flame_graph&from_ts=1773327155183&to_ts=1773413555183&live=false)

_**lock samples CAPTURED**_
<img width="1570" height="846" alt="Screenshot 2026-03-13 at 3 57 19 PM" src="https://github.com/user-attachments/assets/289b3c7b-2a19-49aa-bec5-2a0df5839b20" />

**_Lock names SHOWING_**
<img width="1393" height="310" alt="Screenshot 2026-03-13 at 3 57 32 PM" src="https://github.com/user-attachments/assets/29c0a2b0-3ea8-4e72-8191-ef33c7704856" />

### Verified broken vs fixed (automated comparison)

A verification script (`scripts/verify_lock_profiler_bug.py`) demonstrates the bug end-to-end by running the same workload under `ddtrace-run` + gevent on both `main` and the fix branch:

```
  Check                          main (broken)             fix branch (working)
  ------------------------------ ------------------------- -------------------------
  threading.Lock type            builtin_function_or_method _LockAllocatorWrapper
  threading.Lock() type          lock                      _ProfiledThreadingLock
  Lock patched?                  NO (FAIL)                 yes (PASS)
  Instance profiled?             NO (FAIL)                 yes (PASS)
  Collectors active              14 (duplicates!)           9 (correct)
  Lock ops / 2s                  3,098,468                 1,544,406
  VERDICT                        FAIL                      PASS
```

Key observations:
- **On `main`**: `threading.Lock` is a native builtin — profiler patches were lost after cloning. 14 collectors are "running" but patching a stale, discarded module. User locks are completely invisible.
- **On fix branch**: `threading.Lock` is `_LockAllocatorWrapper` — the `ModuleWatchdog` hook re-applied patches after cloning. 9 collectors (correct, no duplicates). Lock operations are ~2x slower because profiling overhead is actually present (every acquire/release is captured).
- **3M vs 1.5M ops**: the ~2x throughput difference confirms the profiler is doing real work on the fix branch vs being a no-op on `main`.

### DoE benchmark results (independent confirmation)

| Condition | P50 Latency (lock=false) | P50 Latency (lock=true) | Overhead | p-value |
|---|---|---|---|---|
| Broken (cloning active) | 6.89ms | 6.80ms | **-1.2%** | 0.39 |
| Fixed (cloning disabled) | 6.37ms | 9.03ms | **+41.7%** | 0.0002 |

With `lock_ops=200`: overhead jumps to **+56.0%** (p < 0.0001). The negative overhead on main proves the profiler was doing nothing.

### Changes

- **`ddtrace/profiling/collector/_lock.py`**: `LockCollector` now registers a `ModuleWatchdog` hook on start that re-applies patches to the new module if the target module is re-imported (e.g., after `cleanup_loaded_modules()` discards it). The hook is unregistered on stop. Includes a defensive guard against double-wrapping. This fix applies to all 9 lock collector subclasses (5 threading + 4 asyncio) automatically.

- **`ddtrace/profiling/profiler.py`**: Two secondary bugs fixed:
  1. **Duplicate collector guard**: `ModuleWatchdog` hooks persist and fire on every re-import, causing duplicate collector instances to be created (14 collectors on `main` instead of 9). Added a type-based deduplication check.
  2. **`_collectors_on_import` overwrite**: When both lock and pytorch collectors are enabled, `_collectors_on_import` was overwritten (not extended), so only pytorch hooks were unregistered on stop. Fixed by initializing the list early and using `extend()`.

### Reproduction

```bash
# Automated comparison (checks out main, runs, checks out fix, runs, compares):
.venv/bin/python scripts/verify_lock_profiler_bug.py

# Or manually — with gevent installed:
DD_PROFILING_LOCK_ENABLED=true ddtrace-run python3 -c "
import threading
print(type(threading.Lock()))
# Before fix: <class '_thread.lock'>
# After fix:  <class 'ddtrace.profiling.collector.threading._ProfiledThreadingLock'>
"
```

### Impact

- All lock profiling under `ddtrace-run` with gevent installed was silently broken
- Affects both threading and asyncio lock collectors (all 9 collector types)
- No error or warning was emitted — the profiler appeared to be running normally
- Any deployment with `gunicorn[gevent]` installed (even if not using gevent workers) was affected
- Users saw zero lock contention data or only noise from ddtrace-internal locks

## Test Plan
### New unit test
* fails on `main`
```
 $ DD_PROFILE_TEST_GEVENT=1 pytest tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent
...
E           AssertionError: Expected status 0, got 1.
E           === Captured STDOUT ===
E           === End of captured STDOUT ===
E           === Captured STDERR ===
E           Failed to start product 'remote-configuration'
E           Traceback (most recent call last):
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/products.py", line 132, in start_products
E               product.start()
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/remoteconfig/products/client.py", line 47, in start
E               _register_rc_products()
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/remoteconfig/products/client.py", line 15, in _register_rc_products
E               from ddtrace.internal.flare._subscribers import TracerFlareCallback
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/module.py", line 313, in _exec_module
E               self.loader.exec_module(module)
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/flare/_subscribers.py", line 6, in <module>
E               from ddtrace.internal.flare.flare import Flare
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/module.py", line 313, in _exec_module
E               self.loader.exec_module(module)
E             File "/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/flare/flare.py", line 15, in <module>
E               from ddtrace.internal.native._native import native_flare
E           ImportError: cannot import name 'native_flare' from 'ddtrace.internal.native._native' (/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/ddtrace/internal/native/_native.cpython-310-darwin.so)
E           Product 'apm-tracing-rc' won't start because these dependencies failed to start: {'remote-configuration'}
E           Traceback (most recent call last):
E             File "tests/profiling/collector/test_threading.py", line 448, in <module>
E               assert isinstance(threading.Lock, _LockAllocatorWrapper), (
E           AssertionError: threading.Lock should be _LockAllocatorWrapper but is builtin_function_or_method. This means the lock profiler patches were lost after module cloning.
E           Error uploading (ddog_prof_Exporter_send_blocking failed: Failed to send HTTP request: error sending request for url (http://localhost:8126/profiling/v1/input): client error (SendRequest): connection closed before message completed)
E           === End of captured STDERR ===

tests/conftest.py:446: AssertionError
====================================================================== warnings summary ======================================================================
.venv/lib/python3.10/site-packages/_pytest/config/__init__.py:1474
  /Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------- generated xml file: /Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/test-results/junit.xml ---------------------------
==================================================================== slowest 10 durations ====================================================================
0.79s call     tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent
0.01s setup    tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent

(1 durations < 0.005s hidden.  Use -vv to show these durations.)
================================================================== short test summary info ===================================================================
FAILED tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent - AssertionError: Expected status 0, got 1.
================================================================ 1 failed, 1 warning in 1.13s ================================================================
```

* passes on branch
```
 $ DD_PROFILE_TEST_GEVENT=1 pytest tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent
...
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.10.13, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py
configfile: setup.cfg
plugins: hypothesis-6.151.4, ddtrace-4.6.0rc2, cov-7.0.0
collected 1 item                                                                                                                                             

tests/profiling/collector/test_threading.py .                                                                                                          [100%]

====================================================================== warnings summary ======================================================================
.venv/lib/python3.10/site-packages/_pytest/config/__init__.py:1474
  /Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------- generated xml file: /Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py/test-results/junit.xml ---------------------------
==================================================================== slowest 10 durations ====================================================================
0.68s call     tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent
0.01s setup    tests/profiling/collector/test_threading.py::test_lock_profiler_works_under_ddtrace_run_with_gevent

(1 durations < 0.005s hidden.  Use -vv to show these durations.)
================================================================ 1 passed, 1 warning in 1.01s ================================================================
```


- [x] New test `test_lock_patching_survives_module_reimport` — simulates module cloning and verifies patches are re-applied to the new module
- [x] New test `test_lock_unpatch_after_module_reimport` — verifies stop/unpatch works correctly after module swap
- [x] New test `test_all_threading_collectors_survive_module_reimport` — parametrized test for all 5 threading collector types
- [x] Verification script confirms FAIL on `main`, PASS on fix branch
- [x] Existing lock profiler test suite passes with no regressions
