### PR TITLE
chore(web_framework): create events and migrate pyramid/bottle/aiohttp

### DIFF
--- a/ddtrace/_trace/subscribers/__init__.py
+++ b/ddtrace/_trace/subscribers/__init__.py
@@ -1,3 +1,4 @@
 # Import subscriber packages — triggers auto-registration via __init_subclass__
 import ddtrace._trace.subscribers.http_client  # noqa: F401
 import ddtrace._trace.subscribers.llm  # noqa: F401
+import ddtrace._trace.subscribers.web_framework  # noqa: F401

--- a/ddtrace/_trace/subscribers/_base.py
+++ b/ddtrace/_trace/subscribers/_base.py
@@ -60,14 +60,14 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
     """
     event = ctx.event
 
-    activate_distributed_headers = ctx.get_item("activate_distributed_headers")
+    activate_distributed_headers = event.activate_distributed_headers
     integration_config = event.integration_config
     if integration_config and activate_distributed_headers:
         trace_utils.activate_distributed_headers(
             tracer,
             int_config=integration_config,
-            request_headers=ctx.get_item("distributed_headers"),
-            override=ctx.get_item("distributed_headers_config_override"),
+            request_headers=getattr(event, "request_headers", None),
+            override=getattr(event, "distributed_headers_config_override", None),
         )
 
     span_kwargs: dict[str, Any] = {

--- a/ddtrace/_trace/subscribers/http_client.py
+++ b/ddtrace/_trace/subscribers/http_client.py
@@ -43,7 +43,7 @@ class HttpClientTracingSubscriber(TracingSubscriber):
                 ctx.span,
                 event.integration_config,
                 method=event.request_method,
-                url=event.url,
+                url=event.request_url,
                 target_host=event.target_host,
                 status_code=event.response_status_code,
                 query=event.query,

--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -47,12 +47,17 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
             integration_config=event.integration_config,
             method=method,
             url=event.request_url,
+            # set_http_meta will check only integration_config to set or not query
+            # however, aiohttp support per-app trace_query_string config overrides
+            query=event.query if event.trace_query_string is None else None,
             status_code=status_code,
             request_headers=event.request_headers,
             response_headers=dict(res_headers) if res_headers is not None else None,
             route=event.request_route,
         )
 
+        # aiohttp supports per-app trace_query_string overrides that may differ from
+        # integration_config.trace_query_string.
         if event.trace_query_string and event.query is not None:
             span._set_attribute(http.QUERY_STRING, event.query)
 

--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -4,17 +4,20 @@ from typing import Optional
 from ddtrace._trace.span import Span
 from ddtrace._trace.subscribers._base import TracingSubscriber
 from ddtrace._trace.trace_handlers import _set_inferred_proxy_tags
-from ddtrace.contrib._events.web_framework import WebFrameworkEvents
 from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
 from ddtrace.contrib.internal import trace_utils
 from ddtrace.ext import http
 from ddtrace.internal import core
+from ddtrace.internal.logger import get_logger
+
+
+log = get_logger(__name__)
 
 
 class WebFrameworkRequestSubscriber(TracingSubscriber):
     """Shared tracing logic for web framework integrations."""
 
-    event_names = (WebFrameworkEvents.WEB_REQUEST.value,)
+    event_names = (WebFrameworkRequestEvent.event_name,)
 
     @classmethod
     def on_started(cls, ctx: core.ExecutionContext) -> None:
@@ -42,19 +45,22 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
         elif event.set_resource and status_code is not None:
             span.resource = f"{method} {status_code}"
 
-        trace_utils.set_http_meta(
-            span=span,
-            integration_config=event.integration_config,
-            method=method,
-            url=event.request_url,
-            # set_http_meta will check only integration_config to set or not query
-            # however, aiohttp support per-app trace_query_string config overrides
-            query=event.query if event.trace_query_string is None else None,
-            status_code=status_code,
-            request_headers=event.request_headers,
-            response_headers=dict(res_headers) if res_headers is not None else None,
-            route=event.request_route,
-        )
+        try:
+            trace_utils.set_http_meta(
+                span=span,
+                integration_config=event.integration_config,
+                method=method,
+                url=event.request_url,
+                # set_http_meta will check only integration_config to set or not query
+                # however, aiohttp support per-app trace_query_string config overrides
+                query=event.query if event.trace_query_string is None else None,
+                status_code=status_code,
+                request_headers=event.request_headers,
+                response_headers=dict(res_headers) if res_headers is not None else None,
+                route=event.request_route,
+            )
+        except Exception:
+            log.debug("%s: error adding tags", event.integration_config.integration_name, exc_info=True)
 
         # aiohttp supports per-app trace_query_string overrides that may differ from
         # integration_config.trace_query_string.

--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -1,0 +1,61 @@
+from types import TracebackType
+from typing import Optional
+
+from ddtrace._trace.span import Span
+from ddtrace._trace.subscribers._base import TracingSubscriber
+from ddtrace._trace.trace_handlers import _set_inferred_proxy_tags
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
+from ddtrace.contrib.internal import trace_utils
+from ddtrace.ext import http
+from ddtrace.internal import core
+
+
+class WebFrameworkRequestSubscriber(TracingSubscriber):
+    """Shared tracing logic for web framework integrations."""
+
+    event_names = (WebFrameworkEvents.WEB_REQUEST.value,)
+
+    @classmethod
+    def on_started(cls, ctx: core.ExecutionContext) -> None:
+        event: WebFrameworkRequestEvent = ctx.event
+
+        if event.allow_default_resource:
+            event.set_resource = True
+
+    @classmethod
+    def on_ended(
+        cls,
+        ctx: core.ExecutionContext,
+        exc_info: tuple[Optional[type], Optional[BaseException], Optional[TracebackType]],
+    ) -> None:
+        event: WebFrameworkRequestEvent = ctx.event
+        status_code = event.response_status_code
+        method = event.request_method
+        res_headers = event.response_headers
+
+        span: Span = ctx.span
+
+        # event.resource can be updated at span finish time
+        if event.resource:
+            span.resource = event.resource
+        elif event.set_resource and status_code is not None:
+            span.resource = f"{method} {status_code}"
+
+        trace_utils.set_http_meta(
+            span=span,
+            integration_config=event.integration_config,
+            method=method,
+            url=event.request_url,
+            status_code=status_code,
+            request_headers=event.request_headers,
+            response_headers=dict(res_headers) if res_headers is not None else None,
+            route=event.request_route,
+        )
+
+        if event.trace_query_string and event.query is not None:
+            span._set_attribute(http.QUERY_STRING, event.query)
+
+        _set_inferred_proxy_tags(span, status_code)
+        for tk, tv in core.get_item("additional_tags", default=dict()).items():
+            span._set_attribute(tk, tv)

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -336,10 +336,19 @@ def _on_inferred_proxy_start(ctx, span_kwargs, call_trace):
     if ctx.get_item("inferred_proxy_span"):
         return
 
+    event = getattr(ctx, "event", None)
+
     # some integrations like Flask / WSGI store headers from environ in 'distributed_headers'
     # and normalized headers in 'headers'
     headers = ctx.get_item("headers", ctx.get_item("distributed_headers", None))
+    if headers is None and event is not None:
+        # Events-based web framework instrumentation stores request headers on the event.
+        headers = getattr(event, "request_headers", None)
+
     integration_config = ctx.get_item("integration_config")
+    if integration_config is None and event is not None:
+        # Events-based instrumentation stores integration config on the event.
+        integration_config = getattr(event, "integration_config", None)
 
     # Inferred Proxy Spans
     if integration_config and headers is not None:
@@ -1750,8 +1759,6 @@ def listen():
 
     for context_name in (
         # web frameworks
-        "aiohttp.request",
-        "bottle.request",
         "cherrypy.request",
         "falcon.request",
         "molten.request",

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -585,10 +585,15 @@ def start_context(waf_callable: Optional[WafCallable], span: Span, rc_products: 
                 rc_products=rc_products,
             ),
         )
+        headers_case_sensitive = core.get_item("headers_case_sensitive")
+        if headers_case_sensitive is None:
+            event = getattr(getattr(core, "current"), "event", None)
+            headers_case_sensitive = getattr(event, "headers_case_sensitive", False)
+
         asm_request_context_set(
             core.get_item("remote_addr"),
             core.get_item("headers"),
-            core.get_item("headers_case_sensitive"),
+            headers_case_sensitive,
             core.get_item("block_request_callable"),
         )
 

--- a/ddtrace/appsec/_contrib/httpx/subscribers.py
+++ b/ddtrace/appsec/_contrib/httpx/subscribers.py
@@ -81,7 +81,7 @@ class AppSecHttpxSingleRequestContextSubscriber(ContextSubscriber[HttpClientSend
             return
 
         addresses = {
-            EXPLOIT_PREVENTION.ADDRESS.SSRF: ctx.event.url,
+            EXPLOIT_PREVENTION.ADDRESS.SSRF: ctx.event.request_url,
             "DOWN_REQ_METHOD": ctx.event.request_method,
             "DOWN_REQ_HEADERS": ctx.event.request_headers,
         }
@@ -99,7 +99,7 @@ class AppSecHttpxSingleRequestContextSubscriber(ContextSubscriber[HttpClientSend
         asm_context.downstream_requests += 1
         if blocking_config := get_blocked():
             raise BlockingException(
-                blocking_config, EXPLOIT_PREVENTION.BLOCKING, EXPLOIT_PREVENTION.TYPE.SSRF, ctx.event.url
+                blocking_config, EXPLOIT_PREVENTION.BLOCKING, EXPLOIT_PREVENTION.TYPE.SSRF, ctx.event.request_url
             )
 
     @classmethod

--- a/ddtrace/contrib/_events/http.py
+++ b/ddtrace/contrib/_events/http.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import Mapping
+from typing import MutableMapping
+from typing import Optional
+from typing import Protocol
+from typing import Sequence
+from typing import Union
+
+from ddtrace.internal.core.events import Event
+from ddtrace.internal.core.events import event_field
+
+
+JsonType = Union[None, bool, int, float, str, Sequence["JsonType"], Mapping[str, "JsonType"]]
+
+
+class _HttpClientResponse(Protocol):
+    @property
+    def headers(self) -> MutableMapping[str, str]: ...
+
+    @property
+    def status_code(self) -> int: ...
+
+    def json(self) -> JsonType: ...
+
+
+@dataclass
+class HttpBaseEvent(Event):
+    """Common HTTP request/response data.
+
+    This event contains the information needed by both AppSec and APM events when tracing
+    http calls (wether client or server).
+    """
+
+    request_url: str = event_field()
+    request_method: str = event_field()
+    request_headers: MutableMapping[str, str] = event_field()
+
+    response_headers: Mapping[str, str] = event_field(default_factory=dict)
+    response_status_code: Optional[int] = event_field(default=None)
+
+    def set_response(self, response: _HttpClientResponse) -> None:
+        self.response_status_code = response.status_code
+        self.response_headers = response.headers
+
+
+@dataclass
+class HttpRequestBaseEvent(HttpBaseEvent):
+    """Base event for traced HTTP requests."""
+
+    http_operation: str = event_field()
+    query: str = event_field()

--- a/ddtrace/contrib/_events/http.py
+++ b/ddtrace/contrib/_events/http.py
@@ -28,7 +28,7 @@ class HttpBaseEvent(Event):
     """Common HTTP request/response data.
 
     This event contains the information needed by both AppSec and APM events when tracing
