### PR TITLE
chore(tests): migrate CI visibility tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/ddtrace/testing/internal/env_tags.py
+++ b/ddtrace/testing/internal/env_tags.py
@@ -32,9 +32,9 @@ def get_env_tags() -> dict[str, str]:
     merge_tags(
         tags,
         git.get_git_tags_from_git_command(),
-        ci.get_ci_tags(os.environ),
-        git.get_git_tags_from_dd_variables(os.environ),
-        get_custom_dd_tags(os.environ),
+        ci.get_ci_tags(env),
+        git.get_git_tags_from_dd_variables(env),
+        get_custom_dd_tags(env),
     )
 
     if head_sha := tags.get(GitTag.COMMIT_HEAD_SHA):

--- a/tests/ci_visibility/api/fake_runner_all_itr_skip_suite_level.py
+++ b/tests/ci_visibility/api/fake_runner_all_itr_skip_suite_level.py
@@ -7,6 +7,7 @@ from unittest import mock
 import ddtrace
 from ddtrace.ext.test_visibility import ITR_SKIPPING_LEVEL
 from ddtrace.ext.test_visibility import api as ext_api
+from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility import api
 
 
@@ -97,8 +98,7 @@ def main():
 if __name__ == "__main__":
     freeze_support()
     # NOTE: this is only safe because these tests are run in a subprocess
-    import os
 
-    os.environ["_DD_CIVISIBILITY_ITR_SUITE_MODE"] = "1"
+    env["_DD_CIVISIBILITY_ITR_SUITE_MODE"] = "1"
     with mock.patch("ddtrace.internal.ci_visibility.CIVisibility.is_itr_enabled", return_value=True):
         main()

--- a/tests/ci_visibility/api/fake_runner_all_itr_skip_test_level.py
+++ b/tests/ci_visibility/api/fake_runner_all_itr_skip_test_level.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest import mock
 
 from ddtrace.ext.test_visibility import api as ext_api
+from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility import api
 
 
@@ -93,8 +94,7 @@ def main():
 
 if __name__ == "__main__":
     freeze_support()
-    import os
 
-    os.environ["_DD_CIVISIBILITY_ITR_SUITE_MODE"] = "0"
+    env["_DD_CIVISIBILITY_ITR_SUITE_MODE"] = "0"
     with mock.patch("ddtrace.internal.ci_visibility.CIVisibility.is_itr_enabled", return_value=True):
         main()

--- a/tests/ci_visibility/api/fake_runner_mix_fail_itr_test_level.py
+++ b/tests/ci_visibility/api/fake_runner_mix_fail_itr_test_level.py
@@ -23,6 +23,7 @@ import sys
 from unittest import mock
 
 from ddtrace.ext.test_visibility import api as ext_api
+from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility import api
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
 
@@ -393,8 +394,7 @@ def main():
 
 if __name__ == "__main__":
     freeze_support()
-    import os
 
-    os.environ["_DD_CIVISIBILITY_ITR_SUITE_MODE"] = "0"
+    env["_DD_CIVISIBILITY_ITR_SUITE_MODE"] = "0"
     with mock.patch("ddtrace.internal.ci_visibility.CIVisibility.is_itr_enabled", return_value=True):
         main()

--- a/tests/ci_visibility/test_encoder.py
+++ b/tests/ci_visibility/test_encoder.py
@@ -14,6 +14,7 @@ from ddtrace.internal.ci_visibility.constants import SUITE_ID
 from ddtrace.internal.ci_visibility.encoder import CIVisibilityCoverageEncoderV02
 from ddtrace.internal.ci_visibility.encoder import CIVisibilityEncoderV01
 from ddtrace.internal.encoding import JSONEncoder
+from ddtrace.internal.settings import env
 from ddtrace.trace import Span
 from tests.contrib.pytest.test_pytest import PytestTestCaseBase
 
@@ -21,25 +22,25 @@ from tests.contrib.pytest.test_pytest import PytestTestCaseBase
 @pytest.fixture
 def mock_xdist_worker_env():
     """Fixture to mock being in an xdist worker environment"""
-    original_env = os.environ.get("PYTEST_XDIST_WORKER")
-    os.environ["PYTEST_XDIST_WORKER"] = "gw0"
+    original_env = env.get("PYTEST_XDIST_WORKER")
+    env["PYTEST_XDIST_WORKER"] = "gw0"
     yield
     # Restore original environment
     if original_env is None:
