### PR TITLE
fix(internal): do not restart any ThreadRestartTimer threads [backport 4.6]

### DIFF
--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -98,8 +98,10 @@ class ThreadRestartTimer(PeriodicThread):
             # in between forks.
             if monotonic_ns() >= self._timestamp:  # 100ms
                 for thread in _threads_to_restart_after_fork.copy():
-                    if thread is self:
-                        # This has already been restarted by the after-fork hook.
+                    if isinstance(thread, ThreadRestartTimer):
+                        # Skip any ThreadRestartTimer instance,
+                        # to avoid restarting orphaned timer instances that were
+                        # caught in periodic_threads during a fork.
                         continue
                     log.debug("Restarting thread %s after fork", thread.name)
                     thread._after_fork(force=True)

--- a/releasenotes/notes/fix-potential-thread-restart-timer-leak-6ba9eaa0cc4ca49a.yaml
+++ b/releasenotes/notes/fix-potential-thread-restart-timer-leak-6ba9eaa0cc4ca49a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: Fix a potential internal thread leak in fork-heavy applications.


### PR DESCRIPTION
## Description

Backport of https://github.com/DataDog/dd-trace-py/pull/17312