### PR TITLE
chore(tests): migrate profiling tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/internal/crashtracker/test_crashtracker.py
+++ b/tests/internal/crashtracker/test_crashtracker.py
@@ -1,9 +1,9 @@
-import os
 import sys
 import warnings
 
 import pytest
 
+from ddtrace.internal.settings import env
 import tests.internal.crashtracker.utils as utils
 
 
@@ -100,7 +100,6 @@ def test_crashtracker_started():
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
 @pytest.mark.subprocess()
 def test_crashtracker_receiver_not_in_path():
-    import os
     import shutil
 
     import pytest
@@ -113,7 +112,7 @@ def test_crashtracker_receiver_not_in_path():
         # have _dd_crashtracker_receiver in the PATH, for example when running
         # in an injected environment. And we should just load the script
         # directly.
-        os.environ["PATH"] = ""
+        env["PATH"] = ""
         dd_crashtracker_receiver = shutil.which("_dd_crashtracker_receiver")
         assert dd_crashtracker_receiver is None
 
@@ -375,9 +374,9 @@ def test_crashtracker_preload_default(ddtrace_run_python_code_in_subprocess):
 def test_crashtracker_preload_disabled(ddtrace_run_python_code_in_subprocess):
     # Call the program
     with utils.with_test_agent() as client:
-        env = os.environ.copy()
-        env["DD_CRASHTRACKING_ENABLED"] = "false"
-        stdout, stderr, exitcode, _ = ddtrace_run_python_code_in_subprocess(preload_code, env=env)
+        subenv = env.copy()
+        subenv["DD_CRASHTRACKING_ENABLED"] = "false"
+        stdout, stderr, exitcode, _ = ddtrace_run_python_code_in_subprocess(preload_code, env=subenv)
 
         # Check for expected exit condition
         assert not stdout
@@ -426,9 +425,9 @@ def test_crashtracker_auto_nostack(run_python_code_in_subprocess):
 
     # Call the program
     with utils.with_test_agent() as client:
-        env = os.environ.copy()
-        env["DD_CRASHTRACKING_STACKTRACE_RESOLVER"] = "none"
-        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=env)
+        subenv = env.copy()
+        subenv["DD_CRASHTRACKING_STACKTRACE_RESOLVER"] = "none"
+        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=subenv)
 
         # Check for expected exit condition
         assert not stdout
@@ -452,9 +451,9 @@ def test_crashtracker_auto_nostack(run_python_code_in_subprocess):
 def test_crashtracker_auto_disabled(run_python_code_in_subprocess):
     # Call the program
     with utils.with_test_agent() as client:
-        env = os.environ.copy()
-        env["DD_CRASHTRACKING_ENABLED"] = "false"
-        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=env)
+        subenv = env.copy()
+        subenv["DD_CRASHTRACKING_ENABLED"] = "false"
+        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=subenv)
 
         # Check for expected exit condition
         assert not stdout
@@ -471,8 +470,8 @@ def test_crashtracker_runtime_stacktrace_required(run_python_code_in_subprocess)
     import json
 
     with utils.with_test_agent() as client:
-        env = os.environ.copy()
-        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=env)
+        subenv = env.copy()
+        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=subenv)
 
         # Check for expected exit condition
         assert not stdout
@@ -496,7 +495,7 @@ def test_crashtracker_runtime_stacktrace_required(run_python_code_in_subprocess)
 def test_crashtracker_user_tags_envvar(run_python_code_in_subprocess):
     # Call the program
     with utils.with_test_agent() as client:
-        env = os.environ.copy()
+        subenv = env.copy()
 
         # Injecting tags, but since the way we validate them is with a raw-data string search, we make things unique
         tag_prefix = "cryptocrystalline"
@@ -504,8 +503,8 @@ def test_crashtracker_user_tags_envvar(run_python_code_in_subprocess):
             tag_prefix + "_tag1": "quartz_flint",
             tag_prefix + "_tag2": "quartz_chert",
         }
