### PR TITLE
refactor(profiling): `asyncio` wrapper improvements

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -20,9 +20,7 @@ from ddtrace.internal.wrapping import wrap
 ASYNCIO_IMPORTED: bool = False
 
 
-def current_task(
-    loop: typing.Optional["asyncio.AbstractEventLoop"] = None,
-) -> typing.Optional["asyncio.Task[typing.Any]"]:
+def current_task() -> typing.Optional["asyncio.Task[typing.Any]"]:
     return None
 
 
@@ -123,12 +121,7 @@ def _(asyncio: ModuleType) -> None:
                 children = get_argument_value(args, kwargs, 1, "children")
                 assert children is not None  # nosec: assert is used for typing
 
-                # Pass an invalid positional index for 'loop'
-                loop = get_argument_value(args, kwargs, -1, "loop")
-
-                # Link the parent gathering task to the gathered children
-                parent = globals()["current_task"](loop)
-
+                parent = globals()["current_task"]()
                 for child in children:
                     stack.link_tasks(parent, child)
 
@@ -142,10 +135,8 @@ def _(asyncio: ModuleType) -> None:
                 return f(*args, **kwargs)
             finally:
                 futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
-                loop = typing.cast("aio.AbstractEventLoop", get_argument_value(args, kwargs, 3, "loop"))
 
-                # Link the parent gathering task to the gathered children
-                parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"](loop))
+                parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
                 for future in futures:
                     stack.link_tasks(parent, future)
 
@@ -156,7 +147,7 @@ def _(asyncio: ModuleType) -> None:
             kwargs: dict[str, typing.Any],
         ) -> typing.Any:
             loop = typing.cast(typing.Optional["aio.AbstractEventLoop"], kwargs.get("loop"))
