### PR TITLE
ci: migrate to lib_injection image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -509,19 +509,20 @@ lib_injection_tests:
   needs: []
   stage: tests
   tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/mirror/ubuntu:25.04
-  parallel:
-    matrix:
-      - PYTHON: [ "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev" ]
-  script:
-    - export PYENV_ROOT="${HOME}/.pyenv"
-    - export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-    - apt-get update && apt install build-essential zlib1g-dev libssl-dev curl git -y
-    - for i in 1 2 3; do PYENV_GIT_TAG=v2.6.17 curl -sSf https://pyenv.run | bash && break; echo "pyenv install attempt $i failed, retrying..."; sleep 5; [ "$i" -eq 3 ] && { echo "Failed to install pyenv after 3 attempts"; exit 1; }; done
-    - pyenv --version
-    - pyenv install ${PYTHON} && pyenv global ${PYTHON}
-    - python --version
-    - python lib-injection/sources/sitecustomize.py
+  image: registry.ddbuild.io/dd-trace-py:v106957811-b912d74-lib_injection@sha256:d381042ec0c5d8ba617453feec7ccdffefca8ef0e3011d980728fe1a7a9425eb
+  script: |
+    echo -e "\e[0Ksection_start:`date +%s`:info[collapsed=true]\r\e[0KPython versions"
+    pyenv --version
+    pyenv versions --bare
+    echo -e "\e[0Ksection_end:`date +%s`:info\r\e[0K"
+
+    for python_version in $(pyenv versions --bare); do
+      echo -e "\e[0Ksection_start:`date +%s`:test_${python_version}[collapsed=true]\r\e[0KTesting with Python ${python_version}"
+      pyenv global "${python_version}"
+      pyenv exec python --version
+      pyenv exec python lib-injection/sources/sitecustomize.py
+      echo -e "\e[0Ksection_end:`date +%s`:test_${python_version}\r\e[0K"
+    done
 
 # Profiling native tests with sanitizers
 # Uses dedicated profiling-native image with Python, Rust, valgrind, and clang pre-installed


### PR DESCRIPTION
## Description

We have introduced a new lib_injection image which comes with all versions of Python we want to test against.

This has allowed us to reduce from a matrix job down to a single job testing all pyenv installed versions of Python.

With this change the job runtime is under 2 minutes, even with testing all versions in one job. On `main` one single version/job can take 2+ minutes.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

We are using `pyenv versions --bare` (`--bare` just the name, omits "system"), instead of a hard coded list. This means we rely on the image having the right versions. Using `pyenv versions --bare` makes this a bit more opaque and we are likely to forget adding/removing versions in the future.
