### PR TITLE
perf(internal, profiling): native `PeriodicThread` avoids awake() after fork() (#16545) [backport 4.5]

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -203,49 +203,83 @@ class PyRef
     PyObject* _obj;
 };
 
+// Reasons associated with the _request wake channel.
+static constexpr unsigned char REQUEST_REASON_NONE = 0;
+static constexpr unsigned char REQUEST_REASON_AWAKE = 1 << 0;
+static constexpr unsigned char REQUEST_REASON_STOP = 1 << 1;
+static constexpr unsigned char REQUEST_REASON_FORK_STOP = 1 << 2;
+
 // ----------------------------------------------------------------------------
 class Event
 {
   public:
-    void set()
+    void set(unsigned char reasons = REQUEST_REASON_AWAKE)
     {
         std::lock_guard<std::mutex> lock(_mutex);
 
-        if (_set)
+        unsigned char old_reasons = _reasons;
+        _reasons |= reasons;
+
+        if (old_reasons == _reasons)
             return;
 
-        _set = true;
         _cond.notify_all();
     }
 
     void wait()
     {
         std::unique_lock<std::mutex> lock(_mutex);
-        _cond.wait(lock, [this]() { return _set; });
+        _cond.wait(lock, [this]() { return _reasons != REQUEST_REASON_NONE; });
     }
 
     bool wait(std::chrono::milliseconds timeout)
     {
         std::unique_lock<std::mutex> lock(_mutex);
-        return _cond.wait_for(lock, timeout, [this]() { return _set; });
+        return _cond.wait_for(lock, timeout, [this]() { return _reasons != REQUEST_REASON_NONE; });
     }
 
     bool wait(std::chrono::time_point<std::chrono::steady_clock> until)
     {
         std::unique_lock<std::mutex> lock(_mutex);
-        return _cond.wait_until(lock, until, [this]() { return _set; });
+        return _cond.wait_until(lock, until, [this]() { return _reasons != REQUEST_REASON_NONE; });
     }
 
     void clear()
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _set = false;
+        _reasons = REQUEST_REASON_NONE;
+    }
+
+    void clear(unsigned char reasons)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _reasons &= static_cast<unsigned char>(~reasons);
+    }
+
+    unsigned char consume(unsigned char reasons)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        unsigned char matched = _reasons & reasons;
+        _reasons &= static_cast<unsigned char>(~reasons);
+
+        return matched;
+    }
+
+    unsigned char consume_all()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        unsigned char reasons = _reasons;
+        _reasons = REQUEST_REASON_NONE;
+
+        return reasons;
     }
 
   private:
     std::condition_variable _cond;
     std::mutex _mutex;
-    bool _set = false;
+    unsigned char _reasons = REQUEST_REASON_NONE;
 };
 
 // ----------------------------------------------------------------------------
@@ -413,18 +447,29 @@ PeriodicThread_start(PeriodicThread* self, PyObject* Py_UNUSED(args))
 
         bool error = false;
         if (self->_no_wait_at_start)
-            self->_request->set();
+            self->_request->set(REQUEST_REASON_AWAKE);
 
         while (!self->_stopping) {
             {
                 AllowThreads _;
 
                 if (self->_request->wait(self->_next_call_time)) {
-                    if (self->_stopping)
+                    if (self->_stopping) {
+                        // _stopping can be set by:
+                        // 1. pre-fork stop: preserve non-fork reasons (e.g. awake)
+                        //    so they survive restart;
+                        // 2. regular stop(): consume all pending reasons.
+                        const unsigned char stop_reasons =
+                          self->_request->consume(REQUEST_REASON_FORK_STOP | REQUEST_REASON_STOP);
+                        const bool has_fork_stop = (stop_reasons & REQUEST_REASON_FORK_STOP) != 0;
+                        if (!has_fork_stop)
+                            self->_request->consume_all();
                         break;
+                    }
 
-                    // Awake signal
-                    self->_request->clear();
+                    // Request wakeup while running (awake/no_wait_at_start).
+                    // Timer wakeups are the wait(...) == false branch.
+                    self->_request->consume_all();
                 }
             }
 
@@ -489,7 +534,8 @@ PeriodicThread_awake(PeriodicThread* self, PyObject* Py_UNUSED(args))
         std::lock_guard<std::mutex> lock(*self->_awake_mutex);
 
         self->_served->clear();
-        self->_request->set();
+        self->_request->set(REQUEST_REASON_AWAKE);
+
         self->_served->wait();
     }
 
