### PR TITLE
chore(profiling): remove nullptr dereference

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
@@ -83,7 +83,7 @@ VmReader::get_instance()
     if (instance == nullptr) {
         instance = VmReader::create(MB);
         if (!instance) {
-            std::cerr << "Failed to initialize VmReader with buffer size " << instance->sz << std::endl;
+            std::cerr << "Failed to initialize VmReader" << std::endl;
             return nullptr;
         }
     }


### PR DESCRIPTION
## Description

This removes a case where we could in theory dereference a null pointer.