### PR TITLE
chore(profiling): add asyncio_task_count internal profiler metric

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -40,6 +40,9 @@ class ProfilerStats
     // Number of currently tracked allocations in the heap tracker
     std::optional<size_t> heap_tracker_size;
 
+    // Number of asyncio tasks seen across all threads in the last sampling cycle
+    std::optional<size_t> asyncio_task_count;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -67,6 +70,9 @@ class ProfilerStats
 
     void set_heap_tracker_size(size_t count);
     std::optional<size_t> get_heap_tracker_size() const;
+
+    void set_asyncio_task_count(size_t count);
+    std::optional<size_t> get_asyncio_task_count() const;
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -40,7 +40,7 @@ class ProfilerStats
     // Number of currently tracked allocations in the heap tracker
     std::optional<size_t> heap_tracker_size;
 
-    // Number of asyncio tasks seen across all threads in the last sampling cycle
+    // Number of asyncio tasks seen across sampled threads in the last sampling cycle
     std::optional<size_t> asyncio_task_count;
 
   public:

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -48,6 +48,7 @@ Datadog::ProfilerStats::reset_state()
     string_table_ephemeral_count = std::nullopt;
     copy_memory_error_count = 0;
     heap_tracker_size = std::nullopt;
+    asyncio_task_count = std::nullopt;
     // fast_copy_memory_enabled is intentionally not reset: it reflects a static configuration
 }
 
@@ -123,6 +124,18 @@ Datadog::ProfilerStats::get_heap_tracker_size() const
     return heap_tracker_size;
 }
 
