### PR TITLE
chore(aap): improve waf efficiency

### DIFF
--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -5,6 +5,7 @@ import ctypes
 import ctypes.util
 from enum import IntEnum
 from platform import system
+from typing import Any
 from typing import Optional
 
 from ddtrace.appsec._ddwaf.waf_stubs import DDWafRulesType
@@ -87,7 +88,7 @@ class DDWAF_LOG_LEVEL(IntEnum):
 
 def _build_sequence(
     self: "ddwaf_object",
-    struct: DDWafRulesType,
+    struct: Any,
     observator: _observator,
     max_objects: int,
     max_depth: int,
@@ -108,7 +109,7 @@ def _build_sequence(
 
 def _build_mapping(
     self: "ddwaf_object",
-    struct: DDWafRulesType,
+    struct: Any,
     observator: _observator,
     max_objects: int,
     max_depth: int,
@@ -142,7 +143,7 @@ def _build_mapping(
 
 def _build_ddwaf_object(
     self: "ddwaf_object",
-    struct: DDWafRulesType,
+    struct: Any,
     observator: _observator,
     max_objects: int,
     max_depth: int,


### PR DESCRIPTION
APPSEC-61837

## Summary

  - **Optimized `ddwaf_object.__init__`** to eliminate per-node overhead in the recursive Python-to-C structure builder, achieving **~24% faster** `ddwaf_object` creation on typical WAF payloads (benchmarked from 100B to 100KB).
  - **Fixed a bug** in the map iteration counter where non-string keys incorrectly consumed slots in the `max_objects` budget, potentially truncating valid entries.
  - **Cleaned up** the module: removed duplicate type alias, removed unused variable, added documentation comments, fixed typos.

  ## Changes

  ### Performance (ddwaf_object creation)

  - Extracted the recursive build logic from `ddwaf_object.__init__` into a module-level `_build_ddwaf_object` function, eliminating closure re-creation (`truncate_string`) on every recursive call
  - Recursive children now use `__new__` instead of going through `__init__` + `ctypes.Structure.__init__`
  - Replaced `isinstance()` chain with `type(x) is X` identity checks ordered by frequency (dict/str/list first), inlining leaf handlers to avoid extra function calls
  - Inlined string truncation logic to remove `_truncate_string` function call overhead per string node
  - Used `type(key) is str` / `type(key) is bytes` in the mapping handler instead of `isinstance(key, (bytes, str))`
  - Falls back to `isinstance` for `Sequence`/`Mapping` subclasses to preserve compatibility

  ### Bug fix (map counter)

  - The map iteration used `enumerate()` which incremented the counter even for skipped non-string keys, causing them to consume slots in the `max_objects` budget. Replaced with a manual counter that only increments on successful adds.

  ### Cleanup

  - Removed duplicate `DDWafRulesType` definition (now imported from `waf_stubs.py`)
  - Removed unused `ARCHI` variable and its `machine` import
  - Removed unused `Any` and `Union` imports
  - Added comments on unused-but-kept libddwaf API bindings (`ddwaf_object_invalid`, `ddwaf_object_string_from_unsigned`, `ddwaf_object_string_from_signed`, `ddwaf_object_unsigned`)
  - Fixed typo `ddwf_builder` → `ddwaf_builder`
  - Fixed `##` section comments to `#` (cython-lint E266)

  ## Benchmark results

  Measured on Python 3.9, Apple Silicon, comparing original vs optimized:

  | Payload size | Original | Optimized | Speedup |
  |:------------|:---------|:----------|:--------|
  | ~400 B | 0.03 ms | 0.03 ms | ~17% |
  | ~1 KB | 0.10 ms | 0.08 ms | ~22% |
  | ~10 KB | 0.80 ms | 0.61 ms | ~24% |
  | ~100 KB | 7.59 ms | 5.63 ms | ~24% |