### PR TITLE
fix(tracing): use peer ip for network client ip

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -727,7 +727,7 @@ def _on_django_after_request_headers_post(
         response_headers=response_headers,
         request_cookies=request.COOKIES,
         request_path_params=_django_request_path_params(request),
-        peer_ip=core.get_item("http.request.remote_ip"),
+        peer_ip=request.META.get("REMOTE_ADDR"),
         headers_are_case_sensitive=bool(core.get_item("http.request.headers_case_sensitive")),
         response_cookies=response_cookies,
         # Forward ``http.route`` so the AppSec normalized-route listener can fire from this hook. ``_set_resolver_tags``

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -727,7 +727,7 @@ def _on_django_after_request_headers_post(
         response_headers=response_headers,
         request_cookies=request.COOKIES,
         request_path_params=_django_request_path_params(request),
-        peer_ip=request.META.get("REMOTE_ADDR"),
+        peer_ip=core.find_item("remote_addr"),
         headers_are_case_sensitive=bool(core.get_item("http.request.headers_case_sensitive")),
         response_cookies=response_cookies,
         # Forward ``http.route`` so the AppSec normalized-route listener can fire from this hook. ``_set_resolver_tags``

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -513,7 +513,9 @@ def set_http_meta(
 
         if request_ip:
             span._set_attribute(http.CLIENT_IP, request_ip)
-            span._set_attribute("network.client.ip", request_ip)
+
+        if peer_ip:
+            span._set_attribute("network.client.ip", peer_ip)
 
     if response_headers is not None and integration_config.is_header_tracing_configured:
         _store_response_headers(response_headers, span, integration_config)

--- a/releasenotes/notes/network-client-ip-from-peer-ip-113a5f3cee3f4ecf.yaml
+++ b/releasenotes/notes/network-client-ip-from-peer-ip-113a5f3cee3f4ecf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where ``network.client.ip`` was set from the request-derived client IP instead of the peer IP.

--- a/releasenotes/notes/network-client-ip-from-peer-ip-113a5f3cee3f4ecf.yaml
+++ b/releasenotes/notes/network-client-ip-from-peer-ip-113a5f3cee3f4ecf.yaml
@@ -1,4 +1,9 @@
 ---
 fixes:
   - |
-    tracing: This fix resolves an issue where ``network.client.ip`` was set from the request-derived client IP instead of the peer IP.
+    tracing: Fixes ``network.client.ip`` to contain the actual TCP peer IP address (i.e.
+    ``REMOTE_ADDR``) rather than the resolved HTTP client IP (which could originate from
+    forwarding headers such as ``X-Forwarded-For``). This affects the Flask, Django,
+    ASGI (FastAPI/Starlette), and Tornado integrations. The resolved HTTP client IP
+    continues to be reported under ``http.client_ip``, which is the value used by
+    App and API Protection (AAP) for IP-based threat detection and blocking.

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
@@ -44,7 +44,7 @@
       "http.useragent": "python-requests/2.32.3",
       "http.version": "1.1",
       "language": "python",
-      "network.client.ip": "8.8.4.4",
+      "network.client.ip": "127.0.0.1",
       "runtime-id": "4d53068ddf834e61826a4790d3eb7fc9",
       "span.kind": "server"
     },

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
@@ -44,7 +44,7 @@
       "http.useragent": "python-requests/2.32.3",
       "http.version": "1.1",
       "language": "python",
-      "network.client.ip": "8.8.4.4",
+      "network.client.ip": "127.0.0.1",
       "runtime-id": "e2f1123b8cbd4896a6e912e662f81985",
       "span.kind": "server"
     },

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
@@ -39,7 +39,7 @@
       "http.useragent": "python-requests/2.32.3",
       "http.version": "1.1",
       "language": "python",
-      "network.client.ip": "1.1.1.1",
+      "network.client.ip": "127.0.0.1",
       "runtime-id": "039dcee1a392430ea9bd762dbd72c633",
       "span.kind": "server"
     },

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -71,8 +71,7 @@
          "flask.endpoint": "checkuser",
          "flask.url_rule": "/checkuser/<user_id>",
          "flask.view_args.user_id": "111111",
