### PR TITLE
chore(pytest): reset coverage state at session start to prevent in-process leakage

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -9,6 +9,7 @@ from ddtrace import config as dd_config
 from ddtrace.contrib.internal.coverage.patch import _is_coverage_available
 from ddtrace.contrib.internal.coverage.patch import get_coverage_percentage
 from ddtrace.contrib.internal.coverage.patch import patch as patch_coverage
+from ddtrace.contrib.internal.coverage.patch import reset_coverage_state
 from ddtrace.contrib.internal.coverage.patch import run_coverage_report
 from ddtrace.contrib.internal.coverage.patch import start_coverage
 from ddtrace.contrib.internal.coverage.utils import _is_coverage_invoked_by_coverage_run
@@ -484,6 +485,9 @@ def pytest_unconfigure(config: pytest_Config) -> None:
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
+    # Reset stale coverage state from any previous in-process session (e.g. pytester.inline_run)
+    reset_coverage_state()
+
     if not is_test_visibility_enabled():
         return
 


### PR DESCRIPTION
## Summary

- Fixes: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1588858306
- `_cached_coverage_percentage` in `ddtrace/contrib/internal/coverage/patch.py` is a module-level global that persists across `pytester.inline_run` calls in the same process.
- When `test_pytest_cov_percentage_enabled` ran first (with `--cov`), it set the cached value to `85.5` via the `coverage_report_wrapper`.
- `test_pytest_cov_percentage_disabled` (without `--cov`) would then read the stale cached value and fail intermittently depending on test order.
- Fix: call `reset_coverage_state()` at the top of `pytest_sessionstart` so each session starts with a clean slate.

## Test plan

- [x] `tests/testing/internal/pytest/test_pytest_cov.py::TestPytestCovPercentage::test_pytest_cov_percentage_enabled` passes
- [x] `tests/testing/internal/pytest/test_pytest_cov.py::TestPytestCovPercentage::test_pytest_cov_percentage_disabled` passes
- [x] Full `ci_visibility::testing` suite passes (736 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)