### PR TITLE
ci: allow manual trigger of apm-sdks-benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,18 @@ microbenchmarks:
     # Disable VPA for benchmarks
     DD_DISABLE_VPA: true
 
+apm-sdk-benchmarks:
+  stage: benchmarks
+  when: manual
+  allow_failure: true
+  needs:
+    - job: "upload all"
+  trigger:
+    project: DataDog/apm-reliability/apm-sdks-benchmarks
+    branch: main
+  variables:
+    TARGET_REF: $CI_PIPELINE_ID
+
 macrobenchmarks:
   stage: benchmarks
   needs:


### PR DESCRIPTION
## Description

Requires manual trigger in the main pipeline, and manually triggering the right child pipeline jobs for the Python benchmarks as well.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
