### PR TITLE
fix(profiling): fix crash due to Frame cache eviction

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -19,7 +19,10 @@
 class EchionSampler;
 
 // ----------------------------------------------------------------------------
-class FrameStack : public std::deque<Frame::Ref>
+// FrameStack owns the Frames so that they stay valid across cache evictions
+// (asyncio unwind_tasks precomputes per-task stacks via Frame::get, which can
+// evict entries still referenced from an earlier thread-stack capture).
+class FrameStack : public std::deque<Frame>
 {
   public:
     using Key = Frame::Key;

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
@@ -12,7 +12,7 @@ FrameStack::render(EchionSampler& echion)
     auto& registry = Datadog::ProfilerState::get().native_call_registry;
 
     for (auto it = this->begin(); it != this->end(); ++it) {
-        auto& frame = (*it).get();
+        auto& frame = *it;
 
         // Inject native frame BEFORE its Python caller.
         // sys.monitoring reports instruction offsets in bytes, while the sampler computes
@@ -61,7 +61,7 @@ unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, siz
             continue;
         }
 
-        stack.push_back(*maybe_frame);
+        stack.push_back(maybe_frame->get());
         count++;
 
         if (count >= max_depth) {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -209,7 +209,7 @@ TaskInfo::unwind(EchionSampler& echion, FrameStack& stack, bool using_uvloop)
         }
 
         // Skip the uvloop wrapper frame if present (only at the outermost level of the top-level Task)
-        if (!stack.empty() && is_uvloop_wrapper_frame(echion, using_uvloop, stack.back().get())) {
+        if (!stack.empty() && is_uvloop_wrapper_frame(echion, using_uvloop, stack.back())) {
             stack.pop_back();
             continue;
         }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -47,7 +47,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
 
     if (!frame_cache_key) {
         for (size_t i = 0; i < python_stack.size(); i++) {
-            const auto& frame = python_stack[i].get();
+            const auto& frame = python_stack[i];
             auto maybe_frame_name = echion.string_table().lookup(frame.name);
             if (!maybe_frame_name) {
                 continue;
@@ -110,7 +110,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
         }
     } else {
         for (size_t i = 0; i < python_stack.size(); i++) {
-            const auto& frame = python_stack[i].get();
+            const auto& frame = python_stack[i];
             if (frame.cache_key == *frame_cache_key) {
                 upper_python_stack_size = python_stack.size() - i;
                 break;
@@ -248,11 +248,11 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
             size_t task_stack_size = 0;
             if (auto it = task_coro_stacks.find(task.origin); it != task_coro_stacks.end()) {
                 task_stack_size = it->second.size();
-                for (const auto& frame_ref : it->second) {
+                for (const Frame& coro_frame : it->second) {
                     if (stack.size() >= max_frames) {
                         break;
                     }
-                    stack.push_back(frame_ref);
+                    stack.push_back(coro_frame);
                 }
             }
             if (task.is_on_cpu) {
@@ -273,7 +273,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                     const auto& python_frame = python_stack[frames_to_push - i - 1];
 
                     // Skip the uvloop wrapper frame if present in the Python stack
-                    if (using_uvloop && is_uvloop_wrapper_frame(echion, using_uvloop, python_frame.get())) {
+                    if (using_uvloop && is_uvloop_wrapper_frame(echion, using_uvloop, python_frame)) {
                         continue;
                     }
                     stack.push_front(python_frame);

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -273,7 +273,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                     const auto& python_frame = python_stack[frames_to_push - i - 1];
 
                     // Skip the uvloop wrapper frame if present in the Python stack
-                    if (using_uvloop && is_uvloop_wrapper_frame(echion, using_uvloop, python_frame)) {
+                    if (is_uvloop_wrapper_frame(echion, using_uvloop, python_frame)) {
                         continue;
                     }
                     stack.push_front(python_frame);

--- a/releasenotes/notes/profiling-fix-asyncio-unwinding-crash-b192aef728433e7d.yaml
+++ b/releasenotes/notes/profiling-fix-asyncio-unwinding-crash-b192aef728433e7d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: A rare crash occurring when profiling asyncio code with many tasks or deep call stacks has been fixed.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13112

### Crash

This fixes a crash in the Profiler codebase.  
The crash was caused by `ThreadInfo::unwind_task` trying to use `Frame` objects that it had a reference to (`Frame::Ref`) while those same Frames were being evicted from the cache, which can happen under high load. 

```
Error UnixSignal: Process terminated with SI_KERNEL (SIGSEGV)
#0   0x00007f620376cfa2 std::make_unique<StackInfo, unsigned long&, bool&>
#1   0x00007f62037654bb is_uvloop_wrapper_frame
#2   0x00007f620376c9b3 ThreadInfo::unwind_tasks
#3   0x00007f620376cdb9 ThreadInfo::sample
#4   0x00007f620376ceee std::_Function_handler<void (_ts*, ThreadInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}::operator()(InterpreterInfo&) const::{lambda(_ts*, ThreadInfo&)#1}>::_M_invoke
#5   0x00007f62037678b5 for_each_thread
#6   0x00007f620376794d std::_Function_handler<void (InterpreterInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}>::_M_invoke
#7   0x00007f6203766257 for_each_interp
#8   0x00007f6203767cc0 Datadog::Sampler::sampling_thread
#9   0x00007f6203767f27 call_sampling_thread
```

### Proposed fix

The proposed fix is to change `FrameStack` to extend `std::deque<Frame>` instead of `std::deque<Frame::Ref>`, which means pushing frames to `FrameStack` actually copies them and eliminates that race condition.  
This should be OK performance-wise because `Frame` is tiny and only has trivial fields to copy (no memory allocations, only integral types).

Another possible fix would be to "lock" certain `Frame` objects in the cache (to prevent them from being evicted while any Task using them is being unwound) but this would be much more complicated to get right and although it would lead to less copies, the performance picture is blurry for more subtle reasons.  
So I suggest we don't go ahead with the alternative unless we absolutely need to (which we don't seem to).

### Performance

Running DoE with this change on the Enterprise archetype with asyncio/FastAPI  (n=10) shows no significant difference (either in memory or CPU usage / latency), so I think this is safe to merge performance-wise. 

<details>

### Raw runs

| Commit | Run | p50 (ms) | p99 (ms) | CPU% | Mem (MB) |
|--------|-----|----------|----------|------|----------|
| `90de7913` (after) | 1 | 150.43 | 152.88 | 172.68 | 274.9 |
| `90de7913` (after) | 2 | 150.45 | 152.38 | 172.17 | 266.2 |
| `90de7913` (after) | 3 | 150.43 | 153.91 | 172.92 | 266.2 |
| `90de7913` (after) | 4 | 150.46 | 154.16 | 172.83 | 265.8 |
| `90de7913` (after) | 5 | 150.44 | 153.01 | 172.80 | 267.4 |
| `90de7913` (after) | 6 | 150.43 | 153.28 | 172.70 | 265.8 |
| `90de7913` (after) | 7 | 150.54 | 157.48 | 173.32 | 265.8 |
| `90de7913` (after) | 8 | 150.51 | 156.61 | 172.18 | 265.5 |
| `90de7913` (after) | 9 | 150.53 | 157.05 | 172.18 | 265.8 |
| `90de7913` (after) | 10 | 150.45 | 152.84 | 172.08 | 265.5 |
| `c26e6181` (before) | 1 | 150.51 | 152.80 | 173.63 | 265.5 |
| `c26e6181` (before) | 2 | 150.48 | 152.41 | 173.49 | 265.4 |
| `c26e6181` (before) | 3 | 150.47 | 156.31 | 172.53 | 265.9 |
| `c26e6181` (before) | 4 | 150.49 | 152.60 | 172.86 | 265.5 |
| `c26e6181` (before) | 5 | 150.40 | 152.86 | 172.99 | 266.0 |
| `c26e6181` (before) | 6 | 150.46 | 152.66 | 172.53 | 265.5 |
| `c26e6181` (before) | 7 | 150.49 | 154.91 | 172.74 | 265.3 |
| `c26e6181` (before) | 8 | 150.46 | 152.46 | 171.93 | 265.7 |
| `c26e6181` (before) | 9 | 150.52 | 156.70 | 172.96 | 265.7 |
| `c26e6181` (before) | 10 | 150.43 | 153.02 | 172.52 | 265.8 |

### Aggregated (mean ± stdev, n=10)

| Version | p50 (ms) | p99 (ms) | CPU% | Mem (MB) |
|---------|----------|----------|------|----------|
| `c26e6181` (before)  | 150.470 ± 0.034 | 153.67 ± 1.66 | 172.82 ± 0.50 | 265.6 ± 0.2 |
| `90de7913` (after) | 150.465 ± 0.043 | 154.36 ± 1.94 | 172.59 ± 0.41 | 266.9 ± 2.9 |
| **Δ (after − before)** | **−0.005ms (0.00%)** | **+0.69ms (+0.45%)** | **−0.23pp (−0.13%)** | **+1.2MB (+0.47%)** |

</details>