-         "http.client_ip": "127.0.0.1",
-         "network.client.ip": "127.0.0.1"
+         "http.client_ip": "127.0.0.1"
        },
        "duration": 765375,
        "start": 1776102745058976386

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -71,8 +71,7 @@
          "flask.endpoint": "checkuser",
          "flask.url_rule": "/checkuser/<user_id>",
          "flask.view_args.user_id": "111111",
-         "http.client_ip": "127.0.0.1",
-         "network.client.ip": "127.0.0.1"
+         "http.client_ip": "127.0.0.1"
        },
        "duration": 831250,
        "start": 1776102311916572505

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -113,8 +113,7 @@
          "flask.endpoint": "checkuser",
          "flask.url_rule": "/checkuser/<user_id>",
          "flask.view_args.user_id": "123456",
-         "http.client_ip": "127.0.0.1",
-         "network.client.ip": "127.0.0.1"
+         "http.client_ip": "127.0.0.1"
        },
        "duration": 3566167,
        "start": 1776102748069211304

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -113,8 +113,7 @@
          "flask.endpoint": "checkuser",
          "flask.url_rule": "/checkuser/<user_id>",
          "flask.view_args.user_id": "123456",
-         "http.client_ip": "127.0.0.1",
-         "network.client.ip": "127.0.0.1"
+         "http.client_ip": "127.0.0.1"
        },
        "duration": 4795625,
        "start": 1776102315234419215

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -778,6 +778,7 @@ def test_set_http_meta_headers_ip_asm_disabled_env_default_false(span, int_confi
             span,
             int_config.myint,
             request_headers={"x-real-ip": "8.8.8.8"},
+            peer_ip="9.9.9.9",
         )
         result_keys = list(span.get_tags().keys())
         result_keys.sort(reverse=True)
@@ -792,6 +793,7 @@ def test_set_http_meta_headers_ip_asm_disabled_env_false(span, int_config):
             span,
             int_config.myint,
             request_headers={"x-real-ip": "8.8.8.8"},
+            peer_ip="9.9.9.9",
         )
         result_keys = list(span.get_tags().keys())
         result_keys.sort(reverse=True)
@@ -806,11 +808,13 @@ def test_set_http_meta_headers_ip_asm_disabled_env_true(span, int_config):
             span,
             int_config.myint,
             request_headers={"x-real-ip": "8.8.8.8"},
+            peer_ip="9.9.9.9",
         )
         result_keys = list(span.get_tags().keys())
         result_keys.sort(reverse=True)
         assert result_keys == ["runtime-id", "network.client.ip", http.CLIENT_IP]
         assert span.get_tag(http.CLIENT_IP) == "8.8.8.8"
+        assert span.get_tag("network.client.ip") == "9.9.9.9"
 
 
 def test_ip_subnet_regression():


### PR DESCRIPTION
## Description

dd-trace-py sets `network.client.ip` to IP resolved from proxy headers instead of peer IP. This PR changes it to set it from the peer IP.

[Public docs:](https://docs.datadoghq.com/standard-attributes/?search=network.client.ip)

> The IP address of the client that initiated the inbound connection.

Original RFC:

> The IP address of the client that initiated the TCP connection.

Confirmed with RFC authors, and the implementations in other tracers, that setting `network.client.ip` without any proxy header processing was the expected behavior.

## Testing

Updated tests to account for this, see the diff.

system-tests passing depend on this fix: https://github.com/DataDog/dd-trace-py/pull/17411
otherwise, peer ip is not correctly retrieved in FastAPI

## Risks

This affects customers who:

1. Had AppSec enabled (e.g. via `DD_APPSEC_ENABLED=true` or equivalent), or were setting `DD_TRACE_CLIENT_IP_ENABLED=true`), and
2. whose services used a reverse proxy, having proxy headers present

In that case, `network.client.ip` was being populated with the same value as `http.client_ip`.

Existing queries that relied on `network.client.ip` containing values following proxy header resolution will see their results unexpectedly changing.

(On the other hand, those relying on `network.client.ip` in the same way used across the other tracers will start seeing the correct behavior also in Python.

## Additional Notes

[APPSEC-62204](https://datadoghq.atlassian.net/browse/APPSEC-62204)


[APPSEC-62204]: https://datadoghq.atlassian.net/browse/APPSEC-62204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