-    http calls (wether client or server).
+    http calls (whether client or server).
     """
 
     request_url: str = event_field()

--- a/ddtrace/contrib/_events/http_client.py
+++ b/ddtrace/contrib/_events/http_client.py
@@ -41,10 +41,11 @@ class HttpClientEvents(Enum):
 
 
 @dataclass
-class HttpClientBaseEvent(Event):
-    url: str = event_field()
+class HttpBaseEvent(Event):
+    request_url: str = event_field()
     request_method: str = event_field()
     request_headers: MutableMapping[str, str] = event_field()
+
     response_headers: Mapping[str, str] = event_field(default_factory=dict)
     response_status_code: Optional[int] = event_field(default=None)
 
@@ -54,7 +55,13 @@ class HttpClientBaseEvent(Event):
 
 
 @dataclass
-class HttpClientRequestEvent(HttpClientBaseEvent, TracingEvent):
+class HttpRequestBaseEvent(HttpBaseEvent):
+    http_operation: str = event_field()
+    query: str = event_field()
+
+
+@dataclass
+class HttpClientRequestEvent(HttpRequestBaseEvent, TracingEvent):
     """HTTP client request event"""
 
     event_name = HttpClientEvents.HTTP_REQUEST.value
@@ -62,10 +69,7 @@ class HttpClientRequestEvent(HttpClientBaseEvent, TracingEvent):
     span_kind = SpanKind.CLIENT
     span_type = SpanTypes.HTTP
 
-    http_operation: str = event_field()
-    query: str = event_field()
     target_host: Optional[str] = event_field()
-
     response: Optional[_HttpClientResponse] = event_field(default=None)
 
     def __post_init__(self):
@@ -79,7 +83,7 @@ class HttpClientRequestEvent(HttpClientBaseEvent, TracingEvent):
 
 
 @dataclass
-class HttpClientSendEvent(HttpClientBaseEvent):
+class HttpClientSendEvent(HttpBaseEvent):
     """HTTP client send event
 
     This represents individual requests in a single http client call.

