### PR TITLE
chore(tests): migrate contrib integration tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/contrib/aiobotocore/test.py
+++ b/tests/contrib/aiobotocore/test.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 import aiobotocore
@@ -8,6 +7,7 @@ import pytest
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.aiobotocore.patch import patch
 from ddtrace.contrib.internal.aiobotocore.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code
@@ -396,12 +396,12 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name, expected_operation_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if service_name:
-        env["DD_SERVICE"] = service_name
+        subenv["DD_SERVICE"] = service_name
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode()
 
 

--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -1,11 +1,10 @@
-import os
-
 import aiohttp
 import pytest
 
 from ddtrace.contrib.internal.aiohttp.patch import extract_netloc_and_query_info_from_url
 from ddtrace.contrib.internal.aiohttp.patch import patch
 from ddtrace.contrib.internal.aiohttp.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.utils import override_config
 from tests.utils import override_http_config
 
@@ -112,9 +111,9 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_AIOHTTP_CLIENT_DISTRIBUTED_TRACING"] = "false"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_AIOHTTP_CLIENT_DISTRIBUTED_TRACING"] = "false"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 
@@ -138,11 +137,11 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_SERVICE"] = "global-service-name"
+    subenv = env.copy()
+    subenv["DD_SERVICE"] = "global-service-name"
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 
@@ -166,10 +165,10 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 import pytest_asyncio
 
@@ -12,6 +10,7 @@ from ddtrace.contrib.internal.aiohttp.middlewares import CONFIG_KEY
 from ddtrace.contrib.internal.aiohttp.middlewares import trace_app
 from ddtrace.contrib.internal.aiohttp.middlewares import trace_middleware
 from ddtrace.ext import http
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import assert_span_http_status_code
@@ -97,10 +96,10 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name, expected_span_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b""
 

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -1,5 +1,3 @@
-import os
-
 import aiomysql
 import mock
 import pymysql
@@ -8,6 +6,7 @@ import pytest
 from ddtrace.contrib.internal.aiomysql.patch import patch
 from ddtrace.contrib.internal.aiomysql.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.settings import env
 from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
@@ -101,9 +100,9 @@ async def test_user_specified_service_v0(ddtrace_run_python_code_in_subprocess):
     v0: When a user specifies a service for the app
         The aiomysql integration should not use it.
     """
-    env = os.environ.copy()
-    env["DD_SERVICE"] = "my-service-name"
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
+    subenv = env.copy()
+    subenv["DD_SERVICE"] = "my-service-name"
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import asyncio
@@ -117,7 +116,7 @@ async def test():
     await (await conn.cursor()).execute("select 'dba4x4'")
     conn.close()
 asyncio.run(test())""",
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == err == b""
@@ -130,9 +129,9 @@ async def test_user_specified_service_v1(ddtrace_run_python_code_in_subprocess):
     v1: When a user specifies a service for the app
         The aiomysql integration should use it.
     """
-    env = os.environ.copy()
-    env["DD_SERVICE"] = "my-service-name"
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    subenv = env.copy()
+    subenv["DD_SERVICE"] = "my-service-name"
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import asyncio
@@ -146,7 +145,7 @@ async def test():
     await (await conn.cursor()).execute("select 'dba4x4'")
     conn.close()
 asyncio.run(test())""",
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == err == b""
@@ -159,8 +158,8 @@ async def test_unspecified_service_v1(ddtrace_run_python_code_in_subprocess):
     v1: When a user specifies nothing for a service,
         it should default to internal.schema.DEFAULT_SPAN_SERVICE_NAME
     """
-    env = os.environ.copy()
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    subenv = env.copy()
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import asyncio
@@ -173,7 +172,7 @@ async def test():
     await (await conn.cursor()).execute("select 'dba4x4'")
     conn.close()
 asyncio.run(test())""",
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == err == b""
@@ -187,8 +186,8 @@ async def test_schematized_span_name(ddtrace_run_python_code_in_subprocess, vers
     When a user specifies a service for the app
         The aiomysql integration should not use it.
     """
-    env = os.environ.copy()
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = version
+    subenv = env.copy()
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import asyncio
@@ -200,7 +199,7 @@ async def test():
     await (await conn.cursor()).execute("select 'dba4x4'")
     conn.close()
 asyncio.run(test())""",
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == err == b""

--- a/tests/contrib/aredis/test_aredis.py
+++ b/tests/contrib/aredis/test_aredis.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 
 import aredis
 import pytest
@@ -7,6 +6,7 @@ import pytest
 from ddtrace.contrib.internal.aredis.patch import patch
 from ddtrace.contrib.internal.aredis.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
+from ddtrace.internal.settings import env
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.utils import override_config
 
@@ -150,12 +150,12 @@ async def test(tracer, test_spans):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service, expected_operation)
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()
 

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -1,7 +1,6 @@
 import asyncio
 from functools import partial
 import logging
-import os
 import random
 
 from asgiref.testing import ApplicationCommunicator
@@ -14,6 +13,7 @@ from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.asgi.middleware import _parse_response_cookies
 from ddtrace.contrib.internal.asgi.middleware import span_from_scope
+from ddtrace.internal.settings import env
 from ddtrace.propagation import http as http_propagation
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
@@ -222,10 +222,10 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_span_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err, out)
     assert err == b"", f"STDOUT\n{out.decode()}\nSTDERR\n{err.decode()}"
 
@@ -278,12 +278,12 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if global_service_name:
-        env["DD_SERVICE"] = global_service_name
+        subenv["DD_SERVICE"] = global_service_name
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err, out)
     assert err == b""
 

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -1,7 +1,6 @@
 """Ensure that the tracer works with asynchronous executions within the same ``IOLoop``."""
 
 import asyncio
-import os
 import re
 
 import pytest
@@ -9,6 +8,7 @@ import pytest
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.asyncio.patch import patch
 from ddtrace.contrib.internal.asyncio.patch import unpatch
+from ddtrace.internal.settings import env
 
 
 @pytest.fixture(autouse=True)
@@ -214,9 +214,9 @@ async def my_function():
 if __name__ == "__main__":
     asyncio.run(my_function())
 """
-    env = os.environ.copy()
-    env["PYTHONASYNCIODEBUG"] = "1"
-    out, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["PYTHONASYNCIODEBUG"] = "1"
+    out, err, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err + out
 
     pattern = rb"Executing <Task finished name=\'Task-1\' coro=<my_function\(\) done, "

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -1,4 +1,3 @@
-import os
 from typing import Generator  # noqa:F401
 
 import asyncpg
@@ -8,6 +7,7 @@ import pytest
 from ddtrace.contrib.internal.asyncpg.patch import patch
 from ddtrace.contrib.internal.asyncpg.patch import unpatch
 from ddtrace.contrib.internal.trace_utils import iswrapped
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.trace import tracer
 from tests.contrib.asyncio.utils import AsyncioTestCase
@@ -185,10 +185,10 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_ASYNCPG_SERVICE"] = "global-service-name"
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_ASYNCPG_SERVICE"] = "global-service-name"
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 
@@ -214,10 +214,10 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_ASYNCPG_SERVICE"] = "global-service-name"
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_ASYNCPG_SERVICE"] = "global-service-name"
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 
@@ -243,9 +243,9 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 
@@ -271,9 +271,9 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 
@@ -300,9 +300,9 @@ async def test():
 
 asyncio.run(test())
     """
-    env = os.environ.copy()
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert err == b""
 

--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import botocore
 import pytest
 
@@ -7,6 +5,7 @@ from ddtrace.contrib.internal.botocore.patch import patch
 from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.contrib.internal.urllib3.patch import patch as urllib3_patch
 from ddtrace.contrib.internal.urllib3.patch import unpatch as urllib3_unpatch
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs as llmobs_service
 from tests.contrib.botocore.bedrock_utils import get_request_vcr
 from tests.llmobs._utils import TestLLMObsSpanWriter
