### PR TITLE
Abort git upload when search_commits fails

### DIFF
--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -276,7 +276,7 @@ class APIClient:
         self.telemetry_api.record_test_management_tests_count(len(test_properties))
         return test_properties
 
-    def get_known_commits(self, latest_commits: list[str]) -> list[str]:
+    def get_known_commits(self, latest_commits: list[str]) -> t.Optional[list[str]]:
         telemetry = self.telemetry_api.with_request_metric_names(
             count="git_requests.search_commits",
             duration="git_requests.search_commits_ms",
@@ -295,7 +295,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot fetch known commits (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
-            return []
+            return None
 
         try:
             result = self.connector.post_json(
@@ -305,7 +305,7 @@ class APIClient:
 
         except Exception as e:
             log.warning("Error getting known commits from API: %s", e)
-            return []
+            return None
 
         try:
             known_commits = [item["id"] for item in result.parsed_response["data"] if item["type"] == "commit"]
@@ -313,7 +313,7 @@ class APIClient:
         except Exception as e:
             log.warning("Failed to parse search_commits data: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
-            return []
+            return None
 
         return known_commits
 

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -312,7 +312,9 @@ class SessionManager:
 
         latest_commits = git.get_latest_commits()
         backend_commits = self.api_client.get_known_commits(latest_commits)
-        # TODO: ddtrace has a "backend_commits is None" logic here with early return (is it correct?).
+        if backend_commits is None:
+            return
+
         commits_not_in_backend = list(set(latest_commits) - set(backend_commits))
 
         if len(commits_not_in_backend) == 0:
@@ -326,7 +328,9 @@ class SessionManager:
                 log.debug("Unshallow successful, getting latest commits from backend based on unshallowed commits")
                 latest_commits = git.get_latest_commits()
                 backend_commits = self.api_client.get_known_commits(latest_commits)
-                # TODO: ddtrace has a "backend_commits is None" logic here with early return (is it correct?).
+                if backend_commits is None:
+                    return
+
                 commits_not_in_backend = list(set(latest_commits) - set(backend_commits))
             else:
                 log.warning("Failed to unshallow repository, continuing to send pack data")

--- a/tests/testing/internal/test_api_client.py
+++ b/tests/testing/internal/test_api_client.py
@@ -988,7 +988,7 @@ class TestAPIClientGetKnownCommits:
         assert "Git info not available" in caplog.text
         assert mock_connector.post_json.call_args_list == []
 
-        assert commits == []
+        assert commits is None
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.UNKNOWN)
@@ -1025,7 +1025,7 @@ class TestAPIClientGetKnownCommits:
 
         assert "Error getting known commits from API" in caplog.text
 
-        assert commits == []
+        assert commits is None
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == []
 
     def test_get_known_commits_errors_in_response(self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture) -> None:
@@ -1061,7 +1061,7 @@ class TestAPIClientGetKnownCommits:
         assert "Failed to parse search_commits data" in caplog.text
         assert "'data'" in caplog.text
 
-        assert commits == []
+        assert commits is None
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 import os
 import typing as t
+from unittest.mock import call
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
@@ -279,3 +281,41 @@ class TestSessionManagerGitHandling:
             session_manager.upload_git_data()
 
         mock_warning.assert_any_call("Error calling git binary, skipping metadata upload")
+
+    def test_upload_git_data_aborts_when_search_commits_fails(self) -> None:
+        session_manager = SessionManager.__new__(SessionManager)
+        session_manager.api_client = Mock()
+        session_manager.api_client.get_known_commits.return_value = None
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1", "commit-2"]
+
+        with patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git):
+            session_manager.upload_git_data()
+
+        session_manager.api_client.get_known_commits.assert_called_once_with(["commit-1", "commit-2"])
+        mock_git.get_filtered_revisions.assert_not_called()
+        mock_git.pack_objects.assert_not_called()
+        session_manager.api_client.send_git_pack_file.assert_not_called()
+
+    def test_upload_git_data_aborts_when_search_commits_fails_after_unshallow(self) -> None:
+        session_manager = SessionManager.__new__(SessionManager)
+        session_manager.api_client = Mock()
+        session_manager.api_client.get_known_commits.side_effect = [[], None]
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.side_effect = [["commit-1"], ["commit-1", "commit-2"]]
+        mock_git.is_shallow_repository.return_value = True
+        mock_git.get_git_version.return_value = (2, 27, 0)
+        mock_git.try_all_unshallow_repository_methods.return_value = True
+
+        with patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git):
+            session_manager.upload_git_data()
+
+        assert session_manager.api_client.get_known_commits.call_args_list == [
+            call(["commit-1"]),
+            call(["commit-1", "commit-2"]),
+        ]
+        mock_git.get_filtered_revisions.assert_not_called()
+        mock_git.pack_objects.assert_not_called()
+        session_manager.api_client.send_git_pack_file.assert_not_called()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fb4583ab-53b9-465b-be6b-d9628778d970","source":"chat","resourceId":"56719f1b-5ab1-4220-8167-762de5f6e611","workflowId":"659eec60-18ba-463e-9285-8d3b7d565a75","codeChangeId":"659eec60-18ba-463e-9285-8d3b7d565a75","sourceType":"chat"} -->
## Description

This change addresses SDTEST-3701 by modifying the behavior when `/search_commits` fails. Instead of falling back to uploading all commits (which can cause cascading failures), the upload is now aborted entirely.

The fix changes `get_known_commits()` to return `None` on errors instead of an empty list, allowing the caller to distinguish between "no commits found" and "error occurred". When `None` is returned, `upload_git_data()` now performs an early return, preventing the problematic fallback behavior that was creating excessive writes to GitDB and snowballing failures.

## Testing

- Updated `test_api_client.py` to verify that `get_known_commits()` returns `None` on all error conditions (missing git info, API errors, and parse errors)
- Added `test_upload_git_data_aborts_when_search_commits_fails()` to verify the upload is aborted when search_commits fails
- Added `test_upload_git_data_aborts_when_search_commits_fails_after_unshallow()` to verify the upload is aborted when search_commits fails even after unshallowing the repository

## Risks

Low risk. This change prevents a problematic fallback behavior rather than introducing new functionality. The early return when `search_commits` fails is safer than the previous behavior of uploading all commits.

## Additional Notes

This prevents the cascading failure scenario where temporary GitDB unavailability causes tracers to upload large packfiles, which then creates cache invalidations and slows down the read path, potentially causing more search_commits failures.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/56719f1b-5ab1-4220-8167-762de5f6e611)

Comment @datadog to request changes