### PR TITLE
fix(internal): preserve schedule on fork restart

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -455,8 +455,13 @@ PeriodicThread__on_shutdown(PeriodicThread* self)
 }
 
 // ----------------------------------------------------------------------------
+// Internal helper: launches the thread after ensuring preconditions.
+// If reset_next_call_time is true (normal start), _next_call_time is initialised
+// to now + interval before starting; otherwise it is left untouched (important
+// for cases where the thread is being restarted after a fork to preserve the
+// existing next trigger time).
 static PyObject*
-PeriodicThread_start(PeriodicThread* self, PyObject* Py_UNUSED(args))
+_PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false)
 {
     if (self->_thread != nullptr) {
         PyErr_SetString(PyExc_RuntimeError, "Thread already started");
@@ -466,10 +471,9 @@ PeriodicThread_start(PeriodicThread* self, PyObject* Py_UNUSED(args))
     if (self->_stopping)
         Py_RETURN_NONE;
 
-    // Initialize the next call time to the current time plus the interval.
-    // This ensures that the first call happens after the specified interval.
-    self->_next_call_time =
-      std::chrono::steady_clock::now() + std::chrono::milliseconds((long long)(self->interval * 1000));
+    if (reset_next_call_time)
+        self->_next_call_time =
+          std::chrono::steady_clock::now() + std::chrono::milliseconds((long long)(self->interval * 1000));
 
     // Start the thread
     self->_thread = std::make_unique<std::thread>([self]() {
@@ -571,6 +575,13 @@ PeriodicThread_start(PeriodicThread* self, PyObject* Py_UNUSED(args))
     }
 
     Py_RETURN_NONE;
+}
+
+// ----------------------------------------------------------------------------
+static PyObject*
+PeriodicThread_start(PeriodicThread* self, PyObject* Py_UNUSED(args))
+{
+    return _PeriodicThread_do_start(self, true);
 }
 
 // ----------------------------------------------------------------------------
@@ -714,7 +725,11 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
         self->_stopped->clear();
         self->_served->clear();
 
-        PeriodicThread_start(self, NULL);
+        // Use _PeriodicThread_do_start instead of PeriodicThread_start to
+        // preserve _next_call_time from before the fork. This ensures that
+        // a restarted thread fires at the same time it would have without
+        // the fork, rather than being pushed back by a full interval.
+        _PeriodicThread_do_start(self);
     } else {
         // No restart: the common cleanup above is sufficient for fork-specific
         // state. Two additional invariants are preserved intentionally:

--- a/releasenotes/notes/internal-periodic-thread-do-not-reset-after-fork-ff9e801123cc3c28.yaml
+++ b/releasenotes/notes/internal-periodic-thread-do-not-reset-after-fork-ff9e801123cc3c28.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    internal: A bug preventing certain periodic threads of ``ddtrace`` (like the profile uploader) from
+    triggering in fork-heavy applications has been fixed.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f1fb304a-c8a9-462c-aa3a-f14b66a59b15","source":"chat","resourceId":"4ba2b169-aa4a-454f-8f2a-e0d38521a0ee","workflowId":"3a82c015-f41f-4317-bfff-925b91954561","codeChangeId":"3a82c015-f41f-4317-bfff-925b91954561","sourceType":"chat"} -->
## Description

This PR fixes a bug in the `PeriodicThread` implementation that prevents Periodic Threads from ever firing in fork-heavy applications.  
Upon fork, Periodic Threads are stopped and restarted post fork (this both in the parent and the child processes -- the only difference being that the parent has a 100ms cooldown before restarting Periodic Threads in case the process is forking in a loop). 

Before this PR,  when a `PeriodicThread` was restarted in the parent process, `_after_fork` called  `PeriodicThread_start`, which always reset `_next_call_time` to `now + interval`. In workloads that fork frequently (more than once per minute in the case at hand), ever restart pushed the next scheduled execution back by the full interval. For threads with a long interval such as the Profiling Uploader (60s), this could cause the thread to never actually fire.


The proposed and implemented fix is to split the start function into a public and a private one; the public one _does_ set the next execution to `now + interval` before calling the private one; the private function takes care of everything else but does not touch the next execution time. 