### PR TITLE
chore(aap): clean up and fix appsec threats test suite

### DIFF
--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1702,23 +1702,25 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
         import ddtrace.internal.telemetry
 
         def validate_top_function(trace):
-            # Check the first few frames for the expected function name.
-            # The stack may have ddtrace-internal frames (e.g. report_stack,
-            # _waf_action, _traced_subprocess_init) above the expected function
-            # when crop_trace doesn't fully trim the stack.
-            # For httpx SSRF, the stack trace is not cropped (no crop_trace in
-            # the httpx code path) so the stack only contains ddtrace internals.
-            # Skip validation in that case.
+            # Validate that the stack trace contains an expected function near the top.
+            # Several cases to handle:
+            # - Properly cropped stacks: expected function at frame 0 (endswith match)
+            # - Qualified names (Python 3.11+): e.g. "RaspHandler._handle" contains "rasp"
+            # - Intermediate ddtrace frames: search first 6 frames
+            # - Untrimmed httpx stacks: report_stack at frame 0 — skip validation
             if trace["frames"][0]["function"] == "report_stack":
                 return True
             for frame in trace["frames"][:6]:
                 fname = frame["function"]
                 fname_lower = fname.lower()
-                # Use endswith for exact match, and case-insensitive containment
-                # for qualified names (e.g. "RaspHandler._handle" contains "rasp")
                 if any(fname.endswith(tf) or tf.lower() in fname_lower for tf in top_functions) or (
                     asm_config._iast_enabled and fname.endswith("ast_function")
                 ):
+                    return True
+                # On Python <3.11 co_qualname is unavailable, so Tornado's
+                # "RaspHandler._handle" appears as just "_handle". Accept it
+                # only if the frame is from a test app file, not ddtrace internals.
+                if fname == "_handle" and "contrib_appsec" in frame.get("file", ""):
                     return True
             return False
 


### PR DESCRIPTION
APPSEC-61974

## Bug fixes:
  - Fix validate_top_function variable shadowing: loop variable top_function shadowed the outer scope variable, making any(top_function.endswith(top_function) for top_function in top_functions) always True.
  Renamed to tf.
  - Adapt validate_top_function to handle untrimmed stacks (httpx SSRF path lacks crop_trace) and intermediate ddtrace frames (subprocess tracing wrappers).
  - Remove duplicate assertions (copy-paste artifacts at two locations).
  - Re-introduce URL assertion in LFI test with correct interface.SERVER_PORT (was commented out due to hardcoded port 8000), with FastAPI exclusion for path normalization.

## Test optimization (-346 cases, -26%):
  - test_request_suspicious_request_block_custom_actions: Collapse headers/use_html parametrize into the main parametrize — test all 7 Accept header variants only for the auto query where content negotiation
  matters; use 2 representative headers for other queries. 168 → 68 cases.
  - test_auto_user_events: Replace 4 independent parametrize decorators with explicit parameter list covering all meaningful mode combinations plus representative disabled-path cases. 144 → 36 cases.
  - test_auto_user_events_sdk_v2: Remove auto_events_enabled, local_mode, rc_mode parameters that don't affect SDK v2 assertions. 144 → 6 cases.

## Code quality:
  - Extract assert_blocked() helper method on _Contrib_TestClass_Base, replacing 8 copy-pasted blocked-response assertion blocks.
  - Move from ddtrace.ext import http to module level (was duplicated inline in 23 test methods).
  - Remove dead commented-out code (7 blocks: diagnostic printer, disabled assertions, debug breadcrumbs).
  - Remove 9 identical # DEV Warning: encoded URL will behave differently comments with no actionable context.

## Risks

  - The validate_top_function fix changes test behavior: it now actually validates stack trace top functions. The httpx SSRF case is handled by skipping validation when the stack is untrimmed (report_stack at
  frame 0). If new RASP code paths are added without proper crop_trace, they'll be silently accepted rather than failing — this is a conscious trade-off to avoid blocking on a known production limitation.
  - Test case reduction removes redundant combinations but not coverage. If the Accept header parsing logic becomes framework-dependent in the future, the reduced header variants on non-auto queries would miss
  it.

## Additional Notes

  - The validate_top_function fix exposed that httpx SSRF stack traces are not cropped — the httpx instrumentation path (AppSecHttpxSingleRequestContextSubscriber.on_started) doesn't use the crop_trace mechanism,
   so stack traces contain only ddtrace-internal frames. This is a production issue worth tracking separately.
  - FastAPI's test_request_suspicious_request_block_match_uri_lfi skip is due to metastruct trigger storage, not URL normalization (though FastAPI also normalizes /waf/../ → /).