### PR TITLE
chore(tests): migrate tracer/opentelemetry tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/opentelemetry/conftest.py
+++ b/tests/opentelemetry/conftest.py
@@ -1,8 +1,7 @@
-import os
-
 import opentelemetry
 import pytest
 
+from ddtrace.internal.settings import env
 from ddtrace.opentelemetry import TracerProvider
 
 
@@ -16,7 +15,7 @@ def set_otel_python_context():
     # OTEL_PYTHON_CONTEXT overrides the default contextvar used to parent otel spans. Setting this envar to
     # ``ddcontextvars_context`` allows us correlate otel and ddtrace spans by load the following
     # ddtrace entry point: `ddcontextvars_context = ddtrace.internal.opentelemetry.context:DDRuntimeContext`
-    os.environ["OTEL_PYTHON_CONTEXT"] = "ddcontextvars_context"
+    env["OTEL_PYTHON_CONTEXT"] = "ddcontextvars_context"
 
 
 @pytest.fixture

--- a/tests/opentelemetry/test_context.py
+++ b/tests/opentelemetry/test_context.py
@@ -17,6 +17,7 @@ from ddtrace.constants import MANUAL_DROP_KEY
 from ddtrace.constants import MANUAL_KEEP_KEY
 from ddtrace.internal.opentelemetry.logs import MINIMUM_SUPPORTED_VERSION
 from ddtrace.internal.opentelemetry.trace import OTEL_VERSION
+from ddtrace.internal.settings import env
 
 from .test_logs import EXPORTER_VERSION
 
@@ -135,13 +136,12 @@ def test_otel_trace_across_fork():
 def test_sampling_decisions_across_processes():
     # sampling decision in the subprocess task should be the same as the parent
     import multiprocessing
-    import os
 
     from opentelemetry.trace import get_tracer
 
     from tests.opentelemetry.test_context import _subprocess_task
 
-    decision = os.environ["SAMPLING_DECISION"]
+    decision = env["SAMPLING_DECISION"]
     oteltracer = get_tracer(__name__)
 
     errors = multiprocessing.Queue()

--- a/tests/opentelemetry/test_logs.py
+++ b/tests/opentelemetry/test_logs.py
@@ -1,11 +1,11 @@
 from concurrent import futures
-import os
 
 from opentelemetry.version import __version__ as api_version_string
 import pytest
 
 from ddtrace.internal.opentelemetry.logs import API_VERSION
 from ddtrace.internal.opentelemetry.logs import MINIMUM_SUPPORTED_VERSION
+from ddtrace.internal.settings import env
 
 
 try:
@@ -88,9 +88,9 @@ def extract_log_correlation_attributes(captured_logs, log_message: str) -> dict:
 @pytest.mark.skipif(API_VERSION >= (1, 15, 0), reason="OpenTelemetry API >= 1.15.0 supports logs collection")
 def test_otel_api_version_not_supported(ddtrace_run_python_code_in_subprocess):
     """Test error when OpenTelemetry API version is too old."""
-    env = os.environ.copy()
-    env["DD_LOGS_OTEL_ENABLED"] = "true"
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code="import opentelemetry", env=env)
+    subenv = env.copy()
+    subenv["DD_LOGS_OTEL_ENABLED"] = "true"
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code="import opentelemetry", env=subenv)
     assert status == 0, (stdout, stderr)
     assert (
         "OpenTelemetry API requires version 1.15.0 or higher to enable logs collection. "
@@ -105,9 +105,9 @@ def test_otel_api_version_not_supported(ddtrace_run_python_code_in_subprocess):
 )
 def test_otel_sdk_not_installed(ddtrace_run_python_code_in_subprocess):
     """Test error when OpenTelemetry SDK is not installed."""
