### PR TITLE
chore(profiling): guard against `rfind` for ends-with underflow

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -150,7 +150,8 @@ is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& f
     constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
     constexpr std::string_view wrapper = "wrapper";
     auto filename = echion.string_table().lookup(frame.filename)->get();
-    auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
+    auto is_uvloop = filename.size() >= uvloop_init_py.size() &&
+                     filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
     return is_uvloop && (frame_name == wrapper);
 #endif
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -79,8 +79,10 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                 constexpr std::string_view asyncio_events_py = "asyncio/events.py";
                 constexpr std::string_view _run = "_run";
                 auto filename = echion.string_table().lookup(frame.filename)->get();
-                auto is_asyncio = filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
-                is_boundary_frame = is_asyncio && (frame_name.rfind(_run) == frame_name.size() - _run.size());
+                auto is_asyncio = filename.size() >= asyncio_events_py.size() &&
+                                  filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
+                is_boundary_frame = is_asyncio && (frame_name.size() >= _run.size() &&
+                                                   frame_name.rfind(_run) == frame_name.size() - _run.size());
 #endif
             }
 


### PR DESCRIPTION
## Description

Previously, we would compare the position of the function name we were looking for with `haystack.size() - needle.size()` to check whether `haystack` ended with `needle`. However, if `needle.size()` is more than `haystack.size()`, this goes into the negatives. More importantly, if `haystack.size() == needle.size() - 1` then the difference is `-1` which would match the return value of `rfind(needle, haystack)` if `needle` is not in `haystack`, leading to incorrect behaviour. 