### PR TITLE
chore: retain parsed settings values

### DIFF
--- a/ddtrace/internal/settings/_core.py
+++ b/ddtrace/internal/settings/_core.py
@@ -1,5 +1,6 @@
 from collections import ChainMap
 from enum import Enum
+from typing import Any
 from typing import Optional
 
 from envier import Env
@@ -22,6 +23,27 @@ class ValueSource(str, Enum):
     OTEL_ENV_VAR = "otel_env_var"
 
 
+class _ParsedValues:
+    """Namespace of original *scalar* parsed config values, populated at initialization time.
+
+    Holds only the flat ``EnvVariable`` and ``DerivedVariable`` items defined
+    directly on the config class.  Nested sub-config instances are not included;
+    their original values are accessible through the sub-config's own ``parsed``
+    namespace instead::
+
+        # correct
+        config.parsed.enabled
+        config.span.parsed.enabled
+
+        # wrong – span is not a scalar and is not present here
+        config.parsed.span.enabled
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        msg = f"No such configuration item: {name}"
+        raise AttributeError(msg)
+
+
 class DDConfig(Env):
     """Provides support for loading configurations from multiple sources."""
 
@@ -40,6 +62,13 @@ class DDConfig(Env):
 
         # Parse the configuration and initialize the values
         super().__init__(source=full_source, parent=parent, dynamic=dynamic)
+
+        # Shallow pass: cache each direct config item's parsed value before any
+        # runtime overrides can be applied.  Nested sub-config instances handle
+        # their own `parsed` namespace.
+        self.parsed: _ParsedValues = _ParsedValues()
+        for name, e in type(self).items(include_derived=True):
+            setattr(self.parsed, name, getattr(self, name))
 
         # Initialize the value sources
         self._value_source = {}

--- a/tests/internal/test_settings.py
+++ b/tests/internal/test_settings.py
@@ -7,6 +7,7 @@ import pytest
 from ddtrace._trace.product import apm_tracing_rc
 from ddtrace.internal.remoteconfig import Payload
 from ddtrace.internal.settings._config import Config
+from ddtrace.internal.settings._core import DDConfig
 from tests.utils import remote_config_build_payload as build_payload
 from tests.utils import scoped_tracer
 
@@ -687,3 +688,77 @@ def test_remoteconfig_debug_logging():
     assert sorted(mock_log.debug.call_args_list) == sorted(expected_logs), (
         f"expected: {expected_logs} got: {mock_log.debug.call_args_list}"
     )
+
+
+class _TestConfig(DDConfig):
+    __prefix__ = "ddtest"
+
+    flag = DDConfig.v(bool, "flag", default=False)
+    count = DDConfig.v(int, "count", default=0)
+
+
+class _TestParentConfig(DDConfig):
+    __prefix__ = "ddtestparent"
+
+    class _TestSubConfig(DDConfig):
+        __prefix__ = "sub"
+        __item__ = "sub"
+
+        flag = DDConfig.v(bool, "flag", default=False)
+
+
+def test_parsed_reflects_stable_source_values(monkeypatch):
+    monkeypatch.setenv("DDTEST_FLAG", "true")
+    monkeypatch.setenv("DDTEST_COUNT", "42")
+
+    cfg = _TestConfig()
+
+    assert getattr(cfg, "flag") is True
+    assert getattr(cfg, "count") == 42
+    assert cfg.parsed.flag is True
+    assert cfg.parsed.count == 42
+
+
+def test_parsed_unaffected_by_runtime_override(monkeypatch):
+    monkeypatch.setenv("DDTEST_FLAG", "true")
+    monkeypatch.setenv("DDTEST_COUNT", "7")
+
+    cfg = _TestConfig()
+
+    setattr(cfg, "flag", False)
+    setattr(cfg, "count", 99)
+
+    assert getattr(cfg, "flag") is False
+    assert getattr(cfg, "count") == 99
+    assert cfg.parsed.flag is True
+    assert cfg.parsed.count == 7
+
+
+def test_parsed_uses_defaults_when_env_not_set():
+    cfg = _TestConfig()
+
+    assert cfg.parsed.flag is False
+    assert cfg.parsed.count == 0
+
+
+def test_parsed_nested_config_accessed_via_sub_config():
+    # parsed only holds scalar (EnvVariable / DerivedVariable) items defined
+    # directly on the config class.  Nested sub-configs are not included.
+    # Their original values must be reached through the sub-config's own
+    # .parsed namespace, not through the parent's .parsed.
+    cfg = _TestParentConfig()
+    sub = cfg.sub
+    parent_parsed = cfg.parsed
+
+    # The sub-config's parsed namespace reflects its original values.
+    assert sub.parsed.flag is False
+
+    # A runtime override on the live sub-config does not affect its parsed snapshot.
+    sub.flag = True
+    assert sub.flag is True
+    assert sub.parsed.flag is False
+
+    # The parent's parsed namespace has no sub attribute — nested configs are
+    # intentionally excluded.
+    with pytest.raises(AttributeError):
+        _ = parent_parsed.sub


### PR DESCRIPTION
## Description

We extend the DDConfig class to retain the original parsed values under the `parsed` namespace.