### PR TITLE
fix(tracing): incorrectly set client side stats tags (#17133) [backport 4.6]

### DIFF
--- a/releasenotes/notes/fix-libdd-css-missing-tags-aa8ce1c17a692d5d.yaml
+++ b/releasenotes/notes/fix-libdd-css-missing-tags-aa8ce1c17a692d5d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where client side stats tags were not properly set.

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,7 +169,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -206,15 +195,15 @@ checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.5"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95824d1dd4f20b4a4dfa63b72954e81914a718357231468180b30314e85057fa"
+checksum = "48ceccc54b9c3e60e5f36b0498908c8c0f87387229cb0e0e5d65a074e00a8ba4"
 dependencies = [
- "cpp_demangle 0.4.5",
+ "cpp_demangle",
  "gimli 0.32.3",
  "libc",
  "memmap2",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "rustc-demangle",
 ]
 
@@ -238,8 +227,8 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "28.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "28.0.4"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "cbindgen",
  "serde",
@@ -263,15 +252,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bzip2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
-dependencies = [
- "libbz2-rs-sys",
-]
 
 [[package]]
 name = "cadence"
@@ -343,16 +323,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -428,12 +398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,15 +412,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpp_demangle"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "cpp_demangle"
@@ -578,7 +533,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "chrono",
  "derive_more",
@@ -598,7 +553,7 @@ dependencies = [
 [[package]]
 name = "datadog-remote-config"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "base64",
@@ -622,8 +577,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "28.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "28.0.4"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -675,12 +630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate64"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +679,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -855,7 +803,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "zlib-rs",
 ]
 
@@ -1138,15 +1086,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,15 +1356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,12 +1459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libbz2-rs-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,7 +1467,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1552,8 +1476,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1591,8 +1515,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "28.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "28.0.4"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1606,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1637,8 +1561,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1666,16 +1590,16 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "1.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "1.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1688,13 +1612,16 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
+ "libdd-trace-protobuf",
  "memfd",
+ "prost",
  "rand 0.8.5",
  "rmp",
  "rmp-serde",
+ "rustix",
  "serde",
  "serde_yaml",
 ]
@@ -1713,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1738,6 +1665,8 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rustc-hash 1.1.0",
+ "rustls",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "target-triple",
@@ -1750,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1771,15 +1700,15 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "libdd-telemetry"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "base64",
@@ -1803,15 +1732,15 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "1.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1819,8 +1748,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "1.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "prost",
  "serde",
@@ -1829,8 +1758,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "1.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "hashbrown 0.15.5",
  "libdd-ddsketch",
@@ -1840,8 +1769,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.1#647c8ff924070d4e79494ec852d312ff0301fd8a"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v28.0.4#c5f34cfaf4cf95dad4aa4ec1b6df99081280909d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1863,26 +1792,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "liblzma"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
-dependencies = [
- "liblzma-sys",
-]
-
-[[package]]
-name = "liblzma-sys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -2000,6 +1909,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2351,16 +2270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,12 +2336,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppmd-rust"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -3187,17 +3090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,7 +3285,7 @@ version = "12.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
 dependencies = [
- "cpp_demangle 0.5.1",
+ "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
  "symbolic-common",
@@ -4711,20 +4603,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"
@@ -4765,25 +4643,12 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
- "aes",
  "arbitrary",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
- "deflate64",
  "flate2",
- "getrandom 0.3.4",
- "hmac",
  "indexmap 2.13.0",
- "liblzma",
  "memchr",
- "pbkdf2",
- "ppmd-rust",
- "sha1",
- "time",
- "zeroize",
  "zopfli",
- "zstd",
 ]
 
 [[package]]

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -20,26 +20,26 @@ libc = { version = "0.2", optional = true }
 rand = "0.9"
 serde = "1.0"
 serde_json = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1", version = "1.0.0", features = ["pyo3"] }
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
-datadog-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4", version = "1.0.0", features = ["pyo3"] }
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
+datadog-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
 libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v27.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1", optional = true, features = [
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4" }
 pyo3 = { version = "0.27", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.27", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.27"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.1", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v28.0.4", features = [
     "cbindgen",
 ] }
 


### PR DESCRIPTION
## Description

Backport of https://github.com/DataDog/dd-trace-py/pull/17133 to 4.6


Libdatadog fix: https://github.com/DataDog/libdatadog/pull/1790

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