-    env = os.environ.copy()
-    env["DD_LOGS_OTEL_ENABLED"] = "true"
-    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code="import opentelemetry", env=env)
+    subenv = env.copy()
+    subenv["DD_LOGS_OTEL_ENABLED"] = "true"
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code="import opentelemetry", env=subenv)
     assert status == 0, (stdout, stderr)
 
     assert (
@@ -388,7 +388,6 @@ def test_ddtrace_log_injection_otlp_enabled():
 def test_ddtrace_log_correlation():
     """Test OpenTelemetry logs exporter correlates ddtrace traces with logs."""
     from logging import getLogger
-    import os
 
     from opentelemetry._logs import get_logger_provider
 
@@ -396,7 +395,7 @@ def test_ddtrace_log_correlation():
     from tests.opentelemetry.test_logs import create_mock_grpc_server
     from tests.opentelemetry.test_logs import extract_log_correlation_attributes
 
-    otel_context = os.environ.get("OTEL_PYTHON_CONTEXT")
+    otel_context = env.get("OTEL_PYTHON_CONTEXT")
     assert otel_context == "ddcontextvars_context", (
         f"Expected OTEL_PYTHON_CONTEXT to be set to ddcontextvars_context but found: {otel_context}"
     )
@@ -453,7 +452,6 @@ def test_ddtrace_log_correlation():
 def test_otel_trace_log_correlation():
     """Test OpenTelemetry logs exporter correlates OpenTelemetry traces with logs."""
     from logging import getLogger
-    import os
 
     from opentelemetry import trace
     from opentelemetry._logs import get_logger_provider
@@ -461,7 +459,7 @@ def test_otel_trace_log_correlation():
     from tests.opentelemetry.test_logs import create_mock_grpc_server
     from tests.opentelemetry.test_logs import extract_log_correlation_attributes
 
-    otel_context = os.environ.get("OTEL_PYTHON_CONTEXT")
+    otel_context = env.get("OTEL_PYTHON_CONTEXT")
     assert otel_context == "ddcontextvars_context", (
         f"Expected OTEL_PYTHON_CONTEXT to be set to ddcontextvars_context but found: {otel_context}"
     )

--- a/tests/opentelemetry/test_metrics.py
+++ b/tests/opentelemetry/test_metrics.py
@@ -1,7 +1,7 @@
-import os
-
 from opentelemetry import version
 import pytest
+
+from ddtrace.internal.settings import env
 
 
 OTEL_VERSION = tuple(int(x) for x in version.__version__.split(".")[:3])
@@ -21,7 +21,7 @@ def skipif(
     if unsupported_otel_version and OTEL_VERSION < (1, 12):
         return pytest.mark.skipif(True, reason="OpenTelemetry version 1.12 or higher is required for these tests")
 
-    has_exporter = os.getenv("SDK_EXPORTER_INSTALLED", "").lower() in ("true", "1")
+    has_exporter = env.get("SDK_EXPORTER_INSTALLED", "").lower() in ("true", "1")
     if exporter_installed and has_exporter:
         return pytest.mark.skipif(True, reason="Tests not compatible with the opentelemetry exporters")
     elif exporter_not_installed and not has_exporter:

--- a/tests/opentelemetry/test_otlp_trace.py
+++ b/tests/opentelemetry/test_otlp_trace.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 @pytest.mark.subprocess(
     env={
@@ -12,7 +14,6 @@ def test_otlp_traces_sent_via_http():
     """Traces generated with tracer.trace() are exported as OTLP JSON to the configured HTTP endpoint."""
     from http.server import BaseHTTPRequestHandler
     import json
-    import os
     import queue
     import socketserver
     import threading
@@ -33,7 +34,7 @@ def test_otlp_traces_sent_via_http():
     with socketserver.TCPServer(("127.0.0.1", 0), OtlpHandler) as server:
         port = server.server_address[1]
         # Set the endpoint before importing ddtrace so the NativeWriter picks it up at init time.
-        os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = f"http://127.0.0.1:{port}/v1/traces"
+        env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = f"http://127.0.0.1:{port}/v1/traces"
 
         t = threading.Thread(target=server.serve_forever)
         t.daemon = True

--- a/tests/runtime/test_runtime_metrics_api.py
+++ b/tests/runtime/test_runtime_metrics_api.py
@@ -1,9 +1,8 @@
-import os
-
 import pytest
 
 from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
 from ddtrace.internal.service import ServiceStatus
+from ddtrace.internal.settings import env
 from ddtrace.runtime import RuntimeMetrics
 
 
@@ -84,9 +83,9 @@ assert not RuntimeMetrics._enabled
 telemetry_writer.periodic(force_flush=True)
     """
 
-    env = os.environ.copy()
-    env["DD_RUNTIME_METRICS_ENABLED"] = "true"
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_RUNTIME_METRICS_ENABLED"] = "true"
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     runtimemetrics_enabled = test_agent_session.get_configurations("DD_RUNTIME_METRICS_ENABLED")
@@ -203,7 +202,6 @@ def test_runtime_metrics_experimental_runtime_tag():
     When runtime metrics is enabled and DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED=DD_RUNTIME_METRICS_ENABLED
         Runtime metrics worker starts and submits gauge metrics instead of distribution metrics
     """
-    import os
 
     from ddtrace.internal.runtime import get_runtime_id
     from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
@@ -217,13 +215,13 @@ def test_runtime_metrics_experimental_runtime_tag():
 
     runtime_id_tag = f"runtime-id:{get_runtime_id()}"
     if (
-        os.environ["DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"] == "true"
-        or os.environ["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"] == "true"
+        env["DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"] == "true"
+        or env["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"] == "true"
     ):
         assert runtime_id_tag in worker_instance._platform_tags, worker_instance._platform_tags
     elif (
-        os.environ["DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"] == "false"
-        or os.environ["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"] == "false"
+        env["DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"] == "false"
+        or env["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"] == "false"
     ):
         assert runtime_id_tag not in worker_instance._platform_tags, worker_instance._platform_tags
     else:
@@ -241,7 +239,6 @@ def test_runtime_metrics_experimental_metric_type():
     When runtime metrics is enabled and DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED=DD_RUNTIME_METRICS_ENABLED
         Runtime metrics worker starts and submits gauge metrics instead of distribution metrics
     """
-    import os
 
     from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
     from ddtrace.internal.service import ServiceStatus
@@ -251,7 +248,7 @@ def test_runtime_metrics_experimental_metric_type():
 
     worker_instance = RuntimeWorker._instance
     assert worker_instance.status == ServiceStatus.RUNNING
-    if "DD_RUNTIME_METRICS_ENABLED" in os.environ["DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED"]:
+    if "DD_RUNTIME_METRICS_ENABLED" in env["DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED"]:
         assert worker_instance.send_metric == worker_instance._dogstatsd_client.gauge, worker_instance.send_metric
     else:
         assert worker_instance.send_metric == worker_instance._dogstatsd_client.distribution, (

--- a/tests/tracer/test_agent.py
+++ b/tests/tracer/test_agent.py
@@ -3,6 +3,7 @@ import pytest
 
 from ddtrace.internal import agent
 from ddtrace.internal.agent import info
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import is_ipv6_hostname
 from ddtrace.internal.utils.http import verify_url
 
@@ -29,13 +30,12 @@ def test_is_ipv6_hostname(hostname, expected):
     env={"DD_TRACE_AGENT_HOST": None, "DD_TRACE_AGENT_URL": None, "DD_DOGSTATSD_URL": None, "DD_DOGSTATSD_HOST": None},
 )
 def test_hostname():
-    import os
     from urllib.parse import urlparse
 
     from ddtrace.internal.settings._agent import config
 
-    assert urlparse(config.trace_agent_url).hostname == os.environ.get("DD_AGENT_HOST")
-    assert urlparse(config.dogstatsd_url).hostname == os.environ.get("DD_AGENT_HOST"), urlparse(config.dogstatsd_url)
+    assert urlparse(config.trace_agent_url).hostname == env.get("DD_AGENT_HOST")
+    assert urlparse(config.dogstatsd_url).hostname == env.get("DD_AGENT_HOST"), urlparse(config.dogstatsd_url)
 
 
 @pytest.mark.subprocess(

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -32,6 +32,7 @@ from ddtrace.internal.encoding import JSONEncoderV2
 from ddtrace.internal.encoding import MsgpackEncoderV04
 from ddtrace.internal.encoding import MsgpackEncoderV05
 from ddtrace.internal.encoding import _EncoderBase
+from ddtrace.internal.settings import env
 from ddtrace.trace import Context
 from ddtrace.trace import Span
 
@@ -672,8 +673,6 @@ def test_span_link_v04_encoding():
     parametrize={"DD_TRACE_API_VERSION": ["v0.4", "v0.5"], "DD_TRACE_NATIVE_SPAN_EVENTS": ["True", "False"]}, err=None
 )
 def test_span_event_encoding_msgpack():
-    import os
-
     from ddtrace.internal.encoding import MSGPACK_ENCODERS
     from ddtrace.trace import Span
     from tests.tracer.test_encoders import decode
@@ -715,8 +714,8 @@ def test_span_event_encoding_msgpack():
     span._add_event("We are going to the moon", timestamp=2234567890123456)
 
     # Get test parameters from environment variables
-    version = os.getenv("DD_TRACE_API_VERSION")
-    trace_native_span_events = os.getenv("DD_TRACE_NATIVE_SPAN_EVENTS") == "True"
+    version = env.get("DD_TRACE_API_VERSION")
+    trace_native_span_events = env.get("DD_TRACE_NATIVE_SPAN_EVENTS") == "True"
 
     encoder = MSGPACK_ENCODERS[version](1 << 20, 1 << 20)
     encoder.put([span])
@@ -1112,12 +1111,11 @@ def test_json_encoder_traces_bytes():
     as we only accept valid str/bytes/None types for span names.
     """
     import json
-    import os
 
     import ddtrace.internal.encoding as encoding
     from ddtrace.trace import Span
 
-    encoder_class_name = os.getenv("encoder_cls")
+    encoder_class_name = env.get("encoder_cls")
 
     encoder = getattr(encoding, encoder_class_name)()
     data = encoder.encode_traces(

--- a/tests/tracer/test_env_vars.py
+++ b/tests/tracer/test_env_vars.py
@@ -1,7 +1,8 @@
-import os
 import subprocess
 
 import pytest
+
+from ddtrace.internal.settings import env
 
 
 @pytest.mark.parametrize(
@@ -42,8 +43,8 @@ def test_obfuscation_querystring_pattern_env_var(
     """
     Test that obfuscation config is properly configured from env vars
     """
-    env = os.environ.copy()
-    env[env_var_name] = env_var_value
+    subenv = env.copy()
+    subenv[env_var_name] = env_var_value
     out = subprocess.check_output(
         [
             "python",
@@ -62,7 +63,7 @@ assert config._http_tag_query_string == %s
                 )
             ),
         ],
-        env=env,
+        env=subenv,
     )
     assert b"AssertionError" not in out, out
 
@@ -94,11 +95,11 @@ def test_tag_querystring_env_var(
     """
     Test that query string tagging config is properly configured from env vars
     """
-    env = os.environ.copy()
+    subenv = env.copy()
     if server_tag_query_string is not None:
-        env["DD_HTTP_SERVER_TAG_QUERY_STRING"] = server_tag_query_string
+        subenv["DD_HTTP_SERVER_TAG_QUERY_STRING"] = server_tag_query_string
     if client_tag_query_string is not None:
-        env["DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING"] = client_tag_query_string
+        subenv["DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING"] = client_tag_query_string
     out = subprocess.check_output(
         [
             "python",
@@ -122,6 +123,6 @@ assert config.requests.http_tag_query_string == %s
                 )
             ),
         ],
-        env=env,
+        env=subenv,
     )
     assert b"AssertionError" not in out

--- a/tests/tracer/test_gitmetadata.py
+++ b/tests/tracer/test_gitmetadata.py
@@ -9,6 +9,7 @@ import subprocess
 
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.subprocesstest import run_in_subprocess
 from tests.utils import TracerTestCase
 
@@ -18,20 +19,20 @@ def preapare_test_env(mypackage_example):
     subprocess.check_output("python setup.py bdist_wheel", shell=True)
     pkgfile = glob.glob(os.path.join(mypackage_example, "dist", "*.whl"))[0]
 
-    os.environ["SHA_VALUE"] = subprocess.check_output("git rev-parse HEAD", shell=True).decode("utf-8").strip()
+    env["SHA_VALUE"] = subprocess.check_output("git rev-parse HEAD", shell=True).decode("utf-8").strip()
 
     envdir = os.path.join(mypackage_example, "run_env_dir")
     cwd = os.getcwd()
-    python_path = os.getenv("PYTHONPATH", None)
+    python_path = env.get("PYTHONPATH", None)
     try:
         subprocess.check_output("pip install --target=" + envdir + " " + pkgfile, shell=True)
         os.chdir(envdir)
-        os.environ["PYTHONPATH"] = os.getenv("PYTHONPATH", "") + os.pathsep + envdir
+        env["PYTHONPATH"] = env.get("PYTHONPATH", "") + os.pathsep + envdir
         yield
     finally:
         os.chdir(cwd)
         if python_path is not None:
-            os.environ["PYTHONPATH"] = python_path
+            env["PYTHONPATH"] = python_path
 
 
 @pytest.mark.usefixtures("preapare_test_env")
@@ -45,7 +46,7 @@ class GitMetadataTestCase(TracerTestCase):
         with self.tracer.trace("span") as s:
             pass
 
-        assert s.get_tag("_dd.git.commit.sha") == os.getenv("SHA_VALUE")
+        assert s.get_tag("_dd.git.commit.sha") == env.get("SHA_VALUE")
         assert s.get_tag("_dd.git.repository_url") == "https://github.com/companydotcom/repo"
         assert s.get_tag("_dd.python_main_package") == "mypackage"
 

--- a/tests/tracer/test_native_logger.py
+++ b/tests/tracer/test_native_logger.py
@@ -1,10 +1,10 @@
 from contextlib import nullcontext
-import os
 import uuid
 
 import pytest
 
 from ddtrace.internal.native._native import logger
+from ddtrace.internal.settings import env
 
 
 @pytest.fixture(autouse=True)
@@ -114,11 +114,11 @@ def test_logger_subprocess(
     if not tmp_path.exists():
         tmp_path.mkdir(parents=True, exist_ok=True)
 
-    env = os.environ.copy()
-    env["_DD_TRACE_WRITER_NATIVE"] = "1"
-    env["_DD_NATIVE_LOGGING_BACKEND"] = backend
-    env["_DD_NATIVE_LOGGING_FILE_PATH"] = log_path_abs
-    env["_DD_NATIVE_LOGGING_LOG_LEVEL"] = configured_level
+    subenv = env.copy()
+    subenv["_DD_TRACE_WRITER_NATIVE"] = "1"
+    subenv["_DD_NATIVE_LOGGING_BACKEND"] = backend
+    subenv["_DD_NATIVE_LOGGING_FILE_PATH"] = log_path_abs
+    subenv["_DD_NATIVE_LOGGING_LOG_LEVEL"] = configured_level
 
     message = f"msg_{uuid.uuid4().hex}"
     code = """
@@ -127,7 +127,7 @@ from ddtrace.internal.native._native import logger
 message_level = f"{}"
 logger.log(message_level, f"{}")
     """.format(message_level, message)
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
 
     assert status == 0
     if backend == "":

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-import os
 import pickle
 from unittest import mock
 
@@ -23,6 +22,7 @@ from ddtrace.internal.constants import LAST_DD_PARENT_ID_KEY
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_MULTI
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_SINGLE
 from ddtrace.internal.constants import PROPAGATION_STYLE_DATADOG
+from ddtrace.internal.settings import env
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import _HTTP_BAGGAGE_PREFIX
 from ddtrace.propagation.http import _HTTP_HEADER_B3_FLAGS
@@ -2495,12 +2495,12 @@ assert context == expected_context, f"Expected {{expected_context}} but got {{co
         headers,
         pickle.dumps(expected_context),
     )
-    env = os.environ.copy()
+    subenv = env.copy()
     if styles is not None:
-        env["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
+        subenv["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
     if extract_behavior is not None:
-        env["DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT"] = extract_behavior
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+        subenv["DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT"] = extract_behavior
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=subenv)
     print(stderr, stdout)
     assert status == 0, (stdout, stderr)
 
@@ -2597,13 +2597,13 @@ else:
       "dd_origin": context.dd_origin,
     }}))
     """.format(headers)
-    env = os.environ.copy()
+    subenv = env.copy()
     if styles is not None:
-        env["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
+        subenv["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
     if styles_extract is not None:
-        env["DD_TRACE_PROPAGATION_STYLE_EXTRACT"] = ",".join(styles_extract)
+        subenv["DD_TRACE_PROPAGATION_STYLE_EXTRACT"] = ",".join(styles_extract)
 
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
     assert stderr == b"", (stdout, stderr)
 
@@ -3306,10 +3306,10 @@ HTTPPropagator.inject(context, headers)
 print(json.dumps(headers))
     """.format(context)
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if styles is not None:
-        env["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+        subenv["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
     assert stderr == b"", (stdout, stderr)
 
@@ -3371,12 +3371,12 @@ HTTPPropagator.inject(context, headers)
 print(json.dumps(headers))
     """.format(context)
 
-    env = os.environ.copy()
+    subenv = env.copy()
     if styles is not None:
-        env["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
+        subenv["DD_TRACE_PROPAGATION_STYLE"] = ",".join(styles)
     if styles_inject is not None:
-        env["DD_TRACE_PROPAGATION_STYLE_INJECT"] = ",".join(styles_inject)
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+        subenv["DD_TRACE_PROPAGATION_STYLE_INJECT"] = ",".join(styles_inject)
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=subenv)
     assert status == 0, (stdout, stderr)
     assert stderr == b"", (stdout, stderr)
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -29,6 +29,7 @@ from ddtrace.constants import USER_REJECT
 from ddtrace.constants import VERSION_KEY
 from ddtrace.contrib.internal.trace_utils import set_user
 from ddtrace.ext import user
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._config import Config
 from ddtrace.internal.writer import AgentWriterInterface
 from ddtrace.trace import Context
@@ -737,8 +738,6 @@ def test_tracer_shutdown_timeout():
     parametrize={"USE_START_SPAN": ["true", "false"]},
 )
 def test_tracer_shutdown():
-    import os
-
     import mock
 
     from ddtrace._trace.span import Span
@@ -746,7 +745,7 @@ def test_tracer_shutdown():
 
     t.shutdown()
 
-    if os.environ.get("USE_START_SPAN") == "true":
+    if env.get("USE_START_SPAN") == "true":
         create_span = t.start_span
     else:
         create_span = t.trace
@@ -1067,11 +1066,9 @@ def test_tracer_runtime_tags_cross_execution(tracer):
 
 @pytest.mark.subprocess(parametrize={"DD_TRACE_ENABLED": ["true", "false"]})
 def test_enable():
-    import os
-
     from ddtrace.trace import tracer as t2
 
-    if os.environ["DD_TRACE_ENABLED"] == "true":
+    if env["DD_TRACE_ENABLED"] == "true":
         assert t2.enabled
     else:
         assert not t2.enabled

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -21,6 +21,7 @@ from ddtrace.internal.encoding import MSGPACK_ENCODERS
 from ddtrace.internal.native._native import IoError
 from ddtrace.internal.native._native import NetworkError
 from ddtrace.internal.runtime import get_runtime_id
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._opentelemetry import ExporterConfig
 from ddtrace.internal.settings._opentelemetry import _is_otlp_traces_exporter_enabled
 from ddtrace.internal.uds import UDSHTTPConnection
@@ -692,12 +693,12 @@ class CIVisibilityWriterTests(AgentWriterTests):
     WRITER_CLASS = CIVisibilityWriter
 
     def setUp(self):
-        self.original_env = dict(os.environ)
-        os.environ.update(dict(DD_API_KEY="foobar.baz"))
+        self.original_env = dict(env)
+        env.update(dict(DD_API_KEY="foobar.baz"))
 
     def tearDown(self):
-        os.environ.clear()
-        os.environ.update(self.original_env)
+        env.clear()
+        env.update(self.original_env)
 
     # NB these tests are skipped because they exercise max_payload_size and max_item_size functionality
     # that CIVisibilityWriter does not implement


### PR DESCRIPTION
## Description

Migrates 14 test files under `tests/tracer/`, `tests/opentelemetry/`, and `tests/runtime/` (owned by `apm-sdk-capabilities-python` + `apm-core-python`) from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.