### PR TITLE
chore(tests): migrate ml-observability tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/contrib/anthropic/conftest.py
+++ b/tests/contrib/anthropic/conftest.py
@@ -1,10 +1,9 @@
-import os
-
 import mock
 import pytest
 
 from ddtrace.contrib.internal.anthropic.patch import patch
 from ddtrace.contrib.internal.anthropic.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs
 from tests.contrib.anthropic.utils import get_request_vcr
 from tests.utils import override_config
@@ -58,7 +57,7 @@ def anthropic(ddtrace_global_config, ddtrace_config_anthropic):
         with override_config("anthropic", ddtrace_config_anthropic):
             with override_env(
                 dict(
-                    ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
+                    ANTHROPIC_API_KEY=env.get("ANTHROPIC_API_KEY", "<not-a-real-key>"),
                 )
             ):
                 patch()

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch as mock_patch
@@ -7,6 +6,7 @@ import pytest
 
 from ddtrace.contrib.internal.claude_agent_sdk.patch import patch
 from ddtrace.contrib.internal.claude_agent_sdk.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_CLIENT_RAW_MESSAGES
@@ -53,7 +53,7 @@ def claude_agent_sdk(ddtrace_config_claude_agent_sdk):
     with override_config("claude_agent_sdk", ddtrace_config_claude_agent_sdk):
         with override_env(
             dict(
-                ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
+                ANTHROPIC_API_KEY=env.get("ANTHROPIC_API_KEY", "<not-a-real-key>"),
             )
         ):
             patch()

--- a/tests/contrib/google_adk/conftest.py
+++ b/tests/contrib/google_adk/conftest.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -15,6 +14,7 @@ import pytest
 
 from ddtrace.contrib.internal.google_adk.patch import patch as adk_patch
 from ddtrace.contrib.internal.google_adk.patch import unpatch as adk_unpatch
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs
 from tests.contrib.google_adk.utils import get_request_vcr
 from tests.llmobs._utils import TestLLMObsSpanWriter
@@ -29,12 +29,12 @@ def ddtrace_global_config():
 @pytest.fixture
 def adk(ddtrace_global_config):
     # Set dummy API key for VCR mode if no real API key is present
-    if not os.environ.get("GOOGLE_API_KEY"):
-        os.environ["GOOGLE_API_KEY"] = "dummy-api-key-for-vcr"
+    if not env.get("GOOGLE_API_KEY"):
+        env["GOOGLE_API_KEY"] = "dummy-api-key-for-vcr"
 
     # Location/project may be required for client init.
-    os.environ.setdefault("GOOGLE_CLOUD_LOCATION", os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"))
-    os.environ.setdefault("GOOGLE_CLOUD_PROJECT", os.environ.get("GOOGLE_CLOUD_PROJECT", "dummy-project"))
+    env.setdefault("GOOGLE_CLOUD_LOCATION", env.get("GOOGLE_CLOUD_LOCATION", "us-central1"))
+    env.setdefault("GOOGLE_CLOUD_PROJECT", env.get("GOOGLE_CLOUD_PROJECT", "dummy-project"))
 
     with override_global_config(ddtrace_global_config):
         adk_patch()

--- a/tests/contrib/google_genai/conftest.py
+++ b/tests/contrib/google_genai/conftest.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 from typing import Iterator
 from unittest.mock import Mock
@@ -8,6 +7,7 @@ import pytest
 
 from ddtrace.contrib.internal.google_genai.patch import patch
 from ddtrace.contrib.internal.google_genai.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs
 from tests.contrib.google_genai.utils import MOCK_EMBED_CONTENT_RESPONSE
 from tests.contrib.google_genai.utils import MOCK_GENERATE_CONTENT_RESPONSE
@@ -35,8 +35,8 @@ def genai_client(request, genai):
     if request.param == "vertex_ai":
         return genai.Client(
             vertexai=True,
-            project=os.environ.get("GOOGLE_CLOUD_PROJECT", "dummy-project"),
-            location=os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
+            project=env.get("GOOGLE_CLOUD_PROJECT", "dummy-project"),
+            location=env.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
         )
     return genai.Client()
 
@@ -75,9 +75,9 @@ def llmobs_events(genai_llmobs, llmobs_span_writer):
 @pytest.fixture
 def genai(ddtrace_global_config):
     # tests require that these environment variables are set (especially for remote CI testing)
-    os.environ["GOOGLE_CLOUD_LOCATION"] = "<not-a-real-location>"
-    os.environ["GOOGLE_CLOUD_PROJECT"] = "<not-a-real-project>"
-    os.environ["GOOGLE_API_KEY"] = "<not-a-real-key>"
+    env["GOOGLE_CLOUD_LOCATION"] = "<not-a-real-location>"
+    env["GOOGLE_CLOUD_PROJECT"] = "<not-a-real-project>"
+    env["GOOGLE_API_KEY"] = "<not-a-real-key>"
 
     with override_global_config(ddtrace_global_config):
         patch()

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -1,10 +1,10 @@
 import importlib
-import os
 
 import pytest
 
 from ddtrace.contrib.internal.langchain.patch import patch as langchain_core_patch
 from ddtrace.contrib.internal.langchain.patch import unpatch as langchain_core_unpatch
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs as llmobs_service
 from tests.llmobs._utils import TestLLMObsSpanWriter
@@ -54,8 +54,8 @@ def llmobs_events(llmobs, llmobs_span_writer):
 def langchain_core():
     with override_env(
         dict(
-            OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
-            ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
+            OPENAI_API_KEY=env.get("OPENAI_API_KEY", "<not-a-real-key>"),
+            ANTHROPIC_API_KEY=env.get("ANTHROPIC_API_KEY", "<not-a-real-key>"),
         )
     ):
         langchain_core_patch()

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -1,13 +1,13 @@
 import importlib
 import json
 from operator import itemgetter
-import os
 import sys
 
 import mock
 import pytest
 
 from ddtrace import patch
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
 from ddtrace.trace import Span
@@ -1028,17 +1028,17 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
     )
 
     openai_env_config = dict(
-        OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "testing"),
+        OPENAI_API_KEY=env.get("OPENAI_API_KEY", "testing"),
         DD_API_KEY="<not-a-real-key>",
     )
 
     azure_openai_env_config = dict(
         OPENAI_API_VERSION="2024-12-01-preview",
-        AZURE_OPENAI_API_KEY=os.getenv("AZURE_OPENAI_API_KEY", "testing"),
+        AZURE_OPENAI_API_KEY=env.get("AZURE_OPENAI_API_KEY", "testing"),
     )
 
     anthropic_env_config = dict(
-        ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "testing"),
+        ANTHROPIC_API_KEY=env.get("ANTHROPIC_API_KEY", "testing"),
         DD_API_KEY="<not-a-real-key>",
     )
 

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -1,5 +1,4 @@
 import operator
