### PR TITLE
fix(llmobs): prevent evaluator spans from leaking into experiments index

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1925,6 +1925,12 @@ class Experiment:
         log_fn = logger.warning if self._interrupted else logger.info
         log_fn(msg, extra={"product": "llmobs"})
 
+    def _clear_trace_context(self) -> None:
+        """Clear default and LLMObs trace contexts so evaluator spans don't inherit experiment baggage."""
+        if self._llmobs_instance:
+            self._llmobs_instance.tracer.context_provider.activate(None)
+            self._llmobs_instance._llmobs_context_provider.activate(None)
+
     async def _process_record(
         self,
         idx_record: tuple[int, DatasetRecord],
@@ -2243,6 +2249,7 @@ class Experiment:
             )
             if task_result is None:
                 return None, None
+            self._clear_trace_context()
             evaluation = await self._evaluate_record(
                 idx_record[1],
                 task_result,

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -2384,6 +2384,51 @@ def test_experiment_span_multi_run_tags(llmobs, llmobs_events, test_dataset_one_
         assert event["config"] == {"temperature": 0.7}
 
 
+def test_experiment_evaluator_spans_not_in_experiments_scope(llmobs, llmobs_events, test_dataset_one_record):
+    """Evaluator LLM spans must not inherit the experiment scope."""
+    from ddtrace.ext import SpanTypes
+
+    def task_that_creates_llm_span(input_data, config):
+        span = llmobs._instance.tracer.trace("task_llm_call", span_type=SpanTypes.LLM)
+        llmobs._instance._activate_llmobs_span(span)
+        llmobs.annotate(span, input_data="test input", output_data="test output")
+        span.finish()
+        return "task output"
+
+    def evaluator_that_creates_llm_span(input_data, output_data, expected_output):
+        span = llmobs._instance.tracer.trace("evaluator_llm_call", span_type=SpanTypes.LLM)
+        llmobs._instance._activate_llmobs_span(span)
+        llmobs.annotate(span, input_data="judge prompt", output_data="judge verdict")
+        span.finish()
+        return 1
+
+    exp = llmobs.experiment(
+        "test_experiment",
+        task_that_creates_llm_span,
+        test_dataset_one_record,
+        [evaluator_that_creates_llm_span],
+    )
+    exp._experiment._id = "1234567890"
+    task_results, eval_results = asyncio.run(
+        exp._experiment._run_tasks_with_evaluators(1, run=run_info_with_stable_id(0), raise_errors=True)
+    )
+    assert len(task_results) == 1
+    assert len(eval_results) == 1
+
+    task_experiment_spans = [e for e in llmobs_events if e["name"] == "task_that_creates_llm_span"]
+    task_llm_spans = [e for e in llmobs_events if e["name"] == "task_llm_call"]
+    evaluator_llm_spans = [e for e in llmobs_events if e["name"] == "evaluator_llm_call"]
+
+    assert len(task_experiment_spans) == 1
+    assert task_experiment_spans[0]["_dd"]["scope"] == "experiments"
+
+    assert len(task_llm_spans) == 1
+    assert task_llm_spans[0]["_dd"].get("scope") == "experiments"
+
+    assert len(evaluator_llm_spans) == 1
+    assert "scope" not in evaluator_llm_spans[0]["_dd"]
+
+
 def test_experiment_span_no_config_omits_field(llmobs, llmobs_events, test_dataset_one_record_w_metadata):
     """Assert that the config field is omitted from the span event when no config is provided."""
     exp = llmobs.experiment(


### PR DESCRIPTION
## Summary

- Evaluator LLM spans were incorrectly inheriting the experiment span's baggage and getting routed to the experiments index instead of the standard LLMObs index
- Added `_clear_trace_context()` call between task and evaluator execution in `_process_and_evaluate` to clear both the default tracer and LLMObs context providers
- Added test verifying that task spans get `scope=experiments` while evaluator spans do not

## Root Cause

In `_run_tasks_with_evaluators`, the `_process_and_evaluate` coroutine runs `_process_record` (task) and `_evaluate_record` (evaluators) sequentially within the same asyncio Task. The experiment span created during task execution sets `EXPERIMENT_ID_KEY` as baggage on its trace context. After the experiment span finishes, the trace context may still carry this baggage when evaluator code runs, causing any LLM spans created by evaluators to inherit the `scope=experiments` attribute and get routed to the wrong index.

## Test plan

- [ ] New test `test_experiment_evaluator_spans_not_in_experiments_scope` verifies task spans have `scope=experiments` while evaluator spans do not
- [ ] Existing experiment tests continue to pass