### PR TITLE
test(flare): resolve flaky tracer flare tests

### DIFF
--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -47,6 +47,12 @@ class TracerFlareTests(unittest.TestCase):
         self.tmp_path = tmp_path
         self._caplog = caplog
 
+    @fibonacci_backoff_with_jitter(attempts=5, initial_wait=0.1)
+    def _start_session(self):
+        status, body = self.testagent_client._request("GET", self.testagent_client._url("/test/session/start"))
+        assert status == 200, f"Failed to start test session: status={status}, body={body.decode('utf-8')}"
+        self.testagent_client.clear()
+
     def setUp(self):
         # Defensive cleanup: remove any pre-existing tracer flare handlers
         self._remove_handlers()
@@ -61,9 +67,7 @@ class TracerFlareTests(unittest.TestCase):
         )
         self.testagent_token = f"tracer-flare-{uuid4().hex}"
         self.testagent_client = _TestAgentClient(base_url=TRACE_AGENT_URL, token=self.testagent_token)
-        status, _ = self.testagent_client._request("GET", self.testagent_client._url("/test/session/start"))
-        if status == 200:
-            self.testagent_client.clear()
+        self._start_session()
         self.pid = os.getpid()
         self.flare_file_path = str(self.shared_dir / f"tracer_python_{self.pid}.log")
         self.config_file_path = str(self.shared_dir / f"tracer_config_{self.pid}.json")
@@ -77,11 +81,17 @@ class TracerFlareTests(unittest.TestCase):
             pass
         self.confirm_cleanup()
 
-    def _flare_upload_count(self) -> int:
+    @fibonacci_backoff_with_jitter(
+        attempts=10, initial_wait=0.1, until=lambda result: not isinstance(result, Exception)
+    )
+    def _flare_upload_count(self, expected_count: Optional[int] = None) -> int:
         status, body = self.testagent_client._request("GET", self.testagent_client._url("/test/session/requests"))
-        assert status == 200
+        assert status == 200, f"Failed to get test session requests: status={status}, body={body.decode('utf-8')}"
         requests = json.loads(body)
-        return sum(1 for req in requests if (req.get("url") or "").endswith("/tracer_flare/v1"))
+        count = sum(1 for req in requests if (req.get("url") or "").endswith("/tracer_flare/v1"))
+        if expected_count is not None:
+            assert count == expected_count, f"Expected {expected_count} uploads, found {count}"
+        return count
 
     def _get_handler(self) -> Optional[logging.Handler]:
         ddlogger = get_logger("ddtrace")
@@ -266,7 +276,7 @@ class TracerFlareTests(unittest.TestCase):
         uploads_before = self._flare_upload_count()
         self.flare.send(non_numeric_request)
         # Verify that zip_and_send was not attempted
-        assert self._flare_upload_count() == uploads_before
+        self._flare_upload_count(uploads_before)
 
         # Need to prepare again since the previous send would have cleaned up the flare dir and handlers
         self.flare.revert_configs()
@@ -284,7 +294,7 @@ class TracerFlareTests(unittest.TestCase):
         # This should succeed as it matches the pattern \d+-(with-debug|with-content)
         uploads_before = self._flare_upload_count()
         self.flare.send(special_char_request)
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
 
         # Need to prepare again since the previous send would have cleaned up the flare dir and handlers
         self.flare.revert_configs()
@@ -302,7 +312,7 @@ class TracerFlareTests(unittest.TestCase):
         uploads_before = self._flare_upload_count()
         self.flare.send(valid_request)
         # Verify that zip_and_send was attempted for valid case_id
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
 
         # Need to prepare again since the previous send would have cleaned up the flare dir and handlers
         self.flare.revert_configs()
@@ -319,7 +329,7 @@ class TracerFlareTests(unittest.TestCase):
 
         uploads_before = self._flare_upload_count()
         self.flare.send(empty_case_request)
-        assert self._flare_upload_count() == uploads_before
+        self._flare_upload_count(uploads_before)
 
     def test_case_id_cannot_be_zero(self):
         """
@@ -341,7 +351,7 @@ class TracerFlareTests(unittest.TestCase):
         uploads_before = self._flare_upload_count()
         self.flare.send(zero_case_request)
         # Verify that zip_and_send was not attempted
-        assert self._flare_upload_count() == uploads_before
+        self._flare_upload_count(uploads_before)
 
         # Need to prepare again since the previous send would have cleaned up the flare dir and handlers
         self.flare.revert_configs()
@@ -359,7 +369,7 @@ class TracerFlareTests(unittest.TestCase):
         uploads_before = self._flare_upload_count()
         self.flare.send(valid_request)
         # Verify that zip_and_send was attempted for valid case_id
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
 
     def test_flare_dir_cleaned_on_all_send_exit_points(self):
         """
@@ -380,7 +390,7 @@ class TracerFlareTests(unittest.TestCase):
         print(f"zero_case_request: {zero_case_request}")
         uploads_before = self._flare_upload_count()
         self.flare.send(zero_case_request)
-        assert self._flare_upload_count() == uploads_before
+        self._flare_upload_count(uploads_before)
         assert not self.flare.flare_dir.exists()
 
         # Need to prepare again since the previous send would have cleaned up the flare dir and handlers
