### PR TITLE
ci(profiling): make `profiling_native` `retry: 2`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -556,6 +556,7 @@ lib_injection_tests:
 # build files (CMakeLists.txt, .sh, .supp) are listed separately.
 profiling_native:
   extends: .profiling_native_base
+  retry: 2
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "main"


### PR DESCRIPTION
## Description

This is **temporary**. Currently this would make people's CIs fail, which isn't a problem for most PRs (because those tests only run when Profiling files are changed) but is a problem on `main`. We're in the process of fixing this, but until it's fixed and gone, let's not make pipelines fail for nothing. 