### PR TITLE
ci: fix create_package test fixtures hangs outside of run-tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -560,7 +560,7 @@ def create_package(directory, pyproject, setup):
         _run("git config --local user.name user")
         _run("git config --local user.email user@company.com")
         _run("git add .")
-        _run("git commit --no-gpg-sign -m init")
+        _run("git commit --no-verify --no-gpg-sign -m init")
         _run("git remote add origin https://username:password@github.com/companydotcom/repo.git")
 
         yield package_dir


### PR DESCRIPTION
## Description

When running the `tracer` test suite locally (outisde of ddtest/run-tests), I found that the `test_gitmetadata` module has many tests that hang. It freezes on git hooks that are configured globally on Datadog's employees laptops.

This PR skips commit verification for this single test.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
