### PR TITLE
ci: remove the ghost of setuptools_scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1329,7 +1329,12 @@ setup(
         "clean": CleanLibraries,
         "ext_hashes": ExtensionHashes,
     },
-    setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust<2"],
+    setup_requires=[
+        "cython",
+        "cmake>=3.24.2,<3.28",
+        "setuptools-rust<2",
+        "patchelf>=0.17.0.0; sys_platform == 'linux'",
+    ],
     ext_modules=ext_modules + cython_exts + get_exts_for("psutil"),
     distclass=PatchedDistribution,
 )


### PR DESCRIPTION
## Description

`setuptools_scm==10.0.1` was released at 11:30am EST and is causing CI failures.

We don't use `setuptools_scm` anymore, but it was still apart of the setup requires in `setup.py`.

<details>

<summary>Traceback</summary>

```
/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/__init__.py:92: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!
        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************
!!
  dist.fetch_build_eggs(dist.setup_requires)
INFO: building package 'ddtrace'
Traceback (most recent call last):
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/setup.py", line 1309, in <module>
    setup(
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 148, in setup
    _setup_distribution = dist = klass(attrs)
                                 ^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/setup.py", line 290, in __init__
    super().__init__(attrs)
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/dist.py", line 321, in __init__
    _Distribution.__init__(self, dist_attrs)
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 307, in __init__
    self.finalize_options()
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/dist.py", line 789, in finalize_options
    for ep in sorted(loaded, key=by_order):
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/setuptools/dist.py", line 788, in <lambda>
    loaded = map(lambda e: e.load(), filtered)
                           ^^^^^^^^
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.eggs/setuptools_scm-10.0.1-py3.12.egg/setuptools_scm/__init__.py", line 8, in <module>
    from vcs_versioning import Configuration
ModuleNotFoundError: No module named 'vcs_versioning'
```

</details>

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
