### PR TITLE
chore(ci): disable serverless benchmarks to unblock the 4.5 branch (again)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,9 +111,9 @@ serverless lambda tests:
     - job: "upload all"
   rules:
     # AIDEV-NOTE: Temporary guard for 4.5 backports while downstream serverless setup fails independently of dd-trace-py changes.
-    - if: $CI_COMMIT_BRANCH == "4.5"
+    - if: $CI_COMMIT_REF_NAME == "4.5"
       when: never
-    - if: $CI_COMMIT_BRANCH =~ /backport-4\.5$/
+    - if: $CI_COMMIT_REF_NAME =~ /backport-4\.5$/
       when: never
     - allow_failure: true
   variables:

--- a/.gitlab/benchmarks/serverless.yml
+++ b/.gitlab/benchmarks/serverless.yml
@@ -11,9 +11,9 @@ benchmark-serverless:
     - job: "upload all"
   rules:
     # AIDEV-NOTE: Temporary guard for 4.5 backports while serverless-tools setup fails independently of dd-trace-py changes.
-    - if: $CI_COMMIT_BRANCH == "4.5"
+    - if: $CI_COMMIT_REF_NAME == "4.5"
       when: never
-    - if: $CI_COMMIT_BRANCH =~ /backport-4\.5$/
+    - if: $CI_COMMIT_REF_NAME =~ /backport-4\.5$/
       when: never
     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
       allow_failure: true


### PR DESCRIPTION
Signed-off-by: Juanjo Alvarez <juanjo.alvarezmartinez@datadoghq.com>## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
