### PR TITLE
feat(openfeature): stateful merge of multi-environment UFC configs

### DIFF
--- a/ddtrace/internal/openfeature/_remoteconfiguration.py
+++ b/ddtrace/internal/openfeature/_remoteconfiguration.py
@@ -31,13 +31,18 @@ class FFECapabilities(enum.IntFlag):
 class FeatureFlagCallback(RCCallback):
     """Remote Configuration callback for Feature Flagging and Experimentation (FFE)."""
 
+    def __init__(self):
+        self._config_state: dict[str, dict] = {}
+
     def __call__(self, payloads: t.Sequence[Payload]) -> None:
         """
         Process FFE configuration payloads from Remote Configuration.
 
-        Args:
-            payloads: Sequence of configuration payloads
+        Maintains per-path state and merges all UFC configs into a single
+        unified configuration after each delta, so multiple configs (e.g.
+        from different FFE environments) coexist correctly.
         """
+        changed = False
         for payload in payloads:
             if payload.metadata is None:
                 log.debug("Ignoring invalid FFE payload with no metadata, path: %s", payload.path)
@@ -51,15 +56,42 @@ class FeatureFlagCallback(RCCallback):
                     payload.metadata.product_name,
                     payload.path,
                 )
-                # Handle deletion/removal of configuration by clearing the stored config
-                _set_ffe_config(None)
+                if payload.path in self._config_state:
+                    del self._config_state[payload.path]
+                    changed = True
                 continue
 
+            self._config_state[payload.path] = payload.content
+            changed = True
+
+        if not changed:
+            return
+
+        merged = self._merge_configurations()
+        if merged is not None:
             try:
-                process_ffe_configuration(payload.content)
-                log.debug("Processing FFE config ID: %s, size: %d bytes", payload.metadata.id, len(payload.content))
+                process_ffe_configuration(merged)
+                log.debug(
+                    "Processed merged FFE config, %d flags from %d sources",
+                    len(merged["flags"]),
+                    len(self._config_state),
+                )
             except Exception as e:
-                log.debug("Error processing FFE config payload: %s", e, exc_info=True)
+                log.debug("Error processing merged FFE config: %s", e, exc_info=True)
+        else:
+            _set_ffe_config(None)
+
+    def _merge_configurations(self) -> t.Optional[dict]:
+        if not self._config_state:
+            return None
+        configs = list(self._config_state.values())
+        merged = dict(configs[0])
+        merged_flags: dict = {}
+        for config in configs:
+            if "flags" in config:
+                merged_flags.update(config["flags"])
+        merged["flags"] = merged_flags
+        return merged
 
 
 # Global callback instance

--- a/tests/openfeature/test_remoteconfig.py
+++ b/tests/openfeature/test_remoteconfig.py
@@ -1,19 +1,31 @@
+from unittest.mock import patch
+
 from ddtrace.internal.openfeature._remoteconfiguration import FeatureFlagCallback
 from ddtrace.internal.remoteconfig import ConfigMetadata
 from ddtrace.internal.remoteconfig import Payload
 
 