--- a/ddtrace/contrib/_events/http_client.py
+++ b/ddtrace/contrib/_events/http_client.py
@@ -1,17 +1,15 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable
-from typing import Mapping
-from typing import MutableMapping
 from typing import Optional
-from typing import Protocol
-from typing import Sequence
 from typing import Union
 
 from ddtrace._trace.events import TracingEvent
+from ddtrace.contrib._events.http import HttpBaseEvent
+from ddtrace.contrib._events.http import HttpRequestBaseEvent
+from ddtrace.contrib._events.http import _HttpClientResponse
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
-from ddtrace.internal.core.events import Event
 from ddtrace.internal.core.events import event_field
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_url_operation
@@ -21,43 +19,11 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 log = get_logger(__name__)
 
 
-JsonType = Union[None, bool, int, float, str, Sequence["JsonType"], Mapping[str, "JsonType"]]
-
-
-class _HttpClientResponse(Protocol):
-    @property
-    def headers(self) -> MutableMapping[str, str]: ...
-    @property
-    def status_code(self) -> int: ...
-
-    def json(self) -> JsonType: ...
-
-
 class HttpClientEvents(Enum):
     HTTP_REQUEST = "http.client.request"
     HTTPX_REQUEST = "httpx.request"
     HTTP_SEND_REQUEST = "http.client.send_request"
     HTTPX_SEND_REQUEST = "httpx.send_request"
