### PR TITLE
ci: retry downloading wheels

### DIFF
--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -20,7 +20,23 @@ fi
 
 echo "Github workflow finished. Downloading wheels"
 # Download only win_arm64 wheels; amd64 and x86 wheels are built directly in GitLab.
-gh run download $RUN_ID --repo DataDog/dd-trace-py --pattern "wheels-*-win_arm64"
+# Retry on transient HTTP errors (e.g. 503 egress limit).
+MAX_RETRIES=5
+RETRY_DELAY=5
+for attempt in $(seq 1 $MAX_RETRIES); do
+  # Clean any partial results so gh run download can re-extract with O_EXCL
+  rm -rf ./*
+  if gh run download $RUN_ID --repo DataDog/dd-trace-py --pattern "wheels-*-win_arm64"; then
+    break
+  fi
+  if [[ $attempt -eq $MAX_RETRIES ]]; then
+    echo "Failed to download wheels after $MAX_RETRIES attempts"
+    exit 1
+  fi
+  echo "Download attempt $attempt failed, retrying in ${RETRY_DELAY}s..."
+  sleep $RETRY_DELAY
+  RETRY_DELAY=$((RETRY_DELAY * 2))
+done
 
 cd ..
 


### PR DESCRIPTION
## Description

In the interest of making CI more reliable I'm adding this to work around [this error class](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1551271299) 

```
Github workflow finished. Downloading wheels
error downloading wheels-cp314-win_arm64: HTTP 503: 503 Egress is over the account limit. (https://productionresultssa19.blob.core.windows.net/actions-results/1699cddf-4bca-4d1d-a5f6-760b11cadf2d/workflow-job-run-ebdcc570-9acd-5cbe-9328-8614c03c0142/artifacts/xxxx.zip?rscd=attachment%3B+filename%3D%22wheels-cp314-win_arm64.zip%22&rsct=application%2Fzip&se=2026-03-30T17%3A19%3A57Z&sig=llu20%2Fxl7ejPT8zZYGRfijYSQnGwjKw1NVaIq0yxwFw%3D&ske=2026-03-30T18%3A15%3A39Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-03-30T14%3A15%3A39Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-03-30T17%3A09%3A52Z&sv=2025-11-05)
```