### PR TITLE
chore(ci_visibility): add _suspend/_resume and live xdist env detection

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -476,13 +476,10 @@ def pytest_configure(config: pytest_Config) -> None:
 
                 if not hasattr(config, "workerinput"):
                     # Main process: reset per-session xdist ITR skip counter.
-                    # AIDEV-NOTE: Do NOT guard with PYTEST_XDIST_WORKER_VALUE is None here.
-                    # PYTEST_XDIST_WORKER_VALUE is a module-level constant frozen at import time.
-                    # When inline_run() is called inside an outer xdist worker, the constant is
-                    # "gw0" for the entire process lifetime, so the reset would never fire and
-                    # pytest.global_worker_itr_results would accumulate across inline_run calls.
-                    # hasattr(config, "workerinput") is the correct check: it is True only for
-                    # worker configs of the *current* session, not for outer-run workers.
+                    # AIDEV-NOTE: hasattr(config, "workerinput") is the correct worker check here —
+                    # it reflects the *current* session, not the outer process. An os.environ read
+                    # would be wrong inside inline_run() called from an outer xdist worker because
+                    # PYTEST_XDIST_WORKER would still be set in that process's environment.
                     pytest.global_worker_itr_results = 0
 
         else:

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -40,11 +40,11 @@ from ddtrace.contrib.internal.pytest._utils import _pytest_version_supports_retr
 from ddtrace.contrib.internal.pytest._utils import _TestOutcome
 from ddtrace.contrib.internal.pytest._utils import excinfo_by_report
 from ddtrace.contrib.internal.pytest._utils import reports_by_item
-from ddtrace.contrib.internal.pytest._xdist import PYTEST_XDIST_WORKER_VALUE
 from ddtrace.contrib.internal.pytest._xdist import XDIST_UNSET
 from ddtrace.contrib.internal.pytest._xdist import XdistHooks
 from ddtrace.contrib.internal.pytest._xdist import _parse_xdist_args_from_cmd
 from ddtrace.contrib.internal.pytest._xdist import _skipping_level_for_xdist_parallelization_mode
+from ddtrace.contrib.internal.pytest._xdist import is_xdist_worker_env
 from ddtrace.contrib.internal.pytest.constants import FRAMEWORK
 from ddtrace.contrib.internal.pytest.constants import USER_PROPERTY_QUARANTINED
 from ddtrace.contrib.internal.pytest.constants import XFAIL_REASON
@@ -328,7 +328,7 @@ def _pytest_load_initial_conftests_pre_yield(early_config, parser, args):
     take_over_logger_stream_handler()
 
     # Log early initialization details
-    is_worker = PYTEST_XDIST_WORKER_VALUE is not None
+    is_worker = is_xdist_worker_env()
     process_type = "WORKER" if is_worker else "MAIN"
     log.debug("EARLY_INIT: %s process starting pytest_load_initial_conftests_pre_yield", process_type)
 
@@ -421,7 +421,18 @@ def _handle_coverage_patch_early(config):
 
 
 def pytest_configure(config: pytest_Config) -> None:
-    global skip_pytest_runtest_protocol
+    global skip_pytest_runtest_protocol, skipped_suites
+
+    # AIDEV-NOTE: Reset per-session module-level state for every new main-process
+    # session. This is necessary when inline_run() calls pytest.main() inside an
+    # outer xdist worker: the module is already imported, so module-level
+    # initialisations don't re-run. Without this reset, skipped_suites accumulates
+    # entries from previous sessions and skip_pytest_runtest_protocol may stay True.
+    # The hasattr(config, "workerinput") check identifies the main process of the
+    # *current* session (not the outer-run process).
+    if not hasattr(config, "workerinput"):
+        skipped_suites = set()
+        skip_pytest_runtest_protocol = False
 
     if env.get("DD_PYTEST_USE_NEW_PLUGIN_BETA"):
         # Logging the warning at this point ensures it shows up in output regardless of the use of the -s flag.
@@ -463,8 +474,15 @@ def pytest_configure(config: pytest_Config) -> None:
             if config.pluginmanager.hasplugin("xdist"):
                 config.pluginmanager.register(XdistHooks())
 
-                if not hasattr(config, "workerinput") and PYTEST_XDIST_WORKER_VALUE is None:
-                    # Main process
+                if not hasattr(config, "workerinput"):
+                    # Main process: reset per-session xdist ITR skip counter.
+                    # AIDEV-NOTE: Do NOT guard with PYTEST_XDIST_WORKER_VALUE is None here.
+                    # PYTEST_XDIST_WORKER_VALUE is a module-level constant frozen at import time.
+                    # When inline_run() is called inside an outer xdist worker, the constant is
+                    # "gw0" for the entire process lifetime, so the reset would never fire and
+                    # pytest.global_worker_itr_results would accumulate across inline_run calls.
+                    # hasattr(config, "workerinput") is the correct check: it is True only for
+                    # worker configs of the *current* session, not for outer-run workers.
                     pytest.global_worker_itr_results = 0
 
         else:

--- a/ddtrace/contrib/internal/pytest/_xdist.py
+++ b/ddtrace/contrib/internal/pytest/_xdist.py
@@ -20,20 +20,15 @@ from ddtrace.internal.utils.formats import asbool
 log = get_logger(__name__)
 
 # xdist-related constants
