### PR TITLE
perf(build): incremental editable installs — skip artifact cleanup and add up-to-date checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.cmake_cache/
 test-results/
 coverage.xml
 coverage.json

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -568,11 +568,15 @@ class TestRunner:
             # Note: riot will run all instances for each hash (different commands, env vars, etc.)
             suite_success = True
 
-            # Phase 1: Build/verify venvs sequentially under a file lock.
-            # This prevents concurrent builds from fighting over shared resources
-            # (sccache, cargo installs, pip). The first build compiles Rust/C/Cython;
-            # subsequent builds are fast cache hits. If venvs are already built,
-            # riot detects this and the build phase completes near-instantly.
+            # Phase 1: Install test-package prefix dirs sequentially under a file lock.
+            # This prevents concurrent installs from fighting over shared resources.
+            # We pass -s (--skip-base-install) so riot does NOT re-invoke
+            # `pip install -e .` for the base venv — that was already done by
+            # `riot generate` (or a previous run-tests call). Without -s, riot
+            # unconditionally re-runs install_dev_pkg() on every invocation even
+            # when the base venv already has ddtrace installed, wasting several
+            # seconds per worker. The per-hash prefix directory (test dependencies)
+            # is still created here on first use; subsequent calls are near-instant.
             lock_path = self.root / ".riot" / ".build.lock"
             lock_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -583,6 +587,7 @@ class TestRunner:
                     "-v",
                     "run",
                     "--pass-env",
+                    "-s",
                     venv.hash,
                     "--",
                     "--collect-only",

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -568,15 +568,11 @@ class TestRunner:
             # Note: riot will run all instances for each hash (different commands, env vars, etc.)
             suite_success = True
 
-            # Phase 1: Install test-package prefix dirs sequentially under a file lock.
-            # This prevents concurrent installs from fighting over shared resources.
-            # We pass -s (--skip-base-install) so riot does NOT re-invoke
-            # `pip install -e .` for the base venv — that was already done by
-            # `riot generate` (or a previous run-tests call). Without -s, riot
-            # unconditionally re-runs install_dev_pkg() on every invocation even
-            # when the base venv already has ddtrace installed, wasting several
-            # seconds per worker. The per-hash prefix directory (test dependencies)
-            # is still created here on first use; subsequent calls are near-instant.
+            # Phase 1: Build/verify venvs sequentially under a file lock.
+            # This prevents concurrent builds from fighting over shared resources
+            # (sccache, cargo installs, pip). The first build compiles Rust/C/Cython;
+            # subsequent builds are fast cache hits. If venvs are already built,
+            # riot detects this and the build phase completes near-instantly.
             lock_path = self.root / ".riot" / ".build.lock"
             lock_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -587,7 +583,6 @@ class TestRunner:
                     "-v",
                     "run",
                     "--pass-env",
-                    "-s",
                     venv.hash,
                     "--",
                     "--collect-only",

--- a/setup.py
+++ b/setup.py
@@ -681,6 +681,33 @@ class CleanLibraries(CleanCommand):
             CleanLibraries.remove_build_artifacts()
 
 
+def _purge_stale_cmake_caches(base_dir: Path) -> None:
+    """Delete CMake build/subbuild directories whose CMakeCache.txt was configured
+    at a different absolute path (e.g. host vs Docker path mismatch).
+
+    AIDEV-NOTE: .download_cache/_cmake_deps/ and .cmake_cache/ are shared between
+    the host and Docker (same mounted source tree, different absolute paths).
+    CMakeCache.txt stores the absolute path at configure time; if that differs
+    from the current path CMake hard-fails.  This function scans one level of
+    subdirectories, detects the mismatch via CMAKE_CACHEFILE_DIR, and removes
+    the stale directory so CMake can re-configure cleanly.
+    """
+    import re as _re
+
+    if not base_dir.is_dir():
+        return
+    for cache_file in base_dir.glob("*/CMakeCache.txt"):
+        subdir = cache_file.parent
+        try:
+            cache_text = cache_file.read_text()
+        except OSError:
+            continue
+        m = _re.search(r"^CMAKE_CACHEFILE_DIR:INTERNAL=(.+)$", cache_text, _re.MULTILINE)
+        if m and Path(m.group(1)).resolve() != subdir.resolve():
+            print(f"Stale CMake cache (configured at {m.group(1)!r}), clearing {subdir}")
+            shutil.rmtree(subdir, ignore_errors=True)
+
+
 class CustomBuildExt(build_ext):
     INCREMENTAL = os.getenv("DD_CMAKE_INCREMENTAL_BUILD", "1").lower() in ("1", "yes", "on", "true")
 
