### PR TITLE
ci: build windows wheels from PR head sha

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/setup-ci-deps
         with:
           python-version: "3.13"
@@ -63,6 +64,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python


### PR DESCRIPTION
## Description

Right now the windows wheels are built from a merge commit, if the package version changes on the base branch, but the PR has not been updated yet, then the package version generated in GHA windows build will differ from those in the GitLab build job.

This change moves the GHA windows build workflow to use the PR head sha when available instead.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
