### PR TITLE
ci: remove the ghost of setuptools_scm [backport 4.5]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1284,7 +1284,12 @@ setup(
         "clean": CleanLibraries,
         "ext_hashes": ExtensionHashes,
     },
-    setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust<2"],
+    setup_requires=[
+        "cython",
+        "cmake>=3.24.2,<3.28",
+        "setuptools-rust<2",
+        "patchelf>=0.17.0.0; sys_platform == 'linux'",
+    ],
     ext_modules=ext_modules + cython_exts + get_exts_for("psutil"),
     distclass=PatchedDistribution,
 )


### PR DESCRIPTION
## Summary

Backport of #17021 to 4.5.

`setuptools_scm>=10` (released March 19) breaks CI with `ModuleNotFoundError: No module named 'vcs_versioning'` when pip fetches it via the loose `setuptools_scm[toml]>=4` constraint in `setup_requires`. We don't use `setuptools_scm` anymore — removes it from `setup_requires` and adds `patchelf>=0.17.0.0` for Linux.

## Test plan

- [ ] CI passes (no more `vcs_versioning` import error)

changelog/no-changelog