### PR TITLE
ci: fix testrunner image url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
         # build:
         #  context: ./docker
         #  dockerfile: Dockerfile
-        image: ghcr.io/datadog/dd-trace-py/testrunner:1802bf8a83c7826f8414f7dcc18cb29067f7e690@sha256:8ca2c0c6b34db4e0ef7f5ab55f717908ed2b9ae197b2c11b48b7359a1549a202
+        image: ghcr.io/datadog/dd-trace-py/testrunner:1802bf8a83c7826f8414f7dcc18cb29067f7e690
         command: bash
         # Resource limits: defaults to 0 (unlimited, uses all available system resources)
         # Set DD_TEST_CPUS (e.g., "4") and DD_TEST_MEMORY (e.g., "8g") to apply limits


### PR DESCRIPTION
## Description

Right now the image url points to an amd64 specific image, but we publish arm64 images as well for us on macos arm64 dev laptops.

Removing the sha will allow docker to pick/download the correct image for the current os arch.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
