### PR TITLE
fix(llmobs): guard annotate() when LLMObs is disabled

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2274,6 +2274,10 @@ class LLMObs(Service):
         :param metrics: Dictionary of JSON serializable key-value metric pairs,
                         such as `{prompt,completion,total}_tokens`.
         """
+        if cls.enabled is False:
+            log.warning("annotating when LLMObs is disabled. No annotation will be recorded.")
+            return
+
         error = None
         try:
             if span is None:

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -464,6 +464,15 @@ def test_annotate_finished_span_does_nothing(llmobs):
     assert str(excinfo.value) == "Cannot annotate a finished span."
 
 
+def test_annotate_when_llmobs_is_disabled_does_nothing(llmobs, mock_llmobs_logs):
+    llmobs.enabled = False
+    llmobs.annotate(metadata={"test": "test"})
+    mock_llmobs_logs.warning.assert_called_once_with(
+        "annotating when LLMObs is disabled. No annotation will be recorded."
+    )
+    llmobs.enabled = True
+
+
 def test_annotate_metadata(llmobs):
     with llmobs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
         llmobs.annotate(span=span, metadata={"temperature": 0.5, "max_tokens": 20, "top_k": 10, "n": 3})


### PR DESCRIPTION
## Summary

`LLMObs.annotate()` raises `LLMObsExportSpanError` when `DD_TRACE_ENABLED=false` because it lacks the `cls.enabled` guard that all other public LLMObs methods already include.

## Problem

When LLMObs is disabled (`cls.enabled is False`), calling `LLMObs.annotate(tags={"key": "value"})` attempts to find an active span and raises:
```
LLMObsExportSpanError: No span provided and no active LLMObs-generated span found.
```

Every other public method on `LLMObs` (`workflow()`, `llm()`, `tool()`, `flush()`, etc.) already has an early-return guard:
```python
if cls.enabled is False:
    log.warning("... when LLMObs is disabled. ...")
    return
```

## Solution

Add the same `cls.enabled` guard to `annotate()` — early return with a warning log, matching the established pattern.

## Testing

Added `test_annotate_when_llmobs_is_disabled_does_nothing` in `test_llmobs_service.py` following the same pattern as `test_flush_does_not_call_periodic_when_llmobs_is_disabled`.

## Changes

- `ddtrace/llmobs/_llmobs.py`: Add enabled guard at the top of `annotate()`
- `tests/llmobs/test_llmobs_service.py`: Add test for disabled annotate

Fixes #17001