### PR TITLE
Revert "ci: migrate system-tests to dd-sts"

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,11 +10,6 @@ on:
   schedule:
     - cron: '00 04 * * 2-6'
 
-permissions:
-  id-token: write
-  contents: read
-  packages: write
-
 jobs:
   should-run:
     runs-on: ubuntu-latest
@@ -327,17 +322,11 @@ jobs:
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-2'
         run: ./run.sh DEBUGGER_SYMDB
 
-      - name: Get Datadog credentials
-        id: dd-sts
-        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
-        with:
-          policy: dd-trace-py-github
-
       - name: Upload test results to Test Optimization
         if: always() && steps.docker_load.outcome == 'success'
         uses: DataDog/system-tests/.github/actions/push_to_test_optim@main
         with:
-          datadog_api_key: ${{ steps.dd-sts.outputs.api_key }}
+          datadog_api_key: ${{ secrets.DD_API_KEY }}
 
       # The compress step speed up a lot the upload artifact process
       - name: Compress artifact
@@ -385,17 +374,11 @@ jobs:
         if: always() && steps.build_runner.outcome == 'success'
         run: ./run.sh PARAMETRIC
 
-      - name: Get Datadog credentials
-        id: dd-sts
-        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
-        with:
-          policy: dd-trace-py-github
-
       - name: Upload test results to Test Optimization
         if: always() && steps.build_runner.outcome == 'success'
         uses: DataDog/system-tests/.github/actions/push_to_test_optim@main
         with:
-          datadog_api_key: ${{ steps.dd-sts.outputs.api_key }}
+          datadog_api_key: ${{ secrets.DD_API_KEY }}
 
       - name: Compress artifact
         if: always() && steps.build_runner.outcome == 'success'
@@ -440,6 +423,9 @@ jobs:
     # Automatically managed, use scripts/update-system-tests-version to update
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@9b8c686e5301c1b2d6f8530cd119256470d53f08
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
     with:
       library: python_lambda
       binaries_artifact: serverless_system_tests_binaries
@@ -469,18 +455,23 @@ jobs:
     # Automatically managed, use scripts/update-system-tests-version to update
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@9b8c686e5301c1b2d6f8530cd119256470d53f08
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
     with:
       library: python
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
 
   tracer-release:
-    # TODO: re-enable once DataDog/system-tests reusable workflow supports dd-sts
-    if: false
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}
+    permissions:
+      contents: read
+      packages: write
     with:
       library: python
       ref: main
@@ -510,7 +501,7 @@ jobs:
           needs.serverless-system-tests.result == 'failure' ||
           needs.serverless-system-tests.result == 'cancelled' ||
           needs.integration-frameworks-system-tests.result == 'failure' ||
-          needs.integration-frameworks-system-tests.result == 'cancelled'||
+          needs.integration-frameworks-system-tests.result == 'cancelled'|| 
           needs.tracer-release.result == 'failure' ||
           needs.tracer-release.result == 'cancelled'
         run: exit 1


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#17339

dd-sts is having rate limiting issues, reverting for now.