### PR TITLE
fix(llmobs): don't drop streamed beta tool use anthropic responses

### DIFF
--- a/ddtrace/contrib/internal/anthropic/_streaming.py
+++ b/ddtrace/contrib/internal/anthropic/_streaming.py
@@ -147,7 +147,12 @@ def _on_content_block_start_chunk(chunk, message):
 
 
 def _on_content_block_delta_chunk(chunk, message):
-    # delta events contain new content for the current message.content block
+    """Append new content from delta events to current message.content block
+    Note: Anthropic beta streaming can emit content_block_delta without a corresponding
+    content_block_start. Guard to avoid IndexError which breaks span construction.
+    """
+    if not message.get("content"):
+        return message
     delta_block = _get_attr(chunk, "delta", "")
     if delta_block:
         chunk_content_text = _get_attr(delta_block, "text", "")
@@ -156,16 +161,18 @@ def _on_content_block_delta_chunk(chunk, message):
 
         chunk_content_json = _get_attr(delta_block, "partial_json", "")
         if chunk_content_json and _get_attr(delta_block, "type", "") == "input_json_delta":
+            if "input" not in message["content"][-1]:
+                message["content"][-1]["input"] = ""
             # we have a json content block, most likely a tool input dict
             message["content"][-1]["input"] += chunk_content_json
     return message
 
 
 def _on_content_block_stop_chunk(chunk, message):
-    # this is the start to a message.content block (possibly 1 of several content blocks)
-    # Anthropic beta streaming can emit content_block_stop without a corresponding
-    # content_block_start (e.g. empty tool blocks / vendor edge cases). Guard to
-    # avoid IndexError which breaks span construction.
+    """Finalize the current content block, parsing tool_use input JSON into a dict.
+    Anthropic beta streaming can emit content_block_stop without a corresponding
+    content_block_start. Guard to avoid IndexError which breaks span construction.
+    """
     if not message.get("content"):
         return message
 

--- a/releasenotes/notes/fix-llmobs-anthropic-beta-tools-200099849fd61643.yaml
+++ b/releasenotes/notes/fix-llmobs-anthropic-beta-tools-200099849fd61643.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where Anthropic LLM spans were dropped when streaming
+    responses from Anthropic beta API features with tool use, such as ``tool_search_tool_regex``.

--- a/tests/contrib/anthropic/cassettes/anthropic_completion_tools_stream_no_content_block_start.yaml
+++ b/tests/contrib/anthropic/cassettes/anthropic_completion_tools_stream_no_content_block_start.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"max_tokens": 200, "messages": [{"role": "user", "content": "What is the
+      weather in San Francisco, CA?"}], "model": "claude-3-opus-20240229", "stream":
+      true, "tools": [{"name": "get_weather", "description": "Get the weather for
+      a specific location", "input_schema": {"type": "object", "properties": {"location":
+      {"type": "string"}}}}, {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - tool-search-tool-regex-20251119
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01abc","type":"message","role":"assistant","model":"claude-3-opus-20240229","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":599,"output_tokens":2}}}
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check the weather."}}
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\": \"San Francisco, CA\"}"}}
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1}
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":50}}
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"}
+
+
+        '
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      connection:
+      - keep-alive
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -68,6 +68,51 @@ class TestLLMObsAnthropic:
         message = {"content": []}
         assert _on_content_block_stop_chunk(chunk=None, message=message) == message
 
+    @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
+    @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
+    def test_beta_tools_stream_input_json_delta_without_content_block_start(
+        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
+    ):
+        """Regression test: beta API features (e.g. tool_search_tool_regex) can emit input_json_delta
+        chunks without a preceding content_block_start of type tool_use. This previously caused a
+        KeyError on the 'input' key, preventing the LLMObs span from being submitted.
+        """
+        llm = anthropic.Anthropic()
+        with request_vcr.use_cassette("anthropic_completion_tools_stream_no_content_block_start.yaml"):
+            stream = llm.beta.messages.create(
+                model="claude-3-opus-20240229",
+                max_tokens=200,
+                messages=[{"role": "user", "content": WEATHER_PROMPT}],
+                tools=[
+                    *tools,
+                    {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"},
+                ],
+                betas=["tool-search-tool-regex-20251119"],
+                stream=True,
+            )
+            consume_stream(stream)
+
+        span = test_spans.pop_traces()[0][0]
+        assert mock_llmobs_writer.enqueue.call_count == 1
+        mock_llmobs_writer.enqueue.assert_called_with(
+            _expected_llmobs_llm_span_event(
+                span,
+                model_name="claude-3-opus-20240229",
+                model_provider="anthropic",
+                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+                output_messages=[
+                    {"content": "Let me check the weather.", "role": "assistant"},
+                ],
+                metadata={"max_tokens": 200},
+                token_metrics={"input_tokens": 599, "output_tokens": 50, "total_tokens": 649},
+                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic"},
+                tool_definitions=[
+                    *EXPECTED_TOOL_DEFINITIONS,
+                    {"name": "tool_search_tool_regex", "description": "", "schema": {}},
+                ],
+            )
+        )
+
     @patch("anthropic._base_client.SyncAPIClient.post")
     def test_completion_proxy(
         self,


### PR DESCRIPTION
Backport #16984 to 4.6

This PR fixes a bug where Anthropic LLM spans were dropped when streaming responses from beta.messages.create with beta tool features like tool_search_tool_regex. These beta features can emit input_json_delta streaming chunks without a preceding content_block_start of type tool_use, which normally initializes the "input" key on the content block. The missing key caused a KeyError during stream processing, which in turn prevented llmobs_set_tags from running, leaving the span without a kind, causing it to be dropped on finish.

We now initialize "input" to an empty string if it's missing before appending the partial JSON in streaming processing.

<!-- Provide an overview of the change and motivation for the change -->

<!-- Describe your testing strategy or note what tests are included -->

<!-- Note any risks associated with this change, or "None" if no risks -->

<!-- Any other information that would be helpful for reviewers -->

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
