### PR TITLE
fix(ci_visibility): restore itr tags and telemetry [backport #16895 to 4.6]

### DIFF
--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -9,6 +9,7 @@ import typing as t
 import uuid
 
 from ddtrace.testing.internal.constants import EMPTY_NAME
+from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.git import GitTag
 from ddtrace.testing.internal.http import BackendConnectorSetup
 from ddtrace.testing.internal.http import FileAttachment
@@ -17,7 +18,6 @@ from ddtrace.testing.internal.settings_data import Settings
 from ddtrace.testing.internal.settings_data import TestProperties
 from ddtrace.testing.internal.telemetry import ErrorType
 from ddtrace.testing.internal.telemetry import TelemetryAPI
-from ddtrace.testing.internal.test_data import ITRSkippingLevel
 from ddtrace.testing.internal.test_data import ModuleRef
 from ddtrace.testing.internal.test_data import SuiteRef
 from ddtrace.testing.internal.test_data import TestRef

--- a/ddtrace/testing/internal/constants.py
+++ b/ddtrace/testing/internal/constants.py
@@ -1,3 +1,11 @@
+from enum import Enum
+
+
+class ITRSkippingLevel(Enum):
+    SUITE = "suite"
+    TEST = "test"
+
+
 DEFAULT_SERVICE_NAME = "test"
 DEFAULT_ENV_NAME = "none"
 DEFAULT_SITE = "datadoghq.com"

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -349,8 +349,10 @@ class TestOptPlugin:
             if parameters := _get_test_parameters_json(item):
                 test.set_parameters(parameters)
 
-            # Mark test as unskippable if needed
-            if _is_test_unskippable(item):
+            # Mark test as unskippable if needed (only when ITR skipping is enabled, to match v2 and avoid inflating
+            # telemetry). _discover_test runs at run time (from pytest_runtest_protocol_wrapper), so skippable_items
+            # is already populated when the SessionManager was created in pytest_load_initial_conftest.
+            if self.manager.is_skippable_test(test_ref) and _is_test_unskippable(item):
                 test.mark_unskippable()
 
             # Add custom tags if available

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -8,6 +8,7 @@ import typing as t
 from ddtrace.testing.internal.api_client import APIClient
 from ddtrace.testing.internal.ci import CITag
 from ddtrace.testing.internal.constants import DEFAULT_SERVICE_NAME
+from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.env_tags import get_env_tags
 from ddtrace.testing.internal.git import Git
 from ddtrace.testing.internal.git import GitTag
@@ -19,7 +20,6 @@ from ddtrace.testing.internal.retry_handlers import EarlyFlakeDetectionHandler
 from ddtrace.testing.internal.retry_handlers import RetryHandler
 from ddtrace.testing.internal.settings_data import TestProperties
 from ddtrace.testing.internal.telemetry import TelemetryAPI
-from ddtrace.testing.internal.test_data import ITRSkippingLevel
 from ddtrace.testing.internal.test_data import SuiteRef
 from ddtrace.testing.internal.test_data import Test
 from ddtrace.testing.internal.test_data import TestModule
@@ -106,6 +106,11 @@ class SessionManager:
         self.coverage_writer = TestCoverageWriter(connector_setup=self.connector_setup)
         self.session = session
         self.session.set_service(self.service)
+        self.session.set_itr_attributes(
+            itr_enabled=self.settings.itr_enabled,
+            skipping_enabled=self.settings.skipping_enabled,
+            skipping_level=self.itr_skipping_level,
+        )
 
         self.writer.add_metadata("*", self.env_tags)
         self.writer.add_metadata("*", self.platform_tags)

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -10,13 +10,13 @@ import typing as t
 
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.settings_data import Settings
-from ddtrace.testing.internal.test_data import ITRSkippingLevel
-from ddtrace.testing.internal.test_data import TestRun
 
 
 if t.TYPE_CHECKING:
     from ddtrace.testing.internal.http import BackendConnectorSetup
+    from ddtrace.testing.internal.test_data import TestRun
 
 
 log = logging.getLogger(__name__)
@@ -143,6 +143,15 @@ class TelemetryAPI:
             else "itr_skippable_tests.response_tests"
         )
         self.add_count_metric(skippable_count_metric, count)
