### PR TITLE
chore(aiohttp): migrate aiohttp to events API

### DIFF
--- a/benchmarks/events_api/scenario.py
+++ b/benchmarks/events_api/scenario.py
@@ -13,6 +13,7 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.core.events import Event
 from ddtrace.internal.core.events import event_field
 from ddtrace.internal.core.subscriber import Subscriber
+from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.trace import tracer
 
 
@@ -24,6 +25,7 @@ class BenchmarkTracingEvent(TracingEvent):
     span_type = "base"
     span_kind = "client"
     component = "test"
+    config = IntegrationConfig(None, "benchmark")
 
     url: str = event_field()
     method: str = event_field()

--- a/ddtrace/_trace/events.py
+++ b/ddtrace/_trace/events.py
@@ -5,11 +5,13 @@ from typing import ClassVar
 from typing import Optional
 
 from ddtrace.internal.core.events import Event
+from ddtrace.internal.core.events import event_field
 
 
 if TYPE_CHECKING:
     # DEV: potential source of circular import in the future
     from ddtrace._trace.provider import ActiveTrace
+    from ddtrace.internal.settings.integration import IntegrationConfig
 
 
 @dataclass
@@ -19,11 +21,15 @@ class TracingEvent(Event):
     """
 
     span_type: ClassVar[str]
-    span_kind: ClassVar[str]
+    span_kind: ClassVar[str] = "internal"
 
-    # These attributes are required but can be known only at instance-creation time.
+    # AIDEV-NOTE: component and config use event_field() instead of field() for Python 3.9
+    # compatibility. Subclasses may override span_name with event_field() (which adds
+    # default=None on 3.9), and since span_name is positioned before component/config,
+    # plain field() would cause "non-default argument follows default argument" errors.
     span_name: str = field(init=False)
-    component: str = field()
+    component: str = event_field()
+    config: "IntegrationConfig" = event_field()
 
     tags: dict[str, str] = field(default_factory=dict)
     # if False, handlers should not finish a span when the Context finishes.

--- a/ddtrace/_trace/subscribers/__init__.py
+++ b/ddtrace/_trace/subscribers/__init__.py
@@ -1,3 +1,4 @@
 # Import subscriber packages — triggers auto-registration via __init_subclass__
+import ddtrace._trace.subscribers.generic  # noqa: F401
 import ddtrace._trace.subscribers.http_client  # noqa: F401
 import ddtrace._trace.subscribers.llm  # noqa: F401

--- a/ddtrace/_trace/subscribers/_base.py
+++ b/ddtrace/_trace/subscribers/_base.py
@@ -10,7 +10,6 @@ from ddtrace._trace.span import Span
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
-from ddtrace.contrib.internal.trace_utils import maybe_set_service_source_tag
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.core.subscriber import ContextSubscriber
@@ -35,9 +34,6 @@ def _finish_span(
     if not span:
         return
 
-    integration_config = ctx.get_item("integration_config")
-    maybe_set_service_source_tag(span, integration_config or dict())
-
     exc_type, exc_value, exc_traceback = exc_info
     if exc_type and exc_value and exc_traceback:
         span.set_exc_info(exc_type, exc_value, exc_traceback)
@@ -59,11 +55,10 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
     event = ctx.event
 
     activate_distributed_headers = ctx.get_item("activate_distributed_headers")
-    integration_config = ctx.get_item("integration_config")
-    if integration_config and activate_distributed_headers:
+    if activate_distributed_headers:
         trace_utils.activate_distributed_headers(
             tracer,
-            int_config=integration_config,
+            int_config=ctx.event.config,
             request_headers=ctx.get_item("distributed_headers"),
             override=ctx.get_item("distributed_headers_config_override"),
         )
@@ -88,12 +83,12 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
 
     span = tracer.start_span(event.span_name, **span_kwargs)
 
-    span._meta.update({COMPONENT: event.component, SPAN_KIND: event.span_kind, **event.tags})
+    meta = {COMPONENT: event.component, SPAN_KIND: event.span_kind, **event.tags}
+    span._meta.update(meta)
 
     if event.measured:
         span._set_attribute(_SPAN_MEASURED_KEY, 1)
 
-    maybe_set_service_source_tag(span, integration_config or dict())
     ctx.span = span
 
     if config._inferred_proxy_services_enabled:
@@ -105,13 +100,13 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
 
 
 class TracingSubscriber(ContextSubscriber[TracingEventType], Generic[TracingEventType]):
-    """Subscriber that automatically manages span lifecycle for SpanContextEvent.
+    """Subscriber that automatically manages span lifecycle for TracingEvents.
 
     This base class handles span creation and finishing, so subclasses only need to
     override on_started/on_ended for their specific logic.
 
     Example:
-        class MySpanSubscriber(SpanTracingSubscriber):
+        class MySpanSubscriber(TracingSubscriber):
             event_names = ("my.span",)
 
             @classmethod

--- a/ddtrace/_trace/subscribers/generic.py
+++ b/ddtrace/_trace/subscribers/generic.py
@@ -1,0 +1,12 @@
+from ddtrace._trace.subscribers._base import TracingSubscriber
+from ddtrace.contrib._events.generic import GenericOperationEvent
+
+
+class GenericOperationSubscriber(TracingSubscriber):
+    """Subscriber for internal operation spans.
+
+    No custom logic — TracingSubscriber base handles
+    span creation and finishing.
+    """
+
+    event_names = (GenericOperationEvent.event_name,)

--- a/ddtrace/_trace/subscribers/http_client.py
+++ b/ddtrace/_trace/subscribers/http_client.py
@@ -46,6 +46,7 @@ class HttpClientTracingSubscriber(TracingSubscriber):
                 url=event.url,
                 target_host=event.target_host,
                 status_code=event.response_status_code,
+                status_msg=event.response_status_msg,
                 query=event.query,
                 request_headers=event.request_headers,
                 response_headers=event.response_headers,

--- a/ddtrace/contrib/_events/generic.py
+++ b/ddtrace/contrib/_events/generic.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from ddtrace._trace.events import TracingEvent
+from ddtrace.internal.core.events import event_field
+
+
+@dataclass
+class GenericOperationEvent(TracingEvent):
+    """Generic event for internal operations.
+
+    Use for spans that don't fit a specific category (HTTP client, database, etc.)
+    such as connection-level operations, greenlet calls, or framework hooks.
+    """
+
+    event_name = "internal.operation"
+
+    span_type = ""
+    span_kind = "internal"
+
+    span_name: str = event_field()
+    measured: bool = False

--- a/ddtrace/contrib/_events/http_client.py
+++ b/ddtrace/contrib/_events/http_client.py
@@ -9,6 +9,7 @@ from typing import Sequence
 from typing import Union
 
 from ddtrace._trace.events import TracingEvent
+from ddtrace.contrib.internal.trace_utils import ext_service
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.core.events import Event
@@ -48,6 +49,7 @@ class HttpClientBaseEvent(Event):
     request_headers: MutableMapping[str, str] = event_field()
     response_headers: Mapping[str, str] = event_field(default_factory=dict)
     response_status_code: Optional[int] = event_field(default=None)
+    response_status_msg: Optional[str] = event_field(default=None)
 
     def set_response(self, response: _HttpClientResponse) -> None:
         self.response_status_code = response.status_code
@@ -69,11 +71,17 @@ class HttpClientRequestEvent(HttpClientBaseEvent, TracingEvent):
     config: "IntegrationConfig" = event_field()
 
     response: Optional[_HttpClientResponse] = event_field(default=None)
+    split_by_domain_target: Optional[str] = event_field(default=None)
 
     def __post_init__(self):
         self.span_name = schematize_url_operation(
             self.http_operation, protocol="http", direction=SpanDirection.OUTBOUND
         )
+        if self.service is None:
+            if self.config.split_by_domain and self.split_by_domain_target:
+                self.service = self.split_by_domain_target
+            else:
+                self.service = ext_service(None, self.config)
 
     def set_response(self, response: _HttpClientResponse) -> None:
         super().set_response(response)

--- a/ddtrace/contrib/internal/aiohttp/patch.py
+++ b/ddtrace/contrib/internal/aiohttp/patch.py
@@ -1,29 +1,19 @@
-from typing import Optional
-
 import aiohttp
 import wrapt
 from yarl import URL
 
-from ddtrace.constants import SPAN_KIND
-from ddtrace.contrib.internal.trace_utils import ext_service
+from ddtrace import config
+from ddtrace.contrib._events.generic import GenericOperationEvent
+from ddtrace.contrib._events.http_client import HttpClientRequestEvent
 from ddtrace.contrib.internal.trace_utils import extract_netloc_and_query_info_from_url
-from ddtrace.contrib.internal.trace_utils import maybe_set_service_source_tag
-from ddtrace.contrib.internal.trace_utils import set_http_meta
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import wrap
-from ddtrace.ext import SpanKind
-from ddtrace.ext import SpanTypes
-from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.schema import schematize_url_operation
-from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.settings import env
-from ddtrace.internal.settings._config import config
 from ddtrace.internal.telemetry import get_config as _get_config
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import tracer
 
 
 log = get_logger(__name__)
@@ -58,70 +48,62 @@ def _supported_versions() -> dict[str, str]:
 
 
 class _WrappedConnectorClass(wrapt.ObjectProxy):
-    def __init__(self, obj):
-        super().__init__(obj)
-
     async def connect(self, req, *args, **kwargs):
-        with tracer.trace("%s.connect" % self.__class__.__name__) as span:
-            # set component tag equal to name of integration
-            span.set_tag(COMPONENT, config.aiohttp.integration_name)
-            result = await self.__wrapped__.connect(req, *args, **kwargs)
-            return result
+        with core.context_with_event(
+            GenericOperationEvent(
+                span_name="%s.connect" % self.__class__.__name__,
+                component=config.aiohttp.integration_name,
+                config=config.aiohttp,
+            ),
+        ):
+            return await self.__wrapped__.connect(req, *args, **kwargs)
 
     async def _create_connection(self, req, *args, **kwargs):
-        with tracer.trace("%s._create_connection" % self.__class__.__name__) as span:
-            # set component tag equal to name of integration
-            span.set_tag(COMPONENT, config.aiohttp.integration_name)
-            result = await self.__wrapped__._create_connection(req, *args, **kwargs)
-            return result
+        with core.context_with_event(
+            GenericOperationEvent(
+                span_name="%s._create_connection" % self.__class__.__name__,
+                component=config.aiohttp.integration_name,
+                config=config.aiohttp,
+            ),
+        ):
+            return await self.__wrapped__._create_connection(req, *args, **kwargs)
 
 
 async def _traced_clientsession_request(func, instance, args, kwargs):
-    method: str = get_argument_value(args, kwargs, 0, "method")
-    raw_url: URL = URL(str(get_argument_value(args, kwargs, 1, "url")))
-    # Resolve against base_url if present, mirroring aiohttp's internal behaviour.
-    base_url: Optional[URL] = getattr(instance, "_base_url", None)
-    url: URL = base_url.join(raw_url) if base_url is not None else raw_url
+    method = get_argument_value(args, kwargs, 0, "method")
+    raw_url = URL(str(get_argument_value(args, kwargs, 1, "url")))
+    base_url = getattr(instance, "_base_url", None)
+    url = base_url.join(raw_url) if base_url is not None else raw_url
     params = kwargs.get("params")
     headers = kwargs.get("headers") or {}
+    kwargs["headers"] = headers
 
-    with tracer.trace(
-        schematize_url_operation("aiohttp.request", protocol="http", direction=SpanDirection.OUTBOUND),
-        span_type=SpanTypes.HTTP,
-        service=ext_service(None, config.aiohttp_client),
-    ) as span:
-        if config.aiohttp_client.split_by_domain:
-            span.service = url.host
+    url_str = str(url.update_query(params) if params else url)
+    host, query = extract_netloc_and_query_info_from_url(url_str)
 
-        maybe_set_service_source_tag(span, config.aiohttp)
-
-        if config.aiohttp.distributed_tracing:
-            HTTPPropagator.inject(span.context, headers)
-            kwargs["headers"] = headers
-
-        span._set_attribute(COMPONENT, config.aiohttp_client.integration_name)
-
-        # set span.kind tag equal to type of request
-        span._set_attribute(SPAN_KIND, SpanKind.CLIENT)
-
-        # Params can be included separate of the URL so the URL has to be constructed
-        # with the passed params.
-        url_str = str(url.update_query(params) if params else url)
-        host, query = extract_netloc_and_query_info_from_url(url_str)
-        set_http_meta(
-            span,
-            config.aiohttp_client,
-            method=method,
-            url=str(url),
-            target_host=host,
-            query=query,
+    with core.context_with_event(
+        HttpClientRequestEvent(
+            http_operation="aiohttp.request",
+            component=config.aiohttp_client.integration_name,
+            config=config.aiohttp_client,
+            request_method=method,
             request_headers=headers,
-        )
-        resp: aiohttp.ClientResponse = await func(*args, **kwargs)
-        set_http_meta(
-            span, config.aiohttp_client, response_headers=resp.headers, status_code=resp.status, status_msg=resp.reason
-        )
-        return resp
+            url=str(url),
+            query=query,
+            target_host=host,
+            split_by_domain_target=str(url.host),
+            measured=False,
+        ),
+    ) as ctx:
+        resp = None
+        try:
+            resp = await func(*args, **kwargs)
+            return resp
+        finally:
+            if resp is not None:
+                ctx.event.response_status_code = resp.status
+                ctx.event.response_headers = resp.headers
+                ctx.event.response_status_msg = resp.reason
 
 
 def _traced_clientsession_init(func, instance, args, kwargs):
@@ -129,12 +111,16 @@ def _traced_clientsession_init(func, instance, args, kwargs):
     instance._connector = _WrappedConnectorClass(instance._connector)
 
 
+def _patch_client(aiohttp):
+    wrap("aiohttp", "ClientSession.__init__", _traced_clientsession_init)
+    wrap("aiohttp", "ClientSession._request", _traced_clientsession_request)
+
+
 def patch():
     if getattr(aiohttp, "_datadog_patch", False):
         return
 
-    wrap("aiohttp", "ClientSession.__init__", _traced_clientsession_init)
-    wrap("aiohttp", "ClientSession._request", _traced_clientsession_request)
+    _patch_client(aiohttp)
 
     aiohttp._datadog_patch = True
 

--- a/ddtrace/contrib/internal/anthropic/patch.py
+++ b/ddtrace/contrib/internal/anthropic/patch.py
@@ -38,6 +38,7 @@ def traced_chat_model_generate(func: Callable[..., Any], instance: Any, args: An
     integration: AnthropicIntegration = anthropic._datadog_integration
     event = LlmRequestEvent(
         component="anthropic",
+        config=integration.integration_config,
         service=int_service(None, integration.integration_config),
         resource=f"{instance.__class__.__name__}.{func.__name__}",
         provider="anthropic",
@@ -68,6 +69,7 @@ async def traced_async_chat_model_generate(func: Callable[..., Any], instance: A
     integration: AnthropicIntegration = anthropic._datadog_integration
     event = LlmRequestEvent(
         component="anthropic",
+        config=integration.integration_config,
         service=int_service(None, integration.integration_config),
         resource=f"{instance.__class__.__name__}.{func.__name__}",
         provider="anthropic",

--- a/mypy.ini
+++ b/mypy.ini
@@ -54,6 +54,9 @@ disallow_any_generics = true
 [mypy-ddtrace.contrib.*]
 ignore_errors = true
 
+[mypy-ddtrace.contrib.internal.aiohttp,ddtrace.contrib.internal.aiohttp.*]
+ignore_errors = false
+
 [mypy-ddtrace.vendor.*]
 ignore_errors = true
 

--- a/tests/internal/test_subscribers.py
+++ b/tests/internal/test_subscribers.py
@@ -13,10 +13,14 @@ from ddtrace.internal.core.events import Event
 from ddtrace.internal.core.events import event_field
 from ddtrace.internal.core.subscriber import ContextSubscriber
 from ddtrace.internal.core.subscriber import Subscriber
+from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.trace import tracer
 
 
-called = []
+_TEST_CONFIG = IntegrationConfig(None, "test")
+
+
+called: list = []
 
 
 @pytest.fixture(autouse=True)
@@ -179,7 +183,9 @@ def test_base_tracing_subscriber(test_spans):
         event_names = (TestTracingEvent.event_name,)
 
     with core.context_with_event(
-        TestTracingEvent(component="test-component", service="my-service", resource="/api/endpoint")
+        TestTracingEvent(
+            component="test-component", config=_TEST_CONFIG, service="my-service", resource="/api/endpoint"
+        )
     ):
         pass
 
@@ -209,7 +215,7 @@ def test_span_context_event_missing_required_field(test_spans):
         event_names = (TestTracingEvent.event_name,)
 
     with pytest.raises(AttributeError):
-        with core.context_with_event(TestTracingEvent(component="component")):
+        with core.context_with_event(TestTracingEvent(component="component", config=_TEST_CONFIG)):
             pass
 
     test_spans.assert_span_count(0)
@@ -239,7 +245,9 @@ def test_span_context_event_with_custom_fields(test_spans):
             span = ctx.span
             span._set_attribute("http.status_code", ctx.event.status_code)
 
-    with core.context_with_event(TestTracingEvent(my_op="op", my_arg="arg", component="comp", status_code=200)):
+    with core.context_with_event(
+        TestTracingEvent(my_op="op", my_arg="arg", component="comp", config=_TEST_CONFIG, status_code=200)
+    ):
         pass
 
     test_spans.assert_span_count(1)
@@ -284,7 +292,9 @@ def test_span_context_event_inheritance(test_spans):
             span = ctx.span
             span._set_attribute("http.method", ctx.event.method)
 
-    with core.context_with_event(HTTPClientEvent(url="http://example.com", component="http", method="GET")):
+    with core.context_with_event(
+        HTTPClientEvent(url="http://example.com", component="http", config=_TEST_CONFIG, method="GET")
+    ):
         pass
 
     test_spans.assert_span_count(1)
@@ -310,7 +320,7 @@ def test_span_context_event_with_exception(test_spans):
         event_names = (TestSpanEvent.event_name,)
 
     with pytest.raises(ValueError):
-        with core.context_with_event(TestSpanEvent(component="test_component")):
+        with core.context_with_event(TestSpanEvent(component="test_component", config=_TEST_CONFIG)):
             raise ValueError("test error")
 
     test_spans.assert_span_count(1)
@@ -339,6 +349,7 @@ def test_span_parent_child_default(test_spans):
         with core.context_with_event(
             TestSpanEvent(
                 component="test_component",
+                config=_TEST_CONFIG,
             )
         ):
             current_span = tracer.current_span()
@@ -368,6 +379,7 @@ def test_span_context_event_no_active_context_with_distributed_context(test_span
         with core.context_with_event(
             TestSpanEvent(
                 component="test_component",
+                config=_TEST_CONFIG,
                 use_active_context=False,
                 activate=False,
                 distributed_context=tracer.context_provider.active(),
@@ -398,7 +410,7 @@ def test_span_context_event_end_span_false(test_spans):
     class TestSpanSubscriber(TracingSubscriber):
         event_names = (TestSpanEvent.event_name,)
 
-    with core.context_with_event(TestSpanEvent(component="test_component")):
+    with core.context_with_event(TestSpanEvent(component="test_component", config=_TEST_CONFIG)):
         pass
 
     # Span should be started but not finished

--- a/tests/tracer/test_tracing_event.py
+++ b/tests/tracer/test_tracing_event.py
@@ -10,6 +10,10 @@ from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.core import event_hub
 from ddtrace.internal.core.events import event_field
+from ddtrace.internal.settings.integration import IntegrationConfig
+
+
+_TEST_CONFIG = IntegrationConfig(None, "test")
 
 
 ExcInfoType = tuple[Optional[type], Optional[BaseException], Optional[TracebackType]]
@@ -54,7 +58,9 @@ def test_tracing_event_can_create_and_finish_span(test_spans):
 
     try:
         with core.context_with_event(
-            TestTracingEvent(resource="test.resource", service="svc", component="comp", my_span_name="name")
+            TestTracingEvent(
+                resource="test.resource", service="svc", component="comp", config=_TEST_CONFIG, my_span_name="name"
+            )
         ):
             pass
     finally:


### PR DESCRIPTION
Generated by dd-apm for `aiohttp` in `dd_trace_py`.

Migrates aiohttp to use the new events api.

🤖 Generated with dd-apm toolkit