### PR TITLE
chore(profiling): add greenlet_count internal profiler metric

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -40,6 +40,9 @@ class ProfilerStats
     // Number of currently tracked allocations in the heap tracker
     std::optional<size_t> heap_tracker_size;
 
+    // Number of greenlets currently tracked by the stack profiler
+    std::optional<size_t> greenlet_count;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -67,6 +70,9 @@ class ProfilerStats
 
     void set_heap_tracker_size(size_t count);
     std::optional<size_t> get_heap_tracker_size() const;
+
+    void set_greenlet_count(size_t count);
+    std::optional<size_t> get_greenlet_count() const;
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -48,6 +48,7 @@ Datadog::ProfilerStats::reset_state()
     string_table_ephemeral_count = std::nullopt;
     copy_memory_error_count = 0;
     heap_tracker_size = std::nullopt;
+    greenlet_count = std::nullopt;
     // fast_copy_memory_enabled is intentionally not reset: it reflects a static configuration
 }
 
@@ -123,6 +124,18 @@ Datadog::ProfilerStats::get_heap_tracker_size() const
     return heap_tracker_size;
 }
 
+void
+Datadog::ProfilerStats::set_greenlet_count(size_t count)
+{
+    greenlet_count = count;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_greenlet_count() const
+{
+    return greenlet_count;
+}
+
 std::string
 Datadog::ProfilerStats::get_internal_metadata_json()
 {
@@ -171,6 +184,13 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_heap_tracker_count) {
         internal_metadata_json += R"("heap_tracker_count": )";
         append_to_string(internal_metadata_json, *maybe_heap_tracker_count);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_greenlet_count = get_greenlet_count();
+    if (maybe_greenlet_count) {
+        internal_metadata_json += R"("greenlet_count": )";
+        append_to_string(internal_metadata_json, *maybe_greenlet_count);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -291,6 +291,10 @@ Sampler::sampling_thread(const uint64_t seq_num)
         Sample::profile_borrow().stats().set_string_table_count(echion->string_table().size());
         Sample::profile_borrow().stats().set_string_table_ephemeral_count(echion->string_table().ephemeral_size());
         Sample::profile_borrow().stats().set_fast_copy_memory_enabled(fast_copy_active);
+        {
+            const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+            Sample::profile_borrow().stats().set_greenlet_count(echion->greenlet_info_map().size());
+        }
 
         // Drain copy_memory errors accumulated since the last sampling cycle into ProfilerStats
         auto copy_errors = g_copy_memory_error_count.exchange(0, std::memory_order_relaxed);

--- a/tests/profiling/collector/test_greenlet_count.py
+++ b/tests/profiling/collector/test_greenlet_count.py
@@ -1,0 +1,69 @@
+import os
+import sys
+
+import pytest
+
+
+GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", False) and (
+    sys.version_info < (3, 11, 9) or sys.version_info >= (3, 12, 5)
+)
+
+
+@pytest.mark.skipif(
+    not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
+    reason="gevent is not available or not compatible with this Python version",
+)
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_greenlet_count",
+        DD_PROFILING_UPLOAD_INTERVAL="1",
+    ),
+    err=None,
+)
+def test_greenlet_count_present():
+    """greenlet_count is present and positive when gevent greenlets are active."""
+    from gevent import monkey
+
+    monkey.patch_all()
+
+    import glob
+    import json
+    import os
+    import time
+
+    import gevent
+
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+
+    stop = False
+
+    def worker():
+        while not stop:
+            gevent.sleep(0.01)
+
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+
+    greenlets = [gevent.spawn(worker) for _ in range(10)]
+    time.sleep(3)
+
+    stop = True
+    gevent.joinall(greenlets, timeout=5)
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+    assert files, "Expected at least one internal_metadata.json file"
+
+    found_positive = False
+    for f in files:
+        with open(f) as fp:
+            metadata = json.load(fp)
+        if "greenlet_count" in metadata:
+            assert isinstance(metadata["greenlet_count"], int)
+            assert metadata["greenlet_count"] >= 0
+            if metadata["greenlet_count"] > 0:
+                found_positive = True
+
+    assert found_positive, "Expected at least one metadata file with greenlet_count > 0"


### PR DESCRIPTION
## Description

Add `greenlet_count` to `ProfilerStats` internal metadata, tracking the number of gevent greenlets monitored by the stack profiler each sampling cycle. The count is read from `greenlet_info_map` under lock and serialized into the internal metadata JSON sent with profile uploads.

## Testing

- Added `test_greenlet_count_present` in `tests/profiling/collector/test_greenlet_count.py`
- Test spawns 10 gevent greenlets, runs the profiler for ~3s, then verifies `greenlet_count > 0` appears in the internal metadata JSON output
- Passed on Python 3.12 with gevent venv (`13de08c`)

## Risks

None. The lock acquisition to read `greenlet_info_map.size()` is brief and runs once per ~10ms sampling cycle, so contention is negligible.

## Additional Notes

Follows the existing `ProfilerStats` pattern used by `string_table_count`, `heap_tracker_size`, etc.

[PROF-14259](https://datadoghq.atlassian.net/browse/PROF-14259)

[PROF-14259]: https://datadoghq.atlassian.net/browse/PROF-14259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