### PR TITLE
test(anthropic): add regression tests for empty tool_use input handling

### DIFF
--- a/releasenotes/notes/fix-anthropic-tool-use-empty-input-88cf57f0d1234a1b.yaml
+++ b/releasenotes/notes/fix-anthropic-tool-use-empty-input-88cf57f0d1234a1b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    anthropic: Fix JSONDecodeError when streaming tool_use content blocks have empty input.

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -68,6 +68,38 @@ class TestLLMObsAnthropic:
         message = {"content": []}
         assert _on_content_block_stop_chunk(chunk=None, message=message) == message
 
+    @patch("ddtrace.contrib.internal.anthropic._streaming._get_attr")
+    def test_content_block_stop_with_empty_string_input_falls_back_to_empty_json(
+        self, mock_get_attr, ddtrace_global_config
+    ):
+        from ddtrace.contrib.internal.anthropic._streaming import _on_content_block_stop_chunk
+
+        # Given: a tool_use content block whose "input" accumulated as empty string
+        message = {"content": [{"type": "tool_use", "name": "get_weather", "input": ""}]}
+        mock_get_attr.side_effect = lambda obj, attr, default="": obj.get(attr, default)
+
+        # When: content_block_stop fires
+        result = _on_content_block_stop_chunk(chunk=None, message=message)
+
+        # Then: input is parsed as empty dict instead of raising JSONDecodeError
+        assert result["content"][-1]["input"] == {}
+
+    @patch("ddtrace.contrib.internal.anthropic._streaming._get_attr")
+    def test_content_block_stop_with_none_input_falls_back_to_empty_json(
+        self, mock_get_attr, ddtrace_global_config
+    ):
+        from ddtrace.contrib.internal.anthropic._streaming import _on_content_block_stop_chunk
+
+        # Given: a tool_use content block whose "input" is None
+        message = {"content": [{"type": "tool_use", "name": "get_weather", "input": None}]}
+        mock_get_attr.side_effect = lambda obj, attr, default="": obj.get(attr, default)
+
+        # When: content_block_stop fires
+        result = _on_content_block_stop_chunk(chunk=None, message=message)
+
+        # Then: input is parsed as empty dict instead of raising TypeError
+        assert result["content"][-1]["input"] == {}
+
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
     def test_beta_server_tool_use_stream(


### PR DESCRIPTION
## Description

This resolves the merge conflict from DataDog/dd-trace-py#16627.

The code fix from that PR (handling empty `input` in `tool_use` streaming blocks) was already merged to `main` via `safe_load_json(input_json) if input_json else {}`. This PR adds the regression tests and release note from #16627 that were not yet included.

## Changes
- Added `test_content_block_stop_with_empty_string_input_falls_back_to_empty_json`
- Added `test_content_block_stop_with_none_input_falls_back_to_empty_json`
- Added release note

Co-authored-by: lencshu <lencshu@users.noreply.github.com>

## Checklist
- [x] Tests added for the behavior
- [x] Release note included
- [x] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)