### PR TITLE
chore(profiling): fix last `clang-tidy` issues and make `clang-tidy` job fail on warnings

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -13,12 +13,12 @@ class Sample;
 // We avoid including Python.h in this public C++ header because CPython headers
 // use old-style casts and our build treats old-style casts as errors. Keep
 // Python includes in implementation files when full API access is required.
-// NOLINTBEGIN(bugprone-reserved-identifier) -- must match CPython's struct name
+// NOLINTBEGIN(bugprone-reserved-identifier) -- must match CPython's struct names
 struct _frame;
 typedef struct _frame PyFrameObject;
-// NOLINTEND(bugprone-reserved-identifier)
 struct _traceback;
 typedef struct _traceback PyTracebackObject;
+// NOLINTEND(bugprone-reserved-identifier)
 
 #ifdef __cplusplus
 extern "C"
@@ -48,15 +48,17 @@ extern "C"
     void ddup_set_runtime_id(std::string_view runtime_id);
     void ddup_set_process_id();
 
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     // Pass by value is intentional: the map may be modified concurrently by other threads,
     // so we take a copy to avoid data races while iterating.
-    void ddup_profile_set_endpoints(std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints);
+    void ddup_profile_set_endpoints(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
+      std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints);
 
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     // Pass by value is intentional: the map may be modified concurrently by other threads,
     // so we take a copy to avoid data races while iterating.
-    void ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts);
+    void ddup_profile_add_endpoint_counts(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
+      std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts);
 
     bool ddup_upload();
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -14,12 +14,12 @@
 // We avoid including Python.h in this public C++ header because CPython headers
 // use old-style casts and our build treats old-style casts as errors. Keep
 // Python includes in implementation files when full API access is required.
-// NOLINTBEGIN(bugprone-reserved-identifier) -- must match CPython's struct name
+// NOLINTBEGIN(bugprone-reserved-identifier) -- must match CPython's struct names
 struct _frame;
 typedef struct _frame PyFrameObject;
-// NOLINTEND(bugprone-reserved-identifier)
 struct _traceback;
 typedef struct _traceback PyTracebackObject;
+// NOLINTEND(bugprone-reserved-identifier)
 
 namespace Datadog {
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -365,11 +365,11 @@ ddup_upload() // cppcheck-suppress unusedFunction
     return result;
 }
 
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
 // Pass by value is intentional: the map may be modified concurrently by other threads,
 // so we take a copy to avoid data races while iterating.
 void
 ddup_profile_set_endpoints(
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints) // cppcheck-suppress unusedFunction
 {
     static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
@@ -390,11 +390,12 @@ ddup_profile_set_endpoints(
     }
 }
 
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
 // Pass by value is intentional: the map may be modified concurrently by other threads,
 // so we take a copy to avoid data races while iterating.
 void
-ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts)
+ddup_profile_add_endpoint_counts(
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts)
 {
     static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
     auto borrowed = Datadog::ProfilerState::get().profile_state.borrow();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -297,7 +297,7 @@ Datadog::Sample::push_pytraceback(PyTracebackObject* tb)
             // the Python property which calls PyCode_Addr2Line internally.
             PyObject* lineno_obj = PyObject_GetAttrString(reinterpret_cast<PyObject*>(node), "tb_lineno");
             if (lineno_obj != nullptr) {
-                lineno = PyLong_AsLong(lineno_obj);
+                lineno = static_cast<int>(PyLong_AsLong(lineno_obj));
                 Py_DECREF(lineno_obj);
                 if (lineno < 0) {
                     lineno = 0;

--- a/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
+++ b/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
@@ -110,6 +110,7 @@ if [[ -n "${RUN_CLANG_TIDY}" ]]; then
         -j "${JOBS}" \
         -checks="${CHECKS}" \
         -header-filter="${HEADER_FILTER}" \
+        -warnings-as-errors='*' \
         "${SOURCE_FILES[@]}"
 else
     echo "run-clang-tidy not found, falling back to sequential clang-tidy"
@@ -121,6 +122,7 @@ else
             -p "${BUILD_DIR}" \
             -checks="${CHECKS}" \
             -header-filter="${HEADER_FILTER}" \
+            --warnings-as-errors='*' \
             "${file}"; then
             FAILED=1
         fi

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -296,8 +296,8 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
     }
 
     const int lasti =
-      (static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code))))) -
-      offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+      static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code)))) -
+      static_cast<int>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT));
     auto maybe_frame = Frame::get(echion, frame_addr->f_code, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
@@ -18,7 +18,7 @@ MirrorSet::create(PyObject* set_addr)
         return ErrorKind::MirrorError;
     }
 
-    ssize_t table_size = size * sizeof(setentry);
+    ssize_t table_size = static_cast<ssize_t>(size * sizeof(setentry));
     auto data = std::make_unique<char[]>(table_size);
     if (copy_generic(set.table, data.get(), table_size)) {
         return ErrorKind::MirrorError;

--- a/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
@@ -421,6 +421,7 @@ static PyMethodDef native_call_handler_def = {
     "native_call_handler",
     // Double cast: METH_FASTCALL signature (PyObject*, PyObject*const*, Py_ssize_t) differs from
     // PyCFunction (PyObject*, PyObject*), but CPython dispatches correctly based on ml_flags.
+    // NOLINTNEXTLINE(bugprone-casting-through-void)
     reinterpret_cast<PyCFunction>(reinterpret_cast<void*>(native_call_handler)),
     METH_FASTCALL,
     "C callback for sys.monitoring CALL events"

--- a/ddtrace/internal/datadog/profiling/stack/src/thread_span_links.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/thread_span_links.cpp
@@ -13,11 +13,11 @@ ThreadSpanLinks::link_span(uint64_t thread_id, uint64_t span_id, uint64_t local_
 
     auto it = thread_id_to_span.find(thread_id);
     if (it == thread_id_to_span.end()) {
-        thread_id_to_span[thread_id] = std::make_unique<Span>(span_id, local_root_span_id, span_type);
+        thread_id_to_span[thread_id] = std::make_unique<Span>(span_id, local_root_span_id, std::move(span_type));
     } else {
         it->second->span_id = span_id;
         it->second->local_root_span_id = local_root_span_id;
-        it->second->span_type = span_type;
+        it->second->span_type = std::move(span_type);
     }
 }
 


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13775

This addresses the last issues reported by `clang-tidy` and makes the `clang-tidy` job fail if it reports anything.

[Example job with failures](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1523023862) (not failing because currently they're just reported as warnings).

```
...

/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc:299:7: warning: narrowing conversion from 'unsigned long' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
  299 |       (static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code))))) -
      |       ^

/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp:21:8: warning: declaration uses identifier '_traceback', which is reserved in the global namespace [bugprone-reserved-identifier]
   21 | struct _traceback;
      |        ^~~~~~~~~~
      |        traceback
   22 | typedef struct _traceback PyTracebackObject;
      |                ~~~~~~~~~~
      |                traceback

/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp:300:26: warning: narrowing conversion from 'long' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
  300 |                 lineno = PyLong_AsLong(lineno_obj);
      |                          ^
41195 warnings generated.
```