### PR TITLE
chore(aap): enforce type signatures for appsec functions

### DIFF
--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -3,6 +3,8 @@ import collections
 import gzip
 import json
 import time
+from typing import Any
+from typing import Callable
 from typing import Optional
 from typing import Union
 
@@ -37,21 +39,21 @@ class TooLargeSchemaException(Exception):
     pass
 
 
-def path_param_transform(v):
+def path_param_transform(v: Any) -> Union[dict, list]:
     if isinstance(v, (list, tuple)):
         return list(v)
     return dict(v)
 
 
 class APIManager(Service):
-    BLOCK_COLLECTED = [
+    BLOCK_COLLECTED: list[tuple[str, str, Optional[Callable[[Any], Any]]]] = [
         ("REQUEST_HEADERS_NO_COOKIES", API_SECURITY.REQUEST_HEADERS_NO_COOKIES, dict),
         ("REQUEST_COOKIES", API_SECURITY.REQUEST_COOKIES, dict),
         ("REQUEST_QUERY", API_SECURITY.REQUEST_QUERY, dict),
         ("REQUEST_PATH_PARAMS", API_SECURITY.REQUEST_PATH_PARAMS, path_param_transform),
         ("REQUEST_BODY", API_SECURITY.REQUEST_BODY, None),
     ]
-    COLLECTED = BLOCK_COLLECTED + [
+    COLLECTED: list[tuple[str, str, Optional[Callable[[Any], Any]]]] = BLOCK_COLLECTED + [
         ("RESPONSE_HEADERS_NO_COOKIES", API_SECURITY.RESPONSE_HEADERS_NO_COOKIES, dict),
         ("RESPONSE_BODY", API_SECURITY.RESPONSE_BODY, lambda f: f() if callable(f) else f),
     ]

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 import json
 import re
 from types import TracebackType
@@ -175,7 +176,7 @@ class DownstreamRequests:
     sampling_rate: int = int(asm_config._dr_sample_rate * UINT64_MAX)
 
 
-def should_analyze_body_response(env) -> bool:
+def should_analyze_body_response(env: ASM_Environment) -> bool:
     """Check if we should analyze body for API10."""
     DownstreamRequests.counter += 1
     return (
@@ -191,7 +192,7 @@ def get_framework() -> str:
     return env.framework
 
 
-def _use_html(headers) -> bool:
+def _use_html(headers: Mapping) -> bool:
     """decide if the response should be html or json.
 
     Add support for quality values in the Accept header.
@@ -219,8 +220,11 @@ def _use_html(headers) -> bool:
     return html_score > json_score
 
 
-def _ctype_from_headers(block_config, headers) -> None:
+def _ctype_from_headers(block_config: Block_config) -> None:
     """compute MIME type of the blocked response and store it in the block config"""
+    headers = get_headers()
+    if headers is None:
+        return
     if (block_config.type == "auto" and _use_html(headers)) or block_config.type == "html":
         block_config.content_type = "text/html"
 
@@ -230,7 +234,7 @@ def set_blocked(blocked: Block_config) -> None:
     if env is None:
         logger.warning(WARNING_TAGS.SET_BLOCKED_NO_ASM_CONTEXT, extra=log_extra, stack_info=True)
         return
-    _ctype_from_headers(blocked, get_headers())
+    _ctype_from_headers(blocked)
     env.blocked = blocked
 
 
@@ -354,7 +358,7 @@ def set_headers_response(headers: Any) -> None:
         set_waf_address(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES, headers)
 
 
-def set_body_response(body_response):
+def set_body_response(body_response: Any) -> None:
     # local import to avoid circular import
     from ddtrace.appsec._utils import parse_response_body
 
@@ -399,13 +403,13 @@ def get_waf_address(address: str, default: Any = None) -> Any:
     return get_value(_WAF_ADDRESSES, address, default=default)
 
 
-def add_context_callback(function, global_callback: bool = False) -> None:
+def add_context_callback(function: Callable[[ASM_Environment], Any], global_callback: bool = False) -> None:
     if global_callback:
         callbacks = GLOBAL_CALLBACKS.setdefault(_CONTEXT_CALL, [])
         callbacks.append(function)
 
 
-def remove_context_callback(function, global_callback: bool = False) -> None:
+def remove_context_callback(function: Callable[[ASM_Environment], Any], global_callback: bool = False) -> None:
     if global_callback:
         callbacks = GLOBAL_CALLBACKS.get(_CONTEXT_CALL)
         if callbacks:
@@ -461,12 +465,12 @@ def get_ip() -> Optional[str]:
 # early point set_headers is usually called
 
 
-def set_headers(headers: Any) -> None:
+def set_headers(headers: Mapping) -> None:
     if headers is not None:
         set_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, headers)
 
 
-def get_headers() -> Optional[Any]:
+def get_headers() -> Optional[Mapping]:
     return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, {})
 
 
@@ -478,7 +482,7 @@ def get_headers_case_sensitive() -> bool:
     return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES_CASE, False)  # type : ignore
 
 
-def set_block_request_callable(_callable: Optional[Callable], *_) -> None:
+def set_block_request_callable(_callable: Optional[Callable[[], Any]], *_: Any) -> None:
     """
     Sets a callable that could be use to do a best-effort to block the request. If
     the callable need any params, like headers, they should be curried with
@@ -575,7 +579,7 @@ def get_waf_telemetry_results() -> Optional[Telemetry_result]:
     return None
 
 
-def store_waf_results_data(data) -> None:
+def store_waf_results_data(data: list[dict[str, Any]]) -> None:
     if not data:
         return
     env = _get_asm_context()
@@ -606,19 +610,22 @@ def start_context(waf_callable: Optional[WafCallable], span: Span, rc_products: 
         )
 
 
-def end_context(span: Span):
+def end_context(span: Span) -> None:
     env = _get_asm_context()
     if env is not None and env.span is span:
         finalize_asm_env(env)
 
 
-def _on_context_ended(ctx, _exc_info: tuple[Optional[type], Optional[BaseException], Optional[TracebackType]]):
+def _on_context_ended(
+    ctx: Any,
+    _exc_info: tuple[Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]],
+) -> None:
     env = ctx.get_item(_ASM_CONTEXT)
     if env is not None:
         finalize_asm_env(env)
 
 
-def _set_headers_and_response(response, headers, *_):
+def _set_headers_and_response(response: Any, headers: Any, *_: Any) -> None:
     if not asm_config._asm_enabled:
         return
 
@@ -634,7 +641,7 @@ def _set_headers_and_response(response, headers, *_):
             set_body_response(response)
 
 
-def _call_waf_first(integration, *_) -> None:
+def _call_waf_first(integration: Any, *_: Any) -> None:
     if not asm_config._asm_enabled:
         return
     info = f"{integration}::srb_on_request"
@@ -642,7 +649,7 @@ def _call_waf_first(integration, *_) -> None:
     call_waf_callback()
 
 
-def _call_waf(integration, *_) -> None:
+def _call_waf(integration: Any, *_: Any) -> None:
     if not asm_config._asm_enabled:
         return
     info = f"{integration}::srb_on_response"
@@ -650,9 +657,10 @@ def _call_waf(integration, *_) -> None:
     call_waf_callback()
 
 
-def _get_headers_if_appsec():
+def _get_headers_if_appsec() -> Optional[Any]:
     if asm_config._asm_enabled:
         return get_headers()
+    return None
 
 
 ## headers tags
@@ -710,6 +718,6 @@ def _set_headers(span: Span, headers: Any, kind: str, only_asm_enabled: bool = F
             span.set_tag(_normalize_tag_name(kind, key), value)
 
 
-def asm_listen():
+def asm_listen() -> None:
     core.on("asm.set_blocked", set_blocked_dict)
     core.on("asm.get_blocked", get_blocked, "block_config")

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -6,6 +6,7 @@ import os
 from re import Match
 import sys
 from typing import Any
+from typing import Generator
 from typing import Iterator
 from typing import Literal  # noqa:F401
 
@@ -39,7 +40,7 @@ class Constant_Class(type):
         raise TypeError("Constant class does not support item assignment: %s.%s" % (self.__name__, __name))
 
     def __iter__(self) -> Iterator[tuple[str, Any]]:
-        def aux():
+        def aux() -> Generator[tuple[str, Any], Any, None]:
             for t in self.__dict__.items():
                 if not t[0].startswith("_"):
                     yield t

--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
 import ctypes
@@ -209,7 +210,7 @@ class ddwaf_object(ctypes.Structure):
         log.debug("ddwaf_object struct: unknown object type: %s", repr(type(self.type)))
         return None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.struct)
 
 
@@ -273,7 +274,7 @@ class ddwaf_config(ctypes.Structure):
         max_string_length: int = 0,
         key_regex: bytes = b"",
         value_regex: bytes = b"",
-        free_fn=ddwaf_object_free,
+        free_fn: Callable[[ddwaf_object], None] = ddwaf_object_free,
     ) -> None:
         self.limits.max_container_size = max_container_size
         self.limits.max_container_depth = max_container_depth
@@ -311,7 +312,7 @@ ddwaf_init = ctypes.CFUNCTYPE(ddwaf_handle, ddwaf_object_p, ddwaf_config_p, ddwa
 )
 
 
-def py_ddwaf_init(ruleset_map: ddwaf_object, config, info) -> ddwaf_handle_capsule:
+def py_ddwaf_init(ruleset_map: ddwaf_object, config: ddwaf_config, info: ddwaf_object) -> ddwaf_handle_capsule:
     return ddwaf_handle_capsule(ddwaf_init(ruleset_map, config, info), ddwaf_destroy)
 
 

--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -46,8 +46,8 @@ class DDWaf(WAF):
         ruleset_json_str: bytes,
         obfuscation_parameter_key_regexp: bytes,
         obfuscation_parameter_value_regexp: bytes,
-        metrics,
-    ):
+        metrics: Any,
+    ) -> None:
         # avoid circular import
 
         self.report_error = metrics._set_waf_error_log
