### PR TITLE
test(profiling): bump lower tolerance in `test_accuracy_stack`

### DIFF
--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -121,7 +121,7 @@ def test_accuracy_stack():
     # CPU-bound functions guarantee exact CPU time via busy-loop, but wall time
     # can exceed CPU time due to OS preemption, especially in CI environments.
     # Wall time should never be less than the target CPU time.
-    assert_within_tolerance(wall_times["spend_cpu_2"], 2e9, upper_tolerance=0.3, lower_tolerance=0.001)
-    assert_within_tolerance(wall_times["spend_cpu_3"], 3e9, upper_tolerance=0.3, lower_tolerance=0.001)
+    assert_within_tolerance(wall_times["spend_cpu_2"], 2e9, upper_tolerance=0.3, lower_tolerance=0.01)
+    assert_within_tolerance(wall_times["spend_cpu_3"], 3e9, upper_tolerance=0.3, lower_tolerance=0.01)
     assert_almost_equal(cpu_times["spend_cpu_2"], 2e9)
     assert_almost_equal(cpu_times["spend_cpu_3"], 3e9)


### PR DESCRIPTION
## Description

This relaxes the lower bound margin because we're a bit too aggressive and this is making the test flaky. 

```
builtins.AssertionError: Expected status 0, got 1.
=== Captured STDOUT ===
=== End of captured STDOUT ===
=== Captured STDERR ===
Traceback (most recent call last):
  File "tests/profiling/test_accuracy.py", line 124, in <module>
    assert_within_tolerance(wall_times["spend_cpu_2"], 2e9, upper_tolerance=0.3, lower_tolerance=0.001)
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/tests/profiling/test_accuracy.py", line 64, in assert_within_tolerance
    raise AssertionError(
AssertionError: Assertion failed: 1993182000 is less than expected minimum 2000000000.0 (lower_tolerance=0.001)
=== End of captured STDERR ===
```

**Failures recently**

<img width="1174" height="466" alt="image" src="https://github.com/user-attachments/assets/8d132ff9-a28d-41ae-aca9-273cdaf520f6" />