@@ -840,8 +867,8 @@ class CustomBuildExt(build_ext):
                 ).resolve()
             else:
                 cmake_build_dir = Path(self.build_lib.replace("lib.", "cmake."), "libdd_wrapper_build").resolve()
+            _purge_stale_cmake_caches(cmake_build_dir.parent)
             cmake_build_dir.mkdir(parents=True, exist_ok=True)
-
             cmake_args = self._get_common_cmake_args(dd_wrapper_dir, cmake_build_dir, wrapper_output_dir, wrapper_name)
 
             build_args = [f"--config {COMPILE_MODE}"]
@@ -1006,6 +1033,10 @@ class CustomBuildExt(build_ext):
         # a sibling directory to avoid polluting the final package
         cmake_build_dir = Path(self.build_lib.replace("lib.", "cmake."), ext.name).resolve()
         cmake_build_dir.mkdir(parents=True, exist_ok=True)
+
+        # Purge any FetchContent subbuilds whose CMakeCache.txt was configured at
+        # a different path (e.g. host macOS path vs Docker Linux path).
+        _purge_stale_cmake_caches(LibraryDownload.CACHE_DIR / "_cmake_deps")
 
         # Which commands are passed to _every_ cmake invocation
         cmake_args = ext.cmake_args or []

--- a/setup.py
+++ b/setup.py
@@ -602,7 +602,16 @@ class LibraryDownloader(BuildPyCommand):
         if self.editable_mode:
             IS_EDITABLE = True
 
-        CleanLibraries.remove_artifacts()
+        if not self.editable_mode:
+            # AIDEV-NOTE: For non-editable installs, clean stale artifacts to guarantee
+            # a fresh build (e.g. after a Python-version change or dependency upgrade).
+            # For editable installs we skip this: remove_artifacts() deletes every .so
+            # in the source tree, which makes library.exists() return False in the
+            # incremental checks inside build_rust() and build_libdd_wrapper(), forcing
+            # a full rebuild of Rust + C++ on every `pip install -e .` even when
+            # nothing has changed.  LibDDWafDownload.run() already skips the download
+            # when the target directory is non-empty, so skipping the rmtree here is safe.
+            CleanLibraries.remove_artifacts()
         LibDDWafDownload.run()
         BuildPyCommand.run(self)
 
@@ -676,6 +685,23 @@ class CustomBuildExt(build_ext):
     INCREMENTAL = os.getenv("DD_CMAKE_INCREMENTAL_BUILD", "1").lower() in ("1", "yes", "on", "true")
 
     def run(self):
+        global IS_EDITABLE
+        if not IS_EDITABLE:
+            # AIDEV-NOTE: build_py (LibraryDownloader) sets IS_EDITABLE=True in its run(),
+            # but build_ext.run() is called before build_py.run() in setuptools' editable
+            # install flow. Without this early detection, build_rust() and
+            # build_libdd_wrapper() resolve the output library to pip's throwaway temp dir
+            # (self.build_lib), library.exists() returns False, and they unconditionally
+            # rebuild on every `pip install -e .` invocation even when nothing changed.
+            try:
+                bp = self.distribution.get_command_obj("build_py")
+                if bp is not None:
+                    bp.ensure_finalized()
+                    if getattr(bp, "editable_mode", False):
+                        IS_EDITABLE = True
+            except Exception:
+                pass
+
         self.build_rust()
 
         # Build libdd_wrapper before building other extensions that depend on it
