### PR TITLE
refactor(profiling): validate integer in `MirrorSet` construction

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc
@@ -9,14 +9,13 @@ MirrorSet::create(PyObject* set_addr)
         return ErrorKind::MirrorError;
     }
 
-    auto size = set.mask + 1;
-    // Validate size before multiplication to prevent integer overflow.
-    // Without this check, a large mask value could cause size * sizeof(setentry)
-    // to wrap around to a small value, passing the MAX_MIRROR_SIZE check while
-    // the actual size used in iteration remains huge.
-    if (size <= 0 || size > MAX_MIRROR_ITEMS) {
+    // Validate mask before adding 1 then multiplying to prevent signed integer overflow.
+    // The overflow could happen on the +1, or on the *sizeof(setentry), which either
+    // way would wrap to a negative value and cause memory issues.
+    if (set.mask < 0 || set.mask >= MAX_MIRROR_ITEMS) {
         return ErrorKind::MirrorError;
     }
+    auto size = set.mask + 1;
 
     ssize_t table_size = static_cast<ssize_t>(size * sizeof(setentry));
     auto data = std::make_unique<char[]>(table_size);


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13838

This PR fixes a fuzzer-reported undefined behaviour where we add `1` to a value without checking its value is less than the max integer value.

```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
  /src/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc:12:26 in
  /src/ddtrace/internal/datadog/profiling/stack/src/echion/mirrors.cc:12:26:
    runtime error: signed integer overflow: 9223372036854775807
```