### PR TITLE
chore(tests): remove Test from event class names in test

### DIFF
--- a/tests/internal/events/test_base_events.py
+++ b/tests/internal/events/test_base_events.py
@@ -15,12 +15,12 @@ def reset_event_hub():
 
 
 @dataclass
-class TestEvent(Event):
+class BaseEvent(Event):
     event_name = "test.event"
 
 
 @dataclass
-class TestEventWithAttributes(Event):
+class BaseEventWithAttributes(Event):
     event_name = "test.event"
     foo: str
     bar: int
@@ -31,13 +31,13 @@ def test_dispatch_event():
 
     called = []
 
-    def on_event(event_instance: TestEvent):
+    def on_event(event_instance: BaseEvent):
         called.append(event_instance.event_name)
 
-    core.on(TestEvent.event_name, on_event)
-    core.dispatch_event(TestEvent())
+    core.on(BaseEvent.event_name, on_event)
+    core.dispatch_event(BaseEvent())
 
-    assert called == [TestEvent.event_name], (
+    assert called == [BaseEvent.event_name], (
         "dispatching an event should call the handler once with the event name; got %r" % (called,)
     )
 
@@ -47,12 +47,12 @@ def test_dispatch_event_using_attributes():
 
     called = []
 
-    def on_event(event_instance: TestEventWithAttributes):
+    def on_event(event_instance: BaseEventWithAttributes):
         called.append(event_instance.foo)
         called.append(event_instance.bar)
 
-    core.on(TestEventWithAttributes.event_name, on_event)
-    core.dispatch_event(TestEventWithAttributes(foo="test", bar=0))
+    core.on(BaseEventWithAttributes.event_name, on_event)
+    core.dispatch_event(BaseEventWithAttributes(foo="test", bar=0))
 
     assert called == ["test", 0], "event attributes are wrongy populated; got %r" % (called,)
 
@@ -62,12 +62,12 @@ def test_dispatch_event_missing_attribute():
 
     called = []
 
-    def on_event(event_instance: TestEventWithAttributes):
+    def on_event(event_instance: BaseEventWithAttributes):
         called.append(event_instance.foo)
         called.append(event_instance.bar)
 
-    core.on(TestEventWithAttributes.event_name, on_event)
+    core.on(BaseEventWithAttributes.event_name, on_event)
     with pytest.raises(TypeError):
-        core.dispatch_event(TestEventWithAttributes(foo="test"))
+        core.dispatch_event(BaseEventWithAttributes(foo="test"))  # pyright: ignore[reportCallIssue]
 
     assert called == [], "event should not be dispatched when required event args are missing; got %r" % (called,)

--- a/tests/internal/events/test_context_events.py
+++ b/tests/internal/events/test_context_events.py
@@ -24,22 +24,22 @@ def test_basic_context_event():
     called = []
 
     @dataclass
-    class TestContextEvent(Event):
+    class ContextEvent(Event):
         event_name = "test.event"
 
     def on_context_started(ctx: core.ExecutionContext):
-        called.append(f"{TestContextEvent.event_name}.started")
+        called.append(f"{ContextEvent.event_name}.started")
 
     def on_context_ended(ctx: core.ExecutionContext, err_info: Any):
-        called.append(f"{TestContextEvent.event_name}.ended")
+        called.append(f"{ContextEvent.event_name}.ended")
 
-    core.on(f"context.started.{TestContextEvent.event_name}", on_context_started)
-    core.on(f"context.ended.{TestContextEvent.event_name}", on_context_ended)
+    core.on(f"context.started.{ContextEvent.event_name}", on_context_started)
+    core.on(f"context.ended.{ContextEvent.event_name}", on_context_ended)
 
-    with core.context_with_event(TestContextEvent()):
+    with core.context_with_event(ContextEvent()):
         pass
 
-    assert called == [f"{TestContextEvent.event_name}.started", f"{TestContextEvent.event_name}.ended"], (
+    assert called == [f"{ContextEvent.event_name}.started", f"{ContextEvent.event_name}.ended"], (
         "event should trigger started then ended handlers in order; got %r" % (called,)
     )
 
@@ -53,7 +53,7 @@ def test_context_event_enforce_kwargs_error():
     called = []
 
     @dataclass
-    class TestContextEvent(Event):
+    class ContextEvent(Event):
         event_name = "test.event"
         foo: str = event_field()
         bar: int = event_field()
@@ -67,11 +67,11 @@ def test_context_event_enforce_kwargs_error():
     ) -> None:
         called.append("ended")
 
-    core.on(f"context.started.{TestContextEvent.event_name}", on_context_started)
-    core.on(f"context.ended.{TestContextEvent.event_name}", on_context_ended)
+    core.on(f"context.started.{ContextEvent.event_name}", on_context_started)
+    core.on(f"context.ended.{ContextEvent.event_name}", on_context_ended)
 
     with pytest.raises(TypeError):
-        with core.context_with_event(TestContextEvent(foo="toto")):
+        with core.context_with_event(ContextEvent(foo="toto")):  # pyright: ignore[reportCallIssue]
             pass
 
     assert called == [], "event should not be dispatched when required event args are missing; got %r" % (called,)
@@ -82,7 +82,7 @@ def test_context_event_event_field():
     called = []
 
     @dataclass
-    class TestContextEvent(Event):
+    class ContextEvent(Event):
         event_name = "test.event"
         foo: str = event_field()
         with_default: str = event_field(default="test")
@@ -92,7 +92,7 @@ def test_context_event_event_field():
             called.append(not_in_context)
 
     def on_context_started(ctx: core.ExecutionContext) -> None:
-        event: TestContextEvent = ctx.event
+        event: ContextEvent = ctx.event
         called.append(event.foo)
         called.append(event.with_default)
 
@@ -100,9 +100,9 @@ def test_context_event_event_field():
             "InitVar field marked out of context should not be present on context event"
         )
 
