### PR TITLE
chore(ci): make windows build script more robust

### DIFF
--- a/.gitlab/scripts/build-wheel-windows.sh
+++ b/.gitlab/scripts/build-wheel-windows.sh
@@ -409,9 +409,9 @@ debug_system_info() {
     if [[ -d "$vc_tools_dir" ]]; then
       echo "  VC/Tools/MSVC versions: $(ls "$vc_tools_dir" | tr '\n' ' ')"
       local sample_cl
-      sample_cl=$(ls "${vc_tools_dir}"/*/bin/Hostx64/x64/cl.exe 2>/dev/null | head -1)
+      sample_cl=$(ls "${vc_tools_dir}"/*/bin/Hostx64/x64/cl.exe 2>/dev/null | head -1 || true)
       echo "  cl.exe (x64):  ${sample_cl:-NOT FOUND}"
-      sample_cl=$(ls "${vc_tools_dir}"/*/bin/Hostx64/x86/cl.exe 2>/dev/null | head -1)
+      sample_cl=$(ls "${vc_tools_dir}"/*/bin/Hostx64/x86/cl.exe 2>/dev/null | head -1 || true)
       echo "  cl.exe (x86):  ${sample_cl:-NOT FOUND}"
     else
       echo "  VC/Tools/MSVC: NOT FOUND at ${vc_tools_dir}"

--- a/.gitlab/scripts/build-wheel-windows.sh
+++ b/.gitlab/scripts/build-wheel-windows.sh
@@ -206,7 +206,17 @@ setup_msvc() {
   _find_vswhere
 
   # ── Install VS Build Tools if missing ──────────────────────────────────────
+  # Also install when vswhere exists (VS Installer shell present) but finds no
+  # actual VS products — this happens on freshly provisioned runners.
+  local _need_vs_install=false
   if [[ -z "${vswhere:-}" || ! -f "$vswhere" ]]; then
+    _need_vs_install=true
+  elif [[ -z "$("$vswhere" -all -products '*' -property installationPath 2>/dev/null | head -1 | tr -d '\r' || true)" ]]; then
+    echo "vswhere found but no Visual Studio installation detected."
+    _need_vs_install=true
+  fi
+
+  if [[ "$_need_vs_install" == "true" ]]; then
     echo "VS Build Tools not found — installing now."
     echo "  (this is slow ~10-20 min; pre-install on runner image to avoid this)"
 
@@ -237,7 +247,7 @@ setup_msvc() {
   # -all includes "incomplete" installs (installer shell only, no workloads yet).
   local vs_path vs_path_unix
   vs_path=$("$vswhere" -all -products '*' -property installationPath 2>/dev/null | head -1 | tr -d '\r')
-  [[ -n "$vs_path" ]] || { echo "ERROR: No Visual Studio installation found" >&2; exit 1; }
+  [[ -n "$vs_path" ]] || { echo "ERROR: No Visual Studio installation found after install attempt" >&2; exit 1; }
   echo "VS installation path: $vs_path"
   vs_path_unix=$(cygpath -u "${vs_path}" 2>/dev/null || echo "${vs_path//\\//}")
 


### PR DESCRIPTION
APPSEC-62241

## Summary
Fixes two causes of flaky `build windows` CI job failures in `build-wheel-windows.sh`:

- **Exit status 2** — `debug_system_info()` uses `ls` glob patterns to find `cl.exe` under `VC/Tools/MSVC/*/bin/Hostx64/{x64,x86}/`. When the glob doesn't match (depends on the runner's MSVC host-tool layout), `ls` exits with code 2, and `set -euo pipefail` kills the entire script before any actual build step runs. Fix: add `|| true` to the two unprotected command substitutions.

- **Exit status 1** — `setup_msvc()` only installs VS Build Tools when `vswhere.exe` is missing. On freshly provisioned runners, the VS Installer shell is present (`vswhere.exe` exists) but no actual VS products are installed. The script finds `vswhere`, skips the install, then fails at "No Visual Studio installation found". Fix: also check whether `vswhere` finds any VS installation, and trigger the install if not.

## Impact
858+ `build windows` job failures in the last 7 days across all branches (main, merge queue, feature branches), affecting every Python version and architecture combination. The flakiness depends on which EC2 Windows runner the job lands on.