-        os.environ.pop("PYTEST_XDIST_WORKER", None)
+        env.pop("PYTEST_XDIST_WORKER", None)
     else:
-        os.environ["PYTEST_XDIST_WORKER"] = original_env
+        env["PYTEST_XDIST_WORKER"] = original_env
 
 
 @pytest.fixture
 def mock_no_xdist_worker_env():
     """Fixture to ensure we're not in xdist worker environment"""
-    original_env = os.environ.get("PYTEST_XDIST_WORKER")
-    os.environ.pop("PYTEST_XDIST_WORKER", None)
+    original_env = env.get("PYTEST_XDIST_WORKER")
+    env.pop("PYTEST_XDIST_WORKER", None)
     yield
     # Restore original environment
     if original_env is not None:
-        os.environ["PYTEST_XDIST_WORKER"] = original_env
+        env["PYTEST_XDIST_WORKER"] = original_env
 
 
 def test_encode_traces_civisibility_v0():
@@ -234,8 +235,8 @@ def test_build_payload_with_filtered_spans():
     ]
 
     # Set up xdist worker environment to trigger filtering
-    original_env = os.environ.get("PYTEST_XDIST_WORKER")
-    os.environ["PYTEST_XDIST_WORKER"] = "gw0"
+    original_env = env.get("PYTEST_XDIST_WORKER")
+    env["PYTEST_XDIST_WORKER"] = "gw0"
 
     try:
         # Add session type tag to trigger filtering
@@ -257,9 +258,9 @@ def test_build_payload_with_filtered_spans():
 
     finally:
         if original_env is None:
-            os.environ.pop("PYTEST_XDIST_WORKER", None)
+            env.pop("PYTEST_XDIST_WORKER", None)
         else:
-            os.environ["PYTEST_XDIST_WORKER"] = original_env
+            env["PYTEST_XDIST_WORKER"] = original_env
 
 
 def test_build_payload_all_spans_filtered():
@@ -270,8 +271,8 @@ def test_build_payload_all_spans_filtered():
     ]
 
     # Set up xdist worker environment to trigger filtering
-    original_env = os.environ.get("PYTEST_XDIST_WORKER")
-    os.environ["PYTEST_XDIST_WORKER"] = "gw0"
+    original_env = env.get("PYTEST_XDIST_WORKER")
+    env["PYTEST_XDIST_WORKER"] = "gw0"
 
     try:
         # Make both spans session types to trigger filtering
@@ -286,9 +287,9 @@ def test_build_payload_all_spans_filtered():
 
     finally:
         if original_env is None:
-            os.environ.pop("PYTEST_XDIST_WORKER", None)
+            env.pop("PYTEST_XDIST_WORKER", None)
         else:
-            os.environ["PYTEST_XDIST_WORKER"] = original_env
+            env["PYTEST_XDIST_WORKER"] = original_env
 
 
 def test_build_payload_no_infinite_recursion():

--- a/tests/ci_visibility/util.py
+++ b/tests/ci_visibility/util.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-import os
 import typing as t
 from unittest import mock
 
@@ -14,6 +13,7 @@ from ddtrace.internal.ci_visibility.git_client import METADATA_UPLOAD_STATUS
 from ddtrace.internal.ci_visibility.git_client import CIVisibilityGitClient
 from ddtrace.internal.ci_visibility.recorder import CIVisibility
 from ddtrace.internal.ci_visibility.recorder import CIVisibilityTracer
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._config import Config
 from tests.utils import DummyCIVisibilityWriter
 from tests.utils import override_env
@@ -187,7 +187,7 @@ def _get_default_os_env_vars():
         "HOME",
     }
 
-    return {key: os.environ[key] for key in os_env_keys if key in os.environ}
+    return {key: env[key] for key in os_env_keys if key in env}
 
 
 def _get_default_ci_env_vars(

--- a/tests/coverage/test_coverage.py
+++ b/tests/coverage/test_coverage.py
@@ -9,6 +9,8 @@ time rather than at code execution time.
 
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
 def test_coverage_import_time_lib():
@@ -52,7 +54,7 @@ def test_coverage_import_time_lib():
         "tests/coverage/included_path/nested_import_time_lib.py": {1, 4},
     }
 
