### PR TITLE
ci(debugging): improve boto exploration test duration

### DIFF
--- a/.gitlab/templates/debugging/exploration.yml
+++ b/.gitlab/templates/debugging/exploration.yml
@@ -36,4 +36,4 @@
     git clone --depth 1 --branch ${{BOTO3_TAG}} https://github.com/boto/boto3.git
     cd boto3
     python${{PYTHON_VERSION}} scripts/ci/install
-    python${{PYTHON_VERSION}} scripts/ci/run-tests --test-runner 'pytest -svv -W error -W "ignore::dateutil.parser._parser.UnknownTimezoneWarning" -W "ignore::DeprecationWarning"'
+    python${{PYTHON_VERSION}} scripts/ci/run-tests --test-runner 'pytest -svv -W error -W "ignore::dateutil.parser._parser.UnknownTimezoneWarning" -W "ignore::DeprecationWarning" -k "not test_documentation"'


### PR DESCRIPTION
## Description

the `functional/docs/test_smoke.py::test_documentation[*]` tests take about 8 minutes to execute. Ignoring these will have a good meaningful impact on CI duration for these jobs.

This brings the job duration down to about 8 minutes.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