+
+    def record_itr_skipped(self, event_type: EventType) -> None:
+        self.add_count_metric("itr_skipped", 1, {"event_type": event_type.value})
+
+    def record_itr_unskippable(self, event_type: EventType) -> None:
+        self.add_count_metric("itr_unskippable", 1, {"event_type": event_type.value})
+
+    def record_itr_forced_run(self, event_type: EventType) -> None:
+        self.add_count_metric("itr_forced_run", 1, {"event_type": event_type.value})
 
     def record_settings(self, settings: Settings) -> None:
         tags = {

--- a/ddtrace/testing/internal/test_data.py
+++ b/ddtrace/testing/internal/test_data.py
@@ -10,6 +10,9 @@ import typing as t
 
 from ddtrace.testing.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.testing.internal.constants import TAG_TRUE
+from ddtrace.testing.internal.constants import ITRSkippingLevel
+from ddtrace.testing.internal.telemetry import EventType
+from ddtrace.testing.internal.telemetry import TelemetryAPI
 from ddtrace.testing.internal.tracer_api import Time
 from ddtrace.testing.internal.utils import TestContext
 from ddtrace.testing.internal.utils import _gen_item_id
@@ -38,11 +41,6 @@ class TestStatus(Enum):
     FAIL = "fail"
     SKIP = "skip"
     __test__ = False
-
-
-class ITRSkippingLevel(Enum):
-    SUITE = "suite"
-    TEST = "test"
 
 
 class TestType:
@@ -282,12 +280,20 @@ class Test(TestItem["TestSuite", "TestRun"]):
 
     def mark_unskippable(self) -> None:
         self.tags[TestTag.ITR_UNSKIPPABLE] = TAG_TRUE
+        try:
+            TelemetryAPI.get().record_itr_unskippable(EventType.TEST)
+        except RuntimeError:
+            pass
 
     def is_unskippable(self) -> bool:
         return self.tags.get(TestTag.ITR_UNSKIPPABLE) == TAG_TRUE
 
     def mark_forced_run(self) -> None:
         self.tags[TestTag.ITR_FORCED_RUN] = TAG_TRUE
+        try:
+            TelemetryAPI.get().record_itr_forced_run(EventType.TEST)
+        except RuntimeError:
+            pass
 
     def is_forced_run(self) -> bool:
         return self.tags.get(TestTag.ITR_FORCED_RUN) == TAG_TRUE
@@ -295,6 +301,10 @@ class Test(TestItem["TestSuite", "TestRun"]):
     def mark_skipped_by_itr(self) -> None:
         self.tags[TestTag.SKIPPED_BY_ITR] = TAG_TRUE
         self.session.tests_skipped_by_itr += 1
+        try:
+            TelemetryAPI.get().record_itr_skipped(EventType.TEST)
+        except RuntimeError:
+            pass
 
     def is_skipped_by_itr(self) -> bool:
         return self.tags.get(TestTag.SKIPPED_BY_ITR) == TAG_TRUE
@@ -349,6 +359,9 @@ class TestSession(TestItem[t.NoReturn, "TestModule"]):
     def __init__(self, name: str):
         super().__init__(name=name, parent=None)  # type: ignore
         self.tests_skipped_by_itr = 0
+        self.itr_enabled = False
+        self.itr_skipping_enabled = False
+        self.itr_skipping_level = ITRSkippingLevel.TEST
 
     def set_session_id(self, session_id: int) -> None:
         self.item_id = session_id
@@ -357,6 +370,11 @@ class TestSession(TestItem[t.NoReturn, "TestModule"]):
         self.test_command = test_command
         self.test_framework = test_framework
         self.test_framework_version = test_framework_version
+
+    def set_itr_attributes(self, itr_enabled: bool, skipping_enabled: bool, skipping_level: ITRSkippingLevel) -> None:
+        self.itr_enabled = itr_enabled
+        self.itr_skipping_enabled = skipping_enabled
+        self.itr_skipping_level = skipping_level
 
     def set_early_flake_detection_abort_reason(self, reason: str) -> None:
         self.tags[TestTag.EFD_ABORT_REASON] = reason
@@ -367,9 +385,13 @@ class TestSession(TestItem[t.NoReturn, "TestModule"]):
     def set_final_tags(self) -> None:
         super().set_final_tags()
 
-        if self.tests_skipped_by_itr > 0:
-            self.tags[TestTag.ITR_TESTS_SKIPPED] = TAG_TRUE
-            self.tags[TestTag.ITR_TESTS_SKIPPING_TYPE] = "test"
+        self.tags[TestTag.ITR_TESTS_SKIPPING_ENABLED] = TAG_TRUE if self.itr_skipping_enabled else "false"
+
+        if self.itr_enabled:
+            has_itr_skips = self.tests_skipped_by_itr > 0
+            self.tags[TestTag.ITR_TESTS_SKIPPED] = TAG_TRUE if has_itr_skips else "false"
+            self.tags[TestTag.ITR_DD_CI_ITR_TESTS_SKIPPED] = TAG_TRUE if has_itr_skips else "false"
+            self.tags[TestTag.ITR_TESTS_SKIPPING_TYPE] = self.itr_skipping_level.value
             self.metrics[TestTag.ITR_TESTS_SKIPPING_COUNT] = self.tests_skipped_by_itr
 
 
@@ -410,7 +432,9 @@ class TestTag:
     ITR_UNSKIPPABLE = "test.itr.unskippable"
     ITR_FORCED_RUN = "test.itr.forced_run"
     SKIPPED_BY_ITR = "test.skipped_by_itr"
+    ITR_TESTS_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled"
     ITR_TESTS_SKIPPED = "test.itr.tests_skipping.tests_skipped"
+    ITR_DD_CI_ITR_TESTS_SKIPPED = "_dd.ci.itr.tests_skipped"
     ITR_TESTS_SKIPPING_TYPE = "test.itr.tests_skipping.type"
     ITR_TESTS_SKIPPING_COUNT = "test.itr.tests_skipping.count"
 

--- a/releasenotes/notes/fix-ci_visibility-itr-tags-telemetry-f790425758e0cb0c.yaml
+++ b/releasenotes/notes/fix-ci_visibility-itr-tags-telemetry-f790425758e0cb0c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility (pytest): Fixed missing ITR tags in the new pytest plugin that caused
+    time saved by Test Impact Analysis to not appear in dashboards.

--- a/tests/testing/internal/pytest/test_pytest_itr.py
+++ b/tests/testing/internal/pytest/test_pytest_itr.py
@@ -77,7 +77,9 @@ class TestITR:
 
         # Check that session event has the correct tags.
         [session] = event_capture.events_by_type("test_session_end")
+        assert session["content"]["meta"]["test.itr.tests_skipping.enabled"] == "true"
         assert session["content"]["meta"]["test.itr.tests_skipping.tests_skipped"] == "true"
+        assert session["content"]["meta"]["_dd.ci.itr.tests_skipped"] == "true"
         assert session["content"]["meta"]["test.itr.tests_skipping.type"] == "test"
         assert session["content"]["metrics"]["test.itr.tests_skipping.count"] == 1
 
@@ -133,9 +135,86 @@ class TestITR:
 
         # Check that session event has the correct tags.
         [session] = event_capture.events_by_type("test_session_end")
+        assert session["content"]["meta"]["test.itr.tests_skipping.enabled"] == "false"
         assert session["content"]["meta"].get("test.itr.tests_skipping.tests_skipped") is None
+        assert session["content"]["meta"].get("_dd.ci.itr.tests_skipped") is None
         assert session["content"]["meta"].get("test.itr.tests_skipping.type") is None
         assert session["content"]["metrics"].get("test.itr.tests_skipping.count") is None
+
+    def test_itr_unskippable_not_emitted_when_skipping_disabled(self, pytester: Pytester) -> None:
+        """Regression: unskippable tag and telemetry must not be emitted when ITR skipping is disabled."""
+        pytester.makepyfile(
+            test_foo="""
+            import pytest
+
+            @pytest.mark.skipif(False, reason='datadog_itr_unskippable')
+            def test_has_unskippable_marker():
+                '''Has datadog_itr_unskippable marker but skipping is disabled.'''
+                assert True
+        """
+        )
+
+        skippable_items: set[t.Union[TestRef, SuiteRef]] = {
+            TestRef(SuiteRef(ModuleRef(""), "test_foo.py"), "test_has_unskippable_marker"),
+        }
+
+        with (
+            patch(
+                "ddtrace.testing.internal.session_manager.APIClient",
+                return_value=mock_api_client_settings(skipping_enabled=False, skippable_items=skippable_items),
+            ),
+            setup_standard_mocks(),
+        ):
+            with EventCapture.capture() as event_capture:
+                result = pytester.inline_run("--ddtrace", "-v", "-s")
+
+        assert result.ret == 0
+        result.assertoutcome(passed=1)
+
+        test_event = event_capture.event_by_test_name("test_has_unskippable_marker")
+        assert test_event["content"]["meta"]["test.status"] == "pass"
+        # Must NOT have unskippable tag when skipping is disabled (avoids inflating itr_unskippable telemetry).
+        assert test_event["content"]["meta"].get("test.itr.unskippable") is None
+        assert test_event["content"]["meta"].get("test.itr.forced_run") is None
+
+    def test_itr_unskippable_not_emitted_when_test_not_in_skippable_list(self, pytester: Pytester) -> None:
+        """Regression: unskippable tag and telemetry must not be emitted when the test is not in skippable_items.
+
+        Even with skipping_enabled=True, we only mark unskippable when is_skippable_test(test_ref) is True (test or
+        suite in skippable_items). If the test is not in the list, we must not emit itr_unskippable.
+        """
+        pytester.makepyfile(
+            test_foo="""
+            import pytest
+
+            @pytest.mark.skipif(False, reason='datadog_itr_unskippable')
+            def test_has_unskippable_marker_but_not_skippable():
+                '''Has unskippable marker but not in skippable_items (e.g. new test).'''
+                assert True
+        """
+        )
+
+        # Skipping is enabled but this test is NOT in skippable_items (e.g. new test not in ITR response).
+        skippable_items: set[t.Union[TestRef, SuiteRef]] = set()
+
+        with (
+            patch(
+                "ddtrace.testing.internal.session_manager.APIClient",
+                return_value=mock_api_client_settings(skipping_enabled=True, skippable_items=skippable_items),
+            ),
+            setup_standard_mocks(),
+        ):
+            with EventCapture.capture() as event_capture:
+                result = pytester.inline_run("--ddtrace", "-v", "-s")
+
+        assert result.ret == 0
+        result.assertoutcome(passed=1)
+
+        test_event = event_capture.event_by_test_name("test_has_unskippable_marker_but_not_skippable")
+        assert test_event["content"]["meta"]["test.status"] == "pass"
+        # Must NOT have unskippable when test is not in skippable_items (is_skippable_test returns False).
+        assert test_event["content"]["meta"].get("test.itr.unskippable") is None
+        assert test_event["content"]["meta"].get("test.itr.forced_run") is None
 
     def test_itr_one_unskippable_test(self, pytester: Pytester) -> None:
         """Test that IntelligentTestRunner skips tests marked as skippable."""
@@ -204,7 +283,9 @@ class TestITR:
 
         # Check that session event has the correct tags.
         [session] = event_capture.events_by_type("test_session_end")
+        assert session["content"]["meta"]["test.itr.tests_skipping.enabled"] == "true"
         assert session["content"]["meta"]["test.itr.tests_skipping.tests_skipped"] == "true"
+        assert session["content"]["meta"]["_dd.ci.itr.tests_skipped"] == "true"
         assert session["content"]["meta"]["test.itr.tests_skipping.type"] == "test"
         assert session["content"]["metrics"]["test.itr.tests_skipping.count"] == 1
 

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -10,6 +10,7 @@ from ddtrace.testing.internal.settings_data import EarlyFlakeDetectionSettings
 from ddtrace.testing.internal.settings_data import Settings
 from ddtrace.testing.internal.settings_data import TestManagementSettings
 from ddtrace.testing.internal.telemetry import ErrorType
+from ddtrace.testing.internal.telemetry import EventType
 from ddtrace.testing.internal.telemetry import GitTelemetry
 from ddtrace.testing.internal.telemetry import TelemetryAPI
 from ddtrace.testing.internal.test_data import ITRSkippingLevel
@@ -173,6 +174,27 @@ class TestTelemetry:
         # count metric, not distribution metric, for inexplicable reasons
         assert telemetry_api.writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "itr_skippable_tests.response_suites", 42, ())