-    if os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true":
+    if env.get("_DD_COVERAGE_FILE_LEVEL") == "true":
         # In file-level mode, we only track files, not specific line numbers
         assert executable.keys() == expected_executable.keys(), (
             f"Executable files mismatch: expected={expected_executable.keys()} vs actual={executable.keys()}"
@@ -117,7 +119,7 @@ def test_coverage_import_time_function():
         "tests/coverage/included_path/imported_in_function_lib.py": {1, 2, 3, 4, 7},
     }
 
-    if os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true":
+    if env.get("_DD_COVERAGE_FILE_LEVEL") == "true":
         # In file-level mode, we only track files, not specific line numbers
         assert lines.keys() == expected_lines.keys(), (
             f"Executable files mismatch: expected={expected_lines.keys()} vs actual={lines.keys()}"

--- a/tests/coverage/test_coverage_context_reinstrumentation.py
+++ b/tests/coverage/test_coverage_context_reinstrumentation.py
@@ -18,6 +18,8 @@ import sys
 
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
 @pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
@@ -38,7 +40,7 @@ def test_sequential_contexts_with_no_overlap():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 
@@ -122,7 +124,7 @@ def test_context_with_repeated_execution_reinstruments_correctly():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 
@@ -173,7 +175,7 @@ def test_nested_contexts_maintain_independence():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 
@@ -227,7 +229,7 @@ def test_many_sequential_contexts_no_degradation():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 
@@ -294,7 +296,7 @@ def test_context_after_session_coverage():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 
@@ -390,7 +392,7 @@ def test_comprehensive_reinstrumentation_with_simple_module():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 

--- a/tests/coverage/test_coverage_multiprocessing.py
+++ b/tests/coverage/test_coverage_multiprocessing.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(parametrize={"start_method": ["fork", "forkserver", "spawn"]})
 def test_coverage_multiprocessing_without_coverage():
@@ -7,10 +9,9 @@ def test_coverage_multiprocessing_without_coverage():
     import multiprocessing
 
     if __name__ == "__main__":
-        import os
         from pathlib import Path
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         from ddtrace.internal.coverage.installer import install
 
@@ -35,10 +36,9 @@ def test_coverage_multiprocessing_coverage_started():
     import multiprocessing
 
     if __name__ == "__main__":
-        import os
         from pathlib import Path
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         from ddtrace.internal.coverage.code import ModuleCodeCollector
         from ddtrace.internal.coverage.installer import install
@@ -65,10 +65,9 @@ def test_coverage_multiprocessing_coverage_stopped():
     import multiprocessing
 
     if __name__ == "__main__":
-        import os
         from pathlib import Path
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         from ddtrace.internal.coverage.code import ModuleCodeCollector
         from ddtrace.internal.coverage.installer import install
@@ -98,7 +97,7 @@ def test_coverage_multiprocessing_session():
         import os
         from pathlib import Path
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         from ddtrace.internal.coverage.code import ModuleCodeCollector
         from ddtrace.internal.coverage.installer import install
@@ -138,7 +137,7 @@ def test_coverage_multiprocessing_context():
         import os
         from pathlib import Path
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         from ddtrace.internal.coverage.code import ModuleCodeCollector
         from ddtrace.internal.coverage.installer import install
@@ -180,7 +179,7 @@ def test_coverage_concurrent_futures_processpool_session():
     if __name__ == "__main__":
         import os
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         import concurrent.futures
         from pathlib import Path
@@ -222,7 +221,7 @@ def test_coverage_concurrent_futures_processpool_context():
     if __name__ == "__main__":
         import os
 
-        multiprocessing.set_start_method(os.environ["start_method"], force=True)
+        multiprocessing.set_start_method(env["start_method"], force=True)
 
         import concurrent.futures
         from pathlib import Path
@@ -254,7 +253,7 @@ def test_coverage_concurrent_futures_processpool_context():
             "tests/coverage/included_path/in_context_lib.py": {1, 2, 5},
         }
 
-        if os.environ["start_method"] != "fork":
+        if env["start_method"] != "fork":
             # In spawn or forkserver modes, the module is reimported entirely
             expected_lines["tests/coverage/included_path/callee.py"] = {1, 9, 10, 11, 13, 14, 17}
 

--- a/tests/coverage/test_nested_dynamic_imports.py
+++ b/tests/coverage/test_nested_dynamic_imports.py
@@ -17,6 +17,8 @@ import sys
 
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
 @pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
