### PR TITLE
chore: remove some files from the build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1319,7 +1319,7 @@ setup(
         ),
     },
     exclude_package_data={
-        "": ["CMakeLists.txt", "*.pyi", "*.md", "*.sh", "*.cmake", "*.pxd"],
+        "": ["CMakeLists.txt", "*.md", "*.sh", "*.cmake", "*.pxd"],
     },
     zip_safe=False,
     # enum34 is an enum backport for earlier versions of python


### PR DESCRIPTION
## Description

Remove some unneeded files from the build. This makes the compressed build around 200KB smaller, which is important for serverless builds.