### PR TITLE
chore(boostrap): unload reprlib in cleanup

### DIFF
--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -103,6 +103,11 @@ def cleanup_loaded_modules() -> None:
             # CPython on boot.
             "threading",
             "_thread",
+            # reprlib binds _thread.get_ident at import time. If _thread gets
+            # re-imported but reprlib does not, pickle/cloudpickle can see two
+            # different builtin function objects and fail serializing classes
+            # that close over reprlib state.
+            "reprlib",
         ]
     )
     for u in UNLOAD_MODULES:

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -461,6 +461,16 @@ def test_ddtrace_re_module():
     )
 
 
+@pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1"))
+def test_ddtrace_reprlib_get_ident_picklable():
+    import _thread
+    import pickle
+    import reprlib
+
+    assert reprlib.get_ident is _thread.get_ident
+    assert pickle.dumps(reprlib.get_ident)
+
+
 @pytest.mark.subprocess(ddtrace_run=True, err=None)
 def test_ddtrace_run_sitecustomize():
     """When using ddtrace-run we ensure ddtrace.bootstrap.sitecustomize is in sys.module cache"""


### PR DESCRIPTION
## Description

This fixes a PicklingError seen when running Ray Serve with ddtrace-run and module cleanup enabled.
During bootstrap cleanup, ddtrace unloads _thread and threading, but reprlib was left loaded. reprlib keeps a reference to _thread.get_ident, so after _thread is re-imported we end up with two different get_ident builtin function objects in memory. That breaks pickle/cloudpickle identity checks and causes Ray Serve deployment setup to fail.
This change unloads reprlib together with _thread and threading so it is re-imported against the current _thread module and keeps a valid get_ident reference.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
