### PR TITLE
fix(internal): do not early-return on malformed sampling rule

### DIFF
--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -160,7 +160,7 @@ def get_span_sampling_rules() -> list[SpanSamplingRule]:
 
         if not service and not name:
             log.warning("Sampling rules must supply at least 'service' or 'name', got %s", json.dumps(rule))
-            return []
+            continue
 
         # If max_per_second not specified default to no limit
         max_per_second = rule.get("max_per_second", _SINGLE_SPAN_SAMPLING_MAX_PER_SEC_NO_LIMIT)

--- a/releasenotes/notes/sampling-do-not-early-exit-too-much-098fcef099b25239.yaml
+++ b/releasenotes/notes/sampling-do-not-early-exit-too-much-098fcef099b25239.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    tracer: sampling rules do not early exit anymore if a single rule is missing service and name.

--- a/tests/tracer/test_single_span_sampling_rules.py
+++ b/tests/tracer/test_single_span_sampling_rules.py
@@ -6,6 +6,7 @@ from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MECHANISM
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_RATE
+import ddtrace.internal.logger as ddlogger
 from ddtrace.internal.sampling import SamplingMechanism
 from ddtrace.internal.sampling import SpanSamplingRule
 from ddtrace.internal.sampling import _get_file_json
@@ -92,6 +93,34 @@ def test_rule_init_via_env_only_name():
 def test_rule_init_via_env_no_name_or_service():
     with override_global_config(dict(_sampling_rules='[{"sample_rate":1.0}]')):
         assert get_span_sampling_rules() == []
+
+
+def test_rule_init_via_env_no_name_or_service_logs_warning_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed rule (no service/name) should be skipped with a warning; subsequent valid rules
+    must still be parsed.
+    """
+    # Clear the rate-limiter bucket so a prior test hitting the same log line
+    # (e.g. test_rule_init_via_env_no_name_or_service) doesn't suppress the warning.
+    ddlogger._buckets.clear()
+    rules_json = '[{"sample_rate":1.0}, {"service":"my-service","name":"my-op","sample_rate":0.5}]'
+    with override_global_config(dict(_sampling_rules=rules_json)):
+        sampling_rules = get_span_sampling_rules()
+        sampling_records = [r for r in caplog.record_tuples if r[0] == "ddtrace.internal.sampling"]
+        assert sampling_records == [
+            (
+                "ddtrace.internal.sampling",
+                30,
+                "Sampling rules must supply at least 'service' or 'name', got {\"sample_rate\": 1.0}",
+            )
+        ]
+        assert len(sampling_rules) == 1
+        assert sampling_rules[0]._service_matcher is not None
+        assert sampling_rules[0]._service_matcher.pattern == "my-service"
+        assert sampling_rules[0]._name_matcher is not None
+        assert sampling_rules[0]._name_matcher.pattern == "my-op"
+        assert sampling_rules[0]._sample_rate == 0.5
 
 
 def test_rule_init_via_env_service_pattern_contains_unsupported_char():


### PR DESCRIPTION
## Description

This updates the rule parsing logic to not early-return if _one_ rule doesn't match the expected format (and instead just skips _this_ rule).