### PR TITLE
fix(django): support async views and middleware under ASGI on Python 3.13+

### DIFF
--- a/ddtrace/contrib/internal/django/middleware.py
+++ b/ddtrace/contrib/internal/django/middleware.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import cast
 
 import ddtrace
+from ddtrace.contrib.internal import trace_utils as contrib_trace_utils
 from ddtrace.contrib.internal.django.user import _DjangoUserInfoRetriever
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
@@ -181,6 +182,30 @@ def traced_middleware_factory(func: FunctionType, args: tuple[Any], kwargs: dict
     return middleware
 
 
+def _make_async_traced_middleware_hook(mw_path: str, hook: str) -> Any:
+    """Create a wrapt-compatible async wrapper for a middleware hook.
+
+    Used instead of bytecode wrapping for async middleware methods, which
+    would otherwise cause 'RuntimeError: coroutine ignored GeneratorExit'
+    on Python 3.13+. Same pattern as traced_get_response_async in response.py.
+    """
+    event_name = f"django.middleware.{hook}"
+
+    async def wrapper(func: FunctionType, instance: Any, args: tuple[Any], kwargs: dict[str, Any]) -> Any:
+        resource = f"{func_name(instance)}.{hook}"
+        request = get_argument_value(args, kwargs, 0, "request", optional=True)
+        with core.context_with_data(
+            event_name,
+            span_name="django.middleware",
+            resource=resource,
+            tags={COMPONENT: config_django.integration_name},
+            request=request,
+        ):
+            return await func(*args, **kwargs)
+
+    return wrapper
+
+
 def wrap_middleware_class(mw: type, mw_path: str) -> None:
     for hook in (
         "process_response",
@@ -190,7 +215,13 @@ def wrap_middleware_class(mw: type, mw_path: str) -> None:
     ):
         fn = getattr(mw, hook, None)
         if fn and isfunction(fn) and not is_wrapped(fn):
-            wrap(fn, traced_middleware_wrapper(mw_path, hook))
+            if iscoroutinefunction(fn):
+                # DEV: Cannot use bytecode wrappers for async methods, otherwise
+                # Python 3.13+ raises: RuntimeError: coroutine ignored GeneratorExit
+                if not contrib_trace_utils.iswrapped(mw, hook):
+                    contrib_trace_utils.wrap(mw, hook, _make_async_traced_middleware_hook(mw_path, hook))
+            else:
+                wrap(fn, traced_middleware_wrapper(mw_path, hook))
 
     # Special handling for process_request and process_exception
 

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -7,7 +7,9 @@ Django internals are instrumented via normal `patch()`.
 specific Django apps like Django Rest Framework (DRF).
 """
 
+import contextlib
 from inspect import getmro
+from inspect import iscoroutinefunction
 from inspect import unwrap
 import os
 from typing import cast
@@ -158,10 +160,43 @@ def traced_populate(django, pin, func, instance, args, kwargs):
 
 
 def traced_func(django, name, resource=None, ignored_excs=None):
+    @contextlib.asynccontextmanager
+    async def _async_context(tags, pin):
+        with (
+            core.context_with_data(
+                "django.func.wrapped", span_name=name, resource=resource, tags=tags, pin=pin
+            ) as ctx,
+            ctx.span,
+        ):
+            yield ctx
+
     def wrapped(django, pin, func, instance, args, kwargs):
         tags = {COMPONENT: config_django.integration_name}
+
+        if iscoroutinefunction(func):
+
+            async def _async():
+                async with _async_context(tags, pin) as ctx:
+                    core.dispatch(
+                        "django.func.wrapped",
+                        (
+                            args,
+                            kwargs,
+                            django.core.handlers.wsgi.WSGIRequest
+                            if hasattr(django.core.handlers, "wsgi")
+                            else object,
+                            ctx,
+                            ignored_excs,
+                        ),
+                    )
+                    return await func(*args, **kwargs)
+
+            return _async()
+
         with (
-            core.context_with_data("django.func.wrapped", span_name=name, resource=resource, tags=tags, pin=pin) as ctx,
+            core.context_with_data(
+                "django.func.wrapped", span_name=name, resource=resource, tags=tags, pin=pin
+            ) as ctx,
             ctx.span,
         ):
             core.dispatch(

--- a/releasenotes/notes/fix-django-async-middleware-generatorexit-a1b2c3d4e5f6g7h8.yaml
+++ b/releasenotes/notes/fix-django-async-middleware-generatorexit-a1b2c3d4e5f6g7h8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    django: fix ``RuntimeError: coroutine ignored GeneratorExit`` under ASGI with async middleware on Python 3.13+

--- a/tests/contrib/django/django_app/urls.py
+++ b/tests/contrib/django/django_app/urls.py
@@ -96,4 +96,6 @@ urlpatterns = [
     handler(r"^shutdown-tracer/$", shutdown, name="shutdown-tracer"),
     handler(r"^alter-resource/$", views.alter_resource),
     handler(r"^identify/$", views.identify, name="identify"),
+    handler(r"^async-view/$", views.AsyncView.as_view(), name="async-view"),
+    handler(r"^async-fn-view/$", views.async_function_view, name="async-fn-view"),
 ]

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -2721,3 +2721,45 @@ def test_django_base_handler_failure(client, test_spans):
         assert root.resource == "GET ^$"
     finally:
         client.handler.get_response = original
+
+
+@pytest.mark.skipif(django.VERSION < (4, 1, 0), reason="async views require Django 4.1+")
+@pytest.mark.asyncio
+async def test_async_class_view(test_spans):
+    """Async class-based views should be traced without raising
+    'RuntimeError: coroutine ignored GeneratorExit' on Python 3.13+.
+
+    Regression test for the fix to traced_func which previously used a sync
+    context manager around an unawaited coroutine return.
+    """
+    from django.test import AsyncClient
+
+    async_client = AsyncClient()
+    resp = await async_client.get("/async-view/")
+    assert resp.status_code == 200
+    assert resp.content == b"async response"
+
+    assert len(list(test_spans.filter_spans(name="django.view"))) == 1
+    spans = list(test_spans.filter_spans(name="django.view.get"))
+    assert len(spans) == 1
+    span = spans[0]
+    span.assert_matches(
+        resource="tests.contrib.django.views.AsyncView.get",
+        error=0,
+    )
+
+
+@pytest.mark.skipif(django.VERSION < (4, 1, 0), reason="async views require Django 4.1+")
+@pytest.mark.asyncio
+async def test_async_function_view(test_spans):
+    """Async function-based views should be traced without raising
+    'RuntimeError: coroutine ignored GeneratorExit' on Python 3.13+.
+    """
+    from django.test import AsyncClient
+
+    async_client = AsyncClient()
+    resp = await async_client.get("/async-fn-view/")
+    assert resp.status_code == 200
+    assert resp.content == b"async function response"
+
+    assert len(list(test_spans.filter_spans(name="django.view"))) == 1

--- a/tests/contrib/django/views.py
+++ b/tests/contrib/django/views.py
@@ -192,3 +192,12 @@ def identify(request):
         scope="usr.scope",
     )
     return HttpResponse(status=200)
+
+
+class AsyncView(View):
+    async def get(self, request):
+        return HttpResponse("async response")
+
+
+async def async_function_view(request):
+    return HttpResponse("async function response")


### PR DESCRIPTION
## Description

Running Django under ASGI with ddtrace on Python 3.13+ causes `RuntimeError: coroutine ignored GeneratorExit` on every request through async middleware, resulting in 500 errors.

**Root cause:** `wrap_middleware_class` in `middleware.py` uses bytecode wrapping for all middleware hooks including `__call__`. Bytecode wrapping decides sync vs async based on `co_flags`, but Django's `MiddlewareMixin.__call__` is a sync function marked async at runtime via `markcoroutinefunction()`. ddtrace wraps it as sync; Django's ASGI handler awaits it. On Python 3.13+ (stricter coroutine cleanup per [cpython#117714](https://github.com/python/cpython/issues/117714)), this raises RuntimeError.

The same issue class was already fixed for `get_response_async` in `response.py`:
```python
# DEV: We cannot use bytecode wrappers here, otherwise in Python 3.13+ we'll trigger:
#      ValueError: coroutine already executing
```

**Two fixes:**

1. `middleware.py` — In `wrap_middleware_class`, detect `iscoroutinefunction(fn)` and use `trace_utils.wrap` (wrapt) instead of bytecode wrapping for async hooks. Same pattern as `get_response_async`.

2. `patch.py` — In `traced_func`, detect async view methods and `await` inside an `@asynccontextmanager` instead of returning an unawaited coroutine. Same pattern as pymongo fix in #16453.

Also affected but not fixed here: `aiohttp_jinja2/patch.py` has the same sync context manager pattern around an async `func()` call.

Related: #16449, #14506

## Testing

- Added `AsyncView` (class-based) and `async_function_view` (function-based) to the Django test app
- Two new test cases: `test_async_class_view` and `test_async_function_view`
- Tested end-to-end on a production Django ASGI app (25 middleware, 7 async): 120 errors per 5 page loads with unpatched ddtrace → 0 errors with fix applied

## Risks

- Sync middleware paths are completely untouched — the `iscoroutinefunction` check only activates for async functions
- The wrapt-based wrapping for async middleware produces the same span names, resource names, and tags as the bytecode wrapping path

## Additional Notes

- Python 3.13 made coroutine cleanup stricter via [cpython#117714](https://github.com/python/cpython/issues/117714)
- Django 6.0.2, uvicorn 0.35.0, Python 3.14.3
- Error traceback: `django/utils/deprecation.py:325 in __acall__` → `RuntimeError: coroutine ignored GeneratorExit`