### PR TITLE
fix(ci_visibility): restore case of test quarantined and attempt-to-fix [backport #16962 to 4.5]

### DIFF
--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -373,21 +373,22 @@ class TestOptPlugin:
         )
 
     def _apply_test_management_markers(self, item: pytest.Item, test: "Test") -> None:
+        """Apply test management markers for the base plugin (used when an external rerun plugin drives execution).
+
+        ATF retries are not supported in this mode — the external plugin controls the protocol and we cannot intercept
+        individual test runs to capture real FAIL statuses. Disabled+ATF tests therefore get the same xfail treatment
+        as quarantined tests: failures won't break the pipeline, but ATF retry semantics are silently unavailable.
+        If ATF support is needed, disable the external rerun plugin (see the warning emitted at configure time).
+
+        Overridden in TestOptPluginWithProtocol, which drives retries itself and needs real FAIL outcomes for ATF.
+        """
         if not self.manager.settings.test_management.enabled:
             return
         if test.is_disabled() and not test.is_attempt_to_fix():
             item.add_marker(pytest.mark.skip(reason=DISABLED_BY_TEST_MANAGEMENT_REASON))
-        elif test.is_quarantined():
-            # Quarantined tests use xfail so failures don't break the pipeline. This works regardless of who drives
-            # execution (our plugin or an external rerun plugin like pytest-rerunfailures/flaky).
+        elif test.is_quarantined() or (test.is_disabled() and test.is_attempt_to_fix()):
+            # Use xfail so failures don't break the pipeline. Works regardless of who drives test execution.
             item.add_marker(pytest.mark.xfail(strict=False, reason="dd_quarantined", run=True))
