### PR TITLE
chore(tests): migrate misc tests to ddtrace.internal.settings.env

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -32,5 +32,8 @@ class EnvConfig(MutableMapping):
     def __len__(self) -> int:
         return len(os.environ)
 
+    def copy(self) -> dict:
+        return os.environ.copy()
+
 
 dd_environ = EnvConfig()

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -33,7 +33,7 @@ class EnvConfig(MutableMapping):
         return len(os.environ)
 
     def copy(self) -> dict:
-        return os.environ.copy()
+        return dict(self)
 
 
 dd_environ = EnvConfig()

--- a/tests/datastreams/test_processor.py
+++ b/tests/datastreams/test_processor.py
@@ -1,5 +1,4 @@
 import gzip
-import os
 import time
 
 import mock
@@ -12,6 +11,7 @@ from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsProcessor
 from ddtrace.internal.datastreams.processor import DsmPathwayCodec
 from ddtrace.internal.datastreams.processor import PartitionKey
+from ddtrace.internal.settings import env
 
 
 processor = DataStreamsProcessor("http://localhost:8126")
@@ -238,9 +238,9 @@ register_on_exit_signal(set_exit)
 run_test()
 """
 
-    env = os.environ.copy()
-    env["DD_DATA_STREAMS_ENABLED"] = "True"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env, timeout=5)
+    subenv = env.copy()
+    subenv["DD_DATA_STREAMS_ENABLED"] = "True"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv, timeout=5)
     assert out.decode().strip() == "Fake flush called"
 
 
@@ -264,9 +264,9 @@ t.start()
 t.join()
 """
 
-    env = os.environ.copy()
-    env["DD_DATA_STREAMS_ENABLED"] = "True"
-    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env, timeout=5)
+    subenv = env.copy()
+    subenv["DD_DATA_STREAMS_ENABLED"] = "True"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv, timeout=5)
     assert err.decode().strip() == ""
 
 

--- a/tests/debugging/exploration/test_bootstrap.py
+++ b/tests/debugging/exploration/test_bootstrap.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from ddtrace.internal.settings import env
+
 
 NEEDLE = "Enabling debugging exploration testing"
 
@@ -11,7 +13,7 @@ EXPL_FOLDER = Path(__file__).parent.resolve()
 
 def expl_env(**kwargs):
     return {
-        "PYTHONPATH": os.pathsep.join((str(EXPL_FOLDER), os.getenv("PYTHONPATH", ""))),
+        "PYTHONPATH": os.pathsep.join((str(EXPL_FOLDER), env.get("PYTHONPATH", ""))),
         **kwargs,
     }
 

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -489,12 +489,14 @@ def test_debugger_multiple_function_probes_on_same_function(stuff):
         stuff.Stuff().instancestuff(42)
 
         d.collector.wait(
-            lambda q: Counter(s.probe.probe_id for s in q)
-            == {
-                "probe-instance-method-0": 1,
-                "probe-instance-method-1": 1,
-                "probe-instance-method-2": 1,
-            }
+            lambda q: (
+                Counter(s.probe.probe_id for s in q)
+                == {
+                    "probe-instance-method-0": 1,
+                    "probe-instance-method-1": 1,
+                    "probe-instance-method-2": 1,
+                }
+            )
         )
 
         d.remove_probes(probes[1])
@@ -504,12 +506,14 @@ def test_debugger_multiple_function_probes_on_same_function(stuff):
         stuff.Stuff().instancestuff(42)
 
         d.collector.wait(
-            lambda q: Counter(s.probe.probe_id for s in q)
-            == {
-                "probe-instance-method-0": 2,
-                "probe-instance-method-2": 2,
-                "probe-instance-method-1": 1,
-            }
+            lambda q: (
+                Counter(s.probe.probe_id for s in q)
+                == {
+                    "probe-instance-method-0": 2,
+                    "probe-instance-method-2": 2,
+                    "probe-instance-method-1": 1,
+                }
+            )
         )
 
         d.remove_probes(probes[0], probes[2])
@@ -551,6 +555,8 @@ def test_debugger_multiple_function_probes_on_same_lazy_module():
 
 # DEV: The following tests are to ensure compatibility with the tracer
 import wrapt  # noqa:E402,F401
+
+from ddtrace.internal.settings import env  # noqa: E402
 
 
 def wrapper(wrapped, instance, args, kwargs):
