### PR TITLE
chore(profiling): fix fuzzer-found undefined behaviours

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -132,8 +132,9 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
     // In Python 3.13+, instr_ptr points to the current instruction (not past it),
     // so _PyInterpreterFrame_LASTI = instr_ptr - _PyCode_CODE(code) with no -1.
     _Py_CODEUNIT* code_units = reinterpret_cast<_Py_CODEUNIT*>(code_obj);
-    int code_offset = offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    const int lasti = static_cast<int>(frame_addr->instr_ptr - code_units) - code_offset;
+    const int lasti =
+      static_cast<int>((frame_addr->instr_ptr - code_units) -
+                       static_cast<ptrdiff_t>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT)));
     auto maybe_frame = Frame::get(echion, code_obj, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
@@ -146,8 +147,8 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
     }
 
     const int lasti =
-      static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code)))) -
-      static_cast<int>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT));
+      static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>(frame_addr->f_code)) -
+                       static_cast<ptrdiff_t>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT)));
     auto maybe_frame = Frame::get(echion, frame_addr->f_code, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
@@ -196,8 +197,9 @@ Frame::get(EchionSampler& echion, PyCodeObject* code_addr, int lasti)
     // We read only the single int field to keep the cost of cache hits low.
     int firstlineno;
     {
-        auto* firstlineno_addr = reinterpret_cast<decltype(PyCodeObject::co_firstlineno)*>(
-          reinterpret_cast<char*>(code_addr) + offsetof(PyCodeObject, co_firstlineno));
+        auto* firstlineno_addr =
+          reinterpret_cast<decltype(PyCodeObject::co_firstlineno)*>( // NOLINT(performance-no-int-to-ptr)
+            reinterpret_cast<uintptr_t>(code_addr) + offsetof(PyCodeObject, co_firstlineno));
         if (copy_type(firstlineno_addr, firstlineno)) {
             return std::ref(INVALID_FRAME);
         }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b8e0aba0-866b-4142-98b5-d2c7aa4057f4","source":"chat","resourceId":"250f1fc2-bf72-4d91-8d40-fbc1d03d0091","workflowId":"7e1c0836-a6e4-4f60-848c-1a92b20ca37c","codeChangeId":"7e1c0836-a6e4-4f60-848c-1a92b20ca37c","sourceType":"chat"} -->

## Description

https://datadoghq.atlassian.net/browse/PROF-13838

This fixes two sets of errors reported by UBSan by fuzzing (`fuzz_echion_frame_read` job) in `frame.cc`.

**Note** Although the two reported bugs are valid (they could happen in theory since we don't control / can't ensure the memory we copy "makes sense") it's very unlikely this ever caused a bug in any customer's service (it would require successfully copying some memory that would be partially correct and partially corrupt). We should still fix it though, if only to make sure we can continue fuzzing different things (otherwise we'll keep hitting this error while fuzzing).  That is the reason why I decided not to attach a changelog entry.

#### Signed integer overflow in `lasti` computation

The original code computed `lasti` by casting a `ptrdiff_t` pointer-subtraction result to `int` and then subtracting another `int`:

```cpp
int instr_offset = static_cast<int>(frame_addr->instr_ptr - code_units);  // near INT_MIN with fuzz input
int code_offset = offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
const int lasti = instr_offset - code_offset;  // UBSan: -2147483632 - 104 overflows int
```

The subtraction must stay in `ptrdiff_t` space and only be cast to `int` at the very end. This same pattern existed in the Python 3.14 (`>=0x030e0000`), 3.13 (`>=0x030d0000`), and 3.11/3.12 (`>=0x030b0000`) branches — all three are fixed.

#### Pointer index expression overflow in `firstlineno_addr` computation

The original code used `char*` pointer arithmetic which is UB when the base pointer is near the top of the address space (e.g., `0xfffffffffffffffe`):

```cpp
reinterpret_cast<char*>(code_addr) + offsetof(PyCodeObject, co_firstlineno)  // pointer overflow
```

Fixed by using `uintptr_t` integer arithmetic (which wraps without UB) before converting back to a typed pointer.

