### PR TITLE
docs(profiling): add CPython version upgrade runbook and 3.15 analysis

### DIFF
--- a/.claude/skills/compare-cpython-versions/SKILL.md
+++ b/.claude/skills/compare-cpython-versions/SKILL.md
@@ -94,6 +94,45 @@ For each header/struct, look for:
 - Headers split or merged
 - New headers introduced
 
+**Enum Value Changes (easy to miss, high impact):**
+
+Enum renumbering is particularly dangerous because the code compiles cleanly but silently
+misclassifies values at runtime. Always explicitly check every enum echion uses:
+
+- `PyFrameState` (in `pycore_frame.h`) — renumbered completely between 3.14 and 3.15:
+  `FRAME_EXECUTING` changed from `0` to `4`, `FRAME_CREATED` from `-3` to `0`. Code
+  that compared against the old constants compiled fine but returned wrong results.
+- `_frameowner` (in `pycore_interpframe_structs.h`) — `FRAME_OWNED_BY_CSTACK` was
+  removed in 3.15.
+
+For every enum echion touches, run:
+
+```bash
+git diff OLD_VERSION NEW_VERSION -- Include/internal/pycore_frame.h | grep -A 30 "enum "
+git diff OLD_VERSION NEW_VERSION -- Include/internal/pycore_interpframe_structs.h | grep -A 30 "enum "
+```
+
+**Lock in compile-time contracts with `static_assert`:**
+
+After confirming enum values, add or update `static_assert` checks in
+`ddtrace/internal/datadog/profiling/stack/test/test_cpython_layout_contracts.cpp`.
+These fire at *build time* against the actual CPython headers — if CPython renumbers
+an enum value, the build breaks immediately before any test runner runs. Example:
+
+```cpp
+// Add a versioned block for the new CPython version:
+#if PY_VERSION_HEX >= 0x030f0000
+static_assert(FRAME_CREATED == 0,
+              "AIDEV-NOTE: PyFrameState::FRAME_CREATED changed — update tasks.h and tasks.cc");
+static_assert(FRAME_EXECUTING == 4,
+              "AIDEV-NOTE: PyFrameState::FRAME_EXECUTING changed — update tasks.cc gen_is_running check");
+// ... one assert per enum value echion depends on
+#endif
+```
+
+Also add a `-Wswitch`-enabled exhaustive `switch` (no `default:` case) for any enum
+used in a dispatch — the compiler will warn if CPython adds a new value.
+
 ### Step 4: Analyze Impact
 
 For each change identified:

