### PR TITLE
DRAFT feature(llmobs): enabling llmobs annotate() and custom span processor to modify a wider scope of span parameters

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -141,6 +141,7 @@ from ddtrace.llmobs._prompts.manager import PromptManager
 from ddtrace.llmobs._utils import AnnotationContext
 from ddtrace.llmobs._utils import LinkTracker
 from ddtrace.llmobs._utils import _batched
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import _get_ml_app
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
@@ -165,6 +166,7 @@ from ddtrace.llmobs.types import ExportedLLMObsSpan
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import Prompt
 from ddtrace.llmobs.types import PromptFallback
+from ddtrace.llmobs.types import ToolDefinition
 from ddtrace.llmobs.types import _ErrorField
 from ddtrace.llmobs.types import _Meta
 from ddtrace.llmobs.types import _MetaIO
@@ -320,19 +322,51 @@ class LLMObsSpan:
 
     Passed to the `span_processor` function in the `enable` or `register_processor` methods.
 
+    Fields:
+        input: List of input messages. For LLM spans these are role/content dicts; for other kinds,
+               a single-element list with a "content" value string.
+        output: List of output messages. Same conventions as "input".
+        _tags: Raw span tags dict. Access via "get_tag()".
+        name: The display name of the span (e.g. "my_llm_call"). Mutations are written back.
+        _span_kind: The kind of the span (e.g. "llm", "agent", "tool", "task",
+                   "embedding", "retrieval", "workflow"). Read-only; access via "get_span_kind()".
+        model_name: The model name (e.g. "gpt-4o"). Mutations are written back.
+        model_provider: The model provider (e.g. "openai"). Mutations are written back (lowercased).
+        session_id: The session ID to group spans. Mutations are written back.
+        ml_app: The ML app name. Mutations are written back.
+        metadata: Dictionary of arbitrary metadata key-value pairs. Mutations are written back.
+        metrics: Dictionary of numeric metric key-value pairs (e.g. token counts). Mutations are written back.
+        tool_definitions: List of tool definition dicts for LLM tool-calling. Mutations are written back.
+        prompt: The prompt object for LLM spans, or "None". Mutations are written back.
+
     Example::
         def span_processor(span: LLMObsSpan) -> Optional[LLMObsSpan]:
-            # Modify input/output
             if span.get_tag("omit_span") == "1":
                 return None
             if span.get_tag("no_input") == "1":
                 span.input = []
+            # Rename the span based on model
+            span.name = f"{span.model_provider}.{span.model_name}"
             return span
     """
 
     input: list[Message] = field(default_factory=list)
     output: list[Message] = field(default_factory=list)
     _tags: dict[str, str] = field(default_factory=dict)
+
+    # Span-level identity fields
+    name: str = ""
+    _span_kind: str = ""  # read-only — write-back is ignored
+    model_name: str = ""
+    model_provider: str = ""
+    session_id: str = ""
+    ml_app: str = ""
+
+    # Annotation fields
+    metadata: dict[str, Any] = field(default_factory=dict)
+    metrics: dict[str, Any] = field(default_factory=dict)
+    tool_definitions: list[ToolDefinition] = field(default_factory=list)
+    prompt: Optional[Prompt] = field(default=None)
 
     def get_tag(self, key: str) -> Optional[str]:
         """Get a tag from the span.
@@ -342,6 +376,9 @@ class LLMObsSpan:
         :rtype: Optional[str]
         """
         return self._tags.get(key)
+
+    def get_span_kind(self) -> str:
+        return self._span_kind
 
 
 def _build_llmobs_span(
@@ -430,6 +467,14 @@ def _build_span_meta(
     elif output_type == "value" and llmobs_span.output:
         meta["output"]["value"] = llmobs_span.output[0].get("content", "")
 
+    # Write back processor mutations for meta-level fields
+    meta["metadata"] = llmobs_span.metadata
+    meta["model_name"] = llmobs_span.model_name
+    meta["model_provider"] = llmobs_span.model_provider.lower()
+    meta["tool_definitions"] = llmobs_span.tool_definitions
+    if llmobs_span.prompt is not None:
+        meta.setdefault(LLMOBS_STRUCT.INPUT, _MetaIO())["prompt"] = llmobs_span.prompt
+
     return meta
 
 
@@ -514,7 +559,9 @@ class LLMObs(Service):
             return self._build_span_event_from_meta_struct(span, llmobs_data)
         return self._build_span_event_from_ctx_items(span)
 
-    def _apply_user_span_processor(self, llmobs_span: LLMObsSpan, llmobs_data: LLMObsSpanData) -> Optional[LLMObsSpan]:
+    def _apply_user_span_processor(
+        self, span: Span, llmobs_span: LLMObsSpan, llmobs_data: LLMObsSpanData
+    ) -> Optional[LLMObsSpan]:
         """Run the user span processor.
 
         Returns the possibly mutated span, or None if the span should be dropped.
