### PR TITLE
chore(dsm): fix circular import

### DIFF
--- a/ddtrace/internal/datastreams/__init__.py
+++ b/ddtrace/internal/datastreams/__init__.py
@@ -1,7 +1,6 @@
 from ddtrace.internal.settings._config import config
 
 from ...internal.utils.importlib import require_modules
-from . import processor
 
 
 required_modules = ["confluent_kafka", "botocore", "kombu", "aiokafka"]
@@ -22,6 +21,8 @@ if config._data_streams_enabled:
 def data_streams_processor(reset=False):
     global _processor
     if config._data_streams_enabled and (not _processor or reset):
+        from . import processor
+
         _processor = processor.DataStreamsProcessor()
 
     return _processor


### PR DESCRIPTION
DSM was registering:
- The tracer `atexit` hook, which is already done by the tracer and therefore is useless
- Importing `config` module directly from `ddtrace`.

This was causing circular imports that are fixed by this PR.