### PR TITLE
fix(profiling): fix nanosecond timing in the serverless scheduler

### DIFF
--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -79,8 +79,8 @@ class ServerlessScheduler(Scheduler):
 
     def periodic(self) -> None:
         # Check both the number of intervals and time frame to be sure we don't flush, e.g., empty profiles
-        if self._profiled_intervals >= self.FLUSH_AFTER_INTERVALS and (time.time_ns() - self._last_export) >= (
-            self.FORCED_INTERVAL * self.FLUSH_AFTER_INTERVALS
+        if self._profiled_intervals >= self.FLUSH_AFTER_INTERVALS and (time.time_ns() - self._last_export) >= int(
+            self.FORCED_INTERVAL * self.FLUSH_AFTER_INTERVALS * 1e9
         ):
             try:
                 super(ServerlessScheduler, self).periodic()

--- a/releasenotes/notes/serverless-scheduler-ns-fix-5362abc4d19e5299.yaml
+++ b/releasenotes/notes/serverless-scheduler-ns-fix-5362abc4d19e5299.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: the Profiler now correctly flushes profiles at most once per upload
+    interval.

--- a/tests/profiling/test_scheduler.py
+++ b/tests/profiling/test_scheduler.py
@@ -49,7 +49,7 @@ def test_serverless_periodic(mock_periodic):
     s.periodic()
     assert s._profiled_intervals == 1
     mock_periodic.assert_not_called()
-    s._last_export = time.time_ns() - 65
+    s._last_export = time.time_ns() - int(65 * 1e9)
     s._profiled_intervals = 65
     s.periodic()
     assert s._profiled_intervals == 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6d9080c4-5887-451b-adc7-0b8052d915c2","source":"chat","resourceId":"ab7d71a3-4b7d-4797-931b-48557077844d","workflowId":"28d23f8e-1a2d-4dcc-90b7-570f5865b358","codeChangeId":"28d23f8e-1a2d-4dcc-90b7-570f5865b358","sourceType":"chat"} -->
## Description

Fixes a unit mismatch bug in the serverless scheduler's periodic flush logic. The code was comparing nanosecond timestamps (`time.time_ns()`) directly against a value in seconds, causing the flush condition to never be met.   
The fix converts the forced interval calculation to nanoseconds by multiplying by `1e9` to ensure proper comparison with nanosecond timestamps.

**Note** this doesn't mean the Profiler doesn't work at all in serverless today. There are two guards for submitting a profile `_profiled_intervals >= 60` and `(time.time_ns() - self._last_export) >= 60.0` (previously incorrect). The latter was pretty much useless so we only relied on profiled intervals.  
Asking AI, this is probably right most of the time anyway, _The bug only matters in edge cases where wall-clock time and interval count diverge, e.g., if the Lambda container is frozen mid-accumulation then resumes, or if periodic() calls are somehow delayed/batched. In normal operation, 60 × 1-second intervals ≈ 60 seconds of wall clock time, making the two guards roughly equivalent. The time guard was meant as a safety net for those freeze/resume edge cases, and that safety net is what the bug removes._

## Testing

Updated `test_serverless_periodic` to use nanosecond-based timestamps when setting `_last_export`. 

## Risks

Low risk. This fix corrects a logic error that was preventing proper profile flushing in serverless environments. The change aligns timing units throughout the flush condition comparison.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ab7d71a3-4b7d-4797-931b-48557077844d)

Comment @datadog to request changes