@@ -506,7 +552,7 @@ PeriodicThread_stop(PeriodicThread* self, PyObject* Py_UNUSED(args))
     }
 
     self->_stopping = true;
-    self->_request->set();
+    self->_request->set(REQUEST_REASON_STOP);
 
     Py_RETURN_NONE;
 }
@@ -584,8 +630,10 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* Py_UNUSED(args))
     self->_atexit = false;
     self->_skip_shutdown = false;
 
-    // We don't clear the request event because we might have pending awake
-    // requests.
+    // During prefork, stop() sets _request to wake the thread promptly so it
+    // can exit before fork. That wakeup should not trigger a synthetic
+    // periodic() run right after restart.
+    self->_request->clear(REQUEST_REASON_FORK_STOP);
     self->_started->clear();
     self->_stopped->clear();
     self->_served->clear();
@@ -601,7 +649,18 @@ PeriodicThread__before_fork(PeriodicThread* self, PyObject* Py_UNUSED(args))
 {
     self->_skip_shutdown = true;
 
-    PeriodicThread_stop(self, NULL);
+    // Synchronize with awake() so there is no window where _stopping is visible
+    // before the fork-stop wake reason is published.
+    {
+        AllowThreads _;
+        std::lock_guard<std::mutex> lock(*self->_awake_mutex);
+
+        // Equivalent to PeriodicThread_stop(), with an explicit fork-stop
+        // reason. Keep this order so the worker cannot consume fork-stop as a
+        // normal wakeup.
+        self->_stopping = true;
+        self->_request->set(REQUEST_REASON_FORK_STOP);
+    }
 
     Py_RETURN_NONE;
 }

--- a/tests/profiling/collector/test_sample_count.py
+++ b/tests/profiling/collector/test_sample_count.py
@@ -49,7 +49,7 @@ def test_sample_count():
     p.stop()
 
     output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = glob.glob(output_filename + ".*.internal_metadata.json")
+    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
 
     found_at_least_one_with_more_samples_than_sampling_events = False
     for i, f in enumerate(files):

--- a/tests/profiling/gunicorn_count_app.py
+++ b/tests/profiling/gunicorn_count_app.py
@@ -1,0 +1,10 @@
+# -*- encoding: utf-8 -*-
+import os
+import threading
+from typing import Callable
+
+
+def app(environ: dict[str, str], start_response: Callable[[str, list[tuple[str, str]]], None]) -> list[bytes]:
+    response_body = f"ok pid {os.getpid()} tid {threading.get_ident()}".encode("utf-8")
+    start_response("200 OK", [("Content-type", "text/plain")])
+    return [response_body]

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import pathlib
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -37,7 +38,7 @@ TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
 RunGunicornFunc: TypeAlias = Callable[..., subprocess.Popen[bytes]]
 
 
-def _run_gunicorn(*args: str) -> subprocess.Popen[bytes]:
+def _run_gunicorn(*args: str, app: str = "tests.profiling.gunicorn-app:app") -> subprocess.Popen[bytes]:
     cmd = (
         [
             "ddtrace-run",
@@ -52,7 +53,7 @@ def _run_gunicorn(*args: str) -> subprocess.Popen[bytes]:
             os.path.dirname(__file__),
         ]
         + list(args)
-        + ["tests.profiling.gunicorn-app:app"]
+        + [app]
     )
     return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
