### PR TITLE
chore: bump version to 4.8.0rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.8.0rc3"
+version = "4.8.0rc4"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
There will be another release candidate for 4.8 that includes https://github.com/DataDog/dd-trace-py/pull/17495