### PR TITLE
chore(tracer): disable telemetry logs for monkey errors

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -284,6 +284,7 @@ def _on_import_factory(
                 "failed to enable ddtrace support for %s: %s",
                 module,
                 str(e),
+                extra={"send_to_telemetry": False},
             )
             telemetry.telemetry_writer.add_integration(
                 module, False, PATCH_MODULES.get(module) is True, str(e), version=e.installed_version
@@ -296,6 +297,7 @@ def _on_import_factory(
                 module,
                 str(e),
                 exc_info=True,
+                extra={"send_to_telemetry": False},
             )
             telemetry.telemetry_writer.add_integration(module, False, PATCH_MODULES.get(module) is True, str(e))
             telemetry.telemetry_writer.add_count_metric(


### PR DESCRIPTION
<!-- dd-meta {"pullId":"56541014-2fe2-4408-ae74-f9cdee270226","source":"chat","resourceId":"4a040dc6-c328-4178-aa11-626752ef75cc","workflowId":"7edb35d0-3957-46a9-a5a4-036e307e7a4e","codeChangeId":"7edb35d0-3957-46a9-a5a4-036e307e7a4e","sourceType":"assistant"} -->
## Description
This change prevents two expected integration patching error logs in ddtrace/_monkey.py from being forwarded as telemetry error logs, while keeping them at error log level locally.

- Updated both `log.error(...)` calls inside `_on_import_factory` exception handlers in `ddtrace/_monkey.py` to include `extra={"send_to_telemetry": False}`.
- Preserved existing telemetry integration failure reporting via `telemetry.telemetry_writer.add_integration(...)` and `integration_errors` metric emission.
- Motivation: reduce noisy telemetry log ingestion for these handled integration patch failures without losing integration health/error signal.
