### PR TITLE
chore: pin serverless-tools to a specific branch

### DIFF
--- a/.gitlab/benchmarks/serverless.yml
+++ b/.gitlab/benchmarks/serverless.yml
@@ -5,6 +5,7 @@ benchmark-serverless:
   stage: benchmarks
   trigger:
     project: DataDog/serverless-tools
+    branch: dd-trace-py-pinned-ref
     strategy: depend
   needs:
     - job: "upload serverless"


### PR DESCRIPTION
Pinning to a compatible serverless-tools branch
