### PR TITLE
fix(profiling): more resilient "ref counting" of greenlets

### DIFF
--- a/ddtrace/profiling/_gevent.py
+++ b/ddtrace/profiling/_gevent.py
@@ -155,9 +155,11 @@ def _untrack_greenlet_by_id(greenlet_id: int) -> None:
     _tracked_greenlets.discard(greenlet_id)
     _parent_greenlet_count.pop(greenlet_id, None)
     if (parent_id := _greenlet_parent_map.pop(greenlet_id, None)) is not None:
-        _parent_greenlet_count[parent_id] -= 1
-        if _parent_greenlet_count[parent_id] <= 0:
-            del _parent_greenlet_count[parent_id]
+        remaining = _parent_greenlet_count.get(parent_id, 0) - 1
+        if remaining <= 0:
+            _parent_greenlet_count.pop(parent_id, None)
+        else:
+            _parent_greenlet_count[parent_id] = remaining
 
 
 def untrack_greenlet(gl: _Greenlet) -> None:

--- a/releasenotes/notes/fix-profiling-gevent-untrack-keyerror-7f3a9b2c1d4e5f60.yaml
+++ b/releasenotes/notes/fix-profiling-gevent-untrack-keyerror-7f3a9b2c1d4e5f60.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: A ``KeyError`` that could occur when using ``gevent.Timeout`` has
+    been fixed.

--- a/tests/profiling/test_gevent.py
+++ b/tests/profiling/test_gevent.py
@@ -16,6 +16,106 @@ GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", Fals
     reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
 )
 @pytest.mark.subprocess()
