### PR TITLE
chore(profiling): more consistent handling in `Profile::one_time_init`

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
@@ -51,6 +51,8 @@ class Profile
     ddog_prof_Profile& profile_borrow_internal();
     void profile_release();
 
+    void one_time_init_impl(SampleType type, unsigned int _max_nframes);
+
   public:
     // State management
     void one_time_init(SampleType type, unsigned int _max_nframes);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
@@ -166,36 +166,40 @@ Datadog::Profile::profile_release()
 void
 Datadog::Profile::one_time_init(SampleType type, unsigned int _max_nframes)
 {
-    std::call_once(init_once, [&]() {
-        static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
+    std::call_once(init_once, [this, type, _max_nframes]() { one_time_init_impl(type, _max_nframes); });
+}
 
-        // nframes
-        max_nframes = _max_nframes;
+void
+Datadog::Profile::one_time_init_impl(SampleType type, unsigned int _max_nframes)
+{
+    static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
 
-        // Set the type mask
-        const unsigned int mask_as_int = type & SampleType::All;
-        if (mask_as_int == 0) {
-            // This can't happen in contemporary dd-trace-py, but we need better handling around this case
-            if (!already_warned) {
-                already_warned = true;
-                std::cerr << "No valid sample types were enabled" << std::endl;
-            }
-            return;
+    // nframes
+    max_nframes = _max_nframes;
+
+    // Set the type mask
+    const unsigned int mask_as_int = type & SampleType::All;
+    if (mask_as_int == 0) {
+        // This can't happen in contemporary dd-trace-py, but we need better handling around this case
+        if (!already_warned) {
+            already_warned = true;
+            std::cerr << "No valid sample types were enabled" << std::endl;
         }
-        type_mask = static_cast<SampleType>(mask_as_int);
+        return;
+    }
+    type_mask = static_cast<SampleType>(mask_as_int);
 
-        // Setup the samplers
-        setup_samplers();
+    // Setup the samplers
+    setup_samplers();
 
-        // We need to initialize the profiles
-        const ddog_prof_Slice_SampleType sample_types = { .ptr = samplers.data(), .len = samplers.size() };
-        if (!make_profile(sample_types, &default_period, cur_profile)) {
-            if (!already_warned) {
-                already_warned = true;
-                std::cerr << "Error initializing cur_profile" << std::endl;
-            }
+    // We need to initialize the profiles
+    const ddog_prof_Slice_SampleType sample_types = { .ptr = samplers.data(), .len = samplers.size() };
+    if (!make_profile(sample_types, &default_period, cur_profile)) {
+        if (!already_warned) {
+            already_warned = true;
+            std::cerr << "Error initializing cur_profile" << std::endl;
         }
-    });
+    }
 }
 
 const Datadog::ValueIndex&


### PR DESCRIPTION
## Description

This makes a small update to `Profile::one_time_init` to re-check whether `first_time` is true or not since it could have been set by another Thread while we were waiting on the Lock.

Additionally, we also set `first_time` to `false` in the `mask_as_int == 0` (impossible according to the comment, but the check is here so we need to account for it) since we don't want to re-run that code if it ever fails.