### PR TITLE
ci: fix nightly relenv deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,6 +462,15 @@ system_tests:
 
 deploy_to_reliability_env:
   needs: []
+  rules:
+    # Always deploy on main nightly builds
+    - if: $NIGHTLY_BUILD == "true" && $CI_COMMIT_REF_NAME == "main"
+      when: always
+    # Original rules from one-pipeline.yml
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: on_success
+    - when: manual
+      allow_failure: true
 
 deploy_to_di_backend:manual:
   stage: shared-pipeline


### PR DESCRIPTION
## Description

We do not run the nightly jobs on a schedule, the event is now "api", so we need to update the trigger for relenv nightly deploys.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
