### PR TITLE
ci: migrate to noqueue MQ

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -2,8 +2,9 @@
 schema-version: v1
 kind: mergequeue
 enable: true
-# PRs A, B -> A, A+B workflows being generated
-workflow_type: speculative
+# Each PR in the MQ will be rebased on the base branch before merging
+# conflicts between PRs in the MQ will not be able to be detected
+workflow_type: noqueue
 merge_method: squash
 gitlab_check_enable: true
 gitlab_jobs_retry_enable: false
@@ -12,10 +13,6 @@ gitlab_jobs_retry_enable: false
 gitlab_fail_fast: true
 # Do not add merge queue status labels on the PR, they will trigger required status checks and block the PR from the MQ
 skip_labels: true
-# Validate up to 2 PRs from the queue at once
-speculative_max_depth: 2
-# Run CI for A, A+B, and B such that if A or A+B fail, but B passes, we can still merge B
-speculative_fallback_enable: true
 branches:
   main:
     # Allow users to skip checks when merging a PR, but require them to provide a reason for skipping checks


### PR DESCRIPTION
## Description

This will stop stacking PRs, we'll just build full CI ontop of the base and then merge once CI is green.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