@@ -67,6 +68,18 @@ def gunicorn(monkeypatch: pytest.MonkeyPatch) -> Generator[RunGunicornFunc, None
 
 def _get_worker_pids(stdout: str) -> list[int]:
     return [int(_) for _ in re.findall(r"Booting worker with pid: (\d+)", stdout)]
+
+
+def _get_profile_files(filename_prefix: str) -> list[pathlib.Path]:
+    prefix = pathlib.Path(filename_prefix)
+    return sorted(prefix.parent.glob(prefix.name + ".*.pprof"))
+
+
+def _get_profile_pid(profile_file: pathlib.Path) -> int:
+    # pprof file format: <prefix>.<pid>.<counter>.pprof
+    _, pid, _, ext = profile_file.name.rsplit(".", 3)
+    assert ext == "pprof"
+    return int(pid)
 
 
 def _test_gunicorn(
@@ -151,3 +164,110 @@ def test_gunicorn(
 ) -> None:
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
     _test_gunicorn(gunicorn, tmp_path, monkeypatch, *args)
+
+
+def test_gunicorn_profile_export_count_two_workers(
+    gunicorn: RunGunicornFunc,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filename = str(tmp_path / "gunicorn-count.pprof")
+    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
+    monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
+
+    args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
+    proc = gunicorn("-w", "2", *args, app="tests.profiling.gunicorn_count_app:app")
+    time.sleep(5)
+
+    if proc.poll() is not None:
+        assert proc.stdout is not None
+        output = proc.stdout.read().decode()
+        pytest.fail(f"Gunicorn failed to start: {output}")
+
+    try:
+        for _ in range(4):
+            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+                assert f.getcode() == 200
+    except Exception as e:
+        proc.terminate()
+        assert proc.stdout is not None
+        output = proc.stdout.read().decode()
+        pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
+    finally:
+        proc.terminate()
+
+    assert proc.stdout is not None
+    output = proc.stdout.read().decode()
+    worker_pids = _get_worker_pids(output)
+    assert len(worker_pids) == 2, output
+
+    try:
+        assert proc.wait(timeout=5) == 0, output
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Failed to terminate gunicorn process: {output}")
+
+    profile_files = _get_profile_files(filename)
+    exported_pids = {_get_profile_pid(p) for p in profile_files}
+    expected_pids = {proc.pid, *worker_pids}
+
+    assert exported_pids == expected_pids, [str(p) for p in profile_files]
+    assert len(profile_files) == 3, [str(p) for p in profile_files]
+
+
+def test_gunicorn_profile_export_count_two_workers_flush_false(
+    gunicorn: RunGunicornFunc,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filename = str(tmp_path / "gunicorn-count-flush-false.pprof")
+    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
+    monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
+
+    args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
+    proc = subprocess.Popen(
+        [
+            "ddtrace-run",
+            "gunicorn",
+            "--bind",
+            "127.0.0.1:7644",
+            "--worker-tmp-dir",
+            "/dev/shm",
+            "-c",
+            os.path.dirname(__file__) + "/gunicorn.conf.py",
+            "--chdir",
+            os.path.dirname(__file__),
+            "-w",
+            "2",
+            *args,
+            "tests.profiling.gunicorn_count_app:app",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    time.sleep(5)
+    if proc.poll() is not None:
+        assert proc.stdout is not None
+        output = proc.stdout.read().decode()
+        pytest.fail(f"Gunicorn failed to start: {output}")
+
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+            assert f.getcode() == 200
+    except Exception as e:
+        os.killpg(proc.pid, signal.SIGKILL)
+        assert proc.stdout is not None
+        output = proc.stdout.read().decode()
+        pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
+
+    os.killpg(proc.pid, signal.SIGKILL)
+    assert proc.stdout is not None
+    output = proc.stdout.read().decode()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Failed to kill gunicorn process group: {output}")
+
+    profile_files = _get_profile_files(filename)
+    assert profile_files == [], [str(p) for p in profile_files]


### PR DESCRIPTION


## Description

Backport of #16545 to 4.5.