### PR TITLE
test(profiling): unflake `test_top_c_frame_detection_nested_sort_with_key`

### DIFF
--- a/tests/profiling/collector/test_stack_native.py
+++ b/tests/profiling/collector/test_stack_native.py
@@ -1437,7 +1437,7 @@ def test_top_c_frame_detection_nested_sort_with_key() -> None:
     ddup.upload()
 
     def inner_key(x: int) -> int:
-        return math.factorial(x)
+        return math.factorial(x + 2000)
 
     def outer_key(x: int) -> int:
         inner_data = list(range(x + 1))


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-15927

This updates a test to make it non-flaky. Previously some functions were too fast to be sampled consistently in the tiny sampling window we have (2s). 