### PR TITLE
chore(profiling): check guard before dereferencing

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -25,7 +25,7 @@ read_varint(unsigned char* table, ssize_t size, ssize_t* i)
 
     int val = table[++*i] & 63;
     int shift = 0;
-    while (table[*i] & 64 && *i < guard) {
+    while (*i < guard && table[*i] & 64) {
         shift += 6;
         val |= (table[++*i] & 63) << shift;
     }


### PR DESCRIPTION
## Description

Currently, we check the index we want to use in `table` _after_ using it to index into the table instead of _before_. This fixes it. 