### PR TITLE
test(profiling): use `fuzz_base` image for `fuzz_infra`

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -2,6 +2,7 @@ variables:
   REPO_LANG: python # "python" is used everywhere rather than "py"
   FUZZ_IMAGE: registry.ddbuild.io/dd-trace-py-fuzz
   FUZZYDOG_VERSION: "0.26.2"
+  FUZZ_BASE_IMAGE: registry.ddbuild.io/dd-trace-py:v104604389-11e1de9-fuzz_base
   # CI_DEBUG_SERVICES: "true"
 
 fuzz_infra:
@@ -22,17 +23,11 @@ fuzz_infra:
   parallel:
     matrix:
       - PYTHON_VERSION: "3.9"
-        PYTHON_IMAGE_TAG: "3.9.22-slim"
       - PYTHON_VERSION: "3.10"
-        PYTHON_IMAGE_TAG: "3.10.13"
       - PYTHON_VERSION: "3.11"
-        PYTHON_IMAGE_TAG: "3.11.6"
       - PYTHON_VERSION: "3.12"
-        PYTHON_IMAGE_TAG: "3.12.0"
       - PYTHON_VERSION: "3.13"
-        PYTHON_IMAGE_TAG: "3.13.0"
       - PYTHON_VERSION: "3.14"
-        PYTHON_IMAGE_TAG: "3.14.2-slim"
   before_script:
     - apt update && apt install -y python3 unzip
     # TODO: Install fuzzydog on the image directly when version is stable

--- a/.gitlab/scripts/fuzz_infra.py
+++ b/.gitlab/scripts/fuzz_infra.py
@@ -8,8 +8,8 @@
 #
 # Expected environment variables (set by .gitlab/fuzz.yml):
 #   FUZZ_IMAGE          – registry path, e.g. registry.ddbuild.io/dd-trace-py-fuzz
-#   PYTHON_VERSION      – e.g. "3.12"
-#   PYTHON_IMAGE_TAG    – e.g. "3.12.0"
+#   FUZZ_BASE_IMAGE     – pre-built base image ref, e.g. registry.ddbuild.io/dd-trace-py:vXXX-fuzz_base
+#   PYTHON_VERSION      – e.g. "3.12" (must match a pyenv version in fuzz_base)
 #   CI_COMMIT_SHORT_SHA – short SHA from GitLab CI
 
 from __future__ import annotations
@@ -34,8 +34,8 @@ MAX_PKG_NAME_LENGTH = 50
 @dataclass(frozen=True)
 class Config:
     fuzz_image: str
+    fuzz_base_image: str
     python_version: str
-    python_image_tag: str
     commit_short_sha: str
     git_sha: str
 
@@ -45,8 +45,8 @@ class Config:
         git_sha = git_sha.decode("utf-8") if isinstance(git_sha, bytes) else git_sha
         return cls(
             fuzz_image=os.environ["FUZZ_IMAGE"],
+            fuzz_base_image=os.environ["FUZZ_BASE_IMAGE"],
             python_version=os.environ["PYTHON_VERSION"],
-            python_image_tag=os.environ["PYTHON_IMAGE_TAG"],
             commit_short_sha=os.environ["CI_COMMIT_SHORT_SHA"],
             git_sha=git_sha,
         )
@@ -120,7 +120,9 @@ def build_and_push_image(config: Config) -> str:
             "-f",
             "docker/Dockerfile.fuzz",
             "--build-arg",
-            f"PYTHON_IMAGE_TAG={config.python_image_tag}",
+            f"FUZZ_BASE_IMAGE={config.fuzz_base_image}",
+            "--build-arg",
+            f"PYTHON_VERSION={config.python_version}",
             "-t",
             config.full_image_ref,
             "--push",
@@ -174,7 +176,9 @@ def extract_manifest(config: Config) -> list[FuzzBinary]:
             "-f",
             "docker/Dockerfile.fuzz",
             "--build-arg",
