### PR TITLE
chore(tracing): tornado unpatch missing flush unwrap

### DIFF
--- a/ddtrace/contrib/internal/tornado/patch.py
+++ b/ddtrace/contrib/internal/tornado/patch.py
@@ -84,5 +84,6 @@ def unpatch():
     _u(tornado.web.RequestHandler, "_execute")
     _u(tornado.web.RequestHandler, "on_finish")
     _u(tornado.web.RequestHandler, "log_exception")
+    _u(tornado.web.RequestHandler, "flush")
     _u(tornado.web.Application, "__init__")
     _u(tornado.template.Template, "generate")

--- a/tests/contrib/tornado/test_tornado_patch.py
+++ b/tests/contrib/tornado/test_tornado_patch.py
@@ -22,10 +22,25 @@ class TestTornadoPatch(PatchTestCase.Base):
     __get_version__ = get_version
 
     def assert_module_patched(self, tornado):
-        pass
+        self.assert_wrapped(tornado.web.Application.__init__)
+        self.assert_wrapped(tornado.web.RequestHandler._execute)
+        self.assert_wrapped(tornado.web.RequestHandler.on_finish)
+        self.assert_wrapped(tornado.web.RequestHandler.log_exception)
+        self.assert_wrapped(tornado.web.RequestHandler.flush)
+        self.assert_wrapped(tornado.template.Template.generate)
 
     def assert_not_module_patched(self, tornado):
-        pass
+        self.assert_not_wrapped(tornado.web.Application.__init__)
+        self.assert_not_wrapped(tornado.web.RequestHandler._execute)
+        self.assert_not_wrapped(tornado.web.RequestHandler.on_finish)
+        self.assert_not_wrapped(tornado.web.RequestHandler.log_exception)
+        self.assert_not_wrapped(tornado.web.RequestHandler.flush)
+        self.assert_not_wrapped(tornado.template.Template.generate)
 
     def assert_not_module_double_patched(self, tornado):
-        pass
+        self.assert_not_double_wrapped(tornado.web.Application.__init__)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler._execute)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler.on_finish)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler.log_exception)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler.flush)
+        self.assert_not_double_wrapped(tornado.template.Template.generate)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d0d96936-21df-4117-a929-f4d91080aaeb","source":"chat","resourceId":"beb05277-57c4-4288-bf3c-8c445ebc3780","workflowId":"3e0566f8-40e6-42b2-b7ff-0f5cb869c569","codeChangeId":"3e0566f8-40e6-42b2-b7ff-0f5cb869c569","sourceType":"chat"} -->
## What does this PR do?

This PR adds a  `_u` call to unwrap `RequestHandler.flush`, which was patched through `_w("tornado.web", "RequestHandler.flush", handlers._on_flush)`. This meant calling `unpatch` left the `flush` method permanently wrapped, breaking re-patching cycles and test isolation.