-
-
-@dataclass
-class HttpBaseEvent(Event):
-    request_url: str = event_field()
-    request_method: str = event_field()
-    request_headers: MutableMapping[str, str] = event_field()
-
-    response_headers: Mapping[str, str] = event_field(default_factory=dict)
-    response_status_code: Optional[int] = event_field(default=None)
-
-    def set_response(self, response: _HttpClientResponse) -> None:
-        self.response_status_code = response.status_code
-        self.response_headers = response.headers
-
-
-@dataclass
-class HttpRequestBaseEvent(HttpBaseEvent):
-    http_operation: str = event_field()
-    query: str = event_field()
 
 
 @dataclass

--- a/ddtrace/contrib/_events/web_framework.py
+++ b/ddtrace/contrib/_events/web_framework.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from ddtrace._trace.events import TracingEvent
-from ddtrace.contrib._events.http_client import HttpRequestBaseEvent
+from ddtrace.contrib._events.http import HttpRequestBaseEvent
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.core.events import event_field
@@ -37,8 +37,8 @@ class WebFrameworkRequestEvent(HttpRequestBaseEvent, TracingEvent):
     # Framework-resolved route template/path used for http.route and resource enrichment.
     request_route: Optional[str] = event_field(default=None)
 
-    # Optional override controlling whether the query string is tagged on the span.
-    # Created because aiohttp can override that
+    # Optional per-request override for query string tagging.
+    # aiohttp supports app-level trace_query_string that can differ from integration_config.
     trace_query_string: Optional[bool] = event_field(default=None)
 
     def __post_init__(self):

--- a/ddtrace/contrib/_events/web_framework.py
+++ b/ddtrace/contrib/_events/web_framework.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from ddtrace._trace.events import TracingEvent
+from ddtrace.contrib._events.http_client import HttpRequestBaseEvent
+from ddtrace.ext import SpanKind
+from ddtrace.ext import SpanTypes
+from ddtrace.internal.core.events import event_field
+from ddtrace.internal.schema import SpanDirection
+from ddtrace.internal.schema import schematize_url_operation
+
+
+class WebFrameworkEvents(str, Enum):
+    WEB_REQUEST = "web.request"
+
+
+@dataclass
+class WebFrameworkRequestEvent(HttpRequestBaseEvent, TracingEvent):
+    event_name = WebFrameworkEvents.WEB_REQUEST.value
+
+    span_type = SpanTypes.WEB
+    span_kind = SpanKind.SERVER
+
+    # Whether header keys should preserve their original casing during extraction.
+    headers_case_sensitive: bool = event_field()
+
+    # Optional per-request override for distributed tracing header activation.
+    distributed_headers_config_override: Optional[bool] = event_field(default=None)
+
+    # Allow fallback resource naming (for example "METHOD STATUS") when no route/resource is set.
+    allow_default_resource: bool = event_field(default=False)
+
+    # Internal flag indicating fallback resource naming should be applied at finish.
+    set_resource: bool = event_field(default=False)
+
+    # Framework-resolved route template/path used for http.route and resource enrichment.
+    request_route: Optional[str] = event_field(default=None)
+
+    # Optional override controlling whether the query string is tagged on the span.
+    # Created because aiohttp can override that
+    trace_query_string: Optional[bool] = event_field(default=None)
+
+    def __post_init__(self):
+        self.operation_name = schematize_url_operation(
+            self.http_operation, protocol="http", direction=SpanDirection.INBOUND
+        )

