### PR TITLE
fix: periodic thread start race

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -476,6 +476,19 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
     // alive until stopped_event->set() completes.
     std::shared_ptr<Event> stopped_event = self->_stopped;
 
+    // DEV: Pre-increment self's Python refcount before creating the
+    // thread. There is a window between std::thread creation and when the
+    // lambda acquires the GIL and constructs PyRef during which the lambda
+    // holds only a raw C pointer — no Python reference. If any Python thread
+    // running in that window drives self's refcount to zero (e.g. by removing
+    // the service's _worker reference), PeriodicThread_dealloc fires, sets
+    // self->_started = nullptr, and the thread crashes at _started->set().
+    //
+    // The pre-increment keeps the object alive across that gap.  The lambda
+    // calls Py_DECREF (the "hand-off") only AFTER PyRef has taken its own
+    // reference, so the refcount never transiently hits zero.
+    Py_INCREF((PyObject*)self);
+
     // Start the thread
     self->_thread = std::make_unique<std::thread>([self, stopped_event]() {
         module_state* state = self->_state;
@@ -490,7 +503,12 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
         {
             GILGuard _gil(state);
 
+            // PyRef increments the refcount first; only then do we release the
+            // pre-acquired reference.  This order guarantees the refcount never
+            // hits zero between the two operations.
             PyRef _ref((PyObject*)self, state);
+            if (!state->is_finalizing())
+                Py_DECREF((PyObject*)self); // hand-off: balances the Py_INCREF above
 
             // Retrieve the thread ID
             {

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -218,12 +218,25 @@ class PyRef
     {
         Py_INCREF(_obj);
     }
+    // Move transfers ownership: the source is disarmed (its _obj is set to
+    // nullptr) so only the new instance calls Py_DECREF on destruction.
+    inline PyRef(PyRef&& other) noexcept
+      : _obj(other._obj)
+      , _mstate(other._mstate)
+    {
+        other._obj = nullptr;
+    }
+    // Copying is deleted: a shallow copy would produce two PyRef instances
+    // sharing the same _obj pointer, both of which would call Py_DECREF on
+    // destruction, resulting in a double-decrement (use-after-free).
+    PyRef(const PyRef&) = delete;
+    PyRef& operator=(const PyRef&) = delete;
     inline ~PyRef()
     {
         // Avoid calling Py_DECREF during finalization as the thread state
         // may be NULL, causing crashes in Python 3.14+ where _Py_Dealloc
         // dereferences tstate immediately.
-        if (!_mstate->is_finalizing())
+        if (_obj != nullptr && !_mstate->is_finalizing())
             Py_DECREF(_obj);
     }
 
@@ -476,39 +489,37 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
     // alive until stopped_event->set() completes.
     std::shared_ptr<Event> stopped_event = self->_stopped;
 
-    // DEV: Pre-increment self's Python refcount before creating the
-    // thread. There is a window between std::thread creation and when the
-    // lambda acquires the GIL and constructs PyRef during which the lambda
-    // holds only a raw C pointer — no Python reference. If any Python thread
-    // running in that window drives self's refcount to zero (e.g. by removing
-    // the service's _worker reference), PeriodicThread_dealloc fires, sets
-    // self->_started = nullptr, and the thread crashes at _started->set().
+    // AIDEV-NOTE: PyRef is constructed here (GIL held) and moved into the
+    // lambda capture.  This keeps self alive across the entire window between
+    // std::thread creation and the moment the lambda acquires the GIL — during
+    // which the OS thread holds only a raw C pointer.  Without this, another
+    // Python thread could drop the last external reference in that window,
+    // causing PeriodicThread_dealloc to fire, set self->_started = nullptr,
+    // and crash the new thread at _started->set().
     //
-    // The pre-increment keeps the object alive across that gap.  The lambda
-    // calls Py_DECREF (the "hand-off") only AFTER PyRef has taken its own
-    // reference, so the refcount never transiently hits zero.
-    Py_INCREF((PyObject*)self);
+    // Moving into the capture also handles the std::thread construction failure
+    // case for free: if the constructor throws, the lambda is never created,
+    // the local PyRef destructs on this thread (GIL held), and the refcount is
+    // correctly restored.
+    PyRef _self_ref((PyObject*)self, self->_state);
 
     // Start the thread
-    self->_thread = std::make_unique<std::thread>([self, stopped_event]() {
+    self->_thread = std::make_unique<std::thread>([self, stopped_event, ref = std::move(_self_ref)]() mutable {
         module_state* state = self->_state;
 
         // DEV: GILGuard and PyRef are in an inner scope that exits BEFORE
         // stopped_event->set(). This ensures that all Python VM interactions
         // (Py_DECREF, PyGILState_Release) complete before the join() caller is
-        // unblocked. The inner scope also means PyRef::~PyRef may trigger
+        // unblocked. The inner scope also means ~PyRef may trigger
         // PeriodicThread_dealloc (if this thread held the last reference),
         // which is safe because stopped_event is a captured shared_ptr
         // independent of self's lifetime.
         {
             GILGuard _gil(state);
 
-            // PyRef increments the refcount first; only then do we release the
-            // pre-acquired reference.  This order guarantees the refcount never
-            // hits zero between the two operations.
-            PyRef _ref((PyObject*)self, state);
-            if (!state->is_finalizing())
-                Py_DECREF((PyObject*)self); // hand-off: balances the Py_INCREF above
+            // Move ref into this scope so ~PyRef (and thus Py_DECREF) fires
+            // while the GIL is still held, before stopped_event->set().
+            PyRef _ref = std::move(ref);
 
             // Retrieve the thread ID
             {

--- a/releasenotes/notes/fix-periodic-thread-start-race-b9f4ef302d5e09d5.yaml
+++ b/releasenotes/notes/fix-periodic-thread-start-race-b9f4ef302d5e09d5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a race condition with internal periodic threads that could have caused
+    a rare crash when forking.


### PR DESCRIPTION
## Description

### Root cause

In `_PeriodicThread_do_start`, there is a window between `std::thread` creation and when the lambda acquires the GIL and constructs `PyRef`. During that gap the lambda holds only a raw C pointer — no Python reference. The main thread has released the GIL (via `AllowThreads` + `_started->wait()`). If any other Python-executing thread drives self's refcount to zero in that window (e.g. a concurrent periodic function replaces `service._worker`), `PeriodicThread_dealloc` fires and sets `self->_started = nullptr`. The newly started thread then crashes at `self->_started->set()` with `SIGSEGV`.

The crash manifested as `SEGV_MAPERR` at fault address `0x40` with `x0=0x30`. `0x30 = sizeof(std::condition_variable)` = `offsetof(Event, _mutex)` on aarch64/glibc, confirming `Event* this == NULL` (null-pointer-derived address, not a corrupted mutex).

### Fix

`Py_INCREF(self)` before creating the thread (GIL is held). Inside the lambda, `PyRef` increments the refcount first, then `Py_DECREF` drops the pre-acquired reference. This hand-off ensures the refcount never transiently hits zero between thread creation and PyRef construction.