+def test_untrack_parent_before_child_no_keyerror() -> None:
+    """Untracking a parent greenlet before its linked child must not raise KeyError.
+
+    When _untrack_greenlet_by_id(parent) is called, _parent_greenlet_count[parent]
+    is popped. If the child is later untracked and tries to decrement that entry,
+    a KeyError was raised. This test verifies the fix.
+    """
+    from unittest.mock import patch
+
+    from ddtrace.profiling import _gevent as _gevent_module
+
+    saved_tracked = set(_gevent_module._tracked_greenlets)
+    saved_count = dict(_gevent_module._parent_greenlet_count)
+    saved_map = dict(_gevent_module._greenlet_parent_map)
+
+    try:
+        with patch.object(_gevent_module, "stack"):
+            parent_id, child_id = 100001, 100002
+            _gevent_module._tracked_greenlets.update({parent_id, child_id})
+            _gevent_module.link_greenlets(child_id, parent_id)
+
+            assert _gevent_module._parent_greenlet_count.get(parent_id) == 1
+
+            _gevent_module._untrack_greenlet_by_id(parent_id)
+
+            assert parent_id not in _gevent_module._tracked_greenlets
+            assert parent_id not in _gevent_module._parent_greenlet_count
+
+            _gevent_module._untrack_greenlet_by_id(child_id)
+
+            assert child_id not in _gevent_module._tracked_greenlets
+            assert child_id not in _gevent_module._greenlet_parent_map
+            assert parent_id not in _gevent_module._parent_greenlet_count
+    finally:
+        _gevent_module._tracked_greenlets.clear()
+        _gevent_module._tracked_greenlets.update(saved_tracked)
+        _gevent_module._parent_greenlet_count.clear()
+        _gevent_module._parent_greenlet_count.update(saved_count)
+        _gevent_module._greenlet_parent_map.clear()
+        _gevent_module._greenlet_parent_map.update(saved_map)
+
+
+@pytest.mark.skipif(
+    not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
+    reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
+)
+@pytest.mark.subprocess()
+def test_untrack_parent_before_child_no_keyerror_real_greenlets() -> None:
+    """Regression test: no KeyError when a timed-out joiner is untracked before the joined greenlet.
+
+    When a greenlet calls .join() with a Timeout, the joiner can exit before
+    the joined greenlet finishes. This causes _untrack_greenlet_by_id(joiner)
+    to pop joiner's _parent_greenlet_count entry, after which untracking the
+    joined greenlet would raise KeyError trying to decrement that entry.
+    """
+    from unittest.mock import patch
+
+    import gevent
+    import gevent.monkey
+
+    gevent.monkey.patch_all()
+
+    from ddtrace.profiling import _gevent as _gevent_module
+    from ddtrace.profiling._gevent import Greenlet
+
+    caught: list[Exception] = []
+    original = _gevent_module._untrack_greenlet_by_id
+
+    def _spy(greenlet_id: int) -> None:
+        try:
+            original(greenlet_id)
+        except KeyError as e:
+            caught.append(e)
+            raise
+
+    with patch.object(_gevent_module, "_untrack_greenlet_by_id", _spy):
+
+        def slow_task() -> None:
+            gevent.sleep(0.5)
+
+        def joiner() -> None:
+            slow = Greenlet.spawn(slow_task)
+            try:
+                with gevent.Timeout(0.05):
+                    slow.join()
+            except gevent.Timeout:
+                pass
+
+        g = Greenlet.spawn(joiner)
+        g.join()
+        gevent.sleep(1.0)
+
+    assert not caught, f"KeyError raised during untrack: {caught[0]}"
+
+
+@pytest.mark.skipif(
+    not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
+    reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
+)
+@pytest.mark.subprocess()
 def test_joinall_links_to_calling_greenlet_not_hub() -> None:
     """joinall must link joined greenlets to the *calling* Greenlet, not the Hub.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a738411c-114c-46b1-9910-c32a82d37a0c","source":"chat","resourceId":"5ef6e903-9d6c-4428-9614-c2062b617cd7","workflowId":"500504f9-2afb-414b-8300-765b9ec9b44f","codeChangeId":"500504f9-2afb-414b-8300-765b9ec9b44f","sourceType":"chat"} -->
## What is this PR?

This fixes a `KeyError` in the gevent greenlet untracking code that occurs when a parent greenlet is untracked before its linked child greenlets. Previously, the code attempted to decrement the parent's count and delete the entry directly, which would fail with a `KeyError` if the parent had already been removed from the tracking dictionary.

The fix uses safer dictionary operations (`get` and `pop`) to handle the case where the parent greenlet is no longer in the tracking structures when the child is untracked.

The PR also adds a new test that checks the behaviour is the expected one.

## Reproducer

This can happen if the user uses `gevent.Timeout` and the time out occurs.

```py
import gevent
import gevent.monkey

gevent.monkey.patch_all()

def repro() -> None:
    from ddtrace.profiling._gevent import Greenlet

    def slow_task() -> None:
        gevent.sleep(0.5)

    def joiner() -> None:
        slow = Greenlet.spawn(slow_task)
        try:
            with gevent.Timeout(0.05):
                slow.join()      # link_greenlets(slow, joiner) called here
        except gevent.Timeout:
            pass                 # joiner exits; slow is still running

    g = Greenlet.spawn(joiner)
    g.join()
    gevent.sleep(1.0)            # let slow_task finish and trigger untrack

repro()
```

gives

```
% python3 ./repro_greenlet_keyerror.py
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 1018, in gevent._gevent_cgreenlet.Greenlet._notify_links
  File "/Users/thomas.kowalski/go/src/github.com/DataDog/ddtpy/ddtrace/profiling/_gevent.py", line 164, in untrack_greenlet
    _untrack_greenlet_by_id(thread.get_ident(gl))
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thomas.kowalski/go/src/github.com/DataDog/ddtpy/ddtrace/profiling/_gevent.py", line 158, in _untrack_greenlet_by_id
    _parent_greenlet_count[parent_id] -= 1
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 4477074816
2026-03-26T09:47:54Z (<function untrack_greenlet at 0x10aee56f0>, <Greenlet "Greenlet-1" at 0x10aee8540: _run>) failed with KeyError
```