### PR TITLE
ci: cache `pyenv` in `lib_injection_tests`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -506,18 +506,30 @@ lib_injection_tests:
   stage: tests
   tags: [ "arch:amd64" ]
   image: registry.ddbuild.io/images/mirror/ubuntu:25.04
+  cache:
+    key: "v2-lib-injection-pyenv-v2.6.17-${PYTHON}-${CURRENT_YEAR}-${CURRENT_MONTH}"
+    paths:
+      - .cache/pyenv/
+    when: always
   parallel:
     matrix:
       - PYTHON: [ "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev" ]
   script:
-    - export PYENV_ROOT="${HOME}/.pyenv"
+    - export PYENV_ROOT="${CI_PROJECT_DIR}/.cache/pyenv"
     - export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
     - apt-get update && apt install build-essential zlib1g-dev libssl-dev curl git -y
-    - for i in 1 2 3; do PYENV_GIT_TAG=v2.6.17 curl -sSf https://pyenv.run | bash && break; echo "pyenv install attempt $i failed, retrying..."; sleep 5; [ "$i" -eq 3 ] && { echo "Failed to install pyenv after 3 attempts"; exit 1; }; done
+    - |
+      if [ ! -x "${PYENV_ROOT}/bin/pyenv" ]; then
+        for i in 1 2 3; do PYENV_GIT_TAG=v2.6.17 curl -sSf https://pyenv.run | bash && break; echo "pyenv install attempt $i failed, retrying..."; sleep 5; [ "$i" -eq 3 ] && { echo "Failed to install pyenv after 3 attempts"; exit 1; }; done
+      fi
     - pyenv --version
-    - pyenv install ${PYTHON} && pyenv global ${PYTHON}
-    - python --version
-    - python lib-injection/sources/sitecustomize.py
+    - |
+      if ! pyenv prefix ${PYTHON} &>/dev/null; then
+        pyenv install ${PYTHON}
+      fi
+    - pyenv global ${PYTHON}
+    - pyenv exec python${PYTHON%%.*} --version
+    - pyenv exec python${PYTHON%%.*} lib-injection/sources/sitecustomize.py
 
 # Profiling native tests with sanitizers
 # Uses dedicated profiling-native image with Python, Rust, valgrind, and clang pre-installed


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c9a8c08a-805e-4e99-97c7-35e4d95f40e0","source":"chat","resourceId":"a4083762-d870-49c5-94fe-b973fe21afa9","workflowId":"ac0100b7-2d21-4237-b9ad-431c6d8dd69d","codeChangeId":"ac0100b7-2d21-4237-b9ad-431c6d8dd69d","sourceType":"chat"} -->
## What is this PR?

`lib_injection_tests` runs 12 parallel jobs (one per Python version) on every commit. Each job downloads and compiles pyenv, then compiles a Python version from source, taking 5–20 minutes per job even when nothing `lib-injection-related` changed.

This adds a per-Python-version GitLab cache for `pyenv` and the compiled Python installation so that subsequent runs skip the expensive download/compile step.

**Note** Currently, the cache is invalidated every first of the month (so that we pick up whatever latest version of Python `pyenv` has at this point) -- we may want to change this to more often? 🤷 