### PR TITLE
chore(crashtracking): report version and commit sha on release

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -45,7 +45,7 @@ release_pypi_prod:
 
 notify_datadog_release:
   extends: .release_base
-  needs: [ "release_pypi_prod" ]
+  needs: [ "ddtrace package", "release_pypi_prod" ]
   image: ${PYPI_PUBLISH_IMAGE}
   id_tokens:
     DD_STS_OIDC_TOKEN:
@@ -54,11 +54,15 @@ notify_datadog_release:
   before_script:
     - apt-get update && apt-get install --no-install-recommends -y curl
     - >-
-      DD_STS_RESPONSE=$(curl -sS
+      DD_STS_API_KEY=$(curl -sS
       -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
       "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab")
-    - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
-    - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
+    - >-
+      DD_STS_APP_KEY=$(curl -sS
+      -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
+      "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key")
+    - export DD_API_KEY=$(echo "$DD_STS_API_KEY" | jq -re '.api_key')
+    - export DD_APP_KEY=$(echo "$DD_STS_APP_KEY" | jq -re '.application_key')
   script:
     - |
       echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -47,15 +47,18 @@ notify_datadog_release:
   extends: .release_base
   needs: [ "release_pypi_prod" ]
   image: ${PYPI_PUBLISH_IMAGE}
+  id_tokens:
+    DD_STS_OIDC_TOKEN:
+      aud: rapid-seceng-sit
   tags: [ "arch:amd64" ]
   before_script:
-    - |
-      curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.3.zip" -o "awscliv2.zip"
-      echo "13ee8a87756aa61027bd87985d4da4dee7ac777a36410321b03621a943cf030e awscliv2.zip" | sha256sum --check
-      unzip awscliv2.zip
-      ./aws/install
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.${CI_PROJECT_NAME}.dd_api_key" --with-decryption --query "Parameter.Value" --out text)
-    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.${CI_PROJECT_NAME}.dd_app_key" --with-decryption --query "Parameter.Value" --out text)
+    - apt-get update && apt-get install -y curl
+    - >-
+      DD_STS_RESPONSE=$(curl -sS
+      -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
+      "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab")
+    - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
+    - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
   script:
     - |
       echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -52,7 +52,7 @@ notify_datadog_release:
       aud: rapid-seceng-sit
   tags: [ "arch:amd64" ]
   before_script:
-    - apt-get update && apt-get install -y curl
+    - apt-get update && apt-get install --no-install-recommends -y curl
     - >-
       DD_STS_RESPONSE=$(curl -sS
       -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
@@ -62,7 +62,7 @@ notify_datadog_release:
   script:
     - |
       echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"
-      curl -X POST \
+      curl --retry 3 --retry-delay 2 --fail -X POST \
         -H "Content-Type: application/json" \
         -H "DD-API-KEY: ${DD_API_KEY}" \
         -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -42,3 +42,26 @@ release_pypi_prod:
   extends: .release_pypi
   variables:
     PYPI_REPOSITORY: pypi
+
+notify_datadog_release:
+  extends: .release_base
+  needs: [ "release_pypi_prod" ]
+  image: ${PYPI_PUBLISH_IMAGE}
+  tags: [ "arch:amd64" ]
+  before_script:
+    - |
+      curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.3.zip" -o "awscliv2.zip"
+      echo "13ee8a87756aa61027bd87985d4da4dee7ac777a36410321b03621a943cf030e awscliv2.zip" | sha256sum --check
+      unzip awscliv2.zip
+      ./aws/install
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.${CI_PROJECT_NAME}.dd_api_key" --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.${CI_PROJECT_NAME}.dd_app_key" --with-decryption --query "Parameter.Value" --out text)
+  script:
+    - |
+      echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"
+      curl -X POST \
+        -H "Content-Type: application/json" \
+        -H "DD-API-KEY: ${DD_API_KEY}" \
+        -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+        -d "{\"meta\": {\"payload\": {\"version\": \"${CI_COMMIT_TAG}\", \"git_commit_sha\": \"${CI_COMMIT_SHA}\"}}}" \
+        https://api.datadoghq.com/api/v2/workflows/dd0d5405-b38c-4f4f-8f4c-c0cd4a65d4d6/instances


### PR DESCRIPTION
## Description

We want to maintain a mapping of releases and their respective commit SHA in Datadog reference tables for downstream crash log enrichment.

On release, we upsert the ref table: https://app.datadoghq.com/reference-tables/dd_trace_py_git_info_for_error_logs

When error logs are forwarded to telemetry intake, they will be enriched by a downstream logs enrichment pipeline with the commit sha info here


Pipeline trigger: https://app.datadoghq.com/workflow/dd0d5405-b38c-4f4f-8f4c-c0cd4a65d4d6
Reference table: https://app.datadoghq.com/reference-tables/dd_trace_py_git_info_for_error_logs
Logs processor: https://app.datadoghq.com/logs/pipelines?search=last_updated_by%3Agyuheon.oh%40datadoghq.com

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