-        env["DD_CRASHTRACKING_TAGS"] = ",".join(["%s:%s" % (k, v) for k, v in tags.items()])
-        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=env)
+        subenv["DD_CRASHTRACKING_TAGS"] = ",".join(["%s:%s" % (k, v) for k, v in tags.items()])
+        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=subenv)
 
         # Check for expected exit condition
         assert not stdout
@@ -527,9 +526,9 @@ def test_crashtracker_user_tags_envvar(run_python_code_in_subprocess):
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
 def test_crashtracker_set_tag_profiler_config(snapshot_context, run_python_code_in_subprocess):
     with utils.with_test_agent() as client:
-        env = os.environ.copy()
-        env["DD_PROFILING_ENABLED"] = "1"
-        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=env)
+        subenv = env.copy()
+        subenv["DD_PROFILING_ENABLED"] = "1"
+        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(auto_code, env=subenv)
 
         assert not stdout
         assert not stderr
@@ -844,13 +843,13 @@ def test_crashtracker_receiver_env_inheritance():
 
     test_env_key = "DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED"
     test_env_value = "true"
-    os.environ[test_env_key] = test_env_value
+    env[test_env_key] = test_env_value
 
     with utils.with_test_agent() as client:
         # Fork happens after ddtrace started threads; see warning suppression note above.
         pid = os.fork()
         if pid == 0:
-            assert os.environ.get(test_env_key) == test_env_value
+            assert env.get(test_env_key) == test_env_value
 
             ct = utils.CrashtrackerWrapper(base_name="env_inheritance")
             assert ct.start()
@@ -868,4 +867,4 @@ def test_crashtracker_receiver_env_inheritance():
         assert b"string_at" in report["body"]
 
     # Clean up
-    os.environ.pop(test_env_key, None)
+    env.pop(test_env_key, None)

--- a/tests/internal/crashtracker/utils.py
+++ b/tests/internal/crashtracker/utils.py
@@ -9,6 +9,7 @@ from typing import Optional
 import uuid
 
 import ddtrace
+from ddtrace.internal.settings import env
 from tests.utils import TestAgentClient
 from tests.utils import TestAgentRequest
 
@@ -198,7 +199,7 @@ def with_test_agent() -> Generator[TestAgentClient, None, None]:
     # Also propagate via env var so that tests which launch subprocesses with
     # ddtrace.auto (e.g. test_crashtracker_preload_*) pick up the token automatically
     # without any changes to the subprocess code.
-    os.environ["_DD_CRASHTRACKING_TEST_TOKEN"] = token
+    env["_DD_CRASHTRACKING_TEST_TOKEN"] = token
     crashtracker_config._test_token = token
 
     base_url = ddtrace.tracer.agent_trace_url or "http://localhost:9126"
@@ -215,5 +216,5 @@ def with_test_agent() -> Generator[TestAgentClient, None, None]:
         yield client
     finally:
         client.clear()
-        del os.environ["_DD_CRASHTRACKING_TEST_TOKEN"]
+        del env["_DD_CRASHTRACKING_TEST_TOKEN"]
         crashtracker_config._test_token = None

--- a/tests/profiling/collector/test_asyncio_as_completed.py
+++ b/tests/profiling/collector/test_asyncio_as_completed.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -60,7 +62,7 @@ def test_asyncio_as_completed() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_async_generator.py
+++ b/tests/profiling/collector/test_asyncio_async_generator.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -57,7 +59,7 @@ def test_asyncio_executor_wall_time() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_context_manager.py
+++ b/tests/profiling/collector/test_asyncio_context_manager.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -56,7 +58,7 @@ def test_asyncio_context_manager_wall_time() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_coroutines.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -67,7 +69,7 @@ def test_asyncio_coroutines() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_executor.py
+++ b/tests/profiling/collector/test_asyncio_executor.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -37,7 +39,7 @@ def test_asyncio_executor_wall_time() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 
@@ -63,7 +65,7 @@ def test_asyncio_executor_wall_time() -> None:
     samples = pprof_utils.get_samples_with_label_key(profile, "thread name")
     assert len(samples) > 0
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     # uvloop uses ThreadPoolExecutor naming instead of asyncio naming
     if use_uvloop:

