### PR TITLE
feat(mysql): Instrument mysql.connector.aio

### DIFF
--- a/ddtrace/contrib/internal/mysql/__init__.py
+++ b/ddtrace/contrib/internal/mysql/__init__.py
@@ -1,5 +1,6 @@
 """
 The mysql integration instruments the mysql library to trace MySQL queries.
+When available, it also instruments ``mysql.connector.aio`` to trace async queries.
 
 
 Enabling

--- a/ddtrace/contrib/internal/mysql/patch.py
+++ b/ddtrace/contrib/internal/mysql/patch.py
@@ -1,4 +1,7 @@
+import importlib
 import os
+from typing import Any
+from typing import Optional
 
 import mysql.connector
 import wrapt
@@ -6,6 +9,7 @@ import wrapt
 from ddtrace import config
 from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import TracedConnection
+from ddtrace.contrib.dbapi_async import TracedAsyncConnection
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
 from ddtrace.ext import db
 from ddtrace.ext import net
@@ -46,8 +50,35 @@ CONN_ATTR_BY_TAG = {
 }
 
 
+def _get_conn_tags(conn) -> dict[str, str]:
+    tags = {}
+    for tag, attr in CONN_ATTR_BY_TAG.items():
+        value = getattr(conn, attr, "")
+        if value == "":
+            continue
+        string_value = _convert_to_string(value)
+        if string_value is not None:
+            tags[tag] = string_value
+    return tags
+
+
+def _get_mysql_aio_module() -> Optional[Any]:
+    aio_module = getattr(mysql.connector, "aio", None)
+    if aio_module is not None:
+        return aio_module
+
+    try:
+        return importlib.import_module("mysql.connector.aio")
+    except ImportError:
+        return None
+
+
 def patch():
     wrapt.wrap_function_wrapper("mysql.connector", "connect", _connect)
+    aio_module = _get_mysql_aio_module()
+    if aio_module is not None and hasattr(aio_module, "connect"):
+        wrapt.wrap_function_wrapper("mysql.connector.aio", "connect", _connect_async)
+
     # `Connect` is an alias for `connect`, patch it too
     if hasattr(mysql.connector, "Connect"):
         mysql.connector.Connect = mysql.connector.connect
@@ -65,6 +96,11 @@ def unpatch():
         mysql.connector.connect = mysql.connector.connect.__wrapped__
         if hasattr(mysql.connector, "Connect"):
             mysql.connector.Connect = mysql.connector.connect
+
+    aio_module = _get_mysql_aio_module()
+    if aio_module is not None and hasattr(aio_module, "connect") and is_wrapted(aio_module.connect):
+        aio_module.connect = aio_module.connect.__wrapped__
+
     mysql.connector._datadog_patch = False
 
 
@@ -73,14 +109,27 @@ def _connect(func, instance, args, kwargs):
     return patch_conn(conn)
 
 
+async def _connect_async(func, instance, args, kwargs):
+    conn = await func(*args, **kwargs)
+    return patch_conn_async(conn)
+
+
 def patch_conn(conn):
-    tags = {
-        t: _convert_to_string(getattr(conn, a, None)) for t, a in CONN_ATTR_BY_TAG.items() if getattr(conn, a, "") != ""
-    }
+    tags = _get_conn_tags(conn)
     tags[db.SYSTEM] = "mysql"
     pin = Pin(tags=tags)
 
     # grab the metadata from the conn
     wrapped = TracedConnection(conn, pin=pin, cfg=config.mysql)
+    pin.onto(wrapped)
+    return wrapped
+
+
+def patch_conn_async(conn):
+    tags = _get_conn_tags(conn)
+    tags[db.SYSTEM] = "mysql"
+    pin = Pin(tags=tags)
+
+    wrapped = TracedAsyncConnection(conn, pin=pin, cfg=config.mysql)
     pin.onto(wrapped)
     return wrapped

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -1,3 +1,6 @@
+import asyncio
+import importlib
+
 import mock
 import mysql
 
@@ -11,6 +14,14 @@ from tests.utils import assert_is_measured
 
 
 MYSQL_CONFIG["db"] = MYSQL_CONFIG["database"]
+
+
+def _has_mysql_aio():
+    try:
+        aio_module = importlib.import_module("mysql.connector.aio")
+    except ImportError:
+        return False
+    return hasattr(aio_module, "connect")
 
 
 class MySQLCore(object):
@@ -372,6 +383,83 @@ class TestMysqlPatch(MySQLCore, TracerTestCase):
             conn.close()
 
         patch()
+
+    def test_async_simple_query(self):
+        if not _has_mysql_aio():
+            self.skipTest("mysql.connector.aio is not available")
+
+        async def _run_query():
+            aio_module = importlib.import_module("mysql.connector.aio")
+            conn = await aio_module.connect(**MYSQL_CONFIG)
+            try:
+                cursor = await conn.cursor()
+                try:
+                    await cursor.execute("SELECT 1")
+                    return await cursor.fetchall()
+                finally:
+                    await cursor.close()
+            finally:
+                await conn.close()
+
+        rows = asyncio.run(_run_query())
+        assert len(rows) == 1
+
+        spans = self.pop_spans()
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert_is_measured(span)
+        assert span.service == "mysql"
+        assert span.name == "mysql.query"
+        assert span.span_type == "sql"
+        assert span.error == 0
+        assert span.get_metric("network.destination.port") == 3306
+        assert_dict_issuperset(
+            span.get_tags(),
+            {
+                "out.host": "127.0.0.1",
+                "db.name": "test",
+                "db.system": "mysql",
+                "db.user": "test",
+                "component": "mysql",
+                "span.kind": "client",
+            },
+        )
+
+    def test_patch_unpatch_async(self):
+        if not _has_mysql_aio():
+            self.skipTest("mysql.connector.aio is not available")
+
+        async def _run_query():
+            aio_module = importlib.import_module("mysql.connector.aio")
+            conn = await aio_module.connect(**MYSQL_CONFIG)
+            try:
+                cursor = await conn.cursor()
+                try:
+                    await cursor.execute("SELECT 1")
+                    return await cursor.fetchall()
+                finally:
+                    await cursor.close()
+            finally:
+                await conn.close()
+
+        unpatch()
+        asyncio.run(_run_query())
+        spans = self.pop_spans()
+        assert not spans, spans
+
+        patch()
+        try:
+            rows = asyncio.run(_run_query())
+            assert len(rows) == 1
+            spans = self.pop_spans()
+            assert len(spans) == 1
+        finally:
+            unpatch()
+            asyncio.run(_run_query())
+            spans = self.pop_spans()
+            assert not spans, spans
+            patch()
 
     @TracerTestCase.run_in_subprocess(
         env_overrides=dict(DD_MYSQL_SERVICE="mysvc", DD_TRANCE_SPAN_ATTRIBUTE_SCHEMA="v0")


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

Adds auto instrumentation for mysql-connector-python's aio integration.

Closes #10105

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
