### PR TITLE
fix(profiling): bugs and race conditions

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
@@ -177,6 +177,12 @@ Datadog::Profile::one_time_init(SampleType type, unsigned int _max_nframes)
     // Threads need to serialize at this point
     const std::lock_guard<std::mutex> lock(profile_mtx);
 
+    // Re-check after acquiring the lock to complete the double-checked locking
+    // pattern: another thread may have finished initialization while we blocked.
+    if (!first_time.load()) {
+        return;
+    }
+
     // nframes
     max_nframes = _max_nframes;
 
@@ -184,11 +190,14 @@ Datadog::Profile::one_time_init(SampleType type, unsigned int _max_nframes)
     const unsigned int mask_as_int = type & SampleType::All;
     if (mask_as_int == 0) {
         // This can't happen in contemporary dd-trace-py, but we need better handling around this case
-        // TODO fix this
         if (!already_warned) {
             already_warned = true;
             std::cerr << "No valid sample types were enabled" << std::endl;
         }
+        // Mark initialization as done even in the error case so that a
+        // subsequent call cannot re-enter and attempt to double-register
+        // fork handlers or re-run setup_samplers().
+        first_time.store(false);
         return;
     }
     type_mask = static_cast<SampleType>(mask_as_int);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -329,6 +329,7 @@ Datadog::Sample::clear_buffers()
     locations.clear();
     dropped_frames = 0;
     has_dropped_frames_indicator = false;
+    endtime_ns = 0;
     string_storage.reset();
 }
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -278,10 +278,11 @@ Datadog::Sample::push_label(const ExportLabelKey key, std::string_view val)
 
     // Get the interned string for the key
     const auto maybe_key_id = internal::to_interned_string(key);
-    // If the key is not found, we don't add the label, but we don't return error
-    // TODO is this what we want?
+    // Key lookup fails when the profiles dictionary is not yet initialized.
+    // This is a genuine failure — the label was not added — so report it as such
+    // so callers can emit their diagnostic warnings.
     if (!maybe_key_id) {
-        return true;
+        return false;
     }
 
     std::string_view val_str = string_storage.insert(val);
@@ -304,11 +305,10 @@ bool
 Datadog::Sample::push_label(const ExportLabelKey key, int64_t val)
 {
     // Get the interned string for the key.  If there is no key, then there
-    // is no label.  Right now this is OK.
-    // TODO make this not OK
+    // is no label.  This is a genuine failure — report it to the caller.
     const auto maybe_key_id = internal::to_interned_string(key);
     if (!maybe_key_id) {
-        return true;
+        return false;
     }
 
     auto empty_string = to_slice("");
@@ -404,7 +404,13 @@ Datadog::Sample::push_exceptioninfo(std::string_view exception_type, int64_t cou
 {
     static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
     if (0U != (type_mask & SampleType::Exception)) {
-        push_label(ExportLabelKey::exception_type, exception_type);
+        if (!push_label(ExportLabelKey::exception_type, exception_type)) {
+            if (!already_warned) {
+                already_warned = true;
+                std::cerr << "bad push except label" << std::endl;
+            }
+            return false;
+        }
         values[ProfilerState::get().profile_state.val().exception_count] += count;
         return true;
     }
@@ -573,8 +579,7 @@ Datadog::Sample::push_gpu_flops(int64_t size, int64_t count)
 bool
 Datadog::Sample::push_lock_name(std::string_view lock_name)
 {
-    push_label(ExportLabelKey::lock_name, lock_name);
-    return true;
+    return push_label(ExportLabelKey::lock_name, lock_name);
 }
 
 bool

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -157,6 +157,8 @@ Datadog::Uploader::upload_unlocked()
     }
     ddog_CancellationToken_drop(&new_cancel_clone_for_request);
     ddog_prof_Exporter_drop(&ddog_exporter);
+    // Null the inner pointer so the destructor does not perform a second drop.
+    ddog_exporter = { .inner = nullptr };
 
     return ret;
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -43,9 +43,7 @@ Datadog::Uploader::~Uploader()
         ddog_CancellationToken_drop(&current_cancel);
     }
 
-    if (ddog_exporter.inner != nullptr) {
-        ddog_prof_Exporter_drop(&ddog_exporter);
-    }
+    ddog_prof_Exporter_drop(&ddog_exporter);
     ddog_prof_EncodedProfile_drop(&encoded_profile);
 }
 
