### PR TITLE
fix(tracing): update unit tests

### DIFF
--- a/ddtrace/contrib/internal/tornado/patch.py
+++ b/ddtrace/contrib/internal/tornado/patch.py
@@ -84,5 +84,6 @@ def unpatch():
     _u(tornado.web.RequestHandler, "_execute")
     _u(tornado.web.RequestHandler, "on_finish")
     _u(tornado.web.RequestHandler, "log_exception")
+    _u(tornado.web.RequestHandler, "flush")
     _u(tornado.web.Application, "__init__")
     _u(tornado.template.Template, "generate")

--- a/tests/contrib/tornado/test_tornado_patch.py
+++ b/tests/contrib/tornado/test_tornado_patch.py
@@ -22,10 +22,25 @@ class TestTornadoPatch(PatchTestCase.Base):
     __get_version__ = get_version
 
     def assert_module_patched(self, tornado):
-        pass
+        self.assert_wrapped(tornado.web.Application.__init__)
+        self.assert_wrapped(tornado.web.RequestHandler._execute)
+        self.assert_wrapped(tornado.web.RequestHandler.on_finish)
+        self.assert_wrapped(tornado.web.RequestHandler.log_exception)
+        self.assert_wrapped(tornado.web.RequestHandler.flush)
+        self.assert_wrapped(tornado.template.Template.generate)
 
     def assert_not_module_patched(self, tornado):
-        pass
+        self.assert_not_wrapped(tornado.web.Application.__init__)
+        self.assert_not_wrapped(tornado.web.RequestHandler._execute)
+        self.assert_not_wrapped(tornado.web.RequestHandler.on_finish)
+        self.assert_not_wrapped(tornado.web.RequestHandler.log_exception)
+        self.assert_not_wrapped(tornado.web.RequestHandler.flush)
+        self.assert_not_wrapped(tornado.template.Template.generate)
 
     def assert_not_module_double_patched(self, tornado):
-        pass
+        self.assert_not_double_wrapped(tornado.web.Application.__init__)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler._execute)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler.on_finish)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler.log_exception)
+        self.assert_not_double_wrapped(tornado.web.RequestHandler.flush)
+        self.assert_not_double_wrapped(tornado.template.Template.generate)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"609efdbc-3003-4d53-83c3-0df1d6d242e2","source":"chat","resourceId":"818075eb-dae8-4484-8dce-8ef61f9d017b","workflowId":"be609e01-d8b5-4e10-a51b-7ba5170b297a","codeChangeId":"be609e01-d8b5-4e10-a51b-7ba5170b297a","sourceType":"chat"} -->
## Description

The Tornado integration's `patch()` function wraps `RequestHandler.flush` with `handlers._on_flush`, but the corresponding `unpatch()` function was missing the call to unwrap it. This meant that after calling `unpatch()`, the `flush` method remained wrapped, leaving the integration in a partially patched state.

**Changes:**
- Add `_u(tornado.web.RequestHandler, "flush")` to `unpatch()` in `ddtrace/contrib/internal/tornado/patch.py`
- Update `tests/contrib/tornado/test_tornado_patch.py` with proper `assert_module_patched`, `assert_not_module_patched`, and `assert_not_module_double_patched` assertions covering all patched methods including `flush`

## Testing

- `tests/contrib/tornado/test_tornado_patch.py` now asserts all patched methods (including `flush`) are wrapped after `patch()` and not wrapped after `unpatch()`
- Existing `tests/contrib/tornado/test_safety.py` exercises the unpatch/repatch cycle at a higher level

## Risks

None — this is a straightforward symmetry fix: adding the missing `unwrap` call that mirrors the existing `wrap` call.

## Additional Notes

Prior to this fix, calling `unpatch()` after `patch()` left `RequestHandler.flush` still instrumented, which could interfere with users who call `unpatch()` to disable tracing.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/818075eb-dae8-4484-8dce-8ef61f9d017b)

Comment @datadog to request changes