--- a/tests/profiling/collector/test_asyncio_gather.py
+++ b/tests/profiling/collector/test_asyncio_gather.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -56,7 +58,7 @@ def test_asyncio_gather() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_gather_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_gather_coroutines.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -36,7 +38,7 @@ def test_asyncio_gather_wall_time() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_gather_deep_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_gather_deep_coroutines.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -37,7 +39,7 @@ def test_asyncio_gather_deep_coroutines() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_gather_tasks.py
+++ b/tests/profiling/collector/test_asyncio_gather_tasks.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -48,7 +50,7 @@ def test_asyncio_gather_tasks() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_idle.py
+++ b/tests/profiling/collector/test_asyncio_idle.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -47,14 +49,14 @@ def test_asyncio_run_frames_captured():
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     # Get samples with task_name - this is the key check
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0, "No task names found - asyncio task tracking failed!"
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
     # so we only expect these frames when NOT using uvloop

--- a/tests/profiling/collector/test_asyncio_import_order.py
+++ b/tests/profiling/collector/test_asyncio_import_order.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -71,7 +73,7 @@ def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
     assert t1_name == "tracked 1"
     assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -197,7 +199,7 @@ def test_asyncio_start_profiler_from_process_before_starting_loop() -> None:
     assert t1_name == "tracked 1"
     assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -322,7 +324,7 @@ def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
     assert t1_name == "tracked 1"
     assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -449,7 +451,7 @@ def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
     assert t1_name == "tracked 1"
     assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -577,7 +579,7 @@ def test_asyncio_start_profiler_from_process_after_task_start() -> None:
     assert t1_name == "tracked 1"
     assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -725,7 +727,7 @@ def test_asyncio_import_and_start_profiler_from_process_after_task_start() -> No
     assert t1_name == "tracked 1"
     assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")