--- a/docs/contributing-profiling-new-cpython.rst
+++ b/docs/contributing-profiling-new-cpython.rst
@@ -9,11 +9,16 @@ Echion), **asyncio** integration for stack and tasks, **lock** profilers (thread
 **memory** and **heap** (memalloc), **exception** profiling, **PyTorch** hook, **ddup** export, build
 gates, Riot/CI, and **validation tests** for each area.
 
-The best reference implementation is `PR #15546`__ (feat(profiling): support Python 3.14): Echion
-frame/task/asyncio changes, ``setup.py`` un-gating, profiling defaults, Riot venv splits, tests, and
-a release note.
+Reference implementations:
+
+* `PR #15546`__ (feat(profiling): support Python 3.14) — Echion frame/task/asyncio changes,
+  ``setup.py`` un-gating, profiling defaults, Riot venv splits, tests, and a release note.
+* `PR #17294`__ (feat(profiling): support Python 3.15) — native ABI fixes for renumbered
+  ``PyFrameState`` and removed ``FRAME_OWNED_BY_CSTACK``; Python-side ``_asyncio.py`` hardening
+  with tiered ``hasattr`` guards; new compile-time layout contract tests.
 
 __ https://github.com/DataDog/dd-trace-py/pull/15546
+__ https://github.com/DataDog/dd-trace-py/pull/17294
 
 Current status
 --------------
@@ -33,8 +38,12 @@ Current status
      - Echion frame/task/asyncio, ``setup.py`` un-gating, Riot venv splits, tests done.
    * - 3.15
      - `PR #17294`__
-     - ``FRAME_OWNED_BY_CSTACK`` removed; ``FRAME_SUSPENDED_YIELD_FROM_LOCKED`` added;
-       ``PyStackRef`` tag scheme unified. Use ``0x030f0000`` guards.
+     - Echion: ``FRAME_OWNED_BY_CSTACK`` removed; ``PyFrameState`` renumbered;
+       ``FRAME_SUSPENDED_YIELD_FROM_LOCKED`` added for free-threaded builds.
+       ``_asyncio.py``: tiered ``hasattr`` guards for private asyncio APIs
+       (``_GatheringFuture``, ``_wait``, ``_scheduled_tasks``).
+       New compile-time layout contract tests (``test_cpython_layout_contracts.cpp``).
+       Use ``0x030f0000`` guards.
 
 __ https://github.com/DataDog/dd-trace-py/pull/15546
 __ https://github.com/DataDog/dd-trace-py/pull/17294
@@ -221,6 +230,25 @@ migration: ABI changes often break **stack** first, but **memalloc**, **locks**,
 
 Automated tests (what to run)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a quick sanity check on any Python version (import guards + pprof samples), use the
+compatibility script before running the full suite:
+
+.. code-block:: bash
+
+   # Import/guard checks only — no C extensions required (~2 s)
+   python scripts/verify_profiler_compatibility.py --python 3.15 --quick
+
+   # Full check: asyncio guards + real pprof samples with named tasks (~8 s)
+   python scripts/verify_profiler_compatibility.py --python 3.15
+
+   # Save results as the baseline for this MAJOR.MINOR
+   python scripts/verify_profiler_compatibility.py --python 3.15 --baseline
+
+   # Compare against a saved baseline (use in CI or after a change)
+   python scripts/verify_profiler_compatibility.py --python 3.15 --compare
+
+Baselines for Python 3.9–3.14 live in ``scripts/profiles/compatibility_baselines.json``.
 
 Use **`scripts/run-tests`** (see :ref:`testing_guidelines` in ``contributing-testing``) —
 **never** raw ``pytest`` for full-suite validation. For profiling, CI maps paths to Riot via

--- a/docs/contributing-profiling-new-cpython.rst
+++ b/docs/contributing-profiling-new-cpython.rst
@@ -1,0 +1,359 @@
+.. _profiling_new_cpython:
+
+Profiling and new CPython versions
+==================================
+
+This guide is for maintainers who add support for a **new CPython minor release** (e.g. 3.15) across
+**everything dd-trace-py owns in the Continuous Profiler product**: **stack** (CPU / wall samples,
+Echion), **asyncio** integration for stack and tasks, **lock** profilers (threading + asyncio),
+**memory** and **heap** (memalloc), **exception** profiling, **PyTorch** hook, **ddup** export, build
+gates, Riot/CI, and **validation tests** for each area.
+
+The best reference implementation is `PR #15546`__ (feat(profiling): support Python 3.14): Echion
+frame/task/asyncio changes, ``setup.py`` un-gating, profiling defaults, Riot venv splits, tests, and
+a release note.
+
+__ https://github.com/DataDog/dd-trace-py/pull/15546
+
+Current status
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 20 65
+
+   * - Version
+     - Status
+     - Notes
+   * - 3.13
+     - Supported
+     - Last stable release fully supported across all profiler surfaces.
+   * - 3.14
+     - Merged (`PR #15546`__)
+     - Echion frame/task/asyncio, ``setup.py`` un-gating, Riot venv splits, tests done.
+   * - 3.15
+     - `PR #17294`__
+     - ``FRAME_OWNED_BY_CSTACK`` removed; ``FRAME_SUSPENDED_YIELD_FROM_LOCKED`` added;
+       ``PyStackRef`` tag scheme unified. Use ``0x030f0000`` guards.
+
+__ https://github.com/DataDog/dd-trace-py/pull/15546
+__ https://github.com/DataDog/dd-trace-py/pull/17294
+
+Version hex quick reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   Python 3.11  →  0x030b0000
+   Python 3.12  →  0x030c0000
+   Python 3.13  →  0x030d0000
+   Python 3.14  →  0x030e0000   ← last merged
+   Python 3.15  →  0x030f0000   ← current target
+
+Preparation: what tends to break
+---------------------------------
+
+When CPython bumps, expect changes in:
+
+* ``_PyInterpreterFrame`` and related **internal headers** (include paths move between releases;
+  fields may become ``_PyStackRef``, ``stackpointer`` vs ``stacktop``, ``localsplus`` layout).
+* **Tagged pointers** on frame/code objects (recover ``PyObject*`` per upstream notes, e.g.
+  ``python/cpython#123923`` for 3.14).
+* **Asyncio** C layout: ``FutureObj`` / ``TaskObj`` struct layout and where **native** tasks live
+  (e.g. per-thread / per-interpreter linked lists and ``asyncio_tasks_head`` in 3.14+).
+* **Python-visible** asyncio: policy class renames, whether ``_scheduled_tasks`` /
+  ``_eager_tasks`` are exported from the C module or live only in Python.
+* **Free-threaded builds** (``Py_GIL_DISABLED``): from 3.14, struct layouts diverge for nogil
+  builds (e.g. ``task_tid`` in ``TaskObj``). Guard with ``#ifdef Py_GIL_DISABLED`` where needed.
+  On Windows, ``Py_GIL_DISABLED`` must now be set explicitly by the build backend; it is no
+  longer inferred automatically.
+
+Read the PR #15546 description for the concrete 3.14 deltas before extrapolating to the next
+version.
+
+Discover CPython deltas (before writing code)
+---------------------------------------------
+
+1. Use the **compare-cpython-versions skill** first — it runs a systematic diff of the headers
+   we depend on between two CPython tags (e.g. ``v3.14.0`` → ``v3.15.0`` or ``main``). Run it
+   before opening any source file:
+
+   .. code-block:: text
+
+      # Via the Skill tool:
+      compare-cpython-versions  (previous: 3.14, target: 3.15)
+
+2. If you need to manually inspect or regenerate the diff, clone **python/cpython** (the
+   skill uses ``~/dd/cpython`` by convention) and diff the headers we depend on:
+
+   .. code-block:: bash
+
+      # Clone once (or fetch tags on an existing checkout)
+      git clone https://github.com/python/cpython.git ~/dd/cpython
+      cd ~/dd/cpython && git fetch --tags
+
+      # Diff all headers relevant to echion/profiling between two releases
+      # Adjust tag names to actual release tags (e.g. v3.14.0, v3.15.0 or main)
+      git diff v3.14.0 v3.15.0 -- \
+        Include/cpython/genobject.h \
+        Include/internal/pycore_frame.h \
+        Include/internal/pycore_interpframe.h \
+        Include/internal/pycore_interpframe_structs.h \
+        Include/internal/pycore_llist.h \
+        Include/internal/pycore_runtime.h \
+        Include/internal/pycore_stackref.h \
+        Include/internal/pycore_tstate.h \
+        Modules/_asynciomodule.c
+
+   Key files to watch (paths can move between releases — verify they exist on the target tag):
+
+   * ``Include/internal/pycore_interpframe_structs.h``, ``pycore_frame.h``,
+     ``pycore_interpframe.h``, adjacent ``pycore_*`` headers.
+   * ``Include/cpython/genobject.h`` and anything **PyGen_\*** / yield-from paths used in
+     Echion.
+   * ``Modules/_asynciomodule.c`` — only the struct/typedef section matters
+     (``FutureObj_HEAD``, ``TaskObj``, ``_Py_AsyncioModuleDebugOffsets``); function bodies
+     are not relevant to echion.
+   * ``Include/internal/pycore_tstate.h``, ``pycore_llist.h``, ``pycore_stackref.h``,
+     ``pycore_runtime.h`` (all became relevant in 3.14).
+
+   A committed reference diff for 3.13 → 3.14 lives at
+   ``docs/cpython-diffs/cpython_313_to_314_headers.diff`` in the ``DataDog/echion`` repo.
+
+3. In **dd-trace-py**, use the **find-cpython-usage skill** to enumerate every internal header
+   and struct the codebase currently touches:
+
+   .. code-block:: text
+
+      # Via the Skill tool:
+      find-cpython-usage
+
+4. **Version hex:** Python 3.15 is gated with ``PY_VERSION_HEX >= 0x030f0000``. Keep older
+   release guards (e.g. ``0x030e0000`` for 3.14) and only add a new branch when behavior or
+   layout **diverges** from the prior release.
+
+Quick grep in dd-trace-py (find prior-version guards):
+
+.. code-block:: bash
+
+   rg 'PY_VERSION_HEX|0x030e' ddtrace/internal/datadog/profiling ddtrace/profiling setup.py
+   rg '3, 14|3\\.14' tests ddtrace setup.py riotfile.py
+
+Native stack profiler (Echion) — layout in this repo
+-----------------------------------------------------
+
+CMake extension and sources live under:
+
+.. code-block:: text
+
+   ddtrace/internal/datadog/profiling/stack/
+   ├── echion/echion/          # headers (frame, tasks, threads, state, greenlets, …)
+   │   └── cpython/tasks.h     # FutureObj / TaskObj mirrors
+   └── src/echion/             # frame.cc, threads.cc, stack_chunk.cc, …
+
+(Older branches or docs may say ``stack_v2``; on current ``main`` the path is ``stack/``, defined
+in ``setup.py`` as ``STACK_DIR`` under ``ddtrace/internal/datadog/profiling/stack``.)
+
+Typical files to revisit (mirror PR #15546):
+
++---------------------------+------------------------------------------+
+| Area                      | Files                                    |
++===========================+==========================================+
+| Frame ABI / includes      | ``stack/echion/echion/frame.h``,         |
+|                           | ``stack/src/echion/frame.cc``            |
++---------------------------+------------------------------------------+
+| Stack chunk (frame iter)  | ``stack/src/echion/stack_chunk.cc``      |
++---------------------------+------------------------------------------+
+| Task / Future layouts     | ``stack/echion/echion/cpython/tasks.h``  |
++---------------------------+------------------------------------------+
+| Asyncio task enumeration  | ``stack/echion/echion/tasks.h``,         |
+|                           | ``stack/echion/echion/threads.h``,       |
+|                           | ``stack/src/echion/threads.cc``          |
++---------------------------+------------------------------------------+
+| Misc guards               | ``stack/echion/echion/state.h``,         |
+|                           | ``stack/echion/echion/greenlets.h``      |
++---------------------------+------------------------------------------+
+
+Build against the **target** interpreter first and fix compile errors. Then run automated tests
+for **stack** and **asyncio** (see `Validate all profiling features`_).
+
+For C/C++ conventions and safety expectations, see ``.cursor/rules/native-code.mdc``
+(if present).
+
+Python-side integration
+-----------------------
+
+* ``ddtrace/profiling/_asyncio.py`` — event-loop policy names, weak sets for
+  scheduled/eager tasks, version-guarded access patterns.
+* Search under ``ddtrace/profiling/`` for ``sys.version_info``, ``PY_MAJOR_VERSION``, and
+  similar.
+
+Build and product gating
+------------------------
+
+* ``setup.py`` — Ensure **memalloc**, **ddup**, and **stack** CMake extensions (and Rust
+  profiling features, if gated) are **not** skipped on the new Python version. PR #15546
+  **removed** ``sys.version_info < (3, 14)`` style exclusions; do the same for ``(3, 15)``
+  when enabling 3.15. Add a **new** upper bound only if a **future** version is known broken.
+
+* ``ddtrace/internal/settings/profiling.py`` — Remove any "force stack profiler off on X.Y"
+  guards. Keep **ddup** load failures honest: log and disable profiling when the extension
+  truly fails to import.
+
+CI, Riot, and dependencies
+--------------------------
+
+* ``riotfile.py`` — Add or extend ``Venv(pys="3.15", ...)`` where a new Python needs different
+  pins (examples from 3.14 work: **uwsgi**, **protobuf**, **gevent**, memalloc/**lz4** quirks).
+  Follow existing patterns for ``select_pys`` and comments explaining version caps.
+
+* Regenerate ``.riot/requirements/*.txt`` when adding venvs (same workflow as other Python
+  bumps).
+
+* Grep tests: ``3.14``, ``3, 14``, ``max_version``, profiling-related ``skip``.
+
+Validate all profiling features (minor-version migration)
+---------------------------------------------------------
+
+Before merging support for a new CPython, treat **each profiler surface** as part of the
+migration: ABI changes often break **stack** first, but **memalloc**, **locks**, and
+**exceptions** use native or C API-adjacent code that must still pass on the new version.
+
+Automated tests (what to run)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use **`scripts/run-tests`** (see :ref:`testing_guidelines` in ``contributing-testing``) —
+**never** raw ``pytest`` for full-suite validation. For profiling, CI maps paths to Riot via
+**`tests/profiling/suitespec.yml`**: patterns such as **`profile$`**, **`profile-uwsgi`**, and
+**`profile-memalloc`**.
+
+**Feature → code → tests** (paths relative to ``ddtrace/profiling/`` or
+``tests/profiling/``):
+
+* **Stack / wall / CPU** — ``collector/stack.py`` and Echion under
+  ``ddtrace/internal/datadog/profiling/stack/``. Tests: ``collector/test_stack.py``,
+  ``collector/test_stack_native.py``, ``test_accuracy.py``, and the many
+  ``collector/test_asyncio_*.py`` files for asyncio stack semantics.
+
+* **Locks** — ``collector/threading.py``, ``collector/asyncio.py``, ``collector/_lock.pyx``.
+  Tests: ``collector/test_threading.py``, ``collector/test_lock_reflection.py``,
+  ``collector/lock_test_common.py``, plus asyncio tests that cover lock collectors.
+
+* **Memory (allocations)** — ``collector/memalloc.py`` and ``collector/_memalloc*``. Tests:
+  ``collector/test_memalloc.py``, ``test_memalloc_fork.py``,
+  ``collector/test_copy_memory_stats.py``.
+
+* **Heap (live)** — same memalloc pipeline; ``collector/test_heap_tracker_count.py``.
+
+* **Exceptions** — ``collector/exception.py``; ``collector/test_exception.py``.
+
+* **PyTorch** — ``collector/pytorch.py``; ``test_pytorch.py``.
+
+* **Profiler / scheduler** — ``profiler.py``, ``scheduler.py``; ``test_profiler.py``,
+  ``test_scheduler.py``, ``test_profiling_config.py``.
+
+* **ddup / export** — internal ddup + ``tests/profiling/exporter/test_ddup.py``.
+
+**Practical matrix:**
+
+* **Stack / Echion / asyncio framing:** run the **profile** suite (``profile$``); include
+  ``collector/test_stack_native.py`` and representative ``test_asyncio_*.py`` files while
+  iterating.
+* **Memalloc / heap:** run **profile-memalloc**; always include ``collector/test_memalloc.py``
+  and ``collector/test_heap_tracker_count.py``.
+* **Locks / threading:** use ``collector/test_threading.py`` and related asyncio lock tests
+  (file is large — narrow with ``run-tests`` on touched paths during development, then full
+  profile suite before merge).
+* **Full profiling regression:** ``scripts/run-tests`` over ``tests/profiling/`` or let the
+  script pick venvs from changed files; locally mirror CI with ``riot run …`` **profile$** /
+  **profile-memalloc** / **profile-uwsgi** as needed.
+
+**New code paths** (new env flag, CPython branch, or collector behavior) should get **unit or
+subprocess tests** next to the nearest file above; follow existing patterns (many tests use
+``@pytest.mark.subprocess`` and init helpers in ``tests/profiling/collector/conftest.py``).
+
+Manual / dogfood checks (optional but recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Automation does not replace **real workloads** or **Profiling Explorer** behavior. On staging
+or a one-off service, with **Python version + ddtrace commit + ``DD_PROFILING_*``** documented:
+
+* **Stack / CPU:** visible stacks and CPU/wall samples; timeline if enabled.
+* **Locks:** lock / lock-wait views; exercise ``threading`` and ``asyncio`` primitives; if
+  using **``DD_PROFILING_LOCK_EXCLUDE_MODULES``**, compare with it unset vs set.
+* **Memory / heap:** allocation and live-heap signal under load.
+* **Exceptions:** exception profiling after controlled errors.
+* **PyTorch:** small torch workload when that collector is enabled.
+* **Export:** optional **``DD_PROFILING_OUTPUT_PPROF``** for local pprof inspection.
+
+Staging service experiment (recommended for minor CPython bumps)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For migration confidence, mirror how you might run a **targeted staging rollout** (e.g. a
+Cython- or profiler-related change on an internal worker/API): one **representative service**,
+fixed traffic or time window, **documented** build and env.
+
+**Goal:** Prove the new interpreter + dd-trace-py candidate do not regress **runtime health**
+or **profiler signal** under real workloads — not only that unit tests pass.
+
+**Pick a service** that stresses what you changed and what we own:
+
+* **Stack / Echion:** mixed CPU work, deep stacks, **asyncio** (native tasks if you touched
+  task enumeration), optional **gevent**/event-loop variants if the app uses them.
+* **Locks:** workloads with ``threading`` and ``asyncio`` sync primitives (same idea as lock-
+  profiler staging).
+* **Memory / heap:** allocations + longer-lived objects if memalloc paths changed.
+* **Exceptions:** paths that raise and catch often enough to see exception profiles.
+
+**Experiment design (minimal):**
+
+#. **Baseline arm:** current production-like combo (CPython + ddtrace version) on staging,
+   same **service** and **approximate load** (QPS, soak duration).
+#. **Candidate arm:** **only** CPython and/or ddtrace bump (e.g. wheel from your PR build);
+   keep other deps, feature flags, and ``DD_*`` **as equal as possible**.
+#. Record **commit SHAs**, **artifact** (wheel/sdist), **Python ``sys.version``**, and all
+   relevant **`DD_PROFILING_*`**, **`DD_TRACE_*`**, and injection settings for both arms.
+
+**What to watch (staging / Observability):**
+
+* **Health:** error rate, latency, CPU/memory, restarts/crashes, OOMs.
+* **Profiler product:** absence of **profiler** client errors/logs; expected **profile types**
+  still arriving (CPU/wall, allocation, lock/lock-wait, exceptions, heap if enabled).
+* **Profiling Explorer:** open the **same** service + environment + time range pattern for each
+  arm; spot-check **flame graphs**, **lock** facets, **allocations**, **exceptions** for
+  sensible stacks and no obvious holes after the version bump.
+
+**Optional A/B on profiler knobs:** If validating a profiler-only change (e.g. lock exclude
+list), run **two** candidate configs — **full wrap** vs **service-tuned excludes** — with
+identical CPython and ddtrace versions so overhead/signal tradeoffs are isolated.
+
+**Duration and rollback:** Prefer at least one **full business-day** soak or replayed load;
+define **rollback** (revert image or pin) if crash rate, SLO breach, or missing profiles
+exceed agreed thresholds.
+
+**Handoff:** Paste the arm summary (versions, env, links to Explorer time ranges) into the PR
+or JIRA so reviewers can reproduce the staging story.
+
+Release notes
+~~~~~~~~~~~~~
+
+* Add a **release note** with the **releasenote** skill (``AGENTS.md``).
+* Smoke / telemetry / serverless: grep for version conditionals if profiling availability
+  changed (see files touched in PR #15546).
+
+Suggested order of work
+------------------------
+
+#. CPython header/asyncio diff + in-repo grep for the previous release's ``PY_VERSION_HEX`` /
+   version tuples (use the **compare-cpython-versions** and **find-cpython-usage** skills).
+#. Echion (vendor copy): compile on target Python; fix ``#if`` ladders and struct/layout
+   drift header by header.
+#. Apply asyncio task struct / linked-list changes (``cpython/tasks.h``, ``threads.cc``).
+#. ``_asyncio.py`` and any other Python-side version branches.
+#. ``setup.py`` and ``ddtrace/internal/settings/profiling.py`` gating.
+#. Riot, requirements files, test skip cleanup.
+#. **Validate all profiling features** with automated tests (matrix above) on the target
+   Python.
+#. **Staging service experiment** (above) for at least one representative workload, or
+   narrower manual / dogfood checks if staging access is limited.
+#. Release note and final CI green.

--- a/docs/contributing-profiling-new-cpython.rst
+++ b/docs/contributing-profiling-new-cpython.rst
@@ -221,6 +221,93 @@ CI, Riot, and dependencies
 
 * Grep tests: ``3.14``, ``3, 14``, ``max_version``, profiling-related ``skip``.
 
+Wheel build images (manylinux / musllinux)
+------------------------------------------
+
+Linux wheels are built inside PyPA manylinux / musllinux images mirrored into
+``registry.ddbuild.io`` via ``DataDog/images``. The mirrored image must contain a
+``cp3XX-cp3XX`` interpreter for every Python version in the wheel matrix. When a new CPython
+minor is added you have to bump the pinned image tag once upstream PyPA ships it.
+
+Where the image tags are referenced in this repo:
+
+* ``.gitlab/package.yml`` — ``MANYLINUX_AMD64_IMAGE_TAG``, ``.AARCH64_IMAGES``,
+  ``.X86_64_IMAGES``, plus the hard-coded ``IMAGE_TAG`` entries inside the upload-job
+  ``needs:`` blocks.
+* ``.gitlab/benchmarks/microbenchmarks.yml`` — ``PACKAGE_IMAGE`` plus the literal
+  ``needs:`` job-name string that embeds the image tag.
+* ``.gitlab/benchmarks/macrobenchmarks.yml`` — same ``needs:`` job-name string.
+* ``.gitlab-ci.yml``, ``.gitlab/multi-os-tests.yml``, ``.gitlab/system-tests.yml``,
+  ``.gitlab/debugging-exploration.yml`` — additional ``IMAGE_TAG`` references for non-wheel
+  jobs that run inside the manylinux image. Bump these in lockstep.
+
+Find the right PyPA base tag
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Step 1 — list candidate Quay tags newest-first:
+
+.. code-block:: bash
+
+   curl -s 'https://quay.io/api/v1/repository/pypa/manylinux2014_x86_64/tag/?limit=20&onlyActiveTags=true' \
+     | python3 -c "import json,sys; [print(t['name'], t['last_modified']) for t in json.load(sys.stdin).get('tags',[])]"
+
+The tags follow ``YYYY.MM.DD-N``. ``latest`` always points at the newest.
+
+Step 2 — confirm the target ``cp3XX`` interpreter is built into the image. The authoritative
+source is ``pypa/manylinux``'s ``docker/Dockerfile`` on the commit corresponding to the Quay
+tag. Either ``docker run --rm quay.io/pypa/manylinux2014_x86_64:<TAG> ls /opt/python`` and grep
+for ``cp3XX``, or — if Docker is unavailable — read the Dockerfile directly:
+
+.. code-block:: bash
+
+   # Find the commit that added the cpython version you need
+   gh api 'repos/pypa/manylinux/commits?path=docker/Dockerfile&per_page=30' \
+     --jq '.[] | "\(.sha[0:8])\t\(.commit.author.date)\t\(.commit.message | split("\n")[0])"' \
+     | grep -i "cpython 3.15"
+
+   # Inspect the current Dockerfile to see exactly which cpython versions it builds
+   gh api 'repos/pypa/manylinux/contents/docker/Dockerfile' --jq '.download_url' \
+     | xargs curl -sL | grep -E 'build-cpython.sh .* 3\.[0-9]+'
+
+Any Quay tag dated after the "add CPython 3.X" commit will carry the new interpreter. Pick the
+newest one.
+
+Step 3 — confirm the same Quay tag exists across all four image variants we mirror:
+
+.. code-block:: bash
+
+   for img in manylinux2014_x86_64 manylinux2014_aarch64 musllinux_1_2_x86_64 musllinux_1_2_aarch64; do
+     curl -s "https://quay.io/api/v1/repository/pypa/$img/tag/?specificTag=<TAG>&onlyActiveTags=true" \
+       | python3 -c "import json,sys; print('$img', 'OK' if json.load(sys.stdin).get('tags') else 'MISSING')"
+   done
+
+PyPA usually publishes all four together, but verify before relying on it.
+
+Mirror the tag, then bump dd-trace-py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. **DataDog/images PR.** Edit ``mirror.yaml`` (search for the existing
+   ``quay.io/pypa/manylinux2014_x86_64`` entries) and add six new entries — one per arch for
+   manylinux2014 and musllinux_1_2 (x86_64, i686, aarch64) — copying the existing block's
+   shape and bumping the tag. Then from the repo root::
+
+      bzl run //image-mirroring-tooling -- update-digest quay.io/pypa/manylinux2014_x86_64:<TAG>
+      # ...repeat for the other five sources
+
+   Commit ``mirror.yaml`` and ``mirror.lock.yaml`` together. After merge, **wait for the
+   master-branch mirror job** to actually push the images to ``registry.ddbuild.io/images/mirror/pypa/…``.
+
+2. **Trigger the dd-trace-py internal image builds.** Mirroring alone doesn't produce the
+   ``v<pipeline>-<sha>-<base>`` tags consumed by ``.gitlab/package.yml`` (e.g.
+   ``v85383392-751efc0-manylinux2014_x86_64``). Manually re-run CI on ``DataDog/images``
+   master for each of the four images (manylinux2014 x86_64/aarch64,
+   musllinux_1_2 x86_64/aarch64). Record the four new ``v...`` tags.
+
+3. **dd-trace-py PR.** Bump every reference listed at the top of this section to the new
+   tags. The ``needs:`` strings in ``microbenchmarks.yml`` / ``macrobenchmarks.yml`` embed
+   the literal image tag in the cross-job name; they must move in lockstep with
+   ``.X86_64_IMAGES`` or ``needs:`` resolution fails.
+
 Validate all profiling features (minor-version migration)
 ---------------------------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -18,6 +18,8 @@ If you're trying to set up a local development environment, read `this <https://
 
 `Fuzzing native code documentation for contributors <https://github.com/DataDog/dd-trace-py/tree/main/docs/contributing-fuzzing.rst>`_.
 
+`Profiling and new CPython versions <https://github.com/DataDog/dd-trace-py/tree/main/docs/contributing-profiling-new-cpython.rst>`_ (stack profiler / Echion migration checklist).
+
 Thanks for working with us!
 
 .. _change_process:
@@ -164,6 +166,7 @@ about Instrumentation Telemetry.
     contributing-integrations
     contributing-testing
     contributing-fuzzing
+    contributing-profiling-new-cpython
     contributing-tracing
     contributing-release
     releasenotes

--- a/docs/cpython-diffs/analysis_314_to_315.md
+++ b/docs/cpython-diffs/analysis_314_to_315.md
@@ -1,0 +1,227 @@
+# CPython 3.14 → 3.15 Change Analysis (for echion)
+
+**Generated from:** `git diff v3.14.0 v3.15.0a7` on `python/cpython`
+**Latest 3.15 tag used:** `v3.15.0a7` (pre-release; verify against final tag when available)
+**Raw diff:** `cpython_314_to_315_headers.diff` (1,479 lines)
+
+Files with **no changes** relevant to echion (stable between 3.14 and 3.15):
+
+- `Include/cpython/genobject.h` — generator object layout unchanged
+- `Include/internal/pycore_llist.h` — llist API unchanged
+- `Include/internal/pycore_runtime.h` — runtime struct unchanged
+
+---
+
+## Breaking Changes (must fix to compile/run correctly)
+
+### 1. `PyFrameState` enum completely renumbered — `pycore_frame.h`
+
+**Priority: HIGH**
+
+| State | 3.14 value | 3.15 value |
+|---|---|---|
+| `FRAME_CREATED` | -3 | 0 |
+| `FRAME_SUSPENDED` | -2 | 1 |
+| `FRAME_SUSPENDED_YIELD_FROM` | -1 | 2 |
+| `FRAME_SUSPENDED_YIELD_FROM_LOCKED` | *(new)* | 3 |
+| `FRAME_EXECUTING` | 0 | 4 |
+| `FRAME_COMPLETED` | 1 | *(removed)* |
+| `FRAME_CLEARED` | 4 | 5 |
+
+Changed macros:
+
+```c
+// 3.14
+#define FRAME_STATE_SUSPENDED(S) ((S) == FRAME_SUSPENDED || (S) == FRAME_SUSPENDED_YIELD_FROM)
+#define FRAME_STATE_FINISHED(S)  ((S) >= FRAME_COMPLETED)
+
+// 3.15
+#define FRAME_STATE_SUSPENDED(S) ((S) >= FRAME_SUSPENDED && (S) <= FRAME_SUSPENDED_YIELD_FROM_LOCKED)
+#define FRAME_STATE_FINISHED(S)  ((S) == FRAME_CLEARED)
+```
+
+**Echion impact:**
+- Any code reading `_PyInterpreterFrame.f_frame_state` and comparing against old
+  constants will silently misclassify frames (e.g., `FRAME_EXECUTING = 0` in 3.14
+  now means `FRAME_CREATED` in 3.15).
+- `FRAME_COMPLETED` is gone — code checking `>= FRAME_COMPLETED` will break.
+- New `FRAME_SUSPENDED_YIELD_FROM_LOCKED` needs to be included in suspended checks.
+- **Use the `FRAME_STATE_SUSPENDED` / `FRAME_STATE_FINISHED` macros** instead of
+  hardcoding values, so the `#if PY_VERSION_HEX` guard only needs to cover the
+  macro definitions, not every use site.
+
+**Files to update:** `echion/frame.h`, `echion/state.h`, any caller that checks
+`frame_state` directly.
+
+**Guard:** `#if PY_VERSION_HEX >= 0x030f0000`
+
+---
+
+### 2. `FRAME_OWNED_BY_CSTACK` removed — `pycore_interpframe_structs.h`
+
+**Priority: LOW**
+
+```c
+// 3.14
+enum _frameowner {
+    FRAME_OWNED_BY_THREAD = 0,
+    FRAME_OWNED_BY_GENERATOR = 1,
+    FRAME_OWNED_BY_FRAME_OBJECT = 2,
+    FRAME_OWNED_BY_INTERPRETER = 3,
+    FRAME_OWNED_BY_CSTACK = 4,   // <-- removed in 3.15
+};
+```
+
+**Echion impact:** If any code checks `frame->owner == FRAME_OWNED_BY_CSTACK`,
+wrap in `#if PY_VERSION_HEX < 0x030f0000`.
+
+---
+
+### 3. `_PyStackRef` tag scheme unified — `pycore_stackref.h`
+
+**Priority: MEDIUM** (mostly affects free-threaded builds)
+
+Key changes:
+
+- Tag constants moved to top-level (no longer split between GIL/nogil paths):
+  ```c
+  #define Py_INT_TAG    3
+  #define Py_TAG_INVALID 2   // new: marks ERROR sentinel
+  #define Py_TAG_REFCNT 1
+  #define Py_TAG_BITS   3
+  #define Py_TAGGED_SHIFT 2  // new
+  ```
+- `Py_TAG_DEFERRED` (free-threaded) is **gone** — merged with `Py_TAG_REFCNT`.
+- `PyStackRef_FromPyObjectImmortal()` **renamed** to `PyStackRef_FromPyObjectBorrow()`.
+- New `PyStackRef_ERROR` sentinel (`bits == Py_TAG_INVALID`).
+- New predicates: `PyStackRef_IsError()`, `PyStackRef_IsMalformed()`,
+  `PyStackRef_IsValid()`.
+- New `PyStackRef_Wrap()` / `PyStackRef_Unwrap()` for raw pointer wrapping.
+- `INITIAL_STACKREF_INDEX` changed from `8` to `(5 << Py_TAGGED_SHIFT)` = `20`.
+- Tagged int shift changed: `(i << 2)` instead of `(i << 2)` — same for non-debug,
+  but `Py_TAGGED_SHIFT = 2` is now the canonical name.
+
+**Echion impact:**
+- The `PyStackRef_AsPyObjectBorrow(f->f_executable)` call to recover a `PyObject*`
+  from a frame's executable field **still works** — no change to the public API.
+- If echion directly manipulates `.bits` (e.g., checking `(bits & 1)`), update to
+  use the new named constants.
+- If echion uses `PyStackRef_FromPyObjectImmortal()`, rename to
+  `PyStackRef_FromPyObjectBorrow()` under a `#if PY_VERSION_HEX >= 0x030f0000` guard.
+- Free-threaded builds: `Py_TAG_DEFERRED` no longer exists; use `Py_TAG_REFCNT`.
+
+---
+
+## Additive / Beneficial Changes (no breakage, consider adopting)
+
+### 4. `_PyFrame_SafeGetCode()` and `_PyFrame_SafeGetLasti()` — `pycore_interpframe.h`
+
+New in 3.15, **explicitly designed for profilers and debuggers**:
+
+```c
+// Returns NULL if frame is invalid or freed (heuristic, not 100% reliable)
+static inline PyCodeObject* _Py_NO_SANITIZE_THREAD
+_PyFrame_SafeGetCode(_PyInterpreterFrame *f);
+
+// Returns -1 if frame is invalid or freed
+static inline int _Py_NO_SANITIZE_THREAD
+_PyFrame_SafeGetLasti(struct _PyInterpreterFrame *f);
+```
+
+**Recommendation:** Under `#if PY_VERSION_HEX >= 0x030f0000`, use
+`_PyFrame_SafeGetCode()` instead of `_PyFrame_GetCode()` in echion's frame-reading
+path. It checks for freed memory (globals/builtins NULL, `_PyMem_IsPtrFreed`,
+`_PyObject_IsFreed`, `PyCode_Check`) before dereferencing.
+
+---
+
+### 5. `base_frame` sentinel in `_PyThreadStateImpl` — `pycore_tstate.h`
+
+New field, **specifically called out as for profiling/sampling**:
+
+```c
+typedef struct _PyThreadStateImpl {
+    PyThreadState base;
+
+    // Embedded base frame - sentinel at the bottom of the frame stack.
+    // Used by profiling/sampling to detect incomplete stack traces.
+    _PyInterpreterFrame base_frame;   // <-- NEW in 3.15
+
+    // ...
+    Py_ssize_t refcount;
+```
+
+**Recommendation:** Use `&tstate_impl->base_frame` as the termination sentinel when
+walking the frame chain under 3.15. Previously echion checked for NULL
+`previous_instr` or similar; this explicit sentinel is cleaner.
+
+Guard: `#if PY_VERSION_HEX >= 0x030f0000`
+
+---
+
+### 6. `_Py_AsyncioDebug` symbol rename — `_asynciomodule.c`
+
+```c
+// 3.14
+GENERATE_DEBUG_SECTION(AsyncioDebug, Py_AsyncioModuleDebugOffsets _AsyncioDebug)
+
+// 3.15
+GENERATE_DEBUG_SECTION(AsyncioDebug, Py_AsyncioModuleDebugOffsets _Py_AsyncioDebug)
+```
+
+**Echion impact:** Only relevant if echion reads this debug symbol by name from the
+process (e.g., via `/proc/pid/maps` or DWARF). Update the symbol name lookup to
+`_Py_AsyncioDebug` under a `#if PY_VERSION_HEX >= 0x030f0000` guard.
+
+The `TaskObj` struct layout (fields: `task_name`, `task_awaited_by`, `task_coro`,
+`task_node`, `task_is_task`, `task_awaited_by_is_set`) is **unchanged** from 3.14 —
+the `cpython/tasks.h` mirror in echion does not need layout changes.
+
+---
+
+### 7. Other `_PyThreadStateImpl` additions — `pycore_tstate.h`
+
+New fields (low echion impact):
+
+- `c_stack_init_base` / `c_stack_init_top` — stack protection reset values
+- `generator_return_kind` enum — distinguishes yield vs return in `gen_send_ex2()`
+- `pystats_struct` (under `Py_STATS`)
+- `jit_tracer_state` (under `_Py_TIER2`)
+- `__padding[64]` (GIL-disabled, cache-line alignment)
+
+These add fields **after** `asyncio_running_loop` / `asyncio_tasks_head`, so if
+echion accesses those by name (not by offset), no change needed. If accessing by
+raw offset, regenerate offsets.
+
+---
+
+## Work checklist for echion 3.15 port
+
+- [x] Add `#if PY_VERSION_HEX >= 0x030f0000` guard with new `PyFrameState` values
+      (renumbered) and new `FRAME_SUSPENDED_YIELD_FROM_LOCKED` state.
+      → `tasks.h`: new `PyGen_yf` branch for 3.15; `FRAME_SUSPENDED_YIELD_FROM_LOCKED`
+        is only reachable in free-threaded builds so it is guarded with
+        `#ifdef Py_GIL_DISABLED`. GIL builds behave identically to 3.14.
+- [x] Update `FRAME_STATE_SUSPENDED` / `FRAME_STATE_FINISHED` usage to use macros.
+      → Not applicable: echion uses enum constants by name (not hardcoded values),
+        so the renumbering has no effect. `FRAME_STATE_SUSPENDED`/`FRAME_STATE_FINISHED`
+        macros are not used in echion code.
+- [x] Remove any reference to `FRAME_COMPLETED` under 3.15 path.
+      → Not applicable: `FRAME_COMPLETED` is not referenced in echion's codebase.
+- [x] Remove `FRAME_OWNED_BY_CSTACK` reference under 3.15 guard.
+      → `frame.cc`: split `>= 0x030e0000` into `>= 0x030f0000` (no CSTACK) and
+        `>= 0x030e0000` (CSTACK + INTERPRETER). Also fixed `is_entry` assignment.
+- [x] Rename `PyStackRef_FromPyObjectImmortal` → `PyStackRef_FromPyObjectBorrow`
+      (if used) under 3.15 guard.
+      → Not applicable: `PyStackRef_FromPyObjectImmortal` is not used in echion's codebase.
+- [ ] Consider adopting `_PyFrame_SafeGetCode()` for safer frame reading.
+- [ ] Consider using `base_frame` sentinel for frame-chain termination.
+- [x] Update asyncio debug symbol lookup: `_AsyncioDebug` → `_Py_AsyncioDebug`.
+      → Not applicable: echion does not look up the asyncio debug symbol by name.
+- [x] Update CI/build matrix: add `cp315-*` wheels, Python 3.15 test variants.
+      → Done: `pyproject.toml`, `riotfile.py`, `.gitlab/package.yml`,
+        `.gitlab/testrunner.yml`, `.gitlab/templates/build-base-venvs.yml`,
+        `.gitlab/templates/detect-global-locks.yml`, `.gitlab/multi-os-tests.yml`,
+        `.gitlab-ci.yml`, `.github/workflows/generate-package-versions.yml`,
+        `.github/workflows/generate-supported-versions.yml`.
+- [ ] Run echion test suite against a CPython 3.15 build and confirm green.


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/17596)

https://datadoghq.atlassian.net/browse/PROF-14200

## Description

Documentation for v3.14 - 3.15 migration PR: feat(profiling): support Python 3.15 ([#17294](https://github.com/DataDog/dd-trace-py/pull/17294)).

## Changes

- `docs/contributing-profiling-new-cpython.rst`: new maintainer runbook for adding support for a new CPython minor version across the full Continuous Profiler stack (Echion/stack, asyncio, lock, memory/heap). Covers preparation, discovery, implementation checklist, and validation. References PR #17294 as the canonical 3.15 example.
- `docs/cpython-diffs/analysis_314_to_315.md`: reference analysis of every 3.14→3.15 ABI change relevant to echion — per-item impact notes, completed checklist, and cross-references to the guards we added. Useful when doing the 3.16 port.
- `docs/contributing.rst`: adds a link to the new runbook in the contributing index.
- `.claude/skills/compare-cpython-versions/SKILL.md`: adds explicit enum-renumbering checklist item (silent correctness bug, not a compile error) and the `static_assert` / `-Wswitch` contract pattern as the recommended approach for catching future CPython regressions at build time.
