### PR TITLE
ci: cache .download_cache in test sdist job

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -217,6 +217,11 @@ variables:
     - twine check ${SDIST_FILE}
     - pip install ${SDIST_FILE}
     - python ${CI_PROJECT_DIR}/tests/smoke_test.py
+  cache:
+    # Cache downloaded artifacts to avoid network failures in CI
+    - key: v1-download-cache-${CURRENT_YEAR}-${CURRENT_BIWEEK}
+      paths:
+        - .download_cache
 
 "download windows wheels":
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1


### PR DESCRIPTION
## Description

Help alleviate any times when we fail to download artifacts from GitHub dependencies.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
