### PR TITLE
test(profiling): run tests with profiling enabled

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -96,6 +96,7 @@ _base_env = {
     "CARGO_BUILD_JOBS": "12",
     "DD_PYTEST_USE_NEW_PLUGIN": "true",
     "DD_TRACE_COMPUTE_STATS": "false",
+    "DD_PROFILING_ENABLED": "true",
 }
 if _nightly_build:
     _base_env["DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED"] = "1"


### PR DESCRIPTION
## Description

Enable `DD_PROFILING_ENABLED=true` in the riot base environment (`_base_env` in `riotfile.py`) so that all test suites run with the profiler active. This helps catch profiling-related regressions and interactions with other components early in CI.

## Testing

- CI will validate that existing test suites pass with profiling enabled.

## Risks

- Profiling tests (`profile` venv) may behave unexpectedly since they already manage the profiler themselves. We may need to disable `DD_PROFILING_ENABLED` for the `profile` venv specifically.
- Potential for increased CI resource usage and runtime due to the profiler overhead.

## Additional Notes

- The `--ddtrace` pytest flag is already passed in CI (via `.gitlab/tests.yml`), so tests will run with both tracing and profiling active.
- We should confirm that the `profile` / `profile-uwsgi` / `profile-memalloc` venvs are not adversely affected and exclude them if needed.