### PR TITLE
chore: change `chaos-platform` ownership to `chaos-engineering`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -291,6 +291,6 @@ tests/**/*iast*                 @DataDog/asm-python
 tests/tracer/test_propagation.py        @DataDog/apm-sdk-capabilities-python @DataDog/asm-python
 
 # Fuzzing
-.gitlab/fuzz.yml                  @DataDog/chaos-platform @DataDog/profiling-python
-.gitlab/scripts/fuzz_infra.py     @DataDog/chaos-platform @DataDog/profiling-python
-docker/Dockerfile.fuzz            @DataDog/chaos-platform @DataDog/profiling-python
+.gitlab/fuzz.yml                  @DataDog/chaos-engineering @DataDog/profiling-python
+.gitlab/scripts/fuzz_infra.py     @DataDog/chaos-engineering @DataDog/profiling-python
+docker/Dockerfile.fuzz            @DataDog/chaos-engineering @DataDog/profiling-python


### PR DESCRIPTION
## Description

[datadoghq.atlassian.net/browse/PROF-13838](https://datadoghq.atlassian.net/browse/PROF-13838)

As reported by @edznux-dd this isn't valid anymore.

Also added ownership for a file. 