### PR TITLE
chore(appsec): split test suite triggers for appsec, iast, and ai_guard

### DIFF
--- a/scripts/check_suitespec_coverage.py
+++ b/scripts/check_suitespec_coverage.py
@@ -43,7 +43,7 @@ def uncovered(path: Path) -> set[str]:
 
 
 def unmatched() -> set[str]:
-    return {pattern for pattern in SPEC_PATTERNS if not filter_ignored(ROOT.glob(pattern))}
+    return {pattern for pattern in SPEC_PATTERNS if not filter_ignored(ROOT.glob(pattern.lstrip("!")))}
 
 
 uncovered_sources = uncovered(DDTRACE_PATH)

--- a/tests/appsec/suitespec.yml
+++ b/tests/appsec/suitespec.yml
@@ -2,10 +2,10 @@
 components:
   appsec:
     - ddtrace/appsec/*
-    - '!ddtrace/appsec/ai_guard'
-    - '!ddtrace/appsec/_ai_guard'
-    - '!ddtrace/appsec/iast'
-    - '!ddtrace/appsec/_iast'
+    - '!ddtrace/appsec/ai_guard/*'
+    - '!ddtrace/appsec/_ai_guard/*'
+    - '!ddtrace/appsec/iast/*'
+    - '!ddtrace/appsec/_iast/*'
     - ddtrace/internal/settings/asm.py
   appsec_iast:
     - ddtrace/appsec/iast/*


### PR DESCRIPTION
## Summary

- Exclude `iast` and `ai_guard` paths from the `appsec` component so changes in those areas don't trigger unrelated appsec suites
- Remove `@appsec_iast` from the `appsec` suite paths — iast changes no longer trigger appsec tests
- Remove `@appsec` from iast suite paths (`appsec_iast_default`, `appsec_iast_memcheck`, `appsec_iast_native`, `iast_tdd_propagation`) — appsec changes no longer trigger iast tests
- `ai_guard` suites already only referenced `@ai_guard`, no change needed there

Each area (appsec, iast, ai_guard) now only triggers its own tests, reducing unnecessary CI runs.

## Test plan
- [ ] Verify CI only runs appsec tests when changing `ddtrace/appsec/` (excluding iast/ai_guard subdirs)
- [ ] Verify CI only runs iast tests when changing `ddtrace/appsec/iast/`
- [ ] Verify CI only runs ai_guard tests when changing `ddtrace/appsec/ai_guard/`

## Checklist
- [x] No changelog required (CI/internal config change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)