--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -2,11 +2,8 @@ from aiohttp import web
 from aiohttp.web_urldispatcher import SystemRoute
 
 from ddtrace import config
-from ddtrace.ext import SpanTypes
-from ddtrace.ext import http
+from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
 from ddtrace.internal import core
-from ddtrace.internal.schema import schematize_url_operation
-from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.debtcollector import deprecate
 
@@ -29,31 +26,49 @@ async def trace_middleware(app, handler):
 
     async def attach_context(request):
         # application configs
-        service = app[CONFIG_KEY]["service"]
-        # Create a new context based on the propagated information.
+        app_config = app[CONFIG_KEY]
+        service = app_config["service"]
+        request[REQUEST_CONFIG_KEY] = app_config
 
-        with core.context_with_data(
-            "aiohttp.request",
-            span_name=schematize_url_operation("aiohttp.request", protocol="http", direction=SpanDirection.INBOUND),
-            span_type=SpanTypes.WEB,
-            service=service,
-            tags={},
-            distributed_headers=request.headers,
-            integration_config=config.aiohttp,
-            activate_distributed_headers=True,
-            distributed_headers_config_override=app[CONFIG_KEY]["distributed_tracing_enabled"],
-            headers_case_sensitive=True,
+        # The match info object provided by aiohttp's default (and only) router
+        # has a `route` attribute, but routers are susceptible to being replaced/hand-rolled
+        # so we can only support this case.
+        route = None
+        if hasattr(request.match_info, "route"):
+            aiohttp_route = request.match_info.route
+            if not isinstance(aiohttp_route, SystemRoute):
+                # SystemRoute objects exist to throw HTTP errors and have no path
+                route = aiohttp_route.resource.canonical
+
+        trace_query_string = app_config.get("trace_query_string")
+        if trace_query_string is None:
+            trace_query_string = config._http.trace_query_string
+
+        # Create a new context based on the propagated information.
+        with core.context_with_event(
+            WebFrameworkRequestEvent(
+                http_operation="aiohttp.request",
+                component=config.aiohttp.integration_name,
+                integration_config=config.aiohttp,
+                request_headers=request.headers,
+                request_method=request.method,
+                request_url=str(request.url),  # DEV: request.url is a yarl's URL object,
+                request_route=route,
+                headers_case_sensitive=True,
+                activate_distributed_headers=True,
+                distributed_headers_config_override=app_config["distributed_tracing_enabled"],
+                # DEV: aiohttp is special case maintains separate configuration from config api
+                trace_query_string=trace_query_string,
+                query=request.query_string,
+                service=service,
+            ),
+            dispatch_end_event=False,
         ) as ctx:
             req_span = ctx.span
-
-            ctx.set_item("req_span", req_span)
-            core.dispatch("web.request.start", (ctx, config.aiohttp))
-
             # attach the context and the root span to the request; the Context
             # may be freely used by the application code
-            request[REQUEST_CONTEXT_KEY] = req_span.context
-            request[REQUEST_SPAN_KEY] = req_span
-            request[REQUEST_CONFIG_KEY] = app[CONFIG_KEY]
+            request[REQUEST_CONTEXT_KEY] = ctx
+
             try:
                 response = await handler(request)
                 if not config.aiohttp["disable_stream_timing_for_mem_leak"]:
@@ -69,8 +84,8 @@ async def trace_middleware(app, handler):
 
 def finish_request_span(request, response):
     # safe-guard: discard if we don't have a request span
-    request_span = request.get(REQUEST_SPAN_KEY, None)
-    if not request_span:
+    ctx = request.get(REQUEST_CONTEXT_KEY)
+    if not ctx or not ctx.span:
         return
 
     # default resource name
@@ -90,40 +105,11 @@ def finish_request_span(request, response):
         # prefix the resource name by the http method
         resource = "{} {}".format(request.method, resource)
 
-    request_span.resource = resource
-
-    # DEV: aiohttp is special case maintains separate configuration from config api
-    trace_query_string = request[REQUEST_CONFIG_KEY].get("trace_query_string")
-    if trace_query_string is None:
-        trace_query_string = config._http.trace_query_string
-    if trace_query_string:
-        request_span._set_attribute(http.QUERY_STRING, request.query_string)
-
-    # The match info object provided by aiohttp's default (and only) router
-    # has a `route` attribute, but routers are susceptible to being replaced/hand-rolled
-    # so we can only support this case.
-    route = None
-    if hasattr(request.match_info, "route"):
-        aiohttp_route = request.match_info.route
-        if not isinstance(aiohttp_route, SystemRoute):
-            # SystemRoute objects exist to throw HTTP errors and have no path
-            route = aiohttp_route.resource.canonical
-
-    core.dispatch(
-        "web.request.finish",
-        (
-            request_span,
-            config.aiohttp,
-            request.method,
-            str(request.url),  # DEV: request.url is a yarl's URL object
-            response.status,
-            None,  # query arg = None
-            request.headers,
-            response.headers,
-            route,
-            True,
-        ),
-    )
+    event: WebFrameworkRequestEvent = ctx.event
+    event.resource = resource
+    event.response_status_code = response.status
+    event.response_headers = response.headers
+    ctx.dispatch_ended_event()
 
 
 async def on_prepare(request, response):

--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -9,9 +9,8 @@ from ddtrace.vendor.debtcollector import deprecate
 
 
 CONFIG_KEY = "datadog_trace"
-REQUEST_CONTEXT_KEY = "datadog_context"
+REQUEST_EXECUTION_CONTEXT_KEY = "__datadog_execution_context"
 REQUEST_CONFIG_KEY = "__datadog_trace_config"
-REQUEST_SPAN_KEY = "__datadog_request_span"
 
 
 async def trace_middleware(app, handler):
@@ -65,9 +64,9 @@ async def trace_middleware(app, handler):
             dispatch_end_event=False,
         ) as ctx:
             req_span = ctx.span