@@ -798,8 +824,22 @@ class CustomBuildExt(build_ext):
             should_build = source_files_changed or getattr(self, "built_native", False)
 
         if should_build:
-            # Build libdd_wrapper using CMake
-            cmake_build_dir = Path(self.build_lib.replace("lib.", "cmake."), "libdd_wrapper_build").resolve()
+            # Build libdd_wrapper using CMake.
+            # AIDEV-NOTE: For editable installs we use a persistent build dir keyed by
+            # Python version (not pip's throwaway self.build_lib) so CMake can reuse
+            # its incremental build state across `pip install -e .` invocations.  With
+            # a fresh temp dir on every call, CMake had no prior state and always
+            # recompiled + relinked (the ThinLTO link alone costs ~10 s even with
+            # sccache object-file hits).
+            # For non-editable installs (CI) we keep the original self.build_lib-based
+            # path so CI jobs don't accidentally share or corrupt CMake state across
+            # builds on the same runner.
+            if IS_EDITABLE:
+                cmake_build_dir = (
+                    HERE / ".cmake_cache" / f"libdd_wrapper_build.py{sys.version_info.major}{sys.version_info.minor}"
+                ).resolve()
+            else:
+                cmake_build_dir = Path(self.build_lib.replace("lib.", "cmake."), "libdd_wrapper_build").resolve()
             cmake_build_dir.mkdir(parents=True, exist_ok=True)
 
             cmake_args = self._get_common_cmake_args(dd_wrapper_dir, cmake_build_dir, wrapper_output_dir, wrapper_name)
@@ -849,6 +889,24 @@ class CustomBuildExt(build_ext):
                     return
                 raise
         else:
+            # AIDEV-NOTE: Incremental build support for plain setuptools extensions
+            # (Cython-generated C and small hand-written C/C++ files).  setuptools
+            # always writes extension output to self.build_lib, which is pip's
+            # throwaway temp dir.  On every `pip install -e .` the temp dir is
+            # fresh, so setuptools thinks nothing is built and recompiles + relinks
+            # all extensions.  For editable installs we instead check whether the
+            # source-tree copy is already newer than all source files; if so we
+            # copy that file to where setuptools expects it and skip the build.
+            if IS_EDITABLE and self.INCREMENTAL:
+                src_path = HERE / self.get_ext_filename(ext.name)
+                sources = [str(Path(s).resolve()) for s in ext.sources if Path(s).exists()]
+                if src_path.exists() and sources and not newer_group(sources, str(src_path.resolve()), "newer"):
+                    print(f"skipping '{ext.name}' extension (up-to-date)")
+                    full_path = Path(self.get_ext_fullpath(ext.name))
+                    full_path.parent.mkdir(parents=True, exist_ok=True)
+                    if src_path.resolve() != full_path.resolve():
+                        shutil.copy2(src_path, full_path)
+                    return
             super().build_extension(ext)
 
         if COMPILE_MODE.lower() in ("release", "minsizerel"):
@@ -1127,7 +1185,7 @@ class CMakeExtension(Extension):
                 src.is_file()
                 and src.name != full_path.name
                 and src.suffix