-def test_rc_callback_with_deletion():
-    """Test callback with deletion (None content)."""
-    metadata = ConfigMetadata(
-        id="test-config-456",
+def _make_metadata(config_id="test-config"):
+    return ConfigMetadata(
+        id=config_id,
         product_name="FFE_FLAGS",
-        sha256_hash="def456",
-        length=0,
+        sha256_hash="abc123",
+        length=100,
         tuf_version=1,
     )
 
-    payload = Payload(metadata=metadata, path="datadog/1/FFE_FLAGS/test/config.json", content=None)
+
+def _make_config(flags_dict):
+    return {"flags": flags_dict, "format": "SERVER"}
+
+
+def _make_payload(path, content, config_id="test-config"):
+    return Payload(metadata=_make_metadata(config_id), path=path, content=content)
+
+
+def test_rc_callback_with_deletion():
+    """Test callback with deletion (None content)."""
+    payload = _make_payload("datadog/1/FFE_FLAGS/test/config.json", None, "test-config-456")
 
     # Should not raise
     callback = FeatureFlagCallback()
@@ -32,14 +44,6 @@ def test_rc_callback_with_no_metadata():
 
 def test_rc_callback_with_complex_config():
     """Test callback with complex configuration."""
-    metadata = ConfigMetadata(
-        id="test-config-789",
-        product_name="FFE_FLAGS",
-        sha256_hash="ghi789",
-        length=500,
-        tuf_version=2,
-    )
-
     content = {
         "testBooleanAndStringFlags": {
             "flags": {
@@ -94,8 +98,109 @@ def test_rc_callback_with_complex_config():
         }
     }
 
-    payload = Payload(metadata=metadata, path="datadog/1/FFE_FLAGS/test/config.json", content=content)
+    payload = _make_payload("datadog/1/FFE_FLAGS/test/config.json", content, "test-config-789")
 
     # Should process without errors
     callback = FeatureFlagCallback()
     callback([payload])
+
+
+@patch("ddtrace.internal.openfeature._remoteconfiguration.process_ffe_configuration")
+def test_two_configs_single_callback(mock_process):
+    """Two configs in a single callback - both flags accessible after merge."""
+    callback = FeatureFlagCallback()
+
+    config_a = _make_config({"flag-a": {"key": "flag-a", "enabled": True}})
+    config_b = _make_config({"flag-b": {"key": "flag-b", "enabled": True}})
+
+    callback(
+        [
+            _make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", config_a, "config-a"),
+            _make_payload("datadog/1/FFE_FLAGS/env-llmobs/config.json", config_b, "config-b"),
+        ]
+    )
+
+    mock_process.assert_called_once()
+    merged = mock_process.call_args[0][0]
+    assert "flag-a" in merged["flags"]
+    assert "flag-b" in merged["flags"]
+
+
+@patch("ddtrace.internal.openfeature._remoteconfiguration.process_ffe_configuration")
+def test_delta_update_separate_callbacks(mock_process):
+    """Delta update: first config, then second config in separate callbacks - both flags accessible."""
+    callback = FeatureFlagCallback()
+
+    config_a = _make_config({"flag-a": {"key": "flag-a", "enabled": True}})
+    callback([_make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", config_a, "config-a")])
+    assert mock_process.call_count == 1
+
+    config_b = _make_config({"flag-b": {"key": "flag-b", "enabled": True}})
+    callback([_make_payload("datadog/1/FFE_FLAGS/env-llmobs/config.json", config_b, "config-b")])
+    assert mock_process.call_count == 2
+
+    merged = mock_process.call_args[0][0]
+    assert "flag-a" in merged["flags"]
+    assert "flag-b" in merged["flags"]
+
+
+@patch("ddtrace.internal.openfeature._remoteconfiguration._set_ffe_config")
+@patch("ddtrace.internal.openfeature._remoteconfiguration.process_ffe_configuration")
+def test_delete_one_config_other_survives(mock_process, mock_set_config):
+    """Deletion of one config: other config's flags survive."""
+    callback = FeatureFlagCallback()
+
+    config_a = _make_config({"flag-a": {"key": "flag-a", "enabled": True}})
+    config_b = _make_config({"flag-b": {"key": "flag-b", "enabled": True}})
+    callback(
+        [
+            _make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", config_a, "config-a"),
+            _make_payload("datadog/1/FFE_FLAGS/env-llmobs/config.json", config_b, "config-b"),
+        ]
+    )
+
+    # Delete config_a
+    callback([_make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", None, "config-a")])
+
+    merged = mock_process.call_args[0][0]
+    assert "flag-a" not in merged["flags"]
+    assert "flag-b" in merged["flags"]
+    mock_set_config.assert_not_called()
+
+
+@patch("ddtrace.internal.openfeature._remoteconfiguration.process_ffe_configuration")
+def test_update_one_config(mock_process):
+    """Update one config: flags from both configs reflect the update."""
+    callback = FeatureFlagCallback()
+
+    config_a = _make_config({"flag-a": {"key": "flag-a", "enabled": True}})
+    config_b = _make_config({"flag-b": {"key": "flag-b", "enabled": True}})
+    callback(
+        [
+            _make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", config_a, "config-a"),
+            _make_payload("datadog/1/FFE_FLAGS/env-llmobs/config.json", config_b, "config-b"),
+        ]
+    )
+
+    # Update config_a with a new flag value
+    config_a_updated = _make_config({"flag-a": {"key": "flag-a", "enabled": False}})
+    callback([_make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", config_a_updated, "config-a")])
+
+    merged = mock_process.call_args[0][0]
+    assert merged["flags"]["flag-a"]["enabled"] is False
+    assert merged["flags"]["flag-b"]["enabled"] is True
+
+
+@patch("ddtrace.internal.openfeature._remoteconfiguration._set_ffe_config")
+@patch("ddtrace.internal.openfeature._remoteconfiguration.process_ffe_configuration")
+def test_delete_all_configs(mock_process, mock_set_config):
+    """Delete all configs: _set_ffe_config(None) is called."""
+    callback = FeatureFlagCallback()
+
+    config_a = _make_config({"flag-a": {"key": "flag-a", "enabled": True}})
+    callback([_make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", config_a, "config-a")])
+
+    # Delete it
+    callback([_make_payload("datadog/1/FFE_FLAGS/env-prod/config.json", None, "config-a")])
+
+    mock_set_config.assert_called_once_with(None)


### PR DESCRIPTION
## Description

The `FeatureFlagCallback` replaced the entire FFE configuration on each RC payload, so when multiple UFC configs arrived (one per FFE environment), the last one won and the others' flags were lost. Config deletions (`content=None`) were also logged but never cleared.

This PR maintains a `dict[path -> parsed_config]` in the callback and merges all UFC entries into a single unified configuration after each delta. This is a prerequisite for the dedicated LLMObs environment work, where each SDK receives could two UFC configs via Remote Config: one for the customer's `DD_ENV` (regular feature flags) and one for the LLMObs environment (prompt flags).

### How it works

```
                        RC Poller
                           |
                  delivers deltas only
                  (new / changed / removed)
                           |
                           v
               FeatureFlagCallback.__call__
                           |
            +-------- for each payload --------+
            |                                  |
     content != None                    content == None
     store in _config_state             delete from _config_state
            |                                  |
            +----------------------------------+
                           |
                  _merge_configurations()
                           |
              +------------+------------+
              |                         |
        merged != None            merged == None
              |                   (all deleted)
              v                         |
   process_ffe_configuration()          v
      sets FFE_CONFIG            _set_ffe_config(None)
              |                   clears FFE_CONFIG
              v                         |
     native ffe.Configuration           v
      ready for evaluation       evaluations return
                                 default values
```

### Before (last-write-wins)

```
Callback([env-prod UFC, env-llmobs UFC])
  -> process_ffe_configuration(env-prod)     # sets FFE_CONFIG
  -> process_ffe_configuration(env-llmobs)   # overwrites FFE_CONFIG
  # env-prod flags lost
```

### After (stateful merge)

```
Callback([env-prod UFC, env-llmobs UFC])
  -> _config_state["env-prod"] = env-prod UFC
  -> _config_state["env-llmobs"] = env-llmobs UFC
  -> merged = {flags from env-prod} | {flags from env-llmobs}
  -> process_ffe_configuration(merged)
  # all flags available
```

### Merge ordering

The merge uses `dict.update` which means if the same flag key appeared in multiple UFCs, one would silently overwrite the other. This is safe because prompt flags always use the `llmobs.prompt.*` key prefix, and regular feature flags never use that prefix. The two UFCs contain disjoint flag key sets by construction.

### Merge dependency

This PR **must** be merged before https://github.com/DataDog/dd-source/pull/380379 and https://github.com/DataDog/dd-trace-py/pull/16854 - that dd-source PR introduces the dedicated LLMObs environment which will cause multiple UFC configs to be delivered via RC.

## Testing

5 new tests in `tests/openfeature/test_remoteconfig.py`:
- Two configs in single callback - both flags accessible after merge
- Delta update across separate callbacks - both flags accessible
- Deletion of one config - other config's flags survive
- Update one config - flags from both configs reflect the update
- Delete all configs - `_set_ffe_config(None)` is called

Existing tests preserved and refactored to use shared helpers.

## Risks

None. The merge logic is a straightforward `dict.update` over 1-2 configs. The callback is not a hot path (async RC polling). The change is backward-compatible: a single UFC config works identically to before.

## Additional Notes

- The Go SDK equivalent PR: https://github.com/DataDog/dd-trace-go/pull/4622