### PR TITLE
test(profiling): relax wall time assertions in `test_accuracy_stack`

### DIFF
--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -48,11 +48,27 @@ def spend_cpu_3():
 TOLERANCE = 0.1
 
 
-def assert_almost_equal(value, target, tolerance=TOLERANCE):
+def assert_almost_equal(value: float, target: float, tolerance: float = TOLERANCE) -> None:
     if abs(value - target) / target > tolerance:
         raise AssertionError(
             f"Assertion failed: {value} is not approximately equal to {target} "
             f"within tolerance={tolerance}, actual error={abs(value - target) / target}"
+        )
+
+
+def assert_within_tolerance(
+    value: float, target: float, upper_tolerance: float = TOLERANCE, lower_tolerance: float = 0.0
+) -> None:
+    """Assert value >= target * (1 - lower_tolerance) and value <= target * (1 + upper_tolerance)."""
+    if value < target * (1 - lower_tolerance):
+        raise AssertionError(
+            f"Assertion failed: {value} is less than expected minimum {target} (lower_tolerance={lower_tolerance})"
+        )
+
+    if (value - target) / target > upper_tolerance:
+        raise AssertionError(
+            f"Assertion failed: {value} exceeds {target} by more than {upper_tolerance * 100}%, "
+            f"actual excess={((value - target) / target)}"
         )
 
 
@@ -69,6 +85,7 @@ def test_accuracy_stack():
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.test_accuracy import assert_almost_equal
+    from tests.profiling.test_accuracy import assert_within_tolerance
     from tests.profiling.test_accuracy import spend_16
 
     # Set this to 100 so we don't sleep too often and mess with the precision.
@@ -101,7 +118,10 @@ def test_accuracy_stack():
     assert_almost_equal(wall_times["spend_16"], 16e9)
     assert_almost_equal(wall_times["spend_7"], 7e9)
 
-    assert_almost_equal(wall_times["spend_cpu_2"], 2e9)
-    assert_almost_equal(wall_times["spend_cpu_3"], 3e9)
+    # CPU-bound functions guarantee exact CPU time via busy-loop, but wall time
+    # can exceed CPU time due to OS preemption, especially in CI environments.
+    # Wall time should never be less than the target CPU time.
+    assert_within_tolerance(wall_times["spend_cpu_2"], 2e9, upper_tolerance=0.3, lower_tolerance=0.001)
+    assert_within_tolerance(wall_times["spend_cpu_3"], 3e9, upper_tolerance=0.3, lower_tolerance=0.001)
     assert_almost_equal(cpu_times["spend_cpu_2"], 2e9)
     assert_almost_equal(cpu_times["spend_cpu_3"], 3e9)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7423c20e-12a6-43e2-ab82-45dc959146fc","source":"chat","resourceId":"5a1733a2-53bc-4c19-87ff-66a8c357062a","workflowId":"5fb3b5e7-65ca-4b87-b463-1a5f672bf505","codeChangeId":"5fb3b5e7-65ca-4b87-b463-1a5f672bf505","sourceType":"chat"} -->

## Description

This fixes `test_accuracy_stack` by relaxing the accuracy constraint on wall time (from 10% margin to 30%). Whereas CPU time is almost guaranteed (computed by taking Thread clock's elapsed  time), wall time is not as OS scheduling can play a role in making certain Threads take longer to execute a certain amount of CPU time than expected. (I have a feeling this is worse in CI, as I can't reproduce locally...)

On the other hand, I also changed the test so that we allow very little negative margin for wall time -- being less than expected should never happen and would show a correctness problem, so we only accept tiny differences (typically less than 0.01% in my tests).