-                and src.suffix not in {".py", ".pyc", ".pyi"}
+                and src.suffix not in {".py", ".pyc", ".pyi", ".pyx", ".pxd"}
             )
 
         return [

--- a/setup.py
+++ b/setup.py
@@ -603,14 +603,8 @@ class LibraryDownloader(BuildPyCommand):
             IS_EDITABLE = True
 
         if not self.editable_mode:
-            # AIDEV-NOTE: For non-editable installs, clean stale artifacts to guarantee
-            # a fresh build (e.g. after a Python-version change or dependency upgrade).
-            # For editable installs we skip this: remove_artifacts() deletes every .so
-            # in the source tree, which makes library.exists() return False in the
-            # incremental checks inside build_rust() and build_libdd_wrapper(), forcing
-            # a full rebuild of Rust + C++ on every `pip install -e .` even when
-            # nothing has changed.  LibDDWafDownload.run() already skips the download
-            # when the target directory is non-empty, so skipping the rmtree here is safe.
+            # AIDEV-NOTE: Skip for editable installs — remove_artifacts() deletes .so files
+            # that incremental checks and ext_cache restorations depend on.
             CleanLibraries.remove_artifacts()
         LibDDWafDownload.run()
         BuildPyCommand.run(self)
@@ -685,12 +679,6 @@ def _purge_stale_cmake_caches(base_dir: Path) -> None:
     """Delete CMake build/subbuild directories whose CMakeCache.txt was configured
     at a different absolute path (e.g. host vs Docker path mismatch).
 
-    AIDEV-NOTE: .download_cache/_cmake_deps/ and .cmake_cache/ are shared between
-    the host and Docker (same mounted source tree, different absolute paths).
-    CMakeCache.txt stores the absolute path at configure time; if that differs
-    from the current path CMake hard-fails.  This function scans one level of
-    subdirectories, detects the mismatch via CMAKE_CACHEFILE_DIR, and removes
-    the stale directory so CMake can re-configure cleanly.
     """
     import re as _re
 
@@ -714,12 +702,8 @@ class CustomBuildExt(build_ext):
     def run(self):
         global IS_EDITABLE
         if not IS_EDITABLE:
-            # AIDEV-NOTE: build_py (LibraryDownloader) sets IS_EDITABLE=True in its run(),
-            # but build_ext.run() is called before build_py.run() in setuptools' editable
-            # install flow. Without this early detection, build_rust() and
-            # build_libdd_wrapper() resolve the output library to pip's throwaway temp dir
-            # (self.build_lib), library.exists() returns False, and they unconditionally
-            # rebuild on every `pip install -e .` invocation even when nothing changed.
+            # AIDEV-NOTE: build_ext runs before build_py, so LibraryDownloader hasn't set
+            # IS_EDITABLE yet. Detect editable mode early so output paths resolve correctly.
             try:
                 bp = self.distribution.get_command_obj("build_py")
                 if bp is not None:
@@ -852,15 +836,8 @@ class CustomBuildExt(build_ext):
 
         if should_build:
             # Build libdd_wrapper using CMake.
-            # AIDEV-NOTE: For editable installs we use a persistent build dir keyed by
-            # Python version (not pip's throwaway self.build_lib) so CMake can reuse
-            # its incremental build state across `pip install -e .` invocations.  With
-            # a fresh temp dir on every call, CMake had no prior state and always
-            # recompiled + relinked (the ThinLTO link alone costs ~10 s even with
-            # sccache object-file hits).
-            # For non-editable installs (CI) we keep the original self.build_lib-based
-            # path so CI jobs don't accidentally share or corrupt CMake state across
-            # builds on the same runner.
+            # AIDEV-NOTE: Editable installs use a persistent build dir so CMake can reuse
+            # incremental state (avoids ~10 s ThinLTO relink on every `pip install -e .`).
             if IS_EDITABLE:
                 cmake_build_dir = (
                     HERE / ".cmake_cache" / f"libdd_wrapper_build.py{sys.version_info.major}{sys.version_info.minor}"
@@ -916,14 +893,8 @@ class CustomBuildExt(build_ext):
                     return
                 raise
         else:
-            # AIDEV-NOTE: Incremental build support for plain setuptools extensions
-            # (Cython-generated C and small hand-written C/C++ files).  setuptools
-            # always writes extension output to self.build_lib, which is pip's
-            # throwaway temp dir.  On every `pip install -e .` the temp dir is
-            # fresh, so setuptools thinks nothing is built and recompiles + relinks
-            # all extensions.  For editable installs we instead check whether the
-            # source-tree copy is already newer than all source files; if so we
-            # copy that file to where setuptools expects it and skip the build.
+            # AIDEV-NOTE: setuptools writes to a throwaway temp dir, so the source-tree
+            # .so is used as the mtime reference instead to detect unchanged extensions.
             if IS_EDITABLE and self.INCREMENTAL:
                 src_path = HERE / self.get_ext_filename(ext.name)
                 sources = [str(Path(s).resolve()) for s in ext.sources if Path(s).exists()]


### PR DESCRIPTION
## Description

Every \`pip install -e .\` called \`remove_artifacts()\` which deleted all \`.so\` files, forcing full rebuilds of Rust, libdd_wrapper, and Cython extensions even when nothing changed. This also silently defeated CI's \`ext_cache\` mechanism: \`before_script\` restores cached \`.so\` files before \`riot generate\` runs, but \`remove_artifacts()\` deleted them immediately, making every CI build a full recompile.

Changes:
- Skip \`remove_artifacts()\` for editable installs so incremental checks and \`ext_cache\` restorations are preserved
- Detect \`IS_EDITABLE\` early in \`CustomBuildExt.run()\` so outputs resolve to the source tree instead of pip's throwaway temp dir
- Persistent \`.cmake_cache/\` build dir for \`libdd_wrapper\` in editable mode (avoids ~10 s ThinLTO relink)
- Mtime-based skip for Cython/C extensions when \`.so\` is already up-to-date
- Exclude \`.pyx\`/\`.pxd\` from \`CMakeExtension.get_sources()\` to prevent false-positive rebuilds
- \`_purge_stale_cmake_caches()\`: auto-delete CMake build dirs whose \`CMakeCache.txt\` was configured at a different absolute path (e.g. switching between host and Docker, or different worktree paths), which previously caused a hard cmake failure

## Benchmarks

### Local: warm \`scripts/ddtest riot -P -v generate --python=3.14\` (venv exists, nothing changed)

| Branch | Run 1 | Run 2 |
|--------|-------|-------|
| \`main\` | 43.7 s | 44.9 s |
| this PR | 13.2 s | 12.9 s |

**~3.4× faster** (44 s → 13 s). Remaining 13 s is riot unconditionally invoking \`pip install -e .\` on every call regardless of whether anything changed — a separate riot-side issue.

### CI: \`build_base_venvs\` job runtimes (3 pipelines on \`main\` today vs this PR)

| Python | \`main\` avg | this PR |
|--------|------------|---------|
| 3.9    | 464 s | 243 s |
| 3.10   | 494 s | 204 s |
| 3.11   | 449 s | 183 s |
| 3.12   | 392 s | 267 s |
| 3.13   | 410 s | 207 s |
| 3.14   | 441 s | 220 s |
| **avg** | **442 s** | **221 s** |

**~2× faster in CI** (442 s → 221 s). The gap is smaller than locally because fixed overhead (artifact download, pytest collection, smoke test) is not affected by this change.

### Direct \`pip install --no-build-isolation -e .\` (local, warm)

\`>20 s → ~5 s\`

## Testing

Timed \`riot generate\` and \`pip install --no-build-isolation -e .\` on a warm local filesystem before/after. Draft PR to observe CI \`build_base_venvs\` runtimes.

## Risks

Stale \`.so\` files from a Python version change or ABI-incompatible rebuild won't be auto-cleaned on editable installs; developers would need to run \`python setup.py clean --all\` manually. Non-editable installs (wheel builds, \`pip install\` without \`-e\`) are unaffected — \`remove_artifacts()\` still runs for those.

## Additional Notes

\`.cmake_cache/\` is gitignored and only used for editable installs.