### PR TITLE
ci: add retries for `curl`-based installs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -528,7 +528,7 @@ lib_injection_tests:
     - export PYENV_ROOT="${HOME}/.pyenv"
     - export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
     - apt-get update && apt install build-essential zlib1g-dev libssl-dev curl git -y
-    - PYENV_GIT_TAG=v2.6.17 curl https://pyenv.run | bash
+    - for i in 1 2 3; do PYENV_GIT_TAG=v2.6.17 curl -sSf https://pyenv.run | bash && break; echo "pyenv install attempt $i failed, retrying..."; sleep 5; [ "$i" -eq 3 ] && { echo "Failed to install pyenv after 3 attempts"; exit 1; }; done
     - pyenv --version
     - pyenv install ${PYTHON} && pyenv global ${PYTHON}
     - python --version

--- a/.gitlab/benchmarks/steps/build-baseline.sh
+++ b/.gitlab/benchmarks/steps/build-baseline.sh
@@ -17,7 +17,12 @@ else
   else
     echo "Failed to download from S3, building wheel from scratch..."
     ulimit -c unlimited
-    curl -sSf https://sh.rustup.rs | sh -s -- -y;
+    for i in 1 2 3; do
+      curl -sSf https://sh.rustup.rs | sh -s -- -y && break
+      echo "rustup install attempt $i failed, retrying..."
+      sleep 5
+      [ "$i" -eq 3 ] && { echo "Failed to install rustup after 3 attempts"; exit 1; }
+    done
     export PATH="$HOME/.cargo/bin:$PATH"
     echo "Building wheel for ${BASELINE_BRANCH}:${BASELINE_COMMIT_SHA}"
     git checkout "${BASELINE_COMMIT_SHA}"

--- a/.gitlab/scripts/build-wheel-helpers.sh
+++ b/.gitlab/scripts/build-wheel-helpers.sh
@@ -16,7 +16,12 @@ setup_rust() {
   section_start "install_rust" "Rust toolchain"
   export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
   if ! command -v rustc &> /dev/null; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    for i in 1 2 3; do
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && break
+      echo "rustup install attempt $i failed, retrying..."
+      sleep 5
+      [ "$i" -eq 3 ] && { echo "Failed to install rustup after 3 attempts"; exit 1; }
+    done
   fi
   rustup default stable
   which rustc && rustc --version
@@ -33,7 +38,12 @@ setup_python() {
     export PATH="$(dirname "${UV_PYTHON}"):${PATH}"
   fi
   if ! command -v uv &> /dev/null; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    for i in 1 2 3; do
+      curl -LsSf https://astral.sh/uv/install.sh | sh && break
+      echo "uv install attempt $i failed, retrying..."
+      sleep 5
+      [ "$i" -eq 3 ] && { echo "Failed to install uv after 3 attempts"; exit 1; }
+    done
   fi
   which python && python --version
   if [[ ${UNPIN_DEPENDENCIES:-"false"} == "true" ]]

--- a/.gitlab/scripts/multi-os-tests.sh
+++ b/.gitlab/scripts/multi-os-tests.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # Multi-OS test script for Unix-like systems (Linux/macOS)
-set -e
+set -eo pipefail
 
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
+# Install uv (retry up to 3 times)
+for i in 1 2 3; do
+  curl -LsSf https://astral.sh/uv/install.sh | sh && break
+  echo "uv install attempt $i failed, retrying..."
+  sleep 5
+  [ "$i" -eq 3 ] && { echo "Failed to install uv after 3 attempts"; exit 1; }
+done
 export PATH="$HOME/.local/bin:$PATH"
 
 # Create temp directory and install in isolation

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/build.sh
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 FUZZ_TARGETS="fuzz_echion_remote_read fuzz_echion_strings fuzz_echion_mirrors fuzz_echion_stacks"
 BUILD_DIR=/tmp/fuzz/build
@@ -21,7 +21,12 @@ echo "=== Building Rust dependencies ==="
 # Ensure Rust toolchain is available
 if ! command -v cargo &> /dev/null; then
     echo "Rust not found, installing via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    for i in 1 2 3; do
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && break
+      echo "rustup install attempt $i failed, retrying..."
+      sleep 5
+      [ "$i" -eq 3 ] && { echo "Failed to install rustup after 3 attempts"; exit 1; }
+    done
     . "$HOME/.cargo/env"
 fi
 

--- a/scripts/profiles/django-simple/setup.sh
+++ b/scripts/profiles/django-simple/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash -eu
 
-set -eu
+set -euo pipefail
 
 PREFIX=${1}
 AUSTIN_VERSION="3.6"
@@ -37,10 +37,20 @@ popd
 pushd ${PREFIX}
     if [[ "$OSTYPE" == "linux-gnu"* ]]
     then
-        curl -s https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux64.tar.gz -L | tar xvz
+        for i in 1 2 3; do
+            curl -sSf https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux64.tar.gz -L | tar xvz && break
+            echo "k6 download attempt $i failed, retrying..."
+            sleep 5
+            [ "$i" -eq 3 ] && { echo "Failed to download k6 after 3 attempts"; exit 1; }
+        done
     elif [[ "$OSTYPE" == "darwin"* ]]
     then
-        curl -s https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-mac.zip -L -o ${PREFIX}/k6.zip
+        for i in 1 2 3; do
+            curl -sSf https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-mac.zip -L -o ${PREFIX}/k6.zip && break
+            echo "k6 download attempt $i failed, retrying..."
+            sleep 5
+            [ "$i" -eq 3 ] && { echo "Failed to download k6 after 3 attempts"; exit 1; }
+        done
         unzip k6.zip
         rm -f k6.zip
     fi

--- a/scripts/profiles/flask-simple/setup.sh
+++ b/scripts/profiles/flask-simple/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash -eu
 
-set -eu
+set -euo pipefail
 
 PREFIX=${1}
 AUSTIN_VERSION="3.6"
@@ -30,10 +30,20 @@ popd
 pushd ${PREFIX}
     if [[ "$OSTYPE" == "linux-gnu"* ]]
     then
-        curl -s https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux64.tar.gz -L | tar xvz
+        for i in 1 2 3; do
+            curl -sSf https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux64.tar.gz -L | tar xvz && break
+            echo "k6 download attempt $i failed, retrying..."
+            sleep 5
+            [ "$i" -eq 3 ] && { echo "Failed to download k6 after 3 attempts"; exit 1; }
+        done
     elif [[ "$OSTYPE" == "darwin"* ]]
     then
-        curl -s https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-mac.zip -L -o ${PREFIX}/k6.zip
+        for i in 1 2 3; do
+            curl -sSf https://github.com/loadimpact/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-mac.zip -L -o ${PREFIX}/k6.zip && break
+            echo "k6 download attempt $i failed, retrying..."
+            sleep 5
+            [ "$i" -eq 3 ] && { echo "Failed to download k6 after 3 attempts"; exit 1; }
+        done
         unzip k6.zip
         rm -f k6.zip
     fi


### PR DESCRIPTION
## Description

Currently, if we fail to install `uv` because of e.g. a transient issue 
1. We don't exit the script / fail right away, so we get a weird error later ("`uv` not found")
1. We don't retry so we make the whole CI fail / stall it for a transient issue.

**Example**
<img width="489" height="127" alt="image" src="https://github.com/user-attachments/assets/7597a254-77d6-486c-956c-a0953bed4712" />