@@ -27,11 +26,11 @@ def ddtrace_global_config():
 @pytest.fixture
 def aws_credentials():
     """Mocked AWS Credentials. To regenerate test cassettes, comment this out and use real credentials."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    env["AWS_ACCESS_KEY_ID"] = "testing"
+    env["AWS_SECRET_ACCESS_KEY"] = "testing"
+    env["AWS_SECURITY_TOKEN"] = "testing"
+    env["AWS_SESSION_TOKEN"] = "testing"
+    env["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
 @pytest.fixture
@@ -51,10 +50,10 @@ def boto3(aws_credentials, llmobs_span_writer, ddtrace_global_config):
 @pytest.fixture
 def bedrock_client(boto3, request_vcr):
     session = boto3.Session(
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", ""),
-        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-        aws_session_token=os.getenv("AWS_SESSION_TOKEN", ""),
-        region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
+        aws_access_key_id=env.get("AWS_ACCESS_KEY_ID", ""),
+        aws_secret_access_key=env.get("AWS_SECRET_ACCESS_KEY", ""),
+        aws_session_token=env.get("AWS_SESSION_TOKEN", ""),
+        region_name=env.get("AWS_DEFAULT_REGION", "us-east-1"),
     )
     client = session.client("bedrock-runtime")
     yield client
@@ -63,10 +62,10 @@ def bedrock_client(boto3, request_vcr):
 @pytest.fixture
 def bedrock_agent_client(boto3, request_vcr):
     session = boto3.Session(
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", ""),
-        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-        aws_session_token=os.getenv("AWS_SESSION_TOKEN", ""),
-        region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
+        aws_access_key_id=env.get("AWS_ACCESS_KEY_ID", ""),
+        aws_secret_access_key=env.get("AWS_SECRET_ACCESS_KEY", ""),
+        aws_session_token=env.get("AWS_SESSION_TOKEN", ""),
+        region_name=env.get("AWS_DEFAULT_REGION", "us-east-1"),
     )
     client = session.client("bedrock-agent-runtime")
     yield client
@@ -75,10 +74,10 @@ def bedrock_agent_client(boto3, request_vcr):
 @pytest.fixture
 def bedrock_client_proxy(boto3):
     session = boto3.Session(
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", ""),
-        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-        aws_session_token=os.getenv("AWS_SESSION_TOKEN", ""),
-        region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
+        aws_access_key_id=env.get("AWS_ACCESS_KEY_ID", ""),
+        aws_secret_access_key=env.get("AWS_SECRET_ACCESS_KEY", ""),
+        aws_session_token=env.get("AWS_SESSION_TOKEN", ""),
+        region_name=env.get("AWS_DEFAULT_REGION", "us-east-1"),
     )
     bedrock_client = session.client("bedrock-runtime", endpoint_url="http://localhost:4000")
     yield bedrock_client

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -7,6 +7,7 @@ from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.bottle.patch import TracePlugin
 from ddtrace.ext import http
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.settings import env
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
@@ -446,10 +447,9 @@ class TraceBottleTest(TracerTestCase):
         resp = self.app.get("/hi/dougie")
         assert resp.status_int == 200
         root = self.get_root_span()
-        import os
 
-        assert "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA" in os.environ
-        assert os.environ["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] == "v1"
+        assert "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA" in env
+        assert env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] == "v1"
         root.assert_matches(name="http.server.request")
 
     def test_http_request_header_tracing(self):

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -14,6 +14,7 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.celery.patch import patch
 from ddtrace.contrib.internal.celery.patch import unpatch
 import ddtrace.internal.forksafe as forksafe
+from ddtrace.internal.settings import env
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.trace import Context
 
@@ -873,18 +874,18 @@ def is_single_trace(trace_id):
 celery_app.worker_main(["worker", "--loglevel=info"])
 """
 
-    env = os.environ.copy()
-    env["CELERY_BROKER_URL"] = BROKER_URL
-    env["CELERY_RESULT_BACKEND"] = BACKEND_URL
-    env["DD_CELERY_DISTRIBUTED_TRACING"] = str(distributed_tracing_enabled)
+    subenv = env.copy()
+    subenv["CELERY_BROKER_URL"] = BROKER_URL
+    subenv["CELERY_RESULT_BACKEND"] = BACKEND_URL
+    subenv["DD_CELERY_DISTRIBUTED_TRACING"] = str(distributed_tracing_enabled)
     # Disable Redis to reduce noise in the snapshot file
-    env["DD_TRACE_REDIS_ENABLED"] = "false"
+    subenv["DD_TRACE_REDIS_ENABLED"] = "false"
 
     worker_process = subprocess.Popen(
         ["ddtrace-run", sys.executable, "-c", consumer_code],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=env,
+        env=subenv,
         preexec_fn=os.setsid if os.name != "nt" else None,
         close_fds=True,
     )
@@ -897,7 +898,7 @@ celery_app.worker_main(["worker", "--loglevel=info"])
         while _inspect_app.control.inspect(timeout=1).active() is None and waited < max_wait:
             time.sleep(0.5)
             waited += 0.5
-        _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(producer_code, env=env, timeout=30)
+        _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(producer_code, env=subenv, timeout=30)
         assert status == 0, stderr.decode() if stderr else "producer failed"
     finally:
         try:

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import os
 import re
 import time
 from urllib.parse import quote as url_quote
@@ -17,6 +16,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.cherrypy.patch import TraceMiddleware
 from ddtrace.ext import http
+from ddtrace.internal.settings import env
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
@@ -647,11 +647,11 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    env["DD_SERVICE"] = "mysvc"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    subenv["DD_SERVICE"] = "mysvc"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err, out)
     assert b"2 passed" in out
 
@@ -703,10 +703,10 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_operation_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    env["DD_SERVICE"] = "mysvc"
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    subenv["DD_SERVICE"] = "mysvc"
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err, out)
     assert b"2 passed" in out

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -1,5 +1,3 @@
-import os
-
 import consul
 from wrapt import BoundFunctionWrapper
 
@@ -7,6 +5,7 @@ from ddtrace.contrib.internal.consul.patch import patch
 from ddtrace.contrib.internal.consul.patch import unpatch
 from ddtrace.ext import consul as consulx
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.settings import env
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 
@@ -18,8 +17,8 @@ CONSUL_HTTP_ADDR = f"{CONSUL_CONFIG['host']}:{CONSUL_CONFIG['port']}"
 
 class TestConsulPatch(TracerTestCase):
     def setUp(self):
-        if "CONSUL_HTTP_ADDR" in os.environ:
-            del os.environ["CONSUL_HTTP_ADDR"]
+        if "CONSUL_HTTP_ADDR" in env:
+            del env["CONSUL_HTTP_ADDR"]
         super(TestConsulPatch, self).setUp()
         patch()
         c = consul.Consul(

--- a/tests/contrib/django/conftest.py
+++ b/tests/contrib/django/conftest.py
@@ -1,10 +1,9 @@
-import os
-
 import django
 from django.conf import settings
 import pytest
 
 from ddtrace.contrib.internal.django.patch import patch
+from ddtrace.internal.settings import env
 
 
 # We manually designate which settings we will be using in an environment variable
@@ -13,7 +12,7 @@ if django.VERSION >= (2, 0, 0):
     app_name = "django_app"
 else:
     app_name = "django1_app"
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.contrib.django.{0}.settings".format(app_name))
+env.setdefault("DJANGO_SETTINGS_MODULE", "tests.contrib.django.{0}.settings".format(app_name))
 
 
 # `pytest` automatically calls this function once when tests are run.

--- a/tests/contrib/django/django_app/settings.py
+++ b/tests/contrib/django/django_app/settings.py
@@ -2,6 +2,7 @@ import os
 
 import django
 
+from ddtrace.internal.settings import env
 from ddtrace.trace import tracer
 from tests.webclient import PingFilter
 
@@ -86,7 +87,7 @@ MIDDLEWARE = [
     "tests.contrib.django.middleware.EverythingMiddleware",
 ]
 
-if os.getenv("TEST_INCLUDE_ASYNC_ONLY_MIDDLEWARE") == "1":
+if env.get("TEST_INCLUDE_ASYNC_ONLY_MIDDLEWARE") == "1":
     # DEV: Add to the front, since adding at the end causes it to not get called?
     MIDDLEWARE = ["tests.contrib.django.middleware.async_only_middleware"] + MIDDLEWARE
 

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import itertools
-import os
 import subprocess
 import types
 import uuid
@@ -31,6 +30,7 @@ from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import wrapping
 from ddtrace.internal.compat import ensure_text
+from ddtrace.internal.settings import env
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
@@ -1706,14 +1706,14 @@ if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if global_service_name is not None:
-        env["DD_SERVICE"] = global_service_name
+        subenv["DD_SERVICE"] = global_service_name
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)
 
@@ -1753,17 +1753,17 @@ with setup_django_test_spans() as test_spans, with_default_django_db(test_spans)
     assert span.get_tag("django.db.alias") == "default"
     """.format(expected_service_name)
 
-    env = os.environ.copy()
-    env["DD_DJANGO_INSTRUMENT_DATABASES"] = "true"
-    env["DD_TRACE_PSYCOPG_ENABLED"] = "false"
-    env["DD_TRACE_SQLITE3_ENABLED"] = "false"
+    subenv = env.copy()
+    subenv["DD_DJANGO_INSTRUMENT_DATABASES"] = "true"
+    subenv["DD_TRACE_PSYCOPG_ENABLED"] = "false"
+    subenv["DD_TRACE_SQLITE3_ENABLED"] = "false"
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if global_service_name is not None:
-        env["DD_SERVICE"] = global_service_name
+        subenv["DD_SERVICE"] = global_service_name
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)
 
@@ -1797,12 +1797,12 @@ if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_operation_name)
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)
 
@@ -2392,11 +2392,11 @@ def test_enable_django_instrument_env(env_var, instrument_x, ddtrace_run_python_
     Test that {env} enables instrumentation
     """
 
-    env = os.environ.copy()
-    env[env_var] = "true"
+    subenv = env.copy()
+    subenv[env_var] = "true"
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         "import ddtrace;import django;assert ddtrace.config.django.{}".format(instrument_x),
-        env=env,
+        env=subenv,
     )
 
     assert status == 0, (out, err)
