### PR TITLE
chore(ci_visibility): add request_bytes to telemetry

### DIFF
--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -451,8 +451,9 @@ class APIClient:
         telemetry = self.telemetry_api.with_request_metric_names(
             count="coverage_upload.request",
             duration="coverage_upload.request_ms",
-            response_bytes="coverage_upload.request_bytes",  # FIXME: Request bytes != response bytes
+            response_bytes=None,
             error="coverage_upload.request_errors",
+            request_bytes="coverage_upload.request_bytes",
         )
 
         try:

--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -48,6 +48,7 @@ class BackendResult:
     error_type: t.Optional[ErrorType] = None
     error_description: t.Optional[str] = None
     response: t.Optional[http.client.HTTPResponse] = None
+    request_length: t.Optional[int] = None
     response_length: t.Optional[int] = None
     response_body: t.Optional[bytes] = None
     parsed_response: t.Any = None
@@ -280,6 +281,7 @@ class BackendConnector(threading.local):
             full_headers["Content-Encoding"] = "gzip"
 
         result = BackendResult()
+        result.request_length = len(data) if data is not None else 0
         start_time = time.perf_counter()
 
         try:
@@ -376,6 +378,7 @@ class BackendConnector(threading.local):
                     response_bytes=result.response_length,
                     compressed_response=result.is_gzip_response,
                     error=result.error_type,
+                    request_bytes=result.request_length,
                 )
 
             if result.error_type and result.error_type in RETRIABLE_ERRORS and attempts_so_far < max_attempts:

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -73,10 +73,20 @@ class TelemetryAPI:
         return cls._instance
 
     def with_request_metric_names(
-        self, count: str, duration: str, response_bytes: t.Optional[str], error: str
+        self,
+        count: str,
+        duration: str,
+        response_bytes: t.Optional[str],
+        error: str,
+        request_bytes: t.Optional[str] = None,
     ) -> TelemetryAPIRequestMetrics:
         return TelemetryAPIRequestMetrics(
-            telemetry_api=self, count=count, duration=duration, response_bytes=response_bytes, error=error
+            telemetry_api=self,
+            count=count,
+            duration=duration,
+            response_bytes=response_bytes,
+            error=error,
+            request_bytes=request_bytes,
         )
 
     def finish(self) -> None:
@@ -298,9 +308,15 @@ class TelemetryAPIRequestMetrics:
     duration: str
     response_bytes: t.Optional[str]
     error: str
+    request_bytes: t.Optional[str] = None
 
     def record_request(
-        self, seconds: float, response_bytes: t.Optional[int], compressed_response: bool, error: t.Optional[ErrorType]
+        self,
+        seconds: float,
+        response_bytes: t.Optional[int],
+        compressed_response: bool,
+        error: t.Optional[ErrorType],
+        request_bytes: t.Optional[int] = None,
     ) -> None:
         self.telemetry_api.add_count_metric(self.count, 1)
         self.telemetry_api.add_distribution_metric(self.duration, seconds)
@@ -309,6 +325,8 @@ class TelemetryAPIRequestMetrics:
             # means we don't want to record it.
             response_tags = {"rs_compressed": compressed_response}
             self.telemetry_api.add_distribution_metric(self.response_bytes, response_bytes, response_tags)
+        if request_bytes is not None and self.request_bytes is not None:
+            self.telemetry_api.add_distribution_metric(self.request_bytes, request_bytes)
 
         if error is not None:
             self.record_error(error)

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -84,10 +84,17 @@ class TestBackendConnector:
         assert result.parsed_response == {"answer": 42}
         assert result.is_gzip_response is False
         assert result.response_length == 14
