### PR TITLE
chore(llmobs): add auto retry to experiments client requests

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -23,6 +23,7 @@ from ddtrace.internal.periodic import PeriodicService
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.threads import RLock
 from ddtrace.internal.utils.http import Response
+from ddtrace.internal.utils.retry import RetryError
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.llmobs import _telemetry as telemetry
 from ddtrace.llmobs._constants import AGENTLESS_EVAL_BASE_URL
@@ -335,12 +336,22 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
     LIST_RECORDS_TIMEOUT = 20
     SUPPORTED_UPLOAD_EXTS = {"csv"}
 
+    def request(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
+        try:
+            return self._request_with_retry(method, path, body, timeout)
+        except RetryError as e:
+            # Return the last response if all retries were exhausted on 5xx
+            if isinstance(e.args[0], Response):
+                return e.args[0]
+            raise
+
     @fibonacci_backoff_with_jitter(
         attempts=BaseLLMObsWriter.RETRY_ATTEMPTS,
-        initial_wait=0.5,
+        # Retries on 5xx server errors and connection failures, returns immediately on 2xx/4xx
+        initial_wait=0.618 * TIMEOUT / (1.618**BaseLLMObsWriter.RETRY_ATTEMPTS) / 2,
         until=lambda result: isinstance(result, Response) and result.status < 500,
     )
-    def request(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
+    def _request_with_retry(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
         headers = {
             "Content-Type": "application/json",
             "DD-API-KEY": self._api_key,


### PR DESCRIPTION
## Description

Add automatic retry with fibonacci backoff and jitter to `LLMObsExperimentsClient.request()`. This follows the same retry pattern already used by `BaseLLMObsWriter._send_payload`. Retries up to 3 times on server errors (5xx) and connection failures; 4xx responses are returned immediately without retry.

## Testing

- Existing experiment client tests cover the request path
- Retry behavior relies on the already-tested `fibonacci_backoff_with_jitter` utility

## Risks

None — retry only triggers on transient server errors (5xx) and connection failures. Client errors (4xx) are not retried.

## Additional Notes

None