### PR TITLE
fix(serverless): add `base_service` tag for serverless [backport #17238 to 4.6]

### DIFF
--- a/ddtrace/internal/schema/processor.py
+++ b/ddtrace/internal/schema/processor.py
@@ -1,6 +1,5 @@
 from ddtrace._trace.processor import TraceProcessor
 from ddtrace.constants import _BASE_SERVICE_KEY
-from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.settings._config import config
 
 from . import schematize_service_name
@@ -9,12 +8,9 @@ from . import schematize_service_name
 class BaseServiceProcessor(TraceProcessor):
     def __init__(self):
         self._global_service = schematize_service_name((config.service or "").lower())
-        self._in_aws_lambda = in_aws_lambda()
 
     def process_trace(self, trace):
-        # AWS Lambda spans receive unhelpful base_service value of runtime
-        # Remove base_service to prevent service overrides in Lambda spans
-        if not trace or self._in_aws_lambda:
+        if not trace:
             return trace
 
         traces_to_process = filter(

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -499,6 +499,8 @@ class Config(object):
 
         self._inferred_base_service = detect_service(sys.argv)
 
+        if self.service is None and in_aws_lambda():
+            self.service = _get_config("AWS_LAMBDA_FUNCTION_NAME", DEFAULT_SPAN_SERVICE_NAME)
         if self.service is None and in_gcp_function():
             self.service = _get_config(["K_SERVICE", "FUNCTION_NAME"], DEFAULT_SPAN_SERVICE_NAME)
         if self.service is None and in_azure_function():

--- a/releasenotes/notes/serverless-base-service-lambda-b3c9f1e2d4a58701.yaml
+++ b/releasenotes/notes/serverless-base-service-lambda-b3c9f1e2d4a58701.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    serverless: AWS Lambda functions now appear under their function name as the service
+    when ``DD_SERVICE`` is not explicitly configured. Service remapping rules configured
+    in Datadog will now apply correctly to Lambda spans.

--- a/tests/internal/service_name/test_processor.py
+++ b/tests/internal/service_name/test_processor.py
@@ -74,3 +74,20 @@ if __name__ == "__main__":
         env=env,
     )
     assert status == 0, (out, err)
+
+
+@pytest.mark.subprocess(
+    parametrize={"DD_TRACE_SPAN_ATTRIBUTE_SCHEMA": [None, "v0", "v1"]},
+    env={"AWS_LAMBDA_FUNCTION_NAME": "my-lambda-func"},
+)
+def test_base_service_runs_in_lambda():
+    import os
+
+    from ddtrace.constants import _BASE_SERVICE_KEY
+    from ddtrace.internal.schema.processor import BaseServiceProcessor
+    from ddtrace.trace import Span
+
+    processor = BaseServiceProcessor()
+    fake_trace = [Span("op", service="some-other-service", resource="res")]
+    processor.process_trace(fake_trace)
+    assert fake_trace[0].get_tag(_BASE_SERVICE_KEY) == os.environ["AWS_LAMBDA_FUNCTION_NAME"]

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1018,6 +1018,20 @@ def test_detect_agentless_env_with_lambda():
     )
 
 
+@pytest.mark.subprocess(env=dict(AWS_LAMBDA_FUNCTION_NAME="my-lambda-func"))
+def test_service_name_defaults_to_lambda_function_name():
+    import ddtrace
+
+    assert ddtrace.config.service == "my-lambda-func"
+
+
+@pytest.mark.subprocess(env=dict(AWS_LAMBDA_FUNCTION_NAME="my-lambda-func", DD_SERVICE="override-svc"))
+def test_dd_service_takes_precedence_over_lambda_function_name():
+    import ddtrace
+
+    assert ddtrace.config.service == "override-svc"
+
+
 def test_tracer_set_runtime_tags():
     with global_tracer.start_span("foobar") as span:
         pass


### PR DESCRIPTION
Backport of #17238 to 4.6.

(cherry picked from commit 93778ccd9ac45b9123ec7824caf01ab269754e9c)

## Description

Fixes `_dd.base_service` handling for AWS Lambda environments in the Python tracer, enabling service remapping rules to work on Lambda spans and ensuring trace stats contain a meaningful `base_service`.

### Changes

**`ddtrace/internal/settings/_config.py`** — When `DD_SERVICE` is not configured and the tracer is running in AWS Lambda, `config.service` is now automatically set from `AWS_LAMBDA_FUNCTION_NAME`. This mirrors existing GCP (`K_SERVICE`) and Azure (`WEBSITE_SITE_NAME`) auto-detection behavior.

**`ddtrace/internal/schema/processor.py`** — Removes the Lambda-specific early exit from `BaseServiceProcessor`. Previously, the processor skipped all Lambda spans to avoid unhelpful `base_service` values from the runtime. Now that the service is correctly resolved from the function name, the processor runs normally and `_dd.base_service` is properly attached to spans.

## Testing

Existing serverless system tests pass (ALB, API Gateway HTTP/REST, Function URL). Includes new unit tests for Lambda service name auto-detection and base_service processor behavior.

## Risks

Low. The change only affects Lambda environments where `DD_SERVICE` is not explicitly set. The resolved service name (`AWS_LAMBDA_FUNCTION_NAME`) matches what the extension already uses for extension-based languages, ensuring consistency across runtimes.