### PR TITLE
fix(profiling): fix a bug with OR'ing types of wrapped locks (#16748) [backport 4.5]

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -9,9 +9,14 @@ from types import CodeType
 from types import FrameType
 from types import ModuleType
 from types import TracebackType
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Optional
+
+
+if TYPE_CHECKING:
+    from types import UnionType
 
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.internal.settings.profiling import config
@@ -387,6 +392,14 @@ class _LockAllocatorWrapper:
         if original_class is not None:
             return getattr(original_class, name)
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+    def __or__(self, other: type[Any] | None) -> UnionType:
+        """Support PEP 604 type union syntax (e.g., asyncio.Condition | None)."""
+        return (self._original_class | other) if isinstance(self._original_class, type) else NotImplemented
+
+    def __ror__(self, other: type[Any] | None) -> UnionType:
+        """Support PEP 604 type union syntax (e.g., None | asyncio.Condition)."""
+        return (other | self._original_class) if isinstance(self._original_class, type) else NotImplemented
 
     def __mro_entries__(self, bases: tuple[Any, ...]) -> tuple[type[Any], ...]:
         """Support subclassing the wrapped lock type (PEP 560).

--- a/releasenotes/notes/fix-lock-profiler-pep604-type-union-d1c35175fbd78345.yaml
+++ b/releasenotes/notes/fix-lock-profiler-pep604-type-union-d1c35175fbd78345.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where the lock profiler's wrapper class did not support
+    PEP 604 type union syntax (e.g., ``asyncio.Condition | None``). This was causing a ``TypeError`` at
+    import time for libraries such as `kopf <https://kopf.readthedocs.io/en/stable/>`_ that use union type annotations at class definition time.

--- a/tests/profiling/collector/lock_test_common.py
+++ b/tests/profiling/collector/lock_test_common.py
@@ -1,0 +1,44 @@
+"""Shared test assertions for lock profiler tests.
+
+Contains reusable test logic that applies to both threading and asyncio lock collectors.
+For test data helpers (line numbers, etc.), see lock_utils.py.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Optional
+
+import pytest
+
+from ddtrace.profiling.collector._lock import _LockAllocatorWrapper
+
+
+if TYPE_CHECKING:
+    from types import UnionType
+
+
+def assert_pep604_type_union_syntax(lock_class: _LockAllocatorWrapper) -> None:
+    """Assert that PEP 604 type union syntax works with a wrapped lock class.
+
+    Reproduces https://github.com/DataDog/dd-trace-py/issues/16375 where
+    `asyncio.Condition | None` raised TypeError because _LockAllocatorWrapper
+    didn't support the `|` operator used for type unions.
+
+    Requires Python 3.10+ (PEP 604). Callers must skip on older versions.
+    """
+    original: Optional[type[Any]] = lock_class._original_class
+    if not isinstance(original, type):
+        pytest.skip("Original lock is a factory function, not a type — PEP 604 union not supported natively")
+
+    assert isinstance(lock_class, _LockAllocatorWrapper)
+
+    union: UnionType = lock_class | None  # type: ignore[operator]
+    assert isinstance(union, types.UnionType)
+    assert union == (original | None)
+
+    runion: UnionType = None | lock_class  # type: ignore[operator]
+    assert isinstance(runion, types.UnionType)
+    assert runion == (None | original)

--- a/tests/profiling/collector/test_asyncio.py
+++ b/tests/profiling/collector/test_asyncio.py
@@ -21,6 +21,7 @@ from ddtrace.profiling.collector.asyncio import AsyncioLockCollector
 from ddtrace.profiling.collector.asyncio import AsyncioSemaphoreCollector
 from tests.profiling.collector import pprof_utils
 from tests.profiling.collector import test_collector
+from tests.profiling.collector.lock_test_common import assert_pep604_type_union_syntax
 from tests.profiling.collector.lock_utils import get_lock_linenos
 from tests.profiling.collector.lock_utils import init_linenos
 
@@ -299,3 +300,28 @@ class TestAsyncioConditionCollector(BaseAsyncioLockCollectorTest):
     @property
     def lock_class(self) -> type[asyncio.Condition]:
         return asyncio.Condition
+
+
+class TestAsyncGenericLockProfiling:
+    """Generic asyncio lock profiling tests that run once with asyncio.Lock.
+
+    Mirrors TestGenericLockProfiling in test_threading.py. Tests here verify
+    _LockAllocatorWrapper behavior that is shared across all asyncio lock types.
+    """
+
+    @property
+    def collector_class(self) -> type[AsyncioLockCollector]:
+        return AsyncioLockCollector
+
+    @property
+    def lock_class(self) -> type[asyncio.Lock]:
+        return asyncio.Lock
+
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 type union syntax requires Python 3.10+")
+    def test_pep604_type_union_syntax(self) -> None:
+        """Test that PEP 604 type union syntax works with wrapped lock classes.
+
+        Reproduces https://github.com/DataDog/dd-trace-py/issues/16375
+        """
+        with self.collector_class(capture_pct=100):
+            assert_pep604_type_union_syntax(self.lock_class)  # type: ignore[arg-type]

