### PR TITLE
chore(lint): migrate os.environ to env in profiling modules

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -1,5 +1,4 @@
 import importlib.util
-import os
 import platform
 import sys
 from typing import Optional
@@ -11,6 +10,7 @@ from ddtrace.internal import process_tags
 from ddtrace.internal.compat import ensure_text
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.runtime import get_runtime_id
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings.crashtracker import config as crashtracker_config
 from ddtrace.internal.settings.profiling import config as profiling_config
@@ -18,7 +18,6 @@ from ddtrace.internal.settings.profiling import config_str
 
 
 log = get_logger(__name__)
-
 
 is_available = True
 try:
@@ -129,7 +128,7 @@ def _get_args(additional_tags: Optional[dict[str, str]]):
 
     # Don't pass all env vars to the receiver process, because there are
     # conflicts with export location derivation
-    crashtracking_enabled = os.environ.get("DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED")
+    crashtracking_enabled = env.get("DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED")
     if crashtracking_enabled is not None:
         receiver_env["DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED"] = crashtracking_enabled
 
@@ -142,7 +141,7 @@ def _get_args(additional_tags: Optional[dict[str, str]]):
         "PYTHONPATH",  # for loading Python, for the receiver script
     ]
     for env_var in inherited_env_vars:
-        env_value = os.environ.get(env_var)
+        env_value = env.get(env_var)
         if env_value is not None:
             receiver_env[env_var] = env_value
 

--- a/ddtrace/internal/datadog/profiling/code_provenance.py
+++ b/ddtrace/internal/datadog/profiling/code_provenance.py
@@ -12,6 +12,7 @@ import typing as t
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.packages import Distribution
 from ddtrace.internal.packages import _package_for_root_module_mapping
+from ddtrace.internal.settings import env
 
 
 class Library:
@@ -122,7 +123,7 @@ def _safe_mtime_ns(path: t.Optional[str]) -> str:
 
 def _cache_basename() -> str:
     purelib = sysconfig.get_path("purelib")
-    main_package = os.getenv("DD_MAIN_PACKAGE", "")
+    main_package = env.get("DD_MAIN_PACKAGE", "")
     data = "\x00".join(
         (
             _CODE_PROVENANCE_CACHE_VERSION,

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import math
-import os
 import typing as t
 
 from envier import Env
@@ -14,6 +13,7 @@ from ddtrace.ext.git import REPOSITORY_URL
 from ddtrace.internal import compat
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.settings._core import ValueSource
 from ddtrace.internal.telemetry import report_configuration
@@ -74,7 +74,7 @@ def _check_for_stack_available():
 
 def _injection_enabled_has_profiler() -> bool:
     """Return True if DD_INJECTION_ENABLED contains the 'profiler' token."""
-    injection_enabled = os.environ.get("DD_INJECTION_ENABLED")
+    injection_enabled = env.get("DD_INJECTION_ENABLED")
     if injection_enabled is None:
         return False
 
@@ -110,7 +110,7 @@ def _enrich_tags(tags) -> dict[str, str]:
     tags = {
         k: compat.ensure_text(v, "utf-8")
         for k, v in itertools.chain(
-            _update_git_metadata_tags(parse_tags_str(os.environ.get("DD_TAGS"))).items(),
+            _update_git_metadata_tags(parse_tags_str(env.get("DD_TAGS"))).items(),
             tags.items(),
         )
     }


### PR DESCRIPTION
## Description

Part of a series migrating all `os.environ`/`os.getenv` usage in `ddtrace/` to the centralized `env` MutableMapping from `ddtrace.internal.settings` (introduced in #17149).

**This PR covers `@DataDog/profiling-python` owned files (3 files):**
- `ddtrace/internal/core/crashtracking.py`
- `ddtrace/internal/datadog/profiling/code_provenance.py`
- `ddtrace/internal/settings/profiling.py`

**Stacks on:** #17149

**Sister PRs (same migration, different owners):**
- `apm-sdk-capabilities-python`: #16724
- `apm-core-python`: #16725
- `ci-app-libraries`: #16726
- `apm-idm-python` (contrib): #16727
- `asm-python`: #17218
- `ml-observability`: #17219

## Testing

- All ruff checks pass (`ruff check --no-cache .`)
- All ast-grep tests pass (`sg test`)
- No Python syntax errors in migrated files

## Risks

None — mechanical replacement of `os.environ` → `env` and `os.getenv(k)` → `env.get(k)`. No logic changes.

## Additional Notes

The `env` object is a `MutableMapping` wrapping `os.environ`, so it is a drop-in replacement. See #17149 for design details.