-            f"PYTHON_IMAGE_TAG={config.python_image_tag}",
+            f"FUZZ_BASE_IMAGE={config.fuzz_base_image}",
+            "--build-arg",
+            f"PYTHON_VERSION={config.python_version}",
             "--output",
             f"type=local,dest={output_dir}",
             ".",

--- a/docker/Dockerfile.fuzz
+++ b/docker/Dockerfile.fuzz
@@ -1,7 +1,14 @@
-# Minimal fuzzing image for the stack_v2/echion harness (libFuzzer + ASAN/UBSAN).
+# Fuzzing image for the stack_v2/echion harness (libFuzzer + ASAN/UBSAN).
+#
+# Uses the pre-built fuzz_base image (images/dd-trace-py/fuzz_base/) which
+# already contains the C++ toolchain, Rust, fuzzydog, and all Python versions
+# (via pyenv).  This stage only adds source code and runs the actual build.
 #
 # Build:
-#   $ docker build -f docker/Dockerfile.fuzz --build-arg PYTHON_IMAGE_TAG=3.12.0 -t ddtrace-py-stackv2-fuzz .
+#   $ docker build -f docker/Dockerfile.fuzz \
+#       --build-arg FUZZ_BASE_IMAGE=registry.ddbuild.io/dd-trace-py:vXXX-fuzz_base \
+#       --build-arg PYTHON_VERSION=3.10 \
+#       -t ddtrace-py-stackv2-fuzz .
 #
 # Run with fuzzydog (requires FUZZYDOG_AUTH_TOKEN):
 #   $ docker run --rm -it -e FUZZYDOG_AUTH_TOKEN ddtrace-py-stackv2-fuzz
@@ -15,42 +22,16 @@
 #       --slack-channel fuzzing-ops \
 #       --repository-url https://github.com/DataDog/dd-trace-py
 
-# ── Build dependencies ────────────────────────────────────────────────
-ARG PYTHON_IMAGE_TAG=3.12.0
-FROM registry.ddbuild.io/images/mirror/python:${PYTHON_IMAGE_TAG} AS build
+# ── Build stage ───────────────────────────────────────────────────────────────
+ARG FUZZ_BASE_IMAGE=registry.ddbuild.io/dd-trace-py/fuzz_base:latest
+FROM ${FUZZ_BASE_IMAGE} AS build
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Select the Python version for this build (major.minor, e.g. "3.10").
+# Must match one of the versions installed by pyenv in fuzz_base.
+ARG PYTHON_VERSION=3.12
+RUN pyenv global "${PYTHON_VERSION}"
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    clang \
-    cmake \
-    git \
-    libclang-rt-dev \
-    lld \
-    llvm \
-    make \
-    ninja-build \
-    curl \
-  && rm -rf /var/lib/apt/lists/* \
-  && python3 -m pip install setuptools_rust cython requests "setuptools-scm<9" --break-system-packages
-
-# Install Rust toolchain (needed to build _native / libdatadog)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install fuzzydog
-RUN FUZZYDOG_VERSION=0.26.2 \
-  && curl -L "https://binaries.ddbuild.io/fuzzing/fuzzydog/${FUZZYDOG_VERSION}/fuzzydog-tar.tar.gz" -o /tmp/fuzzydog-tar.tar.gz \
-  && tar -C /usr/local/bin -zxf /tmp/fuzzydog-tar.tar.gz fuzzydog-linux-$(dpkg --print-architecture) \
-  && mv /usr/local/bin/fuzzydog-linux-$(dpkg --print-architecture) /usr/local/bin/fuzzydog \
-  && rm /tmp/fuzzydog-tar.tar.gz
-
-# Standard fuzzer directory layout
-RUN mkdir -p /fuzzer/inputs /fuzzer/crashes /fuzzer/builds
-
-# ── Build and package all fuzz targets ────────────────────────────────
+# ── Build and package all fuzz targets ────────────────────────────────────────
 WORKDIR /src
 COPY . /src
 


### PR DESCRIPTION
## What is this PR?

This PR updates the `fuzz_infra` job to use the `fuzz_base` image instead of installing all the dependencies at each run. 

Related: https://github.com/DataDog/images/pull/9221