@@ -524,7 +571,19 @@ class LLMObs(Service):
             return llmobs_span
         error = False
         try:
+            llmobs_meta = llmobs_data.get(LLMOBS_STRUCT.META) or _Meta()
+            llmobs_input = llmobs_meta.get(LLMOBS_STRUCT.INPUT) or _MetaIO()
             llmobs_span._tags = cast(dict[str, str], llmobs_data.get(LLMOBS_STRUCT.TAGS, {}))
+            llmobs_span.name = _get_span_name(span)
+            llmobs_span._span_kind = _get_span_kind(span) or ""
+            llmobs_span.model_name = llmobs_meta.get(LLMOBS_STRUCT.MODEL_NAME) or ""
+            llmobs_span.model_provider = (llmobs_meta.get(LLMOBS_STRUCT.MODEL_PROVIDER) or "custom").lower()
+            llmobs_span.session_id = _get_session_id(span) or ""
+            llmobs_span.ml_app = _get_ml_app(span) or ""
+            llmobs_span.metadata = dict(llmobs_meta.get(LLMOBS_STRUCT.METADATA) or {})
+            llmobs_span.metrics = dict(llmobs_data.get(LLMOBS_STRUCT.METRICS) or {})
+            llmobs_span.tool_definitions = list(llmobs_meta.get(LLMOBS_STRUCT.TOOL_DEFINITIONS) or [])
+            llmobs_span.prompt = llmobs_input.get(LLMOBS_STRUCT.PROMPT)
             result = self._user_span_processor(llmobs_span)
             if result is None:
                 return None
@@ -564,16 +623,17 @@ class LLMObs(Service):
             core.dispatch(DISPATCH_ON_LLM_SPAN_FINISH, (span,))
 
         llmobs_span, input_type, output_type = _build_llmobs_span(span_kind, llmobs_input, llmobs_output)
-        user_processed_span = self._apply_user_span_processor(llmobs_span, llmobs_data)
+        user_processed_span = self._apply_user_span_processor(span, llmobs_span, llmobs_data)
         if user_processed_span is None:
             return None
         llmobs_span = user_processed_span
 
         # Wait to build meta until after user processors apply and potentially mutate I/O
         meta = _build_span_meta(span, llmobs_span, llmobs_meta, span_kind, input_type, output_type)