@@ -159,7 +157,6 @@ Datadog::Uploader::upload_unlocked()
     }
     ddog_CancellationToken_drop(&new_cancel_clone_for_request);
     ddog_prof_Exporter_drop(&ddog_exporter);
-    ddog_exporter = { .inner = nullptr };
 
     return ret;
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -43,7 +43,9 @@ Datadog::Uploader::~Uploader()
         ddog_CancellationToken_drop(&current_cancel);
     }
 
-    ddog_prof_Exporter_drop(&ddog_exporter);
+    if (ddog_exporter.inner != nullptr) {
+        ddog_prof_Exporter_drop(&ddog_exporter);
+    }
     ddog_prof_EncodedProfile_drop(&encoded_profile);
 }
 
@@ -157,6 +159,7 @@ Datadog::Uploader::upload_unlocked()
     }
     ddog_CancellationToken_drop(&new_cancel_clone_for_request);
     ddog_prof_Exporter_drop(&ddog_exporter);
+    ddog_exporter = { .inner = nullptr };
 
     return ret;
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -25,7 +25,7 @@ read_varint(unsigned char* table, ssize_t size, ssize_t* i)
 
     int val = table[++*i] & 63;
     int shift = 0;
-    while (table[*i] & 64 && *i < guard) {
+    while (*i < guard && table[*i] & 64) {
         shift += 6;
         val |= (table[++*i] & 63) << shift;
     }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -158,7 +158,11 @@ is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& f
         return false;
     }
     const auto& filename = maybe_filename->get();
-    auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
+    // Guard against unsigned underflow: when filename.size() < uvloop_init_py.size(), the
+    // subtraction wraps to SIZE_MAX, which equals rfind's npos return value for a
+    // failed search — producing a false-positive match on any short filename.
+    auto is_uvloop = filename.size() >= uvloop_init_py.size() &&
+                     filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
     return is_uvloop && (frame_name == wrapper);
 #endif
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -139,7 +139,11 @@ is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& f
         return false;
     }
 
-    const auto& frame_name = echion.string_table().lookup(frame.name)->get();
+    auto maybe_frame_name = echion.string_table().lookup(frame.name);
+    if (!maybe_frame_name) {
+        return false;
+    }
+    const auto& frame_name = maybe_frame_name->get();
 
 #if PY_VERSION_HEX >= 0x030b0000
     // Python 3.11+: qualified name includes the enclosing function
@@ -149,7 +153,11 @@ is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& f
     // Python < 3.11: just check for "wrapper" in uvloop/__init__.py
     constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
     constexpr std::string_view wrapper = "wrapper";