+        assert result.request_length == len(b'{"question": 1}')
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=None)
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=None,
+                request_bytes=len(b'{"question": 1}'),
+            )
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -128,8 +135,20 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_5XX),
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=None),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_5XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=None,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -170,11 +189,41 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_5XX),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_5XX),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_5XX),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_5XX),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_5XX),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_5XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_5XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_5XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_5XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_5XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -211,11 +260,41 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=ErrorType.BAD_JSON),
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=ErrorType.BAD_JSON),
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=ErrorType.BAD_JSON),
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=ErrorType.BAD_JSON),
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=ErrorType.BAD_JSON),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=ErrorType.BAD_JSON,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=ErrorType.BAD_JSON,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=ErrorType.BAD_JSON,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=ErrorType.BAD_JSON,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=ErrorType.BAD_JSON,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -251,7 +330,13 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.CODE_4XX),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.CODE_4XX,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @pytest.mark.parametrize(
@@ -302,11 +387,41 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.NETWORK),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.NETWORK),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.NETWORK),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.NETWORK),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.NETWORK),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.NETWORK,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.NETWORK,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.NETWORK,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.NETWORK,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.NETWORK,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -340,11 +455,41 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.TIMEOUT),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.TIMEOUT),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.TIMEOUT),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.TIMEOUT),
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.TIMEOUT),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.TIMEOUT,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.TIMEOUT,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.TIMEOUT,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.TIMEOUT,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.TIMEOUT,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -374,7 +519,13 @@ class TestBackendConnector:
         assert isinstance(result.elapsed_seconds, float)
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=None, compressed_response=False, error=ErrorType.UNKNOWN),
+            call(
+                seconds=0.0,
+                response_bytes=None,
+                compressed_response=False,
+                error=ErrorType.UNKNOWN,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -413,8 +564,20 @@ class TestBackendConnector:
         assert result.parsed_response == {"answer": 42}
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.RATE_LIMITED),
-            call(seconds=0.0, response_bytes=14, compressed_response=False, error=None),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.RATE_LIMITED,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                error=None,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")
@@ -451,11 +614,41 @@ class TestBackendConnector:
         assert result.error_description == "429 Too Many Requests"
 
         assert mock_telemetry.record_request.call_args_list == [
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.RATE_LIMITED),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.RATE_LIMITED),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.RATE_LIMITED),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.RATE_LIMITED),
-            call(seconds=0.0, response_bytes=0, compressed_response=False, error=ErrorType.RATE_LIMITED),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.RATE_LIMITED,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.RATE_LIMITED,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.RATE_LIMITED,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.RATE_LIMITED,
+                request_bytes=len(b'{"question": 1}'),
+            ),
+            call(
+                seconds=0.0,
+                response_bytes=0,
+                compressed_response=False,
+                error=ErrorType.RATE_LIMITED,
+                request_bytes=len(b'{"question": 1}'),
+            ),
         ]
 
     @patch("http.client.HTTPSConnection")

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -22,17 +22,19 @@ CIVISIBILITY = TELEMETRY_NAMESPACE.CIVISIBILITY
 
 
 @pytest.fixture
-def telemetry_api() -> t.Generator[TelemetryAPI, None, None]:
+def mock_writer() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def telemetry_api(mock_writer: Mock) -> t.Generator[TelemetryAPI, None, None]:
     api = TelemetryAPI(connector_setup=Mock())
-
-    mock_writer = Mock()
-    api.writer = mock_writer  # type: ignore[assignment]
-
-    yield api  # type: ignore[misc]
+    api.writer = mock_writer
+    yield api
 
 
 class TestTelemetry:
