### PR TITLE
chore(tests): migrate appsec tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/appsec/ai_guard/langchain/conftest.py
+++ b/tests/appsec/ai_guard/langchain/conftest.py
@@ -1,10 +1,9 @@
-import os
-
 import pytest
 
 from ddtrace.appsec._ai_guard import init_ai_guard
 from ddtrace.contrib.internal.langchain.patch import patch
 from ddtrace.contrib.internal.langchain.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.appsec.ai_guard.utils import override_ai_guard_config
 from tests.utils import override_env
 
@@ -26,8 +25,8 @@ def pytest_configure():
 def langchain():
     with override_env(
         dict(
-            OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
-            ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
+            OPENAI_API_KEY=env.get("OPENAI_API_KEY", "<not-a-real-key>"),
+            ANTHROPIC_API_KEY=env.get("ANTHROPIC_API_KEY", "<not-a-real-key>"),
         )
     ):
         patch()

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -3,8 +3,10 @@
 import os
 import sys
 
+from ddtrace.internal.settings import env  # noqa: E402
 
-if os.getenv("_USE_DDTRACE_COMMAND", False) not in ("1", "true", "True"):
+
+if env.get("_USE_DDTRACE_COMMAND", False) not in ("1", "true", "True"):
     import ddtrace.auto  # noqa: F401  # isort: skip
     import logging
 
@@ -1081,7 +1083,7 @@ def subprocess_popen_ok():
 
 
 if __name__ == "__main__":
-    env_port = os.getenv("FLASK_RUN_PORT", 8000)
-    debug = asbool(os.getenv("FLASK_DEBUG", "false"))
+    env_port = env.get("FLASK_RUN_PORT", 8000)
+    debug = asbool(env.get("FLASK_DEBUG", "false"))
     ddtrace_iast_flask_patch()
     app.run(debug=debug, port=env_port)

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import os
 import time
 
 import mock
@@ -20,6 +19,7 @@ from ddtrace.internal.remoteconfig.client import AgentPayload
 from ddtrace.internal.remoteconfig.client import ConfigMetadata
 from ddtrace.internal.remoteconfig.client import TargetFile
 from ddtrace.internal.service import ServiceStatus
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils.formats import asbool
 import tests.appsec.rules as rules
@@ -111,7 +111,7 @@ def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
 def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller):
     with override_env({APPSEC.ENV: appsec_enabled}):
         if appsec_enabled == "":
-            del os.environ[APPSEC.ENV]
+            del env[APPSEC.ENV]
         with override_global_config(dict(_asm_enabled=True)):
             tracer.configure(appsec_enabled=asbool(appsec_enabled))
 

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -13,6 +13,7 @@ from requests.exceptions import ConnectionError  # noqa: A004
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.retry import RetryError
 from ddtrace.vendor import psutil
 from tests.utils import _build_env
