### PR TITLE
chore(tests): migrate serverless tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/contrib/azure_durable_functions/test_azure_durable_functions_snapshot.py
+++ b/tests/contrib/azure_durable_functions/test_azure_durable_functions_snapshot.py
@@ -13,6 +13,7 @@ from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.schema import schematize_cloud_faas_operation
+from ddtrace.internal.settings import env
 from tests.utils import TracerSpanContainer
 from tests.utils import scoped_tracer
 from tests.webclient import Client
@@ -28,12 +29,14 @@ def azure_functions_client(request):
 
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     port = 7072
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+    subenv["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    subenv["DD_TRACE_STATS_COMPUTATION_ENABLED"] = (
+        "False"  # disable stats computation to avoid potential flakes in tests
+    )
 
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
     # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
@@ -42,7 +45,7 @@ def azure_functions_client(request):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         close_fds=True,
-        env=env,
+        env=subenv,
         preexec_fn=os.setsid,
         cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
     )

--- a/tests/contrib/azure_eventhubs/common.py
+++ b/tests/contrib/azure_eventhubs/common.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from threading import Event
 from threading import Lock
 from threading import Thread
@@ -16,6 +15,8 @@ from azure.eventhub.aio import EventHubProducerClient as EventHubProducerClientA
 from azure.eventhub.aio import PartitionContext as PartitionContextAsync
 from azure.eventhub.amqp import AmqpAnnotatedMessage
 import pytest
+
+from ddtrace.internal.settings import env
 
 
 CONNECTION_STRING = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
@@ -307,12 +308,12 @@ async def run_test_async(
 
 @pytest.mark.asyncio
 async def test_common():
-    method = os.environ.get("METHOD")
-    buffered_mode = os.environ.get("BUFFERED_MODE") == "True"
-    is_async = os.environ.get("IS_ASYNC") == "True"
-    message_payload_type = os.environ.get("MESSAGE_PAYLOAD_TYPE")
-    distributed_tracing_enabled = os.environ.get("DD_AZURE_EVENTHUBS_DISTRIBUTED_TRACING", "True") == "True"
-    batch_links_enabled = os.environ.get("DD_TRACE_AZURE_EVENTHUBS_BATCH_LINKS_ENABLED", "True") == "True"
+    method = env.get("METHOD")
+    buffered_mode = env.get("BUFFERED_MODE") == "True"
+    is_async = env.get("IS_ASYNC") == "True"
+    message_payload_type = env.get("MESSAGE_PAYLOAD_TYPE")
+    distributed_tracing_enabled = env.get("DD_AZURE_EVENTHUBS_DISTRIBUTED_TRACING", "True") == "True"
+    batch_links_enabled = env.get("DD_TRACE_AZURE_EVENTHUBS_BATCH_LINKS_ENABLED", "True") == "True"
 
     if is_async:
         producer_client = EventHubProducerClientAsync.from_connection_string(

--- a/tests/contrib/azure_eventhubs/test_azure_eventhubs_snapshot.py
+++ b/tests/contrib/azure_eventhubs/test_azure_eventhubs_snapshot.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 from pathlib import Path
 
 from azure.eventhub import EventData
@@ -8,6 +7,7 @@ import pytest
 
 from ddtrace.contrib.internal.azure_eventhubs.patch import patch
 from ddtrace.contrib.internal.azure_eventhubs.patch import unpatch
+from ddtrace.internal.settings import env
 
 
 CONNECTION_STRING = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
@@ -79,11 +79,11 @@ def patch_azure_eventhubs():
 )
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
 async def test_producer(ddtrace_run_python_code_in_subprocess, env_vars):
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     helper_path = Path(__file__).resolve().parent.joinpath("common.py")
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(helper_path.read_text(), env=env)
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(helper_path.read_text(), env=subenv)
 
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()

--- a/tests/contrib/azure_functions/azure_function_app/function_app.py
+++ b/tests/contrib/azure_functions/azure_function_app/function_app.py
@@ -1,9 +1,8 @@
-import os
-
 import azure.functions as func
 import requests
 
 import ddtrace.auto  # noqa: F401
+from ddtrace.internal.settings import env
 
 
 app = func.FunctionApp()
@@ -61,7 +60,7 @@ def http_get_function_name_decorator_order(req: func.HttpRequest) -> func.HttpRe
 @app.route(route="httpgetroot", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.GET])
 def http_get_root(req: func.HttpRequest) -> func.HttpResponse:
     requests.get(
-        f"http://localhost:{os.environ['AZURE_FUNCTIONS_TEST_PORT']}/api/httpgetchild",
+        f"http://localhost:{env['AZURE_FUNCTIONS_TEST_PORT']}/api/httpgetchild",
         headers={"User-Agent": "python-requests/x.xx.x"},
         timeout=5,
     )