-            # attach the context and the root span to the request; the Context
-            # may be freely used by the application code
-            request[REQUEST_CONTEXT_KEY] = ctx
+
+            # attach the execution context to the request
+            request[REQUEST_EXECUTION_CONTEXT_KEY] = ctx
 
             try:
                 response = await handler(request)
@@ -84,7 +83,7 @@ async def trace_middleware(app, handler):
 
 def finish_request_span(request, response):
     # safe-guard: discard if we don't have a request span
-    ctx = request.get(REQUEST_CONTEXT_KEY)
+    ctx = request.get(REQUEST_EXECUTION_CONTEXT_KEY)
     if not ctx or not ctx.span:
         return
 

--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -9,6 +9,7 @@ from ddtrace.vendor.debtcollector import deprecate
 
 
 CONFIG_KEY = "datadog_trace"
+REQUEST_CONTEXT_KEY = "datadog_context"
 REQUEST_EXECUTION_CONTEXT_KEY = "__datadog_execution_context"
 REQUEST_CONFIG_KEY = "__datadog_trace_config"
 
@@ -67,6 +68,8 @@ async def trace_middleware(app, handler):
 
             # attach the execution context to the request
             request[REQUEST_EXECUTION_CONTEXT_KEY] = ctx
+            # legacy request key kept for backwards compatibility with documentation
+            request[REQUEST_CONTEXT_KEY] = req_span.context
 
             try:
                 response = await handler(request)

--- a/ddtrace/contrib/internal/bottle/trace.py
+++ b/ddtrace/contrib/internal/bottle/trace.py
@@ -1,16 +1,17 @@
+from typing import MutableMapping
+from typing import cast
+
 from bottle import HTTPError
 from bottle import HTTPResponse
 from bottle import request
 from bottle import response
 
 from ddtrace import config
-from ddtrace.ext import SpanTypes
+from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.internal import core
-from ddtrace.internal.schema import schematize_url_operation
-from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import tracer
 from ddtrace.vendor.debtcollector import deprecate
 
 
@@ -40,31 +41,32 @@ class TracePlugin(object):
 
     def apply(self, callback, route):
         def wrapped(*args, **kwargs):
-            if not tracer or not tracer.enabled:
+            if not is_tracing_enabled():
                 return callback(*args, **kwargs)
 
             resource = "{} {}".format(request.method, route.rule)
 