@@ -37,7 +39,7 @@ def test_nested_imports_mixed_path_reinstrumentation():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 
@@ -97,7 +99,7 @@ def test_nested_imports_interleaved_execution():
 
     cwd_path = os.getcwd()
     include_path = Path(cwd_path + "/tests/coverage/included_path/")
-    file_level_mode = os.getenv("_DD_COVERAGE_FILE_LEVEL") == "true"
+    file_level_mode = env.get("_DD_COVERAGE_FILE_LEVEL") == "true"
 
     install(include_paths=[include_path])
 

--- a/tests/integration/test_integration_civisibility.py
+++ b/tests/integration/test_integration_civisibility.py
@@ -1,5 +1,3 @@
-import os
-
 import mock
 import pytest
 
@@ -10,12 +8,13 @@ from ddtrace.internal.ci_visibility.recorder import CIVisibilityTracer
 from ddtrace.internal.evp_proxy.constants import EVP_PROXY_AGENT_ENDPOINT
 from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_EVENT_VALUE
 from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_NAME
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import config as agent_config
 from tests.ci_visibility.util import _get_default_civisibility_ddconfig
 from tests.utils import override_env
 
 
-AGENT_VERSION = os.environ.get("AGENT_VERSION")
+AGENT_VERSION = env.get("AGENT_VERSION")
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/testing/conftest.py
+++ b/tests/testing/conftest.py
@@ -1,12 +1,12 @@
 """Configuration for tests."""
 
-import os
 import subprocess
 import typing as t
 from unittest.mock import Mock
 
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.testing.internal.telemetry import TelemetryAPI
 
 
@@ -19,7 +19,7 @@ def set_env() -> None:
     """
     Make sure that we don't send inner tests to Datadog.
     """
-    os.environ["DD_API_KEY"] = "test-key"
+    env["DD_API_KEY"] = "test-key"
 
 
 @pytest.fixture

