### PR TITLE
fix(profiling): use weighted size for heap live size

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -409,9 +409,11 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
     // Reset the allocation data, keep heap data for tracking
     tb->sample.reset_alloc();
     // pool_get_with_alloc_data_invokes_cpython() creates sample with allocation data only (no heap data)
-    // to avoid double-pushing allocation data, we manually push heap data here
-    // TODO(dsn): figure out if this actually makes sense, or if we should use the weighted size
-    tb->sample.push_heap(size);
+    // to avoid double-pushing allocation data, we manually push heap data here.
+    // Use the weighted size (allocated_memory_val) so the heap profile accounts
+    // for sampling, matching the tcmalloc/Go pprof approach: each sampled live
+    // allocation represents ~R bytes of heap, not just its own raw size.
+    tb->sample.push_heap(allocated_memory_val);
 
     // Check that instance is still valid after GIL release in constructor
     if (heap_tracker_t::instance) {

--- a/releasenotes/notes/profiling-memory-use-weighted-allocation-size-cfe1ff5d2cde9429.yaml
+++ b/releasenotes/notes/profiling-memory-use-weighted-allocation-size-cfe1ff5d2cde9429.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: the memory profiler now uses the weighted allocation size in heap live size,
+    fixing a bug where the reported heap live size was much lower than it really was.


### PR DESCRIPTION
## Description

This updates the memory profiling logic to properly use the weighted memory allocation size instead of the raw memory allocation size to track the heap live size.

**Before**
<img width="621" height="313" alt="image" src="https://github.com/user-attachments/assets/f729974f-1779-43da-b74f-6885180dca25" />


**After**

<img width="638" height="325" alt="image" src="https://github.com/user-attachments/assets/485e07d6-0974-42d2-8b85-3a7a247e4c49" />
