### PR TITLE
chore(tracer): migrate set_tag(SERVICE_KEY, ...) usage to span.service = ...

### DIFF
--- a/.sg/rules/span-set-tag-service-key.yml
+++ b/.sg/rules/span-set-tag-service-key.yml
@@ -1,0 +1,10 @@
+id: span-set-tag-service-key
+message: "Use `span.service = value` directly instead of `set_tag(SERVICE_KEY, value)`"
+severity: warning
+language: python
+rule:
+  pattern: $X.set_tag(SERVICE_KEY, $VALUE)
+fix: $X.service = $VALUE
+note: |
+  `set_tag(SERVICE_KEY, value)` is a special case that routes to `self.service = value`.
+  Use `span.service = value` directly to make this side-effect explicit.

--- a/.sg/tests/__snapshots__/span-set-tag-service-key-snapshot.yml
+++ b/.sg/tests/__snapshots__/span-set-tag-service-key-snapshot.yml
@@ -1,0 +1,27 @@
+id: span-set-tag-service-key
+snapshots:
+  ? |
+    s = tracer.trace("op")
+    s.set_tag(SERVICE_KEY, "local-service")
+  : fixed: |
+      s = tracer.trace("op")
+      s.service = "local-service"
+    labels:
+    - source: s.set_tag(SERVICE_KEY, "local-service")
+      style: primary
+      start: 23
+      end: 62
+  span.set_tag(SERVICE_KEY, "my-service"):
+    fixed: span.service = "my-service"
+    labels:
+    - source: span.set_tag(SERVICE_KEY, "my-service")
+      style: primary
+      start: 0
+      end: 39
+  span.set_tag(SERVICE_KEY, service_name):
+    fixed: span.service = service_name
+    labels:
+    - source: span.set_tag(SERVICE_KEY, service_name)
+      style: primary
+      start: 0
+      end: 39

--- a/.sg/tests/span-set-tag-service-key-test.yml
+++ b/.sg/tests/span-set-tag-service-key-test.yml
@@ -1,0 +1,16 @@
+id: span-set-tag-service-key
+valid:
+  # Direct assignment is the correct pattern
+  - span.service = "my-service"
+  - span.service = value
+  # set_tag with other keys is fine
+  - span.set_tag("some.other.key", "value")
+  - span.set_tag(SOME_OTHER_KEY, value)
+
+invalid:
+  # These should trigger the rule
+  - span.set_tag(SERVICE_KEY, "my-service")
+  - span.set_tag(SERVICE_KEY, service_name)
+  - |
+    s = tracer.trace("op")
+    s.set_tag(SERVICE_KEY, "local-service")

--- a/tests/contrib/logbook/test_logbook_logging.py
+++ b/tests/contrib/logbook/test_logbook_logging.py
@@ -4,7 +4,6 @@ import pytest
 
 from ddtrace import config
 from ddtrace.constants import ENV_KEY
-from ddtrace.constants import SERVICE_KEY
 from ddtrace.constants import VERSION_KEY
 from ddtrace.contrib.internal.logbook.patch import patch
 from ddtrace.contrib.internal.logbook.patch import unpatch
@@ -104,7 +103,7 @@ def test_log_trace_global_values():
     """
     span = tracer.trace("test.logging")
     span.set_tag(ENV_KEY, "local-env")
-    span.set_tag(SERVICE_KEY, "local-service")
+    span.service = "local-service"
     span.set_tag(VERSION_KEY, "local-version")
 
     logbook.info("Hello!")

--- a/tests/contrib/loguru/test_loguru_logging.py
+++ b/tests/contrib/loguru/test_loguru_logging.py
@@ -6,7 +6,6 @@ import pytest
 
 from ddtrace import config
 from ddtrace.constants import ENV_KEY
-from ddtrace.constants import SERVICE_KEY
 from ddtrace.constants import VERSION_KEY
 from ddtrace.contrib.internal.loguru.patch import patch
 from ddtrace.contrib.internal.loguru.patch import unpatch
@@ -94,7 +93,7 @@ def test_log_injection_disabled():
 def test_log_trace_global_values(captured_logs):
     span = tracer.trace("test.logging")
     span.set_tag(ENV_KEY, "local-env")
-    span.set_tag(SERVICE_KEY, "local-service")
+    span.service = "local-service"
     span.set_tag(VERSION_KEY, "local-version")
 
     logger.info("Hello!")

--- a/tests/contrib/structlog/test_structlog_logging.py
+++ b/tests/contrib/structlog/test_structlog_logging.py
@@ -5,7 +5,6 @@ import structlog
 
 from ddtrace import config
 from ddtrace.constants import ENV_KEY
-from ddtrace.constants import SERVICE_KEY
 from ddtrace.constants import VERSION_KEY
 from ddtrace.contrib.internal.structlog.patch import patch
 from ddtrace.contrib.internal.structlog.patch import unpatch
@@ -108,7 +107,7 @@ def test_log_trace_global_values():
     """
     span = tracer.trace("test.logging")
     span.set_tag(ENV_KEY, "local-env")
-    span.set_tag(SERVICE_KEY, "local-service")
+    span.service = "local-service"
     span.set_tag(VERSION_KEY, "local-version")
 
     structlog.get_logger().info("Hello!")
@@ -226,7 +225,6 @@ def test_log_DD_TAGS():
     import structlog
 
     from ddtrace.constants import ENV_KEY
-    from ddtrace.constants import SERVICE_KEY
     from ddtrace.constants import VERSION_KEY
     from ddtrace.contrib.internal.structlog.patch import patch
     from ddtrace.contrib.internal.structlog.patch import unpatch
@@ -243,7 +241,7 @@ def test_log_DD_TAGS():
 
     span = tracer.trace("test.logging")
     span.set_tag(ENV_KEY, "local-env")
-    span.set_tag(SERVICE_KEY, "local-service")
+    span.service = "local-service"
     span.set_tag(VERSION_KEY, "local-version")
 
     logger.info("Hello!")

--- a/tests/tracer/test_span_tags.py
+++ b/tests/tracer/test_span_tags.py
@@ -12,6 +12,7 @@ import pytest
 
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import ENV_KEY
+from ddtrace.constants import SERVICE_KEY
 from ddtrace.constants import SERVICE_VERSION_KEY
 from ddtrace.constants import VERSION_KEY
 from ddtrace.trace import Span
@@ -181,6 +182,13 @@ def test_set_tag_env():
     s = Span(name="test.span")
     s.set_tag(ENV_KEY, "prod")
     assert s.get_tag(ENV_KEY) == "prod"
+
+
+def test_set_tag_service_key():
+    s = Span(name="test.span")
+    s.set_tag(SERVICE_KEY, "my-service")  # ast-grep-ignore: span-set-tag-service-key
+    assert s.service == "my-service"
+    assert s.get_tag(SERVICE_KEY) == "my-service"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

We want to migrate all internal tag setting to the new Span._set_attribute API, however Span.set_tag handles some special case keys/scenarios.

In this PR we migrate any internal usage of `Span.set_tag(SERVICE_KEY, ...)` to `Span.service = ...` instead.

## Testing

We had no tests for the public API handling of `Span.set_tag(SERVICE_KEY, ...)` so I added one.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
