### PR TITLE
chore(scripts): preserve arguments with spaces in ddtest

### DIFF
--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -2,17 +2,17 @@
 
 set -e
 
-CMD=$*
-
-if [ -z "$CMD" ]
-then
-    CMD=bash
-fi
-
 BUILD_FLAG=""
 if [ "${1:-}" = "--build" ]; then
     BUILD_FLAG="--build"
     shift
+fi
+
+if [ "$#" -eq 0 ]; then
+    CMD=bash
+else
+    CMD=$(printf '%q ' "$@")
+    CMD="${CMD% }"
 fi
 # Ensure cache directories exist and are writable by the current user
 # These are mounted into the Docker container at /home/bits/.cache


### PR DESCRIPTION
APPSEC-61974

## Description

`scripts/ddtest` passes its arguments to `bash -c` inside a Docker container. It used `CMD=$*` which joins all arguments into a flat string, losing any quoting. Arguments containing spaces (e.g., `-k "test_request and not test_request_uri"`) would be split incorrectly, causing test selection failures and other errors when passed through `run-tests` → `riot` → `pytest`.

This fix uses `printf '%q ' "$@"` to shell-escape each argument individually before embedding them in the `bash -c` command. It also moves `--build` flag parsing before `CMD` assignment, fixing a secondary bug where `--build` would leak into the inner command.

## Testing

Ran `scripts/run-tests --venv 14f0a7d -- -- -k "test_request and not test_request_uri"` against `appsec_threats_fastapi_no_iast` — 384 passed, 4 skipped, 961 correctly deselected.

