### PR TITLE
ci(llmobs): increase number of google_adk jobs

### DIFF
--- a/tests/llmobs/suitespec.yml
+++ b/tests/llmobs/suitespec.yml
@@ -57,7 +57,7 @@ suites:
       - tests/snapshots/tests.contrib.claude_agent_sdk.*
     snapshot: true
   google_adk:
-    parallelism: 3
+    venvs_per_job: 2
     paths:
       - '@bootstrap'
       - '@core'


### PR DESCRIPTION
## Description

Currently one of the longest running single jobs we have in CI at ~15-16 minutes p75.

There are 12 venvs, so adjusting this to go from 3 to 6 jobs.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