@@ -207,7 +207,7 @@ class DDWaf(WAF):
     def initialized(self) -> bool:
         return bool(self._handle)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, "_default_ruleset"):
             ddwaf_object_free(self._default_ruleset)
 

--- a/ddtrace/appsec/_ddwaf/waf_stubs.py
+++ b/ddtrace/appsec/_ddwaf/waf_stubs.py
@@ -27,10 +27,10 @@ DDWafRulesType = Union[None, int, str, list[Any], dict[str, Any]]
 
 class ddwaf_handle_capsule(Generic[T]):
     def __init__(self, handle: type[T], free_fn: Callable[[type[T]], None]) -> None:
-        self.handle = handle
+        self.handle: Optional[type[T]] = handle
         self.free_fn = free_fn
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.handle:
             try:
                 self.free_fn(self.handle)
@@ -38,13 +38,13 @@ class ddwaf_handle_capsule(Generic[T]):
                 LOGGER.debug("Failed to free handle", exc_info=True)
             self.handle = None
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.handle)
 
 
 class ddwaf_context_capsule(Generic[T]):
     def __init__(self, ctx: type[T], free_fn: Callable[[type[T]], None]) -> None:
-        self.ctx = ctx
+        self.ctx: Optional[type[T]] = ctx
         self.free_fn = free_fn
         self.rc_products: str = ""
         # AIDEV-NOTE: This lock serializes concurrent ddwaf_run calls on the same context.