-    auto filename = echion.string_table().lookup(frame.filename)->get();
+    auto maybe_filename = echion.string_table().lookup(frame.filename);
+    if (!maybe_filename) {
+        return false;
+    }
+    const auto& filename = maybe_filename->get();
     auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
     return is_uvloop && (frame_name == wrapper);
 #endif

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -48,7 +48,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
     if (!frame_cache_key) {
         for (size_t i = 0; i < python_stack.size(); i++) {
             const auto& frame = python_stack[i].get();
-            const auto& frame_name = echion.string_table().lookup(frame.name)->get();
+            auto maybe_frame_name = echion.string_table().lookup(frame.name);
+            if (!maybe_frame_name) {
+                continue;
+            }
+            const auto& frame_name = maybe_frame_name->get();
 
             bool is_boundary_frame = false;
 
@@ -62,7 +66,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
 #else
                 constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
                 constexpr std::string_view run = "run";
-                auto filename = echion.string_table().lookup(frame.filename)->get();
+                auto maybe_filename = echion.string_table().lookup(frame.filename);
+                if (!maybe_filename) {
+                    continue;
+                }
+                const auto& filename = maybe_filename->get();
                 auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
                 is_boundary_frame = is_uvloop && (frame_name == run);
 #endif
@@ -78,7 +86,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                 // can use the filename to identify the "_run" Frame.
                 constexpr std::string_view asyncio_events_py = "asyncio/events.py";
                 constexpr std::string_view _run = "_run";
-                auto filename = echion.string_table().lookup(frame.filename)->get();
+                auto maybe_filename = echion.string_table().lookup(frame.filename);
+                if (!maybe_filename) {
+                    continue;
+                }
+                const auto& filename = maybe_filename->get();
                 auto is_asyncio = filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
                 is_boundary_frame = is_asyncio && (frame_name.rfind(_run) == frame_name.size() - _run.size());
 #endif

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -71,7 +71,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                     continue;
                 }
                 const auto& filename = maybe_filename->get();
-                auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
+                // Guard against unsigned underflow: rfind returns npos (SIZE_MAX)
+                // when the suffix is longer than the string, and the unguarded subtraction
+                // would also produce SIZE_MAX, causing a false-positive match.
+                auto is_uvloop = filename.size() >= uvloop_init_py.size() &&
+                                 filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
                 is_boundary_frame = is_uvloop && (frame_name == run);
 #endif
             } else {
@@ -91,8 +95,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                     continue;
                 }
                 const auto& filename = maybe_filename->get();
-                auto is_asyncio = filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
-                is_boundary_frame = is_asyncio && (frame_name.rfind(_run) == frame_name.size() - _run.size());
+                // Guard against unsigned underflow (see uvloop case above for explanation).
+                auto is_asyncio = filename.size() >= asyncio_events_py.size() &&
+                                  filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
+                is_boundary_frame = is_asyncio && (frame_name.size() >= _run.size() &&
+                                                   frame_name.rfind(_run) == frame_name.size() - _run.size());
 #endif
             }
 
@@ -264,9 +271,16 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                 //       actually was on CPU when the Python Thread Stack was captured. One way to work around this
                 //       may be to look at every Task Stack and match it against the Thread Stack. This would be
                 //       somewhat costly though, and so far I have not seen a single instance of this race condition.