--- a/tests/profiling/collector/test_lock_reflection.py
+++ b/tests/profiling/collector/test_lock_reflection.py
@@ -14,10 +14,14 @@ WHAT THESE TESTS CANNOT CATCH:
   that the ORIGINAL also inherits from object, so comparing finds no gap.
   Such bugs require behavioral tests (actually pickle, actually subclass) which
   are in test_threading.py.
+- Issue #16375 (__or__ / __ror__) - PEP 604 type union syntax (e.g.,
+  asyncio.Condition | None). __or__ lives on the metaclass `type` (Python 3.10+),
+  not on the class itself, so it never appears in dir(). Behavioral tests are in
+  test_threading.py and test_asyncio.py (test_pep604_type_union_syntax).
 
 Pure reflection can only detect missing methods that the original explicitly
-defines. It cannot detect when an inherited method (from object) is semantically
-broken for our wrapper.
+defines. It cannot detect when an inherited method (from object or from a
+metaclass like type) is semantically broken for our wrapper.
 """
 
 from __future__ import annotations

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -29,6 +29,7 @@ from ddtrace.profiling.collector.threading import ThreadingRLockCollector
 from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
 from tests.profiling.collector import pprof_utils
 from tests.profiling.collector import test_collector
+from tests.profiling.collector.lock_test_common import assert_pep604_type_union_syntax
 from tests.profiling.collector.lock_utils import LineNo
 from tests.profiling.collector.lock_utils import get_lock_linenos
 from tests.profiling.collector.lock_utils import init_linenos
@@ -692,6 +693,16 @@ class LockCollectorTestBase:
                 os.remove(f)
             except Exception as e:
                 print("Error removing file: {}".format(e))
+
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 type union syntax requires Python 3.10+")
+    def test_pep604_type_union_syntax(self) -> None:
+        """Test that PEP 604 type union syntax works with wrapped lock classes.
+
+        Reproduces https://github.com/DataDog/dd-trace-py/issues/16375
+        Skips when the lock is a factory function (e.g., threading.Lock) rather than a type.
+        """
+        with self.collector_class(capture_pct=100):
+            assert_pep604_type_union_syntax(self.lock_class)  # type: ignore[arg-type]
 
 
 class TestGenericLockProfiling(LockCollectorTestBase):
@@ -1564,6 +1575,15 @@ class TestThreadingLockCollector(LockCollectorTestBase):
     def lock_class(self) -> type[threading.Lock]:
         return threading.Lock
 
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 type union syntax requires Python 3.10+")
+    def test_pep604_skips_for_lock(self) -> None:
+        """Assert PEP 604 test skips for Lock when it's a factory (Python < 3.14), or runs when it's a type (3.14+)."""
+        with self.collector_class(capture_pct=100):
+            try:
+                assert_pep604_type_union_syntax(self.lock_class)  # type: ignore[arg-type]
+            except pytest.skip.Exception:
+                pass  # Expected when Lock is a factory function (Python < 3.14)
+
     def test_lock_getattr(self) -> None:
         """Test that __getattr__ delegates Lock-specific attributes."""
         with self.collector_class(capture_pct=100):
@@ -1597,6 +1617,15 @@ class TestThreadingRLockCollector(LockCollectorTestBase):
     @property
     def lock_class(self) -> type[threading.RLock]:
         return threading.RLock
+
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 type union syntax requires Python 3.10+")
+    def test_pep604_skips_for_rlock(self) -> None:
+        """Assert PEP 604 test skips for RLock when it's a factory, or runs when it's a type."""
+        with self.collector_class(capture_pct=100):
+            try:
+                assert_pep604_type_union_syntax(self.lock_class)  # type: ignore[arg-type]
+            except pytest.skip.Exception:
+                pass  # Expected when RLock is a factory function
 
     def test_lock_getattr(self) -> None:
         """Test that __getattr__ delegates RLock-specific attributes."""


### PR DESCRIPTION
## Description

Backport of #16748 to the 4.5 release branch.

Fixes #16375

When the lock profiler is active, lock classes (e.g., `asyncio.Condition`) are replaced with
`_LockAllocatorWrapper` instances. Libraries like [kopf](https://github.com/nolar/kopf) use
PEP 604 type union syntax at class definition time: `condition: asyncio.Condition | None = None`

This currently breaks because wrapped locks do not implement bitwise-OR operators:
- `__or__`
- `__ror__` (reflected-OR)

## Fix

Implement `__or__` and `__ror__` on `_LockAllocatorWrapper` to delegate to the original class.

## Cherry-pick

Clean cherry-pick with no conflicts.

## Testing

- CI: same unit tests as #16748