### PR TITLE
fix: capture flask template name on render

### DIFF
--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -32,6 +32,7 @@ from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.importlib import func_name
 from ddtrace.internal.utils.version import parse_version
@@ -477,11 +478,14 @@ def patched_render(wrapped, instance, args, kwargs):
     if not is_tracing_enabled():
         return wrapped(*args, **kwargs)
 
-    def _wrap(template, context, app):
-        core.dispatch("flask.render", (template, config.flask))
-        return wrapped(*args, **kwargs)
+    template_position = 1 if flask_version >= (2, 2, 0) else 0
+    try:
+        template = get_argument_value(args, kwargs, template_position, "template")
+    except ArgumentError:
+        template = None
 
-    return _wrap(*args, **kwargs)
+    core.dispatch("flask.render", (template, config.flask))
+    return wrapped(*args, **kwargs)
 
 
 def patched__register_error_handler(wrapped, instance, args, kwargs):

--- a/releasenotes/notes/flask-fix-template-parameter-capture-4b877496ca810226.yaml
+++ b/releasenotes/notes/flask-fix-template-parameter-capture-4b877496ca810226.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    flask: The Flask integration now properly captures the ``template`` parameter value
+    for all Flask versions.

--- a/tests/contrib/flask/test_template.py
+++ b/tests/contrib/flask/test_template.py
@@ -1,6 +1,5 @@
 import flask
 
-from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.contrib.internal.flask.patch import unpatch
 
 from . import BaseFlaskTestCase
@@ -49,8 +48,8 @@ class FlaskTemplateTestCase(BaseFlaskTestCase):
 
         self.assertEqual(spans[0].service, "tests.contrib.flask")
         self.assertEqual(spans[0].name, "flask.render_template")
-        resource = "tests.contrib.flask" if flask_version >= (2, 2, 0) else "test.html"
-        self.assertEqual(spans[0].resource, resource)  # FIXME: should always be 'test.html'?
+        resource = "test.html"
+        self.assertEqual(spans[0].resource, resource)
         self.assertEqual(
             set(spans[0].get_tags().keys()),
             set(
@@ -65,7 +64,7 @@ class FlaskTemplateTestCase(BaseFlaskTestCase):
                 ]
             ),
         )
-        self.assertEqual(spans[0].get_tag("flask.template_name"), resource)  # FIXME: should always be 'test.html'?
+        self.assertEqual(spans[0].get_tag("flask.template_name"), resource)
         self.assertEqual(spans[1].name, "flask.do_teardown_request")
         self.assertEqual(spans[2].name, "flask.do_teardown_appcontext")
 
@@ -102,8 +101,8 @@ class FlaskTemplateTestCase(BaseFlaskTestCase):
 
         self.assertEqual(spans[0].service, "tests.contrib.flask")
         self.assertEqual(spans[0].name, "flask.render_template_string")
-        resource = "tests.contrib.flask" if flask_version >= (2, 2, 0) else "<memory>"
-        self.assertEqual(spans[0].resource, resource)  # FIXME: should always be '<memory>'?
+        resource = "<memory>"
+        self.assertEqual(spans[0].resource, resource)
         self.assertEqual(
             set(spans[0].get_tags().keys()),
             set(
@@ -118,7 +117,7 @@ class FlaskTemplateTestCase(BaseFlaskTestCase):
                 ]
             ),
         )
-        self.assertEqual(spans[0].get_tag("flask.template_name"), resource)  # FIXME: should always be '<memory>'?
+        self.assertEqual(spans[0].get_tag("flask.template_name"), resource)
         self.assertEqual(spans[1].name, "flask.do_teardown_request")
         self.assertEqual(spans[2].name, "flask.do_teardown_appcontext")
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"77f4bd9f-0204-43f1-bbae-7fd1caaaefa6","source":"chat","resourceId":"acbc2ec1-b0c8-437e-8c23-aaea044e0c5b","workflowId":"d05b5ee6-5f72-44ab-944b-371a92ad15df","codeChangeId":"d05b5ee6-5f72-44ab-944b-371a92ad15df","sourceType":"chat"} -->
## Description

This updates the Flask tracing to properly capture the `template` argument value regardless of the Flask version, and regardless of whether it was passed with a positional or keyword argument.