### PR TITLE
chore(profiling): update Dockerfile for testing Lock profiler Cython-ization changes with dogweb

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,4 +108,10 @@ RUN git clone --depth 1 --branch "v2.6.17" https://github.com/pyenv/pyenv "${PYE
 
 RUN pip install --no-cache-dir -U "riot==${RIOT_VERSION}" "hatch==${HATCH_VERSION}" "uv==${UV_VERSION}"
 
+ENV INDEX_URL=https://dd-trace-py-builds.s3.amazonaws.com/102365409/index-manylinux2014.html
+
+RUN pip download ddtrace --no-deps --no-index --find-links $INDEX_URL
+RUN pip uninstall -y ddtrace || echo "ddtrace not installed"
+RUN pip install ddtrace-*.whl
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

Building a custom `ddtrace` build for dogweb in order to test the Lock profiler Cython changes: [PR](https://github.com/DataDog/dd-trace-py/pull/16868)

The URL was found in `upload manylinux2014` job:

https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1504143856
<img width="849" height="153" alt="Screenshot 2026-03-13 at 10 32 25 AM" src="https://github.com/user-attachments/assets/073276f0-9771-4d4c-b42a-aa099a15ea26" />

## Testing

* Do it