-import os
 from typing import Annotated
 from typing import TypedDict
 
@@ -17,6 +16,7 @@ from ddtrace.contrib.internal.langgraph.patch import patch
 from ddtrace.contrib.internal.langgraph.patch import unpatch
 from ddtrace.contrib.internal.openai.patch import patch as patch_openai
 from ddtrace.contrib.internal.openai.patch import unpatch as unpatch_openai
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs as llmobs_service
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
@@ -279,7 +279,7 @@ def agent_from_create_react_agent(langgraph):
         model="gpt-4o-mini",
         temperature=0.5,
         base_url="http://127.0.0.1:9126/vcr/openai",
-        api_key=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
+        api_key=env.get("OPENAI_API_KEY", "<not-a-real-key>"),
     )
 
     agent = create_react_agent(
@@ -305,7 +305,7 @@ def agent_from_create_react_agent_integrations_enabled(langgraph, openai, langch
         model="gpt-4o-mini",
         temperature=0.5,
         base_url="http://127.0.0.1:9126/vcr/openai",
-        api_key=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
+        api_key=env.get("OPENAI_API_KEY", "<not-a-real-key>"),
     )
 
     agent = create_react_agent(

--- a/tests/contrib/langgraph/test_langgraph_patch.py
+++ b/tests/contrib/langgraph/test_langgraph_patch.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from tempfile import NamedTemporaryFile
 
@@ -6,6 +5,7 @@ from ddtrace.contrib.internal.langgraph.patch import LANGGRAPH_VERSION
 from ddtrace.contrib.internal.langgraph.patch import get_version
 from ddtrace.contrib.internal.langgraph.patch import patch
 from ddtrace.contrib.internal.langgraph.patch import unpatch
+from ddtrace.internal.settings import env
 from tests.contrib.patch import PatchTestCase
 from tests.utils import call_program
 
@@ -126,10 +126,10 @@ if not patched and (
             )
             f.flush()
 
-            env = os.environ.copy()
-            env["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
+            subenv = env.copy()
+            subenv["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
 
-            out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=env)
+            out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=subenv)
 
             self.assertEqual(out, b"OK", "stderr:\n%s" % err.decode())
 
@@ -189,9 +189,9 @@ if not supported_versions_called and (
             )
             f.flush()
 
-            env = os.environ.copy()
-            env["DD_TRACE_SAFE_INSTRUMENTATION_ENABLED"] = "1"
-            env["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
+            subenv = env.copy()
+            subenv["DD_TRACE_SAFE_INSTRUMENTATION_ENABLED"] = "1"
+            subenv["DD_TRACE_%s_ENABLED" % self.__integration_name__.upper()] = "1"
 
-            out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=env)
+            out, err, _, _ = call_program("ddtrace-run", sys.executable, f.name, env=subenv)
             assert "OKK" in out.decode(), "stderr:\n%s" % err.decode()

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -2,11 +2,11 @@ import asyncio
 import importlib.metadata
 from importlib.metadata import version
 import json
-import os
 from textwrap import dedent
 
 import mock
 
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
 from tests.utils import override_config
@@ -307,13 +307,13 @@ def test_server_initialization_span_created(mcp_setup, test_spans, llmobs_events
 
 def test_mcp_distributed_tracing_disabled_env(ddtrace_run_python_code_in_subprocess, llmobs_backend):
     """Test that distributed tracing is disabled when DD_MCP_DISTRIBUTED_TRACING=false."""
-    env = os.environ.copy()
-    env["DD_LLMOBS_ML_APP"] = "test-ml-app"
-    env["DD_API_KEY"] = "test-api-key"
-    env["DD_LLMOBS_ENABLED"] = "1"
-    env["DD_LLMOBS_AGENTLESS_ENABLED"] = "0"
-    env["DD_TRACE_AGENT_URL"] = llmobs_backend.url()
-    env["DD_MCP_DISTRIBUTED_TRACING"] = "false"
+    subenv = env.copy()
+    subenv["DD_LLMOBS_ML_APP"] = "test-ml-app"
+    subenv["DD_API_KEY"] = "test-api-key"
+    subenv["DD_LLMOBS_ENABLED"] = "1"
+    subenv["DD_LLMOBS_AGENTLESS_ENABLED"] = "0"
+    subenv["DD_TRACE_AGENT_URL"] = llmobs_backend.url()
+    subenv["DD_MCP_DISTRIBUTED_TRACING"] = "false"
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         dedent(
             """
@@ -343,7 +343,7 @@ def test_mcp_distributed_tracing_disabled_env(ddtrace_run_python_code_in_subproc
         asyncio.run(test())
         """
         ),
-        env=env,
+        env=subenv,
     )
     assert out == b""
     assert status == 0, err

--- a/tests/contrib/mlflow/conftest.py
+++ b/tests/contrib/mlflow/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from ddtrace.constants import _HOSTNAME_KEY
@@ -7,14 +5,15 @@ from ddtrace.contrib.internal.mlflow.constants import MLFLOW_RUN_ID_TAG
 from ddtrace.contrib.internal.mlflow.patch import patch as mlflow_patch
 from ddtrace.contrib.internal.mlflow.patch import unpatch as mlflow_unpatch
 from ddtrace.internal.hostname import get_hostname
+from ddtrace.internal.settings import env
 
 
 @pytest.fixture(autouse=True, scope="session")
 def mlflow_isolated_tracking_uri(tmp_path_factory):
     db_path = tmp_path_factory.mktemp("mlflow") / "mlflow.db"
-    os.environ["MLFLOW_TRACKING_URI"] = f"sqlite:///{db_path}"
+    env["MLFLOW_TRACKING_URI"] = f"sqlite:///{db_path}"
     yield
-    del os.environ["MLFLOW_TRACKING_URI"]
+    del env["MLFLOW_TRACKING_URI"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/contrib/openai/conftest.py
+++ b/tests/contrib/openai/conftest.py
@@ -1,4 +1,3 @@
-import os
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Optional  # noqa:F401
 
@@ -7,6 +6,7 @@ import pytest
 
 from ddtrace.contrib.internal.openai.patch import patch
 from ddtrace.contrib.internal.openai.patch import unpatch
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs
 from ddtrace.trace import TraceFilter
 from tests.utils import override_config
@@ -40,7 +40,7 @@ def request_api_key(api_key_in_env, openai_api_key):
 
 @pytest.fixture
 def openai_api_key():
-    return os.getenv("OPENAI_API_KEY", "<not-a-real-key>")
+    return env.get("OPENAI_API_KEY", "<not-a-real-key>")
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def openai(openai_api_key, openai_organization, api_key_in_env):
     if api_key_in_env:
         openai.api_key = openai_api_key
     # When testing locally to generate new cassette files, comment the line below to use the real OpenAI API key.
-    os.environ["OPENAI_API_KEY"] = "<not-a-real-key>"
+    env["OPENAI_API_KEY"] = "<not-a-real-key>"
     openai.organization = openai_organization
     yield openai
 

--- a/tests/contrib/openai/test_openai_v1.py
+++ b/tests/contrib/openai/test_openai_v1.py
@@ -4,6 +4,7 @@ import mock
 import openai as openai_module
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.openai.utils import chat_completion_custom_functions
 from tests.contrib.openai.utils import chat_completion_input_description
@@ -849,11 +850,11 @@ def test_integration_sync(openai_api_key, ddtrace_run_python_code_in_subprocess)
     FIXME: there _should_ be httpx spans generated for this test case. There aren't
            because the patching VCR does into httpx interferes with the tracing patching.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"OPENAI_API_KEY": openai_api_key, "DD_TRACE_HTTPX_ENABLED": "0", "PYTHONPATH": ":".join(pypath)})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"OPENAI_API_KEY": openai_api_key, "DD_TRACE_HTTPX_ENABLED": "0", "PYTHONPATH": ":".join(pypath)})
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import openai
@@ -868,7 +869,7 @@ with get_openai_vcr(subdirectory_name="v1").use_cassette("completion.yaml"):
         model="ada", prompt="Hello world", temperature=0.8, n=2, stop=".", max_tokens=10, user="ddtrace-test"
     )
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == b""
@@ -889,11 +890,11 @@ def test_integration_async(openai_api_key, ddtrace_run_python_code_in_subprocess
     FIXME: there _should_ be httpx spans generated for this test case. There aren't
            because the patching VCR does into httpx interferes with the tracing patching.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"OPENAI_API_KEY": openai_api_key, "DD_TRACE_HTTPX_ENABLED": "0", "PYTHONPATH": ":".join(pypath)})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"OPENAI_API_KEY": openai_api_key, "DD_TRACE_HTTPX_ENABLED": "0", "PYTHONPATH": ":".join(pypath)})
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(
         """
 import asyncio
@@ -912,7 +913,7 @@ async def task():
 
 asyncio.run(task())
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == b""
@@ -1073,15 +1074,15 @@ async def test_azure_openai_aembedding(openai, azure_openai_config, openai_vcr, 
 @pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
 @pytest.mark.parametrize("service_name", [None, "mysvc"])
 def test_integration_service_name(openai_api_key, ddtrace_run_python_code_in_subprocess, schema_version, service_name):
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"OPENAI_API_KEY": openai_api_key, "DD_TRACE_HTTPX_ENABLED": "0", "PYTHONPATH": ":".join(pypath)})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"OPENAI_API_KEY": openai_api_key, "DD_TRACE_HTTPX_ENABLED": "0", "PYTHONPATH": ":".join(pypath)})
     if schema_version:
-        env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
+        subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     if service_name:
-        env["DD_SERVICE"] = service_name
+        subenv["DD_SERVICE"] = service_name
     with snapshot_context(
         token="tests.contrib.openai.test_openai_v1.test_integration_service_name[%s-%s]"
         % (service_name, schema_version),
@@ -1100,7 +1101,7 @@ with get_openai_vcr(subdirectory_name="v1").use_cassette("completion.yaml"):
     client = openai.OpenAI()
     resp = client.completions.create(model="ada", prompt="hello world")
     """,
-            env=env,
+            env=subenv,
         )
         assert status == 0, err
         assert out == b""

