### PR TITLE
chore(client-stats): adds process_tags to client stats

### DIFF
--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -7,6 +7,7 @@ from typing import Union
 from ddtrace._trace.processor import SpanProcessor
 from ddtrace._trace.span import Span
 from ddtrace.internal import compat
+from ddtrace.internal import process_tags
 from ddtrace.internal.native import DDSketch
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.threads import Lock
@@ -232,6 +233,8 @@ class SpanStatsProcessorV06(PeriodicService, SpanProcessor):
             raw_payload["Env"] = compat.ensure_text(config.env)
         if config.version:
             raw_payload["Version"] = compat.ensure_text(config.version)
+        if p_tags := process_tags.process_tags:
+            raw_payload["ProcessTags"] = compat.ensure_text(p_tags)
 
         payload = packb(raw_payload)
         try:

--- a/tests/integration/test_trace_stats.py
+++ b/tests/integration/test_trace_stats.py
@@ -122,6 +122,33 @@ def test_stats_report_hostname(get_hostname):
         assert p._hostname == ""
 
 
+@pytest.mark.subprocess(
+    env={
+        "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+    }
+)
+def test_periodic_payload_includes_process_tags():
+    from unittest import mock
+
+    from ddtrace.internal import process_tags
+    from ddtrace.internal.processor import stats
+    from ddtrace.internal.processor.stats import SpanStatsProcessorV06
+
+    assert process_tags.process_tags
+
+    with mock.patch.object(SpanStatsProcessorV06, "start"):
+        p = SpanStatsProcessorV06("http://localhost:8126")
+
+    p._serialize_buckets = mock.Mock(return_value=[{"Start": 1, "Duration": 1, "Stats": [{}]}])
+    p._flush_stats_with_backoff = mock.Mock()
+
+    with mock.patch.object(stats, "packb", side_effect=lambda payload: payload) as packb:
+        p.periodic()
+
+    raw_payload = packb.call_args[0][0]
+    assert raw_payload["ProcessTags"] == process_tags.process_tags
+
+
 # Can't use a value between 0 and 1 since sampling is not deterministic.
 @pytest.mark.parametrize("sample_rate", [1.0, 0.0])
 @pytest.mark.snapshot()


### PR DESCRIPTION
## Description

This PR implements this [RFC](https://docs.google.com/document/d/1AFdLUuVk70i0bJd5335-RxqsvwAV9ovAqcO2z5mEMbA/edit?pli=1&tab=t.0#heading=h.s9l1lctqlg11) for Client Stats. 

**Important**: I'm aware `NativeWriter` will soon be automatically enabled and I'm working with libdatadog to add process tags to the rust side but in the mean time I add that changes