--- a/tests/contrib/azure_functions/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions/test_azure_functions_snapshot.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.webclient import Client
 
 
@@ -24,12 +25,14 @@ def azure_functions_client(request):
 
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+    subenv["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    subenv["DD_TRACE_STATS_COMPUTATION_ENABLED"] = (
+        "False"  # disable stats computation to avoid potential flakes in tests
+    )
 
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
     # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
@@ -38,7 +41,7 @@ def azure_functions_client(request):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         close_fds=True,
-        env=env,
+        env=subenv,
         preexec_fn=os.setsid,
         cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
     )

--- a/tests/contrib/azure_functions_cosmos/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions_cosmos/test_azure_functions_snapshot.py
@@ -7,6 +7,7 @@ from azure.cosmos import CosmosClient
 from azure.cosmos import PartitionKey
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.webclient import Client
 
 
@@ -35,12 +36,14 @@ def azure_functions_client(request):
 
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+    subenv["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    subenv["DD_TRACE_STATS_COMPUTATION_ENABLED"] = (
+        "False"  # disable stats computation to avoid potential flakes in tests
+    )
 
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
     # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
@@ -49,7 +52,7 @@ def azure_functions_client(request):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         close_fds=True,
-        env=env,
+        env=subenv,
         preexec_fn=os.setsid,
         cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
     )

--- a/tests/contrib/azure_functions_eventhubs/azure_function_app/function_app.py
+++ b/tests/contrib/azure_functions_eventhubs/azure_function_app/function_app.py
@@ -1,10 +1,10 @@
-import os
 from uuid import uuid4
 
 import azure.eventhub as azure_eventhub
 import azure.functions as func
 
 import ddtrace.auto  # noqa: F401
+from ddtrace.internal.settings import env
 
 
 app = func.FunctionApp()