+        ]
+
+    def test_record_itr_skipped(self, telemetry_api: TelemetryAPI) -> None:
+        telemetry_api.record_itr_skipped(EventType.TEST)
+
+        assert telemetry_api.writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "itr_skipped", 1, (("event_type", "test"),))
+        ]
+
+    def test_record_itr_unskippable(self, telemetry_api: TelemetryAPI) -> None:
+        telemetry_api.record_itr_unskippable(EventType.TEST)
+
+        assert telemetry_api.writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "itr_unskippable", 1, (("event_type", "test"),))
+        ]
+
+    def test_record_itr_forced_run(self, telemetry_api: TelemetryAPI) -> None:
+        telemetry_api.record_itr_forced_run(EventType.TEST)
+
+        assert telemetry_api.writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "itr_forced_run", 1, (("event_type", "test"),))
         ]
 
     def test_record_settings_all_enabled(self, telemetry_api: TelemetryAPI) -> None:

--- a/tests/testing/internal/test_test_data.py
+++ b/tests/testing/internal/test_test_data.py
@@ -1,6 +1,7 @@
 """Tests for ddtrace.testing.internal.test_data module."""
 
 from typing import Any
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ from ddtrace.testing.internal.test_data import ModuleRef
 from ddtrace.testing.internal.test_data import SuiteRef
 from ddtrace.testing.internal.test_data import TestItem
 from ddtrace.testing.internal.test_data import TestRef
