### PR TITLE
chore(di): agentless mode for ci visibility

### DIFF
--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -112,12 +112,12 @@ class ProbeStatusLogger:
 
         try:
             if di_config._is_agentless:
-                body = f"[{','.join(msgs)}]".encode("utf-8")
-                headers = {
-                    "Content-Type": "application/json",
-                    "DD-API-KEY": di_config._api_key,
-                }
-                self._write_payload_with_backoff((body, headers))
+                self._write_payload_with_backoff(
+                    (
+                        f"[{','.join(msgs)}]".encode("utf-8"),  # body
+                        {"Content-Type": "application/json", "DD-API-KEY": di_config._api_key},  # headers
+                    )
+                )
             else:
                 self._write_payload_with_backoff(
                     multipart(

--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -38,8 +38,12 @@ class ProbeStatusLogger:
             attempts=self.RETRY_ATTEMPTS,
         )(self._write_payload)
 
-        if di_config._tags_in_qs and di_config.tags:
-            self.ENDPOINT += f"?ddtags={quote(di_config.tags)}"
+        if di_config._is_agentless:
+            self._endpoint = "/api/v2/logs"
+        else:
+            self._endpoint = self.ENDPOINT
+            if di_config._tags_in_qs and di_config.tags:
+                self._endpoint += f"?ddtags={quote(di_config.tags)}"
 
     def _payload(
         self, probe: Probe, status: str, message: str, timestamp: float, error: t.Optional[ErrorInfo] = None
@@ -79,7 +83,7 @@ class ProbeStatusLogger:
             with self._connect() as conn:
                 conn.request(
                     "POST",
-                    "/debugger/v1/diagnostics",
+                    self._endpoint,
                     body,
                     headers=headers,
                 )
@@ -107,18 +111,26 @@ class ProbeStatusLogger:
             msgs.append(self._queue.get_nowait())
 
         try:
-            self._write_payload_with_backoff(
-                multipart(
-                    parts=[
-                        FormData(
-                            name="event",
-                            filename="event.json",
-                            data=f"[{','.join(msgs)}]",
-                            content_type="json",
-                        )
-                    ]
+            if di_config._is_agentless:
+                body = f"[{','.join(msgs)}]".encode("utf-8")
+                headers = {
+                    "Content-Type": "application/json",
+                    "DD-API-KEY": di_config._api_key,
+                }
+                self._write_payload_with_backoff((body, headers))
+            else:
+                self._write_payload_with_backoff(
+                    multipart(
+                        parts=[
+                            FormData(
+                                name="event",
+                                filename="event.json",
+                                data=f"[{','.join(msgs)}]",
+                                content_type="json",
+                            )
+                        ]
+                    )
                 )
-            )
         except Exception:
             log.error("Failed to write probe status after retries", exc_info=True)
 

--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -38,12 +38,9 @@ class ProbeStatusLogger:
             attempts=self.RETRY_ATTEMPTS,
         )(self._write_payload)
 
-        if di_config._is_agentless:
-            self._endpoint = "/api/v2/logs"
-        else:
-            self._endpoint = self.ENDPOINT
-            if di_config._tags_in_qs and di_config.tags:
-                self._endpoint += f"?ddtags={quote(di_config.tags)}"
+        self._endpoint = "/api/v2/debugger" if di_config._is_agentless else self.ENDPOINT
+        if di_config._tags_in_qs and di_config.tags:
+            self._endpoint += f"?ddtags={quote(di_config.tags)}"
 
     def _payload(
         self, probe: Probe, status: str, message: str, timestamp: float, error: t.Optional[ErrorInfo] = None

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -71,10 +71,7 @@ class SignalUploader(agent.AgentCheckPeriodicService):
             f"?ddtags={quote(di_config.tags)}" if di_config._tags_in_qs and di_config.tags else ""
         )
 
-        if di_config._is_agentless:
-            initial_endpoint = "/api/v2/logs"
-        else:
-            initial_endpoint = f"/debugger/v2/input{endpoint_suffix}"  # start optimistically
+        initial_endpoint = "/api/v2/logs" if di_config._is_agentless else f"/debugger/v2/input{endpoint_suffix}"
 
         self._tracks = {
             SignalTrack.LOGS: UploaderTrack(
@@ -95,13 +92,10 @@ class SignalUploader(agent.AgentCheckPeriodicService):
             "Content-type": "application/json; charset=utf-8",
             "Accept": "text/plain",
         }
-        if di_config._is_agentless and di_config._api_key:
-            self._headers["DD-API-KEY"] = di_config._api_key
-
         self._connect = connector(di_config._intake_url, timeout=di_config.upload_timeout)
 
         if di_config._is_agentless:
-            # Skip the agent check: go directly to online state
+            self._headers["DD-API-KEY"] = di_config._api_key
             self._state = self._online
 
         # Make it retry-able

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -71,17 +71,22 @@ class SignalUploader(agent.AgentCheckPeriodicService):
             f"?ddtags={quote(di_config.tags)}" if di_config._tags_in_qs and di_config.tags else ""
         )
 
+        if di_config._is_agentless:
+            initial_endpoint = "/api/v2/logs"
+        else:
+            initial_endpoint = f"/debugger/v2/input{endpoint_suffix}"  # start optimistically
+
         self._tracks = {
             SignalTrack.LOGS: UploaderTrack(
                 track=SignalTrack.LOGS,
-                endpoint=f"/debugger/v2/input{endpoint_suffix}",  # start optimistically
+                endpoint=initial_endpoint,
                 queue=self.__queue__(
                     encoder=LogSignalJsonEncoder(di_config.service_name), on_full=self._on_buffer_full
                 ),
             ),
             SignalTrack.SNAPSHOT: UploaderTrack(
                 track=SignalTrack.SNAPSHOT,
-                endpoint=f"/debugger/v2/input{endpoint_suffix}",  # start optimistically
+                endpoint=initial_endpoint,
                 queue=self.__queue__(encoder=SnapshotJsonEncoder(di_config.service_name), on_full=self._on_buffer_full),
             ),
         }
@@ -90,8 +95,14 @@ class SignalUploader(agent.AgentCheckPeriodicService):
             "Content-type": "application/json; charset=utf-8",
             "Accept": "text/plain",
         }
+        if di_config._is_agentless and di_config._api_key:
+            self._headers["DD-API-KEY"] = di_config._api_key
 
         self._connect = connector(di_config._intake_url, timeout=di_config.upload_timeout)
+
+        if di_config._is_agentless:
+            # Skip the agent check: go directly to online state
+            self._state = self._online
 
         # Make it retry-able
         self._write_with_backoff = fibonacci_backoff_with_jitter(
@@ -109,6 +120,10 @@ class SignalUploader(agent.AgentCheckPeriodicService):
         self._flush_full = False
 
     def info_check(self, agent_info: Optional[dict]) -> bool:
+        if di_config._is_agentless:
+            # No agent needed in agentless CI mode; upload directly to logs intake
+            return True
+
         if agent_info is None:
             # Agent is unreachable
             return False
@@ -198,7 +213,7 @@ class SignalUploader(agent.AgentCheckPeriodicService):
                 self._write_with_backoff(payload, track.endpoint)
                 meter.distribution("batch.cardinality", count)
             except SignalUploaderError:
-                if not track.endpoint.startswith("/debugger/v1/diagnostics"):
+                if not di_config._is_agentless and not track.endpoint.startswith("/debugger/v1/diagnostics"):
                     # Downgrade both tracks to diagnostics endpoint and retry once
                     self._downgrade_to_diagnostics()
                     self._write_with_backoff(payload, track.endpoint)
@@ -221,7 +236,9 @@ class SignalUploader(agent.AgentCheckPeriodicService):
             if track.queue.count:
                 self._flush_track(track)
 
-        if not self._tracks[SignalTrack.SNAPSHOT].enabled or not self._tracks[SignalTrack.LOGS].enabled:
+        if not di_config._is_agentless and (
+            not self._tracks[SignalTrack.SNAPSHOT].enabled or not self._tracks[SignalTrack.LOGS].enabled
+        ):
             # If the tracks are not enabled, we raise an exception to
             # transition back to the agent check state in case we detect an
             # agent that can handle logs and snapshots safely.

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -71,7 +71,9 @@ class SignalUploader(agent.AgentCheckPeriodicService):
             f"?ddtags={quote(di_config.tags)}" if di_config._tags_in_qs and di_config.tags else ""
         )
 
-        initial_endpoint = "/api/v2/logs" if di_config._is_agentless else f"/debugger/v2/input{endpoint_suffix}"
+        initial_endpoint = (
+            f"/api/v2/debugger{endpoint_suffix}" if di_config._is_agentless else f"/debugger/v2/input{endpoint_suffix}"
+        )
 
         self._tracks = {
             SignalTrack.LOGS: UploaderTrack(

--- a/ddtrace/internal/settings/dynamic_instrumentation.py
+++ b/ddtrace/internal/settings/dynamic_instrumentation.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import re
 import typing as t
@@ -54,12 +53,12 @@ class DynamicInstrumentationConfig(DDConfig):
     _intake_url = DDConfig.d(
         str,
         lambda c: (
-            f"https://{AGENTLESS_DEBUGGER_INTAKE_HOST_PREFIX}.{os.getenv('DD_SITE', 'datadoghq.com')}"
+            f"https://{AGENTLESS_DEBUGGER_INTAKE_HOST_PREFIX}.{ddconfig._dd_site}"
             if c._is_agentless
             else agent_config.trace_agent_url
         ),
     )
-    _api_key = DDConfig.d(str, lambda _: os.getenv("_CI_DD_API_KEY", os.getenv("DD_API_KEY", "")))
+    _api_key = DDConfig.d(t.Optional[str], lambda _: ddconfig._dd_api_key)
     global_rate_limit = DDConfig.d(float, lambda _: DEFAULT_GLOBAL_RATE_LIMIT)
     _tags_in_qs = DDConfig.d(bool, lambda _: True)
     tags = DDConfig.d(str, _derive_tags)

--- a/ddtrace/internal/settings/dynamic_instrumentation.py
+++ b/ddtrace/internal/settings/dynamic_instrumentation.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import re
 import typing as t
@@ -8,7 +9,11 @@ from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.utils.config import get_application_name
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.version import __version__
+
+
+AGENTLESS_LOGS_INTAKE_HOST_PREFIX = "http-intake.logs"
 
 
 DEFAULT_GLOBAL_RATE_LIMIT = 100.0
@@ -46,7 +51,30 @@ class DynamicInstrumentationConfig(DDConfig):
     __prefix__ = "dd.dynamic_instrumentation"
 
     service_name = DDConfig.d(str, lambda _: ddconfig.service or get_application_name() or DEFAULT_SERVICE_NAME)
-    _intake_url = DDConfig.d(str, lambda _: agent_config.trace_agent_url)
+    # In agentless CI mode with test replay enabled, DI logs go directly to the logs intake.
+    # DD_TEST_FAILED_TEST_REPLAY_ENABLED controls test DI (defaults to enabled)
+    _is_agentless = DDConfig.d(
+        bool,
+        lambda _: (
+            asbool(os.getenv("DD_CIVISIBILITY_AGENTLESS_ENABLED", "false"))
+            and asbool(os.getenv("DD_TEST_FAILED_TEST_REPLAY_ENABLED", "true"))
+        ),
+    )
+    _intake_url = DDConfig.d(
+        str,
+        lambda _: (
+            "https://{}.{}".format(
+                AGENTLESS_LOGS_INTAKE_HOST_PREFIX,
+                os.getenv("DD_SITE", "datadoghq.com"),
+            )
+            if (
+                asbool(os.getenv("DD_CIVISIBILITY_AGENTLESS_ENABLED", "false"))
+                and asbool(os.getenv("DD_TEST_FAILED_TEST_REPLAY_ENABLED", "true"))
+            )
+            else agent_config.trace_agent_url
+        ),
+    )
+    _api_key = DDConfig.d(str, lambda _: os.getenv("_CI_DD_API_KEY", os.getenv("DD_API_KEY", "")))
     global_rate_limit = DDConfig.d(float, lambda _: DEFAULT_GLOBAL_RATE_LIMIT)
     _tags_in_qs = DDConfig.d(bool, lambda _: True)
     tags = DDConfig.d(str, _derive_tags)
@@ -120,9 +148,11 @@ class DynamicInstrumentationConfig(DDConfig):
 
     redacted_types_re = DDConfig.d(
         t.Optional[re.Pattern],
-        lambda c: re.compile(f"^(?:{'|'.join((_.replace('.', '[.]').replace('*', '.*') for _ in c.redacted_types))})$")
-        if c.redacted_types
-        else None,
+        lambda c: (
+            re.compile(f"^(?:{'|'.join((_.replace('.', '[.]').replace('*', '.*') for _ in c.redacted_types))})$")
+            if c.redacted_types
+            else None
+        ),
     )
 
     redaction_excluded_identifiers = DDConfig.v(

--- a/ddtrace/internal/settings/dynamic_instrumentation.py
+++ b/ddtrace/internal/settings/dynamic_instrumentation.py
@@ -51,26 +51,16 @@ class DynamicInstrumentationConfig(DDConfig):
     __prefix__ = "dd.dynamic_instrumentation"
 
     service_name = DDConfig.d(str, lambda _: ddconfig.service or get_application_name() or DEFAULT_SERVICE_NAME)
-    # In agentless CI mode with test replay enabled, DI logs go directly to the logs intake.
-    # DD_TEST_FAILED_TEST_REPLAY_ENABLED controls test DI (defaults to enabled)
     _is_agentless = DDConfig.d(
         bool,
-        lambda _: (
-            asbool(os.getenv("DD_CIVISIBILITY_AGENTLESS_ENABLED", "false"))
-            and asbool(os.getenv("DD_TEST_FAILED_TEST_REPLAY_ENABLED", "true"))
-        ),
+        lambda _: ddconfig._ci_visibility_agentless_enabled
+        and asbool(os.getenv("DD_TEST_FAILED_TEST_REPLAY_ENABLED", "true")),
     )
     _intake_url = DDConfig.d(
         str,
-        lambda _: (
-            "https://{}.{}".format(
-                AGENTLESS_LOGS_INTAKE_HOST_PREFIX,
-                os.getenv("DD_SITE", "datadoghq.com"),
-            )
-            if (
-                asbool(os.getenv("DD_CIVISIBILITY_AGENTLESS_ENABLED", "false"))
-                and asbool(os.getenv("DD_TEST_FAILED_TEST_REPLAY_ENABLED", "true"))
-            )
+        lambda c: (
+            f"https://{AGENTLESS_LOGS_INTAKE_HOST_PREFIX}.{os.getenv('DD_SITE', 'datadoghq.com')}"
+            if c._is_agentless
             else agent_config.trace_agent_url
         ),
     )

--- a/ddtrace/internal/settings/dynamic_instrumentation.py
+++ b/ddtrace/internal/settings/dynamic_instrumentation.py
@@ -9,7 +9,6 @@ from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.utils.config import get_application_name
-from ddtrace.internal.utils.formats import asbool
 from ddtrace.version import __version__
 
 
@@ -51,11 +50,7 @@ class DynamicInstrumentationConfig(DDConfig):
     __prefix__ = "dd.dynamic_instrumentation"
 
     service_name = DDConfig.d(str, lambda _: ddconfig.service or get_application_name() or DEFAULT_SERVICE_NAME)
-    _is_agentless = DDConfig.d(
-        bool,
-        lambda _: ddconfig._ci_visibility_agentless_enabled
-        and asbool(os.getenv("DD_TEST_FAILED_TEST_REPLAY_ENABLED", "true")),
-    )
+    _is_agentless = DDConfig.d(bool, lambda _: ddconfig._ci_visibility_agentless_enabled)
     _intake_url = DDConfig.d(
         str,
         lambda c: (

--- a/ddtrace/internal/settings/dynamic_instrumentation.py
+++ b/ddtrace/internal/settings/dynamic_instrumentation.py
@@ -12,7 +12,7 @@ from ddtrace.internal.utils.config import get_application_name
 from ddtrace.version import __version__
 
 
-AGENTLESS_LOGS_INTAKE_HOST_PREFIX = "http-intake.logs"
+AGENTLESS_DEBUGGER_INTAKE_HOST_PREFIX = "debugger-intake"
 
 
 DEFAULT_GLOBAL_RATE_LIMIT = 100.0
@@ -54,7 +54,7 @@ class DynamicInstrumentationConfig(DDConfig):
     _intake_url = DDConfig.d(
         str,
         lambda c: (
-            f"https://{AGENTLESS_LOGS_INTAKE_HOST_PREFIX}.{os.getenv('DD_SITE', 'datadoghq.com')}"
+            f"https://{AGENTLESS_DEBUGGER_INTAKE_HOST_PREFIX}.{os.getenv('DD_SITE', 'datadoghq.com')}"
             if c._is_agentless
             else agent_config.trace_agent_url
         ),

--- a/tests/debugging/probe/test_status.py
+++ b/tests/debugging/probe/test_status.py
@@ -1,3 +1,4 @@
+import json
 import sys
 
 from ddtrace.debugging._probe.status import ProbeStatusLogger
@@ -22,6 +23,54 @@ class DummyProbeStatusLogger(ProbeStatusLogger):
     def queue(self) -> list:
         self.flush()
         return self._flush_queue
+
+
+class AgentlessDummyProbeStatusLogger(ProbeStatusLogger):
+    """ProbeStatusLogger subclass that captures payloads in agentless mode (no HTTP requests)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._flush_queue = []
+        # Prevent any accidental HTTP request
+        self._connect = lambda: (_ for _ in ()).throw(AssertionError("unexpected HTTP request"))
+
+    def _write_payload(self, data: tuple[bytes, dict]):
+        body, headers = data
+        # Agentless sends JSON array directly
+        self._flush_queue.extend(json.loads(body.decode("utf-8")))
+
+    def clear(self):
+        self._flush_queue[:] = []
+
+    @property
+    def queue(self) -> list:
+        self.flush()
+        return self._flush_queue
+
+
+def test_probe_status_agentless(monkeypatch):
+    """Test ProbeStatusLogger sends to /api/v2/logs with API key in agentless CI mode."""
+    from ddtrace.debugging._config import di_config
+
+    monkeypatch.setattr(di_config, "_is_agentless", True)
+    monkeypatch.setattr(di_config, "_api_key", "test-api-key")
+
+    status_logger = AgentlessDummyProbeStatusLogger("test")
+
+    # Agentless mode: endpoint and headers
+    assert status_logger._endpoint == "/api/v2/logs"
+
+    probe = create_snapshot_line_probe(
+        probe_id="probe-agentless",
+        source_file="tests/debugger/submod/stuff.py",
+        line=36,
+        condition=None,
+    )
+    status_logger.received(probe)
+
+    (entry,) = status_logger.queue
+    assert entry["debugger"]["diagnostics"]["probeId"] == probe.probe_id
+    assert entry["debugger"]["diagnostics"]["status"] == "RECEIVED"
 
 
 def test_probe_status_received():

--- a/tests/debugging/probe/test_status.py
+++ b/tests/debugging/probe/test_status.py
@@ -49,16 +49,17 @@ class AgentlessDummyProbeStatusLogger(ProbeStatusLogger):
 
 
 def test_probe_status_agentless(monkeypatch):
-    """Test ProbeStatusLogger sends to /api/v2/logs with API key in agentless CI mode."""
+    """Test ProbeStatusLogger sends to /api/v2/debugger with API key in agentless CI mode."""
     from ddtrace.debugging._config import di_config
 
     monkeypatch.setattr(di_config, "_is_agentless", True)
     monkeypatch.setattr(di_config, "_api_key", "test-api-key")
+    monkeypatch.setattr(di_config, "tags", "service:mysvc,env:staging,version:1.0")
 
     status_logger = AgentlessDummyProbeStatusLogger("test")
 
-    # Agentless mode: endpoint and headers
-    assert status_logger._endpoint == "/api/v2/logs"
+    # Agentless mode: endpoint should include tags in QS
+    assert status_logger._endpoint.startswith("/api/v2/debugger?ddtags=")
 
     probe = create_snapshot_line_probe(
         probe_id="probe-agentless",

--- a/tests/debugging/test_uploader.py
+++ b/tests/debugging/test_uploader.py
@@ -104,6 +104,35 @@ def test_uploader_502_error():
         uploader._write(b'{"test": "data"}', "/debugger/v1/input")
 
 
+def test_agentless_uploader(monkeypatch):
+    """Test SignalUploader in agentless CI mode (no HTTP requests are made)."""
+    from ddtrace.debugging._config import di_config
+    from ddtrace.debugging._signal.model import SignalTrack
+
+    # Force re-evaluation of derived values on the singleton
+    monkeypatch.setattr(di_config, "_is_agentless", True)
+    monkeypatch.setattr(di_config, "_api_key", "test-api-key")
+    monkeypatch.setattr(di_config, "_intake_url", "https://http-intake.logs.datadoghq.eu")
+
+    uploader = SignalUploader(interval=LONG_INTERVAL)
+    # Prevent any accidental HTTP request
+    uploader._connect = lambda: (_ for _ in ()).throw(AssertionError("unexpected HTTP request"))
+
+    # Agentless mode: endpoint should be /api/v2/logs for both tracks
+    assert uploader._tracks[SignalTrack.LOGS].endpoint == "/api/v2/logs"
+    assert uploader._tracks[SignalTrack.SNAPSHOT].endpoint == "/api/v2/logs"
+
+    # API key must be in headers
+    assert uploader._headers.get("DD-API-KEY") == "test-api-key"
+
+    # State should be _online (skipping agent check)
+    assert uploader._state == uploader._online
+
+    # info_check should return True regardless of agent_info
+    assert uploader.info_check(None) is True
+    assert uploader.info_check({}) is True
+
+
 def test_info_check_endpoint_selection():
     """Test info_check endpoint selection and fallback behavior for both LOGS and SNAPSHOT tracks."""
     from ddtrace.debugging._signal.model import SignalTrack

--- a/tests/debugging/test_uploader.py
+++ b/tests/debugging/test_uploader.py
@@ -112,15 +112,16 @@ def test_agentless_uploader(monkeypatch):
     # Force re-evaluation of derived values on the singleton
     monkeypatch.setattr(di_config, "_is_agentless", True)
     monkeypatch.setattr(di_config, "_api_key", "test-api-key")
-    monkeypatch.setattr(di_config, "_intake_url", "https://http-intake.logs.datadoghq.eu")
+    monkeypatch.setattr(di_config, "_intake_url", "https://debugger-intake.datadoghq.eu")
+    monkeypatch.setattr(di_config, "tags", "service:mysvc,env:staging,version:1.0")
 
     uploader = SignalUploader(interval=LONG_INTERVAL)
     # Prevent any accidental HTTP request
     uploader._connect = lambda: (_ for _ in ()).throw(AssertionError("unexpected HTTP request"))
 
-    # Agentless mode: endpoint should be /api/v2/logs for both tracks
-    assert uploader._tracks[SignalTrack.LOGS].endpoint == "/api/v2/logs"
-    assert uploader._tracks[SignalTrack.SNAPSHOT].endpoint == "/api/v2/logs"
+    # Agentless mode: endpoint should be /api/v2/debugger with tags in QS for both tracks
+    assert uploader._tracks[SignalTrack.LOGS].endpoint.startswith("/api/v2/debugger?ddtags=")
+    assert uploader._tracks[SignalTrack.SNAPSHOT].endpoint.startswith("/api/v2/debugger?ddtags=")
 
     # API key must be in headers
     assert uploader._headers.get("DD-API-KEY") == "test-api-key"


### PR DESCRIPTION
## Description

Adds agentless mode support to Dynamic Instrumentation (DI) for use in CI Visibility environments where no Datadog Agent is available.

When `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` is set (i.e. `di_config._is_agentless` is `True`), the DI uploader and probe status logger now:

- Send data directly to the Datadog debugger intake (`https://debugger-intake.<DD_SITE>`) instead of routing through the agent
- Use the `/api/v2/debugger` endpoint (instead of `/debugger/v2/input` / `/debugger/v1/diagnostics`)
- Authenticate via the `DD-API-KEY` header using `DD_API_KEY`
- Skip the agent `info_check` step (start in `_online` state immediately)
- Skip the diagnostics-endpoint downgrade logic (not applicable without an agent)
- Send probe status payloads as a plain JSON array with `Content-Type: application/json` instead of multipart form data

## Testing

- Added `test_probe_status_agentless` in `tests/debugging/probe/test_status.py`: verifies the correct endpoint (including `ddtags` query string), correct payload format, and that no HTTP request is made (using a dummy logger that captures flushed data).
- Added `test_agentless_uploader` in `tests/debugging/test_uploader.py`: verifies endpoint selection for both `LOGS` and `SNAPSHOT` tracks, presence of `DD-API-KEY` in headers, `_online` initial state, and that `info_check` always returns `True` in agentless mode.

## Risks

None. The agentless code path is only activated when `DD_CIVISIBILITY_AGENTLESS_ENABLED=true`; the existing agent-based path is unchanged.

## Additional Notes

The `redacted_types_re` lambda in `DynamicInstrumentationConfig` was reformatted to satisfy linting (no functional change).