--- a/tests/contrib/ray/test_ray.py
+++ b/tests/contrib/ray/test_ray.py
@@ -7,6 +7,7 @@ import pytest
 import ray
 from ray.util.tracing import tracing_helper
 
+from ddtrace.internal.settings import env
 from tests.utils import TracerTestCase
 from tests.utils import override_config
 
@@ -332,13 +333,13 @@ class TestRayIntegration(TracerTestCase):
 
 def _start_ray_cluster(env_vars=None, ddtrace_run=False):
     """Start a Ray cluster with optional environment variables."""
-    env = os.environ.copy()
+    subenv = env.copy()
     base_env = {
         "DD_PATCH_MODULES": "ray:true,aiohttp:false,grpc:false,requests:false",
     }
     if env_vars:
         base_env.update(env_vars)
-    env.update(base_env)
+    subenv.update(base_env)
 
     cmd = []
     if ddtrace_run:
@@ -361,7 +362,7 @@ def _start_ray_cluster(env_vars=None, ddtrace_run=False):
 
     subprocess.run(
         cmd,
-        env=env,
+        env=subenv,
         check=True,
     )
     # Wait for dashboard to be ready

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -9,6 +9,7 @@ import time
 import mock
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs as llmobs_service
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.llmobs._utils import logs_vcr
@@ -98,7 +99,7 @@ def ddtrace_global_config():
 
 def default_global_config():
     return {
-        "_dd_api_key": os.environ.get("DD_API_KEY", "<not-a-real-api_key>"),
+        "_dd_api_key": env.get("DD_API_KEY", "<not-a-real-api_key>"),
         "_llmobs_ml_app": "unnamed-ml-app",
         "service": "tests.llmobs",
     }