-    def test_record_request(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_request(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         request_telemetry = telemetry_api.with_request_metric_names(
             count="known_tests.request",
             duration="known_tests.request_ms",
@@ -47,7 +49,7 @@ class TestTelemetry:
             error=ErrorType.CODE_4XX,
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request", 1, ()),
             call(
                 CIVISIBILITY,
@@ -57,12 +59,12 @@ class TestTelemetry:
             ),
         ]
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request_ms", 1.41, ()),
             call(CIVISIBILITY, "known_tests.response_bytes", 42, ()),
         ]
 
-    def test_record_request_without_response_bytes(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_request_without_response_bytes(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         request_telemetry = telemetry_api.with_request_metric_names(
             count="known_tests.request",
             duration="known_tests.request_ms",
@@ -77,7 +79,7 @@ class TestTelemetry:
             error=ErrorType.CODE_4XX,
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request", 1, ()),
             call(
                 CIVISIBILITY,
@@ -87,11 +89,11 @@ class TestTelemetry:
             ),
         ]
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request_ms", 1.41, ()),
         ]
 
-    def test_record_request_rate_limited_maps_to_4xx(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_request_rate_limited_maps_to_4xx(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         """RATE_LIMITED is emitted as status_code_4xx_response for cross-language consistency."""
         request_telemetry = telemetry_api.with_request_metric_names(
             count="known_tests.request",
@@ -107,7 +109,7 @@ class TestTelemetry:
             error=ErrorType.RATE_LIMITED,
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request", 1, ()),
             call(
                 CIVISIBILITY,
@@ -117,7 +119,56 @@ class TestTelemetry:
             ),
         ]
 
-    def test_record_request_without_error(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_request_with_request_bytes(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="coverage_upload.request",
+            duration="coverage_upload.request_ms",
+            response_bytes=None,
+            error="coverage_upload.request_errors",
+            request_bytes="coverage_upload.request_bytes",
+        )
+
+        request_telemetry.record_request(
+            seconds=0.5,
+            response_bytes=None,
+            compressed_response=False,
+            error=None,
+            request_bytes=1024,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "coverage_upload.request", 1, ()),
+        ]
+
+        assert mock_writer.add_distribution_metric.call_args_list == [
+            call(CIVISIBILITY, "coverage_upload.request_ms", 0.5, ()),
+            call(CIVISIBILITY, "coverage_upload.request_bytes", 1024, ()),
+        ]
+
+    def test_record_request_without_request_bytes_metric_name(
+        self, telemetry_api: TelemetryAPI, mock_writer: Mock
+    ) -> None:
+        """When request_bytes metric name is not set, request size is not recorded."""
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="known_tests.request",
+            duration="known_tests.request_ms",
+            response_bytes=None,
+            error="known_tests.request_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=1.0,
+            response_bytes=None,
+            compressed_response=False,
+            error=None,
+            request_bytes=512,
+        )
+
+        assert mock_writer.add_distribution_metric.call_args_list == [
+            call(CIVISIBILITY, "known_tests.request_ms", 1.0, ()),
+        ]
+
+    def test_record_request_without_error(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         request_telemetry = telemetry_api.with_request_metric_names(
             count="known_tests.request",
             duration="known_tests.request_ms",
@@ -132,19 +183,19 @@ class TestTelemetry:
             error=None,
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request", 1, ()),
         ]
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.request_ms", 1.41, ()),
             call(CIVISIBILITY, "known_tests.response_bytes", 42, ()),
         ]
 
-    def test_record_coverage_started(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_coverage_started(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_coverage_started(test_framework="pytest", coverage_library="ddtrace")
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "code_coverage_started",
@@ -153,10 +204,10 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_coverage_finished(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_coverage_finished(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_coverage_finished(test_framework="pytest", coverage_library="ddtrace")
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "code_coverage_finished",
@@ -165,65 +216,61 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_coverage_is_empty(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_coverage_is_empty(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_coverage_is_empty()
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
-            call(CIVISIBILITY, "code_coverage.is_empty", 1, ())
-        ]
+        assert mock_writer.add_count_metric.call_args_list == [call(CIVISIBILITY, "code_coverage.is_empty", 1, ())]
 
-    def test_record_coverage_files(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_coverage_files(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_coverage_files(42)
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
-            call(CIVISIBILITY, "code_coverage.files", 42, ())
-        ]
+        assert mock_writer.add_distribution_metric.call_args_list == [call(CIVISIBILITY, "code_coverage.files", 42, ())]
 
-    def test_record_known_tests_count(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_known_tests_count(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_known_tests_count(42)
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "known_tests.response_tests", 42, ())
         ]
 
-    def test_record_skippable_tests_count(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_skippable_tests_count(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_skippable_count(42, ITRSkippingLevel.TEST)
 
         # count metric, not distribution metric, for inexplicable reasons
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "itr_skippable_tests.response_tests", 42, ())
         ]
 
-    def test_record_skippable_suites_count(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_skippable_suites_count(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_skippable_count(42, ITRSkippingLevel.SUITE)
 
         # count metric, not distribution metric, for inexplicable reasons
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "itr_skippable_tests.response_suites", 42, ())
         ]
 
-    def test_record_itr_skipped(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_itr_skipped(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_itr_skipped(EventType.TEST)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "itr_skipped", 1, (("event_type", "test"),))
         ]
 
-    def test_record_itr_unskippable(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_itr_unskippable(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_itr_unskippable(EventType.TEST)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "itr_unskippable", 1, (("event_type", "test"),))
         ]
 
-    def test_record_itr_forced_run(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_itr_forced_run(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_itr_forced_run(EventType.TEST)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "itr_forced_run", 1, (("event_type", "test"),))
         ]
 
-    def test_record_settings_all_enabled(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_settings_all_enabled(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         settings = Settings(
             early_flake_detection=EarlyFlakeDetectionSettings(enabled=True),
             auto_test_retries=AutoTestRetriesSettings(enabled=True),
@@ -236,7 +283,7 @@ class TestTelemetry:
         )
         telemetry_api.record_settings(settings)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "git_requests.settings_response",
@@ -254,7 +301,7 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_settings_some_enabled(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_settings_some_enabled(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         settings = Settings(
             early_flake_detection=EarlyFlakeDetectionSettings(enabled=False),
             auto_test_retries=AutoTestRetriesSettings(enabled=True),
@@ -267,7 +314,7 @@ class TestTelemetry:
         )
         telemetry_api.record_settings(settings)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "git_requests.settings_response",
@@ -280,27 +327,27 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_test_management_tests_count(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_test_management_tests_count(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_test_management_tests_count(42)
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "test_management_tests.response_tests", 42, ())
         ]
 
-    def test_record_git_command_ok(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_git_command_ok(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_git_command(command=GitTelemetry.GET_REPOSITORY, elapsed_seconds=1.2, exit_code=0)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "git.command", 1, (("command", "get_repository"),))
         ]
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "git.command_ms", 1200, (("command", "get_repository"),))
         ]
 
-    def test_record_git_command_error(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_git_command_error(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_git_command(command=GitTelemetry.GET_REPOSITORY, elapsed_seconds=1.2, exit_code=4)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "git.command", 1, (("command", "get_repository"),)),
             call(
                 CIVISIBILITY,
@@ -312,11 +359,11 @@ class TestTelemetry:
                 ),
             ),
         ]
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "git.command_ms", 1200, (("command", "get_repository"),))
         ]
 
-    def test_record_event_payload_ok(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_event_payload_ok(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_event_payload(
             endpoint="test_cycle",
             payload_size=613,
@@ -325,10 +372,10 @@ class TestTelemetry:
             error=None,
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "endpoint_payload.requests", 1, (("endpoint", "test_cycle"),))
         ]
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "endpoint_payload.bytes", 613, (("endpoint", "test_cycle"),)),
             call(CIVISIBILITY, "endpoint_payload.requests_ms", 3140, (("endpoint", "test_cycle"),)),
             call(CIVISIBILITY, "endpoint_payload.events_count", 42, (("endpoint", "test_cycle"),)),
@@ -347,7 +394,7 @@ class TestTelemetry:
         ],
     )
     def test_record_event_payload_error(
-        self, telemetry_api: TelemetryAPI, http_error_type: ErrorType, telemetry_error_type: str
+        self, telemetry_api: TelemetryAPI, mock_writer: Mock, http_error_type: ErrorType, telemetry_error_type: str
     ) -> None:
         telemetry_api.record_event_payload(
             endpoint="test_cycle",
@@ -357,7 +404,7 @@ class TestTelemetry:
             error=http_error_type,
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "endpoint_payload.requests", 1, (("endpoint", "test_cycle"),)),
             call(
                 CIVISIBILITY,
@@ -369,20 +416,20 @@ class TestTelemetry:
                 ),
             ),
         ]
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "endpoint_payload.bytes", 613, (("endpoint", "test_cycle"),)),
             call(CIVISIBILITY, "endpoint_payload.requests_ms", 3140, (("endpoint", "test_cycle"),)),
             call(CIVISIBILITY, "endpoint_payload.events_count", 42, (("endpoint", "test_cycle"),)),
         ]
 
-    def test_record_event_payload_serialization_seconds(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_event_payload_serialization_seconds(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_event_payload_serialization_seconds("test_cycle", 0.5)
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "endpoint_payload.events_serialization_ms", 500, (("endpoint", "test_cycle"),)),
         ]
 
-    def test_record_test_created(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_test_created(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         session = TestSession("pytest")
         module, _ = session.get_or_create_child("module")
         suite, _ = module.get_or_create_child("suite")
@@ -391,7 +438,7 @@ class TestTelemetry:
 
         telemetry_api.record_test_created(test_framework="pytest", test_run=test_run)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "event_created",
@@ -403,7 +450,7 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_test_finished(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_test_finished(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         session = TestSession("pytest")
         module, _ = session.get_or_create_child("module")
         suite, _ = module.get_or_create_child("suite")
@@ -414,7 +461,7 @@ class TestTelemetry:
             test_framework="pytest", test_run=test_run, ci_provider_name="gitlab", is_auto_injected=True
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "event_finished",
@@ -428,7 +475,7 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_test_finished_all_the_tags(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_test_finished_all_the_tags(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         session = TestSession("pytest")
         module, _ = session.get_or_create_child("module")
         suite, _ = module.get_or_create_child("suite")
@@ -442,7 +489,7 @@ class TestTelemetry:
         test.set_early_flake_detection_abort_reason("slow")
         _initial_test_run = test.make_test_run()
         retry_test_run = test.make_test_run()
-        retry_test_run.is_benchmark = lambda: True
+        retry_test_run.is_benchmark = lambda: True  # type: ignore[method-assign]
         retry_test_run.tags[TestTag.IS_RUM_ACTIVE] = "true"
         retry_test_run.tags[TestTag.BROWSER_DRIVER] = "selenium"
         retry_test_run.tags[TestTag.HAS_FAILED_ALL_RETRIES] = "true"
@@ -451,7 +498,7 @@ class TestTelemetry:
             test_framework="pytest", test_run=retry_test_run, ci_provider_name="gitlab", is_auto_injected=True
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "event_finished",
@@ -475,38 +522,38 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_suite_created(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_suite_created(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_suite_created(test_framework="pytest")
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "event_created", 1, (("event_type", "suite"), ("test_framework", "pytest")))
         ]
 
-    def test_record_suite_finished(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_suite_finished(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_suite_finished(test_framework="pytest")
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "event_finished", 1, (("event_type", "suite"), ("test_framework", "pytest")))
         ]
 
-    def test_record_module_created(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_module_created(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_module_created(test_framework="pytest")
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "event_created", 1, (("event_type", "module"), ("test_framework", "pytest")))
         ]
 
-    def test_record_module_finished(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_module_finished(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_module_finished(test_framework="pytest")
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(CIVISIBILITY, "event_finished", 1, (("event_type", "module"), ("test_framework", "pytest")))
         ]
 
-    def test_record_session_created(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_session_created(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_session_created(test_framework="pytest", has_codeowners=True, is_unsupported_ci=True)
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "event_created",
@@ -520,12 +567,12 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_session_finished(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_session_finished(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_session_finished(
             test_framework="pytest", has_codeowners=True, is_unsupported_ci=True, efd_abort_reason="faulty"
         )
 
-        assert telemetry_api.writer.add_count_metric.call_args_list == [
+        assert mock_writer.add_count_metric.call_args_list == [
             call(
                 CIVISIBILITY,
                 "event_finished",
@@ -540,10 +587,10 @@ class TestTelemetry:
             )
         ]
 
-    def test_record_git_pack_data(self, telemetry_api: TelemetryAPI) -> None:
+    def test_record_git_pack_data(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_git_pack_data(uploaded_files=5, uploaded_bytes=200)
 
-        assert telemetry_api.writer.add_distribution_metric.call_args_list == [
+        assert mock_writer.add_distribution_metric.call_args_list == [
             call(CIVISIBILITY, "git_requests.objects_pack_files", 5, ()),
             call(CIVISIBILITY, "git_requests.objects_pack_bytes", 200, ()),
         ]


### PR DESCRIPTION
## Description

Adds request byte tracking capability to the CI Visibility telemetry infrastructure and fixes an incorrectly wired metric in the coverage upload path.

Previously, `upload_coverage_report` registered the metric name `coverage_upload.request_bytes` under `response_bytes`, which caused the HTTP **response** size to be recorded instead of the **request** size. This PR:

1. **Fixes the mislabelled metric** — moves `coverage_upload.request_bytes` from `response_bytes=` to the new `request_bytes=` parameter, and sets `response_bytes=None` (consistent with `send_git_pack_file`, which is also an upload).
2. **Adds `request_bytes` support to `TelemetryAPIRequestMetrics`** — new optional `request_bytes` metric name field on the dataclass and `with_request_metric_names()`.
3. **Tracks request size in `BackendResult`** — adds `request_length` field, populated in `_do_single_request()` after gzip compression so it reflects actual bytes sent on the wire.
4. **Threads `request_bytes` through `record_request()`** — passes `result.request_length` from `http.py`'s `request()` method into `telemetry.record_request()`.

All new parameters default to `None`, so existing callers are unaffected.

## Testing

Covered by existing telemetry unit tests. The new field follows the same optional pattern as `response_bytes`, which is already tested.

## Risks

None — all new parameters are opt-in (`None` by default) and no existing callers are changed.

## Additional Notes

No changelog entry needed (internal telemetry instrumentation, not a user-facing change).