### PR TITLE
feat(tracing): [1/n][NO_MERGE] support Python 3.15 coroutine and generator wrapping

### DIFF
--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -35,8 +35,133 @@ COROUTINE_ASSEMBLY = Assembly()
 ASYNC_GEN_ASSEMBLY = Assembly()
 ASYNC_HEAD_ASSEMBLY = None
 
-if PY >= (3, 15):
+if PY >= (3, 16):
     raise NotImplementedError("This version of CPython is not supported yet")
+
+elif PY >= (3, 15):
+    ASYNC_HEAD_ASSEMBLY = Assembly()
+    ASYNC_HEAD_ASSEMBLY.parse(
+        r"""
+            return_generator
+            pop_top
+        """
+    )
+
+    COROUTINE_ASSEMBLY.parse(
+        r"""
+            get_awaitable                   0
+            load_const                      None
+
+        presend:
+            send                            @send
+            yield_value                     1
+            resume                          3
+            jump_backward_no_interrupt      @presend
+        send:
+            end_send
+        """
+    )
+
+    ASYNC_GEN_ASSEMBLY.parse(
+        r"""
+        try                                 @stopiter
+            copy                            1
+            store_fast                      $__ddgen
+            load_attr                       (False, 'asend')
+            store_fast                      $__ddgensend
+            load_fast                       $__ddgen
+            load_attr                       (True, '__anext__')
+            call                            0
+
+        loop:
+            get_awaitable                   0
+            load_const                      None
+        presend0:
+            send                            @send0
+        tried
+
+        try                                 @genexit lasti
+            yield_value                     1
+            resume                          3
+            jump_backward_no_interrupt      @loop
+        send0:
+            end_send
+
+        yield:
+            call_intrinsic_1                asm.Intrinsic1Op.INTRINSIC_ASYNC_GEN_WRAP
+            yield_value                     0
+            resume                          5
+            push_null
+            load_fast                       $__ddgensend
+            swap                            3
+            call                            1
+            jump_backward                   @loop
+        tried
+
+        genexit:
+        try                                 @stopiter
+            push_exc_info
+            load_const                      GeneratorExit
+            check_exc_match
+            pop_jump_if_false               @exc
+            pop_top
+            load_fast                       $__ddgen
+            load_attr                       (True, 'aclose')
+            call                            0
+            get_awaitable                   0
+            load_const                      None
+
+        presend1:
+            send                            @send1
+            yield_value                     1
+            resume                          3
+            jump_backward_no_interrupt      @presend1
+        send1:
+            end_send
+            pop_top
+            pop_except
+            load_const                      None
+            return_value
+
+        exc:
+            pop_top
+            load_fast                       $__ddgen
+            load_attr                       (False, 'athrow')
+            push_null
+            load_const                      sys.exc_info
+            push_null
+            call                            0
+            push_null
+            call_function_ex
+            get_awaitable                   0
+            load_const                      None
+
+        presend2:
+            send                            @send2
+            yield_value                     1
+            resume                          3
+            jump_backward_no_interrupt      @presend2
+        send2:
+            end_send
+            swap                            2
+            pop_except
+            jump_backward                   @yield
+        tried
+
+        stopiter:
+            push_exc_info
+            load_const                      StopAsyncIteration
+            check_exc_match
+            pop_jump_if_false               @propagate
+            pop_top
+            pop_except
+            load_const                      None
+            return_value
+
+        propagate:
+            reraise                         0
+        """
+    )
 
 elif PY >= (3, 14):
     ASYNC_HEAD_ASSEMBLY = Assembly()

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -78,8 +78,8 @@ CONTEXT_HEAD = Assembly()
 CONTEXT_RETURN = Assembly()
 CONTEXT_FOOT = Assembly()
 
