### PR TITLE
chore: disable telemetry for sampler config error logs

### DIFF
--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -145,11 +145,21 @@ class DatadogSampler:
             json_rules = json.loads(rules)
             for rule in json_rules:
                 if "sample_rate" not in rule:
-                    log.error("No sample_rate provided for sampling rule: %s. Skipping.", rule)
+                    log.error(
+                        "No sample_rate provided for sampling rule: %s. Skipping.",
+                        rule,
+                        extra={"send_to_telemetry": False},
+                    )
                     continue
                 sampling_rules.append(SamplingRule(**rule))
         except (JSONDecodeError, ValueError):
-            log.error("Failed to apply all sampling rules. Rules=%s, Applied=%s", rules, sampling_rules, exc_info=True)
+            log.error(
+                "Failed to apply all sampling rules. Rules=%s, Applied=%s",
+                rules,
+                sampling_rules,
+                exc_info=True,
+                extra={"send_to_telemetry": False},
+            )
         self.rules = sorted(sampling_rules, key=lambda rule: PROVENANCE_ORDER.index(rule.provenance))
 
     def sample(self, span: Span) -> bool:

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -369,6 +369,7 @@ def test_sampling_rule_init_via_env():
             mock.call(
                 "No sample_rate provided for sampling rule: %s. Skipping.",
                 {"service": "xyz", "name": "abc"},
+                extra={"send_to_telemetry": False},
             )
         ]
     )
@@ -383,6 +384,7 @@ def test_sampling_rule_init_via_env():
                 '["sample_rate":1.0,"service":"xyz","name":"abc"]',
                 [],
                 exc_info=True,
+                extra={"send_to_telemetry": False},
             )
         ]
     )
@@ -400,6 +402,7 @@ def test_sampling_rule_init_via_env():
             mock.call(
                 "No sample_rate provided for sampling rule: %s. Skipping.",
                 {"service": "my-service", "name": "my-name"},
+                extra={"send_to_telemetry": False},
             )
         ]
     )


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dbeb42ec-2633-474f-981e-b87d3cbd261c","source":"chat","resourceId":"941b48c5-8172-4e3c-bf95-fea71089ddd7","workflowId":"378ee4b4-2dcd-420e-b546-eb6c8934806d","codeChangeId":"378ee4b4-2dcd-420e-b546-eb6c8934806d","sourceType":"assistant"} -->
## Description

The two logs here are fairly in-actionable on their own when collected as a telemetry error log. (the offending rules are not included in the telemetry log).

Removing from telemetry for now. We could consider a telemetry metric or some other metadata if we are able to expose it to customers to let me know we detected a bad sampling configuration. For now they will only have the error log in their application.