+from ddtrace.testing.internal.test_data import TestSession
 from ddtrace.testing.internal.test_data import TestStatus
 
 
@@ -264,3 +266,40 @@ class TestTestItem:
 
         status = parent._get_status_from_children()
         assert status == TestStatus.PASS
+
+
+class TestITRTelemetry:
+    def _make_test(self):
+        session = TestSession("pytest")
+        module, _ = session.get_or_create_child("module")
+        suite, _ = module.get_or_create_child("suite")
+        test, _ = suite.get_or_create_child("test_name")
+        return session, test
+
+    def test_mark_skipped_by_itr_records_telemetry(self):
+        session, test = self._make_test()
+        telemetry_api = Mock()
+
+        with patch("ddtrace.testing.internal.telemetry.TelemetryAPI.get", return_value=telemetry_api):
+            test.mark_skipped_by_itr()
+
+        assert session.tests_skipped_by_itr == 1
+        telemetry_api.record_itr_skipped.assert_called_once()
+
+    def test_mark_unskippable_records_telemetry(self):
+        _, test = self._make_test()
+        telemetry_api = Mock()
+
+        with patch("ddtrace.testing.internal.telemetry.TelemetryAPI.get", return_value=telemetry_api):
+            test.mark_unskippable()
+
+        telemetry_api.record_itr_unskippable.assert_called_once()
+
+    def test_mark_forced_run_records_telemetry(self):
+        _, test = self._make_test()
+        telemetry_api = Mock()
+
+        with patch("ddtrace.testing.internal.telemetry.TelemetryAPI.get", return_value=telemetry_api):
+            test.mark_forced_run()
+
+        telemetry_api.record_itr_forced_run.assert_called_once()

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -464,23 +464,23 @@ class BackendConnectorMockBuilder:
         mock_connector = Mock()
 
         # Mock methods to prevent real HTTP calls
