### PR TITLE
ci: install `rustup` with the minimal profile by default

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,7 +96,7 @@ ENV NPM_CONFIG_PREFIX=/home/bits/.local/
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain stable -y
+    sh -s -- --profile minimal --default-toolchain stable -y
 
 # Use .python-version to specify all Python versions for testing
 COPY .python-version /home/bits/


### PR DESCRIPTION
## Description

Installs `rustup` with the `minimal` profile, which influences which components are installed by default for any subsequent toolchain installations. Specifically, this avoids installing `rust-docs` which is never needed for CI, and adds around ~600MiB (on disk, uncompressed) to your CI image _per toolchain_.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
