### PR TITLE
fix(profiling): ensure correct order of profiler post-fork hooks

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -351,6 +351,15 @@ stack_init()
 {
     // At just do start-of-process cleanup (e.g., set PID)
     stack_postfork_cleanup();
+
+    // The fork handler is registered at library load time to make sure it
+    // is registered before dd_wrapper's.
+    // The rationale is that both stack and dd_wrapper have post-fork hooks;
+    // and stack needs dd_wrapper's hooks to have completed as it needs the
+    // Profile object to have been reset and be ready for use, and post-fork
+    // hooks are executed in LIFO order.
+    // More details in https://github.com/DataDog/dd-trace-py/pull/17183
+    pthread_atfork(nullptr, nullptr, stack_atfork_child);
 }
 
 void
@@ -359,7 +368,6 @@ Sampler::one_time_setup()
     // It is unlikely, but possible, that the caller has forked since application startup, but before starting echion.
     // Run the cleanup to ensure that we're tracking the correct process.
     stack_postfork_cleanup();
-    pthread_atfork(nullptr, nullptr, stack_atfork_child);
 }
 
 void

--- a/releasenotes/notes/fix-profiler-postfork-hook-ordering.yaml
+++ b/releasenotes/notes/fix-profiler-postfork-hook-ordering.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: A rare crash that could occur post-fork in fork-based applications has been fixed.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13112

This fixes a rare segmentation fault that could occur when a profiled application forks.

#### Stack trace

