### PR TITLE
fix(ci_visibility): handle runtime error if git binary is missing [backport #17018 to 4.6]

### DIFF
--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -303,7 +303,13 @@ class SessionManager:
         return self.session.test_command
 
     def upload_git_data(self) -> None:
-        git = Git()
+        # Missing `git` in minimal containers should not abort pytest startup.
+        try:
+            git = Git()
+        except RuntimeError:
+            log.warning("Error calling git binary, skipping metadata upload")
+            return
+
         latest_commits = git.get_latest_commits()
         backend_commits = self.api_client.get_known_commits(latest_commits)
         # TODO: ddtrace has a "backend_commits is None" logic here with early return (is it correct?).

--- a/releasenotes/notes/fix-ci_visibility-runtime-error-git-command-not-present-9c2ba2ec29399534.yaml
+++ b/releasenotes/notes/fix-ci_visibility-runtime-error-git-command-not-present-9c2ba2ec29399534.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: Fix an unhandled ``RuntimeError`` that occurred when the ``git`` binary was not available. Git metadata upload is now skipped gracefully with a warning instead of aborting pytest startup.

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -266,3 +266,16 @@ class TestSessionManagerEnvVarOverrides:
                 monkeypatch.setenv("_DD_CIVISIBILITY_ITR_FORCE_ENABLE_COVERAGE", env_var_value)
             session_manager = SessionManager(self.session)
             assert session_manager.settings.coverage_enabled is expected_setting
+
+
+class TestSessionManagerGitHandling:
+    def test_upload_git_data_skips_when_git_missing(self) -> None:
+        # Create a session_manager avoid running __init__ bc of side-effects
+        session_manager = SessionManager.__new__(SessionManager)
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", side_effect=RuntimeError("`git` command not found")),
+            patch("ddtrace.testing.internal.session_manager.log.warning") as mock_warning,
+        ):
+            session_manager.upload_git_data()
+
+        mock_warning.assert_any_call("Error calling git binary, skipping metadata upload")


### PR DESCRIPTION
Backport 5f7c3bcddfa77e81d910823e93a74430918ba7cb from #17018 to 4.6.

## Description

Fixes https://github.com/DataDog/dd-trace-py/issues/16932

`SessionManager.upload_git_data()` previously raised an unhandled `RuntimeError` when the `git` binary was not available on the system (e.g. in minimal containers). This caused pytest to abort during startup rather than continuing without git metadata.

 The fix wraps the `Git()` instantiation in a try/except, logs a warning, and returns early so the session can proceed without git metadata upload.

  ## Testing

 A new unit test 

 ## Risks
 None. The change only affects the error path when `git` is unavailable. Environments where `git` is present are unaffected.