-        def mock_post_json(endpoint: str, data: t.Any, telemetry: t.Any = None) -> tuple[Mock, t.Any]:
+        def mock_post_json(endpoint: str, data: t.Any, telemetry: t.Any = None) -> BackendResult:
             if endpoint in self._post_json_responses:
                 return BackendResult(response=Mock(status=200), parsed_response=self._post_json_responses[endpoint])
             return self._make_404_response()
 
-        def mock_get_json(endpoint: str, max_attempts: int = 0) -> tuple[Mock, t.Any]:
+        def mock_get_json(endpoint: str, max_attempts: int = 0) -> BackendResult:
             if endpoint in self._get_json_responses:
                 return BackendResult(response=Mock(status=200), parsed_response=self._get_json_responses[endpoint])
             return self._make_404_response()
 
-        def mock_request(method: str, path: str, **kwargs: t.Any) -> tuple[Mock, t.Any]:
+        def mock_request(method: str, path: str, **kwargs: t.Any) -> BackendResult:
             key = f"{method}:{path}"
             if key in self._request_responses:
-                BackendResult(response=Mock(status=200), parsed_response=self._request_responses[key])
+                return BackendResult(response=Mock(status=200), parsed_response=self._request_responses[key])
             return self._make_404_response()
 
-        def mock_post_files(path: str, files: t.Any, **kwargs: t.Any) -> tuple[Mock, dict[str, t.Any]]:
+        def mock_post_files(path: str, files: t.Any, **kwargs: t.Any) -> BackendResult:
             return BackendResult(response=Mock(status=200))
 
         mock_connector.post_json.side_effect = mock_post_json