-if sys.version_info >= (3, 15):
-    raise NotImplementedError("Python >= 3.15 is not supported yet")
+if sys.version_info >= (3, 16):
+    raise NotImplementedError("Python >= 3.16 is not supported yet")
 elif sys.version_info >= (3, 13):
     CONTEXT_HEAD.parse(
         r"""

--- a/ddtrace/internal/wrapping/generators.py
+++ b/ddtrace/internal/wrapping/generators.py
@@ -33,8 +33,89 @@ PY = sys.version_info[:2]
 GENERATOR_ASSEMBLY = Assembly()
 GENERATOR_HEAD_ASSEMBLY = None
 
-if PY >= (3, 15):
+if PY >= (3, 16):
     raise NotImplementedError("This version of CPython is not supported yet")
+
+elif PY >= (3, 15):
+    # AIDEV-NOTE: Generator yield inside try blocks still uses RESUME 1 in 3.15 (only
+    # unprotected yields changed to RESUME 5). Our wrapper always yields inside a try
+    # block, so the assembly is identical to 3.14.
+    GENERATOR_HEAD_ASSEMBLY = Assembly()
+    GENERATOR_HEAD_ASSEMBLY.parse(
+        r"""
+            return_generator
+            pop_top
+        """
+    )
+
+    GENERATOR_ASSEMBLY.parse(
+        r"""
+        try                             @stopiter
+            copy                        1
+            store_fast                  $__ddgen
+            load_attr                   $send
+            store_fast                  $__ddgensend
+            load_const                  next
+            push_null
+            load_fast_borrow            $__ddgen
+
+        loop:
+            call                        1
+        tried
+
+        yield:
+        try                             @genexit lasti
+            yield_value                 0
+            resume                      1
+            push_null
+            load_fast_borrow            $__ddgensend
+            swap                        3
+            jump_backward               @loop
+        tried
+
+        genexit:
+        try                             @stopiter
+            push_exc_info
+            load_const                  GeneratorExit
+            check_exc_match
+            pop_jump_if_false           @exc
+            pop_top
+            load_fast                   $__ddgen
+            load_method                 $close
+            call                        0
+            swap                        2
+            pop_except
+            return_value
+
+        exc:
+            pop_top
+            load_fast                   $__ddgen
+            load_attr                   $throw
+            push_null
+            load_const                  sys.exc_info
+            push_null
+            call                        0
+            push_null
+            call_function_ex
+            swap                        2
+            pop_except
+            jump_backward               @yield
+        tried
+
+        stopiter:
+            push_exc_info
+            load_const                  StopIteration
+            check_exc_match
+            pop_jump_if_false           @propagate
+            pop_top
+            pop_except
+            load_const                  None
+            return_value
+
+        propagate:
+            reraise                     0
+        """
+    )
 
 elif PY >= (3, 14):
     GENERATOR_HEAD_ASSEMBLY = Assembly()

--- a/releasenotes/notes/tracing-python315-wrapping-support-2f16fdc9f233971c.yaml
+++ b/releasenotes/notes/tracing-python315-wrapping-support-2f16fdc9f233971c.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Tracing: Adds Python 3.15 support for coroutine, generator, and async generator
+    wrapping. CPython 3.15 changed two bytecode operands used in the instrumentation
+    hot path (``YIELD_VALUE`` and ``RESUME`` opcodes in generator and coroutine frames),
+    which caused a ``NotImplementedError`` at import time on Python 3.15. The wrapping
+    modules (``asyncs``, ``generators``, ``context``) are updated with the correct
+    3.15 operands.


### PR DESCRIPTION
| [Next PR >](https://github.com/DataDog/dd-trace-py/pull/17294)

CPython 3.15 changed two bytecode operands in async/generator code paths:
- YIELD_VALUE in SEND loops (await): 0 → 1
- RESUME after async gen yield-to-caller: 1 → 5

asyncs.py: new 3.15 branch with updated operands; ASYNC_HEAD and COROUTINE_ASSEMBLY structure identical to 3.14, ASYNC_GEN_ASSEMBLY yield_value updated in all three await loops (presend0/1/2) and resume updated in the yield-to-caller section.

generators.py: new 3.15 branch identical to 3.14 — generator yields inside try blocks still use RESUME 1 in 3.15 (only unprotected yields changed to RESUME 5).

context.py: extended 3.13 branch to cover 3.15 — no bytecode changes needed for context enter/exit/return assembly.

All version guards bumped from >= (3,15) to >= (3,16).

Validated on Python 3.15.0a7: coroutine, generator, async generator, and generator throw all pass.

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
