### PR TITLE
fix(celery): downgrade spurious warning on Task.replace()

### DIFF
--- a/ddtrace/contrib/internal/celery/signals.py
+++ b/ddtrace/contrib/internal/celery/signals.py
@@ -82,7 +82,10 @@ def trace_postrun(*args, **kwargs):
     # retrieve and finish the Span
     span = retrieve_span(task, task_id)
     if span is None:
-        log.warning("no existing span found for task_id=%s", task_id)
+        # This can happen when Task.replace() is used — the original task's
+        # postrun signal fires but the span has already been detached because
+        # the task was replaced mid-execution. This is expected, not an error.
+        log.debug("no existing span found for task_id=%s", task_id)
         return
     else:
         # request context tags

--- a/releasenotes/notes/fix-celery-replace-log-da6c883512e1a3dd.yaml
+++ b/releasenotes/notes/fix-celery-replace-log-da6c883512e1a3dd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    celery: remove unnecessary warning log about missing span when using ``Task.replace()``.


### PR DESCRIPTION
## Description

Fixes #17089

The existing warning log is unactionable and fine when `Task.replace()` is being used.

> The replacement task itself runs fine and gets its own span, only the replaced (original) task triggers the warning.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
