### PR TITLE
ci: break up aiohttp and aiohttp_jinja2 test suites

### DIFF
--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -3,6 +3,7 @@ components:
   aiohttp:
     - ddtrace/contrib/aiohttp.py
     - ddtrace/contrib/internal/aiohttp/*
+  aiohttp_jinja2:
     - ddtrace/contrib/internal/aiohttp_jinja2/*
   aiopg:
     - ddtrace/contrib/internal/aiopg/*
@@ -230,7 +231,8 @@ suites:
     snapshot: true
     venvs_per_job: 2
   aiohttp:
-    parallelism: 3
+    pattern: ^aiohttp$
+    venvs_per_job: 3
     paths:
       - '@bootstrap'
       - '@core'
@@ -238,8 +240,21 @@ suites:
       - '@tracing'
       - '@aiohttp'
       - tests/contrib/aiohttp/*
+      - tests/snapshots/tests.{suite}.*
+    services:
+      - httpbin
+    snapshot: true
+  aiohttp_jinja2:
+    venvs_per_job: 6
+    paths:
+      - '@bootstrap'
+      - '@core'
+      - '@contrib'
+      - '@tracing'
+      - '@aiohttp'
+      - '@aiohttp_jinja2'
+      - tests/contrib/aiohttp/*
       - tests/contrib/aiohttp_jinja2/*
-      - tests/snapshots/tests.contrib.aiohttp_jinja2.*
       - tests/snapshots/tests.{suite}.*
     services:
       - httpbin


### PR DESCRIPTION
## Description

We currently run `aiohttp` and `aiohttp_jinja2` test suites together in the same jobs. This results in 37 total venvs for the "aiohttp" pattern. Breaking these up into discrete jobs give us more control over the test selection and parallelism for each.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