@@ -904,10 +910,10 @@ def test_debugger_run_module():
 
     # This is also where the sitecustomize resides, so we set the PYTHONPATH
     # accordingly. This is responsible for booting the test debugger
-    env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join((cwd, env.get("PYTHONPATH", "")))
+    subenv = env.copy()
+    subenv["PYTHONPATH"] = os.pathsep.join((cwd, subenv.get("PYTHONPATH", "")))
 
-    out, err, status, _ = call_program(sys.executable, "-m", "target", cwd=cwd, env=env)
+    out, err, status, _ = call_program(sys.executable, "-m", "target", cwd=cwd, env=subenv)
 
     assert out.strip() == b"OK", err.decode()
     assert status == 0

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,9 +1,10 @@
 import copy
-import os
 import platform
 import subprocess
 import sys
 import textwrap
+
+from ddtrace.internal.settings import env
 
 
 # Code need to be run in a separate subprocess to reload since reloading .so files doesn't
@@ -40,7 +41,7 @@ if __name__ == "__main__":
         print("Running native IAST module load test...")
         test_code = textwrap.dedent(test_native_load_code)
         cmd = [sys.executable, "-c", test_code]
-        orig_env = os.environ.copy()
+        orig_env = env.copy()
         copied_env = copy.deepcopy(orig_env)
 
         try:
@@ -59,7 +60,7 @@ if __name__ == "__main__":
             )
             print("IAST module load tests completed successfully")
         finally:
-            os.environ = orig_env
+            env = orig_env
 
     # ASM WAF smoke test
     if platform.system() != "Linux" or sys.maxsize > 2**32:

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,6 +1,6 @@
-import os
-
 import pytest
+
+from ddtrace.internal.settings import env
 
 
 def test_enable(test_agent_session, run_python_code_in_subprocess):
@@ -44,10 +44,10 @@ else:
     # Print the parent process runtime id for validation
     print(get_runtime_id())
     """
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
     assert stderr == b"", stderr
 
@@ -84,10 +84,10 @@ from ddtrace.internal.telemetry import telemetry_writer
 telemetry_writer.reset_queues()
 telemetry_writer.periodic(force_flush=True)
     """
