### PR TITLE
ci(profiling): fuzz image to v105197721-08581d9

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -2,7 +2,7 @@ variables:
   REPO_LANG: python # "python" is used everywhere rather than "py"
   FUZZ_IMAGE: registry.ddbuild.io/dd-trace-py-fuzz
   FUZZYDOG_VERSION: "0.27.1"
-  FUZZ_BASE_IMAGE: registry.ddbuild.io/dd-trace-py:v104604389-11e1de9-fuzz_base
+  FUZZ_BASE_IMAGE: registry.ddbuild.io/dd-trace-py:v105197721-08581d9-fuzz_base
   # CI_DEBUG_SERVICES: "true"
 
 fuzz_infra:


### PR DESCRIPTION
## Description

Bump fuzz base image to get the fuzzydog version bump. 
Tag from: ([build (#1553232310) · Jobs · datadog / images · GitLab](https://gitlab.ddbuild.io/DataDog/images/-/jobs/1553232310))

## Testing

N/A

## Risks

## Additional Notes
