### PR TITLE
fix(openai): handle async AsyncAPIResponse.parse() in endpoint hooks

### DIFF
--- a/ddtrace/contrib/internal/openai/_endpoint_hooks.py
+++ b/ddtrace/contrib/internal/openai/_endpoint_hooks.py
@@ -1,3 +1,5 @@
+import inspect
+
 from openai.version import VERSION as OPENAI_VERSION
 
 from ddtrace.contrib.internal.openai.utils import OpenAIAsyncStreamHandler
@@ -77,7 +79,15 @@ class _EndpointHook:
         if hasattr(resp, "parse"):
             # Users can request the raw response, in which case we need to process on the parsed response
             # and return the original raw APIResponse.
-            self._record_response(pin, integration, span, args, kwargs, resp.parse(), error)
+            parsed = resp.parse()
+            if inspect.isawaitable(parsed):
+                # AsyncAPIResponse.parse() is a coroutine in openai>=2.25.0;
+                # close it to avoid "coroutine was never awaited" warnings and
+                # fall back to recording tags from the raw response instead.
+                parsed.close()
+                self._record_response(pin, integration, span, args, kwargs, resp, error)
+            else:
+                self._record_response(pin, integration, span, args, kwargs, parsed, error)
             return resp
         return self._record_response(pin, integration, span, args, kwargs, resp, error)
 

--- a/tests/contrib/openai/test_endpoint_hooks.py
+++ b/tests/contrib/openai/test_endpoint_hooks.py
@@ -1,0 +1,89 @@
+"""Tests for _EndpointHook.handle_request async parse handling."""
+import asyncio
+import warnings
+
+import mock
+import pytest
+
+from ddtrace.contrib.internal.openai._endpoint_hooks import _EndpointHook
+
+
+class _FakeSyncAPIResponse:
+    """Simulates a sync APIResponse where parse() returns a plain object."""
+
+    def __init__(self, parsed):
+        self._parsed = parsed
+
+    def parse(self):
+        return self._parsed
+
+
+class _FakeAsyncAPIResponse:
+    """Simulates an async APIResponse where parse() returns a coroutine (openai>=2.25.0)."""
+
+    def __init__(self, parsed):
+        self._parsed = parsed
+
+    async def parse(self):
+        return self._parsed
+
+
+def _run_hook(hook, resp, error=None):
+    """Drive the handle_request generator and return the result."""
+    pin = mock.MagicMock()
+    integration = mock.MagicMock()
+    instance = mock.MagicMock()
+    span = mock.MagicMock()
+
+    gen = hook.handle_request(pin, integration, instance, span, (), {})
+    gen.send(None)  # advance to yield
+    try:
+        gen.send((resp, error))
+    except StopIteration as e:
+        return e.value, span
+    return None, span
+
+
+def test_sync_raw_response_parse():
+    """Sync APIResponse.parse() returns a plain object -- tags should be recorded from parsed response."""
+    hook = _EndpointHook()
+    hook._response_attrs = ("model",)
+
+    parsed = mock.MagicMock()
+    parsed.model = "gpt-4"
+    resp = _FakeSyncAPIResponse(parsed)
+
+    result, span = _run_hook(hook, resp)
+
+    assert result is resp
+    span._set_tag_str.assert_any_call("openai.response.model", "gpt-4")
+
+
+def test_async_raw_response_parse_no_warning():
+    """AsyncAPIResponse.parse() returns a coroutine -- should not emit 'coroutine never awaited' warning."""
+    hook = _EndpointHook()
+    hook._response_attrs = ("model",)
+
+    resp = _FakeAsyncAPIResponse(mock.MagicMock(model="gpt-4"))
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result, span = _run_hook(hook, resp)
+
+    coroutine_warnings = [x for x in w if "never awaited" in str(x.message)]
+    assert len(coroutine_warnings) == 0
+    assert result is resp
+
+
+def test_regular_response_without_parse():
+    """Normal response without parse attribute -- should be passed directly to _record_response."""
+    hook = _EndpointHook()
+    hook._response_attrs = ("model",)
+
+    resp = mock.MagicMock(spec=["model"])
+    resp.model = "gpt-4"
+
+    result, span = _run_hook(hook, resp)
+
+    assert result is resp
+    span._set_tag_str.assert_any_call("openai.response.model", "gpt-4")


### PR DESCRIPTION
## Summary

In `openai>=2.25.0`, `AsyncAPIResponse.parse()` became a coroutine (async method). The `_EndpointHook.handle_request()` generator calls `resp.parse()` synchronously without awaiting, which emits:

```
RuntimeWarning: coroutine 'AsyncAPIResponse.parse' was never awaited
    self._record_response(pin, integration, span, args, kwargs, resp.parse(), error)
```

This happens when users use the async OpenAI client (e.g. via `openai-agents` SDK) with `with_raw_response`, since the response object has a `.parse()` attribute.

## Fix

- Detect when `resp.parse()` returns an awaitable (coroutine)
- Properly close the coroutine to avoid the RuntimeWarning
- Fall back to recording span tags from the raw response object instead
- Sync `resp.parse()` behavior is unchanged

## Test plan

- [x] Added unit tests for sync parse, async parse (no warning), and regular response paths
- [ ] Verify with `openai>=2.25.0` + `AsyncOpenAI` client that the warning no longer appears

## Notes

The `handle_request` method is a plain generator (uses `yield`), so it cannot `await` the coroutine directly. The chosen approach gracefully degrades: async raw responses will have slightly fewer span tags (from the parsed object), but the tracing still works correctly and no warnings are emitted.

A more complete fix could refactor the async code path in `_patched_endpoint_async` / `_traced_endpoint` to await `resp.parse()` before passing it to the hook, preserving full tag extraction for async raw responses. Happy to implement that if preferred.