-            parent: typing.Optional["aio.Task[typing.Any]"] = globals()["current_task"](loop)
+            parent: typing.Optional["aio.Task[typing.Any]"] = globals()["current_task"]()
 
             if parent is not None:
                 fs = typing.cast(typing.Iterable["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
@@ -164,8 +155,15 @@ def _(asyncio: ModuleType) -> None:
                 for future in futures:
                     stack.link_tasks(parent, future)
 
-                # Replace fs with the ensured futures to avoid double-wrapping
-                args = (futures,) + args[1:]
+                # Replace fs with the ensured futures to avoid double-wrapping.
+                # Handle both positional (args[0]) and keyword ('fs') call patterns:
+                # if fs was positional we update args; if it was a keyword we must
+                # update kwargs instead, otherwise f() receives fs twice and raises
+                # TypeError: got multiple values for argument 'fs'.
+                if args:
+                    args = (futures,) + args[1:]
+                else:
+                    kwargs = {**kwargs, "fs": futures}
 
             return f(*args, **kwargs)
 
@@ -184,7 +182,13 @@ def _(asyncio: ModuleType) -> None:
             if parent is not None:
                 stack.link_tasks(parent, future)
 
-            args = (future,) + args[1:]
+            # Same positional-vs-keyword handling as the as_completed wrapper above:
+            # if 'arg' was passed positionally update args, otherwise update kwargs to
+            # avoid TypeError: got multiple values for argument 'arg'.
+            if args:
+                args = (future,) + args[1:]
+            else:
+                kwargs = {**kwargs, "arg": future}
 
             return f(*args, **kwargs)
 

--- a/tests/profiling/collector/test_asyncio_param_forwarding.py
+++ b/tests/profiling/collector/test_asyncio_param_forwarding.py
@@ -1,0 +1,168 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_param_forwarding",
+    ),
+    err=None,
+)
+def test_asyncio_param_forwarding() -> None:
+    """Verify that asyncio wrappers correctly forward parameters regardless of
+    whether they are passed as positional args or keyword args.
+
+    The wrappers for as_completed and shield replace the first argument with
+    pre-ensured futures.  They must update either args or kwargs depending on
+    how the caller passed the parameter, otherwise the original function
+    receives the argument twice (TypeError: got multiple values for argument).
+    """
+    import asyncio
+    import sys
+
+    from ddtrace.internal.datadog.profiling import stack
+    from ddtrace.profiling import profiler
+
+    assert stack.is_available, stack.failure_msg
+
+    async def noop() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    # -- as_completed --------------------------------------------------------
+
+    async def test_as_completed_positional() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(coros):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
+
+    async def test_as_completed_keyword() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(fs=coros):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
+
+    async def test_as_completed_positional_with_timeout() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(coros, timeout=10):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
+
+    async def test_as_completed_keyword_with_timeout() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(fs=coros, timeout=10):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
+
+    # -- as_completed with loop (Python < 3.10) ------------------------------
+
+    async def test_as_completed_positional_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(coros, loop=loop):  # type: ignore[call-arg]
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
+
+    async def test_as_completed_keyword_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(fs=coros, loop=loop):  # type: ignore[call-arg]
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
+
+    # -- shield --------------------------------------------------------------
+
+    async def test_shield_positional() -> None:
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(task)
+        assert result == 42
+
+    async def test_shield_keyword() -> None:
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(arg=task)
+        assert result == 42
+
+    # -- shield with loop (Python < 3.10) ------------------------------------
+
+    async def test_shield_positional_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(task, loop=loop)  # type: ignore[call-arg]
+        assert result == 42
+
+    async def test_shield_keyword_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(arg=task, loop=loop)  # type: ignore[call-arg]
+        assert result == 42
+
+    # -- wait ----------------------------------------------------------------
+
+    async def test_wait_positional() -> None:
+        tasks = {asyncio.create_task(noop()) for _ in range(3)}
+        done, pending = await asyncio.wait(tasks)
+        assert len(done) == 3
+        assert len(pending) == 0
+        assert all(t.result() == 42 for t in done)
+
+    async def test_wait_keyword() -> None:
+        tasks = {asyncio.create_task(noop()) for _ in range(3)}
+        done, pending = await asyncio.wait(fs=tasks)
+        assert len(done) == 3
+        assert len(pending) == 0
+        assert all(t.result() == 42 for t in done)
+
+    # -- create_task ---------------------------------------------------------
+
+    async def test_create_task_positional() -> None:
+        task = asyncio.create_task(noop())
+        assert await task == 42
+
+    async def test_create_task_keyword() -> None:
+        task = asyncio.create_task(noop(), name="test-task")
+        assert await task == 42
+        assert task.get_name() == "test-task"
+
+    # -- Run all tests -------------------------------------------------------
+
+    p = profiler.Profiler()
+    p.start()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    tests = [
+        test_as_completed_positional,
+        test_as_completed_keyword,
+        test_as_completed_positional_with_timeout,
+        test_as_completed_keyword_with_timeout,
+        test_shield_positional,
+        test_shield_keyword,
+        test_wait_positional,
+        test_wait_keyword,
+        test_create_task_positional,
+        test_create_task_keyword,
+    ]
+
+    # loop parameter was removed from as_completed and shield in Python 3.10
+    if sys.hexversion < 0x030A0000:
+        tests += [
+            test_as_completed_positional_with_loop,
+            test_as_completed_keyword_with_loop,
+            test_shield_positional_with_loop,
+            test_shield_keyword_with_loop,
+        ]
+
+    for test in tests:
+        try:
+            loop.run_until_complete(test())
+        except Exception as e:
+            raise AssertionError(f"{test.__name__} failed: {e}") from e
+
+    p.stop()


### PR DESCRIPTION
## Description

This improves our `asyncio` wrappers following Python changes and updates
- Removes the `loop` argument from `current_task` calls (`loop` has always been optional and in the future it won't exist anymore so passing it will not work); also we didn't have a correct way of getting the `loop` argument using `get_argument_value` (no way to ask only for a keyword arg) so it was error-prone
- Updates logic around `args` and `kwargs` forwarding to respect what the user passed -- if their parameter was in `args` it'll be forwarded in `args`, and the same for `kwargs`

## Testing

I added new tests that ensure that no matter how they are passed (and if they are passed), arguments end up in the right place when forwarded to the underlying `asyncio` utils. 