### PR TITLE
fix(ci): download win_amd64 wheels from main when build windows is skipped

### DIFF
--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -37,9 +37,7 @@ os tests ubuntu:
 os tests macos:
   extends: .multi_os_test_base
   tags: ["macos:sonoma-amd64", "specific:true"]
-  needs:
-    - job: "build macos"
-      optional: true
+  needs: [ "build macos" ]
   variables:
     WHEEL_PATTERN: "macosx*x86_64.whl"
     PLATFORM: "macOS"

--- a/.gitlab/scripts/multi-os-tests.sh
+++ b/.gitlab/scripts/multi-os-tests.sh
@@ -18,30 +18,7 @@ export WHEEL_TAG="cp${PYTHON_VERSION//./}"
 echo "Installing Python $PYTHON_VERSION and dependencies in $TMPDIR..."
 uv python install $PYTHON_VERSION
 uv venv --python $PYTHON_VERSION .venv
-
-WHEEL_PATH=$(ls $CI_PROJECT_DIR/pywheels/ddtrace*${WHEEL_TAG}*${WHEEL_PATTERN} 2>/dev/null | head -1)
-
-# If no local wheel, download from the last successful build on main
-if [ -z "$WHEEL_PATH" ] && [ "$PLATFORM" = "macOS" ]; then
-    echo "No local wheel found. Downloading from last successful main pipeline..."
-    mkdir -p "$CI_PROJECT_DIR/pywheels"
-    ENCODED_JOB=$(python3 -c "import urllib.parse; print(urllib.parse.quote('build macos'))")
-    curl -fsSL --header "JOB-TOKEN: $CI_JOB_TOKEN" \
-      -o /tmp/wheels.zip \
-      "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/jobs/artifacts/main/download?job=${ENCODED_JOB}"
-    unzip -o /tmp/wheels.zip -d "$CI_PROJECT_DIR/pywheels"
-    # Flatten nested pywheels/pywheels/ structure from artifact zip
-    find "$CI_PROJECT_DIR/pywheels" -mindepth 2 -name "*.whl" -exec mv {} "$CI_PROJECT_DIR/pywheels/" \;
-    WHEEL_PATH=$(ls $CI_PROJECT_DIR/pywheels/ddtrace*${WHEEL_TAG}*${WHEEL_PATTERN} 2>/dev/null | head -1)
-fi
-
-if [ -z "$WHEEL_PATH" ]; then
-    echo "ERROR: No wheel found for tag '${WHEEL_TAG}' with pattern '${WHEEL_PATTERN}'."
-    ls -la "$CI_PROJECT_DIR/pywheels/" 2>/dev/null || echo "pywheels/ does not exist"
-    exit 1
-fi
-
-echo "Using wheel: $WHEEL_PATH"
+WHEEL_PATH="$CI_PROJECT_DIR/pywheels/ddtrace*${WHEEL_TAG}*${WHEEL_PATTERN}"
 uv pip install --python $PYTHON_VERSION -r "$CI_PROJECT_DIR/.gitlab/requirements/multi-os-tests.txt" $WHEEL_PATH
 
 # Run tests


### PR DESCRIPTION
## Description

Fixes Windows OS test failures caused by DDCI's pipeline optimization skipping the `build windows` job.

**Root cause:** When DDCI generates a lean pipeline for PRs that don't touch native code, the `build windows` job is either absent (causing a `needs` rejection) or substituted with a job that only downloads `win_arm64` wheels. The `os tests windows` job then fails with `Cannot index into a null array` because no `win_amd64` wheels exist.

**Fix:** When no local `win_amd64` wheel is found, download it from the last successful `build windows` job on `main` via the GitLab artifacts API. This is safe because PRs that don't touch native code produce identical wheels to `main`.

**Affected PRs:** Any PR that doesn't touch native code, e.g. #16723, #17076. Brett identified this in [#guild-dd-trace-py on March 20](https://dd.slack.com/archives/C02E4BKJQBT/p1774017677616619).

### Changes

**`.gitlab/multi-os-tests.yml`**
- Add `optional: true` to `build windows` `needs` so the pipeline isn't rejected when the job is absent

**`.gitlab/scripts/multi-os-tests.ps1`**
- Use `uv python install --force` to handle pre-existing Python executables on runners
- When no local wheel exists, download from `build windows: [$PYTHON_VERSION, amd64]` artifacts on `main` via `CI_JOB_TOKEN`
- If the download fails, `$ErrorActionPreference = "Stop"` halts with the error (no silent swallowing)

## Testing

**API validation (tested locally against gitlab.ddbuild.io):**

```
GET /projects/358/jobs/artifacts/main/download?job=build%20windows%3A%20%5B3.10%2C%20amd64%5D
→ HTTP 200, 6MB zip
```

Zip contents:
```
  1297157  03-23-2026 16:58   debugwheelhouse/build_cp310-win_amd64.log
  6251417  03-23-2026 16:58   pywheels/ddtrace-4.7.0rc1-cp310-cp310-win_amd64.whl
```

Confirmed:
- The GitLab artifacts API works with matrix job names (`build windows: [3.10, amd64]`)
- The zip extracts directly to `pywheels/ddtrace*cp310*win_amd64.whl`, matching the glob pattern in the script
- Job name format verified by decoding base64 DDCI task IDs from the latest main pipeline

**Note:** Local test used `PRIVATE-TOKEN`; CI will use `JOB-TOKEN` (`CI_JOB_TOKEN`). Both are documented auth methods for this endpoint with artifact download permissions within the same project.

## Risks

- The artifacts API call uses the exact matrix job name `build windows: [3.10, amd64]`. If the matrix format in `package.yml` changes, this will break — but it will break loudly (download fails → error exit).
- Downloads wheels from `main`, not the PR branch. Safe for non-native PRs since wheel contents are identical.

## Additional Notes

cc @brettlangdon