### PR TITLE
fix: periodic thread start/restart race (#16693) [backport 4.5]

### DIFF
--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -96,7 +96,7 @@ class ThreadRestartTimer(PeriodicThread):
             # threads. This way we avoid stopping and restarting the threads
             # in between forks.
             if monotonic_ns() >= self._timestamp:  # 100ms
-                for thread in _threads_to_restart_after_fork:
+                for thread in _threads_to_restart_after_fork.copy():
                     if thread is self:
                         # This has already been restarted by the after-fork hook.
                         continue
@@ -144,14 +144,14 @@ def _after_fork_child():
 
     # Restart the threads immediately. It is unlikely that there will be another
     # call to fork here.
-    for thread in _threads_to_restart_after_fork:
+    for thread in _threads_to_restart_after_fork.copy():
         if isinstance(thread, PeriodicThread) and not thread.__autorestart__:
             continue
         log.debug("Restarting thread %s after fork in child", thread.name)
         thread._after_fork()
     _threads_to_restart_after_fork.clear()
 
-    for thread_start in _threads_to_start_after_fork:
+    for thread_start in _threads_to_start_after_fork.copy():
         log.debug("Starting thread %s after fork in child", thread_start.__self__.name)
         thread_start()
     _threads_to_start_after_fork.clear()

--- a/releasenotes/notes/fix-periodic-thread-start-restart-iteration-37b0e4ebc8b46dba.yaml
+++ b/releasenotes/notes/fix-periodic-thread-start-restart-iteration-37b0e4ebc8b46dba.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix for a potential race condition affecting internal periodic worker
+    threads that could have caused a ``RuntimeError`` during forks.


### PR DESCRIPTION
## Description

We fix an issue with the at-fork start/restart logic that could have caused a race condition. This arises from the fact that we have a performance improvement in place whereby we only restart periodic threads in the parent process with a delay to avoid restarting threads multiple times if multiple forks occur in a tight loop. However, this could give rise to a race condition whereby the collection of threads that need to be started/restarted can be mutated by the timer thread while they are being iterated over.

Fixes #16684.


(cherry picked from commit b279d08691c213b009db9c0939a2dadf4e3b29ad)