@@ -397,7 +407,7 @@ class TracerFlareTests(unittest.TestCase):
         )
         uploads_before = self._flare_upload_count()
         self.flare.send(valid_request)
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
         assert not self.flare.flare_dir.exists()
 
     def test_prepare_creates_flare_dir(self):
@@ -457,7 +467,7 @@ class TracerFlareTests(unittest.TestCase):
 
         uploads_before = self._flare_upload_count()
         self.flare.send(valid_request)
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
 
         self.flare.revert_configs()
         self.flare.prepare("DEBUG")
@@ -469,7 +479,7 @@ class TracerFlareTests(unittest.TestCase):
 
         uploads_before = self._flare_upload_count()
         self.flare.send(empty_uuid_request)
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
 
     def test_config_file_contents_validation(self):
         """
@@ -703,14 +713,18 @@ class TracerFlareSubscriberTests(unittest.TestCase):
     def inject_fixtures(self, tmp_path):
         self.tmp_path = tmp_path
 
+    @fibonacci_backoff_with_jitter(attempts=5, initial_wait=0.1)
+    def _start_session(self):
+        status, body = self.testagent_client._request("GET", self.testagent_client._url("/test/session/start"))
+        assert status == 200, f"Failed to start test session: status={status}, body={body.decode('utf-8')}"
+        self.testagent_client.clear()
+
     def setUp(self):
         self.shared_dir = self.tmp_path / "tracer_flare_test"
         self.shared_dir.mkdir(parents=True, exist_ok=True)
         self.testagent_token = f"tracer-flare-sub-{uuid4().hex}"
         self.testagent_client = _TestAgentClient(base_url=TRACE_AGENT_URL, token=self.testagent_token)
-        status, _ = self.testagent_client._request("GET", self.testagent_client._url("/test/session/start"))
-        if status == 200:
-            self.testagent_client.clear()
+        self._start_session()
         self.connector = PublisherSubscriberConnector()
         self.tracer_flare_sub = TracerFlareSubscriber(
             data_connector=self.connector,
@@ -745,11 +759,17 @@ class TracerFlareSubscriberTests(unittest.TestCase):
         self.connector.write([build_payload("AGENT_TASK", self.agent_task, "task")])
         self.get_data_from_connector_and_exec()
 
-    def _flare_upload_count(self) -> int:
+    @fibonacci_backoff_with_jitter(
+        attempts=10, initial_wait=0.1, until=lambda result: not isinstance(result, Exception)
+    )
+    def _flare_upload_count(self, expected_count: Optional[int] = None) -> int:
         status, body = self.testagent_client._request("GET", self.testagent_client._url("/test/session/requests"))
-        assert status == 200
+        assert status == 200, f"Failed to get test session requests: status={status}, body={body.decode('utf-8')}"
         requests = json.loads(body)
-        return sum(1 for req in requests if (req.get("url") or "").endswith("/tracer_flare/v1"))
+        count = sum(1 for req in requests if (req.get("url") or "").endswith("/tracer_flare/v1"))
+        if expected_count is not None:
+            assert count == expected_count, f"Expected {expected_count} uploads, found {count}"
+        return count
 
     def test_process_flare_request_success(self):
         """
@@ -764,7 +784,7 @@ class TracerFlareSubscriberTests(unittest.TestCase):
 
         # Generate an AGENT_TASK product to complete the request
         self.generate_agent_task()
-        assert self._flare_upload_count() == uploads_before + 1
+        self._flare_upload_count(uploads_before + 1)
 
         # Timestamp cleared after request completed
         assert self.tracer_flare_sub.current_request_start is None, (


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5df161a2-aaed-48d6-a6b6-37e0c80647e5","source":"chat","resourceId":"193cf1ba-dff6-4d41-892a-8f474ab462ba","workflowId":"344baafb-c823-4965-ac27-4f9046a059be","codeChangeId":"344baafb-c823-4965-ac27-4f9046a059be","sourceType":"test-optimization"} -->
## Description

Fixing `TracerFlareTests::test_case_id_must_be_numeric[py3.10]` • [View in Test Optimization](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdd-trace-py%22+%40test.name%3A%22TracerFlareTests%3A%3Atest_case_id_must_be_numeric%5Bpy3.10%5D%22&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%228ff68ff39d4dd978%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D) • **Questions?** Ask in #code-gen-flaky-tests

This PR fixes the flakiness of the `TracerFlareTests::test_case_id_must_be_numeric` test (and others in the same suite).

The flakiness manifested as `assert 400 == 200` when calling `/test/session/requests` on the test agent, indicating that the test session was being lost or not correctly recognized by the test agent.

To address this, the following changes were made:
- Added a retry mechanism (using `fibonacci_backoff_with_jitter`) for starting the test agent session in `setUp`.
- Added a retry mechanism for getting the flare upload count, which now retries on any `Exception` (including `AssertionError` from a non-200 status).
- Updated the `_flare_upload_count` method to accept an `expected_count` parameter, allowing it to retry until the expected number of flare uploads is recorded.
- Updated all test cases to use this robust wait-and-assert mechanism for flare uploads.

These changes ensure that tests are resilient to transient test agent errors and handle potential delays in flare upload recording.

## Testing

Verified by code inspection and linting. Direct test execution was limited by environment proxy issues, but the implementation follows existing patterns for robust testing in this repository.

## Risks

Low. These changes only affect tests and use established retry patterns.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/193cf1ba-dff6-4d41-892a-8f474ab462ba)

Comment @datadog to request changes