### PR TITLE
chore(lint): migrate os.environ to env in data streams processor

### DIFF
--- a/ddtrace/internal/datastreams/processor.py
+++ b/ddtrace/internal/datastreams/processor.py
@@ -3,7 +3,6 @@ import base64
 from collections import defaultdict
 from functools import partial
 import gzip
-import os
 import struct
 import threading
 import time
@@ -16,6 +15,7 @@ from ddtrace.internal import process_tags
 from ddtrace.internal.atexit import register_on_exit_signal
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.native import DDSketch
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.threads import Lock
@@ -49,7 +49,6 @@ The processor flushes stats periodically (every 10 sec) to the Datadog agent.
 This powers the data streams monitoring product. More details about the product can be found here:
 https://docs.datadoghq.com/data_streams/
 """
-
 
 log = get_logger(__name__)
 
@@ -103,7 +102,7 @@ class DataStreamsProcessor(PeriodicService):
         retry_attempts: int = 3,
     ):
         if interval is None:
-            interval = float(os.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
+            interval = float(env.get("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
         super(DataStreamsProcessor, self).__init__(interval=interval)
         self._enabled: bool = True
         self._agent_url = agent_url or agent_config.trace_agent_url


### PR DESCRIPTION
## Description

Part of a series migrating all `os.environ`/`os.getenv` usage in `ddtrace/` to the centralized `env` MutableMapping from `ddtrace.internal.settings` (introduced in #17149).

**This PR covers `@DataDog/data-streams-monitoring` owned files (1 file):**
- `ddtrace/internal/datastreams/processor.py`

**Stacks on:** #17149

**Sister PRs (same migration, different owners):**
- `apm-sdk-capabilities-python`: #16724
- `apm-core-python`: #16725
- `ci-app-libraries`: #16726
- `apm-idm-python` (contrib): #16727
- `asm-python`: #17218
- `ml-observability`: #17219
- `profiling-python`: #17220

## Testing

- All ruff checks pass (`ruff check --no-cache .`)
- All ast-grep tests pass (`sg test`)
- No Python syntax errors in migrated files

## Risks

None — mechanical replacement of `os.environ` → `env` and `os.getenv(k)` → `env.get(k)`. No logic changes.

## Additional Notes

The `env` object is a `MutableMapping` wrapping `os.environ`, so it is a drop-in replacement. See #17149 for design details.