@@ -682,14 +682,14 @@ class EventCapture:
             if event["type"] == event_type:
                 yield event
 
-    def events_by_test_name(self, test_name: str) -> t.Iterable[Event]:
+    def events_by_test_name(self, test_name: str) -> t.Iterator[Event]:
         for event in self.events():
             if event["type"] == "test" and event["content"]["meta"]["test.name"] == test_name:
                 yield event
 
     def event_by_test_name(self, test_name: str) -> Event:
         try:
-            return next(self.events_by_test_name(test_name))
+            return next(iter(self.events_by_test_name(test_name)))
         except StopIteration:
             raise AssertionError(f"Expected event with test name {test_name!r}, found none")
 


### PR DESCRIPTION
Backport 02d281a40a7c7107de30d14096455f1f943d5d6f from #16895 to 4.6.

<!-- dd-meta {"pullId":"e36d1cce-fe97-4106-9ce8-2225c2ad01e3","source":"chat","resourceId":"be069317-1a77-4862-8796-e95b75554d56","workflowId":"23df7ce4-81cb-4785-8093-1267dac682d5","codeChangeId":"23df7ce4-81cb-4785-8093-1267dac682d5","sourceType":"chat"} -->
## Description

Restore ITR/TIA parity between pytest v2 and the new pytest plugin by keeping the previously restored session tags and now also restoring ITR telemetry counters used by downstream aggregation.

- Previously restored missing session ITR metadata in the new plugin path:
  - Added ITR session attributes to `TestSession` in `ddtrace/testing/internal/test_data.py` and populated them from `SessionManager` in `ddtrace/testing/internal/session_manager.py`.
  - Updated session final tagging to emit `test.itr.tests_skipping.enabled` for all sessions and, when ITR is enabled, emit `_dd.ci.itr.tests_skipped`, `test.itr.tests_skipping.tests_skipped`, `test.itr.tests_skipping.type`, and `test.itr.tests_skipping.count`.
  - Extended `tests/testing/internal/pytest/test_pytest_itr.py` assertions for those compatibility tags.
- Added missing ITR telemetry event counters in `ddtrace/testing/internal/telemetry.py`:
  - `record_itr_skipped`
  - `record_itr_unskippable`
  - `record_itr_forced_run`
- Wired new plugin ITR actions to telemetry in `ddtrace/testing/internal/test_data.py`:
  - `Test.mark_skipped_by_itr()` records `itr_skipped`
  - `Test.mark_unskippable()` records `itr_unskippable`
  - `Test.mark_forced_run()` records `itr_forced_run`
  - Added safe handling for contexts where `TelemetryAPI` is not initialized.
- Added telemetry validation tests:
  - `tests/testing/internal/test_telemetry.py` for the new telemetry API methods.
  - `tests/testing/internal/test_test_data.py` to assert ITR mark methods invoke telemetry.

## Testing

Unit tests adjusted

## Risks

Low to medium: this changes emitted test telemetry and session tags in the new pytest plugin to align with v2 behavior, which may affect consumers that relied on the previous omission.

## Additional Notes

This follow-up keeps behavior focused on observability parity (tags + telemetry) and does not change test selection/skipping decisions.

---
Fixes SDTEST-3564

PR by Bits
Comment @datadog to request changes