-    env = os.environ.copy()
-    env["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = "false"
+    subenv = env.copy()
+    subenv["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = "false"
     # Prevents dependencies loaded event from being generated
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    stdout, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
     assert stderr == b"", stderr
 
@@ -113,9 +113,9 @@ assert telemetry_writer.interval == 10
 assert telemetry_writer._periodic_threshold == 5
     """
 
-    env = os.environ.copy()
-    env["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = "61"
-    _, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = "61"
+    _, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
     assert stderr == b""
 
@@ -227,9 +227,9 @@ from ddtrace import patch, tracer
 patch(raise_errors=False, sqlite3=True)
 """
 
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
-    _, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    _, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
 
     assert status == 0, stderr
     assert b"failed to enable ddtrace support for sqlite3" in stderr
@@ -293,8 +293,8 @@ f.wsgi_app()
 
 
 def test_app_started_with_install_metrics(test_agent_session, run_python_code_in_subprocess):
-    env = os.environ.copy()
-    env.update(
+    subenv = env.copy()
+    subenv.update(
         {
             "DD_INSTRUMENTATION_INSTALL_ID": "68e75c48-57ca-4a12-adfc-575c4b05fcbe",
             "DD_INSTRUMENTATION_INSTALL_TYPE": "k8s_single_step",
@@ -303,7 +303,7 @@ def test_app_started_with_install_metrics(test_agent_session, run_python_code_in
         }
     )
     # Generate a trace to trigger app-started event
-    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace", env=env)
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace", env=subenv)
     assert status == 0, stderr
 
     app_started_event = test_agent_session.get_events("app-started")
@@ -317,8 +317,8 @@ def test_app_started_with_install_metrics(test_agent_session, run_python_code_in
 
 def test_instrumentation_telemetry_disabled(test_agent_session, run_python_code_in_subprocess):
     """Ensure no telemetry events are sent when telemetry is disabled"""
-    env = os.environ.copy()
-    env["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
+    subenv = env.copy()
+    subenv["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
 
     code = """
 from ddtrace.trace import tracer
@@ -327,7 +327,7 @@ from ddtrace.trace import tracer
 import sys
 assert "ddtrace.internal.telemetry" in sys.modules
 """
-    _, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
 
     events = test_agent_session.get_events()
     assert len(events) == 0
@@ -356,13 +356,13 @@ def test_installed_excepthook():
 def test_telemetry_multiple_sources(test_agent_session, run_python_code_in_subprocess):
     """Test that a config is submitted for multiple sources with increasing seq_id"""
 
-    env = os.environ.copy()
-    env["OTEL_TRACES_EXPORTER"] = "none"
-    env["DD_TRACE_ENABLED"] = "false"
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["OTEL_TRACES_EXPORTER"] = "none"
+    subenv["DD_TRACE_ENABLED"] = "false"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
     _, err, status, _ = run_python_code_in_subprocess(
-        "from ddtrace import config; config._tracing_enabled = True", env=env
+        "from ddtrace import config; config._tracing_enabled = True", env=subenv
     )
     assert status == 0, err
 
@@ -399,10 +399,10 @@ if pid1 == 0:
 else:
     os.waitpid(pid1, 0)
 """
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # One representative request per process
@@ -443,13 +443,13 @@ else:
 def test_extended_heartbeat_sent(collect_dependencies, ddtrace_run_python_code_in_subprocess, test_agent_session):
     """Assert at least one extended heartbeat is sent when the extended heartbeat interval has elapsed."""
 
-    env = os.environ.copy()
-    env["_DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL"] = "1"
-    env["DD_TELEMETRY_LOG_COLLECTION_ENABLED"] = "0.1"
-    env["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = str(collect_dependencies)
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL"] = "1"
+    subenv["DD_TELEMETRY_LOG_COLLECTION_ENABLED"] = "0.1"
+    subenv["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = str(collect_dependencies)
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess("import time; time.sleep(1.5)", env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess("import time; time.sleep(1.5)", env=subenv)
     assert status == 0, stderr
     assert stderr == b""
 

--- a/tests/telemetry/test_telemetry_metrics.py
+++ b/tests/telemetry/test_telemetry_metrics.py
@@ -1,8 +1,8 @@
-import os
 from time import sleep
 
 from mock.mock import ANY
 
+from ddtrace.internal.settings import env
 from ddtrace.internal.telemetry.constants import TELEMETRY_EVENT_TYPE
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -369,10 +369,10 @@ headers = {
 context = HTTPPropagator.extract(headers)
 """
 
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # Get extraction telemetry metrics
@@ -413,10 +413,10 @@ headers = {}
 HTTPPropagator.inject(context, headers)
 """
 
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # Get injection telemetry metrics
@@ -463,10 +463,10 @@ headers_items = {}
 HTTPPropagator.inject(context_items, headers_items)
 """
 
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # Get baggage truncation metrics
@@ -499,10 +499,10 @@ headers_bytes = {}
 HTTPPropagator.inject(context_bytes, headers_bytes)
 """
 
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # Get baggage truncation metrics
@@ -529,10 +529,10 @@ malformed_headers = {"baggage": "invalid,test=value"}
 HTTPPropagator.extract(malformed_headers)
 """
 
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # Get malformed baggage metrics

--- a/tests/telemetry/test_telemetry_metrics_e2e.py
+++ b/tests/telemetry/test_telemetry_metrics_e2e.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
+from ddtrace.internal.settings import env
 from ddtrace.internal.utils.retry import RetryError
 from tests.utils import _build_env
 from tests.webclient import Client
@@ -21,7 +22,7 @@ def gunicorn_server(telemetry_metrics_enabled="true", token=None):
     cmd = ["ddtrace-run", "gunicorn", "-w", "1", "-b", "0.0.0.0:8000", "tests.telemetry.app:app"]
     env = _build_env(file_path=FILE_PATH)
     env["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"] = "X-Datadog-Test-Session-Token:{}".format(token)
-    env["DD_TRACE_AGENT_URL"] = os.environ.get("DD_TRACE_AGENT_URL", "")
+    env["DD_TRACE_AGENT_URL"] = env.get("DD_TRACE_AGENT_URL", "")
     env["DD_TRACE_DEBUG"] = "true"
     # do not patch flask because we will end up with confusing metrics
     # now that we generate metrics for spans
@@ -97,9 +98,9 @@ for _ in range(10):
         span.set_tag("component", "custom")
         pass
 """
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
     metrics_sc = test_agent_session.get_metrics("spans_created")
 
@@ -124,10 +125,10 @@ for _ in range(9):
     with ot.start_span('span'):
         pass
 """
-    env = os.environ.copy()
-    env["DD_TRACE_OTEL_ENABLED"] = "true"
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
+    subenv = env.copy()
+    subenv["DD_TRACE_OTEL_ENABLED"] = "true"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     metrics_sc = test_agent_session.get_metrics("spans_created")

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import sysconfig
 import time
@@ -10,6 +9,7 @@ import httpretty
 import pytest
 
 from ddtrace import config
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import get_agent_hostname
 from ddtrace.internal.settings._telemetry import config as telemetry_config
 import ddtrace.internal.telemetry
@@ -40,11 +40,11 @@ def test_app_started_event_configuration_override_asm(
     test_agent_session, run_python_code_in_subprocess, env_var, value, expected_value
 ):
     """asserts that asm configuration value is changed and queues a valid telemetry request"""
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
-    env["DD_APPSEC_ENABLED"] = "true"
-    env[env_var] = value
-    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace.auto", env=env)
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv["DD_APPSEC_ENABLED"] = "true"
+    subenv[env_var] = value
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace.auto", env=subenv)
     assert status == 0, stderr
 
     configuration = test_agent_session.get_configurations(name=env_var, remove_seq_id=True, effective=True)
@@ -84,72 +84,72 @@ import ddtrace.internal.settings.exception_replay
 import opentelemetry
     """
 
-    env = os.environ.copy()
+    subenv = env.copy()
     # Change configuration default values
-    env["DD_EXCEPTION_REPLAY_ENABLED"] = "True"
-    env["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "True"
-    env["DD_TRACE_STARTUP_LOGS"] = "True"
-    env["DD_LOGS_INJECTION"] = "True"
-    env["DD_DATA_STREAMS_ENABLED"] = "true"
-    env["DD_APPSEC_ENABLED"] = "False"
-    env["DD_RUNTIME_METRICS_ENABLED"] = "True"
-    env["DD_SERVICE_MAPPING"] = "default_dd_service:remapped_dd_service"
-    env["DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED"] = "True"
-    env["DD_TRACE_CLIENT_IP_ENABLED"] = "True"
-    env["DD_TRACE_COMPUTE_STATS"] = "True"
-    env["DD_TRACE_DEBUG"] = "True"
-    env["DD_TRACE_ENABLED"] = "False"
-    env["DD_TRACE_HEALTH_METRICS_ENABLED"] = "True"
-    env["DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP"] = ".*"
-    env["DD_TRACE_OTEL_ENABLED"] = "True"
-    env["DD_TRACE_PROPAGATION_STYLE_EXTRACT"] = "tracecontext"
-    env["DD_TRACE_PROPAGATION_STYLE_INJECT"] = "tracecontext"
-    env["DD_REMOTE_CONFIGURATION_ENABLED"] = "True"
-    env["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS"] = "1"
-    env["DD_TRACE_RATE_LIMIT"] = "50"
-    env["DD_TRACE_SAMPLING_RULES"] = '[{"sample_rate":1.0,"service":"xyz","name":"abc"}]'
-    env["DD_PROFILING_ENABLED"] = "True"
-    env["DD_PROFILING_STACK_ENABLED"] = "False"
-    env["DD_PROFILING_MEMORY_ENABLED"] = "False"
-    env["DD_PROFILING_HEAP_ENABLED"] = "False"
-    env["DD_PROFILING_LOCK_ENABLED"] = "False"
-    env["DD_PROFILING_CAPTURE_PCT"] = "5.0"
-    env["DD_PROFILING_UPLOAD_INTERVAL"] = "10.0"
-    env["DD_PROFILING_MAX_FRAMES"] = "512"
-    env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
-    env["DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED"] = "True"
-    env["DD_TRACE_PEER_SERVICE_MAPPING"] = "default_service:remapped_service"
-    env["DD_TRACE_API_VERSION"] = "v0.5"
-    env["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
-    env["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "9999"
-    env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "30"
-    env["DD_TRACE_WRITER_REUSE_CONNECTIONS"] = "True"
-    env["DD_TAGS"] = "team:apm,component:web"
-    env["DD_INSTRUMENTATION_CONFIG_ID"] = "abcedf123"
-    env["DD_LOGS_OTEL_ENABLED"] = "True"
-    env["DD_METRICS_OTEL_ENABLED"] = "True"
-    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4317"
+    subenv["DD_EXCEPTION_REPLAY_ENABLED"] = "True"
+    subenv["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "True"
+    subenv["DD_TRACE_STARTUP_LOGS"] = "True"
+    subenv["DD_LOGS_INJECTION"] = "True"
+    subenv["DD_DATA_STREAMS_ENABLED"] = "true"
+    subenv["DD_APPSEC_ENABLED"] = "False"
+    subenv["DD_RUNTIME_METRICS_ENABLED"] = "True"
+    subenv["DD_SERVICE_MAPPING"] = "default_dd_service:remapped_dd_service"
+    subenv["DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED"] = "True"
+    subenv["DD_TRACE_CLIENT_IP_ENABLED"] = "True"
+    subenv["DD_TRACE_COMPUTE_STATS"] = "True"
+    subenv["DD_TRACE_DEBUG"] = "True"
+    subenv["DD_TRACE_ENABLED"] = "False"
+    subenv["DD_TRACE_HEALTH_METRICS_ENABLED"] = "True"
+    subenv["DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP"] = ".*"
+    subenv["DD_TRACE_OTEL_ENABLED"] = "True"
+    subenv["DD_TRACE_PROPAGATION_STYLE_EXTRACT"] = "tracecontext"
+    subenv["DD_TRACE_PROPAGATION_STYLE_INJECT"] = "tracecontext"
+    subenv["DD_REMOTE_CONFIGURATION_ENABLED"] = "True"
+    subenv["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS"] = "1"
+    subenv["DD_TRACE_RATE_LIMIT"] = "50"
+    subenv["DD_TRACE_SAMPLING_RULES"] = '[{"sample_rate":1.0,"service":"xyz","name":"abc"}]'
+    subenv["DD_PROFILING_ENABLED"] = "True"
+    subenv["DD_PROFILING_STACK_ENABLED"] = "False"
+    subenv["DD_PROFILING_MEMORY_ENABLED"] = "False"
+    subenv["DD_PROFILING_HEAP_ENABLED"] = "False"
+    subenv["DD_PROFILING_LOCK_ENABLED"] = "False"
+    subenv["DD_PROFILING_CAPTURE_PCT"] = "5.0"
+    subenv["DD_PROFILING_UPLOAD_INTERVAL"] = "10.0"
+    subenv["DD_PROFILING_MAX_FRAMES"] = "512"
+    subenv["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
+    subenv["DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED"] = "True"
+    subenv["DD_TRACE_PEER_SERVICE_MAPPING"] = "default_service:remapped_service"
+    subenv["DD_TRACE_API_VERSION"] = "v0.5"
+    subenv["DD_TRACE_WRITER_BUFFER_SIZE_BYTES"] = "1000"
+    subenv["DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES"] = "9999"
+    subenv["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "30"
+    subenv["DD_TRACE_WRITER_REUSE_CONNECTIONS"] = "True"
+    subenv["DD_TAGS"] = "team:apm,component:web"
+    subenv["DD_INSTRUMENTATION_CONFIG_ID"] = "abcedf123"
+    subenv["DD_LOGS_OTEL_ENABLED"] = "True"
+    subenv["DD_METRICS_OTEL_ENABLED"] = "True"
+    subenv["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4317"
 
     file = tmpdir.join("moon_ears.json")
     file.write('[{"service":"xy?","name":"a*c"}]')
-    env["DD_SPAN_SAMPLING_RULES"] = '[{"service":"xyz", "sample_rate":0.23}]'
-    env["DD_SPAN_SAMPLING_RULES_FILE"] = str(file)
-    env["DD_TRACE_PARTIAL_FLUSH_ENABLED"] = "false"
-    env["DD_TRACE_PARTIAL_FLUSH_MIN_SPANS"] = "3"
-    env["DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT"] = "restart"
-    env["DD_SITE"] = "datadoghq.com"
-    env["DD_APPSEC_RASP_ENABLED"] = "False"
-    env["DD_API_SECURITY_ENABLED"] = "False"
-    env["DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED"] = "False"
-    env["DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE"] = "disabled"
-    env["DD_INJECT_FORCE"] = "true"
-    env["DD_INJECTION_ENABLED"] = "tracer"
+    subenv["DD_SPAN_SAMPLING_RULES"] = '[{"service":"xyz", "sample_rate":0.23}]'
+    subenv["DD_SPAN_SAMPLING_RULES_FILE"] = str(file)
+    subenv["DD_TRACE_PARTIAL_FLUSH_ENABLED"] = "false"
+    subenv["DD_TRACE_PARTIAL_FLUSH_MIN_SPANS"] = "3"
+    subenv["DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT"] = "restart"
+    subenv["DD_SITE"] = "datadoghq.com"
+    subenv["DD_APPSEC_RASP_ENABLED"] = "False"
+    subenv["DD_API_SECURITY_ENABLED"] = "False"
+    subenv["DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED"] = "False"
+    subenv["DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE"] = "disabled"
+    subenv["DD_INJECT_FORCE"] = "true"
+    subenv["DD_INJECTION_ENABLED"] = "tracer"
 
     # Ensures app-started event is queued immediately after ddtrace is imported
     # instead of waiting for 10 seconds.
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    _, stderr, status, _ = run_python_code_in_subprocess(code, env=subenv)
     assert status == 0, stderr
 
     # DD_TRACE_AGENT_URL in gitlab is different from CI, to keep things simple we will
@@ -521,24 +521,24 @@ import opentelemetry
 
 
 def test_update_dependencies_event(test_agent_session, ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     # app-started events are sent 10 seconds after ddtrace imported, this configuration overrides this
     # behavior to force the app-started event to be queued immediately
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
     # Import httppretty after ddtrace is imported, this ensures that the module is sent in a dependencies event
     # Imports httpretty twice and ensures only one dependency entry is sent
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess("import xmltodict", env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess("import xmltodict", env=subenv)
     assert status == 0, stderr
     deps = test_agent_session.get_dependencies("xmltodict")
     assert len(deps) == 1, deps
 
 
 def test_endpoint_discovery_event(test_agent_session, ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     # app-started events are sent 10 seconds after ddtrace imported, this configuration overrides this
     # behavior to force the app-started event to be queued immediately
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
     # Import httppretty after ddtrace is imported, this ensures that the module is sent in a dependencies event
     # Imports httpretty twice and ensures only one dependency entry is sent
@@ -580,7 +580,7 @@ def mini_app(request):
 urlpatterns = [ path('mini_app/',mini_app), path('view_name/', view_name) ]
 """
 
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(mini_django_app, env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(mini_django_app, env=subenv)
     assert status == 0, stderr
     deps = test_agent_session.get_dependencies("django")
     assert len(deps) == 1, deps
@@ -606,46 +606,46 @@ urlpatterns = [ path('mini_app/',mini_app), path('view_name/', view_name) ]
 def test_instrumentation_source_config(
     test_agent_session, ddtrace_run_python_code_in_subprocess, run_python_code_in_subprocess
 ):
-    env = os.environ.copy()
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = call_program("ddtrace-run", sys.executable, "-c", "", env=env)
+    _, stderr, status, _ = call_program("ddtrace-run", sys.executable, "-c", "", env=subenv)
     assert status == 0, stderr
     configs = test_agent_session.get_configurations("instrumentation_source")
     assert configs and configs[-1]["value"] == "cmd_line"
     test_agent_session.clear()
 
-    _, stderr, status, _ = call_program(sys.executable, "-c", "import ddtrace.auto", env=env)
+    _, stderr, status, _ = call_program(sys.executable, "-c", "import ddtrace.auto", env=subenv)
     assert status == 0, stderr
     configs = test_agent_session.get_configurations("instrumentation_source")
     assert configs and configs[-1]["value"] == "manual"
     test_agent_session.clear()
 
-    _, stderr, status, _ = call_program(sys.executable, "-c", "import ddtrace", env=env)
+    _, stderr, status, _ = call_program(sys.executable, "-c", "import ddtrace", env=subenv)
     assert status == 0, stderr
     configs = test_agent_session.get_configurations("instrumentation_source")
     assert not configs, "instrumentation_source should not be set when ddtrace instrumentation is not used"
 
 
 def test_update_dependencies_event_when_disabled(test_agent_session, ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     # app-started events are sent 10 seconds after ddtrace imported, this configuration overrides this
     # behavior to force the app-started event to be queued immediately
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
-    env["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = "false"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = "false"
 
     # Import httppretty after ddtrace is imported, this ensures that the module is sent in a dependencies event
     # Imports httpretty twice and ensures only one dependency entry is sent
-    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess("import xmltodict", env=env)
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess("import xmltodict", env=subenv)
     events = test_agent_session.get_events("app-dependencies-loaded")
     assert len(events) == 0, events
 
 
 def test_update_dependencies_event_not_stdlib(test_agent_session, ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
+    subenv = env.copy()
     # app-started events are sent 10 seconds after ddtrace imported, this configuration overrides this
     # behavior to force the app-started event to be queued immediately
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
     # Import httppretty after ddtrace is imported, this ensures that the module is sent in a dependencies event
     # Imports httpretty twice and ensures only one dependency entry is sent
@@ -656,7 +656,7 @@ import httpretty
 del sys.modules["httpretty"]
 import httpretty
 """,
-        env=env,
+        env=subenv,
     )
     assert status == 0, stderr
     deps = test_agent_session.get_dependencies("httpretty")
@@ -944,21 +944,21 @@ def test_otel_config_telemetry(test_agent_session, run_python_code_in_subprocess
     asserts that telemetry data is submitted for OpenTelemetry configurations
     """
 
-    env = os.environ.copy()
-    env["DD_SERVICE"] = "dd_service"
-    env["OTEL_SERVICE_NAME"] = "otel_service"
-    env["OTEL_LOG_LEVEL"] = "DEBUG"
-    env["OTEL_PROPAGATORS"] = "tracecontext"
-    env["OTEL_TRACES_SAMPLER"] = "always_on"
-    env["OTEL_TRACES_EXPORTER"] = "none"
-    env["OTEL_LOGS_EXPORTER"] = "otlp"
-    env["OTEL_METRICS_EXPORTER"] = "otlp"
-    env["OTEL_RESOURCE_ATTRIBUTES"] = "team=apm,component=web"
-    env["OTEL_SDK_DISABLED"] = "true"
-    env["OTEL_UNSUPPORTED_CONFIG"] = "value"
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    subenv = env.copy()
+    subenv["DD_SERVICE"] = "dd_service"
+    subenv["OTEL_SERVICE_NAME"] = "otel_service"
+    subenv["OTEL_LOG_LEVEL"] = "DEBUG"
+    subenv["OTEL_PROPAGATORS"] = "tracecontext"
+    subenv["OTEL_TRACES_SAMPLER"] = "always_on"
+    subenv["OTEL_TRACES_EXPORTER"] = "none"
+    subenv["OTEL_LOGS_EXPORTER"] = "otlp"
+    subenv["OTEL_METRICS_EXPORTER"] = "otlp"
+    subenv["OTEL_RESOURCE_ATTRIBUTES"] = "team=apm,component=web"
+    subenv["OTEL_SDK_DISABLED"] = "true"
+    subenv["OTEL_UNSUPPORTED_CONFIG"] = "value"
+    subenv["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace", env=env)
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace", env=subenv)
     assert status == 0, stderr
 
     configurations = {c["name"]: c for c in test_agent_session.get_configurations(remove_seq_id=True, effective=True)}
@@ -996,15 +996,15 @@ def test_otel_config_telemetry(test_agent_session, run_python_code_in_subprocess
         "value": "true",
     }
 
-    env_hiding_metrics = test_agent_session.get_metrics("otel.env.hiding")
+    env_hiding_metrics = test_agent_session.get_metrics("otel.subenv.hiding")
     tags = [m["tags"] for m in env_hiding_metrics]
     assert tags == [["config_opentelemetry:otel_service_name", "config_datadog:dd_service"]]
 
-    env_unsupported_metrics = test_agent_session.get_metrics("otel.env.unsupported")
+    env_unsupported_metrics = test_agent_session.get_metrics("otel.subenv.unsupported")
     tags = [m["tags"] for m in env_unsupported_metrics]
     assert tags == [["config_opentelemetry:otel_unsupported_config"]]
 
-    env_invalid_metrics = test_agent_session.get_metrics("otel.env.invalid")
+    env_invalid_metrics = test_agent_session.get_metrics("otel.subenv.invalid")
     tags = [m["tags"] for m in env_invalid_metrics]
     assert tags == [["config_opentelemetry:otel_logs_exporter"]]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,6 @@ from http.client import RemoteDisconnected
 import importlib.metadata as importlib_metadata
 import inspect
 import json
-import os
 from pathlib import Path
 import subprocess
 import sys
@@ -37,6 +36,7 @@ from ddtrace.internal.packages import filename_to_package
 from ddtrace.internal.packages import is_third_party
 from ddtrace.internal.remoteconfig import Payload
 from ddtrace.internal.schema import SCHEMA_VERSION
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._database_monitoring import dbm_config
 from ddtrace.internal.settings.asm import config as asm_config
@@ -90,24 +90,24 @@ def override_env(env, replace_os_env=False):
             # Your test
     """
     # Copy the full original environment
-    original = dict(os.environ)
+    original = dict(env)
 
     # We allow callers to clear out the environment to prevent leaking variables into the test
     if replace_os_env:
-        os.environ.clear()
+        env.clear()
 
-    for k in os.environ.keys():
+    for k in env.keys():
         if k.startswith(("_CI_DD_", "DD_CIVISIBILITY_", "DD_SITE")):
-            del os.environ[k]
+            del env[k]
 
     # Update based on the passed in arguments
-    os.environ.update(env)
+    env.update(env)
     try:
         yield
     finally:
         # Full clear the environment out and reset back to the original
-        os.environ.clear()
-        os.environ.update(original)
+        env.clear()
+        env.update(original)
 
 
 @contextlib.contextmanager
@@ -1248,9 +1248,9 @@ def snapshot_context(
                 tracer._span_aggregator.writer._headers["X-Datadog-Test-Session-Token"] = token
 
             # Also add a header to the environment for subprocesses test cases that might use snapshotting.
-            existing_headers = parse_tags_str(os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS", ""))
+            existing_headers = parse_tags_str(env.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS", ""))
             existing_headers.update({"X-Datadog-Test-Session-Token": token})
-            os.environ["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"] = ",".join(
+            env["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"] = ",".join(
                 ["%s:%s" % (k, v) for k, v in existing_headers.items()]
             )
         try:
@@ -1288,7 +1288,7 @@ def snapshot_context(
                     tracer._span_aggregator.writer.set_test_session_token(None)
                 else:
                     del tracer._span_aggregator.writer._headers["X-Datadog-Test-Session-Token"]
-                del os.environ["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"]
+                del env["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"]
 
         conn = httplib.HTTPConnection(parsed.hostname, parsed.port)
 
@@ -1490,7 +1490,7 @@ def check_test_agent_status():
 
 
 def add_dd_env_variables_to_headers(headers):
-    dd_env_vars = {key: value for key, value in os.environ.items() if key.startswith("DD_")}
+    dd_env_vars = {key: value for key, value in env.items() if key.startswith("DD_")}
     dd_env_vars["DD_SERVICE"] = dd_config.service
     dd_env_vars["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = SCHEMA_VERSION
 
@@ -1516,10 +1516,10 @@ def _build_env(env=None, file_path=FILE_PATH):
     CI environments
     """
     environ = dict(PATH="%s:%s" % (DDTRACE_PATH, file_path), PYTHONPATH="%s:%s" % (DDTRACE_PATH, file_path))
-    if os.environ.get("PATH"):
-        environ["PATH"] = "%s:%s" % (os.environ.get("PATH"), environ["PATH"])
-    if os.environ.get("PYTHONPATH"):
-        environ["PYTHONPATH"] = "%s:%s" % (os.environ.get("PYTHONPATH"), environ["PYTHONPATH"])
+    if env.get("PATH"):
+        environ["PATH"] = "%s:%s" % (env.get("PATH"), environ["PATH"])
+    if env.get("PYTHONPATH"):
+        environ["PYTHONPATH"] = "%s:%s" % (env.get("PYTHONPATH"), environ["PYTHONPATH"])
     if env:
         for k, v in env.items():
             environ[k] = v


### PR DESCRIPTION
## Description

Migrates 9 test files with mixed ownership from \`os.environ\`/\`os.getenv\` to \`ddtrace.internal.settings.env\`.

| Path | Owner |
|------|-------|
| \`tests/telemetry/\` (4 files) | \`apm-python\` |
| \`tests/debugging/\` (2 files) | \`debugger-python\` |
| \`tests/smoke_test.py\` | \`python-guild\` |
| \`tests/utils.py\` | \`python-guild\` |
| \`tests/datastreams/test_processor.py\` | \`data-streams-monitoring\` |

## Testing

No behavior change. Existing tests validate correctness.

## Risks

None. \`env\` is a \`MutableMapping\` drop-in for \`os.environ\`.

## Additional Notes

Part of the \`os.environ\` → \`ddtrace.internal.settings.env\` migration campaign.
Depends on #17344 (adds \`env.copy()\` to \`EnvConfig\`) — merge that first.

Mechanical change: all \`os.environ\`/\`os.getenv\` references replaced with \`env\` from \`ddtrace.internal.settings\`. No logic changes.