+void
+Datadog::ProfilerStats::set_asyncio_task_count(size_t count)
+{
+    asyncio_task_count = count;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_asyncio_task_count() const
+{
+    return asyncio_task_count;
+}
+
 std::string
 Datadog::ProfilerStats::get_internal_metadata_json()
 {
@@ -171,6 +184,13 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_heap_tracker_count) {
         internal_metadata_json += R"("heap_tracker_count": )";
         append_to_string(internal_metadata_json, *maybe_heap_tracker_count);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_asyncio_task_count = get_asyncio_task_count();
+    if (maybe_asyncio_task_count) {
+        internal_metadata_json += R"("asyncio_task_count": )";
+        append_to_string(internal_metadata_json, *maybe_asyncio_task_count);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -41,6 +41,10 @@ class EchionSampler
     std::optional<Frame::Key> uvloop_frame_cache_key_;
     std::unordered_set<PyObject*> previous_task_objects_;
 
+    // Accumulated asyncio task count across all threads in the current sampling cycle.
+    // Only accessed from the sampling thread, so no lock is needed.
+    size_t asyncio_task_count_ = 0;
+
     // Caches
     StringTable string_table_;
     LRUCache<uintptr_t, Frame> frame_cache_;
@@ -81,6 +85,10 @@ class EchionSampler
     std::optional<Frame::Key>& asyncio_frame_cache_key() { return asyncio_frame_cache_key_; }
     std::optional<Frame::Key>& uvloop_frame_cache_key() { return uvloop_frame_cache_key_; }
     std::unordered_set<PyObject*>& previous_task_objects() { return previous_task_objects_; }
+
+    void reset_asyncio_task_count() { asyncio_task_count_ = 0; }
+    void add_asyncio_task_count(size_t count) { asyncio_task_count_ += count; }
+    size_t asyncio_task_count() const { return asyncio_task_count_; }
 
     // Accessor for StringTable operations
     StringTable& string_table() { return string_table_; }

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -41,7 +41,9 @@ class EchionSampler
     std::optional<Frame::Key> uvloop_frame_cache_key_;
     std::unordered_set<PyObject*> previous_task_objects_;
 
-    // Accumulated asyncio task count across all threads in the current sampling cycle.
+    // Accumulated asyncio task count across sampled threads in the current sampling cycle.
+    // When thread subsampling is enabled (_DD_PROFILING_STACK_MAX_THREADS), this only
+    // reflects tasks from the sampled subset, not all threads in the process.
     // Only accessed from the sampling thread, so no lock/atomic is needed.
     size_t asyncio_task_count_ = 0;
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -42,7 +42,7 @@ class EchionSampler
     std::unordered_set<PyObject*> previous_task_objects_;
 
     // Accumulated asyncio task count across all threads in the current sampling cycle.
-    // Only accessed from the sampling thread, so no lock is needed.
+    // Only accessed from the sampling thread, so no lock/atomic is needed.
     size_t asyncio_task_count_ = 0;
 
     // Caches

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -129,6 +129,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
     }
 
     auto all_tasks = std::move(*maybe_all_tasks);
+    echion.add_asyncio_task_count(all_tasks.size());
     {
         auto& previous_task_objects = echion.previous_task_objects();
         std::lock_guard<std::mutex> lock(echion.task_link_map_lock());

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -196,6 +196,9 @@ Sampler::sampling_thread(const uint64_t seq_num)
         auto wall_time_us = duration_cast<microseconds>(sample_time_now - sample_time_prev).count();
         sample_time_prev = sample_time_now;
 
+        // Reset per-cycle asyncio task accumulator before iterating threads
+        echion->reset_asyncio_task_count();
+
         // When max_threads_per_sample is set, we collect all threads first, then apply
         // reservoir sampling (Algorithm R) to select a uniform random subset, and only
         // sample the selected threads. This caps the O(n_threads) stack-unwinding cost.
@@ -291,6 +294,7 @@ Sampler::sampling_thread(const uint64_t seq_num)
         Sample::profile_borrow().stats().set_string_table_count(echion->string_table().size());
         Sample::profile_borrow().stats().set_string_table_ephemeral_count(echion->string_table().ephemeral_size());
         Sample::profile_borrow().stats().set_fast_copy_memory_enabled(fast_copy_active);
+        Sample::profile_borrow().stats().set_asyncio_task_count(echion->asyncio_task_count());
 
         // Drain copy_memory errors accumulated since the last sampling cycle into ProfilerStats
         auto copy_errors = g_copy_memory_error_count.exchange(0, std::memory_order_relaxed);

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -196,7 +196,7 @@ Sampler::sampling_thread(const uint64_t seq_num)
         auto wall_time_us = duration_cast<microseconds>(sample_time_now - sample_time_prev).count();
         sample_time_prev = sample_time_now;
 
-        // Reset per-cycle asyncio task accumulator before iterating threads
+        // Reset per-cycle asyncio task accumulator before iterating sampled threads
         echion->reset_asyncio_task_count();
 
         // When max_threads_per_sample is set, we collect all threads first, then apply

--- a/tests/profiling/collector/test_asyncio_task_count.py
+++ b/tests/profiling/collector/test_asyncio_task_count.py
@@ -1,0 +1,54 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_task_count",
+        DD_PROFILING_UPLOAD_INTERVAL="1",
+    ),
+    err=None,
+)
+def test_asyncio_task_count_present():
+    """asyncio_task_count is present and positive when asyncio tasks are active."""
+    import asyncio
+    import glob
+    import json
+    import os
+    import time
+
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+
+    async def worker():
+        await asyncio.sleep(0.5)
+
+    async def main():
+        tasks = [asyncio.create_task(worker(), name=f"worker-{i}") for i in range(10)]
+        await asyncio.gather(*tasks)
+
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    # Run multiple rounds to ensure tasks are active during profiling
+    for _ in range(4):
+        loop.run_until_complete(main())
+    time.sleep(1)
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+    assert files, "Expected at least one internal_metadata.json file"
+
+    found_positive = False
+    for f in files:
+        with open(f) as fp:
+            metadata = json.load(fp)
+        if "asyncio_task_count" in metadata:
+            assert isinstance(metadata["asyncio_task_count"], int)
+            assert metadata["asyncio_task_count"] >= 0
+            if metadata["asyncio_task_count"] > 0:
+                found_positive = True
+
+    assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"


### PR DESCRIPTION
## Description

Add `asyncio_task_count` to `ProfilerStats` internal metadata, tracking the total number of asyncio tasks seen across all threads during each sampling cycle. The count is accumulated in `EchionSampler` as each thread's tasks are unwound in `unwind_tasks()`, then serialized into the internal metadata JSON sent with profile uploads.

## Testing

- Added `test_asyncio_task_count_present` in `tests/profiling/collector/test_asyncio_task_count.py`
- Test creates 10 asyncio tasks across multiple rounds, runs the profiler, then verifies `asyncio_task_count > 0` appears in the internal metadata JSON output
- Passed on Python 3.13 with standard profiling venv (`9710280`)

## Risks

None. The accumulator field (`asyncio_task_count_`) is only accessed from the sampling thread, so no additional locking is needed. The single addition in `unwind_tasks()` is negligible overhead.

## Additional Notes

Follows the existing `ProfilerStats` pattern used by `string_table_count`, `heap_tracker_size`, etc. Unlike greenlets (which have a persistent tracking map), asyncio tasks are discovered per-thread during each sampling cycle, so this uses an accumulator that resets each cycle.

[PROF-14259](https://datadoghq.atlassian.net/browse/PROF-14259)

[PROF-14259]: https://datadoghq.atlassian.net/browse/PROF-14259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