### PR TITLE
ci: remove slim wheels before uploading everything else

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -26,6 +26,7 @@ variables:
     - pip install -r ci/requirements/ci.txt
     - python -m twine check --strict pywheels/*
   script:
+    - rm -rf pywheels/ddtraceslim*
     - python -m twine upload --repository ${PYPI_REPOSITORY} pywheels/*
   artifacts:
     paths:


### PR DESCRIPTION
This change fixes failures like [this one](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1515746929) that only occur on tag builds by removing `ddtraceslim` wheels before attempting PyPI uploads.