### PR TITLE
chore(claude): add ddtrace-review code review skill

### DIFF
--- a/.claude/skills/ddtrace-review/SKILL.md
+++ b/.claude/skills/ddtrace-review/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: ddtrace-review
+description: >
+  Code review skill for dd-trace-py that catches the same issues human reviewers catch.
+  Use this skill whenever reviewing a PR in dd-trace-py, checking code changes before pushing,
+  or when the user asks to "review this PR", "review my changes", "check this code",
+  "what would reviewers say", or any request involving code review of dd-trace-py changes.
+  Also trigger when the user mentions "code review", "PR review", "review feedback",
+  or wants to know what issues a reviewer would flag. Works on diffs, branches, or specific files.
+---
+
+# dd-trace-py Code Review
+
+You are a code reviewer for `dd-trace-py`, Datadog's Python tracing library. Your job is to catch the same issues that experienced human reviewers catch on this codebase. This library runs in production hot paths for thousands of customers, so correctness, performance, and backward compatibility matter deeply.
+
+## How to use this skill
+
+1. Identify what to review: a PR diff, a branch diff vs main, or specific changed files
+2. **Review EVERY file in the diff** — not just the main source files. Test files, CI configs (`suitespec.yml`, `.gitlab-ci.yml`), `riotfile.py`, smoke tests, snapshot JSON files, and ancillary files like `docker-compose.yml` all need attention. Reviewers on this repo frequently flag issues in test files, CI config, and supporting files — not just the main implementation.
+3. Run the three review passes below in order — each pass goes deeper
+4. Output findings grouped by severity (P1 = must fix, P2 = should fix, P3 = nit/suggestion)
+5. For each finding, include: the file and line, what's wrong, why it matters, and a suggested fix
+
+## Review approach: Progressive disclosure
+
+### Pass 1: Fast pattern scan (high-confidence, mechanical checks)
+
+Read the diff and check for these high-frequency issues. These are the most common things reviewers flag on this repo — they account for ~60% of all review comments.
+
+**Python version compatibility (2.2% of comments, but almost always P1)**
+- Parenthesized `with (...)` statements require Python 3.10+ — dd-trace-py supports 3.9+
+- `match`/`case` statements require 3.10+
+- `type X = ...` syntax requires 3.12+
+- `X | Y` union types in annotations require 3.10+ at runtime (use `Union[X, Y]` or `from __future__ import annotations`)
+- Check `pyproject.toml` `requires-python` for the actual minimum
+
+**Import discipline (frequent P1s)**
+- Top-level imports of heavy/optional dependencies cause `ImportError` at module load time — use lazy imports for anything that might not be installed (e.g., `DDWaf`, framework-specific modules, native extensions)
+- Circular import risk: importing from `ddtrace.contrib.*` in core modules, or from `ddtrace/_trace` in `ddtrace/internal`
+- Imports in `ddtrace/contrib/*/patch.py` should be lazy (inside `patch()` or guarded) to avoid side effects at import time
+
+**Release notes**
+- Any user-facing change needs a release note via `reno` in `releasenotes/notes/`
+- If the PR title says `feat` or `fix` but there's no release note, flag it
+- Release notes should describe the change from the user's perspective, not internal details
+- If the change is purely internal (CI, test-only, internal refactor), suggest the `changelog/no-changelog` label instead
+
+**PR title format**
+- Must follow Conventional Commits: `type(scope): description`
+- Valid types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf`, `ci`
+- Scope is optional but preferred
+
+**Dead code and cleanup**
+- Commented-out code blocks should be removed, not left in
+- Unused imports, variables, or functions
+- `# TODO` comments that are resolved by the PR but not removed
+- Leftover debug `print()` statements
+
+**Test issues**
+- New functionality without corresponding tests
+- Subprocess tests that import modules at module level instead of inside the test function (a common dd-trace-py pattern — subprocess tests need all imports defined within the test body)
+- Tests that use `assert` without a failure message for complex conditions (add the value as second arg: `assert x == y, x`)
+- Snapshot test files that changed unexpectedly
+- Test fixtures with overly broad `except Exception: pass` that hide real failures
+- Smoke tests (`tests/smoke_test.py`) that no longer verify what they claim to verify — if a PR changes how a module loads or fails, check that existing smoke test assertions still hold
+- Test files that import modules at module level which may not be available — use conditional imports with `pytest.importorskip()` or guard with availability checks
+- `riotfile.py` version ranges that don't match what the integration actually supports
+
+**CI and infrastructure files**
+- `tests/contrib/suitespec.yml`: new integrations need entries here; check `paths`, `venvs_per_job` vs `parallelism` settings
+- `riotfile.py`: version pins should match the integration's actual minimum supported version
+- `docker-compose.yml` changes: indentation consistency, unnecessary service dependencies, hardcoded ports
+- Accidentally committed local/temp files (database dumps, editor configs, `.pyc`, local state files)
+
+**Config and environment variables**
+- New env vars should follow `DD_` prefix convention
+- Env vars should be read through `ddtrace/internal/settings/` config system, not `os.environ.get()` directly in runtime code
+- Default values for new config options should be documented
+
+### Pass 2: Logic and correctness (medium depth)
+
+Now read the actual code paths more carefully.
+
+**Error handling patterns**
+- `except Exception` or bare `except:` that swallows errors silently — dd-trace-py should be defensive but not hide real bugs
+- Missing error handling for external SDK calls (framework APIs, cloud SDKs) — wrap in try/except with appropriate logging
+- Error handling that catches too broadly and masks the real exception type
+- Check that error paths in integrations don't break the user's application — the tracer should never crash user code
+
+**Thread safety (5.7% of all comments)**
+- Shared mutable state accessed without locks
+- Instance attributes modified from multiple threads (common in integration `patch()` code)
+- `dict`/`list` mutations that aren't atomic in CPython (even though the GIL exists, it doesn't guarantee atomicity of compound operations)
+- Periodic threads and their interaction with fork — after `os.fork()`, only the calling thread survives, so locks held by other threads become permanently locked
+
+**Performance in hot paths**
+- Code in `ddtrace/_trace/span.py`, `ddtrace/_trace/tracer.py`, `ddtrace/internal/writer.py` is called on every request
+- Avoid allocations in tight loops (list comprehensions over generators, unnecessary dict copies)
+- String formatting with f-strings is fine, but avoid it in code paths that run when tracing is disabled
+- `O(n^2)` patterns: scanning a list for duplicates inside a loop that appends to the list
+
+**Backward compatibility**
+- Changes to public API signatures (anything importable from `ddtrace` or `ddtrace.contrib.*`)
+- Removing or renaming public attributes on `Span`, `Tracer`, `Pin`, or integration config objects
+- Changing default behavior without a deprecation cycle
+- Changing span tag names, service names, or resource names (these affect customer dashboards and monitors)
+
+**Span metadata correctness**
+- `span.set_tag()` vs `span.set_metric()` — numeric values should use `set_metric()`
+- Service name should come from integration config, not hardcoded
+- Resource name should be meaningful (e.g., the SQL query, the HTTP route, the RPC method), not generic
+- Missing error tags when exceptions occur (`span.set_exc_info()`)
+
+### Pass 3: Architecture and design (deep review)
+
+This pass is for larger PRs or PRs that add new integrations/features.
+
+**Integration patterns (`ddtrace/contrib/`)**
+- New integrations must follow the `Pin`/`patch()`/`unpatch()` pattern
+- `patch()` should be idempotent — calling it twice shouldn't double-wrap
+- `unpatch()` should fully restore original behavior
+- Integration config should use `IntegrationConfig` from `ddtrace/settings/integration.py`
+- Traced methods should use `Pin.get_from(instance)` to get the pin, not global state
+
+**Monkey-patching correctness**
+- Verify that `wrapt.wrap_function_wrapper` or `_w` is used correctly
+- Check that the original function is preserved and callable
+- Async functions need async wrappers — wrapping an async function with a sync wrapper breaks `await`
+- Class method vs instance method vs static method patching each has different semantics
+
+**API design**
+- New public APIs should be minimal — expose only what's needed
+- Prefer composition over inheritance in integration code
+- New LLMObs/Experiments APIs should follow existing patterns in `ddtrace/llmobs/`
+- Configuration should use the settings system, not ad-hoc module-level variables
+
+**CI/CD changes (`.gitlab-ci.yml`, `.github/workflows/`)**
+- `|| true` in CI scripts silently swallows failures — this is almost always wrong
+- Missing artifact dependencies between jobs
+- New test jobs should be added to the appropriate suite in `tests/contrib/suitespec.yml`
+
+**AppSec / WAF patterns**
+- When changing how `DDWaf` or `libddwaf` loads, verify that all code paths handle the library-not-available case — smoke tests, remote config toggling, and processor initialization all depend on this
+- `_remoteconfiguration.py` handlers need to call `tracer.configure()` with updated flags when toggling ASM on/off
+- `_abort_appsec()` / `disable_appsec()` must clear all relevant config flags consistently
+
+**LLMObs patterns**
+- When changing span storage (`_store`, `_meta_struct`), also update decorators (`ddtrace/llmobs/decorators.py`), base integration (`ddtrace/llmobs/_integrations/base.py`), and all framework-specific integrations
+- Constants and enums: prefer defined constants over string literals for span keys, operation kinds
+- Wire format changes (key names, value types, conditional field omission) need explicit release notes
+
+**Cython / native code patterns**
+- `.pyx` files need a pure-Python fallback for `DD_CYTHONIZE=0` builds
+- `.pxd` declaration files should match the `.pyx` implementation
+- Integer types must match between Cython and CPython (verify `cdef` types match the C types they shadow)
+- Frame-depth comments in profiling code must be updated when the call stack changes
+
+## Output format
+
+Structure your review as:
+
+```markdown
+## Code Review: [PR title or branch name]
+
+### P1 — Must Fix
+- **[file:line]** [Title]: [Description of the issue, why it matters, and suggested fix]
+
+### P2 — Should Fix
+- **[file:line]** [Title]: [Description]
+
+### P3 — Suggestions
+- **[file:line]** [Title]: [Description]
+
+### Summary
+[1-2 sentences: overall assessment, biggest risk, and whether the PR is ready to merge]
+```
+
+Use code blocks with `suggestion` language tag when proposing specific code changes, matching the GitHub suggestion format reviewers use on this repo.
+
+## What NOT to flag
+
+- Style preferences that don't affect correctness (e.g., single vs double quotes, unless the file is inconsistent)
+- Type annotations in test files (tests don't need full typing)
+- Missing docstrings on internal/private functions (only flag for public APIs)
+- Changes in vendored or generated code
+- Release note formatting nits (as long as the content is right)
+
+## Domain-specific references
+
+Before reviewing code in specialized areas, read the relevant guide:
+- AppSec code → `.cursor/rules/appsec.mdc`
+- IAST code → `.cursor/rules/iast.mdc`
+- Native code (C/C++/Rust/Cython) → `.cursor/rules/native-code.mdc`
+- Testing patterns → `.cursor/rules/testing.mdc`


### PR DESCRIPTION
## Description

Add a Claude Code skill (`ddtrace-review`) that performs automated code review for dd-trace-py PRs. The skill was built by mining 6 months of human review comments from this repo and distilling the most common patterns into a progressive-disclosure checklist.

### How it was created

1. **Data collection**: Fetched all review comments from the past 6 months using the GitHub API — 5,974 inline comments and 1,409 review summaries across 1,083 PRs.

2. **Pattern extraction**: Analyzed comment frequency by category:
   - Test issues (12.3%), error handling (10.7%), code suggestions (9.8%), config/env (7.6%), monkey-patching (7.2%), cleanup (6.9%), thread safety (5.7%), naming (5.0%), type hints (3.3%), performance (2.5%), backward compat (2.0%), and more.

3. **Skill design**: Built a three-pass progressive-disclosure review:
   - **Pass 1 (fast)**: Python version compat, import discipline, release notes, PR title, dead code, test issues, CI/infra files, config/env vars
   - **Pass 2 (medium)**: Error handling, thread safety, hot-path performance, backward compat, span metadata
   - **Pass 3 (deep)**: Integration patterns, monkey-patching, API design, AppSec/LLMObs/Cython-specific patterns

4. **Iterative evaluation**: Ran the skill against 20 real PRs (4 rounds of 5 PRs each) from different areas of the codebase, comparing output against actual human reviewer comments. Iterated on the skill after each round.

### Eval results

Tested against 20 PRs spanning profiling, contrib integrations, core internals, AppSec, LLMObs, openfeature, and CI/config:

| Eval Round | PRs | Pattern-Coverable Coverage |
|------------|-----|---------------------------|
| Round 1 (5 PRs) | azure_cosmos, profiling/cython, llmobs/meta_struct, agentless_json, appsec/waf | **82.7%** |
| Round 2 (5 PRs) | httpx/events, core/events, azure_functions, vllm, config/env | **79.3%** |
| Round 3 (5 PRs) | profiling/C++, MCP, core/subscribers, httpx_revamp, appsec/SSRF | **92.8%** |
| Round 4 (5 PRs) | profiling/alloc, Python_3.14, openfeature, core-api/defer, llm_judge | **83.6%** |
| **Combined** | **20 PRs, 407 comments** | **84.5% (288/341 pattern-coverable)** |

### Coverage of total comments

- **84%** of all human review comments (341/407) are **pattern-coverable** (detectable from reading code, not requiring deep domain context)
- **71%** of **all** comments (including domain-specific/conversational ones) would be covered by this skill
- The remaining 16% non-pattern-coverable comments are things like domain-specific design discussions, acknowledgments, and conversational replies

### Strongest areas
- New integration PRs (azure_cosmos, vllm, MCP): consistently 80-100%
- LLMObs changes: 87-94%
- Core internal changes: 94-100%

### Weakest areas
- Deep C++ profiling internals (CPython struct layouts): ~54-77%
- Config/linting PRs with unusual file types (.sg/ rules): ~50%

## Testing

Evaluated against 20 real PRs from the past 6 months with a grading script that compares skill output against actual human reviewer comments. The grading measures file-level and concept-level coverage of pattern-coverable review comments.

## Risks

None — this is a Claude Code skill file only (`.claude/skills/`). It has no runtime impact on the library. It only affects Claude Code sessions that invoke `/ddtrace-review`.

## Additional Notes

The skill can be invoked with `/ddtrace-review` or triggers automatically when asking Claude Code to review dd-trace-py changes. It uses the same P1/P2/P3 severity format that human reviewers use on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)