-        elif test.is_disabled() and test.is_attempt_to_fix():
-            # Attempt-to-fix tests use a user property instead of xfail, so that _get_test_outcome captures the real
-            # FAIL status (needed by AttemptToFixHandler.get_final_status). The report is mangled to "skipped" after
-            # the real status is captured, so the failure doesn't break the pipeline.
-            # AIDEV-NOTE: ATF cannot use xfail because xfail turns failures into SKIP, which breaks the retry handler's
-            # ability to count failures and determine HAS_FAILED_ALL_RETRIES / ATTEMPT_TO_FIX_PASSED tags.
-            item.user_properties += [("dd_disabled_attempt_to_fix", True)]
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True, specname="pytest_runtest_protocol")
     def pytest_runtest_protocol_wrapper(
@@ -772,6 +773,31 @@ class TestOptPluginWithProtocol(TestOptPlugin):
     the base class is registered instead, so the external plugin drives retries while the wrapper hook still handles
     span bookkeeping.
     """
+
+    def _apply_test_management_markers(self, item: pytest.Item, test: "Test") -> None:
+        """Apply test management markers for the plugin that drives retries itself.
+
+        ATF tests must NOT use xfail here: xfail converts failures into SKIP outcomes, which prevents
+        AttemptToFixHandler.get_final_status from seeing real FAIL counts and computing correct tags
+        (HAS_FAILED_ALL_RETRIES, ATTEMPT_TO_FIX_PASSED). Instead, ATF tests set a user property so
+        _get_test_outcome captures the true status, and reports are mangled to "skipped" afterwards so
+        failures still don't break the pipeline.
+
+        The outer condition mirrors the original logic: only quarantined tests and disabled+ATF tests
+        are treated as "run but don't fail the pipeline" — plain ATF (neither disabled nor quarantined)
+        runs normally without any report suppression.
+        """
+        if not self.manager.settings.test_management.enabled:
+            return
+        if test.is_disabled() and not test.is_attempt_to_fix():
+            item.add_marker(pytest.mark.skip(reason=DISABLED_BY_TEST_MANAGEMENT_REASON))
+        elif test.is_quarantined() or (test.is_disabled() and test.is_attempt_to_fix()):
+            # AIDEV-NOTE: keep is_attempt_to_fix() check inside this branch, not outside — plain ATF tests that are
+            # neither disabled nor quarantined run normally and must not get report mangling or a user property.
+            if test.is_attempt_to_fix():
+                item.user_properties += [("dd_disabled_attempt_to_fix", True)]
+            else:
+                item.add_marker(pytest.mark.xfail(strict=False, reason="dd_quarantined", run=True))
 
     @catch_and_log_exceptions()
     def pytest_runtest_protocol(self, item: pytest.Item, nextitem: t.Optional[pytest.Item]) -> bool:

--- a/releasenotes/notes/fix-ci_visibility-quarantined-atr-233203d2d3db4651.yaml
+++ b/releasenotes/notes/fix-ci_visibility-quarantined-atr-233203d2d3db4651.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixed an issue where a test marked as both quarantined and attempt-to-fix was incorrectly treated as plain quarantined, preventing attempt-to-fix flow from running.

--- a/tests/contrib/pytest/test_pytest_configure_plugin_selection.py
+++ b/tests/contrib/pytest/test_pytest_configure_plugin_selection.py
@@ -169,27 +169,65 @@ class TestPluginClassSelection:
 
         item.add_marker.assert_called_once()
 
-    def test_attempt_to_fix_uses_user_property_not_xfail(self):
-        """ATF tests use user property instead of xfail, so _get_test_outcome captures real FAIL status."""
+    @pytest.mark.parametrize(
+        "is_quarantined,is_disabled,is_attempt_to_fix",
+        [
+            (True, False, False),  # quarantined
+            (False, True, True),  # disabled + ATF (ATF retries unavailable, treated same as quarantine)
+            (True, False, True),  # quarantined + ATF (same: ATF retries unavailable in base class)
+        ],
+    )
+    def test_base_plugin_uses_xfail_for_quarantine_and_atf(self, is_quarantined, is_disabled, is_attempt_to_fix):
+        """Base plugin (no retry control) always uses xfail for quarantine/ATF — ATF retries can't fire anyway."""
         plugin = mock.MagicMock()
         plugin.manager.settings.test_management.enabled = True
 
         test = mock.MagicMock()
-        test.is_quarantined.return_value = False
-        test.is_disabled.return_value = True
-        test.is_attempt_to_fix.return_value = True
+        test.is_quarantined.return_value = is_quarantined
+        test.is_disabled.return_value = is_disabled
+        test.is_attempt_to_fix.return_value = is_attempt_to_fix
 
         item = mock.MagicMock()
         item.user_properties = []
 
         TestOptPlugin._apply_test_management_markers(plugin, item=item, test=test)
 
-        # ATF should NOT use xfail (no marker added), but set a user property instead
+        xfail_calls = [
+            call
+            for call in item.add_marker.call_args_list
+            if len(call[0]) > 0 and hasattr(call[0][0], "mark") and call[0][0].mark.name == "xfail"
+        ]
+        assert len(xfail_calls) == 1
+        assert xfail_calls[0][0][0].mark.kwargs["reason"] == "dd_quarantined"
+        assert item.user_properties == []
+
+    @pytest.mark.parametrize(
+        "is_quarantined,is_disabled,is_attempt_to_fix",
+        [
+            (False, True, True),  # disabled + ATF
+            (True, False, True),  # quarantined + ATF
+        ],
+    )
+    def test_child_plugin_uses_user_property_for_atf(self, is_quarantined, is_disabled, is_attempt_to_fix):
+        """Child plugin (drives retries) uses user property for ATF so real FAIL status is captured."""
+        plugin = mock.MagicMock()
+        plugin.manager.settings.test_management.enabled = True
+
+        test = mock.MagicMock()
+        test.is_quarantined.return_value = is_quarantined
+        test.is_disabled.return_value = is_disabled
+        test.is_attempt_to_fix.return_value = is_attempt_to_fix
+
+        item = mock.MagicMock()
+        item.user_properties = []
+
+        TestOptPluginWithProtocol._apply_test_management_markers(plugin, item=item, test=test)
+
         item.add_marker.assert_not_called()
         assert ("dd_disabled_attempt_to_fix", True) in item.user_properties
 
-    def test_quarantined_uses_xfail(self):
-        """Quarantined tests use xfail marker for compatibility with external rerun plugins."""
+    def test_child_plugin_uses_xfail_for_quarantine_without_atf(self):
+        """Child plugin uses xfail for quarantined non-ATF tests (same as base)."""
         plugin = mock.MagicMock()
         plugin.manager.settings.test_management.enabled = True
 
@@ -201,9 +239,8 @@ class TestPluginClassSelection:
         item = mock.MagicMock()
         item.user_properties = []
 
-        TestOptPlugin._apply_test_management_markers(plugin, item=item, test=test)
+        TestOptPluginWithProtocol._apply_test_management_markers(plugin, item=item, test=test)
 
-        # Quarantined should use xfail marker
         xfail_calls = [
             call
             for call in item.add_marker.call_args_list
@@ -211,4 +248,25 @@ class TestPluginClassSelection:
         ]
         assert len(xfail_calls) == 1
         assert xfail_calls[0][0][0].mark.kwargs["reason"] == "dd_quarantined"
-        assert item.user_properties == []  # No user property for quarantine
+        assert item.user_properties == []
+
+    @pytest.mark.parametrize("plugin_class", [TestOptPlugin, TestOptPluginWithProtocol])
+    def test_plain_atf_no_markers_applied(self, plugin_class):
+        """A test that is attempt-to-fix but neither disabled nor quarantined gets no marker or property.
+        ATF retry semantics only apply when the test is also disabled or quarantined; plain ATF runs normally.
+        """
+        plugin = mock.MagicMock()
+        plugin.manager.settings.test_management.enabled = True
+
+        test = mock.MagicMock()
+        test.is_quarantined.return_value = False
+        test.is_disabled.return_value = False
+        test.is_attempt_to_fix.return_value = True
+
+        item = mock.MagicMock()
+        item.user_properties = []
+
+        plugin_class._apply_test_management_markers(plugin, item=item, test=test)
+
+        item.add_marker.assert_not_called()
+        assert item.user_properties == []


### PR DESCRIPTION
Backport b35504efba11ff92ce833f1472a8ec73abf73016 from #16962 to 4.5.

## Description

Follow-up PR after https://github.com/DataDog/dd-trace-py/pull/16873

  When a test is both quarantined and marked as Attempt-to-Fix (ATF), the previous PR logic treated it as a plain quarantined test (applying `xfail`) — the ATF handling was inadvertently dropped.
   This meant `AttemptToFixHandler.get_final_status` could not see real `FAIL` outcomes for quarantined+ATF tests, breaking the `HAS_FAILED_ALL_RETRIES` / `ATTEMPT_TO_FIX_PASSED` tag computation.

  The fix restores correct handling for the quarantined+ATF case by overriding `_apply_test_management_markers` in `TestOptPluginWithProtocol` (the class that drives retries and owns`pytest_runtest_protocol`):

  - **Base class (`TestOptPlugin`)** — used alongside external rerun plugins (ATR/EFD disabled): applies `xfail` for all quarantine/ATF cases. Since the external plugin controls execution, ATF retries can never fire anyway, so `xfail` is the correct safe fallback.
  - **Child class (`TestOptPluginWithProtocol`)** — drives retries itself: quarantined non-ATF tests get `xfail`, but disabled+ATF and quarantined+ATF tests get the `dd_disabled_attempt_to_fix` user property instead, so `_get_test_outcome` captures the real `FAIL` status before reports are mangled to `skipped`.

  In both classes, a plain ATF test (neither disabled nor quarantined) continues to run normally with no marker or user property — matching original behavior.

  ## Testing

  Extended `TestPluginClassSelection` in `tests/contrib/pytest/test_pytest_configure_plugin_selection.py`:

  - `test_base_plugin_uses_xfail_for_quarantine_and_atf` — parametrized over quarantined, disabled+ATF, and quarantined+ATF; all three get `xfail` in the base class.
  - `test_child_plugin_uses_user_property_for_atf` — disabled+ATF and quarantined+ATF get `dd_disabled_attempt_to_fix` user property (no marker) in the child class.
  - `test_child_plugin_uses_xfail_for_quarantine_without_atf` — quarantined non-ATF gets `xfail` in the child class.
  - `test_plain_atf_no_markers_applied` — parametrized over both classes; neither adds a marker nor sets a user property.

  ## Risks

  Low. The only behavior change is for the quarantined+ATF combination, which was broken (silently dropped to xfail-only). All other cases are unchanged.

  ## Additional Notes

  - The `dd_disabled_attempt_to_fix` user property is only consumed by `_do_test_runs` and `_do_retries` in `TestOptPluginWithProtocol`, so it belongs in the override rather than the base class.