-            with (
-                core.context_with_data(
-                    "bottle.request",
-                    span_name=schematize_url_operation(
-                        "bottle.request", protocol="http", direction=SpanDirection.INBOUND
-                    ),
-                    span_type=SpanTypes.WEB,
+            method = request.method
+            url = request.url
+            full_route = "/".join([request.script_name.rstrip("/"), route.rule.lstrip("/")])
+
+            with core.context_with_event(
+                WebFrameworkRequestEvent(
+                    http_operation="bottle.request",
                     service=self.service,
                     resource=resource,
-                    tags={},
-                    distributed_headers=request.headers,
+                    component=config.bottle.integration_name,
+                    request_headers=cast(MutableMapping[str, str], request.headers),
+                    request_url=url,
+                    query=request.query_string,
+                    request_route=full_route,
+                    request_method=method,
+                    trace_query_string=config.bottle.trace_query_string,
                     integration_config=config.bottle,
                     headers_case_sensitive=True,
                     activate_distributed_headers=True,
-                ) as ctx,
-                ctx.span as req_span,
-            ):
-                ctx.set_item("req_span", req_span)
-                core.dispatch("web.request.start", (ctx, config.bottle))
-
+                )
+            ) as ctx:
                 code = None
                 result = None
                 try:
@@ -92,24 +94,8 @@ class TracePlugin(object):
                         # will be default
                         response_code = response.status_code
 
-                    method = request.method
-                    url = request.urlparts._replace(query="").geturl()
-                    full_route = "/".join([request.script_name.rstrip("/"), route.rule.lstrip("/")])
-
-                    core.dispatch(
-                        "web.request.finish",
-                        (
-                            req_span,
-                            config.bottle,
-                            method,
-                            url,
-                            response_code,
-                            request.query_string,
-                            request.headers,
-                            response.headers,
-                            full_route,
-                            False,
-                        ),
-                    )
+                    event: WebFrameworkRequestEvent = ctx.event
+                    event.response_status_code = response_code
+                    event.response_headers = response.headers
 
         return wrapped

--- a/ddtrace/contrib/internal/bottle/trace.py
+++ b/ddtrace/contrib/internal/bottle/trace.py
@@ -61,7 +61,6 @@ class TracePlugin(object):
                     query=request.query_string,
                     request_route=full_route,
                     request_method=method,
-                    trace_query_string=config.bottle.trace_query_string,
                     integration_config=config.bottle,
                     headers_case_sensitive=True,
                     activate_distributed_headers=True,