```
#0 0x0000ffffaf48f6d0 free
#1 0x0000ffffae4367e4 core::ptr::drop_in_place<indexmap::set::IndexSet<libdd_profiling::internal::stack_trace::StackTrace,core::hash::BuildHasherDefault<rustc_hash::FxHasher>>>::hbe422e96ad1ad3f9
#2 0x0000ffffae436478 core::ptr::drop_in_place<libdd_profiling::internal::profile::Profile>::h4a6aee0579496bfb
#3 0x0000ffffae43e244 ddog_prof_Profile_drop
#4 0x0000ffff9fe5a724 Datadog::Profile::postfork_child
#5 0x0000ffffaf4b8804 __libc_fork
#6 0x0000ffffaf6bf058 os_fork_impl (/usr/src/python/./Modules/posixmodule.c:7757)
#7 0x0000ffffaf6bf058 os_fork (/usr/src/python/./Modules/clinic/posixmodule.c.h:3986)
#8 0x0000ffffaf725d2c cfunction_vectorcall_NOARGS (/usr/src/python/Objects/methodobject.c:481:24)
#9 0x0000ffffaf72f420 PyCFunction_Call (/usr/src/python/Objects/call.c:387:12)
#10 0x0000ffffaf72f420 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:3263:26)
#11 0x0000ffffaf750430 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#12 0x0000ffffaf750430 object_vacall (/usr/src/python/Objects/call.c:850:14)
#13 0x0000ffffaf7cf1b8 PyObject_CallFunctionObjArgs (/usr/src/python/Objects/call.c:957:14)
#14 0x0000ffffae18453c WraptFunctionWrapperBase_call (/project/src/wrapt/_wrappers.c:2455:14)
#15 0x0000ffffaf7225c4 _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:240:18)
#16 0x0000ffffaf72db54 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2715:19)
#17 0x0000ffffaf725b60 _PyFunction_Vectorcall (/usr/src/python/Objects/call.c:419:16)
#18 0x0000ffffaf725b60 _PyObject_FastCallDictTstate (/usr/src/python/Objects/call.c:133:15)
#19 0x0000ffffaf75b928 _PyObject_Call_Prepend (/usr/src/python/Objects/call.c:508:24)
#20 0x0000ffffaf75b928 slot_tp_init (/usr/src/python/Objects/typeobject.c:9026:15)
#21 0x0000ffffaf722878 type_call (/usr/src/python/Objects/typeobject.c:1679:19)
#22 0x0000ffffaf7225c4 _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:240:18)
#23 0x0000ffffaf72db54 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2715:19)
#24 0x0000ffffaf775c74 _PyFunction_Vectorcall (/usr/src/python/Objects/call.c:419:16)
#25 0x0000ffffaf775c74 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#26 0x0000ffffaf775c74 method_vectorcall (/usr/src/python/Objects/classobject.c:91:18)
#27 0x0000ffffaf72f420 PyCFunction_Call (/usr/src/python/Objects/call.c:387:12)
#28 0x0000ffffaf72f420 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:3263:26)
#29 0x0000ffffaf7745a4 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:89:16)
#30 0x0000ffffaf7745a4 gen_send_ex2 (/usr/src/python/Objects/genobject.c:230:14)
#31 0x0000ffffaf78cf48 gen_iternext (/usr/src/python/Objects/genobject.c:603:9)
#32 0x0000ffffaf78cf48 builtin_next_impl (/usr/src/python/Python/bltinmodule.c:1510)
#33 0x0000ffffaf78cf48 builtin_next (/usr/src/python/Python/clinic/bltinmodule.c.h:730)
#34 0x0000ffffaf730b30 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2938:20)
#35 0x0000ffffaf775d28 _PyFunction_Vectorcall (/usr/src/python/Objects/call.c:419:16)
#36 0x0000ffffaf775d28 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#37 0x0000ffffaf775d28 method_vectorcall (/usr/src/python/Objects/classobject.c:61:18)
#38 0x0000ffffaf75f614 _PyVectorcall_Call (/usr/src/python/Objects/call.c:283:24)
#39 0x0000ffffaf72f420 PyCFunction_Call (/usr/src/python/Objects/call.c:387:12)
#40 0x0000ffffaf72f420 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:3263:26)
#41 0x0000ffffaf775d28 _PyFunction_Vectorcall (/usr/src/python/Objects/call.c:419:16)
#42 0x0000ffffaf775d28 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#43 0x0000ffffaf775d28 method_vectorcall (/usr/src/python/Objects/classobject.c:61:18)
#44 0x0000ffffaf75f614 _PyVectorcall_Call (/usr/src/python/Objects/call.c:283:24)
#45 0x0000ffffaf72f420 PyCFunction_Call (/usr/src/python/Objects/call.c:387:12)
#46 0x0000ffffaf72f420 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:3263:26)
#47 0x0000ffffaf725bd8 _PyObject_FastCallDictTstate (/usr/src/python/Objects/call.c:144:15)
#48 0x0000ffffaf75bc30 _PyObject_Call_Prepend (/usr/src/python/Objects/call.c:508:24)
#49 0x0000ffffaf831e40 slot_tp_call (/usr/src/python/Objects/typeobject.c:8782)
#50 0x0000ffffaf722678 _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:240:18)
#51 0x0000ffffaf72db54 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2715:19)
#52 0x0000ffffaf7cb914 PyEval_EvalCode (/usr/src/python/Python/ceval.c:578:21)
#53 0x0000ffffaf7f6af8 builtin_exec_impl (/usr/src/python/Python/bltinmodule.c:1096)
#54 0x0000ffffaf7f6af8 builtin_exec (/usr/src/python/Python/clinic/bltinmodule.c.h:586)
#55 0x0000ffffaf74844c cfunction_vectorcall_FASTCALL_KEYWORDS (/usr/src/python/Objects/methodobject.c:438:24)
#56 0x0000ffffaf747804 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#57 0x0000ffffaf747804 PyObject_Vectorcall (/usr/src/python/Objects/call.c:325:12)
#58 0x0000ffffaf72db54 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2715:19)
#59 0x0000ffffaf811728 pymain_run_module (/usr/src/python/Modules/main.c:300)
#60 0x0000ffffaf810a78 pymain_run_python (/usr/src/python/Modules/main.c:627)
#61 0x0000ffffaf810a78 Py_RunMain (/usr/src/python/Modules/main.c:713)
#62 0x0000ffffaf7b321c Py_BytesMain (/usr/src/python/Modules/main.c:767:12)
#63 0x0000ffffaf427818 __libc_start_main
#64 0x0000aaaae4960870 _start
```

#### Root cause

The root cause of this crash seems to be unfortunate timing on fork. What happened was that, due to ordering of fork handlers, `stack`'s post-fork hook would run _before_ `dd_wrapper`'s. On multi-core systems where we got unlucky, because `stack`'s post-fork hook would restart the Sampling Thread, this meant the Sampling Thread could start before `dd_wrapper`'s post-fork hook had completed (or even before it had started).  
As a result, `dd_wrapper` would (try to) reset the `Profile` object that the Sampling Thread was writing to through the `Sample` APIs, resulting in a race and all kinds of fun memory issues, such as this crash.  
Note that the other way around could also happen, where the Sampling Thread could try to write to the `Profile` object that had already been dropped/freed by `dd_wrapper`. 

#### Are other Profilers impacted?

AFAIK, other Profilers shouldn't be impacted as they run in the Main Thread, so I think the risk that they may be writing to the Profile before it's ready post-fork is effectively inexistent.

#### Is registering this _at library load time_ OK?

As far as I can tell, there is no risk in registering that post-fork hook at library load time, instead of when the Stack Profiler is started. What `stack_atfork_child` is calling `stack_postfork_cleanup`, which we already did at library load time [meaning it's safe to do even when the Profiler doesn't run], then calling `Sampler::restart_after_fork`, which only restarts the Profiler if it was running pre-fork (which in an app that does not use the Profiler is a no-op).