-    core.on(f"context.started.{TestContextEvent.event_name}", on_context_started)
+    core.on(f"context.started.{ContextEvent.event_name}", on_context_started)
 
-    with core.context_with_event(TestContextEvent(foo="toto", not_in_context=0)):
+    with core.context_with_event(ContextEvent(foo="toto", not_in_context=0)):
         pass
 
     assert called == [0, "toto", "test"], (
@@ -116,7 +116,7 @@ def test_context_with_event_context_name_override():
     called = []
 
     @dataclass
-    class TestContextEvent(Event):
+    class ContextEvent(Event):
         event_name = "test.event.default_name"
 
     override_name = "test.event.override_name"
@@ -135,10 +135,10 @@ def test_context_with_event_context_name_override():
 
     core.on(f"context.started.{override_name}", on_override_started)
     core.on(f"context.ended.{override_name}", on_override_ended)
-    core.on(f"context.started.{TestContextEvent.event_name}", on_default_started)
-    core.on(f"context.ended.{TestContextEvent.event_name}", on_default_ended)
+    core.on(f"context.started.{ContextEvent.event_name}", on_default_started)
+    core.on(f"context.ended.{ContextEvent.event_name}", on_default_ended)
 
-    with core.context_with_event(TestContextEvent(), context_name_override=override_name):
+    with core.context_with_event(ContextEvent(), context_name_override=override_name):
         pass
 
     assert called == ["override_started", "override_ended"], (
@@ -152,7 +152,7 @@ def test_context_with_event_dispatch_end_event_false_no_auto_end():
     called = []
 
     @dataclass
-    class TestContextEvent(Event):
+    class ContextEvent(Event):
         event_name = "test.event.no_auto_end"
 
     def on_context_started(ctx: core.ExecutionContext):
@@ -161,10 +161,10 @@ def test_context_with_event_dispatch_end_event_false_no_auto_end():
     def on_context_ended(ctx: core.ExecutionContext, err_info: Any):
         called.append("ended")
 
-    core.on(f"context.started.{TestContextEvent.event_name}", on_context_started)
-    core.on(f"context.ended.{TestContextEvent.event_name}", on_context_ended)
+    core.on(f"context.started.{ContextEvent.event_name}", on_context_started)
+    core.on(f"context.ended.{ContextEvent.event_name}", on_context_ended)
 
-    with core.context_with_event(TestContextEvent(), dispatch_end_event=False):
+    with core.context_with_event(ContextEvent(), dispatch_end_event=False):
         pass
 
     assert called == ["started"], (

--- a/tests/internal/test_subscribers.py
+++ b/tests/internal/test_subscribers.py
@@ -28,7 +28,7 @@ def reset_event_hub():
 
 
 @dataclass
-class TestEvent(Event):
+class SubscriberEvent(Event):
     event_name = "test.subscriber.event"
 
 
@@ -36,15 +36,17 @@ def test_base_subscriber():
     """Test that a direct BaseSubscriber receives dispatched events."""
 
     class DirectSubscriber(Subscriber):
-        event_names = (TestEvent.event_name,)
+        event_names = (SubscriberEvent.event_name,)
 
         @classmethod
         def on_event(cls, event_instance):
             called.append(event_instance.event_name)
 
-    core.dispatch_event(TestEvent())
+    core.dispatch_event(SubscriberEvent())
 
-    assert called == [TestEvent.event_name], "subscriber should be called once with the event name; got %r" % (called,)
+    assert called == [SubscriberEvent.event_name], "subscriber should be called once with the event name; got %r" % (
+        called,
+    )
 
 
 def test_base_subscriber_inheritance():
@@ -56,13 +58,13 @@ def test_base_subscriber_inheritance():
             called.append("parent")
 
     class ChildSubscriber(ParentSubscriber):
-        event_names = (TestEvent.event_name,)
+        event_names = (SubscriberEvent.event_name,)
 
         @classmethod
         def on_event(cls, event_instance):
             called.append("child")
 
-    core.dispatch_event(TestEvent())
+    core.dispatch_event(SubscriberEvent())
 
     assert called == ["parent", "child"], "parent and child subscribers should run in order; got %r" % (called,)
 
@@ -71,24 +73,24 @@ def test_base_subscriber_multiple_event_names():
     """Test that a Subscriber can register for and handle multiple events."""
 
     @dataclass
-    class TestEventOne(Event):
+    class SubscriberEventOne(Event):
         event_name = "test.subscriber.event.one"
 
     @dataclass
-    class TestEventTwo(Event):
+    class SubscriberEventTwo(Event):
         event_name = "test.subscriber.event.two"
 
     class MultiEventSubscriber(Subscriber):
-        event_names = (TestEventOne.event_name, TestEventTwo.event_name)
+        event_names = (SubscriberEventOne.event_name, SubscriberEventTwo.event_name)
 
         @classmethod
         def on_event(cls, event_instance):
             called.append(event_instance.event_name)
 
-    core.dispatch_event(TestEventOne())
-    core.dispatch_event(TestEventTwo())
+    core.dispatch_event(SubscriberEventOne())
+    core.dispatch_event(SubscriberEventTwo())
 
-    assert called == [TestEventOne.event_name, TestEventTwo.event_name], (
+    assert called == [SubscriberEventOne.event_name, SubscriberEventTwo.event_name], (
         "subscriber should listen to both events in dispatch order; got %r" % (called,)
     )
 


### PR DESCRIPTION
Internal test suite was raising warning because Event class contained Test in tests.

Therefore pytest thought it was test classes (this was not the case).

This PR removes `Test` from Event class names.