### PR TITLE
fix(internal): detach threads if joinable before destroying [backport 4.6]

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -718,6 +718,10 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
     // joinable() is always false here. No OS call needed on the inherited handle.
 
     if (should_restart) {
+        // Clean up any potentially bad state post-fork
+        if (self->_thread != nullptr && self->_thread->joinable())
+            self->_thread->detach();
+
         self->_thread = nullptr;
 
         self->_started->clear();

--- a/releasenotes/notes/internal-periodic-thread-crash-after-fork-4d1571830c582d21.yaml
+++ b/releasenotes/notes/internal-periodic-thread-crash-after-fork-4d1571830c582d21.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    internal: A crash that could occur post-fork in fork-heavy applications has been fixed.


### PR DESCRIPTION
Backport of https://github.com/DataDog/dd-trace-py/pull/17297