### PR TITLE
ci(celery): fix flaky celery test teardown file removal

### DIFF
--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -1,5 +1,6 @@
 from collections import Counter
 import os
+from pathlib import Path
 import subprocess
 import sys
 import time
@@ -34,10 +35,8 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
 
     def tearDown(self):
         super(CeleryIntegrationTask, self).tearDown()
-        if os.path.isfile("celerybeat-schedule.dir"):
-            os.remove("celerybeat-schedule.bak")
-            os.remove("celerybeat-schedule.dat")
-            os.remove("celerybeat-schedule.dir")
+        for file_path in ("celerybeat-schedule.bak", "celerybeat-schedule.dat", "celerybeat-schedule.dir"):
+            Path(file_path).unlink(missing_ok=True)
 
     def test_concurrent_delays(self):
         # it should create one trace for each delayed execution


### PR DESCRIPTION
## Description

Fixes a critical flaky test bug in `tests/contrib/celery/test_integration.py` causing 990 test failures in the last 30 days across 21 different tests in the `CeleryIntegrationTask` class.

The `tearDown` method had a logic error: it checked if `celerybeat-schedule.dir` exists, then unconditionally attempted to remove `.bak` and `.dat` files. However, Python's `shelve`/`dbm` backend doesn't always create all three files — which files exist depends on the dbm implementation. When `pytest-randomly` reorders tests and a celery beat test hasn't created these files, `tearDown` crashes with `FileNotFoundError`.

The fix replaces the conditional file removal with safe removal using `pathlib.Path.unlink(missing_ok=True)`, which gracefully handles missing files without raising exceptions.