@@ -54,7 +54,7 @@ class ddwaf_context_capsule(Generic[T]):
         # is not thread-safe for concurrent runs, so we must serialize them here.
         self._lock: threading_Lock = threading_Lock()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.ctx:
             try:
                 self.free_fn(self.ctx)
@@ -62,16 +62,16 @@ class ddwaf_context_capsule(Generic[T]):
                 LOGGER.debug("Failed to free context", exc_info=True)
             self.ctx = None
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.ctx)
 
 
 class ddwaf_builder_capsule(Generic[T]):
     def __init__(self, builder: type[T], free_fn: Callable[[type[T]], None]) -> None:
-        self.builder = builder
+        self.builder: Optional[type[T]] = builder
         self.free_fn = free_fn
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.builder:
             try:
                 self.free_fn(self.builder)
@@ -79,7 +79,7 @@ class ddwaf_builder_capsule(Generic[T]):
                 LOGGER.debug("Failed to free builder", exc_info=True)
             self.builder = None
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.builder)
 
 
@@ -120,8 +120,8 @@ class WAF(ABC):
         rules: bytes,
         obfuscation_parameter_key_regexp: bytes,
         obfuscation_parameter_value_regexp: bytes,
-        metrics,
-    ):
+        metrics: Any,
+    ) -> None:
         pass
 
     @property