--- a/tests/testing/internal/pytest/test_plugin.py
+++ b/tests/testing/internal/pytest/test_plugin.py
@@ -4,13 +4,13 @@ This file is organized with high-level feature tests first, followed by unit tes
 Integration tests are in tests/test_integration.py.
 """
 
-import os
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.testing.internal.pytest.plugin import DISABLED_BY_TEST_MANAGEMENT_REASON
 from ddtrace.testing.internal.pytest.plugin import SKIPPED_BY_ITR_REASON
 from ddtrace.testing.internal.pytest.plugin import TestOptPlugin
@@ -374,7 +374,7 @@ class TestSessionManagement:
         mock_config.invocation_params = mock_invocation_params
 
         # Mock environment variable
-        with patch.dict(os.environ, {"PYTEST_ADDOPTS": "--maxfail=1"}):
+        with patch.dict(env, {"PYTEST_ADDOPTS": "--maxfail=1"}):
             command = _get_test_command(mock_config)
 
         expected = "pytest --tb=short -v tests/ --maxfail=1"
@@ -385,7 +385,7 @@ class TestSessionManagement:
         mock_config = Mock()
         mock_config.invocation_params = None
 
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(env, {}, clear=True):
             command = _get_test_command(mock_config)
 
         assert command == "pytest"

--- a/tests/testing/internal/test_logging.py
+++ b/tests/testing/internal/test_logging.py
@@ -1,11 +1,11 @@
 """Tests for ddtrace.testing.internal.logging module."""
 
 import logging
-import os
 from typing import Optional
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from ddtrace.internal.settings import env
 from ddtrace.testing.internal.logging import catch_and_log_exceptions
 from ddtrace.testing.internal.logging import setup_logging
 from ddtrace.testing.internal.logging import testing_logger
@@ -23,7 +23,7 @@ class TestSetupLogging:
         testing_logger.propagate = True
         testing_logger.setLevel(logging.NOTSET)
 
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(env, {}, clear=True)
     def test_setup_logging_default_level(self) -> None:
         """Test setup_logging with default (INFO) level."""
         setup_logging()
@@ -35,7 +35,7 @@ class TestSetupLogging:
         handler = testing_logger.handlers[0]
         assert isinstance(handler, logging.StreamHandler)
 
-    @patch.dict(os.environ, {"DD_TEST_DEBUG": "true"})
+    @patch.dict(env, {"DD_TEST_DEBUG": "true"})
     def test_setup_logging_debug_level_true(self) -> None:
         """Test setup_logging with DEBUG level enabled via true."""
         setup_logging()
@@ -44,21 +44,21 @@ class TestSetupLogging:
         assert testing_logger.level == logging.DEBUG
         assert len(testing_logger.handlers) == 1
 
-    @patch.dict(os.environ, {"DD_TEST_DEBUG": "1"})
+    @patch.dict(env, {"DD_TEST_DEBUG": "1"})
     def test_setup_logging_debug_level_one(self) -> None:
         """Test setup_logging with DEBUG level enabled via 1."""
         setup_logging()
 
         assert testing_logger.level == logging.DEBUG
 
-    @patch.dict(os.environ, {"DD_TEST_DEBUG": "false"})
+    @patch.dict(env, {"DD_TEST_DEBUG": "false"})
     def test_setup_logging_debug_level_false(self) -> None:
         """Test setup_logging with DEBUG level disabled."""
         setup_logging()
 
         assert testing_logger.level == logging.INFO
 
-    @patch.dict(os.environ, {"DD_TEST_DEBUG": "0"})
+    @patch.dict(env, {"DD_TEST_DEBUG": "0"})
     def test_setup_logging_debug_level_zero(self) -> None:
         """Test setup_logging with DEBUG level disabled via 0."""
         setup_logging()

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import contextlib
 import gzip
 import json
-import os
 from pathlib import Path
 import typing as t
 from unittest.mock import Mock
@@ -21,6 +20,7 @@ from unittest.mock import patch
 
 from _pytest.reports import TestReport
 
+from ddtrace.internal.settings import env
 from ddtrace.testing.internal.http import BackendConnectorSetup
 from ddtrace.testing.internal.http import BackendResult
 from ddtrace.testing.internal.http import ErrorType
@@ -201,7 +201,7 @@ class SessionManagerMockBuilder:
                 patch("ddtrace.testing.internal.session_manager.get_env_tags", return_value=self._env_tags),
                 patch("ddtrace.testing.internal.session_manager.get_platform_tags", return_value={}),
                 patch("ddtrace.testing.internal.session_manager.Git", return_value=get_mock_git_instance()),
-                patch.dict(os.environ, test_env),
+                patch.dict(env, test_env),
             ):
                 # Create session manager
                 test_session = MockDefaults.test_session()

--- a/tests/testing/test_integration.py
+++ b/tests/testing/test_integration.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-import os
 from unittest.mock import Mock
 from unittest.mock import patch
 
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Pytester
 
+from ddtrace.internal.settings import env
 from ddtrace.testing.internal.session_manager import SessionManager
 from ddtrace.testing.internal.test_data import ModuleRef
 from ddtrace.testing.internal.test_data import SuiteRef
@@ -538,7 +538,7 @@ class TestRetryHandler:
             ),
             setup_standard_mocks(),
             patch.dict(
-                os.environ,  # Mock environment variables
+                env,  # Mock environment variables
                 {
                     "DD_API_KEY": "test-key",
                     "DD_CIVISIBILITY_AGENTLESS_ENABLED": "true",
@@ -580,7 +580,7 @@ class TestRetryHandler:
 
         # Create AutoTestRetriesHandler
         with patch.dict(
-            os.environ,
+            env,
             {
                 "DD_API_KEY": "foobar",
                 "DD_CIVISIBILITY_AGENTLESS_ENABLED": "true",

--- a/tests/tracer/test_ci_utils.py
+++ b/tests/tracer/test_ci_utils.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 
 from ddtrace.ext.ci import github_actions
+from ddtrace.internal.settings import env
 
 
 class TestGitHubActionsJobID:
@@ -204,7 +205,7 @@ class TestGitHubActionsJobID:
     def test_get_github_diag_dirs_windows(self):
         """Test Windows diagnostics directory paths."""
         with mock.patch("platform.system", return_value="Windows"):
-            with mock.patch.dict(os.environ, {"ProgramFiles": "C:\\Program Files"}):
+            with mock.patch.dict(env, {"ProgramFiles": "C:\\Program Files"}):
                 dirs = github_actions._get_diag_dirs()
                 assert os.path.join("C:\\Program Files", "actions-runner", "cached", "_diag") in dirs
                 assert os.path.join("C:\\Program Files", "actions-runner", "_diag") in dirs


### PR DESCRIPTION
## Description

Migrates 16 files owned by `ci-app-libraries` from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

Paths covered: `ddtrace/testing/internal/env_tags.py`, `tests/ci_visibility/`, `tests/coverage/`, `tests/testing/`, `tests/tracer/test_ci_utils.py`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.