### PR TITLE
chore(lint): migrate os.environ to env in appsec modules

### DIFF
--- a/ddtrace/appsec/_iast/__init__.py
+++ b/ddtrace/appsec/_iast/__init__.py
@@ -28,13 +28,13 @@ def wrapped_function(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 """
 
-import os
 import sys
 import types
 
 from ddtrace.internal import forksafe
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 from ._listener import iast_listen
@@ -229,9 +229,9 @@ def _iast_pytest_activation():
     # This flag is checked by the fork handler to disable IAST in child processes
     _iast_in_pytest_mode = True
 
-    os.environ["DD_IAST_REQUEST_SAMPLING"] = os.environ.get("DD_IAST_REQUEST_SAMPLING") or "100.0"
-    os.environ["_DD_APPSEC_DEDUPLICATION_ENABLED"] = os.environ.get("_DD_APPSEC_DEDUPLICATION_ENABLED") or "false"
-    os.environ["DD_IAST_VULNERABILITIES_PER_REQUEST"] = os.environ.get("DD_IAST_VULNERABILITIES_PER_REQUEST") or "1000"
+    env["DD_IAST_REQUEST_SAMPLING"] = env.get("DD_IAST_REQUEST_SAMPLING") or "100.0"
+    env["_DD_APPSEC_DEDUPLICATION_ENABLED"] = env.get("_DD_APPSEC_DEDUPLICATION_ENABLED") or "false"
+    env["DD_IAST_VULNERABILITIES_PER_REQUEST"] = env.get("DD_IAST_VULNERABILITIES_PER_REQUEST") or "1000"
 
     asm_config._iast_request_sampling = 100.0
     asm_config._deduplication_enabled = False

--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -13,6 +13,7 @@ from ddtrace.appsec._iast._logs import iast_compiling_debug_log
 from ddtrace.appsec._iast._logs import iast_instrumentation_ast_patching_debug_log
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import origin
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils.formats import asbool
 
@@ -291,7 +292,7 @@ def astpatch_module(module: ModuleType) -> tuple[str, Optional[ast.Module]]:
         iast_compiling_debug_log(f"Empty file: {module_path}")
         return "", None
 
-    if not asbool(os.environ.get(IAST.ENV_NO_DIR_PATCH, "false")):
+    if not asbool(env.get(IAST.ENV_NO_DIR_PATCH, "false")):
         # Add the dir filter so __ddtrace stuff is not returned by dir(module)
         source_text += _DIR_WRAPPER
 

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -2,7 +2,6 @@ import dataclasses
 from functools import reduce
 import json
 import operator
-import os
 from typing import Any
 from typing import Optional
 import zlib
@@ -16,6 +15,7 @@ from ddtrace.appsec._iast.constants import VULN_INSECURE_HASHING_TYPE
 from ddtrace.appsec._iast.constants import VULN_WEAK_CIPHER_TYPE
 from ddtrace.appsec._iast.constants import VULN_WEAK_RANDOMNESS
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 
@@ -109,7 +109,7 @@ class Vulnerability:
     type: str
     evidence: Evidence
     location: Location
-    hash: int = dataclasses.field(init=False, compare=False, hash=("PYTEST_CURRENT_TEST" in os.environ), repr=False)
+    hash: int = dataclasses.field(init=False, compare=False, hash=("PYTEST_CURRENT_TEST" in env), repr=False)
 
     def __post_init__(self):
         self.hash = zlib.crc32(repr(self).encode())

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 from typing import Callable
 from typing import Text
@@ -12,6 +11,7 @@ from ddtrace.appsec._iast.constants import RC2_DEF
 from ddtrace.appsec._iast.constants import RC4_DEF
 from ddtrace.appsec._iast.constants import VULN_WEAK_CIPHER_TYPE
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 from .._logs import iast_error
@@ -27,7 +27,7 @@ log = get_logger(__name__)
 
 def get_weak_cipher_algorithms() -> set:
     CONFIGURED_WEAK_CIPHER_ALGORITHMS = None
-    DD_IAST_WEAK_CIPHER_ALGORITHMS = os.getenv("DD_IAST_WEAK_CIPHER_ALGORITHMS")
+    DD_IAST_WEAK_CIPHER_ALGORITHMS = env.get("DD_IAST_WEAK_CIPHER_ALGORITHMS")
     if DD_IAST_WEAK_CIPHER_ALGORITHMS:
         CONFIGURED_WEAK_CIPHER_ALGORITHMS = set(
             algo.strip() for algo in DD_IAST_WEAK_CIPHER_ALGORITHMS.lower().split(",")

--- a/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
@@ -1,8 +1,8 @@
-import os
 from typing import Any
 from typing import Callable
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 from ..._common_module_patches import try_unwrap
@@ -27,7 +27,7 @@ log = get_logger(__name__)
 
 def get_weak_hash_algorithms() -> set:
     CONFIGURED_WEAK_HASH_ALGORITHMS = None
-    DD_IAST_WEAK_HASH_ALGORITHMS = os.getenv("DD_IAST_WEAK_HASH_ALGORITHMS")
+    DD_IAST_WEAK_HASH_ALGORITHMS = env.get("DD_IAST_WEAK_HASH_ALGORITHMS")
     if DD_IAST_WEAK_HASH_ALGORITHMS:
         CONFIGURED_WEAK_HASH_ALGORITHMS = set(algo.strip() for algo in DD_IAST_WEAK_HASH_ALGORITHMS.lower().split(","))
 

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -2,7 +2,6 @@ import dataclasses
 import errno
 import functools
 from json.decoder import JSONDecodeError
-import os
 from typing import Any
 from typing import ClassVar
 from typing import Optional
@@ -37,6 +36,7 @@ from ddtrace.internal._unpatched import unpatched_open as open  # noqa: A004
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.rate_limiter import RateLimiter
 from ddtrace.internal.remoteconfig import PayloadType
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 
@@ -79,7 +79,7 @@ def get_rules() -> str:
 
 
 def _get_rate_limiter() -> RateLimiter:
-    return RateLimiter(int(os.getenv("DD_APPSEC_TRACE_RATE_LIMIT", DEFAULT.TRACE_RATE_LIMIT)))
+    return RateLimiter(int(env.get("DD_APPSEC_TRACE_RATE_LIMIT", DEFAULT.TRACE_RATE_LIMIT)))
 
 
 @dataclasses.dataclass(eq=False)

--- a/ddtrace/contrib/internal/subprocess/patch.py
+++ b/ddtrace/contrib/internal/subprocess/patch.py
@@ -16,6 +16,7 @@ from ddtrace.contrib.internal.subprocess.constants import COMMANDS
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.threads import RLock
@@ -26,7 +27,7 @@ log = get_logger(__name__)
 
 config._add(
     "subprocess",
-    dict(sensitive_wildcards=os.getenv("DD_SUBPROCESS_SENSITIVE_WILDCARDS", default="").split(",")),
+    dict(sensitive_wildcards=env.get("DD_SUBPROCESS_SENSITIVE_WILDCARDS", default="").split(",")),
 )
 
 

--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -1,4 +1,3 @@
-import os
 import os.path
 from platform import machine
 from platform import system
@@ -21,6 +20,7 @@ from ddtrace.internal.constants import AI_GUARD_MAX_CONTENT_SIZE
 from ddtrace.internal.constants import AI_GUARD_MAX_MESSAGES_LENGTH
 from ddtrace.internal.constants import AI_GUARD_TIMEOUT
 from ddtrace.internal.serverless import in_aws_lambda
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._config import config as tracer_config
 from ddtrace.internal.settings._core import DDConfig
 
@@ -303,7 +303,7 @@ class ASMConfig(DDConfig):
 
     @property
     def asm_enabled_origin(self):
-        if APPSEC_ENV in os.environ:
+        if APPSEC_ENV in env:
             return APPSEC.ENABLED_ORIGIN_ENV
         return self._asm_enabled_origin
 
@@ -312,10 +312,10 @@ class ASMConfig(DDConfig):
         self.__init__()
 
     def _eval_asm_can_be_enabled(self) -> None:
-        self._asm_can_be_enabled = APPSEC_ENV not in os.environ and tracer_config._remote_config_enabled
+        self._asm_can_be_enabled = APPSEC_ENV not in env and tracer_config._remote_config_enabled
         self._load_modules = bool(self._ep_enabled and (self._asm_enabled or self._asm_can_be_enabled))
         self._asm_rc_enabled = (self._asm_enabled and tracer_config._remote_config_enabled) or self._asm_can_be_enabled
-        if APPSEC_ENV in os.environ and self._asm_enabled:
+        if APPSEC_ENV in env and self._asm_enabled:
             tracer_config._trace_resource_renaming_enabled = True
 
     @property


### PR DESCRIPTION
## Description

Part of a series migrating all `os.environ`/`os.getenv` usage in `ddtrace/` to the centralized `env` MutableMapping from `ddtrace.internal.settings` (introduced in #17149).

**This PR covers `@DataDog/asm-python` owned files (8 files):**
- `ddtrace/appsec/_iast/__init__.py`
- `ddtrace/appsec/_iast/_ast/ast_patching.py`
- `ddtrace/appsec/_iast/reporter.py`
- `ddtrace/appsec/_iast/taint_sinks/weak_cipher.py`
- `ddtrace/appsec/_iast/taint_sinks/weak_hash.py`
- `ddtrace/appsec/_processor.py`
- `ddtrace/contrib/internal/subprocess/patch.py`
- `ddtrace/internal/settings/asm.py`

**Stacks on:** #17149

**Sister PRs (same migration, different owners):**
- `apm-sdk-capabilities-python`: #16724
- `apm-core-python`: #16725
- `ci-app-libraries`: #16726
- `apm-idm-python` (contrib): #16727

## Testing

- All ruff checks pass (`ruff check --no-cache .`)
- All ast-grep tests pass (`sg test`)
- No Python syntax errors in migrated files

## Risks

None — mechanical replacement of `os.environ` → `env` and `os.getenv(k)` → `env.get(k)`. No logic changes.

## Additional Notes

The `env` object is a `MutableMapping` wrapping `os.environ`, so it is a drop-in replacement. See #17149 for design details.