### PR TITLE
fix(profiling): fix invalid access in `GenInfo::create_impl`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/cpython/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/cpython/tasks.h
@@ -377,7 +377,11 @@ extern "C"
             if (c == nullptr)
                 return NULL;
 
-            if (c[(frame.f_lasti + 1) * sizeof(_Py_CODEUNIT)] != YIELD_FROM)
+            Py_ssize_t idx = (frame.f_lasti + 1) * sizeof(_Py_CODEUNIT);
+            if (idx < 0 || idx >= s)
+                return NULL;
+
+            if (c[idx] != YIELD_FROM)
                 return NULL;
 
             ssize_t nvalues = frame.f_stackdepth;
@@ -421,7 +425,11 @@ extern "C"
             if (c == nullptr)
                 return NULL;
 
-            if (c[f->f_lasti + sizeof(_Py_CODEUNIT)] != YIELD_FROM)
+            Py_ssize_t idx = frame.f_lasti + sizeof(_Py_CODEUNIT);
+            if (idx < 0 || idx >= s)
+                return NULL;
+
+            if (c[idx] != YIELD_FROM)
                 return NULL;
 
             auto stacktop = std::make_unique<PyObject*>();

--- a/releasenotes/notes/fix-profiler-segv-pygenobject-raw-dereference-6ac21aa1da2048c6.yaml
+++ b/releasenotes/notes/fix-profiler-segv-pygenobject-raw-dereference-6ac21aa1da2048c6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: A crash that could happen on Python < 3.11 when profiling asynchronous
+    code was fixed.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9ca64abe-0b5f-46f0-89da-3bdb697ffc92","source":"chat","resourceId":"5c3f2f1d-5fcc-49ad-8e50-a6fcc3c59a0f","workflowId":"e4947bdf-8cda-4343-9793-b19e1d61b32f","codeChangeId":"e4947bdf-8cda-4343-9793-b19e1d61b32f","sourceType":"chat"} -->
## Description

https://datadoghq.atlassian.net/browse/PROF-13112

This fixes a segmentation fault / invalid memory read I discovered through [Crash Logs](https://app.datadoghq.com/logs?query=service%3Ainstrumentation-telemetry-data%20%28%40tags.severity%3Acrash%20OR%20severity%3Acrash%20OR%20signum%3A%2A%20OR%20%40error.is_crash%3Atrue%29%20%40lib_language%3Apython%20%40tracer_version%3A4.5.4%20%40tags.crash_datadog%3Atrue%20-%40tags.crash_runtime%3Atrue%20-%40org_id%3A1000070889%20%40instrumented_service%3A%2A%20%40error.stack.frames.function%3A%28%22dqsddprof%3A%3ASpinLock%3A%3Atry_lock_until_slow%22%20OR%20%22GenInfo%3A%3Acreate_impl%22%29&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=%40org_id&event=AwAAAZ0GnroQqtZgEgAAABhBWjBHbnJvUUFBQ0VIemZrSkNfbVlnQUEAAABdMTE5ZDA2YTktODBkMS00ZmJjLWJmYWItZjMxZTZiODE4MzdlLXN5bnRoZXRpYy10aW1lLTE3NzM5MzI0MDAwMDAwMDAwMDBjLTE3NzM5MzMyNjUxMDUwMDAwMDFvAA09QA&messageDisplay=inline&refresh_mode=sliding&saved-view-id=3973332&storage=hot&stream_sort=desc&viz=stream&from_ts=1773397848141&to_ts=1774002648141&live=true).

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x00007f67211ab61c GenInfo::create_impl
#1   0x00007f67211ab6ea GenInfo::create_impl
#2   0x00007f67211ab6ea GenInfo::create_impl
#3   0x00007f67211ab6ea GenInfo::create_impl
#4   0x00007f67211ab6ea GenInfo::create_impl
#5   0x00007f67211ab7f0 GenInfo::create
#6   0x00007f67211ab865 TaskInfo::create_impl
#7   0x00007f67211aba52 TaskInfo::create
#8   0x00007f67211abbde ThreadInfo::get_all_tasks
#9   0x00007f67211ac2a9 ThreadInfo::unwind_tasks
#10  0x00007f67211b000f ThreadInfo::sample
#11  0x00007f67211b013e std::_Function_handler<void (_ts*, ThreadInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}::operator()(InterpreterInfo&) const::{lambda(_ts*, ThreadInfo&)#1}>::_M_invoke
#12  0x00007f67211acef0 for_each_thread
#13  0x00007f67211acf88 std::_Function_handler<void (InterpreterInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}>::_M_invoke
#14  0x00007f67211aa590 for_each_interp
#15  0x00007f67211ad2f9 Datadog::Sampler::sampling_thread
#16  0x00007f67211ad4a1 call_sampling_thread
#17  0x00007f6723eaaea7 start_thread
#18  0x00007f6723fc0adf clone
```

The problem is similar to others we've already seen in the past; `f->f_lasti` was used to index into a bytecode buffer, but `f` was a "real" pointer and not a `copy_memory`'d one.   
Since we don't hold the GIL is not held during sampling, this is possibly an invalid read, which seems to happen rarely (I had never seen this before) but can happen.

This should only have happened on Python < 3.11 given what code it is, but it's still worth fixing. 

Additionally, neither the Python < 3.10 nor the Python 3.10 code paths performed bounds checking on the computed bytecode index before accessing the `c[]` buffer. With stale frame data, `frame.f_lasti` can be an arbitrary value, leading to an out-of-bounds read on the locally-allocated bytecode buffer.

## Risks

This should remove risks more than it adds. As far as I can tell, it is safe as the only changes are for reading local memory as opposed to unsafe memory.
