### PR TITLE
ci: upload serverless artifacts to branch paths

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -210,6 +210,16 @@ variables:
     - job: "package version"
   variables:
     UPLOAD_SUFFIX: "serverless"
+  script:
+    - !reference [.upload_wheels_base, script]
+    - |
+      set -euo pipefail
+
+      # Upload to branch path (only for main/release branches)
+      if [ "${CI_COMMIT_BRANCH:-}" = "main" ] || [[ "${CI_COMMIT_BRANCH:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_BRANCH}" ${UPLOAD_SUFFIX:-}
+      fi
+
 
 "test sdist":
   image: "${IMAGE_BASE_URL}:${ALPINE_BUILD_IMAGE_TAG}"


### PR DESCRIPTION
## Description

Ensure we upload to `/main/index-serverless.html` for the serverless specific wheels. They want to consume these in a downstream pipeline.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
