### PR TITLE
ci: allow lambda size check to fail - stopgap to unblock main CI [backport 4.5]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,6 +109,8 @@ serverless lambda tests:
     branch: main
   needs:
     - job: "upload all"
+  rules:
+    - allow_failure: true
   variables:
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
     UPSTREAM_PROJECT_URL: $CI_PROJECT_URL


### PR DESCRIPTION
## Description

This change marks the serveless trigger job as allowed to fail. This unblocks main CI while we investigate the root cause.


(cherry picked from commit b6b46c5c1113d5f769240ea6e642ca470af56e8a)

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
