### PR TITLE
feat(profiling): weak-ref backed id caching

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 # Library sources
 add_library(
     dd_wrapper SHARED
+    src/code_object_cache.cpp
     src/code_provenance.cpp
     src/code_provenance_interface.cpp
     src/ddup_interface.cpp
@@ -71,8 +72,9 @@ add_library(
 # Add common configuration flags
 add_ddup_config(dd_wrapper)
 
-# Disable -Wold-style-cast for sample.cpp because Python C API headers use old-style casts
+# Disable -Wold-style-cast for files that include Python C API headers (which use old-style casts)
 set_source_files_properties(src/sample.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast")
+set_source_files_properties(src/code_object_cache.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast")
 
 target_include_directories(dd_wrapper PRIVATE include ${Datadog_INCLUDE_DIRS} ${Python3_INCLUDE_DIRS})
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/code_object_cache.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/code_object_cache.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#ifndef Py_PYTHON_H
+struct _object;                  // NOLINT(bugprone-reserved-identifier)
+typedef struct _object PyObject; // NOLINT(bugprone-reserved-identifier)
+#endif
+
+#include "sample.hpp" // for Datadog::function_id
+
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
+namespace Datadog {
+
+// CodeObjectFunctionCache maps PyCodeObject* addresses to libdatadog function_id values,
+// removing repeated FFI calls to intern_string / intern_function on hot paths.
+//
+// LIFETIME:
+//   ddog_prof_FunctionId2 (function_id) is an opaque handle into the ProfilesDictionary,
+//   which is an Arc<ProfilesDictionary> that persists across all profile upload cycles
+//   by design. Cached values are therefore valid for the entire process lifetime, and are invalidared events:
+//     1. fork() — child process gets a fresh ProfilesDictionary; all IDs are stale
+//     2. GC of the code object itself
+//
+// GC SAFETY with weak references:
+//   Each entry stores a PyWeakReference* (owned reference) to its code object.
+//   On get(), PyWeakref_GET_OBJECT() is checked:
+//     - alive (not Py_None) -> return cached function_id
+//     - dead  (== Py_None)  -> evict entry, Py_DECREF the weakref, return nullopt
+//   This prevents a new code object allocated at the same address from receiving
+//   a stale ID.
+//
+// THREAD SAFETY:
+//   All public methods acquire mtx_ internally.  Callers need only hold the GIL
+//   (which it seems like all current callers of push_pyframes/push_pytraceback do)
+//   Do not call allocating Python APIs while holding mtx_.
+//
+// GIL REQUIREMENT:
+//   Every public method must be called with the GIL held.
+//   PyWeakref_NewRef, PyWeakref_GET_OBJECT, and Py_DECREF are not safe without it.
+class CodeObjectFunctionCache
+{
+  public:
+    static CodeObjectFunctionCache& instance();
+
+    // Returns cached function_id if the code object is still alive, nullopt otherwise.
+    // Evicts the entry if the code object has been GC'd.
+    std::optional<function_id> get(PyObject* code);
+
+    // Stores fn_id for code, creating a weak reference.
+    // Silently skips if PyWeakref_NewRef fails (should not happen for PyCodeObject).
+    // If two threads race on a cache miss for the same key, the second insert is ignored
+    void insert(PyObject* code, function_id fn_id);
+
+    // Py_DECREF all held weak references (if interpreter is still alive) and clear the map.
+    // Call when the ProfilesDictionary is about to be released.
+    void clear();
+
+    // Reinitialise the mutex via placement-new, then call clear().
+    // Must be called in postfork_child() before release_profiles_dictionary().
+    void postfork_child();
+
+  private:
+    CodeObjectFunctionCache() = default;
+    ~CodeObjectFunctionCache() = default;
+    CodeObjectFunctionCache(const CodeObjectFunctionCache&) = delete;
+    CodeObjectFunctionCache& operator=(const CodeObjectFunctionCache&) = delete;
+
+    struct Entry
+    {
+        PyObject* weak_ref; // owned PyWeakReference* to the code object
+        function_id fn_id;
+    };
+
+    std::mutex mtx_;
+    std::unordered_map<uintptr_t, Entry> map_;
+};
+
+}

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/code_object_cache.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/code_object_cache.cpp
@@ -1,0 +1,116 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "code_object_cache.hpp"
+
+namespace {
+
+// Returns true if the weak reference's referent is still alive
+//   < 3.13: PyWeakref_GetObject() is the stable API (borrowed ref)
+//  >= 3.13: PyWeakref_GetObject() and PyWeakref_GET_OBJECT() are deprecated so we
+//           use PyWeakref_GetRef() (intro in 3.13, returns strong ref through out-param)
+inline bool
+weakref_is_alive(PyObject* wr)
+{
+#if PY_VERSION_HEX >= 0x030d0000 // Python 3.13+
+    PyObject* obj = nullptr;
+    int rc = PyWeakref_GetRef(wr, &obj);
+    if (rc == 1) {
+        // Referent is alive; obj is a new strong reference so release it immediately
+        Py_DECREF(obj);
+        return true;
+    }
+    // rc == 0: referent is dead (obj is NULL)
+    // rc == -1: not a weakref (should not happen here); treat as dead
+    return false;
+#else
+    // Python < 3.13: PyWeakref_GetObject returns a borrowed reference
+    return PyWeakref_GetObject(wr) != Py_None;
+#endif
+}
+
+}
+
+namespace Datadog {
+
+CodeObjectFunctionCache&
+CodeObjectFunctionCache::instance()
+{
+    static CodeObjectFunctionCache inst;
+    return inst;
+}
+
+std::optional<function_id>
+CodeObjectFunctionCache::get(PyObject* code)
+{
+    const auto key = reinterpret_cast<uintptr_t>(code);
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    auto it = map_.find(key);
+    if (it == map_.end()) {
+        return std::nullopt;
+    }
+
+    if (!weakref_is_alive(it->second.weak_ref)) {
+        // Stale entry: code object was freed. Evict since its a cache miss
+        Py_DECREF(it->second.weak_ref);
+        map_.erase(it);
+        return std::nullopt;
+    }
+
+    return it->second.fn_id;
+}
+
+void
+CodeObjectFunctionCache::insert(PyObject* code, function_id fn_id)
+{
+    // Create a weak reference with no callback
+    PyObject* wr = PyWeakref_NewRef(code, nullptr);
+    if (wr == nullptr) {
+        // Should not happen for PyCodeObject
+        PyErr_Clear();
+        return;
+    }
+
+    const auto key = reinterpret_cast<uintptr_t>(code);
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    // emplace returns {iterator, inserted}.  If two threads race on a cache miss
+    // for the same key, the second call loses and we discard the extra weakref.
+    // TODO: Take another look at this
+    auto [it, inserted] = map_.emplace(key, Entry{ wr, fn_id });
+    if (!inserted) {
+        Py_DECREF(wr);
+    }
+}
+
+void
+CodeObjectFunctionCache::clear()
+{
+    std::lock_guard<std::mutex> lock(mtx_);
+    // Only call Python's reference counting if the interpreter is still alive.
+    // At C++ static-destructor / atexit time the interpreter may already be gone.
+    if (Py_IsInitialized()) {
+        for (auto& [key, entry] : map_) {
+            Py_DECREF(entry.weak_ref);
+        }
+    }
+    map_.clear();
+}
+
+void
+CodeObjectFunctionCache::postfork_child()
+{
+    // After fork() the child inherits the parent's heap and all cached
+    // function_ids are stale (the ProfilesDictionary is about to be recreated).
+    // This mirrors the pattern used in NativeCallRegistry::postfork_child().
+    new (&mtx_) std::mutex();
+
+    // Abandon all cache entries without calling Py_DECREF on the weakrefs.
+    // Calling Py_DECREF here is unsafe: Python's fork reinitialisation
+    // (pthread_atfork child handler) may still be running
+    std::lock_guard<std::mutex> lock(mtx_);
+    map_.clear();
+}
+
+}

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
@@ -1,5 +1,6 @@
 #include "profiler_state.hpp"
 
+#include "code_object_cache.hpp"
 #include "libdatadog_helpers.hpp"
 
 #include <chrono>
@@ -73,16 +74,17 @@ ProfilerState::init_interned_strings()
         return false;
     }
 
-    // Intern the empty string, which is used frequently
-    ddog_prof_StringId2 string_id;
+    // Intern the empty string, which is used frequently.
+    // Use a distinct local name to avoid shadowing Datadog::string_id (a type alias from sample.hpp).
+    ddog_prof_StringId2 empty_str_id;
     auto result = ddog_prof_ProfilesDictionary_insert_str(
-      &string_id, maybe_dict.value(), to_slice(""), ddog_prof_Utf8Option::DDOG_PROF_UTF8_OPTION_CONVERT_LOSSY);
+      &empty_str_id, maybe_dict.value(), to_slice(""), ddog_prof_Utf8Option::DDOG_PROF_UTF8_OPTION_CONVERT_LOSSY);
 
     if (result.flags) {
         std::cerr << "Error interning empty string: " << result.err << std::endl;
         return false;
     }
-    cached_empty_string_id = string_id;
+    cached_empty_string_id = empty_str_id;
 
     return true;
 }
@@ -180,6 +182,15 @@ ProfilerState::postfork_child()
     // Re-init the native call registry mutex (data is preserved so forked
     // children can still see native frames from the parent's warmup phase)
     native_call_registry.postfork_child();
+
+    // Clear the code-object → function_id cache.  The cached function_ids are
+    // pointers into the Profiles Dictionary that is about to be freed below.
+    // Must happen before release_profiles_dictionary() to avoid use-after-free.
+    // We do not call Py_DECREF here (postfork child handler runs while Python's
+    // own fork reinitialisation may still be in progress), so weakrefs are
+    // abandoned.  This is safe: fork children are typically short-lived and the
+    // OS reclaims all memory on exit.
+    CodeObjectFunctionCache::instance().postfork_child();
 
     // Free our copy of the Profiles Dictionary - its String IDs refer to memory
     // that doesn't exist in the child process

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -5,6 +5,8 @@
 #include <Python.h>
 #include <frameobject.h>
 
+#include "code_object_cache.hpp"
+
 #include "libdatadog_helpers.hpp"
 #include "profiler_state.hpp"
 #include "pymacro.hpp"
@@ -205,23 +207,40 @@ Datadog::Sample::push_pyframes(PyFrameObject* frame)
         // Python 3.9+: PyFrame_GetCode() returns a new reference
         PyCodeObject* code = PyFrame_GetCode(f);
 
-        std::string_view name_sv = "<unknown>";
-        std::string_view filename_sv = "<unknown>";
-
         if (code != nullptr) {
-            // Extract function name (use co_qualname for Python 3.11+ for better context)
-#if defined(PY311_AND_LATER)
-            PyObject* name_obj = code->co_qualname ? code->co_qualname : code->co_name;
-#else
-            PyObject* name_obj = code->co_name;
-#endif
-            name_sv = unicode_to_string_view(name_obj);
-            filename_sv = unicode_to_string_view(code->co_filename);
-        }
+            // look up the cached function_id for this code object.
+            // Cache key is the code object's address
+            auto& fn_cache = CodeObjectFunctionCache::instance();
+            auto maybe_fn_id = fn_cache.get(reinterpret_cast<PyObject*>(code));
 
-        // Push frame to Sample (leaf to root order)
-        // push_frame copies the strings immediately into its StringArena
-        push_frame(name_sv, filename_sv, 0, lineno_val);
+            if (!maybe_fn_id) {
+                // Cache miss: intern strings and function, then populate the cache.
+#if defined(PY311_AND_LATER)
+                PyObject* name_obj = code->co_qualname ? code->co_qualname : code->co_name;
+#else
+                PyObject* name_obj = code->co_name;
+#endif
+                auto maybe_name_id = intern_string(unicode_to_string_view(name_obj));
+                auto maybe_file_id = intern_string(unicode_to_string_view(code->co_filename));
+
+                if (maybe_name_id && maybe_file_id) {
+                    auto interned = intern_function(*maybe_name_id, *maybe_file_id);
+                    if (interned) {
+                        fn_cache.insert(reinterpret_cast<PyObject*>(code), *interned);
+                        maybe_fn_id = interned;
+                    }
+                }
+            }
+
+            if (maybe_fn_id) {
+                push_frame(*maybe_fn_id, 0, lineno_val);
+            }
+            // If maybe_fn_id is still nullopt, the frame is silently dropped
+            // same as the existing error path in push_frame_impl().
+        } else {
+            // code == nullptr: preserve original behavior of pushing unknown frame.
+            push_frame("<unknown>", "<unknown>", 0, lineno_val);
+        }
 
         // Python 3.9+: PyFrame_GetBack() and PyFrame_GetCode() return new references.
         PyFrameObject* back = PyFrame_GetBack(f);
