### PR TITLE
ci: increase job parallelism for integration_testagent

### DIFF
--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -174,7 +174,7 @@ suites:
     pattern: integration-latest*
     runner: riot
   integration_testagent:
-    parallelism: 3
+    venvs_per_job: 3
     paths:
       - '@tracing'
       - '@bootstrap'


### PR DESCRIPTION
## Description

Changes from 3 to 6 jobs, will be 3 venvs per job.

Current runtime is about 15-18 minutes, so hoping this cuts that in half.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
