### PR TITLE
chore(profiling): fix fuzzer-found heap buffer overflow

### DIFF
--- a/ddtrace/internal/datadog/profiling/profiling_helpers/linetable_parser.h
+++ b/ddtrace/internal/datadog/profiling/profiling_helpers/linetable_parser.h
@@ -109,6 +109,13 @@ parse_linetable(const unsigned char* table, Py_ssize_t len, int lasti, int first
     /* Python 3.10: PEP 626 line table in co_linetable.
      * Pairs of (sdelta, ldelta) bytes.  lasti is in codeunit units;
      * the table bytecode deltas are in byte units, so convert. */
+
+    /* Check for even-ness as we expect pairs of (sdelta, ldelta) bytes.
+     * This precondition is not guaranteed when using data copied from
+     * the process and not "actual" code objects. */
+    if (len % 2 != 0)
+        return 0;
+
     lasti *= static_cast<int>(sizeof(_Py_CODEUNIT));
     for (Py_ssize_t i = 0, bc = 0; i < len; i++) {
         int sdelta = table[i++];
@@ -128,6 +135,13 @@ parse_linetable(const unsigned char* table, Py_ssize_t len, int lasti, int first
 #else
     /* Python 3.9: co_lnotab format — pairs of (bytecode_delta, line_delta)
      * unsigned bytes.  lasti is a byte offset. */
+
+    /* Check for even-ness as we expect pairs of (bytecode_delta, line_delta) bytes.
+     * This precondition is not guaranteed when using data copied from
+     * the process and not "actual" code objects. */
+    if (len % 2 != 0)
+        return 0;
+
     for (Py_ssize_t i = 0, bc = 0; i < len; i++) {
         bc += table[i++];
         if (bc > lasti)


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13838

This fixes a heap buffer overflow reported by the fuzzer where we expect buffer sizes to be even (because that's what the PEP prescribes) but those data structures/buffers come from copied process memory (so we can't assume anything).

**Note** this bug is very unlikely to occur in real life as it would require us to successfully copy memory from the Python process _and_ copy partially valid (for precondition checks) and invalid (for the actual contents) data. It is not impossible, but it's probably pretty rare (we've never seen crash logs for that) so I'm not adding a changelog entry. 