### PR TITLE
chore(profiling): properly reset `endtime_ns` in `Sample::clear_buffers`

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -108,7 +108,7 @@ class Sample
     bool push_label(ExportLabelKey key, int64_t val);
     void push_frame_impl(std::string_view name, std::string_view filename, uint64_t address, int64_t line);
     void push_frame_impl(function_id function_id, uint64_t address, int64_t line);
-    void clear_buffers();
+    void clear();
 
     // Add values
     bool push_walltime(int64_t walltime, int64_t count);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -322,7 +322,7 @@ Datadog::Sample::push_label(const ExportLabelKey key, int64_t val)
 }
 
 void
-Datadog::Sample::clear_buffers()
+Datadog::Sample::clear()
 {
     std::fill(values.begin(), values.end(), 0);
     labels.clear();
@@ -340,7 +340,7 @@ Datadog::Sample::flush_sample()
     auto ret = export_sample();
 
     // Clear buffers after exporting
-    clear_buffers();
+    clear();
     return ret;
 }
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
@@ -37,7 +37,7 @@ StaticSamplePool::return_sample(Sample* sample)
 {
     // Clear any data pushed to this sample before returning it to the pool.
     // This prevents stale data (like span_id) from leaking to the next user.
-    sample->clear_buffers();
+    sample->clear();
 
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* expected = nullptr;

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -178,7 +178,7 @@ heap_tracker_t::pool_put_no_cpython(std::unique_ptr<traceback_t> tb)
     }
 
     /* Clear buffers before returning to pool to prevent memory leaks */
-    tb->sample.clear_buffers();
+    tb->sample.clear();
 
     /* Try to return the traceback to the pool */
     if (pool.size() < POOL_CAPACITY) {

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1089,7 +1089,7 @@ def test_no_duplicate_dropped_frames_indicator(tmp_path: Path) -> None:
     The bug occurred when:
     1. A sample had dropped frames (deep stack > max_nframes)
     2. export_sample() was called, adding the indicator frame
-    3. export_sample() was called again before clear_buffers()
+    3. export_sample() was called again before clear()
     4. Another indicator frame was incorrectly added
 
     This test creates allocations from a very deep stack to trigger frame dropping,


### PR DESCRIPTION
## Description

This updates `Sample::clear_buffers` to be consistent and reset everything, including `endtime_ns`.