### PR TITLE
fix(profiling): fix invalid lookups for asyncio frames

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -139,7 +139,11 @@ is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& f
         return false;
     }
 
-    const auto& frame_name = echion.string_table().lookup(frame.name)->get();
+    auto maybe_name = echion.string_table().lookup(frame.name);
+    if (!maybe_name) {
+        return false;
+    }
+    const auto& frame_name = maybe_name->get();
 
 #if PY_VERSION_HEX >= 0x030b0000
     // Python 3.11+: qualified name includes the enclosing function
@@ -149,7 +153,11 @@ is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& f
     // Python < 3.11: just check for "wrapper" in uvloop/__init__.py
     constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
     constexpr std::string_view wrapper = "wrapper";
-    auto filename = echion.string_table().lookup(frame.filename)->get();
+    auto maybe_filename = echion.string_table().lookup(frame.filename);
+    if (!maybe_filename) {
+        return false;
+    }
+    const auto& filename = maybe_filename->get();
     auto is_uvloop = filename.size() >= uvloop_init_py.size() &&
                      filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
     return is_uvloop && (frame_name == wrapper);

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -48,7 +48,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
     if (!frame_cache_key) {
         for (size_t i = 0; i < python_stack.size(); i++) {
             const auto& frame = python_stack[i].get();
-            const auto& frame_name = echion.string_table().lookup(frame.name)->get();
+            auto maybe_frame_name = echion.string_table().lookup(frame.name);
+            if (!maybe_frame_name) {
+                continue;
+            }
+            const auto& frame_name = maybe_frame_name->get();
 
             bool is_boundary_frame = false;
 
@@ -62,7 +66,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
 #else
                 constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
                 constexpr std::string_view run = "run";
-                auto filename = echion.string_table().lookup(frame.filename)->get();
+                auto maybe_filename = echion.string_table().lookup(frame.filename);
+                if (!maybe_filename) {
+                    continue;
+                }
+                const auto& filename = maybe_filename->get();
                 auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
                 is_boundary_frame = is_uvloop && (frame_name == run);
 #endif
@@ -78,7 +86,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                 // can use the filename to identify the "_run" Frame.
                 constexpr std::string_view asyncio_events_py = "asyncio/events.py";
                 constexpr std::string_view _run = "_run";
-                auto filename = echion.string_table().lookup(frame.filename)->get();
+                auto maybe_filename = echion.string_table().lookup(frame.filename);
+                if (!maybe_filename) {
+                    continue;
+                }
+                const auto& filename = maybe_filename->get();
                 auto is_asyncio = filename.size() >= asyncio_events_py.size() &&
                                   filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
                 is_boundary_frame = is_asyncio && (frame_name.size() >= _run.size() &&

--- a/releasenotes/notes/fix-stack-profiler-string-table-crash-cf4e7a9ec1af48bd.yaml
+++ b/releasenotes/notes/fix-stack-profiler-string-table-crash-cf4e7a9ec1af48bd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: A rare crash that could happen when profiling asyncio code
+    has been fixed.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d7a9f7a0-5d19-40b6-aa6e-b72774b0338c","source":"chat","resourceId":"9b7cdf25-5ff6-4ae8-bde8-b3efd6b0708a","workflowId":"adf4395f-1539-478b-bc32-61c7b33fe595","codeChangeId":"adf4395f-1539-478b-bc32-61c7b33fe595","sourceType":"chat"} -->
## Description

This fixes a rare crash in the asyncio / uvloop sampling logic which could happen due to unwrapping a `Result` that was not `ok`.

I am planning to add a build option to the Profiler which will allow to add additional debug logging (something like `PROFILING_DEBUG` or something, like @taegyunkim added for `memalloc` with re-entry assertions). Under this condition, we could print or `assert` when that happens since I don't really think we expect those cases to ever happen... so it'd be helpful for debugging. (But not in this PR!)

**Crash telemetry**: ~58 crashes observed on v4.6.0 over the past 7 days, with the top crash signature being `is_uvloop_wrapper_frame / ThreadInfo::unwind_tasks / ThreadInfo::sample / sampling_thread`.

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x000073c78eeaf4b3 is_uvloop_wrapper_frame
#1   0x000073c78eeb69b3 ThreadInfo::unwind_tasks
#2   0x000073c78eeb6db9 ThreadInfo::sample
#3   0x000073c78eeb6eee std::_Function_handler<void (_ts*, ThreadInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}::operator()(InterpreterInfo&) const::{lambda(_ts*, ThreadInfo&)#1}>::_M_invoke
#4   0x000073c78eeb18b5 for_each_thread
#5   0x000073c78eeb194d std::_Function_handler<void (InterpreterInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}>::_M_invoke
#6   0x000073c78eeb0257 for_each_interp
#7   0x000073c78eeb1cc0 Datadog::Sampler::sampling_thread
#8   0x000073c78eeb1f27 call_sampling_thread
```