@@ -122,7 +123,7 @@ def ragas(mock_llmobs_eval_metric_writer):
             import ragas
         except ImportError:
             pytest.skip("Ragas not installed")
-        with override_env(dict(OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"))):
+        with override_env(dict(OPENAI_API_KEY=env.get("OPENAI_API_KEY", "<not-a-real-key>"))):
             yield ragas
 
 
@@ -160,9 +161,9 @@ def mock_ragas_answer_relevancy_calculate_similarity():
 @pytest.fixture
 def llmobs_env():
     return {
-        "DD_API_KEY": os.environ.get("DD_API_KEY", "<default-not-a-real-key>"),
+        "DD_API_KEY": env.get("DD_API_KEY", "<default-not-a-real-key>"),
         "DD_LLMOBS_ML_APP": "unnamed-ml-app",
-        "DD_LLMOBS_PROJECT_NAME": os.environ.get("DD_LLMOBS_PROJECT_NAME", "test-project-clean"),
+        "DD_LLMOBS_PROJECT_NAME": env.get("DD_LLMOBS_PROJECT_NAME", "test-project-clean"),
     }
 
 
@@ -234,7 +235,7 @@ def llmobs_backend(_llmobs_backend):
 
 @pytest.fixture
 def llmobs_enable_opts():
-    yield {"project_name": os.environ.get("DD_LLMOBS_PROJECT_NAME", "test-project-clean")}
+    yield {"project_name": env.get("DD_LLMOBS_PROJECT_NAME", "test-project-clean")}
 
 
 @pytest.fixture
@@ -254,8 +255,8 @@ def llmobs(
     mock_llmobs_eval_metric_writer,
     mock_llmobs_evaluator_runner,
 ):
-    for env, val in llmobs_env.items():
-        monkeypatch.setenv(env, val)
+    for env_key, val in llmobs_env.items():
+        monkeypatch.setenv(env_key, val)
     global_config = default_global_config()
     global_config.update(dict(_llmobs_ml_app=llmobs_env.get("DD_LLMOBS_ML_APP")))
     global_config.update(ddtrace_global_config)

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -35,6 +35,7 @@ import mock
 import pytest
 
 import ddtrace
+from ddtrace.internal.settings import env
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 from ddtrace.llmobs._experiment import DatasetRecordNew
@@ -46,11 +47,11 @@ from tests.utils import override_global_config
 
 
 TMP_CSV_FILE = "tmp.csv"
-TEST_PROJECT_NAME = os.environ.get("DD_LLMOBS_PROJECT_NAME", "test-project-clean")
+TEST_PROJECT_NAME = env.get("DD_LLMOBS_PROJECT_NAME", "test-project-clean")
 
 
 def wait_for_backend(sleep_dur=2):
-    if os.environ.get("RECORD_REQUESTS", "0") != "0":
+    if env.get("RECORD_REQUESTS", "0") != "0":
         time.sleep(sleep_dur)
 
 
@@ -1489,11 +1490,11 @@ def test_experiment_invalid_evaluator_signature_raises(llmobs, test_dataset_one_
 
 
 def test_project_name_set(run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"PYTHONPATH": ":".join(pypath), "DD_TRACE_ENABLED": "0"})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"PYTHONPATH": ":".join(pypath), "DD_TRACE_ENABLED": "0"})
     out, err, status, pid = run_python_code_in_subprocess(
         """
 from ddtrace.llmobs import LLMObs
@@ -1501,17 +1502,17 @@ from ddtrace.llmobs import LLMObs
 LLMObs.enable(ml_app="ml-app", project_name="test-project-123")
 assert LLMObs._project_name == "test-project-123"
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
 
 
 def test_project_name_set_env(ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update(
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update(
         {
             "PYTHONPATH": ":".join(pypath),
             "DD_TRACE_ENABLED": "0",
@@ -1525,17 +1526,17 @@ from ddtrace.llmobs import LLMObs
 
 assert LLMObs._project_name == "test-project-123"
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
 
 
 def test_project_name_not_set_env(ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update(
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update(
         {
             "PYTHONPATH": ":".join(pypath),
             "DD_TRACE_ENABLED": "0",
@@ -1549,7 +1550,7 @@ from ddtrace.llmobs._constants import DEFAULT_PROJECT_NAME
 
 assert LLMObs._project_name == DEFAULT_PROJECT_NAME
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
 

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -1,11 +1,11 @@
 import asyncio
-import os
 from textwrap import dedent
 from typing import Optional
 
 import pytest
 
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs import LLMObsSpan
 from ddtrace.llmobs import _constants as const
@@ -186,13 +186,13 @@ class TestLLMIOProcessing:
 
     def test_ddtrace_run_register_processor(self, ddtrace_run_python_code_in_subprocess, llmobs_backend):
         """Users using ddtrace-run can register a processor to be called on each LLMObs span."""
-        env = os.environ.copy()
-        env["DD_LLMOBS_ML_APP"] = "test-ml-app"
-        env["DD_API_KEY"] = "test-api-key"
-        env["DD_LLMOBS_ENABLED"] = "1"
-        env["DD_LLMOBS_AGENTLESS_ENABLED"] = "0"
-        env["DD_TRACE_ENABLED"] = "0"
-        env["DD_TRACE_AGENT_URL"] = llmobs_backend.url()
+        subenv = env.copy()
+        subenv["DD_LLMOBS_ML_APP"] = "test-ml-app"
+        subenv["DD_API_KEY"] = "test-api-key"
+        subenv["DD_LLMOBS_ENABLED"] = "1"
+        subenv["DD_LLMOBS_AGENTLESS_ENABLED"] = "0"
+        subenv["DD_TRACE_ENABLED"] = "0"
+        subenv["DD_TRACE_AGENT_URL"] = llmobs_backend.url()
         out, err, status, _ = ddtrace_run_python_code_in_subprocess(
             dedent(
                 """
@@ -212,7 +212,7 @@ class TestLLMIOProcessing:
                 LLMObs.annotate(llm_span, input_data="value", output_data="value", tags={"scrub_values": "0"})
             """
             ),
-            env=env,
+            env=subenv,
         )
         assert out == b""
         assert status == 0, err
@@ -246,13 +246,13 @@ class TestLLMIOProcessing:
 
     def test_processor_error_is_logged(self, ddtrace_run_python_code_in_subprocess, llmobs_backend):
         """Ensure that when an exception is raised an exception is logged."""
-        env = os.environ.copy()
-        env["DD_LLMOBS_ML_APP"] = "test-ml-app"
-        env["DD_API_KEY"] = "test-api-key"
-        env["DD_LLMOBS_AGENTLESS_ENABLED"] = "0"
-        env["DD_TRACE_ENABLED"] = "0"
-        env["DD_TRACE_AGENT_URL"] = llmobs_backend.url()
-        env["DD_TRACE_LOGGING_RATE"] = "0"
+        subenv = env.copy()
+        subenv["DD_LLMOBS_ML_APP"] = "test-ml-app"
+        subenv["DD_API_KEY"] = "test-api-key"
+        subenv["DD_LLMOBS_AGENTLESS_ENABLED"] = "0"
+        subenv["DD_TRACE_ENABLED"] = "0"
+        subenv["DD_TRACE_AGENT_URL"] = llmobs_backend.url()
+        subenv["DD_TRACE_LOGGING_RATE"] = "0"
         out, err, status, _ = ddtrace_run_python_code_in_subprocess(
             dedent(
                 """
@@ -273,7 +273,7 @@ class TestLLMIOProcessing:
                 LLMObs.annotate(llm_span, input_data="value", output_data="value", tags={"scrub_values": "1"})
             """
             ),
-            env=env,
+            env=subenv,
         )
         assert status == 0, err
         assert b"something bad happened" in err

--- a/tests/llmobs/test_llmobs_eval_metric_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_eval_metric_agentless_writer.py
@@ -7,6 +7,7 @@ import time
 import mock
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.llmobs._writer import LLMObsEvalMetricWriter
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
 from tests.utils import override_global_config
@@ -14,7 +15,7 @@ from tests.utils import override_global_config
 
 DD_SITE = "datad0g.com"
 INTAKE_ENDPOINT = "https://api.datad0g.com/api/intake/llm-obs/v2/eval-metric"
-DD_API_KEY = os.getenv("DD_API_KEY", default="<not-a-real-api-key>")
+DD_API_KEY = env.get("DD_API_KEY", default="<not-a-real-api-key>")
 
 
 def _categorical_metric_event(label: str, value: str) -> LLMObsEvaluationMetricEvent:
@@ -208,11 +209,11 @@ def test_send_on_exit(run_python_code_in_subprocess):
 
     mock_url = f"http://localhost:{server.server_address[1]}"
 
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"PYTHONPATH": ":".join(pypath), "DD_LLMOBS_OVERRIDE_ORIGIN": mock_url})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"PYTHONPATH": ":".join(pypath), "DD_LLMOBS_OVERRIDE_ORIGIN": mock_url})
 
     out, err, status, pid = run_python_code_in_subprocess(
         """
@@ -225,7 +226,7 @@ llmobs_eval_metric_writer = LLMObsEvalMetricWriter(
 llmobs_eval_metric_writer.start()
 llmobs_eval_metric_writer.enqueue(_categorical_metric_event(label="toxicity", value="very"))
 """,
-        env=env,
+        env=subenv,
     )
 
     server.shutdown()

--- a/tests/llmobs/test_llmobs_evaluator_runner.py
+++ b/tests/llmobs/test_llmobs_evaluator_runner.py
@@ -5,6 +5,7 @@ import time
 import mock
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.llmobs._evaluators.runner import EvaluatorRunner
 from ddtrace.llmobs._evaluators.sampler import EvaluatorRunnerSampler
 from ddtrace.llmobs._evaluators.sampler import EvaluatorRunnerSamplingRule
@@ -94,11 +95,11 @@ def test_evaluator_runner_multiple_evaluators(llmobs, mock_llmobs_eval_metric_wr
 
 @pytest.mark.skip(reason="Skipping due to flakiness in hitting the staging endpoint")
 def test_evaluator_runner_on_exit(mock_writer_logs, run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update(
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update(
         {"PYTHONPATH": ":".join(pypath), "_DD_LLMOBS_EVALUATOR_INTERVAL": "0.01", "_DD_LLMOBS_WRITER_INTERVAL": "0.01"}
     )
     out, err, status, pid = run_python_code_in_subprocess(
@@ -117,7 +118,7 @@ LLMObs._instance._evaluator_runner.evaluators.append(DummyEvaluator(llmobs_servi
 LLMObs._instance._evaluator_runner.start()
 LLMObs._instance._evaluator_runner.enqueue({"span_id": "123", "trace_id": "1234"}, None)
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
     assert out == b""

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -8,6 +8,7 @@ import pytest
 
 import ddtrace
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs import LLMObs as llmobs_service
 from ddtrace.llmobs._constants import ML_APP
@@ -45,7 +46,7 @@ from tests.utils import override_env
 from tests.utils import override_global_config
 
 
-RAGAS_AVAILABLE = os.getenv("RAGAS_AVAILABLE", False)
+RAGAS_AVAILABLE = env.get("RAGAS_AVAILABLE", False)
 
 
 def run_llmobs_trace_filter(tracer, test_spans):
@@ -1137,11 +1138,11 @@ def test_listener_hooks_enqueue_correct_writer(run_python_code_in_subprocess):
     Regression test that ensures that listener hooks enqueue span events to the correct writer,
     not the default writer created at startup.
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"PYTHONPATH": ":".join(pypath), "DD_TRACE_ENABLED": "0"})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"PYTHONPATH": ":".join(pypath), "DD_TRACE_ENABLED": "0"})
     out, err, status, pid = run_python_code_in_subprocess(
         """
 import mock
@@ -1152,7 +1153,7 @@ from ddtrace.llmobs import LLMObs
 LLMObs.enable(ml_app="repro-issue", agentless_enabled=True, api_key="foobar.baz", site="datad0g.com")
 assert LLMObs._instance._llmobs_span_writer._url == "https://llmobs-intake.datad0g.com/api/v2/llmobs"
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, err
 
@@ -1296,9 +1297,9 @@ def test_llmobs_fork_evaluator_runner_run():
     except ImportError:
         sys.exit(0)
 
-    os.environ["DD_LLMOBS_EVALUATOR_INTERVAL"] = "5.0"
-    os.environ["DD_LLMOBS_EVALUATORS"] = "ragas_faithfulness"
-    os.environ.setdefault("OPENAI_API_KEY", "<not-a-real-key>")
+    env["DD_LLMOBS_EVALUATOR_INTERVAL"] = "5.0"
+    env["DD_LLMOBS_EVALUATORS"] = "ragas_faithfulness"
+    env.setdefault("OPENAI_API_KEY", "<not-a-real-key>")
     with mock.patch("ddtrace.llmobs._evaluators.runner.EvaluatorRunner.periodic"):
         llmobs_service.enable(_tracer=ddtrace.tracer, ml_app="test_app", api_key="test_api_key")
         pid = os.fork()
@@ -1358,7 +1359,7 @@ def test_llmobs_fork_disabled_then_enabled():
     assert svc._llmobs_eval_metric_writer.status == ServiceStatus.STOPPED
     if not pid:
         # Enable the service in the child
-        os.environ["DD_LLMOBS_ENABLED"] = "1"
+        env["DD_LLMOBS_ENABLED"] = "1"
         with override_global_config(dict(_dd_api_key="<not-a-real-api-key>", _llmobs_ml_app="<ml-app-name>")):
             llmobs_service.enable(_tracer=ddtrace.tracer)
         svc = llmobs_service._instance

--- a/tests/llmobs/test_llmobs_span_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_span_agentless_writer.py
@@ -7,6 +7,7 @@ import time
 import mock
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.llmobs._constants import AGENTLESS_SPAN_BASE_URL
 from ddtrace.llmobs._constants import SPAN_ENDPOINT
 from ddtrace.llmobs._writer import LLMObsSpanWriter
@@ -20,7 +21,7 @@ from tests.utils import override_global_config
 
 
 DD_SITE = "datad0g.com"
-DD_API_KEY = os.getenv("DD_API_KEY", default="<not-a-real-api-key>")
+DD_API_KEY = env.get("DD_API_KEY", default="<not-a-real-api-key>")
 INTAKE_URL = f"{AGENTLESS_SPAN_BASE_URL}.{DD_SITE}{SPAN_ENDPOINT}"
 
 
@@ -194,11 +195,11 @@ def test_send_on_exit(run_python_code_in_subprocess):
 
     mock_url = f"http://localhost:{server.server_address[1]}"
 
-    env = os.environ.copy()
+    subenv = env.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]
     if "PYTHONPATH" in env:
-        pypath.append(env["PYTHONPATH"])
-    env.update({"PYTHONPATH": ":".join(pypath), "DD_LLMOBS_OVERRIDE_ORIGIN": mock_url})
+        pypath.append(subenv["PYTHONPATH"])
+    subenv.update({"PYTHONPATH": ":".join(pypath), "DD_LLMOBS_OVERRIDE_ORIGIN": mock_url})
 
     out, err, status, pid = run_python_code_in_subprocess(
         """
@@ -209,7 +210,7 @@ llmobs_span_writer = LLMObsSpanWriter(1000, 1, is_agentless=True, _api_key="<not
 llmobs_span_writer.start()
 llmobs_span_writer.enqueue(_completion_event())
 """,
-        env=env,
+        env=subenv,
     )
 
     server.shutdown()

--- a/tests/llmobs/test_logger.py
+++ b/tests/llmobs/test_logger.py
@@ -1,9 +1,9 @@
-import os
 import time
 
 import mock
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.llmobs._log_writer import V2LogWriter
 
 
@@ -35,7 +35,7 @@ def test_buffer_limit(mock_logs):
 
 @pytest.mark.vcr_logs
 def test_send_log(mock_logs):
-    logger = V2LogWriter(site="datadoghq.com", api_key=os.getenv("DD_API_KEY"), interval=1, timeout=1)
+    logger = V2LogWriter(site="datadoghq.com", api_key=env.get("DD_API_KEY"), interval=1, timeout=1)
     logger.start()
     mock_logs.debug.assert_has_calls(
         [mock.call("started log writer to %r", "https://http-intake.logs.datadoghq.com/api/v2/logs")]
@@ -66,7 +66,7 @@ def test_send_log_bad_api_key(mock_logs):
 
 @pytest.mark.vcr_logs
 def test_send_timed(mock_logs):
-    logger = V2LogWriter(site="datadoghq.com", api_key=os.getenv("DD_API_KEY"), interval=0.01, timeout=1)
+    logger = V2LogWriter(site="datadoghq.com", api_key=env.get("DD_API_KEY"), interval=0.01, timeout=1)
     logger.start()
 
     logger.enqueue(_test_log())
@@ -91,7 +91,6 @@ def test_send_timed(mock_logs):
 @pytest.mark.subprocess()
 def test_send_on_exit():
     import atexit
-    import os
     import time
 
     from ddtrace.llmobs._log_writer import V2LogWriter
@@ -103,7 +102,7 @@ def test_send_on_exit():
     # registered before logger.start() is called so that the request
     # can be captured. Handlers run in stack order.
     atexit.register(lambda: ctx.__exit__())
-    logger = V2LogWriter(site="datadoghq.com", api_key=os.getenv("DD_API_KEY"), interval=1, timeout=1)
+    logger = V2LogWriter(site="datadoghq.com", api_key=env.get("DD_API_KEY"), interval=1, timeout=1)
     logger.start()
     logger.enqueue(
         {

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -1,11 +1,11 @@
 import json
-import os
 from typing import Optional
 from typing import Union
 from unittest.mock import patch
 
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._prompts.manager import PromptManager
 from ddtrace.llmobs._prompts.prompt import ManagedPrompt
@@ -156,7 +156,7 @@ class TestPrompts:
             call_count += 1
             return MockHTTPConnection(MockHTTPResponse(200, TEXT_PROMPT_RESPONSE))
 
-        with patch.dict(os.environ, {"DD_LLMOBS_PROMPTS_CACHE_TTL": "0"}):
+        with patch.dict(env, {"DD_LLMOBS_PROMPTS_CACHE_TTL": "0"}):
             with patch("ddtrace.llmobs._prompts.manager.get_connection", counting_conn):
                 prompt1 = LLMObs.get_prompt("greeting")
                 prompt2 = LLMObs.get_prompt("greeting")

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import pytest
 
@@ -7,6 +6,7 @@ from ddtrace.contrib.internal.asyncio.patch import patch as patch_asyncio
 from ddtrace.contrib.internal.asyncio.patch import unpatch as unpatch_asyncio
 from ddtrace.contrib.internal.futures.patch import patch as patch_futures
 from ddtrace.contrib.internal.futures.patch import unpatch as unpatch_futures
+from ddtrace.internal.settings import env
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
@@ -91,9 +91,9 @@ with LLMObs.workflow("LLMObs span") as root_span:
 
 print(json.dumps(headers))
         """
-    env = os.environ.copy()
-    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -123,9 +123,9 @@ with LLMObs.workflow("LLMObs span") as root_span:
 
 print(json.dumps(headers))
         """
-    env = os.environ.copy()
-    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -157,9 +157,9 @@ with tracer.trace("Non-LLMObs span") as span:
 
 print(json.dumps(headers))
         """
-    env = os.environ.copy()
-    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -222,9 +222,9 @@ with LLMObs.workflow("LLMObs span") as root_span:
 
 print(json.dumps(headers))
         """
-    env = os.environ.copy()
-    env.update({"DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -257,9 +257,9 @@ with LLMObs.workflow("LLMObs span") as root_span:
 
 print(json.dumps(headers))
         """
-    env = os.environ.copy()
-    env.update({"DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -292,9 +292,9 @@ with LLMObs.workflow(name="LLMObs span", ml_app="local-ml-app") as root_span:
 print(json.dumps(headers))
 """
 
-    env = os.environ.copy()
-    env.update({"DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -325,9 +325,9 @@ with tracer.trace("Non-LLMObs span") as root_span:
 print(json.dumps(headers))
 """
 
-    env = os.environ.copy()
-    env.update({"DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
@@ -357,9 +357,9 @@ with tracer.trace("Non-LLMObs span") as root_span:
 
 print(json.dumps(headers))
         """
-    env = os.environ.copy()
-    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    subenv = env.copy()
+    subenv.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())

--- a/tests/llmobs/test_pydantic_evaluators.py
+++ b/tests/llmobs/test_pydantic_evaluators.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from dataclasses import dataclass
-import os
 
 import pytest
 
@@ -18,6 +17,7 @@ from pydantic_evals.reporting import ReportAnalysis  # noqa: E402
 from pydantic_evals.reporting import ScalarResult  # noqa: E402
 from pydantic_evals.reporting import TableResult  # noqa: E402
 
+from ddtrace.internal.settings import env  # noqa: E402
 from ddtrace.llmobs._experiment import Dataset  # noqa: E402
 from ddtrace.llmobs._experiment import _ExperimentRunInfo  # noqa: E402
 from ddtrace.llmobs._experiment import _is_pydantic_evaluator  # noqa: E402
@@ -450,7 +450,7 @@ class TestPydanticLLMJudge:
         assert result["reasoning"] == "mocked judge pass"
 
     @pytest.mark.skipif(
-        not os.environ.get("OPENAI_API_KEY"),
+        not env.get("OPENAI_API_KEY"),
         reason="OPENAI_API_KEY required for real LLMJudge with OpenAI",
     )
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Migrates 24 test files under `tests/llmobs/` and AI/LLM contrib tests (owned by `ml-observability`) from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.