-        metrics = llmobs_data.get(LLMOBS_STRUCT.METRICS) or {}
-        session_id = _get_session_id(span)
-        tags = self._llmobs_tags(span, ml_app, session_id, True, llmobs_data)
+        metrics = llmobs_span.metrics
+        session_id = llmobs_span.session_id or _get_session_id(span)
+        ml_app_final = llmobs_span.ml_app or ml_app
+        tags = self._llmobs_tags(span, ml_app_final, session_id, True, llmobs_data)
         span_links = get_span_links(span)
         _dd_attrs = {
             "span_id": str(span.span_id),
@@ -587,7 +647,7 @@ class LLMObs(Service):
             "trace_id": llmobs_trace_id,
             "span_id": str(span.span_id),
             "parent_id": parent_id,
-            "name": _get_span_name(span),
+            "name": llmobs_span.name or _get_span_name(span),
             "start_ns": span.start_ns,
             "duration": cast(int, span.duration_ns),
             "status": "error" if span.error else "ok",
@@ -721,6 +781,16 @@ class LLMObs(Service):
             error = False
             try:
                 llmobs_span._tags = cast(dict[str, str], span._get_ctx_item(TAGS))
+                llmobs_span.name = _get_span_name(span)
+                llmobs_span._span_kind = span_kind
+                llmobs_span.model_name = span._get_ctx_item(MODEL_NAME) or ""
+                llmobs_span.model_provider = (span._get_ctx_item(MODEL_PROVIDER) or "custom").lower()
+                llmobs_span.session_id = _get_session_id(span) or ""
+                llmobs_span.ml_app = _get_ml_app(span) or ""
+                llmobs_span.metadata = dict(span._get_ctx_item(METADATA) or {})
+                llmobs_span.metrics = dict(span._get_ctx_item(METRICS) or {})
+                llmobs_span.tool_definitions = list(span._get_ctx_item(TOOL_DEFINITIONS) or [])
+                llmobs_span.prompt = span._get_ctx_item(INPUT_PROMPT)
                 user_llmobs_span = self._user_span_processor(llmobs_span)
                 if user_llmobs_span is None:
                     return None
@@ -750,11 +820,18 @@ class LLMObs(Service):
             elif output_type == "value":
                 meta["output"]["value"] = llmobs_span.output[0].get("content", "")
 
+        # Write back processor mutations for meta-level fields
+        meta["metadata"] = llmobs_span.metadata
+        meta["model_name"] = llmobs_span.model_name
+        meta["model_provider"] = llmobs_span.model_provider.lower()
+        meta["tool_definitions"] = llmobs_span.tool_definitions
+        if llmobs_span.prompt is not None:
+            meta.setdefault(LLMOBS_STRUCT.INPUT, _MetaIO())["prompt"] = llmobs_span.prompt
+
         if not meta["input"]:
             meta.pop("input")
         if not meta["output"]:
             meta.pop("output")
-        metrics = span._get_ctx_item(METRICS) or {}
         ml_app = _get_ml_app(span)
 
         if ml_app is None:
@@ -763,18 +840,21 @@ class LLMObs(Service):
                 "Ensure this configuration is set before running your application."
             )
 
-        span._set_ctx_item(ML_APP, ml_app)
+        ml_app_final = llmobs_span.ml_app or ml_app
+        span._set_ctx_item(ML_APP, ml_app_final)
         parent_id = span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID
 
         llmobs_trace_id = span._get_ctx_item(LLMOBS_TRACE_ID)
         if llmobs_trace_id is None:
             raise ValueError("Failed to extract LLMObs trace ID from span context.")
 
+        metrics = llmobs_span.metrics
+        session_id = llmobs_span.session_id or _get_session_id(span)
         llmobs_span_event: LLMObsSpanEvent = {
             "trace_id": format_trace_id(llmobs_trace_id),
             "span_id": str(span.span_id),
             "parent_id": parent_id,
-            "name": _get_span_name(span),
+            "name": llmobs_span.name or _get_span_name(span),
             "start_ns": span.start_ns,
             "duration": cast(int, span.duration_ns),
             "status": "error" if span.error else "ok",
@@ -783,12 +863,11 @@ class LLMObs(Service):
             "tags": [],
             "_dd": _dd_attrs,
         }
-        session_id = _get_session_id(span)
         if session_id is not None:
             span._set_ctx_item(SESSION_ID, session_id)
             llmobs_span_event["session_id"] = session_id
 
-        llmobs_span_event["tags"] = self._llmobs_tags(span, ml_app, session_id, False, None)
+        llmobs_span_event["tags"] = self._llmobs_tags(span, ml_app_final, session_id, False, None)
 
         span_links = span._get_ctx_item(SPAN_LINKS)
         if isinstance(span_links, list) and span_links:
@@ -2418,7 +2497,12 @@ class LLMObs(Service):
         metrics: Optional[dict[str, Any]] = None,
         tags: Optional[dict[str, Any]] = None,
         tool_definitions: Optional[list[dict[str, Any]]] = None,
-        _name: Optional[str] = None,
+        name: Optional[str] = None,
+        model_name: Optional[str] = None,
+        model_provider: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        _name: Optional[str] = None,  # kept for backwards compatibility; "name" takes precedence when both provided
         _linked_spans: Optional[list[ExportedLLMObsSpan]] = None,
         _suppress_span_kind_error: bool = False,
     ) -> None:
@@ -2473,6 +2557,12 @@ class LLMObs(Service):
                                    and optional "description" (string) and "schema" (JSON serializable dictionary) keys.
         :param metrics: Dictionary of JSON serializable key-value metric pairs,
                         such as `{prompt,completion,total}_tokens`.
+        :param name: The display name for the span. Takes priority over `_name` when both are supplied.
+                     `_name` param was kept for backwards compatibility
+        :param model_name: The model name (e.g. `"gpt-4o"`). Only applies to LLM and embedding spans.
+        :param model_provider: The model provider (e.g. `"openai"`). Only applies to LLM and embedding spans.
+        :param session_id: The session ID to group spans under a common user session.
+        :param ml_app: The name of the ML application.
         """
         error = None
         try:
@@ -2510,17 +2600,35 @@ class LLMObs(Service):
                         "span tags must be a dictionary of string key - primitive value pairs."
                     )
                 else:
-                    session_id = tags.get("session_id")
-                    if session_id:
-                        span._set_ctx_item(SESSION_ID, str(session_id))
+                    tag_session_id = tags.get("session_id")
+                    if tag_session_id:
+                        span._set_ctx_item(SESSION_ID, str(tag_session_id))
                     cls._set_dict_attribute(span, TAGS, tags)
             if tool_definitions is not None:
                 validated_tool_definitions = extract_tool_definitions(tool_definitions)
                 if validated_tool_definitions:
                     span._set_ctx_item(TOOL_DEFINITIONS, validated_tool_definitions)
             span_kind = span._get_ctx_item(SPAN_KIND)
-            if _name is not None:
-                span.name = _name
+            # name takes priority over _name; fall back to _name if name is not provided
+            effective_name = name if name is not None else _name
+            if effective_name is not None:
+                span.name = effective_name
+            if model_name is not None:
+                span._set_ctx_item(MODEL_NAME, model_name)
+                if _get_llmobs_data_metastruct(span):
+                    _annotate_llmobs_span_data(span, model_name=model_name)
+            if model_provider is not None:
+                span._set_ctx_item(MODEL_PROVIDER, model_provider.lower())
+                if _get_llmobs_data_metastruct(span):
+                    _annotate_llmobs_span_data(span, model_provider=model_provider.lower())
+            if session_id is not None:
+                span._set_ctx_item(SESSION_ID, session_id)
+                if _get_llmobs_data_metastruct(span):
+                    _annotate_llmobs_span_data(span, session_id=session_id)
+            if ml_app is not None:
+                span._set_ctx_item(ML_APP, ml_app)
+                if _get_llmobs_data_metastruct(span):
+                    _annotate_llmobs_span_data(span, ml_app=ml_app)
             if prompt is not None:
                 try:
                     validated_prompt = _validate_prompt(prompt, strict_validation=False)

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -249,6 +249,158 @@ class TestLLMIOProcessing:
             llmobs.annotate(llm_span, input_data="value")
         assert llmobs_events[1]["meta"]["input"]["messages"][0]["content"] == "value"
 
+    # -----------------------------------------------------------------------
+    # Tests for new LLMObsSpan fields (metadata, metrics, tool_definitions,
+    # model_name, model_provider, session_id, ml_app, name, span_kind)
+    # -----------------------------------------------------------------------
+
+    def _read_and_mutate_metadata(span: LLMObsSpan):
+        span.metadata["processed"] = True
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_read_and_mutate_metadata)])
+    def test_processor_reads_and_mutates_metadata(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can read and mutate metadata; mutations appear in the event."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, metadata={"original": "value"})
+        assert llmobs_events[0]["meta"]["metadata"]["original"] == "value"
+        assert llmobs_events[0]["meta"]["metadata"]["processed"] is True
+
+    def _read_and_mutate_metrics(span: LLMObsSpan):
+        span.metrics["total_tokens"] = 999
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_read_and_mutate_metrics)])
+    def test_processor_reads_and_mutates_metrics(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can read and mutate metrics; mutations appear in the event."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, metrics={"input_tokens": 10})
+        assert llmobs_events[0]["metrics"]["input_tokens"] == 10
+        assert llmobs_events[0]["metrics"]["total_tokens"] == 999
+
+    def _read_and_mutate_tool_definitions(span: LLMObsSpan):
+        span.tool_definitions = [{"name": "mutated_tool"}]
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_read_and_mutate_tool_definitions)])
+    def test_processor_reads_and_mutates_tool_definitions(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can read and mutate tool_definitions; mutations appear in the event."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, tool_definitions=[{"name": "original_tool"}])
+        assert llmobs_events[0]["meta"]["tool_definitions"] == [{"name": "mutated_tool"}]
+
+    def _mutate_model_name_and_provider(span: LLMObsSpan):
+        span.model_name = "gpt-4o-mutated"
+        span.model_provider = "openai-mutated"
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_mutate_model_name_and_provider)])
+    def test_processor_reads_and_mutates_model_name_provider(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can mutate model_name and model_provider; mutations appear in the event meta."""
+        with llmobs.llm(model_name="gpt-4", model_provider="openai"):
+            pass
+        assert llmobs_events[0]["meta"]["model_name"] == "gpt-4o-mutated"
+        assert llmobs_events[0]["meta"]["model_provider"] == "openai-mutated"
+
+    def _mutate_session_id(span: LLMObsSpan):
+        span.session_id = "mutated-session"
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_mutate_session_id)])
+    def test_processor_reads_and_mutates_session_id(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can mutate session_id; mutation appears in event['session_id'] and tags."""
+        with llmobs.llm(session_id="original-session"):
+            pass
+        assert llmobs_events[0]["session_id"] == "mutated-session"
+        assert "session_id:mutated-session" in llmobs_events[0]["tags"]
+
+    def _mutate_ml_app(span: LLMObsSpan):
+        span.ml_app = "mutated-ml-app"
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_mutate_ml_app)])
+    def test_processor_reads_and_mutates_ml_app(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can mutate ml_app; mutation appears in event tags."""
+        with llmobs.llm():
+            pass
+        assert "ml_app:mutated-ml-app" in llmobs_events[0]["tags"]
+
+    def _mutate_name(span: LLMObsSpan):
+        span.name = "mutated-name"
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_mutate_name)])
+    def test_processor_reads_and_mutates_name(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can mutate name; mutation appears in event['name']."""
+        with llmobs.llm("original-name"):
+            pass
+        assert llmobs_events[0]["name"] == "mutated-name"
+
+    def _read_span_kind(span: LLMObsSpan):
+        span._span_kind_seen = span.span_kind  # type: ignore[attr-defined]
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_read_span_kind)])
+    def test_processor_reads_span_kind(self, llmobs, llmobs_enable_opts, llmobs_events):
+        """Processor can read span_kind."""
+        captured = []
+
+        def _capture_span_kind(span: LLMObsSpan):
+            captured.append(span.span_kind)
+            return span
+
+        llmobs.register_processor(_capture_span_kind)
+        with llmobs.llm("my-span"):
+            pass
+        assert captured == ["llm"]
+
+    # -----------------------------------------------------------------------
+    # Tests for new annotate() parameters
+    # -----------------------------------------------------------------------
+
+    def test_annotate_model_name(self, llmobs, llmobs_events):
+        """annotate(model_name=...) updates the event meta.model_name."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, model_name="gpt-4o-annotated")
+        assert llmobs_events[0]["meta"]["model_name"] == "gpt-4o-annotated"
+
+    def test_annotate_model_provider(self, llmobs, llmobs_events):
+        """annotate(model_provider=...) updates the event meta.model_provider (lowercased)."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, model_provider="OpenAI-Annotated")
+        assert llmobs_events[0]["meta"]["model_provider"] == "openai-annotated"
+
+    def test_annotate_session_id(self, llmobs, llmobs_events):
+        """annotate(session_id=...) updates event['session_id']."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, session_id="annotated-session")
+        assert llmobs_events[0]["session_id"] == "annotated-session"
+        assert "session_id:annotated-session" in llmobs_events[0]["tags"]
+
+    def test_annotate_ml_app(self, llmobs, llmobs_events):
+        """annotate(ml_app=...) updates the ml_app in event tags."""
+        with llmobs.llm() as span:
+            llmobs.annotate(span, ml_app="annotated-ml-app")
+        assert "ml_app:annotated-ml-app" in llmobs_events[0]["tags"]
+
+    def test_annotate_name(self, llmobs, llmobs_events):
+        """annotate(name=...) renames the span in event['name']."""
+        with llmobs.llm("original-name") as span:
+            llmobs.annotate(span, name="annotated-name")
+        assert llmobs_events[0]["name"] == "annotated-name"
+
+    def test_annotate_name_takes_priority_over_private_name(self, llmobs, llmobs_events):
+        """annotate(name=...) takes priority over _name when both supplied."""
+        with llmobs.llm("original-name") as span:
+            llmobs.annotate(span, _name="private-name", name="public-name")
+        assert llmobs_events[0]["name"] == "public-name"
+
+    def test_annotate_private_name_fallback(self, llmobs, llmobs_events):
+        """annotate(_name=...) still works when name is not provided."""
+        with llmobs.llm("original-name") as span:
+            llmobs.annotate(span, _name="private-name")
+        assert llmobs_events[0]["name"] == "private-name"
+
     def test_processor_error_is_logged(self, ddtrace_run_python_code_in_subprocess, llmobs_backend):
         """Ensure that when an exception is raised an exception is logged."""
         env = os.environ.copy()


### PR DESCRIPTION
## Description

Expands the scope of LLMObs span fields that can be read and mutated — both via `LLMObs.annotate()` and via custom span processors registered with `enable()` or `register_processor()`.

`LLMObs.annotate()` new parameters: `name`, `model_name`, `model_provider`, `session_id`, `ml_app`

`LLMObsSpan` (span processor object) new fields: `name`, `model_name`, `model_provider`, `session_id`, `ml_app`, `metadata`, `metrics`, `tool_definitions`, `prompt`, and `_span_kind` (read-only via `get_span_kind()``). All mutable fields are written back to the outgoing span event.

Motivation: Auto-instrumentation currently captures a wide range of span data but exposes only a narrow slice of it for user modification. This gap creates two common pain points:

1. Model aliasing (e.g. AWS Bedrock application inference profiles): Bedrock best practice is to call models via application inference profile IDs (e.g. `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/a1b2c3d4e5f6`) for cost attribution. Auto-instrumentation records this opaque ID ("a1b2c3d4e5f6") as the model name and "custom" as the provider, breaking Datadog's token-to-dollar-cost estimates. Users now have a first-class way to override model_name and model_provider with the underlying model identity while keeping auto-instrumentation intact.
2. Post-response span enrichment: In cases where span annotations depend on the LLM response (e.g. tagging a span `end_conversation:true` based on response content), auto-instrumented spans are already committed before user code can inspect the result. A custom span processor is the natural solution, but was previously too limited in what it could modify. Users can now mutate the full set of span fields from a processor.

In both cases, manual instrumentation was technically possible but undesirable — it requires reimplementing conversion logic (Bedrock JSON → LLMObs message format, tool schema normalization, token count normalization, etc.) that already exists inside the auto-instrumentation integration and is not exposed as public helpers.

## Testing

Unit tests added in `tests/llmobs/test_llmobs.py` covering:
- Processor read/mutate round-trips for each new `LLMObsSpan` field (`metadata`, `metrics`, `tool_definitions`, `model_name`, `model_provider`, `session_id`, `ml_app`, `name`)
- Read-only enforcement for span_kind
- `annotate()` parameter tests for each new argument (`name`, `model_name`, `model_provider`, `session_id`, `ml_app`)
- `name` vs `_name` precedence and backwards-compatibility

## Risks

- `_name` backwards compatibility: The existing private `_name` parameter on annotate() is preserved; name takes precedence when both are provided. Existing callers using `_name` are unaffected.
- Write-back side effects: Processor mutations to model_provider are lowercased before write-back, consistent with existing normalization. Processors that set an empty string for name, session_id, or ml_app fall back to the original value (the or fallback guards in the event builder).

## Additional Notes

`_span_kind` is intentionally read-only (exposed via `get_span_kind()`). Allowing processors to change the span kind would silently break I/O serialization (LLM vs. embedding vs. retrieval shapes differ), so mutation of that field is ignored.