### PR TITLE
ci: increase mlflow parallelism

### DIFF
--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -919,7 +919,7 @@ suites:
     snapshot: true
     venvs_per_job: 2
   mlflow:
-    parallelism: 2
+    venvs_per_job: 2
     paths:
       - '@bootstrap'
       - '@core'


### PR DESCRIPTION
## Description

Currently the job takes about 13 minutes p75. There are 10 venvs with a current parallelism of `2`.

This PR migrates the job to `venvs_per_job: 2`, so we should be able to cut the CI runtime in little less than half.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
