### PR TITLE
chore(crashtracker): process tags were import time static

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -7,9 +7,9 @@ from typing import Optional
 from ddtrace import config
 from ddtrace import version
 from ddtrace.internal import forksafe
+from ddtrace.internal import process_tags
 from ddtrace.internal.compat import ensure_text
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.process_tags import process_tags
 from ddtrace.internal.runtime import get_runtime_id
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings.crashtracker import config as crashtracker_config
@@ -60,8 +60,8 @@ def _get_tags(additional_tags: Optional[dict[str, str]]) -> dict[str, str]:
     library_version = version.__version__
     if library_version:
         tags["library_version"] = library_version
-    if process_tags:
-        tags["process_tags"] = process_tags
+    if p_tags := process_tags.process_tags:
+        tags["process_tags"] = p_tags
 
     for k, v in crashtracker_config.tags.items():
         if k and v:


### PR DESCRIPTION
Crash tracker was the only one not using `process_tags.process_tags`.

It meant that if process tags are modified after import, the changes will not be reflected in crash tracking product
