### PR TITLE
ci: reduce profiling_native timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -555,7 +555,7 @@ lib_injection_tests:
   stage: tests
   tags: [ "arch:amd64" ]
   image: ${PROFILING_NATIVE_IMAGE}
-  timeout: 90m
+  timeout: 15m
   variables:
     CMAKE_BUILD_PARALLEL_LEVEL: "12"
     CARGO_BUILD_JOBS: "12"


### PR DESCRIPTION
## Description

The P99 duration for these jobs is 8 minutes. Lowering this duration will help the CI to fail faster if we end up in a bad deadlock/infra state.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
