### PR TITLE
chore(ci): add test dd-sts manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ serverless lambda tests:
   trigger:
     project: DataDog/datadog-lambda-python
     strategy: depend
-    branch: main 
+    branch: main
   needs:
     - job: "upload serverless"
   variables:
@@ -602,3 +602,18 @@ profiling_native:
       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         MEMCPY_MODE: ["fast"]
         SANITIZER: ["safety", "thread"]
+
+test-dd-sts:
+  stage: tests
+  needs: []
+  tags: ["arch:amd64"]
+  when: manual
+  allow_failure: true
+  image: registry.ddbuild.io/images/mirror/ubuntu:24.04
+  id_tokens:
+    DD_STS_OIDC_TOKEN:
+      aud: rapid-seceng-sit
+  script:
+    - apt-get update && apt-get install -y curl
+    - 'curl -s -o /dev/null -w "API key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab"'
+    - 'curl -s -o /dev/null -w "APP key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key"'


### PR DESCRIPTION
## Description

We should use `dd-sts` in gitlab.


Adding a manual test job that queries `dd-sts` 

## Testing

This is the test

https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1573509692

## Risks

None, this is a one off manual job to verify `dd-sts` access
## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