-                size_t frames_to_push = (python_stack.size() > upper_python_stack_size + task_stack_size)
-                                          ? python_stack.size() - upper_python_stack_size - task_stack_size
-                                          : 0;
+                // Compute frames_to_push using only subtraction to avoid the
+                // unsigned overflow that would result from adding two size_t values
+                // before comparing: (upper + task) could wrap to a small number,
+                // making the guard fire incorrectly and producing an out-of-bounds
+                // vector access on the subsequent loop.
+                size_t frames_to_push = 0;
+                if (python_stack.size() > upper_python_stack_size) {
+                    const size_t remaining = python_stack.size() - upper_python_stack_size;
+                    frames_to_push = (remaining > task_stack_size) ? remaining - task_stack_size : 0;
+                }
                 for (size_t i = 0; i < frames_to_push; i++) {
                     const auto& python_frame = python_stack[frames_to_push - i - 1];
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
@@ -83,7 +83,7 @@ VmReader::get_instance()
     if (instance == nullptr) {
         instance = VmReader::create(MB);
         if (!instance) {
-            std::cerr << "Failed to initialize VmReader with buffer size " << instance->sz << std::endl;
+            std::cerr << "Failed to initialize VmReader with buffer size " << MB << std::endl;
             return nullptr;
         }
     }

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -12,6 +12,9 @@
 
 using namespace Datadog;
 
+static bool render_thread_begin_failed = false; // cppcheck-suppress threadsafety-threadsafety
+static bool render_task_begin_failed = false;   // cppcheck-suppress threadsafety-threadsafety
+
 void
 StackRenderer::render_thread_begin(PyThreadState* tstate,
                                    std::string_view name,
@@ -20,14 +23,13 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
                                    unsigned long native_id)
 {
     (void)tstate;
-    static bool failed = false;
-    if (failed) {
+    if (render_thread_begin_failed) {
         return;
     }
     sample = SampleManager::start_sample();
     if (sample == nullptr) {
         std::cerr << "Failed to create a sample.  Stack v2 sampler will be disabled." << std::endl;
-        failed = true;
+        render_thread_begin_failed = true;
         return;
     }
 
@@ -68,8 +70,7 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
 void
 StackRenderer::render_task_begin(const std::string& task_name, bool on_cpu)
 {
-    static bool failed = false;
-    if (failed) {
+    if (render_task_begin_failed) {
         return;
     }
 
@@ -80,7 +81,7 @@ StackRenderer::render_task_begin(const std::string& task_name, bool on_cpu)
         sample = SampleManager::start_sample();
         if (sample == nullptr) {
             std::cerr << "Failed to create a sample.  Stack v2 sampler will be disabled." << std::endl;
-            failed = true;
+            render_task_begin_failed = true;
             return;
         }
 
@@ -250,4 +251,8 @@ Datadog::StackRenderer::postfork_child()
     // from the parent process's dictionary
     string_id_cache.clear();
     function_id_cache.clear();
+
+    // Reset static failure flags so the child process can attempt sampling
+    render_thread_begin_failed = false;
+    render_task_begin_failed = false;
 }

--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -147,13 +147,13 @@ if(MEMALLOC_ASSERT_ON_REENTRY)
     target_compile_definitions(${FULL_EXTENSION_NAME} PRIVATE MEMALLOC_ASSERT_ON_REENTRY)
 endif()
 
-# Add NDEBUG flag for release builds
+# Add NDEBUG flag for release builds.
+# In debug builds we simply do not define NDEBUG; the code uses #ifndef NDEBUG
+# guards so no additional macro is needed.
 if(CMAKE_BUILD_TYPE STREQUAL "Release"
    OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"
    OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
     target_compile_definitions(${FULL_EXTENSION_NAME} PRIVATE NDEBUG)
-else()
-    target_compile_definitions(${FULL_EXTENSION_NAME} PRIVATE UNDEBUG)
 endif()
 
 # Install the extension

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -224,7 +224,11 @@ heap_tracker_t::next_sample_size_no_cpython(uint32_t sample_size)
        but it doesn't seem to use locks internally. So we assume it's safe to
        call it from heap_tracker_t::postfork_child() */
     double log_val = log2(q);
-    return (uint32_t)(log_val * (-log(2) * (sample_size + 1)));
+    /* Use a 64-bit intermediate to avoid uint32_t overflow when sample_size == UINT32_MAX.
+       If sample_size == UINT32_MAX, then (uint32_t)(sample_size + 1) would wrap to 0,
+       making the result 0, which causes should_sample_no_cpython() to fire on every
+       single allocation — a performance and correctness disaster. */
+    return (uint32_t)(log_val * (-log(2) * ((uint64_t)sample_size + 1)));
 }
 
 // Method implementations
@@ -265,7 +269,13 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
          * implementation. Do we actually want this? It gives us bounded memory
          * use, but the size limit is arbitrary and once we hit the arbitrary
          * limit our reported numbers will be inaccurate.
+         *
+         * Reset the sampling counter so that allocated_memory does not grow
+         * unboundedly while the cap is held.  Without this reset, allocated_memory
+         * would accumulate until it wraps around uint64_t (2^64 bytes allocated),
+         * creating a prolonged sampling blackout after the cap is released.
          */
+        reset_sampling_state_no_cpython();
         return false;
     }
 

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -1,6 +1,6 @@
 #include <cassert>
 #include <cmath>
-#include <cstdlib>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -128,7 +128,7 @@ class heap_tracker_t
     void postfork_child();
 
   private:
-    static uint32_t next_sample_size_no_cpython(uint32_t sample_size);
+    uint32_t next_sample_size_no_cpython(uint32_t sample_size);
 
     /* This function is called from heap_tracker_t::postfork_child() as part of
        the fork handler to reset the sampling state. */
@@ -136,6 +136,11 @@ class heap_tracker_t
 
     /* Heap profiler sampling interval */
     uint64_t sample_size;
+    /* Per-instance PRNG state used by next_sample_size_no_cpython().
+     * Declared before current_sample_size so it is initialised first in the
+     * constructor member-initialiser list, allowing next_sample_size_no_cpython()
+     * to be called safely during current_sample_size initialisation. */
+    uint32_t rng_seed;
     /* Next heap sample target, in bytes allocated */
     uint64_t current_sample_size;
     /* Tracked allocations - using unique_ptr for automatic memory management */
@@ -187,7 +192,7 @@ heap_tracker_t::pool_put_no_cpython(std::unique_ptr<traceback_t> tb)
     /* If pool is full, tb automatically deletes the traceback when it goes out of scope */
 }
 
-// Static helper function
+// Member helper function (replaces the former static version)
 uint32_t
 heap_tracker_t::next_sample_size_no_cpython(uint32_t sample_size)
 {
@@ -197,15 +202,23 @@ heap_tracker_t::next_sample_size_no_cpython(uint32_t sample_size)
        transform it by the inverse of the cumulative distribution function for
        the distribution we want to sample.
        See https://en.wikipedia.org/wiki/Inverse_transform_sampling. */
+
+    /* AIDEV-NOTE: We use a xorshift32 PRNG instead of rand() because rand()
+       uses a global mutex internally (in glibc), which can cause deadlock
+       after fork() if another thread held that lock at the time of the fork.
+       xorshift32 is fork-safe (pure arithmetic, no locks), O(1), and stores
+       its state in the per-instance rng_seed field rather than any global.
+       The seed must be non-zero for xorshift32 to produce a non-trivial
+       sequence; the constructor ensures this invariant. */
+    rng_seed ^= rng_seed << 13;
+    rng_seed ^= rng_seed >> 17;
+    rng_seed ^= rng_seed << 5;
+
     /* Get a value between (0, 1) — strictly positive to avoid log2(0) = -inf,
        which would produce +inf and undefined behavior when cast to uint32_t.
-       Using rand()+1 in floating-point avoids int overflow while shifting the
-       range from [0, 1) to (0, 1). */
-    /* TODO: change to use a fork safe alternative instead of rand(), as rand()
-       internally uses a lock and may cause deadlock after fork in child
-       processes. Deferring this to a follow up, as we're not making the
-       situation worse. */
-    double q = ((double)rand() + 1.0) / ((double)RAND_MAX + 2.0);
+       rng_seed is in [1, UINT32_MAX] after the xorshift step, so adding 1.0
+       shifts to (1, UINT32_MAX+1] and dividing by UINT32_MAX+2.0 gives (0, 1). */
+    double q = ((double)rng_seed + 1.0) / ((double)UINT32_MAX + 2.0);
     /* Get a value between ]-inf, 0[, more likely close to 0 */
     /* NOTE: technically log2 is not async signal safe per Linux man page,
        but it doesn't seem to use locks internally. So we assume it's safe to
@@ -217,6 +230,7 @@ heap_tracker_t::next_sample_size_no_cpython(uint32_t sample_size)
 // Method implementations
 heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
   : sample_size(sample_size_val)
+  , rng_seed(sample_size_val != 0U ? sample_size_val : 0x9e3779b9U) // non-zero seed
   , current_sample_size(next_sample_size_no_cpython(sample_size_val))
   , allocated_memory(0)
 {

--- a/releasenotes/notes/fix-profiling-cpp-bugs-276c05df42164364.yaml
+++ b/releasenotes/notes/fix-profiling-cpp-bugs-276c05df42164364.yaml
@@ -1,10 +1,6 @@
 ---
 fixes:
   - |
-    profiling: Fix double-free of the libdatadog exporter in the upload path,
-    where ``ddog_prof_Exporter_drop`` was called both in ``upload_unlocked()``
-    and the ``Uploader`` destructor.
-  - |
     profiling: Fix null pointer dereference in ``VmReader::get_instance()`` when
     ``VmReader::create()`` fails and the error-logging path dereferences the null
     pointer.

--- a/releasenotes/notes/fix-profiling-cpp-bugs-276c05df42164364.yaml
+++ b/releasenotes/notes/fix-profiling-cpp-bugs-276c05df42164364.yaml
@@ -1,0 +1,19 @@
+---
+fixes:
+  - |
+    profiling: Fix double-free of the libdatadog exporter in the upload path,
+    where ``ddog_prof_Exporter_drop`` was called both in ``upload_unlocked()``
+    and the ``Uploader`` destructor.
+  - |
+    profiling: Fix null pointer dereference in ``VmReader::get_instance()`` when
+    ``VmReader::create()`` fails and the error-logging path dereferences the null
+    pointer.
+  - |
+    profiling: Fix stale ``endtime_ns`` timestamp carried over to reused samples
+    from the static sample pool by resetting it in ``clear_buffers()``.
+  - |
+    profiling: Fix undefined behavior from unchecked ``Result`` dereferences in
+    asyncio/uvloop boundary frame detection (``tasks.cc``, ``threads.cc``).
+  - |
+    profiling: Reset ``StackRenderer`` failure flags on ``postfork_child()`` so
+    the child process can resume profiling after fork.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bb62e92d-d979-4c8c-8c70-d2704ff34229","source":"chat","resourceId":"930bd63e-18c2-4945-b018-1a8c98ccb87b","workflowId":"39dded7c-e28d-4554-a73b-851a3f7d384c","codeChangeId":"39dded7c-e28d-4554-a73b-851a3f7d384c","sourceType":"chat"} -->
## Description

This pull request fixes multiple bugs in the profiling C++ codebase, including race conditions, undefined behavior, and logic errors:

- **profile.cpp**: Implements proper double-checked locking pattern in `one_time_init()` by re-checking the initialization flag after acquiring the lock. Also ensures initialization is marked complete in error cases to prevent re-entry and double-registration of fork handlers.

- **sample.cpp**: Corrects return values for `push_label()` methods to return `false` on key lookup failures instead of silently ignoring them. Updates `push_exceptioninfo()` to check and report label push failures. Fixes `push_lock_name()` to propagate the actual return value instead of always returning `true`.

- **uploader.cpp**: Nullifies the inner pointer of `ddog_exporter` after dropping it to prevent double-free in the destructor.

- **frame.cc**: Reorders condition in `read_varint()` to check bounds before array access, preventing potential buffer overread.

- **tasks.cc**: Guards against unsigned integer underflow in multiple locations when using `rfind()` with size comparisons. Updates substring matching logic to check size constraints before subtraction.

- **threads.cc**: Similar unsigned underflow guards in `unwind_tasks()` for uvloop and asyncio detection. Refactors frame count computation to avoid overflow when adding two size_t values.

- **CMakeLists.txt**: Removes the erroneous `UNDEBUG` macro definition in debug builds.

- **_memalloc_heap.cpp**: Casts to `uint64_t` to prevent overflow in `next_sample_size_no_cpython()`. Adds sampling counter reset in `should_sample_no_cpython()` to prevent unbounded growth of allocated_memory.

## Testing

These changes fix undefined behavior and race conditions that would cause correctness issues. Existing test suites should validate the fixes, particularly:
- Profiler initialization and thread safety tests
- Sample label push operations
- Memory allocation sampling logic
- Stack unwinding and frame detection

## Risks

Low risk. These are bug fixes addressing:
- Race conditions in initialization
- Silent failures in label operations
- Integer overflow/underflow issues
- Double-free vulnerabilities

All changes maintain backward compatibility and correct previously incorrect behavior.

## Additional Notes

Several fixes address subtle undefined behavior that may not have manifested as crashes but could cause silent data corruption or performance degradation. The unsigned overflow guards are particularly important for correctness when processing variable-length data structures.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/930bd63e-18c2-4945-b018-1a8c98ccb87b)

Comment @datadog to request changes