--- a/tests/profiling/collector/test_asyncio_mixed_workload.py
+++ b/tests/profiling/collector/test_asyncio_mixed_workload.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.skip(reason="This is flaky in CI")
 @pytest.mark.subprocess(
@@ -52,7 +54,7 @@ def test_asyncio_mixed_workload() -> None:
     main()
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_coros.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_coros.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -66,13 +68,13 @@ def test_asyncio_recursive_on_cpu_coros():
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
         return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
     # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -69,13 +71,13 @@ def test_asyncio_recursive_on_cpu_tasks():
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
         return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
     # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main

--- a/tests/profiling/collector/test_asyncio_shield.py
+++ b/tests/profiling/collector/test_asyncio_shield.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -46,7 +48,7 @@ def test_asyncio_shield() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_taskgroup.py
+++ b/tests/profiling/collector/test_asyncio_taskgroup.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -53,7 +55,7 @@ def test_asyncio_taskgroup() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_timeout.py
+++ b/tests/profiling/collector/test_asyncio_timeout.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -52,7 +54,7 @@ def test_asyncio_timeout() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_timeout_at.py
+++ b/tests/profiling/collector/test_asyncio_timeout_at.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -55,7 +57,7 @@ def test_asyncio_timeout_at() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_wait.py
+++ b/tests/profiling/collector/test_asyncio_wait.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -54,7 +56,7 @@ def test_asyncio_wait() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")

--- a/tests/profiling/collector/test_asyncio_wall_time_on_and_off_cpu.py
+++ b/tests/profiling/collector/test_asyncio_wall_time_on_and_off_cpu.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -69,7 +71,7 @@ def test_asyncio_wall_time_on_and_off_cpu() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -80,7 +82,7 @@ def test_asyncio_wall_time_on_and_off_cpu() -> None:
 
     # On Python < 3.11 with uvloop, the runner is uvloop/__init__.py, not asyncio/runners.py
     # On Python >= 3.11, uvloop delegates to asyncio.Runner, so it's still runners.py
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
     if use_uvloop and sys.version_info < (3, 11):
         run_file = "__init__.py"
     else:

--- a/tests/profiling/collector/test_asyncio_weak_links.py
+++ b/tests/profiling/collector/test_asyncio_weak_links.py
@@ -1,12 +1,12 @@
-import os
-
 import pytest
+
+from ddtrace.internal.settings import env
 
 
 # Skip this test when using uvloop - the weak link feature relies on asyncio internals
 # that uvloop doesn't expose the same way
 @pytest.mark.skipif(
-    os.environ.get("USE_UVLOOP", "0") == "1",
+    env.get("USE_UVLOOP", "0") == "1",
     reason="uvloop does not support weak link detection the same way as asyncio",
 )
 @pytest.mark.subprocess(
@@ -57,7 +57,7 @@ def test_asyncio_weak_links_wall_time() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_asyncio_within_function.py
+++ b/tests/profiling/collector/test_asyncio_within_function.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -61,13 +63,13 @@ def test_asyncio_within_function() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
         return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
     # With uvloop: async_starter → async_run → run (uvloop) → Runner.run → async_main

--- a/tests/profiling/collector/test_copy_memory_stats.py
+++ b/tests/profiling/collector/test_copy_memory_stats.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -23,7 +25,7 @@ def test_copy_memory_error_count_present():
     time.sleep(3)
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
     assert files, "Expected at least one internal_metadata.json file"
 
@@ -57,7 +59,7 @@ def test_fast_copy_memory_disabled():
     time.sleep(3)
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
     assert files, "Expected at least one internal_metadata.json file"
 
@@ -95,7 +97,7 @@ def test_fast_copy_memory_enabled():
     time.sleep(3)
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
     assert files, "Expected at least one internal_metadata.json file"
 

--- a/tests/profiling/collector/test_generators.py
+++ b/tests/profiling/collector/test_generators.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -41,7 +43,7 @@ def test_generators_stacks() -> None:
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_heap_tracker_count.py
+++ b/tests/profiling/collector/test_heap_tracker_count.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -32,7 +34,7 @@ def test_heap_tracker_count_present():
 
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
     assert files, "Expected at least one internal_metadata.json file"
 

--- a/tests/profiling/collector/test_internal_adaptive_sampling.py
+++ b/tests/profiling/collector/test_internal_adaptive_sampling.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -51,7 +53,7 @@ def test_internal_adaptive_sampling():
         loop.run_until_complete(main_task)
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
 
     # With adaptive sampling enabled, the sampling interval can grow up to 1 second

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -17,6 +17,7 @@ from typing import cast
 import pytest
 
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.profiling import ProfilingConfig
 from ddtrace.internal.settings.profiling import (
     _derive_default_heap_sample_size,  # pyright: ignore[reportAttributeAccessIssue]
@@ -78,7 +79,7 @@ def test_heap_samples_collected() -> None:
     from tests.profiling.collector.test_memalloc import _allocate_1k
 
     # Test for https://github.com/DataDog/dd-trace-py/issues/11069
-    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
+    pprof_prefix = env["DD_PROFILING_OUTPUT_PPROF"]
     output_filename = pprof_prefix + "." + str(os.getpid())
 
     p = Profiler()
@@ -377,8 +378,8 @@ def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: 
     test_name = f"test_memory_collector_allocation_accuracy_with_tracemalloc_{sample_interval}"
     output_filename = _setup_profiling_prelude(tmp_path, test_name)
 
-    old = os.environ.get("_DD_MEMALLOC_DEBUG_RNG_SEED")
-    os.environ["_DD_MEMALLOC_DEBUG_RNG_SEED"] = "42"
+    old = env.get("_DD_MEMALLOC_DEBUG_RNG_SEED")
+    env["_DD_MEMALLOC_DEBUG_RNG_SEED"] = "42"
 
     mc = memalloc.MemoryCollector(heap_sample_size=sample_interval)
 
@@ -403,10 +404,10 @@ def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: 
 
     finally:
         if old is not None:
-            os.environ["_DD_MEMALLOC_DEBUG_RNG_SEED"] = old
+            env["_DD_MEMALLOC_DEBUG_RNG_SEED"] = old
         else:
-            if "_DD_MEMALLOC_DEBUG_RNG_SEED" in os.environ:
-                del os.environ["_DD_MEMALLOC_DEBUG_RNG_SEED"]
+            if "_DD_MEMALLOC_DEBUG_RNG_SEED" in env:
+                del env["_DD_MEMALLOC_DEBUG_RNG_SEED"]
 
     # Get sample type indices
     heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")

--- a/tests/profiling/collector/test_sample_count.py
+++ b/tests/profiling/collector/test_sample_count.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -48,7 +50,7 @@ def test_sample_count():
         loop.run_until_complete(maintask)
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
 
     found_at_least_one_with_more_samples_than_sampling_events = False

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -15,6 +15,7 @@ from pytest import MonkeyPatch
 
 from ddtrace import ext
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.internal.settings import env
 from ddtrace.profiling.collector import stack
 from ddtrace.trace import Tracer
 from tests.conftest import get_original_test_name
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
 # https://github.com/python/cpython/issues/117983
 # The fix was not backported to 3.11. The fix was first released in 3.12.5 for
 # Python 3.12. Tested with Python 3.11.8 and 3.12.5 to confirm the issue.
-GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", False) and (
+GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = env.get("DD_PROFILE_TEST_GEVENT", False) and (
     sys.version_info < (3, 11, 9) or sys.version_info >= (3, 12, 5)
 )
 
@@ -74,10 +75,10 @@ def test_collect_truncate() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_stack import func1
 
-    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
+    pprof_prefix = env["DD_PROFILING_OUTPUT_PPROF"]
     output_filename = pprof_prefix + "." + str(os.getpid())
 
-    max_nframes = int(os.environ["DD_PROFILING_MAX_FRAMES"])
+    max_nframes = int(env["DD_PROFILING_MAX_FRAMES"])
 
     p = profiler.Profiler()
     p.start()
@@ -619,7 +620,7 @@ def test_collect_gevent_task_started_before_profiler() -> None:
         pre_started_greenlet.join(timeout=2)
         p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0

--- a/tests/profiling/collector/test_stack_asyncio_basic.py
+++ b/tests/profiling/collector/test_stack_asyncio_basic.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -58,7 +60,7 @@ def test_asyncio_basic() -> None:
     assert t1_name == "sleep 1"
     assert t2_name == "sleep 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     profile = pprof_utils.parse_newest_profile(output_filename)
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -20,6 +20,7 @@ from ddtrace import ext
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.internal.settings import env
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
@@ -236,7 +237,7 @@ def test_user_threads_have_native_id():
 
 # This test has to be run in a subprocess because it calls gevent.monkey.patch_all()
 # which affects the whole process.
-@pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT"), reason="gevent is not available")
+@pytest.mark.skipif(not env.get("DD_PROFILE_TEST_GEVENT"), reason="gevent is not available")
 @pytest.mark.subprocess(
     env=dict(DD_PROFILING_FILE_PATH=__file__),
 )
@@ -269,7 +270,7 @@ def test_lock_gevent_tasks() -> None:
     )  # pyright: ignore[reportCallIssue]
     ddup.start()
 
-    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    init_linenos(env["DD_PROFILING_FILE_PATH"])
 
     def play_with_lock() -> None:
         lock: threading.Lock = threading.Lock()  # !CREATE! test_lock_gevent_tasks
@@ -325,7 +326,7 @@ def test_lock_gevent_tasks() -> None:
 
 # This test has to be run in a subprocess because it calls gevent.monkey.patch_all()
 # which affects the whole process.
-@pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT"), reason="gevent is not available")
+@pytest.mark.skipif(not env.get("DD_PROFILE_TEST_GEVENT"), reason="gevent is not available")
 @pytest.mark.subprocess(
     env=dict(DD_PROFILING_FILE_PATH=__file__),
 )
@@ -358,7 +359,7 @@ def test_rlock_gevent_tasks() -> None:
     )  # pyright: ignore[reportCallIssue]
     ddup.start()
 
-    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    init_linenos(env["DD_PROFILING_FILE_PATH"])
 
     def play_with_lock() -> None:
         lock: threading.RLock = threading.RLock()  # !CREATE! test_rlock_gevent_tasks

--- a/tests/profiling/collector/test_threading_asyncio.py
+++ b/tests/profiling/collector/test_threading_asyncio.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env=dict(
@@ -18,7 +20,7 @@ def test_lock_acquire_events():
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
 
-    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    init_linenos(env["DD_PROFILING_FILE_PATH"])
 
     from tests.profiling.collector.test_utils import async_run
 
@@ -44,7 +46,7 @@ def test_lock_acquire_events():
     p.stop()
 
     expected_filename = "test_threading_asyncio.py"
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
 
     linenos_1 = get_lock_linenos("test_lock_acquire_events_1")
     linenos_2 = get_lock_linenos("test_lock_acquire_events_2")
@@ -57,7 +59,7 @@ def test_lock_acquire_events():
     # is reported from uvloop's wrapper code, not from _lock. We skip the _lock lock
     # event check when using uvloop since the filename and line numbers would be from
     # uvloop's source code.
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     expected_acquire_events = [
         pprof_utils.LockAcquireEvent(

--- a/tests/profiling/collector/test_utils.py
+++ b/tests/profiling/collector/test_utils.py
@@ -1,7 +1,6 @@
 """Shared utilities for profiling collector tests."""
 
 import asyncio
-import os
 from types import TracebackType
 from typing import Any
 from typing import Coroutine
@@ -9,6 +8,7 @@ from typing import Optional
 from typing import TypeVar
 
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.internal.settings import env
 from ddtrace.profiling import profiler
 
 
@@ -34,7 +34,7 @@ def init_ddup(test_name: str) -> None:
 
 
 def async_run(coro: Coroutine[Any, Any, T]) -> T:
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = env.get("USE_UVLOOP", "0") == "1"
 
     if use_uvloop:
         import uvloop

--- a/tests/profiling/collector/test_uvloop_multi_threaded.py
+++ b/tests/profiling/collector/test_uvloop_multi_threaded.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.profiling.collector import test_utils
 
 
@@ -65,7 +66,7 @@ def test_uvloop_multi_threaded() -> None:
         # Wait for the thread to finish
         thread.join()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")

--- a/tests/profiling/collector/test_uvloop_variations.py
+++ b/tests/profiling/collector/test_uvloop_variations.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.profiling.collector import test_utils
 
 
@@ -50,7 +51,7 @@ def test_uvloop_variations_install_and_run() -> None:
         uvloop.install()
         asyncio.run(outer())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -171,7 +172,7 @@ def test_uvloop_variations_uvloop_run() -> None:
     with ProfilerContextManager():
         uvloop.run(outer())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
@@ -293,7 +294,7 @@ def test_uvloop_variations_import_uvloop_dont_use_it() -> None:
         # uvloop is not installed nor used!
         asyncio.run(outer())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    output_filename = env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
     profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")

--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -3,6 +3,8 @@ import time
 
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 def spend_1():
     time.sleep(1)
@@ -95,7 +97,7 @@ def test_accuracy_stack():
     p.stop()
     wall_times = collections.defaultdict(lambda: 0)
     cpu_times = collections.defaultdict(lambda: 0)
-    profile = pprof_utils.parse_newest_profile(os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid()))
+    profile = pprof_utils.parse_newest_profile(env["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid()))
 
     for sample in profile.sample:
         wall_time_index = pprof_utils.get_sample_type_index(profile, "wall-time")

--- a/tests/profiling/test_gevent.py
+++ b/tests/profiling/test_gevent.py
@@ -1,12 +1,13 @@
 """Tests for ddtrace/profiling/_gevent.py task-linkage helpers."""
 
-import os
 import sys
 
 import pytest
 
+from ddtrace.internal.settings import env
 
-GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", False) and (
+
+GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = env.get("DD_PROFILE_TEST_GEVENT", False) and (
     sys.version_info < (3, 11, 9) or sys.version_info >= (3, 12, 5)
 )
 

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -17,6 +17,7 @@ import urllib.request
 import pytest
 from typing_extensions import TypeAlias
 
+from ddtrace.internal.settings import env
 from tests.profiling.collector import pprof_utils
 
 
@@ -34,7 +35,7 @@ def debug_print(*args: Any) -> None:
 if sys.platform == "win32":
     pytestmark = pytest.mark.skip
 
-TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
+TESTING_GEVENT = env.get("DD_PROFILE_TEST_GEVENT", False)
 
 RunGunicornFunc: TypeAlias = Callable[..., subprocess.Popen[bytes]]
 

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -6,16 +6,17 @@ import sys
 
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.profiling.collector import lock_utils
 from tests.profiling.collector import pprof_utils
 from tests.utils import call_program
 
 
 def test_call_script() -> None:
-    env = os.environ.copy()
-    env["DD_PROFILING_ENABLED"] = "1"
+    subenv = env.copy()
+    subenv["DD_PROFILING_ENABLED"] = "1"
     stdout, stderr, exitcode, _ = call_program(
-        "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program.py"), env=env
+        "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program.py"), env=subenv
     )
     if sys.platform == "win32":
         assert exitcode == 0, (stdout, stderr)
@@ -27,12 +28,12 @@ def test_call_script() -> None:
     assert hello == "hello world", stdout.strip()
 
 
-@pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
+@pytest.mark.skipif(not env.get("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
 def test_call_script_gevent():
-    env = os.environ.copy()
-    env["DD_PROFILING_ENABLED"] = "1"
+    subenv = env.copy()
+    subenv["DD_PROFILING_ENABLED"] = "1"
     stdout, stderr, exitcode, pid = call_program(
-        sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_gevent.py"), env=env
+        sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_gevent.py"), env=subenv
     )
     assert exitcode == 0, (stdout, stderr)
 
@@ -43,15 +44,15 @@ def test_call_script_pprof_output(tmp_path: Path) -> None:
     The script does not run for one minute, so if the `stop_on_exit` flag is broken, this test will fail.
     """
     filename = str(tmp_path / "pprof")
-    env = os.environ.copy()
-    env["DD_PROFILING_OUTPUT_PPROF"] = filename
-    env["DD_PROFILING_CAPTURE_PCT"] = "100"
-    env["DD_PROFILING_ENABLED"] = "1"
+    subenv = env.copy()
+    subenv["DD_PROFILING_OUTPUT_PPROF"] = filename
+    subenv["DD_PROFILING_CAPTURE_PCT"] = "100"
+    subenv["DD_PROFILING_ENABLED"] = "1"
     stdout, stderr, exitcode, _ = call_program(
         "ddtrace-run",
         sys.executable,
         os.path.join(os.path.dirname(__file__), "simple_program.py"),
-        env=env,
+        env=subenv,
     )
     if sys.platform == "win32":
         assert exitcode == 0, (stdout, stderr)
@@ -68,11 +69,11 @@ def test_call_script_pprof_output(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="fork only available on Unix")
 def test_fork(tmp_path: Path) -> None:
     filename = str(tmp_path / "pprof")
-    env = os.environ.copy()
-    env["DD_PROFILING_OUTPUT_PPROF"] = filename
-    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    subenv = env.copy()
+    subenv["DD_PROFILING_OUTPUT_PPROF"] = filename
+    subenv["DD_PROFILING_CAPTURE_PCT"] = "100"
     stdout, stderr, exitcode, pid = call_program(
-        sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=env
+        sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=subenv
     )
     assert exitcode == 0, stderr
     stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
@@ -150,10 +151,10 @@ def test_fork(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fork only available on Unix")
-@pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
+@pytest.mark.skipif(not env.get("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
 def test_fork_gevent() -> None:
-    env = os.environ.copy()
-    _, _, exitcode, _ = call_program("python", os.path.join(os.path.dirname(__file__), "gevent_fork.py"), env=env)
+    subenv = env.copy()
+    _, _, exitcode, _ = call_program("python", os.path.join(os.path.dirname(__file__), "gevent_fork.py"), env=subenv)
     assert exitcode == 0
 
 
@@ -166,16 +167,16 @@ methods = multiprocessing.get_all_start_methods()
 )
 def test_multiprocessing(method: str, tmp_path: Path) -> None:
     filename = str(tmp_path / "pprof")
-    env = os.environ.copy()
-    env["DD_PROFILING_OUTPUT_PPROF"] = filename
-    env["DD_PROFILING_ENABLED"] = "1"
-    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    subenv = env.copy()
+    subenv["DD_PROFILING_OUTPUT_PPROF"] = filename
+    subenv["DD_PROFILING_ENABLED"] = "1"
+    subenv["DD_PROFILING_CAPTURE_PCT"] = "100"
     stdout, stderr, exitcode, _ = call_program(
         "ddtrace-run",
         sys.executable,
         os.path.join(os.path.dirname(__file__), "_test_multiprocessing.py"),
         method,
-        env=env,
+        env=subenv,
     )
     assert exitcode == 0, (stdout, stderr)
     stdout = stdout.decode() if isinstance(stdout, bytes) else stdout

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 import time
 from unittest import mock
@@ -8,6 +7,7 @@ import pytest
 
 import ddtrace
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
+from ddtrace.internal.settings import env
 from ddtrace.profiling import collector
 from ddtrace.profiling import profiler
 from ddtrace.profiling import scheduler
@@ -16,7 +16,7 @@ from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading
 
 
-TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT") or False
+TESTING_GEVENT = env.get("DD_PROFILE_TEST_GEVENT") or False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/profiling/test_pytorch.py
+++ b/tests/profiling/test_pytorch.py
@@ -3,11 +3,12 @@ import sys
 
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.profiling.collector import pprof_utils
 from tests.utils import call_program
 
 
-@pytest.mark.skipif(not os.getenv("DD_PROFILING_PYTORCH_ENABLED", False), reason="Not testing pytorch GPU")
+@pytest.mark.skipif(not env.get("DD_PROFILING_PYTORCH_ENABLED", False), reason="Not testing pytorch GPU")
 def test_call_script_pytorch_gpu(tmp_path, monkeypatch):
     filename = str(tmp_path / "pprof")
     monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -34,6 +34,7 @@ from typing import Optional
 
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.profiling import profiler
 from tests.contrib.uwsgi import run_uwsgi
 from tests.profiling.collector import pprof_utils
@@ -47,7 +48,7 @@ if TYPE_CHECKING:
 if sys.platform == "win32":
     pytestmark = pytest.mark.skip
 
-TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
+TESTING_GEVENT = env.get("DD_PROFILE_TEST_GEVENT", False)
 THREADS_MSG = (
     b"ddtrace.internal.uwsgi.uWSGIConfigError: enable-threads option must be set to true, or a positive "
     b"number of threads must be set"


### PR DESCRIPTION
## Description

Migrates 42 test files under `tests/profiling/` (owned by `profiling-python`) from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.