@@ -312,12 +331,30 @@ Datadog::Sample::push_pytraceback(PyTracebackObject* tb)
 
         PyCodeObject* code = (node->tb_frame != nullptr) ? PyFrame_GetCode(node->tb_frame) : nullptr;
         if (code != nullptr) {
+            auto& fn_cache = CodeObjectFunctionCache::instance();
+            auto maybe_fn_id = fn_cache.get(reinterpret_cast<PyObject*>(code));
+
+            if (!maybe_fn_id) {
 #if defined(PY311_AND_LATER)
-            PyObject* name_obj = code->co_qualname ? code->co_qualname : code->co_name;
+                PyObject* name_obj = code->co_qualname ? code->co_qualname : code->co_name;
 #else
-            PyObject* name_obj = code->co_name;
+                PyObject* name_obj = code->co_name;
 #endif
-            push_frame(unicode_to_string_view(name_obj), unicode_to_string_view(code->co_filename), 0, lineno);
+                auto maybe_name_id = intern_string(unicode_to_string_view(name_obj));
+                auto maybe_file_id = intern_string(unicode_to_string_view(code->co_filename));
+
+                if (maybe_name_id && maybe_file_id) {
+                    auto interned = intern_function(*maybe_name_id, *maybe_file_id);
+                    if (interned) {
+                        fn_cache.insert(reinterpret_cast<PyObject*>(code), *interned);
+                        maybe_fn_id = interned;
+                    }
+                }
+            }
+
+            if (maybe_fn_id) {
+                push_frame(*maybe_fn_id, 0, lineno);
+            }
             Py_DECREF(code);
         }
     }
