### PR TITLE
fix(llmobs): ensure no json decoding errors in anthropic streamed tool call chunks

### DIFF
--- a/ddtrace/contrib/internal/anthropic/_streaming.py
+++ b/ddtrace/contrib/internal/anthropic/_streaming.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import anthropic
@@ -8,6 +7,7 @@ from ddtrace.llmobs._integrations.base_stream_handler import AsyncStreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import StreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._utils import _get_attr
+from ddtrace.llmobs._utils import safe_load_json
 
 
 log = get_logger(__name__)
@@ -201,7 +201,7 @@ def _on_content_block_stop_chunk(chunk, message):
     content_type = _get_attr(message["content"][-1], "type", "")
     if "tool_use" in content_type:
         input_json = _get_attr(message["content"][-1], "input", "{}")
-        message["content"][-1]["input"] = json.loads(input_json)
+        message["content"][-1]["input"] = safe_load_json(input_json) if input_json else {}
     return message
 
 

--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from typing import Iterable
 from typing import Optional
@@ -26,6 +25,7 @@ from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import update_proxy_workflow_input_output_value
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
+from ddtrace.llmobs._utils import safe_load_json
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import ToolCall
 from ddtrace.llmobs.types import ToolDefinition
@@ -125,22 +125,23 @@ class AnthropicIntegration(BaseLLMIntegration):
 
             elif isinstance(content, list):
                 for block in content:
-                    if _get_attr(block, "type", None) == "text":
+                    content_type = _get_attr(block, "type", None)
+                    if content_type == "text":
                         input_messages.append(Message(content=str(_get_attr(block, "text", "")), role=str(role)))
 
-                    elif _get_attr(block, "type", None) == "image":
+                    elif content_type == "image":
                         # Store a placeholder for potentially enormous binary image data.
                         input_messages.append(Message(content="([IMAGE DETECTED])", role=str(role)))
 
-                    elif _get_attr(block, "type", None) == "thinking":
+                    elif content_type == "thinking":
                         thinking_text = _get_attr(block, "thinking", "")
                         input_messages.append(Message(content=str(thinking_text), role="reasoning"))
 
-                    elif "tool_use" in _get_attr(block, "type", None):
+                    elif "tool_use" in (content_type or ""):
                         text = _get_attr(block, "text", None)
-                        input_data = _get_attr(block, "input", "")
+                        input_data = _get_attr(block, "input", {})
                         if isinstance(input_data, str):
-                            input_data = json.loads(input_data)
+                            input_data = safe_load_json(input_data)
                         tool_call_info = ToolCall(
                             name=str(_get_attr(block, "name", "")),
                             arguments=input_data,
@@ -151,7 +152,7 @@ class AnthropicIntegration(BaseLLMIntegration):
                             text = ""
                         input_messages.append(Message(content=str(text), role=str(role), tool_calls=[tool_call_info]))
 
-                    elif "tool_result" in _get_attr(block, "type", None):
+                    elif "tool_result" in (content_type or ""):
                         content = _get_attr(block, "content", None)
                         formatted_content = self._format_tool_result_content(content)
                         tool_result_info = ToolResult(
@@ -192,24 +193,25 @@ class AnthropicIntegration(BaseLLMIntegration):
 
         elif isinstance(content, list):
             for completion in content:
-                if _get_attr(completion, "type", None) == "thinking":
+                completion_type = _get_attr(completion, "type", "") or ""
+                if completion_type == "thinking":
                     thinking_text = _get_attr(completion, "thinking", "")
                     output_messages.append(Message(content=str(thinking_text), role="reasoning"))
                     continue
                 text = _get_attr(completion, "text", None)
                 output_message = Message(content=str(text) if text else "", role=str(role))
-                if "tool_use" in _get_attr(completion, "type", None):
-                    input_data = _get_attr(completion, "input", "")
+                if "tool_use" in completion_type:
+                    input_data = _get_attr(completion, "input", {})
                     if isinstance(input_data, str):
-                        input_data = json.loads(input_data)
+                        input_data = safe_load_json(input_data)
                     tool_call_info = ToolCall(
                         name=str(_get_attr(completion, "name", "")),
                         arguments=input_data,
                         tool_id=str(_get_attr(completion, "id", "")),
-                        type=str(_get_attr(completion, "type", "")),
+                        type=str(completion_type),
                     )
                     output_message["tool_calls"] = [tool_call_info]
-                if "tool_result" in _get_attr(completion, "type", None):
+                if "tool_result" in completion_type:
                     result = _get_attr(completion, "content", {})
                     if hasattr(result, "model_dump") and callable(result.model_dump):
                         result = result.model_dump()

--- a/releasenotes/notes/fix-anthropic-partial-json-tool-use-e13fa00764dc2feb.yaml
+++ b/releasenotes/notes/fix-anthropic-partial-json-tool-use-e13fa00764dc2feb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix avoids potential ``JSONDecodeError`` when parsing tool call arguments
+    from streamed Anthropic response message chunks.


### PR DESCRIPTION
## Description
Make sure we safely json.loads() incoming anthropic streamed tool call message chunks. If they are ever not valid JSON, this breaks our Anthropic integration and prevents LLMObs spans from being emitted.

I am having trouble coming up with a regression test but this is a safe enough fix that I don't believe we need a test specifically here.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
