### PR TITLE
fix(test): resolve flakiness in crashtracker test

### DIFF
--- a/tests/internal/crashtracker/test_crashtracker.py
+++ b/tests/internal/crashtracker/test_crashtracker.py
@@ -58,6 +58,7 @@ def test_crashtracker_config_bytes():
         crashtracker_config.stdout_filename = stdout
         crashtracker_config.stderr_filename = stderr
         crashtracker_config.resolve_frames = "full"
+        crashtracker_config._stacktrace_resolver = "full"
 
         tags = {
             "service": b"my_favorite_service",
@@ -198,6 +199,9 @@ def test_crashtracker_simple_fork():
         # Fork happens after ddtrace started threads; see warning suppression note above.
         pid = os.fork()
         if pid == 0:
+            import time
+
+            time.sleep(0.1)
             ctypes.string_at(0)
             sys.exit(-1)  # just in case
 

--- a/tests/internal/crashtracker/utils.py
+++ b/tests/internal/crashtracker/utils.py
@@ -23,6 +23,7 @@ def start_crashtracker(port: int, stdout: Optional[str] = None, stderr: Optional
         crashtracker_config.stdout_filename = stdout
         crashtracker_config.stderr_filename = stderr
         crashtracker_config.resolve_frames = "full"
+        crashtracker_config._stacktrace_resolver = "full"
 
         tags.update(
             {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7766ea12-2d00-4d74-9b86-29e9596eb861","source":"chat","resourceId":"a8fe8db2-a2ca-445e-b3c0-85ae8a91ad08","workflowId":"85829ce7-c7ee-4e1c-8dbe-b76bc36ee091","codeChangeId":"85829ce7-c7ee-4e1c-8dbe-b76bc36ee091","sourceType":"test-optimization"} -->
## Description

Fixing `test_crashtracker_simple_fork` • [View in Test Optimization](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdd-trace-py%22+%40test.name%3A%22test_crashtracker_simple_fork%22&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%229366aaadf5cf2b12%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D) • **Questions?** Ask in #code-gen-flaky-tests

The flaky test `test_crashtracker_simple_fork` was failing because the crashtracker report was missing the expected symbol `string_at`. This was primarily due to the configuration of the crashtracker in the test and utility code, where `resolve_frames` was used instead of `_stacktrace_resolver`. This caused the crashtracker to default to "safe" (out-of-process) symbolication instead of the intended "full" (in-process) symbolication, which is more reliable for resolving symbols during a crash.

Additionally, a small delay was added to the child process in `test_crashtracker_simple_fork` immediately after the fork to ensure that the crashtracker's fork handler has sufficient time to complete before the crash occurs.

## Changes
- Fixed configuration: added `_stacktrace_resolver = "full"` in `tests/internal/crashtracker/utils.py` and `tests/internal/crashtracker/test_crashtracker.py`. (Existing `resolve_frames = "full"` was kept to avoid breaking potential dependencies).
- Added a 100ms delay in the child process before crashing in `test_crashtracker_simple_fork` to avoid race conditions with fork handling.

## Testing
Manual verification of the code changes. Automated tests could not be run locally due to missing native components and Docker dependencies in the current environment, but the changes address clear issues and race conditions identified in the code.

## Risks
None. These changes only affect tests and use existing configuration parameters correctly.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a8fe8db2-a2ca-445e-b3c0-85ae8a91ad08)

Comment @datadog to request changes