### PR TITLE
ci: increase aiokafka parallelism

### DIFF
--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -263,7 +263,7 @@ suites:
     env:
       TEST_KAFKA_HOST: kafka
       TEST_KAFKA_PORT: '29092'
-    parallelism: 2
+    venvs_per_job: 2
     paths:
       - '@bootstrap'
       - '@core'


### PR DESCRIPTION
## Description

Current CI runtime is about 12 minutes p75. There are 12 venvs and the current parallelism is 2.

This PR changes to `venvs_per_job: 2` so we'll get 6 jobs instead of 2, we should be able to cut runtime closer to 4-5 minutes.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
