### PR TITLE
refactor(profiling): fix UB in memory profiling

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -197,12 +197,15 @@ heap_tracker_t::next_sample_size_no_cpython(uint32_t sample_size)
        transform it by the inverse of the cumulative distribution function for
        the distribution we want to sample.
        See https://en.wikipedia.org/wiki/Inverse_transform_sampling. */
-    /* Get a value between [0, 1[ */
+    /* Get a value between (0, 1) — strictly positive to avoid log2(0) = -inf,
+       which would produce +inf and undefined behavior when cast to uint32_t.
+       Using rand()+1 in floating-point avoids int overflow while shifting the
+       range from [0, 1) to (0, 1). */
     /* TODO: change to use a fork safe alternative instead of rand(), as rand()
        internally uses a lock and may cause deadlock after fork in child
        processes. Deferring this to a follow up, as we're not making the
        situation worse. */
-    double q = (double)rand() / ((double)RAND_MAX + 1);
+    double q = ((double)rand() + 1.0) / ((double)RAND_MAX + 2.0);
     /* Get a value between ]-inf, 0[, more likely close to 0 */
     /* NOTE: technically log2 is not async signal safe per Linux man page,
        but it doesn't seem to use locks internally. So we assume it's safe to


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6d7e3b08-fea9-4f48-b89f-45f460fbd0aa","source":"chat","resourceId":"ef735cb0-5b59-4390-8815-ee755ebd8570","workflowId":"8eba4070-e0f2-4b48-b331-20d886c031f2","codeChangeId":"8eba4070-e0f2-4b48-b331-20d886c031f2","sourceType":"chat"} -->
## Description

This PR fixes a possible undefined behaviour in the memory profiler.  
The random number generation for heap sampling has a  flaw where it could produce a value of 0, leading to `log2(0) = -inf` and undefined behavior when cast to `uint32_t`.  

The fix ensures the random value is strictly within the range `(0, 1)`.

_On x86/SSE2, this UB manifests as current_sample_size ≈ 2 GB, so the accumulated byte counter never reaches the sampling threshold, heap profiling silently stops for the lifetime of the process. For a service allocating 100 MB/s, expected time to first hit: ~hours._