### PR TITLE
chore: remove source artifacts from release wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,23 +6,3 @@ prune .riot/
 prune benchmarks/
 prune releasenotes/
 prune src/native/target*
-
-# Exclude C++ test/fuzz infrastructure not needed to build or run
-prune ddtrace/appsec/_iast/_taint_tracking/tests
-# NOTE: _vendor/pybind11 must stay in the sdist — it is a vendored build-time
-# dependency required by the IAST taint tracking CMakeLists.txt.
-# It is excluded from the wheel via find_packages() in setup.py.
-prune ddtrace/internal/datadog/profiling/test
-prune ddtrace/internal/datadog/profiling/dd_wrapper/test
-prune ddtrace/internal/datadog/profiling/stack/test
-prune ddtrace/internal/datadog/profiling/stack/fuzz
-prune ddtrace/internal/datadog/profiling/ddup/test
-
-# Exclude developer tooling files not needed to build or run
-# NOTE: cmake/sh files are intentionally kept — they are required to build
-# the native extensions when installing from the sdist.
-# Wheel-level stripping of those files is handled in setup.py.
-global-exclude *.plantuml
-global-exclude .clang-format
-global-exclude .gitignore
-global-exclude *.supp


### PR DESCRIPTION
## Description

We are accidentally including some source files in our wheels.

This only drops like 30kb from the wheel size, but still a good idea.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