-# AIDEV-NOTE: PYTEST_XDIST_WORKER_VALUE is frozen at import time and must NOT be used
-# for session-level worker detection — it stays set to the outer worker id for the entire
-# process lifetime when inline_run() is called inside an outer xdist worker.
-# Use is_xdist_worker_env() for any live check that must reflect the current environment.
-PYTEST_XDIST_WORKER_VALUE = env.get("PYTEST_XDIST_WORKER")
 XDIST_UNSET = "UNSET"
 
 
 def is_xdist_worker_env() -> bool:
-    """Return True if the current process is currently running as an xdist worker.
+    """Return True if the current process is running as an xdist worker.
 
-    Unlike PYTEST_XDIST_WORKER_VALUE (frozen at import time), this reads os.environ
-    live, so it returns the correct answer even when inline_run() is called inside
-    an outer xdist worker that has cleared PYTEST_XDIST_WORKER from the environment.
+    Reads os.environ live so it returns the correct answer even when inline_run()
+    is called inside an outer xdist worker that has cleared PYTEST_XDIST_WORKER
+    from the environment.
     """
     return env.get("PYTEST_XDIST_WORKER") is not None
 

--- a/ddtrace/contrib/internal/pytest/_xdist.py
+++ b/ddtrace/contrib/internal/pytest/_xdist.py
@@ -20,8 +20,24 @@ from ddtrace.internal.utils.formats import asbool
 log = get_logger(__name__)
 
 # xdist-related constants
+# AIDEV-NOTE: PYTEST_XDIST_WORKER_VALUE is frozen at import time and must NOT be used
+# for session-level worker detection — it stays set to the outer worker id for the entire
+# process lifetime when inline_run() is called inside an outer xdist worker.
+# Use is_xdist_worker_env() for any live check that must reflect the current environment.
 PYTEST_XDIST_WORKER_VALUE = env.get("PYTEST_XDIST_WORKER")
 XDIST_UNSET = "UNSET"
+
+
+def is_xdist_worker_env() -> bool:
+    """Return True if the current process is currently running as an xdist worker.
+
+    Unlike PYTEST_XDIST_WORKER_VALUE (frozen at import time), this reads os.environ
+    live, so it returns the correct answer even when inline_run() is called inside
+    an outer xdist worker that has cleared PYTEST_XDIST_WORKER from the environment.
+    """
+    return env.get("PYTEST_XDIST_WORKER") is not None
+
+
 XDIST_AUTO = "auto"
 XDIST_LOGICAL = "logical"
 

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -665,6 +665,33 @@ class CIVisibility(Service):
             cls._instance.is_known_tests_enabled(),
         )
 
+    # AIDEV-NOTE: _suspend()/_resume() allow a nested pytest session (e.g. inline_run())
+    # or a test fixture to get a clean-slate view of CIVisibility without stopping the
+    # outer session's instance.  Unlike calling disable(), _suspend() never calls stop()
+    # on the instance, so the outer tracer and telemetry keep running.  Pair them in a
+    # try/finally block: suspended = _suspend() ... finally: _resume(suspended).
+    @classmethod
+    def _suspend(cls) -> Optional["CIVisibility"]:
+        """Remove the active instance without stopping it.  Returns the instance for _resume()."""
+        if cls._instance is None:
+            return None
+        instance = cls._instance
+        cls._instance = None
+        cls.enabled = False
+        unregister_ci_visibility_instance()
+        return instance
+
+    @classmethod
+    def _resume(cls, instance: Optional["CIVisibility"]) -> None:
+        """Restore a previously suspended instance as the active singleton."""
+        if instance is None:
+            return
+        cls._instance = instance
+        cls.enabled = True
+        register_ci_visibility_instance(instance)
+        # Re-register atexit: any inner disable() will have called atexit.unregister.
+        atexit.register(cls.disable)
+
     @classmethod
     def disable(cls) -> None:
         if cls._instance is None:


### PR DESCRIPTION
## Summary

Foundational production-code changes that allow the outer pytest session to run with `--ddtrace` and xdist without corrupting inner `inline_run()` sessions.

Three sources of module-level bleed-through are fixed:

- **`CIVisibility._suspend()`/`_resume()`** — removes/restores the active singleton without calling `stop()`, so the outer session's tracer keeps running while inner sessions get a clean slate. `enable()` and `disable()` are completely unchanged.
- **`is_xdist_worker_env()`** — replaces the frozen-at-import-time `PYTEST_XDIST_WORKER_VALUE` constant with a live `os.environ` read, so inner `inline_run()` sessions (which clear `PYTEST_XDIST_WORKER` from the env) correctly detect they are not workers.
- **Module-level state reset in `pytest_configure`** — resets `skipped_suites` and `skip_pytest_runtest_protocol` for each new main-process session (guarded by `not hasattr(config, "workerinput")`), preventing stale state from accumulating across `inline_run()` calls.

## Test plan

- [x] `ci_visibility::pytest` suite passes with `--ddtrace -n auto` (validated in follow-up PR)
- [x] `ci_visibility::ci_visibility` suite passes with `--ddtrace -n auto` (validated in follow-up PR)
- [x] CI green

## Stacked PRs

1. **This PR** — plugin changes
2. DataDog/dd-trace-py#17458 test isolation fixes (depends on this PR)
3. DataDog/dd-trace-py#17459 enable `--ddtrace -n auto` in riotfile (depends on PR 1 + 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)