### PR TITLE
ci: download serverless build for serverless system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -391,9 +391,42 @@ jobs:
           name: logs_parametric
           path: artifact.tar.gz
 
+  download-serverless-s3-wheels:
+    needs: [should-run]
+    if: needs.should-run.outputs.run == 'true' && (github.event_name != 'schedule' || github.event.repository.fork == false)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve commit SHA
+        id: resolve-sha
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download wheels from S3
+        run: |
+          bash scripts/download-s3-wheels.sh \
+            "${{ steps.resolve-sha.outputs.sha }}" \
+            ./wheels \
+            serverless
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: serverless-wheels
+          path: ./wheels/*.whl
+          if-no-files-found: error
+
   serverless-system-tests-build-layer:
     runs-on: ubuntu-latest
-    needs: [download-s3-wheels]
+    needs: [download-serverless-s3-wheels]
     steps:
       - name: Checkout datadog-lambda-python
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -404,12 +437,12 @@ jobs:
       - name: Download wheel to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wheels-manylinux_x86_64
+          name: serverless-wheels
           path: artifacts/
 
       - name: Build datadog_lambda layer
         run: |
-          wheel_path=$(find ./artifacts -name "*cp313*manylinux*.whl" | head -n 1)
+          wheel_path=$(find ./artifacts -name "*cp313*manylinux2014_x86_64.whl" | head -n 1)
           ARCH=amd64 PYTHON_VERSION=3.13 DD_TRACE_WHEEL=$wheel_path ./scripts/build_layers.sh
 
       - name: Upload layer artifact

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -197,15 +197,15 @@ variables:
 "upload serverless":
   extends: .upload_wheels_base
   needs:
-    - job: "build linux"
+    - job: "build linux serverless"
       artifacts: true
       parallel:
         matrix:
           - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp311-cp311"
+            PYTHON_TAG: ["cp311-cp311", "cp313-cp313"]
             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
           - ARCH_TAG: "arm64"
-            PYTHON_TAG: "cp311-cp311"
+            PYTHON_TAG: ["cp311-cp311", "cp313-cp313"]
             IMAGE_TAG: "v85383414-751efc0-manylinux2014_aarch64"
     - job: "package version"
   variables:


### PR DESCRIPTION
## Description

Following the merging of https://github.com/DataDog/datadog-lambda-python/pull/762, we should start using the serverless build for the serverless-system-tests.

Otherwise this causes errors like: https://github.com/DataDog/dd-trace-py/actions/runs/23892977918/job/69671527213?pr=17272#step:4:197

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
