### PR TITLE
fix(profiling): clean up containers post-fork

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/cache.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/cache.h
@@ -32,6 +32,17 @@ class LRUCache
         index.clear();
     }
 
+    void postfork_child()
+    {
+        // At fork, the sampling thread may have been modifying the list
+        // mid-operation (e.g., splice in lookup, emplace in store). Traversing
+        // the list to free nodes (as std::list::clear does) can crash on corrupted
+        // pointers. Use placement new to construct fresh empty containers,
+        // abandoning the old data (intentional one-time leak).
+        new (&items) std::list<std::pair<K, std::unique_ptr<V>>>();
+        new (&index) std::unordered_map<K, typename std::list<std::pair<K, std::unique_ptr<V>>>::iterator>();
+    }
+
   private:
     size_t capacity;
     std::list<std::pair<K, std::unique_ptr<V>>> items;

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -109,8 +109,10 @@ class EchionSampler
         // Reset string_table mutex
         string_table_.postfork_child();
 
-        // Clear frame cache after fork (prevent stale pointers)
-        frame_cache_.clear();
+        // Reset frame cache. Use postfork_child (placement new) instead of std::list::clear
+        // because the Sampling Thread may have been modifying the cache when fork
+        // took its snapshot. Traversing a corrupted list to free nodes would crash.
+        frame_cache_.postfork_child();
 
         // Clear stale entries from parent process.
         // No lock needed: only one thread exists in child immediately after fork.

--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -58,7 +58,13 @@ class Sampler
     std::vector<PyThreadState> thread_candidates;
     void adapt_sampling_interval();
 
+    // Tracks whether the sampler was running when prefork was called,
+    // so that postfork_parent/restart_after_fork can restore it.
+    bool was_running_at_fork_{ false };
+
     void atfork_child();
+    friend void stack_atfork_prepare();
+    friend void stack_atfork_parent();
     friend void stack_atfork_child();
 
   public:
@@ -98,6 +104,12 @@ class Sampler
 
     // Delegates to the StackRenderer to clear its caches after fork
     void postfork_child();
+
+    // Record whether the Sampler was running before fork
+    void prefork();
+
+    // Restart the sampling thread in the parent after fork
+    void postfork_parent();
 
     // Restart the sampler after fork if it was running
     void restart_after_fork();

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -403,13 +403,39 @@ Sampler::postfork_child()
 }
 
 void
+Sampler::prefork()
+{
+    was_running_at_fork_ = thread_seq_num.load() & 1;
+}
+
+void
+Sampler::postfork_parent()
+{
+    // The parent's sampling thread survives the fork unchanged; no restart needed.
+    // Calling start() here would launch a second thread, corrupt the thread_seq_num
+    // parity invariant used by prefork(), and cause a data race on EchionSampler state.
+}
+
+void
 Sampler::restart_after_fork()
 {
     // Restart the sampler if it was running before fork.
-    // Odd thread_seq_num means the sampler was started and not stopped.
-    if (thread_seq_num.load() & 1) {
+    // We use the saved flag because prefork changed the thread_seq_num parity.
+    if (was_running_at_fork_) {
         start();
     }
+}
+
+static void
+stack_atfork_prepare()
+{
+    Sampler::get().prefork();
+}
+
+static void
+stack_atfork_parent()
+{
+    Sampler::get().postfork_parent();
 }
 
 static void
@@ -455,7 +481,7 @@ Sampler::one_time_setup()
     // postfork_child runs first — rebuilding the Profiles Dictionary before the
     // sampling thread restarts and calls intern_string.
     // More details in https://github.com/DataDog/dd-trace-py/pull/17183
-    pthread_atfork(nullptr, nullptr, stack_atfork_child);
+    pthread_atfork(stack_atfork_prepare, stack_atfork_parent, stack_atfork_child);
 }
 
 void

--- a/releasenotes/notes/fix-profiling-fork-crash-lru-cache-b80e6574fc304037.yaml
+++ b/releasenotes/notes/fix-profiling-fork-crash-lru-cache-b80e6574fc304037.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: A crash that could happen in child processes after fork
+    has been fixed.


### PR DESCRIPTION
## Description

This PR fixes a crash in the Profiler that occurred when `fork` was called while the Sampling Thread was actively modifying the `LRUCache` for Frames (about 100 crashes per week).