@@ -311,7 +312,7 @@ def appsec_application_server(
 
     if tracer_enabled:
         env["DD_TRACE_ENABLED"] = tracer_enabled
-    env["DD_TRACE_AGENT_URL"] = os.environ.get("DD_TRACE_AGENT_URL", "")
+    env["DD_TRACE_AGENT_URL"] = env.get("DD_TRACE_AGENT_URL", "")
     env["FLASK_RUN_PORT"] = str(port)
     env["PYTHONFAULTHANDLER"] = "1"
     env["MALLOC_PERTURB_"] = "glibc.malloc.tcache_max=0"
@@ -340,7 +341,7 @@ def appsec_application_server(
         # Run the server command by replacing the child Python process with the target binary (exec),
         # ensuring signals/termination behave like the subprocess.Popen path.
         # Build the environment for the child exec
-        mp_env = dict(subprocess_kwargs["env"]) if "env" in subprocess_kwargs else os.environ.copy()
+        mp_env = dict(subprocess_kwargs["env"]) if "env" in subprocess_kwargs else env.copy()
         server_process: _t.Union[subprocess.Popen, multiprocessing.Process]
         server_process = multiprocessing.Process(target=_mp_target, args=(cmd, mp_env), daemon=True)
         server_process.start()
@@ -470,9 +471,9 @@ def _make_preexec() -> _t.Optional[_t.Callable[[], None]]:
 
     Returns None if no limits were requested.
     """
-    mem_mb = os.environ.get("TEST_SUBPROC_MEM_MB")
-    cpu_aff = os.environ.get("TEST_SUBPROC_CPU_AFFINITY")
-    nice_val = os.environ.get("TEST_SUBPROC_NICE")
+    mem_mb = env.get("TEST_SUBPROC_MEM_MB")
+    cpu_aff = env.get("TEST_SUBPROC_CPU_AFFINITY")
+    nice_val = env.get("TEST_SUBPROC_NICE")
     if not any((mem_mb, cpu_aff, nice_val)):
         return None
 

--- a/tests/appsec/architectures/mini.py
+++ b/tests/appsec/architectures/mini.py
@@ -12,6 +12,7 @@ from flask import request  # noqa: E402
 import requests  # noqa: E402 F401
 
 from ddtrace import __version__  # noqa: E402
+from ddtrace.internal.settings import env  # noqa: E402
 from ddtrace.internal.settings.asm import config as asm_config  # noqa: E402
 import ddtrace.internal.telemetry.writer  # noqa: E402
 
@@ -45,9 +46,9 @@ def hello_world():
         "asm_config": {
             k: getattr(asm_config, k) for k in dir(asm_config) if isinstance(getattr(asm_config, k), (int, bool, float))
         },
-        "aws": "AWS_LAMBDA_FUNCTION_NAME" in os.environ,
+        "aws": "AWS_LAMBDA_FUNCTION_NAME" in env,
         "version": __version__,
-        "env": dict(os.environ),
+        "env": dict(env),
         "file_length": file_length,
     }
 

--- a/tests/appsec/architectures/test_appsec_loading_modules.py
+++ b/tests/appsec/architectures/test_appsec_loading_modules.py
@@ -1,5 +1,4 @@
 import json
-import os
 import pathlib
 import subprocess
 import sys
@@ -9,6 +8,7 @@ from urllib.request import urlopen
 
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 
@@ -26,26 +26,26 @@ MODULE_IAST_ONLY = [
 @pytest.mark.parametrize("aws_lambda", [None, "any"])
 def test_loading(appsec_enabled, iast_enabled, aws_lambda):
     flask_app = pathlib.Path(__file__).parent / "mini.py"
-    env = os.environ.copy()
+    subenv = env.copy()
     if appsec_enabled:
-        env["DD_APPSEC_ENABLED"] = appsec_enabled
+        subenv["DD_APPSEC_ENABLED"] = appsec_enabled
     else:
-        env.pop("DD_APPSEC_ENABLED", None)
+        subenv.pop("DD_APPSEC_ENABLED", None)
     if iast_enabled:
-        env["DD_IAST_ENABLED"] = iast_enabled
+        subenv["DD_IAST_ENABLED"] = iast_enabled
     else:
-        env.pop("DD_IAST_ENABLED", None)
+        subenv.pop("DD_IAST_ENABLED", None)
     if aws_lambda:
-        env["AWS_LAMBDA_FUNCTION_NAME"] = aws_lambda
+        subenv["AWS_LAMBDA_FUNCTION_NAME"] = aws_lambda
     else:
-        env.pop("AWS_LAMBDA_FUNCTION_NAME", None)
+        subenv.pop("AWS_LAMBDA_FUNCTION_NAME", None)
 
     # Disable debug logging as it creates too large buffer to handle
-    env["DD_TRACE_DEBUG"] = "false"
+    subenv["DD_TRACE_DEBUG"] = "false"
 
     print(f"\nStarting server {sys.executable} {str(flask_app)}", flush=True)
 
-    process = subprocess.Popen([sys.executable, str(flask_app)], env=env)
+    process = subprocess.Popen([sys.executable, str(flask_app)], env=subenv)
     try:
         print("process started", flush=True)
         for i in range(24):
@@ -103,9 +103,9 @@ def test_package(module, expected):
 
     print(f"\nStarting server {sys.executable} {str(flask_app)}", flush=True)
 
-    env = os.environ.copy()
-    env["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = "4"
-    process = subprocess.Popen([sys.executable, str(flask_app)], env=env)
+    subenv = env.copy()
+    subenv["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = "4"
+    process = subprocess.Popen([sys.executable, str(flask_app)], env=subenv)
     try:
         print("process started", flush=True)
         for i in range(24):

--- a/tests/appsec/contrib_appsec/test_django.py
+++ b/tests/appsec/contrib_appsec/test_django.py
@@ -1,10 +1,9 @@
-import os
-
 import django
 from django.conf import settings
 from django.test.client import Client
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.propagation._utils import get_wsgi_header
 from tests.appsec.contrib_appsec import utils
 from tests.utils import scoped_tracer
@@ -15,7 +14,7 @@ class _Test_Django_Base:
 
     @pytest.fixture
     def interface(self, printer):
-        os.environ["DJANGO_SETTINGS_MODULE"] = "tests.appsec.contrib_appsec.django_app.settings"
+        env["DJANGO_SETTINGS_MODULE"] = "tests.appsec.contrib_appsec.django_app.settings"
         settings.DEBUG = False
         django.setup()
         client = Client(

--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -22,6 +22,7 @@ from ddtrace.appsec._iast.taint_sinks.untrusted_serialization import patch as un
 from ddtrace.appsec._iast.taint_sinks.weak_cipher import patch as weak_cipher_patch
 from ddtrace.appsec._iast.taint_sinks.weak_hash import patch as weak_hash_patch
 from ddtrace.appsec._iast.taint_sinks.weak_hash import unpatch_iast as weak_hash_unpatch
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.http import Response
 from ddtrace.internal.utils.http import get_connection
 from tests.appsec.iast.iast_utils import IAST_VALID_LOG
@@ -177,7 +178,7 @@ def configuration_endpoint():
 
 @pytest.fixture(autouse=True)
 def clear_iast_env_vars():
-    os.environ[IAST.PATCH_MODULES] = "benchmarks.,tests.appsec."
-    if IAST.DENY_MODULES in os.environ:
-        os.environ.pop("_DD_IAST_DENY_MODULES")
+    env[IAST.PATCH_MODULES] = "benchmarks.,tests.appsec."
+    if IAST.DENY_MODULES in env:
+        env.pop("_DD_IAST_DENY_MODULES")
     yield

--- a/tests/appsec/iast/fixtures/integration/main_configure.py
+++ b/tests/appsec/iast/fixtures/integration/main_configure.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import logging
-import os
 import sys
 
 import ddtrace.auto  # noqa: F401
@@ -14,6 +13,7 @@ logger.setLevel(logging.DEBUG)
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
 
+from ddtrace.internal.settings import env  # noqa: E402
 from tests.appsec.iast.fixtures.integration.print_str import print_str  # noqa: E402
 
 
@@ -23,7 +23,7 @@ def main():
 
 
 if __name__ == "__main__":
-    iast_enabled = bool(os.environ.get("DD_IAST_ENABLED", "") == "true")
+    iast_enabled = bool(env.get("DD_IAST_ENABLED", "") == "true")
     logger.info("IAST env var: %s", iast_enabled)
     tracer.configure(iast_enabled=not iast_enabled)
     main()

--- a/tests/appsec/iast/fixtures/integration/main_configure_right.py
+++ b/tests/appsec/iast/fixtures/integration/main_configure_right.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import sys
 
 from ddtrace.ext import SpanTypes
@@ -13,6 +12,7 @@ logger.setLevel(logging.DEBUG)
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
 
+from ddtrace.internal.settings import env  # noqa: E402
 from tests.appsec.iast.fixtures.integration.print_str import print_str  # noqa: E402
 
 
@@ -22,7 +22,7 @@ def main():
 
 
 if __name__ == "__main__":
-    iast_enabled = bool(os.environ.get("DD_IAST_ENABLED", "") == "true")
+    iast_enabled = bool(env.get("DD_IAST_ENABLED", "") == "true")
     logger.info("configuring IAST to %s", iast_enabled)
     tracer.configure(iast_enabled=iast_enabled)
     main()

--- a/tests/appsec/iast/fixtures/integration/main_configure_wrong.py
+++ b/tests/appsec/iast/fixtures/integration/main_configure_wrong.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import sys
 
 from ddtrace.ext import SpanTypes
@@ -13,6 +12,7 @@ logger.setLevel(logging.DEBUG)
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
 
+from ddtrace.internal.settings import env  # noqa: E402
 from tests.appsec.iast.fixtures.integration.print_str import print_str  # noqa: E402
 
 
@@ -22,7 +22,7 @@ def main():
 
 
 if __name__ == "__main__":
-    iast_enabled = os.environ.get("DD_IAST_ENABLED", "false")
+    iast_enabled = env.get("DD_IAST_ENABLED", "false")
     logger.info("configuring IAST to %s", iast_enabled)
     tracer.configure(iast_enabled=iast_enabled)
     main()

--- a/tests/appsec/iast/secure_marks/test_security_controls_configuration.py
+++ b/tests/appsec/iast/secure_marks/test_security_controls_configuration.py
@@ -1,7 +1,6 @@
 """Tests for DD_IAST_SECURITY_CONTROLS_CONFIGURATION environment variable functionality."""
 
 import functools
-import os
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +16,7 @@ from ddtrace.appsec._iast.secure_marks.configuration import parse_security_contr
 from ddtrace.appsec._iast.secure_marks.configuration import parse_vulnerability_types
 from ddtrace.appsec._iast.secure_marks.sanitizers import create_sanitizer
 from ddtrace.appsec._iast.secure_marks.validators import create_validator
+from ddtrace.internal.settings import env
 from tests.utils import override_global_config
 
 
@@ -213,7 +213,7 @@ def test_get_security_controls_from_env_valid():
     assert result[1].module_path == "html"
 
 
-@patch.dict(os.environ, {"DD_IAST_SECURITY_CONTROLS_CONFIGURATION": "INVALID:FORMAT"})
+@patch.dict(env, {"DD_IAST_SECURITY_CONTROLS_CONFIGURATION": "INVALID:FORMAT"})
 def test_get_security_controls_from_env_invalid():
     """Test getting security controls from invalid environment variable."""
     result = get_security_controls_from_env()

--- a/tests/appsec/iast/taint_tracking/test_multiprocessing_tracer_iast_env.py
+++ b/tests/appsec/iast/taint_tracking/test_multiprocessing_tracer_iast_env.py
@@ -9,6 +9,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import is_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.internal.settings import env
 from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _start_iast_context_and_oce
 
@@ -68,7 +69,7 @@ def _child_check(q: Queue):
             {
                 "pid": os.getpid(),
                 "tracer_enabled": bool(tracer.enabled),
-                "iast_env": os.environ.get("DD_IAST_ENABLED"),
+                "iast_env": env.get("DD_IAST_ENABLED"),
                 "text_is_tainted": is_tainted(tainted_text),
                 "text_is_tainted2": is_tainted(tainted_text2),
                 "iast_enabled_flag": bool(asm_config._iast_enabled),

--- a/tests/appsec/iast/test_env_var.py
+++ b/tests/appsec/iast/test_env_var.py
@@ -6,6 +6,7 @@ import pytest
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._ast import iastpatch
+from ddtrace.internal.settings import env
 from tests.appsec.iast.conftest import CONFIG_SERVER_PORT
 from tests.utils import _build_env
 
@@ -28,10 +29,10 @@ def _run_python_file(*args, **kwargs):
 
 def test_env_var_iast_enabled(capfd):
     # type: (...) -> None
-    env = os.environ.copy()
-    env["DD_IAST_ENABLED"] = "true"
-    env["DD_TRACE_DEBUG"] = "true"
-    _run_python_file(env=env)
+    subenv = env.copy()
+    subenv["DD_IAST_ENABLED"] = "true"
+    subenv["DD_TRACE_DEBUG"] = "true"
+    _run_python_file(env=subenv)
     captured = capfd.readouterr()
     assert "iast" in captured.err
     assert "hi" in captured.out
@@ -39,10 +40,10 @@ def test_env_var_iast_enabled(capfd):
 
 def test_env_var_iast_disabled(monkeypatch, capfd):
     # type: (...) -> None
-    env = os.environ.copy()
-    env["DD_IAST_ENABLED"] = "false"
-    env["DD_TRACE_DEBUG"] = "true"
-    _run_python_file(env=env)
+    subenv = env.copy()
+    subenv["DD_IAST_ENABLED"] = "false"
+    subenv["DD_TRACE_DEBUG"] = "true"
+    _run_python_file(env=subenv)
     captured = capfd.readouterr()
     assert "hi" in captured.out
     assert "iast::instrumentation::starting IAST" not in captured.err
@@ -87,10 +88,10 @@ def test_env_var_iast_unset(monkeypatch, capfd):
     ],
 )
 def test_env_var_iast_enabled_parametrized(capfd, configuration_endpoint, env_vars):
-    env = os.environ.copy()
+    subenv = env.copy()
     for k, v in env_vars.items():
-        env[k] = v
-    _run_python_file(env=env)
+        subenv[k] = v
+    _run_python_file(env=subenv)
     captured = capfd.readouterr()
     assert "hi" in captured.out
     assert "iast::instrumentation::starting IAST" in captured.err
@@ -136,10 +137,10 @@ def test_env_var_iast_enabled_parametrized(capfd, configuration_endpoint, env_va
     ],
 )
 def test_env_var_iast_disabled_parametrized(capfd, configuration_endpoint, env_vars):
-    env = os.environ.copy()
+    subenv = env.copy()
     for k, v in env_vars.items():
-        env[k] = v
-    _run_python_file(env=env)
+        subenv[k] = v
+    _run_python_file(env=subenv)
     captured = capfd.readouterr()
     assert "hi" in captured.out
     assert "iast::instrumentation::starting IAST" not in captured.err
@@ -153,11 +154,11 @@ def test_env_var_iast_enabled_no__native_module_warning():
 @pytest.mark.skip(reason="IAST not working with Gevent yet")
 def test_env_var_iast_enabled_gevent_unload_modules_true(capfd):
     # type: (...) -> None
-    env = os.environ.copy()
-    env["DD_IAST_ENABLED"] = "true"
-    env["DD_TRACE_DEBUG"] = "true"
-    env["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "true"
-    _run_python_file(filename="main_gevent.py", env=env)
+    subenv = env.copy()
+    subenv["DD_IAST_ENABLED"] = "true"
+    subenv["DD_TRACE_DEBUG"] = "true"
+    subenv["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "true"
+    _run_python_file(filename="main_gevent.py", env=subenv)
     captured = capfd.readouterr()
     assert "iast::instrumentation::starting IAST" in captured.err
     assert "hi" in captured.out
@@ -166,11 +167,11 @@ def test_env_var_iast_enabled_gevent_unload_modules_true(capfd):
 @pytest.mark.skip(reason="IAST not working with Gevent yet")
 def test_env_var_iast_enabled_gevent_unload_modules_false(capfd):
     # type: (...) -> None
-    env = os.environ.copy()
-    env["DD_IAST_ENABLED"] = "true"
-    env["DD_TRACE_DEBUG"] = "true"
-    env["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "false"
-    _run_python_file(filename="main_gevent.py", env=env)
+    subenv = env.copy()
+    subenv["DD_IAST_ENABLED"] = "true"
+    subenv["DD_TRACE_DEBUG"] = "true"
+    subenv["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "false"
+    _run_python_file(filename="main_gevent.py", env=subenv)
     captured = capfd.readouterr()
     assert "iast::instrumentation::starting IAST" in captured.err
     assert "hi" in captured.out
@@ -179,10 +180,10 @@ def test_env_var_iast_enabled_gevent_unload_modules_false(capfd):
 @pytest.mark.skip(reason="IAST not working with Gevent yet")
 def test_env_var_iast_enabled_gevent_patch_all_true(capfd):
     # type: (...) -> None
-    env = os.environ.copy()
-    env["DD_IAST_ENABLED"] = "true"
-    env["DD_TRACE_DEBUG"] = "true"
-    _run_python_file(filename="main_gevent.py", env=env)
+    subenv = env.copy()
+    subenv["DD_IAST_ENABLED"] = "true"
+    subenv["DD_TRACE_DEBUG"] = "true"
+    _run_python_file(filename="main_gevent.py", env=subenv)
     captured = capfd.readouterr()
     assert "iast::instrumentation::starting IAST" in captured.err
     assert "hi" in captured.out
@@ -213,10 +214,10 @@ def test_env_var_iast_enabled_gevent_patch_all_true(capfd):
 )
 def test_env_var_iast_modules_to_patch(module_name, expected_result):
     # type: (...) -> None
-    os.environ[IAST.PATCH_MODULES] = IAST.SEP_MODULES.join(
+    env[IAST.PATCH_MODULES] = IAST.SEP_MODULES.join(
         ["ddtrace.allowed.", "please_patch.", "also.that.", "please_patch.do_not.but_yes."]
     )
-    os.environ[IAST.DENY_MODULES] = IAST.SEP_MODULES.join(["please_patch.do_not.", "also.that.but.not.that."])
+    env[IAST.DENY_MODULES] = IAST.SEP_MODULES.join(["please_patch.do_not.", "also.that.but.not.that."])
     iastpatch.build_list_from_env(IAST.PATCH_MODULES)
     iastpatch.build_list_from_env(IAST.DENY_MODULES)
 
@@ -249,43 +250,43 @@ def assert_configure_right_enabled(monkeypatch, capfd, iast_enabled, env):
 
 def test_env_var__configure_wrong(monkeypatch, capfd):
     # type: (...) -> None
-    env = os.environ.copy()
+    subenv = env.copy()
     iast_enabled = "false"
     # Test with DD_IAST_ENABLED = "false"
-    env["DD_IAST_ENABLED"] = iast_enabled
-    env["DD_TRACE_DEBUG"] = "true"
-    assert_configure_wrong(monkeypatch, capfd, iast_enabled, env)
+    subenv["DD_IAST_ENABLED"] = iast_enabled
+    subenv["DD_TRACE_DEBUG"] = "true"
+    assert_configure_wrong(monkeypatch, capfd, iast_enabled, subenv)
     # Test with env var unset
-    del env["DD_IAST_ENABLED"]
-    assert_configure_wrong(monkeypatch, capfd, iast_enabled, env)
+    del subenv["DD_IAST_ENABLED"]
+    assert_configure_wrong(monkeypatch, capfd, iast_enabled, subenv)
 
 
 def test_env_var__configure_right(monkeypatch, capfd):
     # type: (...) -> None
-    env = os.environ.copy()
+    subenv = env.copy()
     iast_enabled = "false"
     # Test with DD_IAST_ENABLED = "false"
-    env["DD_IAST_ENABLED"] = iast_enabled
-    env["DD_TRACE_DEBUG"] = "true"
-    assert_configure_right_disabled(monkeypatch, capfd, iast_enabled, env)
+    subenv["DD_IAST_ENABLED"] = iast_enabled
+    subenv["DD_TRACE_DEBUG"] = "true"
+    assert_configure_right_disabled(monkeypatch, capfd, iast_enabled, subenv)
     # Test with env var unset
-    del env["DD_IAST_ENABLED"]
-    assert_configure_right_disabled(monkeypatch, capfd, iast_enabled, env)
+    del subenv["DD_IAST_ENABLED"]
+    assert_configure_right_disabled(monkeypatch, capfd, iast_enabled, subenv)
 
     iast_enabled = "true"
     # Test with DD_IAST_ENABLED = "true"
-    env["DD_IAST_ENABLED"] = iast_enabled
-    assert_configure_right_enabled(monkeypatch, capfd, iast_enabled, env)
+    subenv["DD_IAST_ENABLED"] = iast_enabled
+    assert_configure_right_enabled(monkeypatch, capfd, iast_enabled, subenv)
 
 
 @pytest.mark.parametrize("_iast_enabled", ["true", "false"])
 @pytest.mark.parametrize("no_ddtracerun", [True, False])
 def test_config_over_env_var(_iast_enabled, no_ddtracerun, monkeypatch, capfd):
     # Test that ``tracer.configure`` takes precedence over env var value
-    env = os.environ.copy()
-    env["DD_IAST_ENABLED"] = _iast_enabled
-    env["DD_TRACE_DEBUG"] = "true"
-    _run_python_file(_iast_enabled, env=env, filename="main_configure.py", no_ddtracerun=True, returncode=0)
+    subenv = env.copy()
+    subenv["DD_IAST_ENABLED"] = _iast_enabled
+    subenv["DD_TRACE_DEBUG"] = "true"
+    _run_python_file(_iast_enabled, env=subenv, filename="main_configure.py", no_ddtracerun=True, returncode=0)
     captured = capfd.readouterr()
     assert f"IAST env var: {_iast_enabled.capitalize()}" in captured.out
     assert "hi" in captured.out
@@ -309,8 +310,8 @@ def test_should_iast_patch_invalid_input(module_name, expected_error):
 
 
 def test_should_iast_patch_empty_lists():
-    os.environ[IAST.PATCH_MODULES] = ""
-    os.environ[IAST.DENY_MODULES] = ""
+    env[IAST.PATCH_MODULES] = ""
+    env[IAST.DENY_MODULES] = ""
     iastpatch.build_list_from_env(IAST.PATCH_MODULES)
     iastpatch.build_list_from_env(IAST.DENY_MODULES)
 
@@ -319,7 +320,7 @@ def test_should_iast_patch_empty_lists():
 
 def test_should_iast_patch_max_list_size():
     large_list = ",".join([f"module{i}." for i in range(1000)])
-    os.environ[IAST.PATCH_MODULES] = large_list
+    env[IAST.PATCH_MODULES] = large_list
     iastpatch.build_list_from_env(IAST.PATCH_MODULES)
     assert iastpatch.should_iast_patch("module1") == iastpatch.ALLOWED_USER_ALLOWLIST
     assert iastpatch.should_iast_patch("module2") == iastpatch.ALLOWED_USER_ALLOWLIST
@@ -337,8 +338,8 @@ def test_should_iast_patch_max_list_size():
     ],
 )
 def test_should_iast_patch_priority_conflicts(module_name, allowlist, denylist, expected_result):
-    os.environ[IAST.PATCH_MODULES] = allowlist
-    os.environ[IAST.DENY_MODULES] = denylist
+    env[IAST.PATCH_MODULES] = allowlist
+    env[IAST.DENY_MODULES] = denylist
     iastpatch.build_list_from_env(IAST.PATCH_MODULES)
     iastpatch.build_list_from_env(IAST.DENY_MODULES)
     assert iastpatch.should_iast_patch(module_name) == expected_result

--- a/tests/appsec/iast/test_reporter.py
+++ b/tests/appsec/iast/test_reporter.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from ddtrace.appsec._iast.reporter import Evidence
@@ -7,6 +5,7 @@ from ddtrace.appsec._iast.reporter import Location
 from ddtrace.appsec._iast.reporter import Source
 from ddtrace.appsec._iast.reporter import Vulnerability
 from ddtrace.appsec._iast.reporter import _truncate_evidence_value
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 
 
@@ -167,7 +166,7 @@ class TestEvidenceTruncation:
         max_length = asm_config._iast_truncation_max_value_length
 
         # Default should be 250 unless overridden by env var
-        env_value = os.environ.get("DD_IAST_TRUNCATION_MAX_VALUE_LENGTH")
+        env_value = env.get("DD_IAST_TRUNCATION_MAX_VALUE_LENGTH")
         if env_value:
             assert max_length == int(env_value)
         else:

--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -9,6 +9,7 @@ import sys
 import pytest
 
 from ddtrace.appsec._constants import IAST
+from ddtrace.internal.settings import env
 from tests.appsec.appsec_utils import flask_server
 from tests.appsec.iast_packages import clonevirtualenv
 from tests.utils import DDTRACE_PATH
@@ -18,12 +19,10 @@ from tests.utils import override_env
 PYTHON_VERSION = sys.version_info[:2]
 
 # Add modules in the denylist that must be tested anyway
-if IAST.PATCH_MODULES in os.environ:
-    os.environ[IAST.PATCH_MODULES] += IAST.SEP_MODULES + IAST.SEP_MODULES.join(
-        ["moto", "moto[all]", "moto[ec2]", "moto[s3]"]
-    )
+if IAST.PATCH_MODULES in env:
+    env[IAST.PATCH_MODULES] += IAST.SEP_MODULES + IAST.SEP_MODULES.join(["moto", "moto[all]", "moto[ec2]", "moto[s3]"])
 else:
-    os.environ[IAST.PATCH_MODULES] = IAST.SEP_MODULES.join(["moto", "moto[all]", "moto[ec2]", "moto[s3]"])
+    env[IAST.PATCH_MODULES] = IAST.SEP_MODULES.join(["moto", "moto[all]", "moto[ec2]", "moto[s3]"])
 
 
 FILE_PATH = Path(__file__).resolve().parent
@@ -36,7 +35,7 @@ SKIP_FUNCTION = lambda package: True  # noqa: E731
 # Remember to set to False before pushing it!
 _DEBUG_MODE = False
 
-IN_GITLAB = os.environ.get("GITLAB_CI", "false") in ("1", "true", "True")
+IN_GITLAB = env.get("GITLAB_CI", "false") in ("1", "true", "True")
 TEMPLATE_VENV_DIR = os.path.join(DDTRACE_PATH, "template_venv")
 CLONED_VENVS_DIR = os.path.join(DDTRACE_PATH, "cloned_venvs")
 PIP_EXECUTABLE = os.path.join(TEMPLATE_VENV_DIR, "bin", "pip")
@@ -65,7 +64,7 @@ def cleanup(request):
 
 
 def get_pip_cache_dir(python):
-    cache_dir = os.environ.get("PIP_CACHE_DIR")
+    cache_dir = env.get("PIP_CACHE_DIR")
     if cache_dir:
         return cache_dir
 
@@ -79,16 +78,16 @@ def get_pip_cache_dir(python):
 @contextmanager
 def set_pip_cache_dir():
     """Set PIP_CACHE_DIR and restore its original state on exit."""
-    original_value = os.environ.get("PIP_CACHE_DIR")
+    original_value = env.get("PIP_CACHE_DIR")
     os.makedirs(PIP_CACHE_SHARED_VENVS_DIR, exist_ok=True)  # Ensure cache dir exists
-    os.environ["PIP_CACHE_DIR"] = PIP_CACHE_SHARED_VENVS_DIR
+    env["PIP_CACHE_DIR"] = PIP_CACHE_SHARED_VENVS_DIR
     try:
         yield
     finally:
         if original_value is not None:
-            os.environ["PIP_CACHE_DIR"] = original_value
+            env["PIP_CACHE_DIR"] = original_value
         else:
-            del os.environ["PIP_CACHE_DIR"]
+            del env["PIP_CACHE_DIR"]
 
 
 class PackageForTesting:
@@ -183,7 +182,7 @@ class PackageForTesting:
 
         cmd = [python_cmd, "-m", "pip", "install", "-U", package_fullversion]
         env = {}
-        env.update(os.environ)
+        env.update(env)
         # CAVEAT: we use subprocess instead of `pip.main(["install", package_fullversion])` due to pip package
         # doesn't work correctly with riot environment and python packages path
         proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, close_fds=True, env=env)
@@ -924,7 +923,7 @@ PACKAGES = sorted(_PACKAGES, key=lambda x: x.name)
 
 
 def _detect_virtualenv():
-    venv_path = os.environ.get("VIRTUAL_ENV")
+    venv_path = env.get("VIRTUAL_ENV")
     if venv_path:
         return True, venv_path
 

--- a/tests/appsec/iast_tdd_propagation/flask_orm_app.py
+++ b/tests/appsec/iast_tdd_propagation/flask_orm_app.py
@@ -3,7 +3,6 @@
 """This Flask application is imported on tests.appsec.appsec_utils.gunicorn_flask_server"""
 
 import importlib
-import os
 import sys
 
 from flask import Flask
@@ -19,10 +18,12 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
 import ddtrace.auto  # noqa: F401  # isort: skip
+from ddtrace.internal.settings import env
 
-orm = os.getenv("FLASK_ORM", "sqlite")
 
-port = int(os.getenv("FLASK_RUN_PORT", 8000))
+orm = env.get("FLASK_ORM", "sqlite")
+
+port = int(env.get("FLASK_RUN_PORT", 8000))
 
 orm_impl = importlib.import_module(f"{orm}_impl")
 

--- a/tests/appsec/iast_tdd_propagation/flask_propagation_app.py
+++ b/tests/appsec/iast_tdd_propagation/flask_propagation_app.py
@@ -1,11 +1,10 @@
-import os
-
 from flask_propagation_views import create_app
 
 from ddtrace import auto  # noqa: F401
+from ddtrace.internal.settings import env
 
 
-port = int(os.getenv("FLASK_RUN_PORT", 8000))
+port = int(env.get("FLASK_RUN_PORT", 8000))
 
 app = create_app()
 

--- a/tests/appsec/iast_tdd_propagation/flask_taint_sinks_app.py
+++ b/tests/appsec/iast_tdd_propagation/flask_taint_sinks_app.py
@@ -1,11 +1,10 @@
-import os
-
 from flask_taint_sinks_views import create_app
 
 from ddtrace import auto  # noqa: F401
+from ddtrace.internal.settings import env
 
 
-port = int(os.getenv("FLASK_RUN_PORT", 8000))
+port = int(env.get("FLASK_RUN_PORT", 8000))
 
 app = create_app()
 

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import django
 from django.conf import settings
 import pytest
@@ -13,12 +11,13 @@ from ddtrace.contrib.internal.django.patch import patch as django_patch
 from ddtrace.contrib.internal.psycopg.patch import patch as psycopg_patch
 from ddtrace.contrib.internal.requests.patch import patch as requests_patch
 from ddtrace.contrib.internal.sqlite3.patch import patch as sqlite3_patch
+from ddtrace.internal.settings import env
 from tests.utils import TracerSpanContainer
 from tests.utils import override_env
 from tests.utils import override_global_config
 
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.appsec.integrations.django_tests.django_app.settings")
+env.setdefault("DJANGO_SETTINGS_MODULE", "tests.appsec.integrations.django_tests.django_app.settings")
 
 
 # `pytest` automatically calls this function once when tests are run.

--- a/tests/appsec/integrations/django_tests/django_app/manage.py
+++ b/tests/appsec/integrations/django_tests/django_app/manage.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 import ddtrace.auto  # noqa: F401  # isort: skip
-import os
 import sys
+
+from ddtrace.internal.settings import env
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.appsec.integrations.django_tests.django_app.settings")
+    env.setdefault("DJANGO_SETTINGS_MODULE", "tests.appsec.integrations.django_tests.django_app.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/tests/appsec/integrations/django_tests/django_app/wsgi.py
+++ b/tests/appsec/integrations/django_tests/django_app/wsgi.py
@@ -5,11 +5,12 @@ This enables running the Django test app under Gunicorn using the
 """
 
 import ddtrace.auto  # noqa: F401  # isort: skip
-import os
 
 from django.core.wsgi import get_wsgi_application
 
+from ddtrace.internal.settings import env
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.appsec.integrations.django_tests.django_app.settings")
+
+env.setdefault("DJANGO_SETTINGS_MODULE", "tests.appsec.integrations.django_tests.django_app.settings")
 
 application = get_wsgi_application()

--- a/tests/appsec/integrations/packages_tests/db_utils.py
+++ b/tests/appsec/integrations/packages_tests/db_utils.py
@@ -1,12 +1,12 @@
-import os
-
 import psycopg
 import psycopg2
 import pymysql
 
+from ddtrace.internal.settings import env
 
-POSTGRES_HOST = os.getenv("TEST_POSTGRES_HOST", "127.0.0.1")
-MYSQL_HOST = os.getenv("TEST_MYSQL_HOST", "127.0.0.1")
+
+POSTGRES_HOST = env.get("TEST_POSTGRES_HOST", "127.0.0.1")
+MYSQL_HOST = env.get("TEST_MYSQL_HOST", "127.0.0.1")
 
 
 def get_psycopg2_connection():

--- a/tests/appsec/integrations/pygoat_tests/test_pygoat.py
+++ b/tests/appsec/integrations/pygoat_tests/test_pygoat.py
@@ -1,10 +1,10 @@
 import json
-import os
 import time
 
 import pytest
 import requests
 
+from ddtrace.internal.settings import env
 from tests.appsec.iast.conftest import iast_context_defaults
 from tests.appsec.iast.iast_utils import load_iast_report
 
@@ -17,7 +17,7 @@ span_defaults = iast_context_defaults  # So ruff does not remove it
 
 IMAGE_NAME = "pygoat:2.0.1"
 PYGOAT_URL = "http://0.0.0.0:8321"
-TESTAGENT_URL = os.getenv("DD_TRACE_AGENT_URL", "http://localhost:9126")
+TESTAGENT_URL = env.get("DD_TRACE_AGENT_URL", "http://localhost:9126")
 TESTAGENT_TOKEN = "pygoat_test"
 TESTAGENT_HEADERS = {"X-Datadog-Test-Session-Token": TESTAGENT_TOKEN}
 TESTAGENT_TOKEN_PARAM = "?test_session_token=" + TESTAGENT_TOKEN

--- a/tests/appsec/integrations/stripe_tests/test_stripe.py
+++ b/tests/appsec/integrations/stripe_tests/test_stripe.py
@@ -11,12 +11,13 @@ import vcr
 
 from ddtrace._trace.tracer import Tracer
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.settings import env
 from tests.utils import override_global_config
 
 
 RULES_STRIPE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "rules-stripe.json")
 
-STRIPE_API_KEY = os.environ.get(
+STRIPE_API_KEY = env.get(
     "STRIPE_API_KEY",
     "fake_stripe_key",
 )

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-import os
 import re
 import subprocess
 
@@ -9,6 +8,7 @@ import pytest
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import FINGERPRINTING
 import ddtrace.internal.constants as constants
+from ddtrace.internal.settings import env
 import tests.appsec.rules as rules
 from tests.utils import snapshot
 from tests.webclient import Client
@@ -29,10 +29,10 @@ def daphne_client(django_asgi, additional_env=None):
 
     # Make sure to copy the environment as we need the PYTHONPATH and _DD_TRACE_WRITER_ADDITIONAL_HEADERS (for the test
     # token) propagated to the new process.
-    env = os.environ.copy()
-    env.update(additional_env or {})
+    subenv = env.copy()
+    subenv.update(additional_env or {})
     assert "_DD_TRACE_WRITER_ADDITIONAL_HEADERS" in env, "Client fixture needs test token in headers"
-    env.update(
+    subenv.update(
         {
             "DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings",
         }
@@ -41,7 +41,7 @@ def daphne_client(django_asgi, additional_env=None):
     # ddtrace-run uses execl which replaces the process but the webserver process itself might spawn new processes.
     # Right now it doesn't but it's possible that it might in the future (ex. uwsgi).
     cmd = ["ddtrace-run", "daphne", "-p", str(SERVER_PORT), "tests.contrib.django.asgi:%s" % django_asgi]
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=subenv)
 
     client = Client("http://localhost:%d" % SERVER_PORT)
 

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -10,6 +10,7 @@ import pytest
 
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.contrib.internal.flask.patch import flask_version
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.retry import RetryError
 import tests.appsec.rules as rules
 from tests.webclient import Client
@@ -42,8 +43,8 @@ def flask_command(flask_wsgi_application: str, flask_port: str) -> list[str]:
 
 
 def flask_appsec_good_rules_env(flask_wsgi_application: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
             # Avoid noisy database spans being output on app startup/teardown.
             "DD_TRACE_SQLITE3_ENABLED": "0",

--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -1,11 +1,10 @@
-import os
-
 import grpc
 from grpc._grpcio_metadata import __version__ as _GRPC_VERSION
 from grpc.framework.foundation import logging_pool
 
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.utils import TracerTestCase
 
 from .hello_pb2_grpc import add_HelloServicer_to_server
@@ -13,7 +12,7 @@ from .hello_servicer import _HelloServicer
 
 
 def _get_grpc_port():
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    worker = env.get("PYTEST_XDIST_WORKER", "gw0")
     try:
         worker_num = int(worker[2:])
     except (ValueError, IndexError):


### PR DESCRIPTION
## Description

Migrates 28 test files under `tests/appsec/` and appsec-related contrib tests (owned by `asm-python`) from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.