### PR TITLE
chore(llmobs): restore constants removed in meta_struct migration for backwards compat

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -8,6 +8,7 @@ PROPAGATED_PARENT_ID_KEY = "_dd.p.llmobs_parent_id"
 LLMOBS_SUBMITTED_TAG_KEY = "_dd.llmobs.submitted"
 PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
+LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils
 
 UNKNOWN_MODEL_PROVIDER = "unknown"
 
@@ -172,3 +173,8 @@ SUPPORTED_LLMOBS_INTEGRATIONS: dict[str, str] = {
     "pydantic_ai": "pydantic_ai",
     "claude_agent_sdk": "claude_agent_sdk",
 }
+
+# Deprecated constants kept for backwards compatibility with downstream consumers of ddtrace internals.
+# These were removed in the span._store -> span._meta_struct migration (PR #16774).
+EXPERIMENT_RECORD_METADATA = "_ml_obs.meta.metadata"
+EXPERIMENT_EXPECTED_OUTPUT = "_ml_obs.meta.input.expected_output"


### PR DESCRIPTION
## Summary

`LLMOBS_TRACE_ID`, `EXPERIMENT_EXPECTED_OUTPUT`, and `EXPERIMENT_RECORD_METADATA` were removed from `ddtrace.llmobs._constants` in #16774 as part of the `span._store` → `span._meta_struct` migration. However these constants are imported directly by downstream services in `dd-source`, causing `ImportError`s and CI failures when testing against `ddtrace==4.8.0rc3`.

This PR restores the three constants with deprecation comments to unblock the 4.8.0 release.

## Root cause

PR #16774 (`feat(llmobs): migrate using span._store to span._meta_struct`) removed these internal constants assuming no external consumers. Multiple `dd-source` services import them:
- `domains/ai_platform/shared/libs/eval_worker/activities.py`
- `domains/assistant/apps/evaluation/acceptance/conftest.py`
- `domains/graphing/apps/apis/graphing_ai/aspects/ccm_reports_agent/agent.py`

## Test plan

- [ ] `mypy` passes on `//domains/ai_platform/shared/libs/eval_worker:py_default_library.mypy`
- [ ] `mypy` passes on `//domains/assistant/apps/evaluation/acceptance:py_default_library.mypy`
- [ ] `//domains/graphing/.../ccm_reports_agent/tests:py_default_test` passes