--- a/ddtrace/contrib/internal/httpx/patch.py
+++ b/ddtrace/contrib/internal/httpx/patch.py
@@ -69,7 +69,7 @@ def _wrapped_sync_send_single_request(
     req: httpx.Request = get_argument_value(args, kwargs, 0, "request")
     with core.context_with_event(
         event=HttpClientSendEvent(
-            url=httpx_url_to_str(req.url),
+            request_url=httpx_url_to_str(req.url),
             request_method=req.method,
             request_headers=req.headers,
             request_body=lambda: req.content,
@@ -94,7 +94,7 @@ async def _wrapped_async_send_single_request(
     req: httpx.Request = get_argument_value(args, kwargs, 0, "request")
     with core.context_with_event(
         event=HttpClientSendEvent(
-            url=httpx_url_to_str(req.url),
+            request_url=httpx_url_to_str(req.url),
             request_method=req.method,
             request_headers=req.headers,
             request_body=lambda: req.content,
@@ -126,7 +126,7 @@ async def _wrapped_async_send(
             request_method=req.method,
             request_headers=req.headers,
             integration_config=config.httpx,
-            url=httpx_url_to_str(req.url),
+            request_url=httpx_url_to_str(req.url),
             query=ensure_text(req.url.query),
             target_host=req.url.host,
         ),
@@ -157,7 +157,7 @@ def _wrapped_sync_send(
             request_method=req.method,
             request_headers=req.headers,
             integration_config=config.httpx,
-            url=httpx_url_to_str(req.url),
+            request_url=httpx_url_to_str(req.url),
             query=ensure_text(req.url.query),
             target_host=req.url.host,
         ),

--- a/ddtrace/contrib/internal/pyramid/trace.py
+++ b/ddtrace/contrib/internal/pyramid/trace.py
@@ -4,14 +4,13 @@ from pyramid.settings import asbool
 import wrapt
 
 from ddtrace import config
+from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal.compat import is_wrapted
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.internal.schema import schematize_url_operation
-from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 # project
 from ddtrace.trace import tracer
@@ -63,26 +62,23 @@ def trace_tween_factory(handler, registry):
     if enabled:
         # make a request tracing function
         def trace_tween(request):
-            with (
-                core.context_with_data(
-                    "pyramid.request",
-                    span_name=schematize_url_operation(
-                        "pyramid.request", protocol="http", direction=SpanDirection.INBOUND
-                    ),
-                    span_type=SpanTypes.WEB,
+            with core.context_with_event(
+                WebFrameworkRequestEvent(
+                    http_operation="pyramid.request",
                     service=service,
                     resource="404",
-                    tags={},
-                    distributed_headers=request.headers,
                     integration_config=config.pyramid,
+                    component=config.pyramid.integration_name,
+                    request_headers=request.headers,
+                    request_url=request.url,
+                    request_method=request.method,
+                    request_route=None,
+                    trace_query_string=config.pyramid.trace_query_string,
+                    query=request.query_string,
                     activate_distributed_headers=True,
                     headers_case_sensitive=True,
-                ) as ctx,
-                ctx.span as req_span,
-            ):
-                ctx.set_item("req_span", req_span)
-                core.dispatch("web.request.start", (ctx, config.pyramid))
-
+                )
+            ) as ctx:
                 response = None
                 status = None
                 try:
@@ -99,32 +95,20 @@ def trace_tween_factory(handler, registry):
                     status = 500
                     raise
                 finally:
+                    event: WebFrameworkRequestEvent = ctx.event
                     # set request tags
                     if request.matched_route:
-                        req_span.resource = "{} {}".format(request.method, request.matched_route.name)
-                        req_span._set_attribute("pyramid.route.name", request.matched_route.name)
+                        event.resource = "{} {}".format(request.method, request.matched_route.name)
+                        event.request_route = request.matched_route.pattern
+                        ctx.span._set_attribute("pyramid.route.name", request.matched_route.name)
                     # set response tags
                     if response:
                         status = response.status_code
                         response_headers = response.headers
                     else:
-                        response_headers = None
-
-                    core.dispatch(
-                        "web.request.finish",
-                        (
-                            req_span,
-                            config.pyramid,
-                            request.method,
-                            request.path_url,
-                            status,
-                            request.query_string,
-                            request.headers,
-                            response_headers,
-                            request.matched_route.pattern if request.matched_route else None,
-                            False,
-                        ),
-                    )
+                        response_headers = {}
+                    event.response_headers = response_headers
+                    event.response_status_code = status
 
                 return response
 

--- a/ddtrace/contrib/internal/pyramid/trace.py
+++ b/ddtrace/contrib/internal/pyramid/trace.py
@@ -73,7 +73,6 @@ def trace_tween_factory(handler, registry):
                     request_url=request.url,
                     request_method=request.method,
                     request_route=None,
-                    trace_query_string=config.pyramid.trace_query_string,
                     query=request.query_string,
                     activate_distributed_headers=True,
                     headers_case_sensitive=True,

--- a/ddtrace/contrib/internal/requests/connection.py
+++ b/ddtrace/contrib/internal/requests/connection.py
@@ -91,7 +91,7 @@ def _wrap_send(func, instance, args, kwargs):
             integration_config=config.requests,
             request_method=request.method,
             request_headers=request.headers,
-            url=request.url,
+            request_url=request.url,
             query=_extract_query_string(url) or "",
             target_host=host_without_port,
         ),

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -11,6 +11,7 @@ from typing import Callable  # noqa:F401
 from typing import Generator  # noqa:F401
 from typing import Iterator  # noqa:F401
 from typing import Mapping  # noqa:F401
+from typing import MutableMapping  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Union  # noqa:F401
 from typing import cast  # noqa:F401
@@ -542,7 +543,7 @@ def set_http_meta(
 def activate_distributed_headers(
     tracer: "Tracer",
     int_config: Optional["IntegrationConfig"] = None,
-    request_headers: Optional[dict[str, str]] = None,
+    request_headers: Optional[MutableMapping[str, str]] = None,
     override: Optional[bool] = None,
 ) -> None:
     """


### PR DESCRIPTION
Add Web Framework Events and migrate pyramid bottle and aiohttp to use it.

Good to know:
- No tests had to be modified for this migration, which _should_ ensure we did not break anything.
- Web Framework events shared the same base as HTTP Client events