--- a/ddtrace/appsec/_deduplications.py
+++ b/ddtrace/appsec/_deduplications.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 from time import monotonic
+from typing import Any
+from typing import Callable
 
 from ddtrace.internal.settings.asm import config as asm_config
 
@@ -11,27 +13,27 @@ class deduplication:
     _time_lapse = 3600  # 1 hour
     _max_cache_size = 256
 
-    def __init__(self, func) -> None:
+    def __init__(self, func: Callable[..., Any]) -> None:
         self.func = func
         self.reported_logs: OrderedDict[int, float] = OrderedDict()
 
-    def _extract(self, args):
+    def _extract(self, args: tuple[Any, ...]) -> tuple[Any, ...]:
         return args
 
     def get_last_time_reported(self, raw_log_hash: int) -> float:
         return self.reported_logs.get(raw_log_hash, 0.0)
 
-    def _reset_cache(self):
+    def _reset_cache(self) -> None:
         """
         Reset the cache of reported logs
         For testing purposes only
         """
         self.reported_logs.clear()
 
-    def _check_deduplication(self):
+    def _check_deduplication(self) -> bool:
         return asm_config._asm_deduplication_enabled
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         result = False
         if self._check_deduplication():
             raw_log_hash = hash("".join([str(arg) for arg in self._extract(args)]))

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -1,3 +1,9 @@
+from collections.abc import Mapping
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.internal import core
@@ -13,20 +19,20 @@ logger = get_logger(__name__)
 
 
 def _on_set_http_meta(
-    span,
-    request_ip,
-    raw_uri,
-    route,
-    method,
-    request_headers,
-    request_cookies,
-    parsed_query,
-    request_path_params,
-    request_body,
-    status_code,
-    response_headers,
-    response_cookies,
-):
+    span: Span,
+    request_ip: Optional[str],
+    raw_uri: Optional[str],
+    route: Optional[str],
+    method: Optional[str],
+    request_headers: Optional[Mapping[str, Optional[str]]],
+    request_cookies: Optional[dict[str, str]],
+    parsed_query: Optional[Mapping[str, Any]],
+    request_path_params: Optional[Mapping[str, Any]],
+    request_body: Any,
+    status_code: Optional[Union[int, str]],
+    response_headers: Optional[Mapping[str, Optional[str]]],
+    response_cookies: Optional[Mapping[str, str]],
+) -> None:
     if asm_config._asm_enabled and span.span_type in asm_config._asm_http_span_types:
         # avoid circular import
         from ddtrace.appsec._asm_request_context import set_waf_address
