### PR TITLE
ci(aiokafka): stabilize snapshot flake in test_send_multiple_servers

### DIFF
--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -86,6 +86,7 @@ async def test_send_multiple_servers():
     topic = await create_topic("send_multiple_servers")
     async with producer_ctx([BOOTSTRAP_SERVERS] * 3) as producer:
         await producer.send_and_wait(topic, value=PAYLOAD, key=KEY)
+        await producer.flush()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3082b921-b29e-4b65-9187-f0b0de240c35","source":"chat","resourceId":"27a7e863-d410-459f-9518-a5d5c78c7f50","workflowId":"75d4fdd8-bda9-4e31-8d9e-a3076fd2276c","codeChangeId":"75d4fdd8-bda9-4e31-8d9e-a3076fd2276c","sourceType":"test-optimization"} -->
## Description

Fixing `test_send_multiple_servers[py3.10]` • **Questions?** Ask in #code-gen-flaky-tests

This change stabilizes a flaky aiokafka snapshot test that intermittently reported no `kafka.produce` trace in CI (`test_send_multiple_servers[py3.10]`).

The test currently exits immediately after `send_and_wait`, while the instrumentation for `AIOKafkaProducer.send` finalizes span completion from a future callback. In CI, this could race with snapshot collection and lead to `0 received trace(s)` for the expected `kafka.produce` span.

This flake is in the `network` category and is impacting CI reliability (0.1% flake rate, ~29 minutes of CI time wasted, 1 failed pipeline).

Changes made:
- In `tests/contrib/aiokafka/test_aiokafka.py`, updated `test_send_multiple_servers` to call `await producer.flush()` immediately after `send_and_wait`.
- This adds an explicit synchronization point in the test so async producer work/callback processing completes before teardown and snapshot assertion.

## Testing

- `scripts/run-tests --list tests/contrib/aiokafka/test_aiokafka.py`
- `scripts/run-tests --venv c6f2827 -- -- tests/contrib/aiokafka/test_aiokafka.py -k test_send_multiple_servers -q` *(failed in sandbox due missing Docker daemon, so Kafka/testagent services could not start)*
- `ruff format tests/contrib/aiokafka/test_aiokafka.py` (via `Format` tool)
- `ruff check --fix tests/contrib/aiokafka/test_aiokafka.py` (via `Lint` tool)

## Risks

Low. Test-only change with minimal scope; behavior under test is unchanged, and the added flush is a deterministic synchronization step.

## Additional Notes

No production code was modified.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/27a7e863-d410-459f-9518-a5d5c78c7f50)

Comment @datadog to request changes