### PR TITLE
test(profiling): unflake `test_exception_uses_push_monotonic_ns`

### DIFF
--- a/tests/profiling/collector/test_exception.py
+++ b/tests/profiling/collector/test_exception.py
@@ -659,10 +659,11 @@ def test_exception_uses_push_monotonic_ns() -> None:
     ):
         mock_ddup.SampleHandle.return_value = mock_handle
 
-        try:
-            raise ValueError("test")
-        except ValueError:
-            pass
+        for _ in range(10):
+            try:
+                raise ValueError("test")
+            except ValueError:
+                pass
     after: int = time.monotonic_ns()
 
     assert mock_handle.push_monotonic_ns.called, "push_monotonic_ns should be called"


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-15927

This fixes `test_exception_uses_push_monotonic_ns` flakes by raising more exceptions. Previously, the test was sensitive to timing. 

The fix retries the exception handling 10 times within the time window to increase the likelihood of capturing the profiling event, making the test more resilient to timing variations across different Python versions and system loads. Since the test validates that we push monotonic timestamps, we don't really care about raising more than one exception in order to make sure we do trigger a push.