@@ -2416,11 +2416,11 @@ def test_disable_django_instrument_env(env_var, instrument_x, ddtrace_run_python
     Test that {env} disables instrumentation
     """
 
-    env = os.environ.copy()
-    env[env_var] = "false"
+    subenv = env.copy()
+    subenv[env_var] = "false"
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         "import ddtrace;import django;assert not ddtrace.config.django.{}".format(instrument_x),
-        env=env,
+        env=subenv,
     )
 
     assert status == 0, (out, err)

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-import os
 import re
 import subprocess
 
@@ -9,6 +8,7 @@ import pytest
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import FINGERPRINTING
 import ddtrace.internal.constants as constants
+from ddtrace.internal.settings import env
 import tests.appsec.rules as rules
 from tests.utils import snapshot
 from tests.webclient import Client
@@ -29,10 +29,10 @@ def daphne_client(django_asgi, additional_env=None):
 
     # Make sure to copy the environment as we need the PYTHONPATH and _DD_TRACE_WRITER_ADDITIONAL_HEADERS (for the test
     # token) propagated to the new process.
-    env = os.environ.copy()
-    env.update(additional_env or {})
+    subenv = env.copy()
+    subenv.update(additional_env or {})
     assert "_DD_TRACE_WRITER_ADDITIONAL_HEADERS" in env, "Client fixture needs test token in headers"
-    env.update(
+    subenv.update(
         {
             "DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings",
         }
@@ -41,7 +41,7 @@ def daphne_client(django_asgi, additional_env=None):
     # ddtrace-run uses execl which replaces the process but the webserver process itself might spawn new processes.
     # Right now it doesn't but it's possible that it might in the future (ex. uwsgi).
     cmd = ["ddtrace-run", "daphne", "-p", str(SERVER_PORT), "tests.contrib.django.asgi:%s" % django_asgi]
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=subenv)
 
     client = Client("http://localhost:%d" % SERVER_PORT)
 

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-import os
 from pathlib import Path
 import subprocess
 import sys
@@ -7,6 +6,7 @@ import sys
 import django
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.utils import _build_env
 from tests.utils import package_installed
 from tests.utils import snapshot
@@ -32,10 +32,10 @@ def daphne_client(django_asgi, additional_env=None):
 
     # Make sure to copy the environment as we need the PYTHONPATH and _DD_TRACE_WRITER_ADDITIONAL_HEADERS (for the test
     # token) propagated to the new process.
-    env = _build_env(os.environ.copy(), file_path=FILE_PATH)
-    env.update(additional_env or {})
-    assert "_DD_TRACE_WRITER_ADDITIONAL_HEADERS" in env, "Client fixture needs test token in headers"
-    env.update(
+    subenv = _build_env(env.copy(), file_path=FILE_PATH)
+    subenv.update(additional_env or {})
+    assert "_DD_TRACE_WRITER_ADDITIONAL_HEADERS" in subenv, "Client fixture needs test token in headers"
+    subenv.update(
         {
             "DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings",
         }
@@ -52,7 +52,7 @@ def daphne_client(django_asgi, additional_env=None):
         "tests.contrib.django.asgi:%s" % django_asgi,
     ]
     subprocess_kwargs = {
-        "env": env,
+        "env": subenv,
         "start_new_session": True,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,

--- a/tests/contrib/django/test_django_wsgi.py
+++ b/tests/contrib/django/test_django_wsgi.py
@@ -12,6 +12,7 @@ import pytest
 
 from ddtrace.contrib.internal.wsgi.wsgi import DDWSGIMiddleware
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
+from ddtrace.internal.settings import env
 from tests.contrib.django.utils import make_soap_request
 from tests.webclient import Client
 
@@ -51,10 +52,10 @@ app = DDWSGIMiddleware(get_wsgi_application(), app_is_iterator=True)
 
 @pytest.fixture()
 def wsgi_app():
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
-            "PYTHONPATH": os.path.dirname(os.path.abspath(__file__)) + ":" + env["PYTHONPATH"],
+            "PYTHONPATH": os.path.dirname(os.path.abspath(__file__)) + ":" + subenv["PYTHONPATH"],
             "DJANGO_SETTINGS_MODULE": "test_django_wsgi",
             "DD_TRACE_ENABLED": "true",
         }
@@ -65,7 +66,7 @@ def wsgi_app():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
-        env=env,
+        env=subenv,
     )
 
     yield proc

--- a/tests/contrib/django_celery/app/manage.py
+++ b/tests/contrib/django_celery/app/manage.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-import os
 import sys
+from ddtrace.internal.settings import env
 
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "proj.settings")
+    env.setdefault("DJANGO_SETTINGS_MODULE", "proj.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/tests/contrib/django_celery/app/proj/celery.py
+++ b/tests/contrib/django_celery/app/proj/celery.py
@@ -1,10 +1,10 @@
-import os
 
 from celery import Celery
+from ddtrace.internal.settings import env
 
 
 # Set the default Django settings module for the 'celery' program.
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "proj.settings")
+env.setdefault("DJANGO_SETTINGS_MODULE", "proj.settings")
 
 app = Celery("proj")
 

--- a/tests/contrib/django_celery/app/proj/wsgi.py
+++ b/tests/contrib/django_celery/app/proj/wsgi.py
@@ -14,15 +14,15 @@ framework.
 
 """
 
-import os
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
+from ddtrace.internal.settings import env
 
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "proj.settings")
+env.setdefault("DJANGO_SETTINGS_MODULE", "proj.settings")
 
 application = get_wsgi_application()
 

--- a/tests/contrib/django_hosts/conftest.py
+++ b/tests/contrib/django_hosts/conftest.py
@@ -1,14 +1,13 @@
-import os
-
 import django
 from django.conf import settings
 
 from ddtrace.contrib.internal.django.patch import patch
+from ddtrace.internal.settings import env
 
 
 # We manually designate which settings we will be using in an environment variable
 # This is similar to what occurs in the `manage.py`
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.contrib.django_hosts.django_app.settings")
+env.setdefault("DJANGO_SETTINGS_MODULE", "tests.contrib.django_hosts.django_app.settings")
 
 
 # `pytest` automatically calls this function once when tests are run.

--- a/tests/contrib/djangorestframework/conftest.py
+++ b/tests/contrib/djangorestframework/conftest.py
@@ -1,16 +1,16 @@
 __all__ = ["pytest_configure"]
 
-import os
 
 import django
 from django.conf import settings
 
 from ddtrace.contrib.internal.django.patch import patch
+from ddtrace.internal.settings import env
 
 
 # We manually designate which settings we will be using in an environment variable
 # This is similar to what occurs in the `manage.py`
-os.environ["DJANGO_SETTINGS_MODULE"] = "tests.contrib.djangorestframework.app.settings"
+env["DJANGO_SETTINGS_MODULE"] = "tests.contrib.djangorestframework.app.settings"
 
 
 # `pytest` automatically calls this function once when tests are run.

--- a/tests/contrib/djangorestframework/test_djangorestframework.py
+++ b/tests/contrib/djangorestframework/test_djangorestframework.py
@@ -1,11 +1,10 @@
-import os
-
 import django
 import pytest
 
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
+from ddtrace.internal.settings import env
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import assert_span_http_status_code
@@ -142,12 +141,12 @@ def test(client, test_spans):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)
 
@@ -177,11 +176,11 @@ def test(client, test_spans):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_operation_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)

--- a/tests/contrib/dogpile_cache/test_tracing.py
+++ b/tests/contrib/dogpile_cache/test_tracing.py
@@ -1,10 +1,9 @@
-import os
-
 import dogpile
 import pytest
 
 from ddtrace.contrib.internal.dogpile_cache.patch import patch
 from ddtrace.contrib.internal.dogpile_cache.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.utils import assert_is_measured
 
@@ -235,11 +234,11 @@ def test(tracer, single_cache, test_spans):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service, expected_operation)
-    env = os.environ.copy()
+    subenv = env.copy()
     if service_override:
-        env["DD_SERVICE"] = service_override
+        subenv["DD_SERVICE"] = service_override
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode()
     assert err == b"", err.decode()

--- a/tests/contrib/elasticsearch/test_async.py
+++ b/tests/contrib/elasticsearch/test_async.py
@@ -1,7 +1,7 @@
-import os
 import subprocess
 import sys
 
+from ddtrace.internal.settings import env
 from tests.conftest import create_ddtrace_subprocess_dir_and_return_test_pyfile
 from tests.utils import snapshot
 
@@ -41,11 +41,11 @@ asyncio.run(main())
 def do_test(tmpdir, es_module, async_class):
     f = create_ddtrace_subprocess_dir_and_return_test_pyfile(tmpdir)
     f.write(code % {"module": es_module, "class": async_class})
-    env = os.environ.copy()
+    subenv = env.copy()
     # ddtrace-run patches sqlite3 which is used by coverage to store coverage
     # results. This generates sqlite3 spans during the test run which interfere
     # with the snapshot. So disable sqlite3.
