### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/ddtrace/appsec/_http_utils.py
+++ b/ddtrace/appsec/_http_utils.py
@@ -45,15 +45,17 @@ def parse_http_body(
         if not content_type:
             return None
 
-        if content_type in ("application/json", "application/vnd.api+json", "text/json"):
+        media_type = content_type.split(";", 1)[0].strip().lower()
+
+        if media_type in ("application/json", "application/vnd.api+json", "text/json"):
             return json.loads(body)
-        elif content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
+        elif media_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
             return parse_qs(body)
-        elif content_type in ("application/xml", "text/xml"):
+        elif media_type in ("application/xml", "text/xml"):
             return xmltodict.parse(body)
-        elif content_type.startswith("multipart/form-data"):
+        elif media_type == "multipart/form-data":
             return http_utils.parse_form_multipart(body, normalized_headers)
-        elif content_type == "text/plain":
+        elif media_type == "text/plain":
             return None
         else:
             return None


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `ddtrace/appsec/_http_utils.py:L49`

HTTP body parsing for AppSec uses exact string comparison on the `content-type` header (e.g., `application/json`). Common valid values like `application/json; charset=utf-8` will not match and return `None`, which can skip request-body inspection logic and reduce detection coverage.

## Solution

Parse MIME types robustly (e.g., split parameters on `;` or use `cgi.parse_header` / `email.message` parsing) and match on the normalized media type only. Ensure equivalent types with parameters are still inspected.

## Changes

- `ddtrace/appsec/_http_utils.py` (modified)