### PR TITLE
fix(tracing): handle OSError in origin()

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -118,13 +118,13 @@ def origin(module: ModuleType) -> t.Optional[Path]:
         try:
             # DEV: Use object.__getattribute__ to avoid potential side-effects.
             orig = Path(object.__getattribute__(module, "__file__")).resolve()
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, OSError):
             # Module is probably only partially initialised, so we look at its
             # spec instead
             try:
                 # DEV: Use object.__getattribute__ to avoid potential side-effects.
                 orig = Path(object.__getattribute__(module, "__spec__").origin).resolve()
-            except (AttributeError, ValueError, TypeError):
+            except (AttributeError, ValueError, TypeError, OSError):
                 orig = None
 
         if orig is not None and orig.suffix == "pyc":

--- a/releasenotes/notes/fix-origin-oserror-gvisor-32adb2bbacc3904e.yaml
+++ b/releasenotes/notes/fix-origin-oserror-gvisor-32adb2bbacc3904e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where ``origin()`` in ``ddtrace.internal.module`` raised an unhandled
+    ``OSError`` when ``Path.resolve()`` failed on gVisor containers, causing import-time failures.

--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -612,3 +612,19 @@ def test_lazy_decorator():
     import tests.internal.lazy as lazy
 
     assert lazy.new_value == 42
+
+
+def test_origin_returns_none_on_oserror():
+    """origin() handles OSError from Path.resolve() on gVisor containers."""
+    from types import ModuleType
+
+    module = ModuleType("fake_module")
+    module.__file__ = "/some/path.py"
+
+    # __spec__.origin also needs to trigger OSError to cover the fallback
+    module.__spec__ = type("FakeSpec", (), {"origin": "/some/path.py"})()
+
+    with mock.patch("ddtrace.internal.module.Path") as MockPath:
+        MockPath.return_value.resolve.side_effect = FileNotFoundError
+        result = origin(module)
+    assert result is None


### PR DESCRIPTION
## Description

`origin()` in `ddtrace/internal/module.py` calls
`Path.resolve()` which can raise `FileNotFoundError` (a subclass of `OSError`) on [gVisor](https://gvisor.dev/) containers. The
existing `except` clauses only caught `AttributeError`, `TypeError`, and `ValueError`, so the exception escaped and caused import-time failures.

Add `OSError` to both `except` clauses so that
`origin()` gracefully returns `None` when path
resolution fails.

## Testing

Add `test_origin_returns_none_on_oserror` which mocks `Path.resolve` to raise `FileNotFoundError` and asserts `origin()` returns `None`. Ran against the `internal` suite on Python 3.13 — all tests pass.

## Risks

None. This only broadens the set of caught exceptions in a fallback path that already returns `None`.

## Additional Notes

Includes a Reno release note fragment.