### PR TITLE
chore(tracer): move span finish handler to before important span processors

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -579,13 +579,15 @@ class Tracer(object):
         if span._parent is not None and active is not span._parent:
             log.debug("span %r closing after its parent %r, this is an error when not using async", span, span._parent)
 
+        # run handlers before flushing that don't need the span in its final state
+        core.dispatch("trace.span_finish", (span,))
+
         # Only call span processors if the tracer is enabled (even if APM opted out)
         if self.enabled or asm_config._apm_opt_out:
             for p in chain(self._span_processors, SpanProcessor.__processors__, [self._span_aggregator]):
                 if p:
                     p.on_span_finish(span)
 
-        core.dispatch("trace.span_finish", (span,))
         log.debug("finishing span - %r (enabled:%s)", span, self.enabled)
 
     def _log_compat(self, level, msg):


### PR DESCRIPTION
## Description
This change moves the `trace.span_finish` signal dispatching to before important span/trace processors, like the dd_processors and the span aggregator. We need this to happen before the span is flushed to APM because we need to potentially strip redundant LLMObs data from being dual shipped on the APM span.

There should be no functional changes from this PR. This just unblocks #16774 stripping LLMObs data from the span._meta_struct before we flush the span to APM.

Currently the only listener for this signal is LLMObs and our use case does not require seeing the span in its final state:
1. in a very short while we're not going to send spans directly to llmobs anymore, which is all our span finish handler even does (besides sending telemetry and queuing up evaluations that aren't tracing-specific)
2. even in the interim before we stop sending spans directly to llmobs, our writing only cares about llmobs-specific internal data in span._store or span._meta_struct, which I've audited and verified don't get modified by any existing SpanProcessors.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
