### PR TITLE
chore(mysql): revamp integration to repo standard

### DIFF
--- a/ddtrace/contrib/internal/mysql/patch.py
+++ b/ddtrace/contrib/internal/mysql/patch.py
@@ -1,17 +1,17 @@
 import mysql.connector
-import wrapt
+from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
 from ddtrace.ext import db
 from ddtrace.ext import net
-from ddtrace.internal.compat import is_wrapted
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 
 
@@ -44,28 +44,6 @@ CONN_ATTR_BY_TAG = {
 }
 
 
-def patch():
-    wrapt.wrap_function_wrapper("mysql.connector", "connect", _connect)
-    # `Connect` is an alias for `connect`, patch it too
-    if hasattr(mysql.connector, "Connect"):
-        mysql.connector.Connect = mysql.connector.connect
-
-    if asm_config._iast_enabled:
-        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-        from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
-
-        _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
-    mysql.connector._datadog_patch = True
-
-
-def unpatch():
-    if is_wrapted(mysql.connector.connect):
-        mysql.connector.connect = mysql.connector.connect.__wrapped__
-        if hasattr(mysql.connector, "Connect"):
-            mysql.connector.Connect = mysql.connector.connect
-    mysql.connector._datadog_patch = False
-
-
 def _connect(func, instance, args, kwargs):
     conn = func(*args, **kwargs)
     return patch_conn(conn)
@@ -77,3 +55,25 @@ def patch_conn(conn):
     }
     tags[db.SYSTEM] = "mysql"
     return TracedConnection(conn, cfg=config.mysql, db_tags=tags)
+
+
+def patch():
+    if getattr(mysql, "_datadog_patch", False):
+        return
+
+    mysql._datadog_patch = True
+    _w("mysql.connector", "connect", _connect)
+
+    if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+
+        _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
+
+
+def unpatch():
+    if not getattr(mysql, "_datadog_patch", False):
+        return
+
+    mysql._datadog_patch = False
+    _u(mysql.connector, "connect")


### PR DESCRIPTION
I'm going to patch a new function for mysql in a follow up PR.

The integration was not following the standard monkey-patch wise. This small PR resolves that.

Also i put patch and unpatch at the end of the file for code readibility.