-    env.update(
+    subenv.update(
         {
             "DD_TRACE_SQLITE3_ENABLED": "false",
             "DD_TRACE_AIOHTTP_ENABLED": "false",
@@ -56,7 +56,7 @@ def do_test(tmpdir, es_module, async_class):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=str(tmpdir),
-        env=env,
+        env=subenv,
     )
     p.wait()
     stderr = p.stderr.read()

--- a/tests/contrib/elasticsearch/test_elasticsearch_multi.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch_multi.py
@@ -1,7 +1,7 @@
-import os
 import subprocess
 import sys
 
+from ddtrace.internal.settings import env
 from tests.conftest import create_ddtrace_subprocess_dir_and_return_test_pyfile
 from tests.utils import snapshot
 
@@ -33,17 +33,17 @@ else:
 def do_test(tmpdir, es_version):
     f = create_ddtrace_subprocess_dir_and_return_test_pyfile(tmpdir)
     f.write(code % es_version)
-    env = os.environ.copy()
+    subenv = env.copy()
     # ddtrace-run patches sqlite3 which is used by coverage to store coverage
     # results. This generates sqlite3 spans during the test run which interfere
     # with the snapshot. So disable sqlite3.
-    env.update({"DD_TRACE_SQLITE3_ENABLED": "false"})
+    subenv.update({"DD_TRACE_SQLITE3_ENABLED": "false"})
     p = subprocess.Popen(
         ["ddtrace-run", sys.executable, str(f)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=str(tmpdir),
-        env=env,
+        env=subenv,
     )
     p.wait()
     stderr = p.stderr.read()

--- a/tests/contrib/falcon/test_schematization.py
+++ b/tests/contrib/falcon/test_schematization.py
@@ -1,7 +1,6 @@
-import os
-
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 
 
@@ -43,12 +42,12 @@ class TestCase(TracerTestCase, testing.TestCase, FalconTestMixin):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)
 
@@ -91,11 +90,11 @@ class TestCase(TracerTestCase, testing.TestCase, FalconTestMixin):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_operation_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, (out, err)

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import time
 
 import fastapi
@@ -11,6 +10,7 @@ import starlette
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.starlette.patch import patch as patch_starlette
 from ddtrace.contrib.internal.starlette.patch import unpatch as unpatch_starlette
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation import http as http_propagation
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
@@ -783,13 +783,13 @@ def test_read_homepage(snapshot_client):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if service_override:
-        env["DD_SERVICE"] = service_override
+        subenv["DD_SERVICE"] = service_override
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    env["DD_TRACE_REQUESTS_ENABLED"] = "false"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    subenv["DD_TRACE_REQUESTS_ENABLED"] = "false"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode()
     assert err == b"", err.decode()
 

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -10,6 +10,7 @@ import pytest
 
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.contrib.internal.flask.patch import flask_version
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.retry import RetryError
 import tests.appsec.rules as rules
 from tests.webclient import Client
@@ -42,8 +43,8 @@ def flask_command(flask_wsgi_application: str, flask_port: str) -> list[str]:
 
 
 def flask_appsec_good_rules_env(flask_wsgi_application: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
             # Avoid noisy database spans being output on app startup/teardown.
             "DD_TRACE_SQLITE3_ENABLED": "0",

--- a/tests/contrib/flask/test_flask_openapi3.py
+++ b/tests/contrib/flask/test_flask_openapi3.py
@@ -1,4 +1,4 @@
-import os
+from ddtrace.internal.settings import env
 
 
 def test_flask_openapi3_instrumentation(ddtrace_run_python_code_in_subprocess):
@@ -13,7 +13,7 @@ app = OpenAPI(__name__, info=info)
 def hello_world():
     return 'Hello, World!'
 """
-    env = os.environ.copy()
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (out, err)
     assert err == b"", (out, err)

--- a/tests/contrib/flask/test_flask_snapshot.py
+++ b/tests/contrib/flask/test_flask_snapshot.py
@@ -8,6 +8,7 @@ from typing import Generator  # noqa:F401
 import pytest
 
 from ddtrace.contrib.internal.flask.patch import flask_version
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.retry import RetryError
 from tests.webclient import Client
 
@@ -34,8 +35,8 @@ def flask_command(flask_wsgi_application: str, flask_port: str) -> list[str]:
 
 
 def flask_default_env(flask_wsgi_application: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
             # Avoid noisy database spans being output on app startup/teardown.
             "DD_TRACE_SQLITE3_ENABLED": "0",

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-import os
 import subprocess
 import sys
 import time
@@ -15,6 +14,7 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.ext import http
+from ddtrace.internal.settings import env
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
@@ -1173,12 +1173,12 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if service_name:
-        env["DD_SERVICE"] = service_name
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_SERVICE"] = service_name
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (out, err)
     assert err == b""
 
@@ -1215,10 +1215,10 @@ if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_operation_name)
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (out, err)
     assert err == b"", (out, err)
 

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -5,6 +5,7 @@ from ddtrace.contrib.internal.flask_cache.patch import CACHE_BACKEND
 from ddtrace.contrib.internal.flask_cache.patch import get_traced_cache
 from ddtrace.ext import net
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.settings import env
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset
 from tests.utils import assert_is_measured
@@ -364,9 +365,8 @@ class TestFlaskCacheSchematization(TracerTestCase):
 
         self.cache.get("á_complex_operation")
         spans = self.get_spans()
-        import os
 
-        assert os.environ.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA") == "v1"
+        assert env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA") == "v1"
 
         for span in spans:
             assert span.service == "mysvc", "Expected service name to be 'mysvc' but was '{}'".format(span.service)

--- a/tests/contrib/graphql/test_graphql.py
+++ b/tests/contrib/graphql/test_graphql.py
@@ -1,5 +1,3 @@
-import os
-
 import graphql
 from graphql import build_schema
 from graphql import graphql_sync
@@ -8,6 +6,7 @@ import pytest
 from ddtrace.contrib.internal.graphql.patch import _graphql_version as graphql_version
 from ddtrace.contrib.internal.graphql.patch import patch
 from ddtrace.contrib.internal.graphql.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.trace import tracer
 from tests.utils import override_config
 from tests.utils import snapshot
@@ -233,11 +232,11 @@ if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if service_name:
-        env["DD_SERVICE"] = service_name
+        subenv["DD_SERVICE"] = service_name
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode()
     assert err == b"", err.decode()

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections import namedtuple
-import os
 import sys
 
 import grpc
@@ -13,6 +12,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.contrib.internal.grpc.utils import _parse_rpc_repr_string
+from ddtrace.internal.settings import env
 import ddtrace.vendor.packaging.version as packaging_version
 from tests.contrib.grpc.hello_pb2 import HelloReply
 from tests.contrib.grpc.hello_pb2 import HelloRequest
@@ -847,12 +847,12 @@ async def test_client_streaming(server_info, tracer):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__, "--asyncio-mode=auto"]))
     """.format(expected_operation_name_format)
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()
 

--- a/tests/contrib/gunicorn/test_gunicorn.py
+++ b/tests/contrib/gunicorn/test_gunicorn.py
@@ -58,20 +58,20 @@ def _gunicorn_settings_factory(
     if directory is None:
         directory = os.getcwd()
     if env is None:
-        env = os.environ.copy()
+        subenv = env.copy()
     if import_auto_in_app is not None:
-        env["_DD_TEST_IMPORT_AUTO"] = str(import_auto_in_app)
-    env["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "1" if enable_module_cloning else "0"
-    env["DD_REMOTE_CONFIGURATION_ENABLED"] = str(True)
-    env["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS"] = str(SERVICE_INTERVAL)
-    env["DD_PROFILING_UPLOAD_INTERVAL"] = str(SERVICE_INTERVAL)
-    env["DD_TRACE_DEBUG"] = str(debug_mode)
+        subenv["_DD_TEST_IMPORT_AUTO"] = str(import_auto_in_app)
+    subenv["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "1" if enable_module_cloning else "0"
+    subenv["DD_REMOTE_CONFIGURATION_ENABLED"] = str(True)
+    subenv["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS"] = str(SERVICE_INTERVAL)
+    subenv["DD_PROFILING_UPLOAD_INTERVAL"] = str(SERVICE_INTERVAL)
+    subenv["DD_TRACE_DEBUG"] = str(debug_mode)
     if dd_service is not None:
-        env["DD_SERVICE"] = dd_service
+        subenv["DD_SERVICE"] = dd_service
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     return GunicornServerSettings(
-        env=env,
+        env=subenv,
         directory=directory,
         app_path=app_path,
         num_workers=num_workers,

--- a/tests/contrib/gunicorn/wsgi_mw_app.py
+++ b/tests/contrib/gunicorn/wsgi_mw_app.py
@@ -3,10 +3,10 @@ This app exists to replicate and report on failures and degraded behavior that c
 gunicorn
 """
 
-import os
+from ddtrace.internal.settings import env  # noqa: E402
 
 
-if os.getenv("_DD_TEST_IMPORT_AUTO"):
+if env.get("_DD_TEST_IMPORT_AUTO"):
     import ddtrace.auto  # noqa: F401  # isort: skip
 
 import json

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import random
 import time
 
@@ -13,6 +12,7 @@ from ddtrace.contrib.internal.kafka.patch import TracedConsumer
 from ddtrace.contrib.internal.kafka.patch import TracedProducer
 from ddtrace.contrib.internal.kafka.patch import patch
 from ddtrace.contrib.internal.kafka.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from tests.utils import override_config
 
@@ -295,10 +295,10 @@ def test():
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(kafka_topic)
-    env = os.environ.copy()
-    env["DD_KAFKA_SERVICE"] = "my-custom-service-name"
-    env["DD_KAFKA_EMPTY_POLL_ENABLED"] = "False"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_KAFKA_SERVICE"] = "my-custom-service-name"
+    subenv["DD_KAFKA_EMPTY_POLL_ENABLED"] = "False"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode()
     assert err == b"", err.decode()
 
@@ -318,13 +318,13 @@ def test():
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(kafka_topic)
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
-    env["DD_KAFKA_EMPTY_POLL_ENABLED"] = "False"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+    subenv["DD_KAFKA_EMPTY_POLL_ENABLED"] = "False"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode()
     assert err == b"", err.decode()
 
@@ -427,9 +427,9 @@ if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
 
-    env = os.environ.copy()
-    env["DD_KAFKA_PROPAGATION_ENABLED"] = "true"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_KAFKA_PROPAGATION_ENABLED"] = "true"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode() + err.decode()
 
 
@@ -627,9 +627,9 @@ def test(kafka_tracer, consumer, producer, kafka_topic, test_spans):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
-    env["DD_KAFKA_EMPTY_POLL_ENABLED"] = "False"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_KAFKA_EMPTY_POLL_ENABLED"] = "False"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, out.decode() + err.decode()
 
 

--- a/tests/contrib/logging/test_logging.py
+++ b/tests/contrib/logging/test_logging.py
@@ -1,6 +1,5 @@
 from io import StringIO
 import logging
-import os
 
 import pytest
 import wrapt
@@ -13,6 +12,7 @@ from ddtrace.contrib.internal.logging.patch import unpatch
 from ddtrace.internal.constants import LOG_ATTR_SPAN_ID
 from ddtrace.internal.constants import LOG_ATTR_TRACE_ID
 from ddtrace.internal.constants import MAX_UINT_64BITS
+from ddtrace.internal.settings import env
 from tests.utils import TracerTestCase
 
 
@@ -322,9 +322,9 @@ logging.basicConfig(level=logging.INFO, format=format_string)
 log.info("Hello!")
     """
 
-    env = os.environ.copy()
-    env["DD_LOGS_INJECTION"] = dd_logs_enabled
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_LOGS_INJECTION"] = dd_logs_enabled
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     assert stdout == b"", stderr

--- a/tests/contrib/logging/test_tracer_logging.py
+++ b/tests/contrib/logging/test_tracer_logging.py
@@ -3,6 +3,8 @@ import re
 
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 # example: '2022-06-10 21:49:26,010 CRITICAL [ddtrace] [test.py:15] - ddtrace critical log\n'
 # example: '2025-07-16 16:27:02,708 CRITICAL [ddtrace] [test.py:8] [dd.service=ddtrace_subprocess_dir
@@ -61,17 +63,17 @@ def test_unrelated_logger_loaded_first(
     When the tracer is imported after logging has been configured,
     the ddtrace logger does not override any custom logs settings.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if dd_trace_debug is not None:
-        env["DD_TRACE_DEBUG"] = dd_trace_debug
+        subenv["DD_TRACE_DEBUG"] = dd_trace_debug
 
     if dd_trace_log_file_level is not None:
-        env["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
+        subenv["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
 
     ddtrace_log_path = None
     if dd_trace_log_file is not None:
         ddtrace_log_path = tmpdir.strpath + "/" + dd_trace_log_file
-        env["DD_TRACE_LOG_FILE"] = ddtrace_log_path
+        subenv["DD_TRACE_LOG_FILE"] = ddtrace_log_path
     code = """
 import logging
 custom_logger = logging.getLogger('custom')
@@ -88,7 +90,7 @@ assert custom_logger.level == logging.WARN
 ddtrace_logger = logging.getLogger('ddtrace')
 ddtrace_logger.critical('ddtrace critical log')
 """
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert_file_logging(b"ddtrace critical log", out, err, dd_trace_debug, ddtrace_log_path)
 
@@ -103,17 +105,17 @@ def test_unrelated_logger_loaded_last(
     When the tracer is imported before logging has been configured in debug mode,
     the ddtrace logger does not override any custom logs settings.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if dd_trace_debug is not None:
-        env["DD_TRACE_DEBUG"] = dd_trace_debug
+        subenv["DD_TRACE_DEBUG"] = dd_trace_debug
 
     if dd_trace_log_file_level is not None:
-        env["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
+        subenv["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
 
     ddtrace_log_path = None
     if dd_trace_log_file is not None:
         ddtrace_log_path = tmpdir.strpath + "/" + dd_trace_log_file
-        env["DD_TRACE_LOG_FILE"] = tmpdir.strpath + "/" + dd_trace_log_file
+        subenv["DD_TRACE_LOG_FILE"] = tmpdir.strpath + "/" + dd_trace_log_file
     code = """
 import ddtrace
 import logging
@@ -128,7 +130,7 @@ ddtrace_logger = logging.getLogger('ddtrace')
 ddtrace_logger.critical('ddtrace critical log')
 """
 
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
 
     assert_file_logging(b"ddtrace critical log", out, err, dd_trace_debug, ddtrace_log_path)
@@ -144,15 +146,15 @@ def test_unrelated_logger_in_debug_with_ddtrace_run(
     When using ddtrace-run with a custom logger,
     the ddtrace logger does not override any custom logs settings.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if dd_trace_debug is not None:
-        env["DD_TRACE_DEBUG"] = dd_trace_debug
+        subenv["DD_TRACE_DEBUG"] = dd_trace_debug
 
     if dd_trace_log_file_level is not None:
-        env["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
+        subenv["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
 
     if dd_trace_log_file is not None:
-        env["DD_TRACE_LOG_FILE"] = tmpdir.strpath + "/" + dd_trace_log_file
+        subenv["DD_TRACE_LOG_FILE"] = tmpdir.strpath + "/" + dd_trace_log_file
     code = """
 import logging
 custom_logger = logging.getLogger('custom')
@@ -163,7 +165,7 @@ ddtrace_logger = logging.getLogger('ddtrace')
 ddtrace_logger.critical('ddtrace critical log')
 ddtrace_logger.warning('ddtrace warning log')
 """
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert out == b""
 
@@ -213,10 +215,10 @@ def test_warn_logs_can_go_to_file(run_python_code_in_subprocess, ddtrace_run_pyt
     When DD_TRACE_DEBUG is false and DD_TRACE_LOG_FILE_LEVEL hasn't been configured,
     warn logs are emitted to the path defined in DD_TRACE_LOG_FILE.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     log_file = tmpdir.strpath + "/testlog.log"
-    env["DD_TRACE_LOG_FILE"] = log_file
-    env["DD_TRACE_LOG_FILE_SIZE_BYTES"] = "200000"
+    subenv["DD_TRACE_LOG_FILE"] = log_file
+    subenv["DD_TRACE_LOG_FILE_SIZE_BYTES"] = "200000"
     patch_code = """
 import logging
 import ddtrace
@@ -248,7 +250,7 @@ ddtrace_logger.warning('warning log')
         (run_python_code_in_subprocess, patch_code),
         (ddtrace_run_python_code_in_subprocess, ddtrace_run_code),
     ]:
-        out, err, status, pid = run_in_subprocess(code, env=env)
+        out, err, status, pid = run_in_subprocess(code, env=subenv)
         assert status == 0, err
         assert b"warning log\n" in err, err.decode()
         assert out == b"", out.decode()
@@ -269,10 +271,10 @@ def test_debug_logs_streamhandler_default(
     Note: When running ddtrace-run, the ddtrace-run logs still emit to stderr.
     DD_TRACE_LOG_FILE_LEVEL does not affect this setting.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if dd_trace_log_file_level is not None:
-        env["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
-    env["DD_TRACE_DEBUG"] = "true"
+        subenv["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
+    subenv["DD_TRACE_DEBUG"] = "true"
     code = """
 import logging
 import ddtrace
@@ -286,7 +288,7 @@ ddtrace_logger.warning('warning log')
 ddtrace_logger.debug('debug log')
 """
 
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert re.search(LOG_PATTERN, str(err)) is None
     assert b"warning log" in err
@@ -305,7 +307,7 @@ ddtrace_logger.warning('warning log')
 ddtrace_logger.debug('debug log')
 """
 
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert re.search(LOG_PATTERN, str(err)) is None
     assert "program executable" in str(err)  # comes from ddtrace-run debug logging
@@ -323,14 +325,14 @@ def test_debug_logs_can_go_to_file_backup_count(
     written to a file at the expected backup count, based on the DD_TRACE_LOG_FILE_LEVEL setting.
     Note: When running ddtrace-run, the ddtrace-run logs still emit to stderr.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if dd_trace_log_file_level is not None:
-        env["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
+        subenv["DD_TRACE_LOG_FILE_LEVEL"] = dd_trace_log_file_level
 
     log_file = tmpdir.strpath + "/testlog.log"
-    env["DD_TRACE_LOG_FILE"] = log_file
-    env["DD_TRACE_DEBUG"] = "true"
-    env["DD_TRACE_LOG_FILE_SIZE_BYTES"] = "10"
+    subenv["DD_TRACE_LOG_FILE"] = log_file
+    subenv["DD_TRACE_DEBUG"] = "true"
+    subenv["DD_TRACE_LOG_FILE_SIZE_BYTES"] = "10"
     code = """
 import logging
 import os
@@ -352,7 +354,7 @@ for attempt in range(100):
     ddtrace_logger.critical('ddtrace multiple debug log')
 """
 
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
 
     assert status == 0, err
 
@@ -379,7 +381,7 @@ for attempt in range(100):
     ddtrace_logger.critical('ddtrace multiple debug log')
 """
 
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err.decode()
 
     assert "program executable" in str(err)  # comes from ddtrace-run debug logging
@@ -393,18 +395,18 @@ def test_unknown_log_level_error(run_python_code_in_subprocess, ddtrace_run_pyth
     """
     When DD_TRACE_LOG_FILE_LEVEL is set to an unknown env var, the application raises an error and no logs are written.
     """
-    env = os.environ.copy()
-    env["DD_TRACE_LOG_FILE_LEVEL"] = "UNKNOWN"
+    subenv = env.copy()
+    subenv["DD_TRACE_LOG_FILE_LEVEL"] = "UNKNOWN"
     log_file = tmpdir.strpath + "/testlog.log"
-    env["DD_TRACE_LOG_FILE"] = log_file
-    env["DD_TRACE_DEBUG"] = "true"
-    env["DD_TRACE_LOG_FILE_SIZE_BYTES"] = "10"
+    subenv["DD_TRACE_LOG_FILE"] = log_file
+    subenv["DD_TRACE_DEBUG"] = "true"
+    subenv["DD_TRACE_LOG_FILE_SIZE_BYTES"] = "10"
     code = """
 import logging
 import ddtrace
 """
 
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 1, err
     assert "ValueError" in str(err)
     assert out == b""
@@ -415,7 +417,7 @@ import ddtrace
 import logging
 """
 
-    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 1, err
     assert "ValueError" in str(err)
     assert out == b""
@@ -447,8 +449,8 @@ def test_dd_trace_log_level_overrides_root_logger(dd_log_level, run_python_code_
     """
     import logging
 
-    env = os.environ.copy()
-    env["DD_TRACE_LOG_LEVEL"] = dd_log_level
+    subenv = env.copy()
+    subenv["DD_TRACE_LOG_LEVEL"] = dd_log_level
     level_value = getattr(logging, dd_log_level.upper())
     # NOTSET follows the root logger's level
     effective_level = logging.DEBUG if level_value == logging.NOTSET else level_value
@@ -479,7 +481,7 @@ for level_num, level_name in levels_to_test:
     else:
         ddtrace_logger.log(level_num, f'{{level_name}} log should not appear')
 """
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
 
     levels_to_check = [
@@ -504,9 +506,9 @@ def test_dd_trace_debug_takes_precedence_over_dd_trace_log_level(run_python_code
     """
     When both DD_TRACE_DEBUG and DD_TRACE_LOG_LEVEL are set, DD_TRACE_DEBUG takes precedence.
     """
-    env = os.environ.copy()
-    env["DD_TRACE_DEBUG"] = "true"
-    env["DD_TRACE_LOG_LEVEL"] = "WARNING"
+    subenv = env.copy()
+    subenv["DD_TRACE_DEBUG"] = "true"
+    subenv["DD_TRACE_LOG_LEVEL"] = "WARNING"
     code = """
 import logging
 import ddtrace
@@ -517,15 +519,15 @@ assert ddtrace_logger.getEffectiveLevel() == logging.DEBUG
 
 ddtrace_logger.debug('this is a debug log')
 """
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert b"this is a debug log" in err
 
 
 def test_dd_trace_log_level_does_not_enable_debug_mode(run_python_code_in_subprocess):
     """DD_TRACE_LOG_LEVEL=DEBUG sets log level but not debug mode."""
-    env = os.environ.copy()
-    env["DD_TRACE_LOG_LEVEL"] = "DEBUG"
+    subenv = env.copy()
+    subenv["DD_TRACE_LOG_LEVEL"] = "DEBUG"
     code = """
 import logging
 import ddtrace
@@ -533,7 +535,7 @@ ddtrace_logger = logging.getLogger('ddtrace')
 assert ddtrace_logger.getEffectiveLevel() == logging.DEBUG
 assert ddtrace.config._debug_mode is False
 """
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
 
 
@@ -559,8 +561,8 @@ ddtrace_logger.info('this is an info log')
 )
 def test_dd_trace_log_level_invalid_value(run_in_subprocess, request):
     """Invalid DD_TRACE_LOG_LEVEL logs warning and inherits from root."""
-    env = os.environ.copy()
-    env["DD_TRACE_LOG_LEVEL"] = "INVALID"
+    subenv = env.copy()
+    subenv["DD_TRACE_LOG_LEVEL"] = "INVALID"
     code = """
 import logging
 import ddtrace
@@ -570,7 +572,7 @@ assert ddtrace_logger.level == logging.NOTSET
 assert ddtrace_logger.getEffectiveLevel() == logging.INFO
 """
     run_func = request.getfixturevalue(run_in_subprocess)
-    out, err, status, pid = run_func(code, env=env)
+    out, err, status, pid = run_func(code, env=subenv)
     assert status == 0, err
     assert "DD_TRACE_LOG_LEVEL is invalid" in str(err)
     assert "warning" in str(err).lower()
@@ -578,10 +580,10 @@ assert ddtrace_logger.getEffectiveLevel() == logging.INFO
 
 def test_dd_trace_log_level_with_dd_trace_log_file(run_python_code_in_subprocess, tmpdir):
     """DD_TRACE_LOG_LEVEL logger level vs DD_TRACE_LOG_FILE_LEVEL handler level."""
-    env = os.environ.copy()
-    env["DD_TRACE_LOG_LEVEL"] = "WARNING"
-    env["DD_TRACE_LOG_FILE"] = tmpdir.strpath + "/test.log"
-    env["DD_TRACE_LOG_FILE_LEVEL"] = "DEBUG"
+    subenv = env.copy()
+    subenv["DD_TRACE_LOG_LEVEL"] = "WARNING"
+    subenv["DD_TRACE_LOG_FILE"] = tmpdir.strpath + "/test.log"
+    subenv["DD_TRACE_LOG_FILE_LEVEL"] = "DEBUG"
     code = """
 import logging
 import ddtrace
@@ -592,7 +594,7 @@ assert file_handler is not None and file_handler.level == logging.DEBUG
 ddtrace_logger.debug('this is a debug log')
 ddtrace_logger.warning('this is a warning log')
 """
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert b"this is a debug log" not in err
     assert b"this is a warning log" in err

--- a/tests/contrib/loguru/test_loguru_logging.py
+++ b/tests/contrib/loguru/test_loguru_logging.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 from loguru import logger
 import pytest
@@ -10,6 +9,7 @@ from ddtrace.constants import VERSION_KEY
 from ddtrace.contrib.internal.loguru.patch import patch
 from ddtrace.contrib.internal.loguru.patch import unpatch
 from ddtrace.internal.constants import MAX_UINT_64BITS
+from ddtrace.internal.settings import env
 from ddtrace.trace import tracer
 from tests.utils import override_global_config
 
@@ -116,9 +116,9 @@ with tracer.trace("test.logging") as span:
     logger.info("Hello!")
     """
 
-    env = os.environ.copy()
-    env.update(dict(LOGURU_SERIALIZE="1", DD_LOGS_INJECTION="1", DD_SERVICE="dds", DD_ENV="ddenv", DD_VERSION="vv"))
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv.update(dict(LOGURU_SERIALIZE="1", DD_LOGS_INJECTION="1", DD_SERVICE="dds", DD_ENV="ddenv", DD_VERSION="vv"))
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
 
     assert status == 0, err + out
 
@@ -143,9 +143,9 @@ with tracer.trace("test.logging") as span:
     logger.info("Hello!")
     """
 
-    env = os.environ.copy()
-    env.update(dict(LOGURU_SERIALIZE="1", DD_LOGS_INJECTION="1", DD_SERVICE="dds", DD_ENV="ddenv", DD_VERSION="vv"))
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv.update(dict(LOGURU_SERIALIZE="1", DD_LOGS_INJECTION="1", DD_SERVICE="dds", DD_ENV="ddenv", DD_VERSION="vv"))
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
 
     assert status == 0, err + out
 

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -1,10 +1,9 @@
-import os
-
 import mariadb
 import pytest
 
 from ddtrace.contrib.internal.mariadb.patch import patch
 from ddtrace.contrib.internal.mariadb.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.contrib.config import MARIADB_CONFIG
 from tests.utils import assert_dict_issuperset
 from tests.utils import assert_is_measured
@@ -160,13 +159,13 @@ def test():
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
 
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()
 

--- a/tests/contrib/patch.py
+++ b/tests/contrib/patch.py
@@ -2,7 +2,6 @@ import functools
 import http.client as httplib
 import importlib
 import json
-import os
 import sys
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
@@ -10,6 +9,7 @@ import unittest
 
 from ddtrace import __version__
 from ddtrace.internal.compat import is_wrapted
+from ddtrace.internal.settings import env
 from tests.subprocesstest import SubprocessTestCase
 from tests.subprocesstest import run_in_subprocess
 from tests.utils import call_program
@@ -773,10 +773,10 @@ class PatchTestCase(object):
                 )
                 f.flush()
 
-                env = os.environ.copy()
-                env["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
+                subenv = env.copy()
+                subenv["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
 
-                out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=env)
+                out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=subenv)
 
                 self.assertEqual(out, b"OK", "stderr:\n%s" % err.decode())
 
@@ -901,9 +901,9 @@ class PatchTestCase(object):
                 )
                 f.flush()
 
-                env = os.environ.copy()
-                env["DD_TRACE_SAFE_INSTRUMENTATION_ENABLED"] = "1"
-                env["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
+                subenv = env.copy()
+                subenv["DD_TRACE_SAFE_INSTRUMENTATION_ENABLED"] = "1"
+                subenv["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
 
-                out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=env)
+                out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=subenv)
                 assert "OKK" in out.decode(), "stderr:\n%s" % err.decode()

--- a/tests/contrib/protobuf/schemas/message_pb2.py
+++ b/tests/contrib/protobuf/schemas/message_pb2.py
@@ -18,9 +18,6 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
-from tests.contrib.protobuf.schemas import (
-    other_message_pb2 as tests_dot_contrib_dot_protobuf_dot_schemas_dot_other__message__pb2,
-)
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(

--- a/tests/contrib/psycopg/test_psycopg_snapshot.py
+++ b/tests/contrib/psycopg/test_psycopg_snapshot.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import psycopg
@@ -7,6 +6,7 @@ import pytest
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
+from ddtrace.internal.settings import env
 
 
 @pytest.fixture(autouse=True)
@@ -80,8 +80,8 @@ conn = psycopg.connect(**POSTGRES_CONFIG)
 assert conn
     """
 
-    env = os.environ.copy()
-    env["DD_PSYCOPG_TRACE_CONNECT"] = "true"
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_PSYCOPG_TRACE_CONNECT"] = "true"
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert out == b"", err

--- a/tests/contrib/psycopg2/test_psycopg_patch.py
+++ b/tests/contrib/psycopg2/test_psycopg_patch.py
@@ -15,6 +15,7 @@ try:
     from ddtrace.contrib.internal.psycopg.patch import unpatch
 except ImportError:
     unpatch = None
+from ddtrace.internal.settings import env
 from tests.contrib.patch import PatchTestCase
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 
@@ -47,9 +48,9 @@ class TestPsycopgPatch(PatchTestCase.Base):
     def test_psycopg_circular_import_fix(self):
         fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", "reproduce_psycopg_cyclic_import_error.py")
 
-        env = os.environ.copy()
+        subenv = env.copy()
         codebase_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-        env["PYTHONPATH"] = os.pathsep.join([codebase_root, env.get("PYTHONPATH", "")])
+        subenv["PYTHONPATH"] = os.pathsep.join([codebase_root, subenv.get("PYTHONPATH", "")])
 
         # Run the reproduction script with ddtrace-run
         # Note: tried with @run_in_subprocess but that fails to reproduce the error in the affected version
@@ -58,7 +59,7 @@ class TestPsycopgPatch(PatchTestCase.Base):
             [sys.executable, "-m", "ddtrace.commands.ddtrace_run", "python", fixture_path],
             capture_output=True,
             text=True,
-            env=env,
+            env=subenv,
             timeout=30,
         )
 

--- a/tests/contrib/psycopg2/test_psycopg_snapshot.py
+++ b/tests/contrib/psycopg2/test_psycopg_snapshot.py
@@ -1,11 +1,10 @@
-import os
-
 import psycopg2
 import pytest
 
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
+from ddtrace.internal.settings import env
 
 
 @pytest.fixture(autouse=True)
@@ -62,9 +61,9 @@ conn = psycopg2.connect(**POSTGRES_CONFIG)
 assert conn
     """
 
-    env = os.environ.copy()
-    env["DD_PSYCOPG2_TRACE_CONNECT"] = "true"
-    out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_PSYCOPG2_TRACE_CONNECT"] = "true"
+    out, err, status, pid = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, err
     assert out == b"", err
     assert err == b""

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -9,6 +9,7 @@ from ddtrace import config
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.settings import env
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.webclient import Client
@@ -231,8 +232,8 @@ def pyramid_client(snapshot, pyramid_app):
     at the end of the testcase.
     """
 
-    env = os.environ.copy()
-    env["SERVER_PORT"] = str(SERVER_PORT)
+    subenv = env.copy()
+    subenv["SERVER_PORT"] = str(SERVER_PORT)
 
     # Create a temp folder as if run_function_from_file was used
     temp_dir = gettempdir()
@@ -259,7 +260,7 @@ def pyramid_client(snapshot, pyramid_app):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
-        env=env,
+        env=subenv,
     )
 
     client = Client("http://localhost:%d" % SERVER_PORT)

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -28,6 +28,7 @@ from ddtrace.internal.ci_visibility._api_client import TestVisibilityAPISettings
 from ddtrace.internal.ci_visibility.constants import COVERAGE_TAG_NAME
 from ddtrace.internal.ci_visibility.constants import ITR_CORRELATION_ID_TAG_NAME
 from ddtrace.internal.ci_visibility.encoder import CIVisibilityEncoderV01
+from ddtrace.internal.settings import env
 from tests.ci_visibility.api_client._util import _make_fqdn_suite_ids
 from tests.ci_visibility.api_client._util import _make_fqdn_test_ids
 from tests.ci_visibility.util import _ci_override_env
@@ -738,7 +739,7 @@ class PytestTestCase(PytestTestCaseBase):
 
     def test_dd_service_name(self):
         """Test dd service name."""
-        if "DD_PYTEST_SERVICE" in os.environ:
+        if "DD_PYTEST_SERVICE" in env:
             self.monkeypatch.delenv("DD_PYTEST_SERVICE")
 
         py_file = self.testdir.makepyfile(

--- a/tests/contrib/pytest/test_pytest_coverage_upload_v2.py
+++ b/tests/contrib/pytest/test_pytest_coverage_upload_v2.py
@@ -1,6 +1,5 @@
 """Integration tests for coverage report upload functionality in pytest plugin V2."""
 
-import os
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -8,6 +7,7 @@ import pytest
 
 from ddtrace.internal.ci_visibility.recorder import CIVisibility
 from ddtrace.internal.ci_visibility.writer import CIVisibilityWriter
+from ddtrace.internal.settings import env
 
 
 COVERAGE_UPLOAD_ENABLED_ENV = "DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED"
@@ -60,11 +60,11 @@ class TestPytestV2CoverageUpload:
             return_value=mock_service,
         ):
             # Test env var enabled (should override)
-            with patch.dict(os.environ, {COVERAGE_UPLOAD_ENABLED_ENV: "1"}):
+            with patch.dict(env, {COVERAGE_UPLOAD_ENABLED_ENV: "1"}):
                 assert _is_coverage_report_upload_enabled() is True
 
             # Test env var disabled (should respect API setting)
-            with patch.dict(os.environ, {COVERAGE_UPLOAD_ENABLED_ENV: "0"}):
+            with patch.dict(env, {COVERAGE_UPLOAD_ENABLED_ENV: "0"}):
                 assert _is_coverage_report_upload_enabled() is False
 
     def test_is_coverage_report_upload_enabled_exception_handling(self):
@@ -79,7 +79,7 @@ class TestPytestV2CoverageUpload:
             assert _is_coverage_report_upload_enabled() is False
 
             # But env var should still work
-            with patch.dict(os.environ, {COVERAGE_UPLOAD_ENABLED_ENV: "1"}):
+            with patch.dict(env, {COVERAGE_UPLOAD_ENABLED_ENV: "1"}):
                 assert _is_coverage_report_upload_enabled() is True
 
     @patch("ddtrace.contrib.internal.pytest._plugin_v2.log")

--- a/tests/contrib/pytest/test_pytest_xdist_atr.py
+++ b/tests/contrib/pytest/test_pytest_xdist_atr.py
@@ -3,19 +3,19 @@
 The tests in this module only validate the exit status from pytest-xdist.
 """
 
-import os  # Just for the RIOT env var check
 from unittest import mock
 
 import pytest
 
 from ddtrace.contrib.internal.pytest._utils import _pytest_version_supports_atr
+from ddtrace.internal.settings import env
 from tests.ci_visibility.util import _get_default_civisibility_ddconfig
 from tests.contrib.pytest.test_pytest import PytestTestCaseBase
 
 
 ######
 # Skip these tests if they are not running under riot
-riot_env_value = os.getenv("RIOT", None)
+riot_env_value = env.get("RIOT", None)
 if not riot_env_value:
     pytest.importorskip("xdist", reason="Auto Test Retries + xdist tests, not running under riot")
 ######

--- a/tests/contrib/pytest/test_pytest_xdist_snapshot.py
+++ b/tests/contrib/pytest/test_pytest_xdist_snapshot.py
@@ -1,10 +1,10 @@
-import os
 import subprocess
 from unittest import mock
 
 import pytest
 
 from ddtrace.internal.ci_visibility._api_client import TestVisibilityAPISettings
+from ddtrace.internal.settings import env
 from tests.ci_visibility.util import _get_default_ci_env_vars
 from tests.utils import TracerTestCase
 from tests.utils import snapshot
@@ -12,7 +12,7 @@ from tests.utils import snapshot
 
 ######
 # Skip these tests if they are not running under riot
-riot_env_value = os.getenv("RIOT", None)
+riot_env_value = env.get("RIOT", None)
 if not riot_env_value:
     pytest.importorskip("xdist", reason="Pytest xdist tests, not running under riot")
 ######

--- a/tests/contrib/rq/test_rq.py
+++ b/tests/contrib/rq/test_rq.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import time
 
@@ -9,6 +8,7 @@ import rq
 from ddtrace.contrib.internal.rq.patch import get_version
 from ddtrace.contrib.internal.rq.patch import patch
 from ddtrace.contrib.internal.rq.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.utils import override_config
 from tests.utils import snapshot
@@ -138,13 +138,13 @@ def test_enqueue(queue, distributed_tracing_enabled, worker_service_name):
     )
     num_traces_expected = 2 if distributed_tracing_enabled is False else 1
     with snapshot_context(token, ignores=snapshot_ignores, wait_for_num_traces=num_traces_expected):
-        env = os.environ.copy()
-        env["DD_TRACE_REDIS_ENABLED"] = "false"
+        subenv = env.copy()
+        subenv["DD_TRACE_REDIS_ENABLED"] = "false"
         if distributed_tracing_enabled is not None:
-            env["DD_RQ_DISTRIBUTED_TRACING_ENABLED"] = str(distributed_tracing_enabled)
+            subenv["DD_RQ_DISTRIBUTED_TRACING_ENABLED"] = str(distributed_tracing_enabled)
         if worker_service_name is not None:
-            env["DD_SERVICE"] = "custom-worker-service"
-        p = subprocess.Popen(["ddtrace-run", "rq", "worker", "q"], env=env)
+            subenv["DD_SERVICE"] = "custom-worker-service"
+        p = subprocess.Popen(["ddtrace-run", "rq", "worker", "q"], env=subenv)
         try:
             job = queue.enqueue(job_add1, 1)
             # Wait for job to complete
@@ -198,12 +198,12 @@ def test_worker_class_job(queue):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
-    env["DD_TRACE_REDIS_ENABLED"] = "false"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+    subenv["DD_TRACE_REDIS_ENABLED"] = "false"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()

--- a/tests/contrib/sanic/run_server.py
+++ b/tests/contrib/sanic/run_server.py
@@ -1,10 +1,10 @@
 import asyncio
-import os
 import random
 
 from sanic import Sanic
 from sanic.response import json
 
+from ddtrace.internal.settings import env
 from ddtrace.trace import tracer
 from tests.webclient import PingFilter
 
@@ -41,4 +41,4 @@ async def shutdown_tracer(request):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=int(os.environ["SANIC_PORT"]), access_log=False)
+    app.run(host="0.0.0.0", port=int(env["SANIC_PORT"]), access_log=False)

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import random
 import re
 
@@ -20,6 +19,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.sanic.patch import patch
 from ddtrace.contrib.internal.sanic.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.propagation import http as http_propagation
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
@@ -478,14 +478,14 @@ if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_service_name)
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if service_name is not None:
-        env["DD_SERVICE"] = service_name
+        subenv["DD_SERVICE"] = service_name
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, out or err
 
@@ -526,12 +526,12 @@ if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """.format(expected_operation_name)
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         code,
-        env=env,
+        env=subenv,
     )
     assert status == 0, out or err
 

--- a/tests/contrib/sanic/test_sanic_server.py
+++ b/tests/contrib/sanic/test_sanic_server.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 from sanic import __version__ as sanic_version
 
+from ddtrace.internal.settings import env
 from tests.webclient import Client
 
 
@@ -17,11 +18,11 @@ sanic_version = tuple(map(int, sanic_version.split(".")))
 @pytest.fixture()
 def sanic_client():
     """Fixture for using sanic async HTTP server rather than a asgi async server used by test client"""
-    env = os.environ.copy()
-    env["SANIC_PORT"] = str(SERVER_PORT)
+    subenv = env.copy()
+    subenv["SANIC_PORT"] = str(SERVER_PORT)
     args = ["ddtrace-run", "python", RUN_SERVER_PY]
     subp = subprocess.Popen(
-        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, env=env, preexec_fn=os.setsid
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, env=subenv, preexec_fn=os.setsid
     )
     client = Client("http://0.0.0.0:{}".format(SERVER_PORT))
     client.wait(path="/hello")

--- a/tests/contrib/snowflake/test_snowflake.py
+++ b/tests/contrib/snowflake/test_snowflake.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import os
 
 import pytest
 import responses
@@ -8,6 +7,7 @@ import snowflake.connector
 
 from ddtrace.contrib.internal.snowflake.patch import patch
 from ddtrace.contrib.internal.snowflake.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.utils import override_config
 from tests.utils import snapshot
 
@@ -238,12 +238,12 @@ def test_snowflake_service_env():
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
-    env["DD_TRACE_REQUESTS_ENABLED"] = "false"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+    subenv["DD_TRACE_REQUESTS_ENABLED"] = "false"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 
 import httpx
 import pytest
@@ -12,6 +11,7 @@ from ddtrace.contrib.internal.sqlalchemy.patch import patch as sql_patch
 from ddtrace.contrib.internal.sqlalchemy.patch import unpatch as sql_unpatch
 from ddtrace.contrib.internal.starlette.patch import patch as starlette_patch
 from ddtrace.contrib.internal.starlette.patch import unpatch as starlette_unpatch
+from ddtrace.internal.settings import env
 from ddtrace.propagation import http as http_propagation
 from tests.contrib.starlette.app import get_app
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
@@ -582,17 +582,17 @@ def test(snapshot_client):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
     # We only care about the starlette traces
-    env["DD_TRACE_SQLALCHEMY_ENABLED"] = "false"
-    env["DD_TRACE_SQLITE3_ENABLED"] = "false"
-    env["DD_TRACE_HTTPX_ENABLED"] = "false"
-    env["DD_TRACE_REQUESTS_ENABLED"] = "false"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv["DD_TRACE_SQLALCHEMY_ENABLED"] = "false"
+    subenv["DD_TRACE_SQLITE3_ENABLED"] = "false"
+    subenv["DD_TRACE_HTTPX_ENABLED"] = "false"
+    subenv["DD_TRACE_REQUESTS_ENABLED"] = "false"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()
 

--- a/tests/contrib/uwsgi/__init__.py
+++ b/tests/contrib/uwsgi/__init__.py
@@ -1,10 +1,11 @@
-import os
 import subprocess
+
+from ddtrace.internal.settings import env
 
 
 def run_uwsgi(cmd):
     def _run(*args):
-        env = os.environ.copy()
-        return subprocess.Popen(cmd + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+        subenv = env.copy()
+        return subprocess.Popen(cmd + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=subenv)
 
     return _run

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from webtest import TestApp
 
@@ -7,6 +5,7 @@ from ddtrace import config
 from ddtrace.contrib.internal.wsgi.wsgi import DDWSGIMiddleware
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
 from ddtrace.contrib.internal.wsgi.wsgi import get_request_headers
+from ddtrace.internal.settings import env
 from tests.utils import override_config
 from tests.utils import override_http_config
 from tests.utils import snapshot
@@ -402,10 +401,10 @@ from tests.contrib.wsgi.test_wsgi import application
 app = TestApp(DDWSGIMiddleware(application))
 app.get("/")"""
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if schema_version is not None:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if service_name is not None:
-        env["DD_SERVICE"] = service_name
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_SERVICE"] = service_name
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr

--- a/tests/contrib/yaaredis/test_yaaredis.py
+++ b/tests/contrib/yaaredis/test_yaaredis.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import os
 import uuid
 
 import pytest
@@ -8,6 +7,7 @@ import yaaredis
 from ddtrace.contrib.internal.yaaredis.patch import patch
 from ddtrace.contrib.internal.yaaredis.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
+from ddtrace.internal.settings import env
 from tests.utils import override_config
 
 from ..config import REDIS_CONFIG
@@ -168,13 +168,13 @@ async def test_basics(traced_yaaredis):
 if __name__ == "__main__":
     sys.exit(pytest.main(["-x", __file__]))
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if service:
-        env["DD_SERVICE"] = service
+        subenv["DD_SERVICE"] = service
     if schema:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
-    env["PYTHONWARNINGS"] = "ignore::UserWarning:ddtrace.internal.module"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
+    subenv["PYTHONWARNINGS"] = "ignore::UserWarning:ddtrace.internal.module"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()
 


### PR DESCRIPTION
## Description

Migrates 61 test files under `tests/contrib/` (general integrations owned by `apm-core-python` + `apm-idm-python`) from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.