### PR TITLE
fix(profiling): gevent.wait kwarg lookup in profiler

### DIFF
--- a/ddtrace/profiling/_gevent.py
+++ b/ddtrace/profiling/_gevent.py
@@ -225,7 +225,7 @@ def wait_wrapper(original: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
         try:
             objects = args[0]
         except IndexError:
-            objects = kwargs.get("args", [])
+            objects = kwargs.get("objects", [])
 
         if greenlets := [_ for _ in objects if isinstance(_, (greenlet, gevent.Greenlet))]:
             current_greenlet = gevent.getcurrent()

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -480,6 +480,38 @@ def test_gevent_patched_when_profiling_auto():
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="gevent is not available")
+def test_gevent_wait_wrapper_tracks_greenlets_via_keyword_arg():
+    """wait_wrapper must track greenlets when 'objects' is passed as a keyword argument."""
+    from unittest import mock
+
+    import gevent
+    from gevent import thread
+
+    from ddtrace.profiling import _gevent as _ddgevent
+
+    captured = []
+
+    def fake_link_greenlets(greenlet_id: int, parent_id: int) -> None:
+        captured.append(greenlet_id)
+
+    g1 = gevent.spawn(lambda: None)
+    g2 = gevent.spawn(lambda: None)
+
+    with mock.patch.object(_ddgevent, "link_greenlets", side_effect=fake_link_greenlets):
+        _ddgevent.patch()
+        try:
+            # Pass objects as a keyword argument — this is the case the bug missed.
+            gevent.wait(objects=[g1, g2])
+        finally:
+            _ddgevent.unpatch()
+
+    g1_id = thread.get_ident(g1)
+    g2_id = thread.get_ident(g2)
+    assert g1_id in captured, f"g1 ({g1_id}) was not tracked; captured={captured}"
+    assert g2_id in captured, f"g2 ({g2_id}) was not tracked; captured={captured}"
+
+
+@pytest.mark.skipif(not TESTING_GEVENT, reason="gevent is not available")
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_ENABLED="false",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9c3e58a5-9394-4006-b8d6-e7ce0d0654f6","source":"chat","resourceId":"df92db0c-24ef-44ec-8c2b-a779f95b2789","workflowId":"21aea9b8-6a20-4fbc-af39-c22fb3dca541","codeChangeId":"21aea9b8-6a20-4fbc-af39-c22fb3dca541","sourceType":"chat"} -->
## Summary

Fix a bug in the profiler's `wait_wrapper` for `gevent.wait` / `gevent.iwait` where greenlets passed via keyword argument were silently not tracked, and add a regression test to cover it.

## Changes

- In `ddtrace/profiling/_gevent.py`, `wait_wrapper` fell back to `kwargs.get("args", [])` when no positional args were present. The `gevent.wait` and `gevent.iwait` functions name their first parameter `objects`, not `args`, so any call like `gevent.wait(objects=[g1, g2])` would return an empty list and skip greenlet tracking entirely. Changed to `kwargs.get("objects", [])`.
- In `tests/profiling/test_profiler.py`, added `test_gevent_wait_wrapper_tracks_greenlets_via_keyword_arg` which calls `gevent.wait(objects=[g1, g2])` and asserts both greenlets are passed to `link_greenlets`. This test would have failed against the old code.

## Why didn't the existing tests catch this?

The existing `test_gevent_patched_*` tests only assert that `gevent.wait.__module__ == "ddtrace.profiling._gevent"` — i.e., that the wrapper *is installed*. They never call `gevent.wait(objects=...)` and verify that greenlets are actually tracked. The wrapper was installed correctly; the bug was inside it.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/df92db0c-24ef-44ec-8c2b-a779f95b2789)

Comment @datadog to request changes