@@ -13,7 +13,7 @@ app = func.FunctionApp()
 @app.route(route="sendeventsingle", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def send_event(req: func.HttpRequest) -> func.HttpResponse:
     with azure_eventhub.EventHubProducerClient.from_connection_string(
-        conn_str=os.getenv("CONNECTION_STRING", ""),
+        conn_str=env.get("CONNECTION_STRING", ""),
         eventhub_name="eh1",
     ) as eventhub_producer_client:
         event = azure_eventhub.EventData('{"body":"test message"}')
@@ -25,7 +25,7 @@ def send_event(req: func.HttpRequest) -> func.HttpResponse:
 @app.route(route="sendeventbatch", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def send_batch(req: func.HttpRequest) -> func.HttpResponse:
     with azure_eventhub.EventHubProducerClient.from_connection_string(
-        conn_str=os.getenv("CONNECTION_STRING", ""),
+        conn_str=env.get("CONNECTION_STRING", ""),
         eventhub_name="eh1",
     ) as eventhub_producer_client:
         batch = eventhub_producer_client.create_batch()
@@ -35,7 +35,7 @@ def send_batch(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse("Hello Datadog!")
 
 
-if os.getenv("IS_ASYNC") == "True":
+if env.get("IS_ASYNC") == "True":
 
     @app.function_name(name="eventhub")
     @app.event_hub_message_trigger(
@@ -43,7 +43,7 @@ if os.getenv("IS_ASYNC") == "True":
         event_hub_name="eh1",
         consumer_group="cg1",
         connection="CONNECTION_STRING",
-        cardinality=os.getenv("CARDINALITY", "one"),
+        cardinality=env.get("CARDINALITY", "one"),
     )
     async def event_hub_trigger(event: func.EventHubEvent):
         pass
@@ -56,7 +56,7 @@ else:
         event_hub_name="eh1",
         consumer_group="cg1",
         connection="CONNECTION_STRING",
-        cardinality=os.getenv("CARDINALITY", "one"),
+        cardinality=env.get("CARDINALITY", "one"),
     )
     def event_hub_trigger(event: func.EventHubEvent):
         pass

--- a/tests/contrib/azure_functions_eventhubs/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions_eventhubs/test_azure_functions_snapshot.py
@@ -8,6 +8,7 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.webclient import Client
 
 
@@ -45,12 +46,14 @@ def azure_functions_client(request):
 
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+    subenv["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    subenv["DD_TRACE_STATS_COMPUTATION_ENABLED"] = (
+        "False"  # disable stats computation to avoid potential flakes in tests
+    )
 
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
     # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
@@ -59,7 +62,7 @@ def azure_functions_client(request):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         close_fds=True,
-        env=env,
+        env=subenv,
         preexec_fn=os.setsid,
         cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
     )

--- a/tests/contrib/azure_functions_servicebus/azure_function_app/function_app.py
+++ b/tests/contrib/azure_functions_servicebus/azure_function_app/function_app.py
@@ -1,9 +1,8 @@
-import os
-
 import azure.functions as func
 import azure.servicebus as azure_servicebus
 
 import ddtrace.auto  # noqa: F401
+from ddtrace.internal.settings import env
 
 
 app = func.FunctionApp()
@@ -12,7 +11,7 @@ app = func.FunctionApp()
 @app.route(route="queuesendmessagesingle", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def queue_send_single_message(req: func.HttpRequest) -> func.HttpResponse:
     with azure_servicebus.ServiceBusClient.from_connection_string(
-        conn_str=os.getenv("CONNECTION_STRING", "")
+        conn_str=env.get("CONNECTION_STRING", "")
     ) as servicebus_client:
         with servicebus_client.get_queue_sender(queue_name="queue.1") as queue_sender:
             queue_sender.send_messages(azure_servicebus.ServiceBusMessage('{"body":"test message"}'))
@@ -22,7 +21,7 @@ def queue_send_single_message(req: func.HttpRequest) -> func.HttpResponse:
 @app.route(route="queuesendmessagebatch", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def queue_send_message_batch(req: func.HttpRequest) -> func.HttpResponse:
     with azure_servicebus.ServiceBusClient.from_connection_string(
-        conn_str=os.getenv("CONNECTION_STRING", "")
+        conn_str=env.get("CONNECTION_STRING", "")
     ) as servicebus_client:
         with servicebus_client.get_queue_sender(queue_name="queue.1") as queue_sender:
             batch = queue_sender.create_message_batch()
@@ -35,7 +34,7 @@ def queue_send_message_batch(req: func.HttpRequest) -> func.HttpResponse:
 @app.route(route="topicsendmessagesingle", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def topic_send_single_message(req: func.HttpRequest) -> func.HttpResponse:
     with azure_servicebus.ServiceBusClient.from_connection_string(
-        conn_str=os.getenv("CONNECTION_STRING", "")
+        conn_str=env.get("CONNECTION_STRING", "")
     ) as servicebus_client:
         with servicebus_client.get_topic_sender(topic_name="topic.1") as topic_sender:
             topic_sender.send_messages(azure_servicebus.ServiceBusMessage('{"body":"test message"}'))
@@ -45,7 +44,7 @@ def topic_send_single_message(req: func.HttpRequest) -> func.HttpResponse:
 @app.route(route="topicsendmessagebatch", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def topic_send_message_batch(req: func.HttpRequest) -> func.HttpResponse:
     with azure_servicebus.ServiceBusClient.from_connection_string(
-        conn_str=os.getenv("CONNECTION_STRING", "")
+        conn_str=env.get("CONNECTION_STRING", "")
     ) as servicebus_client:
         with servicebus_client.get_topic_sender(topic_name="topic.1") as topic_sender:
             batch = topic_sender.create_message_batch()
@@ -55,14 +54,14 @@ def topic_send_message_batch(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse("Hello Datadog!")
 
 
-if os.getenv("IS_ASYNC") == "True":
+if env.get("IS_ASYNC") == "True":
 
     @app.function_name(name="servicebusqueue")
     @app.service_bus_queue_trigger(
         arg_name="msg",
         queue_name="queue.1",
         connection="CONNECTION_STRING",
-        cardinality=os.getenv("CARDINALITY", "one"),
+        cardinality=env.get("CARDINALITY", "one"),
     )
     async def service_bus_queue(msg: func.ServiceBusMessage):
         pass
@@ -73,7 +72,7 @@ if os.getenv("IS_ASYNC") == "True":
         topic_name="topic.1",
         subscription_name="subscription.3",
         connection="CONNECTION_STRING",
-        cardinality=os.getenv("CARDINALITY", "one"),
+        cardinality=env.get("CARDINALITY", "one"),
     )
     async def service_bus_topic(msg: func.ServiceBusMessage):
         pass
@@ -85,7 +84,7 @@ else:
         arg_name="msg",
         queue_name="queue.1",
         connection="CONNECTION_STRING",
-        cardinality=os.getenv("CARDINALITY", "one"),
+        cardinality=env.get("CARDINALITY", "one"),
     )
     def service_bus_queue(msg: func.ServiceBusMessage):
         pass
@@ -96,7 +95,7 @@ else:
         topic_name="topic.1",
         subscription_name="subscription.3",
         connection="CONNECTION_STRING",
-        cardinality=os.getenv("CARDINALITY", "one"),
+        cardinality=env.get("CARDINALITY", "one"),
     )
     def service_bus_topic(msg: func.ServiceBusMessage):
         pass

--- a/tests/contrib/azure_functions_servicebus/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions_servicebus/test_azure_functions_snapshot.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 
+from ddtrace.internal.settings import env
 from tests.webclient import Client
 
 
@@ -43,12 +44,14 @@ def azure_functions_client(request):
 
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+    subenv["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    subenv["DD_TRACE_STATS_COMPUTATION_ENABLED"] = (
+        "False"  # disable stats computation to avoid potential flakes in tests
+    )
 
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
     # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
@@ -57,7 +60,7 @@ def azure_functions_client(request):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         close_fds=True,
-        env=env,
+        env=subenv,
         preexec_fn=os.setsid,
         cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
     )

--- a/tests/contrib/azure_servicebus/common.py
+++ b/tests/contrib/azure_servicebus/common.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from datetime import timezone
-import os
 from typing import Union
 from uuid import uuid4
 
@@ -14,6 +13,8 @@ from azure.servicebus.aio import ServiceBusReceiver as ServiceBusReceiverAsync
 from azure.servicebus.aio import ServiceBusSender as ServiceBusSenderAsync
 from azure.servicebus.amqp import AmqpAnnotatedMessage
 import pytest
+
+from ddtrace.internal.settings import env
 
 
 CONNECTION_STRING = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
@@ -164,11 +165,11 @@ async def run_test_async(
 
 @pytest.mark.asyncio
 async def test_common():
-    method = os.environ.get("METHOD")
-    is_async = os.environ.get("IS_ASYNC") == "True"
-    message_payload_type = os.environ.get("MESSAGE_PAYLOAD_TYPE")
-    distributed_tracing_enabled = os.environ.get("DD_AZURE_SERVICEBUS_DISTRIBUTED_TRACING", "True") == "True"
-    batch_links_enabled = os.environ.get("DD_TRACE_AZURE_SERVICEBUS_BATCH_LINKS_ENABLED", "True") == "True"
+    method = env.get("METHOD")
+    is_async = env.get("IS_ASYNC") == "True"
+    message_payload_type = env.get("MESSAGE_PAYLOAD_TYPE")
+    distributed_tracing_enabled = env.get("DD_AZURE_SERVICEBUS_DISTRIBUTED_TRACING", "True") == "True"
+    batch_links_enabled = env.get("DD_TRACE_AZURE_SERVICEBUS_BATCH_LINKS_ENABLED", "True") == "True"
 
     if is_async:
         client = ServiceBusClientAsync.from_connection_string(CONNECTION_STRING)

--- a/tests/contrib/azure_servicebus/test_azure_servicebus_snapshot.py
+++ b/tests/contrib/azure_servicebus/test_azure_servicebus_snapshot.py
@@ -1,11 +1,11 @@
 import itertools
-import os
 from pathlib import Path
 
 import pytest
 
 from ddtrace.contrib.internal.azure_servicebus.patch import patch
 from ddtrace.contrib.internal.azure_servicebus.patch import unpatch
+from ddtrace.internal.settings import env
 
 
 # Ignoring span link attributes until values are normalized: https://github.com/DataDog/dd-apm-test-agent/issues/154
@@ -61,11 +61,11 @@ def patch_azure_servicebus():
 )
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
 async def test_producer(ddtrace_run_python_code_in_subprocess, env_vars):
-    env = os.environ.copy()
-    env.update(env_vars)
+    subenv = env.copy()
+    subenv.update(env_vars)
 
     helper_path = Path(__file__).resolve().parent.joinpath("common.py")
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(helper_path.read_text(), env=env)
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(helper_path.read_text(), env=subenv)
 
     assert status == 0, (err.decode(), out.decode())
     assert err == b"", err.decode()

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -2,6 +2,7 @@ import pytest
 
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
+from ddtrace.internal.settings import env
 from tests.utils import override_env
 
 
@@ -77,10 +78,9 @@ def test_slow_imports(package, blocklist, run_python_code_in_subprocess):
     # We should lazy load certain modules to avoid slowing down the startup
     # time when running in a serverless environment.  This test will fail if
     # any of those modules are imported during the import of ddtrace.
-    import os
 
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
             "AWS_LAMBDA_FUNCTION_NAME": "foobar",
             "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "False",
@@ -104,7 +104,7 @@ sys.meta_path = [BlockListFinder()] + sys.meta_path
 import {package}
 """
 
-    stderr, stdout, status, _ = run_python_code_in_subprocess(code, env=env)
+    stderr, stdout, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert stdout.decode() == ""
     assert stderr.decode() == ""
     assert status == 0
@@ -144,10 +144,9 @@ def test_serverless_imports(from_, import_, run_python_code_in_subprocess):
     # test ensures that none of those imports break.  If this test fails, then
     # either you will need to retain the import that was removed or you must
     # update datadog-lambda-python to support the new import path.
-    import os
 
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
             "AWS_LAMBDA_FUNCTION_NAME": "foobar",
             "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "False",
@@ -157,7 +156,7 @@ def test_serverless_imports(from_, import_, run_python_code_in_subprocess):
 
     code = f"from {from_} import {import_}"
 
-    stderr, stdout, status, _ = run_python_code_in_subprocess(code, env=env)
+    stderr, stdout, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert stdout.decode() == ""
     assert stderr.decode() == ""
     assert status == 0


### PR DESCRIPTION
## Description

Migrates 12 test files under `tests/contrib/azure_*` (owned by `apm-serverless` + `serverless-azure-and-gcp`) from `os.environ`/`os.getenv` to `ddtrace.internal.settings.env`.

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. `env` is a `MutableMapping` drop-in for `os.environ`.


## Additional Notes

Part of the `os.environ` → `ddtrace.internal.settings.env` migration campaign.
Depends on #17344 (adds `env.copy()` to `EnvConfig`) — merge that first.

Mechanical change: all `os.environ`/`os.getenv` references replaced with `env` from `ddtrace.internal.settings`. No logic changes.