### PR TITLE
chore(ci): disable serverless benchmarks to unblock the 4.5 branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,6 +110,9 @@ serverless lambda tests:
   needs:
     - job: "upload all"
   rules:
+    # NOTE: Temporary guard for 4.5 backports while downstream serverless setup fails independently of dd-trace-py changes.
+    - if: $CI_COMMIT_BRANCH == "4.5"
+      when: never
     - allow_failure: true
   variables:
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID

--- a/.gitlab/benchmarks/serverless.yml
+++ b/.gitlab/benchmarks/serverless.yml
@@ -10,6 +10,9 @@ benchmark-serverless:
   needs:
     - job: "upload all"
   rules:
+    # NOTE: Temporary guard for 4.5 backports while serverless-tools setup fails independently of dd-trace-py changes.
+    - if: $CI_COMMIT_BRANCH == "4.5"
+      when: never
     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
       allow_failure: true
     - allow_failure: false


### PR DESCRIPTION
## Description

Disable serverless benchmark and lambda test since they are failing for unrelated reasons and we need to fix some issues in the 4.5 branch and make a release.
