### PR TITLE
chore(codeowners): add idm on tracing events/subscribers folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 # Framework Integrations
 ddtrace/ext/                        @DataDog/apm-core-python @DataDog/apm-idm-python
 ddtrace/contrib/                    @DataDog/apm-core-python @DataDog/apm-idm-python
+ddtrace/contrib/_events/            @DataDog/apm-core-python @DataDog/apm-idm-python
 ddtrace/internal/schema/            @DataDog/apm-core-python @DataDog/apm-idm-python
 tests/contrib/                      @DataDog/apm-core-python @DataDog/apm-idm-python
 tests/internal/peer_service         @DataDog/apm-core-python @DataDog/apm-idm-python
@@ -222,6 +223,7 @@ tests/openfeature/                        @DataDog/feature-flagging-and-experime
 # API SDK
 ddtrace/trace/                                     @DataDog/apm-sdk-capabilities-python
 ddtrace/_trace/                                    @DataDog/apm-sdk-capabilities-python
+ddtrace/_trace/subscribers/                        @DataDog/apm-sdk-capabilities-python @DataDog/apm-core-python @DataDog/apm-idm-python
 ddtrace/_trace/span.py                             @DataDog/apm-sdk-capabilities-python @DataDog/apm-core-python
 # File commonly updated for integrations, widen ownership to help with PR review
 ddtrace/_trace/trace_handlers.py                   @DataDog/apm-sdk-capabilities-python @DataDog/apm-core-python @DataDog/apm-idm-python


### PR DESCRIPTION
Update codeowners so idm is a code owner of tracing events/subscribers. 