@@ -51,22 +57,18 @@ def _on_set_http_meta(
                 set_waf_address(k, v)
 
 
-def _on_telemetry_periodic():
+def _on_telemetry_periodic() -> None:
     try:
-        telemetry.telemetry_writer.add_configurations(
-            [
-                (
-                    APPSEC.ENV,
-                    int(asm_config._asm_enabled),
-                    asm_config.asm_enabled_origin,
-                )
-            ]
+        telemetry.telemetry_writer.add_configuration(
+            APPSEC.ENV,
+            int(asm_config._asm_enabled),
+            asm_config.asm_enabled_origin,
         )
     except Exception:
         logger.debug("Could not set appsec_enabled telemetry config status", exc_info=True)
 
 
-def listen():
+def listen() -> None:
     core.on("telemetry.periodic", _on_telemetry_periodic)
 
     core.on("set_http_meta_for_asm", _on_set_http_meta)

--- a/ddtrace/appsec/_listeners.py
+++ b/ddtrace/appsec/_listeners.py
@@ -58,7 +58,7 @@ def load_appsec() -> None:
             APIManager.enable()
 
 
-def load_common_appsec_modules():
+def load_common_appsec_modules() -> None:
     """Lazily load the common module patches."""
     from ddtrace.internal.settings.asm import config as asm_config
 

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -4,6 +4,7 @@ from ddtrace.appsec import _constants
 from ddtrace.appsec._deduplications import deduplication
 from ddtrace.appsec._utils import DDWaf_info
 from ddtrace.appsec._utils import Telemetry_result
+from ddtrace.appsec._utils import _observator
 from ddtrace.internal import telemetry
 import ddtrace.internal.logger as ddlogger
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
@@ -55,7 +56,7 @@ def _set_waf_error_log(msg: str, version: str, action: str, error_level: bool = 
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)
 
 
-def _set_waf_updates_metric(info: DDWaf_info, success: bool):
+def _set_waf_updates_metric(info: DDWaf_info, success: bool) -> None:
     try:
         tags: tuple[tuple[str, str], ...] = (
             ("event_rules_version", info.version or UNKNOWN_VERSION),
@@ -70,7 +71,7 @@ def _set_waf_updates_metric(info: DDWaf_info, success: bool):
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)
 
 
-def _set_waf_init_metric(info: DDWaf_info, success: bool):
+def _set_waf_init_metric(info: DDWaf_info, success: bool) -> None:
     try:
         tags: tuple[tuple[str, str], ...] = (
             ("event_rules_version", info.version or UNKNOWN_VERSION),
@@ -104,7 +105,7 @@ TAGS_CONTAINER_SIZE = (("truncation_reason", "2"),)
 TAGS_CONTAINER_DEPTH = (("truncation_reason", "4"),)
 
 
-def _report_waf_truncations(observator):
+def _report_waf_truncations(observator: _observator) -> None:
     try:
         bitfield = 0
         if observator.string_length is not None:
@@ -134,7 +135,7 @@ def _report_waf_truncations(observator):
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)
 
 
-def _report_waf_run_error(error: int, rule_version: str, rule_type: typing.Optional[str]):
+def _report_waf_run_error(error: int, rule_version: str, rule_type: typing.Optional[str]) -> None:
     """used for waf run errors"""
     try:
         if rule_type is None:

--- a/ddtrace/appsec/_patch_utils.py
+++ b/ddtrace/appsec/_patch_utils.py
@@ -1,6 +1,7 @@
 import ctypes
 from typing import Any
 from typing import Callable
+from typing import Optional
 
 from wrapt import FunctionWrapper
 from wrapt import resolve_path
@@ -14,7 +15,7 @@ log = get_logger(__name__)
 _DD_ORIGINAL_ATTRIBUTES: dict[Any, Any] = {}
 
 
-def try_unwrap(module, name):
+def try_unwrap(module: Any, name: str) -> None:
     try:
         (parent, attribute, _) = resolve_path(module, name)
         if (parent, attribute) in _DD_ORIGINAL_ATTRIBUTES:
@@ -25,16 +26,22 @@ def try_unwrap(module, name):
         log.debug("ERROR unwrapping %s.%s ", module, name)
 
 
-def try_wrap_function_wrapper(module_name: str, name: str, wrapper: Callable) -> None:
+def try_wrap_function_wrapper(module_name: str, name: str, wrapper: Callable[..., Any]) -> None:
     @ModuleWatchdog.after_module_imported(module_name)
-    def _(module):
+    def _(module: Any) -> None:
         try:
             wrap_object(module, name, FunctionWrapper, (wrapper,))
         except (ImportError, AttributeError):
             log.debug("Module %s.%s does not exist", module_name, name)
 
 
-def wrap_object(module, name, factory, args=(), kwargs=None):
+def wrap_object(
+    module: Any,
+    name: str,
+    factory: Callable[..., Any],
+    args: tuple[Any, ...] = (),
+    kwargs: Optional[dict[str, Any]] = None,
+) -> Any:
     if kwargs is None:
         kwargs = {}
     (parent, attribute, original) = resolve_path(module, name)
@@ -44,7 +51,7 @@ def wrap_object(module, name, factory, args=(), kwargs=None):
     return wrapper
 
 
-def apply_patch(parent, attribute, replacement):
+def apply_patch(parent: Any, attribute: str, replacement: Any) -> None:
     try:
         current_attribute = getattr(parent, attribute)
         # Avoid overwriting the original function if we call this twice
@@ -60,12 +67,12 @@ def apply_patch(parent, attribute, replacement):
         patch_builtins(parent, attribute, replacement)
 
 
-def patchable_builtin(klass):
+def patchable_builtin(klass: type[Any]) -> Any:
     refs = gc.get_referents(klass.__dict__)
     return refs[0]
 
 
-def patch_builtins(klass, attr, value):
+def patch_builtins(klass: type[Any], attr: str, value: Any) -> None:
     """Based on forbiddenfruit package:
     https://github.com/clarete/forbiddenfruit/blob/master/forbiddenfruit/__init__.py#L421
     ---

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -97,7 +97,7 @@ class AppSecSpanProcessor(SpanProcessor):
             cls._instance = None
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         return self._ddwaf is not None
 
     def __post_init__(self) -> None:
@@ -150,7 +150,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
         self._update_required()
 
-    def _update_required(self):
+    def _update_required(self) -> None:
         if self._ddwaf is None:
             return
         self._addresses_to_keep.clear()

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -65,7 +65,7 @@ def enable_appsec_rc() -> None:
     asm_config._rc_client_id = remoteconfig_poller._client.id
 
 
-def disable_appsec_rc():
+def disable_appsec_rc() -> None:
     # only used to avoid data leaks between tests
     for product_name in APPSEC_PRODUCTS:
         remoteconfig_poller.unregister_callback(product_name)
@@ -150,7 +150,7 @@ def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[
     return res
 
 
-def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str, Any]] = {}):
+def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str, Any]] = {}) -> None:
     """This callback updates appsec enabled in tracer and config instances following this logic:
     ```
     | DD_APPSEC_ENABLED | RC Enabled | Result   |
@@ -174,7 +174,7 @@ def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str
         asm_config._auto_user_instrumentation_rc_mode = result["auto_user_instrum"].get("mode", None)
 
 
-def disable_asm():
+def disable_asm() -> None:
     if asm_config._asm_enabled:
         from ddtrace.appsec._processor import AppSecSpanProcessor
 
@@ -189,7 +189,7 @@ def disable_asm():
         tracer.configure(appsec_enabled=False)
 
 
-def enable_asm():
+def enable_asm() -> None:
     if asm_config._asm_can_be_enabled and not asm_config._asm_enabled:
         from ddtrace.appsec._listeners import load_appsec
 

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -102,7 +102,7 @@ class DDWaf_result:
                 self.metrics[k] = v
         self.keep = keep
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"DDWaf_result(return_code: {self.return_code} data: {self.data},"
             f" actions: {self.actions}, runtime: {self.runtime},"
@@ -166,7 +166,7 @@ class Block_config:
         grpc_status_code: int = 10,
         security_response_id: str = "default",
         location: str = "",
-        **_kwargs,
+        **_kwargs: Any,
     ) -> None:
         self.block_id: str = security_response_id
         self.grpc_status_code: int = grpc_status_code
@@ -224,23 +224,23 @@ class Telemetry_result:
         self.error = 0
 
 
-def parse_response_body(raw_body, headers):
+def parse_response_body(raw_body: Any, headers: Any) -> Optional[Any]:
     if not raw_body:
-        return
+        return None
 
     if isinstance(raw_body, dict):
         return raw_body
 
     if not headers:
-        return
+        return None
     content_type = _get_header_value_case_insensitive(
         {str(k): str(v) for k, v in dict(headers).items()},
         "content-type",
     )
     if not content_type:
-        return
+        return None
 
-    def access_body(bd):
+    def access_body(bd: Any) -> Any:
         if isinstance(bd, list) and isinstance(bd[0], (str, bytes)):
             bd = bd[0][:0].join(bd)
         if getattr(bd, "decode", False):
@@ -259,11 +259,12 @@ def parse_response_body(raw_body, headers):
 
             req_body = xmltodict.parse(access_body(raw_body))
         else:
-            return
+            return None
     except Exception:
         log.debug("Failed to parse response body", exc_info=True)
     else:
         return req_body
+    return None
 
 
 def _hash_user_id(user_id: str) -> str:
@@ -272,7 +273,7 @@ def _hash_user_id(user_id: str) -> str:
     return f"anon_{hashlib.sha256(user_id.encode()).hexdigest()[:32]}"
 
 
-def _safe_userid(user_id):
+def _safe_userid(user_id: Any) -> Optional[Any]:
     try:
         _ = int(user_id)
         return user_id
@@ -291,7 +292,7 @@ def _safe_userid(user_id):
 
 
 class _UserInfoRetriever:
-    def __init__(self, user):
+    def __init__(self, user: Any) -> None:
         self.user = user
         self.possible_user_id_fields = ["pk", "id", "uid", "userid", "user_id", "PK", "ID", "UID", "USERID"]
         self.possible_login_fields = ["username", "user", "login", "USERNAME", "USER", "LOGIN"]
@@ -315,7 +316,7 @@ class _UserInfoRetriever:
 
         return None  # explicit to make clear it has a meaning
 
-    def get_userid(self):
+    def get_userid(self) -> Any:
         user_login = getattr(self.user, asm_config._user_model_login_field, None)
         if user_login is not None:
             return user_login
@@ -323,7 +324,7 @@ class _UserInfoRetriever:
         user_login = self.find_in_user_model(self.possible_user_id_fields)
         return user_login
 
-    def get_username(self):
+    def get_username(self) -> Any:
         username = getattr(self.user, asm_config._user_model_name_field, None)
         if username is not None:
             return username
@@ -336,21 +337,21 @@ class _UserInfoRetriever:
 
         return self.find_in_user_model(self.possible_login_fields)
 
-    def get_user_email(self):
+    def get_user_email(self) -> Any:
         email = getattr(self.user, asm_config._user_model_email_field, None)
         if email is not None:
             return email
 
         return self.find_in_user_model(self.possible_email_fields)
 
-    def get_name(self):
+    def get_name(self) -> Any:
         name = getattr(self.user, asm_config._user_model_name_field, None)
         if name is not None:
             return name
 
         return self.find_in_user_model(self.possible_name_fields)
 
-    def get_user_info(self, login=False, email=False, name=False):
+    def get_user_info(self, login: bool = False, email: bool = False, name: bool = False) -> tuple[Any, dict[str, Any]]:
         """
         In safe mode, try to get the user id from the user object.
         In extended mode, try to also get the username (which will be the returned user_id),
@@ -371,13 +372,13 @@ class _UserInfoRetriever:
         return user_id, user_extra_info
 
 
-def has_triggers(span) -> bool:
+def has_triggers(span: Span) -> bool:
     if asm_config._use_metastruct_for_triggers:
         return (span._get_struct_tag(APPSEC.STRUCT) or {}).get("triggers", None) is not None
     return span.get_tag(APPSEC.JSON) is not None
 
 
-def get_triggers(span) -> Any:
+def get_triggers(span: Span) -> Any:
     if asm_config._use_metastruct_for_triggers:
         return (span._get_struct_tag(APPSEC.STRUCT) or {}).get("triggers", None)
     json_payload = span.get_tag(APPSEC.JSON)
@@ -395,7 +396,7 @@ def add_context_log(logger: logging.Logger, msg: str, offset: int = 0) -> str:
 
 
 @contextlib.contextmanager
-def unpatching_popen():
+def unpatching_popen() -> typing.Iterator[None]:
     """
     Context manager to temporarily unpatch `subprocess.Popen` for testing purposes.
     This is useful to ensure that the original `Popen` behavior is restored after the context.
@@ -409,14 +410,14 @@ def unpatching_popen():
     original_os_close = os.close
     os.close = unpatched_close
     original_popen = subprocess.Popen
-    subprocess.Popen = unpatched_Popen
+    setattr(subprocess, "Popen", unpatched_Popen)
     # Save the original bypass flag value
     original_bypass_flag = asm_config._bypass_instrumentation_for_waf
     asm_config._bypass_instrumentation_for_waf = True
     try:
         yield
     finally:
-        subprocess.Popen = original_popen
+        setattr(subprocess, "Popen", original_popen)
         os.close = original_os_close
         # In tests, restore the original value to avoid corrupting test configurations
         # In production, force to False to ensure instrumentation is re-enabled

--- a/ddtrace/appsec/trace_utils/__init__.py
+++ b/ddtrace/appsec/trace_utils/__init__.py
@@ -1,6 +1,10 @@
 """Public API for User events"""
 
 from functools import wraps
+from typing import Any
+from typing import Callable
+from typing import TypeVar
+from typing import cast
 
 from ddtrace.appsec import _metrics
 from ddtrace.appsec._trace_utils import block_request  # noqa: F401
@@ -15,20 +19,22 @@ import ddtrace.internal.core
 
 ddtrace.internal.core.on("set_user_for_asm", block_request_if_user_blocked, "block_user")
 
+F = TypeVar("F", bound=Callable[..., Any])
 
-def _telemetry_report_factory(event_name: str):
+
+def _telemetry_report_factory(event_name: str) -> Callable[[F], F]:
     """
     Factory function to create a telemetry report decorator.
     This decorator will report the event name when the decorated function is called.
     """
 
-    def decorator(func):
+    def decorator(func: F) -> F:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             _metrics._report_ato_sdk_usage(event_name, False)
             return func(*args, **kwargs)
 
-        return wrapper
+        return cast(F, wrapper)
 
     return decorator
 

--- a/ddtrace/appsec/track_user_sdk.py
+++ b/ddtrace/appsec/track_user_sdk.py
@@ -38,7 +38,7 @@ def track_login_failure(
     user_id: t.Any = None,
     metadata: t.Optional[dict[str, t.Any]] = None,
     _auto: bool = False,
-):
+) -> None:
     """
     Track a failed user login event.
 
@@ -58,7 +58,7 @@ def track_signup(
     success: bool = True,
     metadata: t.Optional[dict[str, t.Any]] = None,
     _auto: bool = False,
-):
+) -> None:
     """
     Track a user signup event.
 
@@ -78,7 +78,7 @@ def track_user(
     session_id: t.Optional[str] = None,
     metadata: t.Optional[dict[str, t.Any]] = None,
     _auto: bool = False,
-):
+) -> None:
     """
     Track an authenticated user.
 
@@ -132,7 +132,7 @@ def track_user_id(
     session_id: t.Optional[str] = None,
     metadata: t.Optional[dict[str, t.Any]] = None,
     _auto: bool = False,
-):
+) -> None:
     """
     Track an authenticated user with only user id.
 
@@ -178,7 +178,7 @@ def track_user_id(
                 raise BlockingException(_get_blocked())
 
 
-def track_custom_event(event_name: str, metadata: dict[str, t.Any]):
+def track_custom_event(event_name: str, metadata: dict[str, t.Any]) -> None:
     """
     Track a custom user event.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,7 +23,7 @@ disallow_incomplete_defs = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
-[mypy-ddtrace.appsec.contrib.*]
+[mypy-ddtrace.appsec._contrib.*]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 


### PR DESCRIPTION
## Description

`mypy` skips untyped definitions when performing type-checking. This results in a lot of AppSec functions not being properly type-checked.

The goal of this PR is to start an effort to incrementally remove all untyped functions from the `ddtrace.appsec` module.

This PR enforces the following `mypy` flags for the AppSec module (with a lot of exceptions...):
- disallow_untyped_defs 
- disallow_incomplete_defs

This introduces many `Any` types. These are not "new" they are just explicit. Getting rid of them will be done incrementally in following PRs.

This first pass skips:
- _iast <- will be done in a following PR
- _ai_guard <- will be done in a following PR
- _common_module_patches.py <- skipped for now as it would result in everything being Any
- contrib.* <- skipped for now as it would mostly result in everything being Any

## Testing

Typing Only pull request, should have no impact. I trust the regression tests.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
