### PR TITLE
test(profiling): bump fuzzydog to 0.27.1

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -1,7 +1,7 @@
 variables:
   REPO_LANG: python # "python" is used everywhere rather than "py"
   FUZZ_IMAGE: registry.ddbuild.io/dd-trace-py-fuzz
-  FUZZYDOG_VERSION: "0.26.2"
+  FUZZYDOG_VERSION: "0.27.1"
   FUZZ_BASE_IMAGE: registry.ddbuild.io/dd-trace-py:v104604389-11e1de9-fuzz_base
   # CI_DEBUG_SERVICES: "true"
 


### PR DESCRIPTION
## Description

Bump fuzzydog to 0.27.1 to fix some issues with the setup of OCI images based fuzzers like here.

## Testing
Run the fuzz job in gitlab.