```
Error UnixSignal: Process terminated with SI_TKILL (SIGABRT)
#0 0x0000ffffb293cb3c raise
#1 0x0000ffffb2927e00 abort
#2 0x0000ffffb2996f98 free
#3 0x0000ffffa3f47cc4 std::_List_base<std::pair<unsigned long, std::unique_ptr<Frame, std::default_delete<Frame> > >, std::allocator<std::pair<unsigned long, std::unique_ptr<Frame, std::default_delete<Frame> > > > >::_M_clear
#4 0x0000ffffa3f50ea4 Datadog::Sampler::postfork_child
#5 0x0000ffffa3f51cc0 _stack_atfork_child
#6 0x0000ffffb29c1cd4 __libc_fork
#7 0x0000aaaabbd4b998 os_fork_impl
#8 0x0000aaaabbdaff58 cfunction_vectorcall_NOARGS.llvm.1085662745629047260
#9 0x0000aaaabbe197d4 _PyEval_EvalFrameDefault
#10 0x0000aaaabbd87548 _PyObject_VectorcallTstate.llvm.15733451206353458062
#11 0x0000aaaabbd89df8 object_vacall.llvm.15733451206353458062
#12 0x0000aaaabbe7f378 PyObject_CallFunctionObjArgs
#13 0x0000ffffb1a4453c WraptFunctionWrapperBase_call (/project/src/wrapt/_wrappers.c:2455:14)
#14 0x0000aaaabbe15fe0 _PyEval_EvalFrameDefault
#15 0x0000aaaabbdcaa78 slot_tp_init
#16 0x0000aaaabbdc32b0 type_call
#17 0x0000aaaabbe15fe0 _PyEval_EvalFrameDefault
#18 0x0000aaaabbd8a464 method_vectorcall.llvm.15917642511948773313
#19 0x0000aaaabbe197d4 _PyEval_EvalFrameDefault
#20 0x0000aaaabbd8e354 gen_iternext
#21 0x0000aaaabbde9a58 builtin_next
#22 0x0000aaaabbe187d0 _PyEval_EvalFrameDefault
#23 0x0000aaaabbd8a4c4 method_vectorcall.llvm.15917642511948773313
#24 0x0000aaaabbe1a02c _PyEval_EvalFrameDefault
#25 0x0000aaaabbd8a4c4 method_vectorcall.llvm.15917642511948773313
#26 0x0000aaaabbe1a02c _PyEval_EvalFrameDefault
#27 0x0000aaaabbd89480 _PyObject_Call_Prepend
#28 0x0000aaaabbebba50 slot_tp_call
#29 0x0000aaaabbe15fe0 _PyEval_EvalFrameDefault
#30 0x0000aaaabbf15ea4 PyEval_EvalCode
#31 0x0000aaaabbf48b8c run_mod.llvm.17615948296688877498
#32 0x0000aaaabbcb34b4 pyrun_file
#33 0x0000aaaabbcb288c _PyRun_SimpleFileObject
#34 0x0000aaaabbcb2488 _PyRun_AnyFileObject
#35 0x0000aaaabbcbfc1c pymain_run_file_obj
#36 0x0000aaaabbcbf994 pymain_run_file
#37 0x0000aaaabbf60d2c Py_RunMain
#38 0x0000aaaabbf611f0 pymain_main.llvm.144270552765144348
#39 0x0000aaaabbe589d0 main
#40 0x0000ffffb2928598 __libc_start_main
```

The Sampling Thread is not stopped before forking. This means when `fork` is called, the Sampling Thread could be mutating `frame_cache_` (backed by `std::list` + `std::unordered_map`) via `lookup` (splice) and `store` (`emplace_front`/`pop_back`). As a result, those data structures could end up in a corrupt state at the moment the child process is created. When the child process resumes work, calling `frame_cache_.clear()` post-fork, the crash can happen. 

The most natural thing to do to avoid this would be to ask the Sampling Thread to stop at fork time, then making sure it is restarted both in the parent and the child post-fork (if it was running). However, this approach has a significant caveat: depending on the current state of adaptive sampling, doing this may result in blocking the fork for up to 100ms (worst case scenario) which is not an acceptable side effect for the user.  
By not stopping the Thread but cleaning up in the child process, we keep state consistency without having to wait, at the cost of a small one-time leak (the data in the containers that we placement-new).