@@ -834,11 +871,18 @@ Datadog::Sample::profile_borrow()
 void
 Datadog::Sample::postfork_child()
 {
+    // CodeObjectFunctionCache::instance().postfork_child() is called from
+    // ProfilerState::postfork_child() (the pthread_atfork child handler), which
+    // runs before this function and before the ProfilesDictionary is recreated.
     ProfilerState::get().profile_state.postfork_child();
 }
 
 void
 Datadog::Sample::cleanup()
 {
+    // CodeObjectFunctionCache is not cleared here.
+    // The ProfilesDictionary persists across profile uploads by design, so function_id values remain valid
+    // for the entire process lifetime. The cache is only invalidated on fork (ProfilerState::postfork_child())
+    // when the dictionary is recreated.
     ProfilerState::get().profile_state.cleanup();
 }


### PR DESCRIPTION
## Description

Not that much improvement

```
➜ dd-trace-doe git:(main) ✗ ./doe report \
  --fields library_version,resolved_library_version,cpu,latency_p99,memory,errors

2026-04-14T18:05:00Z:
  archetype=throughput,
  language=python,
  framework=flask,
  workers=4,
  loops_cpu=0.009,
  off_cpu=0.1,
  rps=0,
  clients=100,
  duration=180


library_version | resolved_library_version | cpu%   | diff (%)              | latency_p99 | diff (%)              | memory     | diff (%)              | errors
----------------|--------------------------|--------|------------------------|-------------|------------------------|------------|------------------------|--------
dev             | dev                      | 320.2% | +0.9pp (+0.3%)        | 751.90 ms   | +4.03 ms (+0.5%)      | 162.90 MB  | +0.03 MB (+0.0%)      | 0 (baseline)
dev             | dev                      | 319.2% | -0.1pp (-0.1%)        | 756.60 ms   | +8.72 ms (+1.2%)      | 163.01 MB  | +0.14 MB (+0.1%)      | 0 (baseline)
dev             | dev                      | 319.4% | +0.0pp (+0.2%)        | 740.84 ms   | -7.04 ms (-0.9%)      | 162.93 MB  | +0.06 MB (+0.0%)      | 0 (baseline)
dev             | dev                      | 318.8% | -0.6pp (-0.1%)        | 764.77 ms   | +16.90 ms (+2.3%)     | 163.34 MB  | +0.47 MB (+0.3%)      | 0 (baseline)
dev             | dev                      | 319.6% | +0.3pp (-0.0%)        | 763.42 ms   | +15.55 ms (+2.1%)     | 162.93 MB  | +0.06 MB (+0.0%)      | 0 (baseline)

local           | local                    | 319.2% | ±0.1pp (+0.1%)        | 739.96 ms   | -7.92 ms (-1.1%)      | 163.17 MB  | +0.30 MB (+0.2%)      | 0 (baseline)
local           | local                    | 319.6% | +0.3pp (+0.0%)        | 732.78 ms   | -15.09 ms (-2.0%)     | 162.64 MB  | -0.22 MB (-0.1%)      | 0 (baseline)
local           | local                    | 319.4% | +0.1pp (-0.0%)        | 737.43 ms   | -10.44 ms (-1.4%)     | 162.32 MB  | -0.55 MB (-0.3%)      | 0 (baseline)
local           | local                    | 319.2% | -0.1pp (-0.1%)        | 746.43 ms   | -1.45 ms (-0.2%)      | 162.68 MB  | -0.19 MB (-0.1%)      | 0 (baseline)
local           | local                    | 318.7% | -0.7pp (-0.2%)        | 744.62 ms   | -3.25 ms (-0.4%)      | 162.77 MB  | -0.10 MB (-0.1%)      | 0 (baseline)


startup_wall summary
--------------------
library_version | loops_num | n | mean (95% CI)                | diff (%)                              | stddev    | min      | p50      | p99      | max
----------------|-----------|---|------------------------------|----------------------------------------|-----------|----------|----------|----------|----------
dev             | 1537486   | 5 | 1.643 s [1.631 s, 1.656 s]  ~|                                        | 11.00 ms  | 1.626 s  | 1.645 s  | 1.655 s  | 1.655 s  (baseline)
local           | 1514795   | 5 | 1.641 s [1.624 s, 1.657 s]  ~| -2.28 ms ±29.16 ms (-0.1% ±1.8%)       | 14.35 ms  | 1.618 s  | 1.642 s  | 1.654 s  | 1.654 s


Statistical Significance Legend
------------------------------
✓  High confidence   (n ≥ 10, CV < 0.1)  → Very reliable measurement
~  Medium confidence (n ≥ 5,  CV < 0.2)  → Reasonably reliable measurement
?  Low confidence    (n > 1)             → Limited reliability, more samples needed
-  No indicator                          → Single measurement, cannot assess significance
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
