### PR TITLE
ci: set commit-headless version to one that exists

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -100,10 +100,13 @@ jobs:
           git branch -D ${BACKPORT_BRANCH} || true
           git switch --create ${BACKPORT_BRANCH}
 
+          echo "Cherrypicking"
           set +e
           CHERRYPICK_OUT=$(git cherry-pick -x --mainline 1 ${MERGE_COMMIT} 2>&1)
           CHERRYPICK_STATUS=$?
           set -e
+          echo "Cherrypicking complete"
+          echo "${CHERRYPICK_STATUS}"
           if [ "${CHERRYPICK_STATUS}" -ne 0 ]; then
             echo "Cherry-pick failed for ${TARGET_BRANCH}:"
             echo "${CHERRYPICK_OUT}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -118,7 +118,6 @@ jobs:
 
           echo "branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "branch-from=$(git rev-parse ${TARGET_BRANCH})" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "target-branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Push Commit
@@ -129,7 +128,6 @@ jobs:
           target: "DataDog/dd-trace-py"
           create-branch: true
           command: push
-          commits: ${{ steps.create-commit.outputs.commit }}
           force: true
 
       - name: Create PR

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -119,7 +119,7 @@ jobs:
           echo "target-branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Push Commit
-        uses: DataDog/commit-headless@action/v3.1.0
+        uses: DataDog/commit-headless@action/v3.2.0
         with:
           branch: ${{ steps.create-commit.outputs.branch }}
           head-sha: ${{ steps.create-commit.outputs.branch-from }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -118,16 +118,18 @@ jobs:
 
           echo "branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "branch-from=$(git rev-parse ${TARGET_BRANCH})" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "target-branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Push Commit
-        uses: DataDog/commit-headless@action/v3.2.0
+        uses: DataDog/commit-headless@action/v2.0.3
         with:
           branch: ${{ steps.create-commit.outputs.branch }}
           head-sha: ${{ steps.create-commit.outputs.branch-from }}
           target: "DataDog/dd-trace-py"
           create-branch: true
           command: push
+          commits: ${{ steps.create-commit.outputs.commit }}
           force: true
 
       - name: Create PR

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
       github.event.pull_request.merged
-      || (
+      && (
         (
           github.event.action == 'closed'
           && contains(join(github.event.pull_request.labels.*.name, ','), 'backport ')

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
       github.event.pull_request.merged
-      && (
+      || (
         (
           github.event.action == 'closed'
           && contains(join(github.event.pull_request.labels.*.name, ','), 'backport ')


### PR DESCRIPTION
## Description

commit-headless seems to have deleted the release on which the backport job depends (see https://github.com/DataDog/commit-headless/tags). This change sets it to a version that is available on github. Major version 2 is chosen over 3 because 3 seems to have broken commit-headless' utility for backports.

## Testing

https://github.com/DataDog/dd-trace-py/actions/runs/24214079409/job/70690173277?pr=17440

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
