### PR TITLE
feat(gcp): google pub/sub admin operations

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -1420,7 +1420,6 @@ def _on_pubsub_request_start(ctx: core.ExecutionContext) -> None:
     span._set_attribute(SPAN_KIND, SpanKind.CLIENT)
     span._set_attribute("gcloud.project_id", ctx.get_item("project_id"))
     span._set_attribute("pubsub.method", ctx.get_item("pubsub_method"))
-    span._set_attribute(_SPAN_MEASURED_KEY, 1)
 
 
 def _on_pubsub_send_start(ctx: core.ExecutionContext) -> None:

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -1412,6 +1412,17 @@ def _on_aiokafka_getmany_message(
                     span.link_span(context)
 
 
+def _on_pubsub_request_start(ctx: core.ExecutionContext) -> None:
+    _start_span(ctx)
+    span = ctx.span
+
+    span._set_attribute(COMPONENT, config.google_cloud_pubsub.integration_name)
+    span._set_attribute(SPAN_KIND, SpanKind.CLIENT)
+    span._set_attribute("gcloud.project_id", ctx.get_item("project_id"))
+    span._set_attribute("pubsub.method", ctx.get_item("pubsub_method"))
+    span._set_attribute(_SPAN_MEASURED_KEY, 1)
+
+
 def _on_pubsub_send_start(ctx: core.ExecutionContext) -> None:
     _start_span(ctx)
     span = ctx.span
@@ -1721,6 +1732,7 @@ def listen():
     core.on("aiokafka.getone.message", _on_aiokafka_getone_message)
     core.on("aiokafka.getmany.message", _on_aiokafka_getmany_message)
     core.on("aiokafka.send.completed", _on_aiokafka_send_complete)
+    core.on("context.started.google_cloud_pubsub.request", _on_pubsub_request_start)
     core.on("context.started.google_cloud_pubsub.send", _on_pubsub_send_start)
     core.on("google_cloud_pubsub.send.completed", _on_pubsub_send_complete)
     core.on("context.started.google_cloud_pubsub.receive", _on_pubsub_receive_start)
@@ -1850,6 +1862,7 @@ def listen():
         "aiokafka.getone",
         "aiokafka.getmany",
         "google_cloud_pubsub.receive",
+        "google_cloud_pubsub.request",
     ):
         core.on(f"context.ended.{name}", _finish_span)
 

--- a/ddtrace/contrib/internal/google_cloud_pubsub/patch.py
+++ b/ddtrace/contrib/internal/google_cloud_pubsub/patch.py
@@ -24,49 +24,49 @@ ensure_config_registered()
 
 
 # Method descriptors for admin/management operations.
-# Format: method_name -> dotted attr path on the request proto/dict/kwargs
+# Format: method_name -> (resource_name, [attribute, path])
 
-_PUBLISHER_ADMIN_METHODS = {
-    "create_topic": "name",
-    "update_topic": "topic.name",
-    "get_topic": "topic",
-    "list_topics": "project",
-    "list_topic_subscriptions": "topic",
-    "list_topic_snapshots": "topic",
-    "delete_topic": "topic",
-    "detach_subscription": "subscription",
+_PUBLISHER_ADMIN_METHODS: dict[str, tuple[str, list[str]]] = {
+    "create_topic": ("createTopic", ["name"]),
+    "update_topic": ("updateTopic", ["topic", "name"]),
+    "get_topic": ("getTopic", ["topic"]),
+    "list_topics": ("listTopics", ["project"]),
+    "list_topic_subscriptions": ("listTopicSubscriptions", ["topic"]),
+    "list_topic_snapshots": ("listTopicSnapshots", ["topic"]),
+    "delete_topic": ("deleteTopic", ["topic"]),
+    "detach_subscription": ("detachSubscription", ["subscription"]),
 }
 
-_SUBSCRIBER_ADMIN_METHODS = {
-    "create_subscription": "name",
-    "get_subscription": "subscription",
-    "update_subscription": "subscription.name",
-    "list_subscriptions": "project",
-    "delete_subscription": "subscription",
-    "modify_push_config": "subscription",
-    "get_snapshot": "snapshot",
-    "list_snapshots": "project",
-    "create_snapshot": "name",
-    "update_snapshot": "snapshot.name",
-    "delete_snapshot": "snapshot",
-    "seek": "subscription",
+_SUBSCRIBER_ADMIN_METHODS: dict[str, tuple[str, list[str]]] = {
+    "create_subscription": ("createSubscription", ["name"]),
+    "get_subscription": ("getSubscription", ["subscription"]),
+    "update_subscription": ("updateSubscription", ["subscription", "name"]),
+    "list_subscriptions": ("listSubscriptions", ["project"]),
+    "delete_subscription": ("deleteSubscription", ["subscription"]),
+    "modify_push_config": ("modifyPushConfig", ["subscription"]),
+    "get_snapshot": ("getSnapshot", ["snapshot"]),
+    "list_snapshots": ("listSnapshots", ["project"]),
+    "create_snapshot": ("createSnapshot", ["name"]),
+    "update_snapshot": ("updateSnapshot", ["snapshot", "name"]),
+    "delete_snapshot": ("deleteSnapshot", ["snapshot"]),
+    "seek": ("seek", ["subscription"]),
 }
 
-_SCHEMA_METHODS = {
-    "create_schema": "parent",
-    "get_schema": "name",
-    "list_schemas": "parent",
-    "delete_schema": "name",
-    "validate_schema": "parent",
-    "validate_message": "parent",
+_SCHEMA_METHODS: dict[str, tuple[str, list[str]]] = {
+    "create_schema": ("createSchema", ["parent"]),
+    "get_schema": ("getSchema", ["name"]),
+    "list_schemas": ("listSchemas", ["parent"]),
+    "delete_schema": ("deleteSchema", ["name"]),
+    "validate_schema": ("validateSchema", ["parent"]),
+    "validate_message": ("validateMessage", ["parent"]),
 }
 
 # These methods do not exist in older SDK versions (<2.16.0).
-_SCHEMA_OPTIONAL_METHODS = {
-    "list_schema_revisions": "name",
-    "commit_schema": "name",
-    "rollback_schema": "name",
-    "delete_schema_revision": "name",
+_SCHEMA_OPTIONAL_METHODS: dict[str, tuple[str, list[str]]] = {
+    "list_schema_revisions": ("listSchemaRevisions", ["name"]),
+    "commit_schema": ("commitSchema", ["name"]),
+    "rollback_schema": ("rollbackSchema", ["name"]),
+    "delete_schema_revision": ("deleteSchemaRevision", ["name"]),
 }
 
 
@@ -101,15 +101,6 @@ def _traced_subscribe_callback(callback, project_id, subscription_id, message):
         callback(message)
 
 
-def _snake_to_camel(name: str) -> str:
-    """Convert snake_case to camelCase.
-
-    Uses camelCase for consistency with other Datadog tracers (Node).
-    """
-    parts = name.split("_")
-    return parts[0] + "".join(p.capitalize() for p in parts[1:])
-
-
 def _get_nested_attr(obj: object, parts: list[str]):
     """
     Walk an attribute path on an object or a dict.
@@ -121,10 +112,8 @@ def _get_nested_attr(obj: object, parts: list[str]):
     return obj
 
 
-def _make_admin_wrapper(method_name: str, attr_path: str):
+def _make_admin_wrapper(resource_name: str, request_attr: list[str]):
     """Factory that creates a traced wrapper for a Pub/Sub admin/management method."""
-    camel_name = _snake_to_camel(method_name)
-    parts = attr_path.split(".")
 
     def wrapper(func, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]):
         # GAPIC methods support three calling conventions:
@@ -132,9 +121,9 @@ def _make_admin_wrapper(method_name: str, attr_path: str):
         # 2. create_topic(CreateTopicRequest(name="..."))         - supported by get_argument_value
         # 3. create_topic(name="...")                             - fall back to kwargs
         request = get_argument_value(args, kwargs, 0, "request", optional=True) or kwargs
-        resource_path = _get_nested_attr(request, parts) or ""
+        resource_path = _get_nested_attr(request, request_attr) or ""
         project_id, _ = parse_resource_path(resource_path)
-        resource = "{} {}".format(camel_name, resource_path) if resource_path else camel_name
+        resource = f"{resource_name} {resource_path}" if resource_path else resource_name
 
         with core.context_with_data(
             "google_cloud_pubsub.request",
@@ -143,26 +132,27 @@ def _make_admin_wrapper(method_name: str, attr_path: str):
             service=None,
             resource=resource,
             project_id=project_id,
-            pubsub_method=camel_name,
+            pubsub_method=resource_name,
+            measured=True,
         ):
             return func(*args, **kwargs)
 
     return wrapper
 
 
-def _wrap_methods(module_path: str, cls: type[Any], methods: dict[str, str], optional: bool = False):
+def _wrap_methods(module_path: str, cls: type[Any], methods: dict[str, tuple[str, list[str]]], optional: bool = False):
     """Wrap multiple methods on a class. Skip missing methods when optional=True."""
-    for method_name, attr_path in methods.items():
+    for method_name, (resource_name, request_attr) in methods.items():
         if optional and not hasattr(cls, method_name):
             continue
         _w(
             module_path,
-            "{}.{}".format(cls.__name__, method_name),
-            _make_admin_wrapper(method_name, attr_path),
+            f"{cls.__name__}.{method_name}",
+            _make_admin_wrapper(resource_name, request_attr),
         )
 
 
-def _unwrap_methods(cls: type[Any], methods: dict[str, str], optional: bool = False):
+def _unwrap_methods(cls: type[Any], methods: dict[str, tuple[str, list[str]]], optional: bool = False):
     """Unwrap multiple methods on a class."""
     for method_name in methods:
         if optional and not hasattr(cls, method_name):

--- a/ddtrace/contrib/internal/google_cloud_pubsub/patch.py
+++ b/ddtrace/contrib/internal/google_cloud_pubsub/patch.py
@@ -1,7 +1,11 @@
 from functools import partial
 import importlib.metadata as importlib_metadata
+from typing import Any
 
 import google.cloud.pubsub_v1 as pubsub_v1
+from google.pubsub_v1.services.publisher.client import PublisherClient as GapicPublisher
+from google.pubsub_v1.services.schema_service.client import SchemaServiceClient
+from google.pubsub_v1.services.subscriber.client import SubscriberClient as GapicSubscriber
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
@@ -17,6 +21,53 @@ from ddtrace.propagation.http import HTTPPropagator
 
 
 ensure_config_registered()
+
+
+# Method descriptors for admin/management operations.
+# Format: method_name -> dotted attr path on the request proto/dict/kwargs
+
+_PUBLISHER_ADMIN_METHODS = {
+    "create_topic": "name",
+    "update_topic": "topic.name",
+    "get_topic": "topic",
+    "list_topics": "project",
+    "list_topic_subscriptions": "topic",
+    "list_topic_snapshots": "topic",
+    "delete_topic": "topic",
+    "detach_subscription": "subscription",
+}
+
+_SUBSCRIBER_ADMIN_METHODS = {
+    "create_subscription": "name",
+    "get_subscription": "subscription",
+    "update_subscription": "subscription.name",
+    "list_subscriptions": "project",
+    "delete_subscription": "subscription",
+    "modify_push_config": "subscription",
+    "get_snapshot": "snapshot",
+    "list_snapshots": "project",
+    "create_snapshot": "name",
+    "update_snapshot": "snapshot.name",
+    "delete_snapshot": "snapshot",
+    "seek": "subscription",
+}
+
+_SCHEMA_METHODS = {
+    "create_schema": "parent",
+    "get_schema": "name",
+    "list_schemas": "parent",
+    "delete_schema": "name",
+    "validate_schema": "parent",
+    "validate_message": "parent",
+}
+
+# These methods do not exist in older SDK versions (<2.16.0).
+_SCHEMA_OPTIONAL_METHODS = {
+    "list_schema_revisions": "name",
+    "commit_schema": "name",
+    "rollback_schema": "name",
+    "delete_schema_revision": "name",
+}
 
 
 def get_version() -> str:
@@ -50,6 +101,77 @@ def _traced_subscribe_callback(callback, project_id, subscription_id, message):
         callback(message)
 
 
+def _snake_to_camel(name: str) -> str:
+    """Convert snake_case to camelCase.
+
+    Uses camelCase for consistency with other Datadog tracers (Node).
+    """
+    parts = name.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def _get_nested_attr(obj: object, parts: list[str]):
+    """
+    Walk an attribute path on an object or a dict.
+    """
+    for part in parts:
+        if obj is None:
+            break
+        obj = obj.get(part) if isinstance(obj, dict) else getattr(obj, part, None)
+    return obj
+
+
+def _make_admin_wrapper(method_name: str, attr_path: str):
+    """Factory that creates a traced wrapper for a Pub/Sub admin/management method."""
+    camel_name = _snake_to_camel(method_name)
+    parts = attr_path.split(".")
+
+    def wrapper(func, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]):
+        # GAPIC methods support three calling conventions:
+        # 1. create_topic(request=CreateTopicRequest(name="...")) - supported by get_argument_value
+        # 2. create_topic(CreateTopicRequest(name="..."))         - supported by get_argument_value
+        # 3. create_topic(name="...")                             - fall back to kwargs
+        request = get_argument_value(args, kwargs, 0, "request", optional=True) or kwargs
+        resource_path = _get_nested_attr(request, parts) or ""
+        project_id, _ = parse_resource_path(resource_path)
+        resource = "{} {}".format(camel_name, resource_path) if resource_path else camel_name
+
+        with core.context_with_data(
+            "google_cloud_pubsub.request",
+            span_name="gcp.pubsub.request",
+            span_type=SpanTypes.WORKER,
+            service=None,
+            resource=resource,
+            project_id=project_id,
+            pubsub_method=camel_name,
+        ):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _wrap_methods(module_path: str, cls: type[Any], methods: dict[str, str], optional: bool = False):
+    """Wrap multiple methods on a class. Skip missing methods when optional=True."""
+    for method_name, attr_path in methods.items():
+        if optional and not hasattr(cls, method_name):
+            continue
+        _w(
+            module_path,
+            "{}.{}".format(cls.__name__, method_name),
+            _make_admin_wrapper(method_name, attr_path),
+        )
+
+
+def _unwrap_methods(cls: type[Any], methods: dict[str, str], optional: bool = False):
+    """Unwrap multiple methods on a class."""
+    for method_name in methods:
+        if optional and not hasattr(cls, method_name):
+            continue
+        attr = getattr(cls, method_name, None)
+        if attr is not None and hasattr(attr, "__wrapped__"):
+            _u(cls, method_name)
+
+
 def patch():
     if getattr(pubsub_v1, "_datadog_patch", False):
         return
@@ -57,6 +179,16 @@ def patch():
 
     _w("google.cloud.pubsub_v1.publisher.client", "Client.publish", _traced_publish)
     _w("google.cloud.pubsub_v1.subscriber.client", "Client.subscribe", _traced_subscribe)
+
+    _wrap_methods("google.pubsub_v1.services.publisher.client", GapicPublisher, _PUBLISHER_ADMIN_METHODS)
+    _wrap_methods("google.pubsub_v1.services.subscriber.client", GapicSubscriber, _SUBSCRIBER_ADMIN_METHODS)
+    _wrap_methods("google.pubsub_v1.services.schema_service.client", SchemaServiceClient, _SCHEMA_METHODS)
+    _wrap_methods(
+        "google.pubsub_v1.services.schema_service.client",
+        SchemaServiceClient,
+        _SCHEMA_OPTIONAL_METHODS,
+        optional=True,
+    )
 
 
 def unpatch():
@@ -66,6 +198,11 @@ def unpatch():
 
     _u(pubsub_v1.publisher.client.Client, "publish")
     _u(pubsub_v1.subscriber.client.Client, "subscribe")
+
+    _unwrap_methods(GapicPublisher, _PUBLISHER_ADMIN_METHODS)
+    _unwrap_methods(GapicSubscriber, _SUBSCRIBER_ADMIN_METHODS)
+    _unwrap_methods(SchemaServiceClient, _SCHEMA_METHODS)
+    _unwrap_methods(SchemaServiceClient, _SCHEMA_OPTIONAL_METHODS, optional=True)
 
 
 def _traced_publish(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/google_cloud_pubsub/patch.py
+++ b/ddtrace/contrib/internal/google_cloud_pubsub/patch.py
@@ -102,8 +102,19 @@ def _traced_subscribe_callback(callback, project_id, subscription_id, message):
 
 
 def _get_nested_attr(obj: object, parts: list[str]):
-    """
-    Walk an attribute path on an object or a dict.
+    """Walk `parts` to extract a nested value from a proto message or plain dict
+
+    Each step in the for loop resolves one level of nesting
+    * obj.get(part) for dicts
+    * getattr(obj, part) for proto messages
+
+    This is because GAPIC client methods accept both forms as requests
+    Returns None if any intermediate level is missing.
+
+    Example:
+      _get_nested_attr({"topic": {"name": "{topicName}"}}, ["topic", "name"])
+      _get_nested_attr(UpdateTopicRequest(topic=Topic(name="topicName")), ["topic", "name"])
+      return => "topicName"
     """
     for part in parts:
         if obj is None:

--- a/releasenotes/notes/google-cloud-pubsub-admin-operations-4ea156113882ccb7.yaml
+++ b/releasenotes/notes/google-cloud-pubsub-admin-operations-4ea156113882ccb7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    google_cloud_pubsub: This adds tracing for Google Cloud Pub/Sub admin operations on topic, subscription, snapshot, and schema management methods.

--- a/tests/contrib/google_cloud_pubsub/test_pubsub.py
+++ b/tests/contrib/google_cloud_pubsub/test_pubsub.py
@@ -22,7 +22,7 @@ TRACE_CONTEXT_KEYS = [
 ]
 
 
-@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
+@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES, wait_for_num_traces=3)
 def test_publish(publisher, topic_path):
     with tracer.trace("parent.span"):
         future = publisher.publish(topic_path, b"Hello World")
@@ -68,7 +68,7 @@ def test_propagation_disabled(publisher, topic_path, subscriber, subscription_pa
     assert not any(key in dict(response.received_messages[0].message.attributes) for key in TRACE_CONTEXT_KEYS)
 
 
-@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.tracestate"])
+@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.tracestate"], wait_for_num_traces=5)
 def test_subscribe_propagation_as_span_links_disabled(publisher, topic_path, subscriber, subscription_path):
     """Test publish-subscribe with propagation_as_span_links disabled (default). Validates span tags,
     trace hierarchy (receive is child of send), span links, and that child spans inside the callback
@@ -90,7 +90,7 @@ def test_subscribe_propagation_as_span_links_disabled(publisher, topic_path, sub
         future.result(timeout=5)
 
 
-@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.tracestate"])
+@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.tracestate"], wait_for_num_traces=6)
 def test_subscribe_propagation_as_span_links_enabled(publisher, topic_path, subscriber, subscription_path, test_spans):
     """Test publish-subscribe with propagation_as_span_links enabled. Validates that the receive span
     is in a separate trace from the producer and span links to the producer still exist.
@@ -118,7 +118,7 @@ def test_subscribe_propagation_as_span_links_enabled(publisher, topic_path, subs
     assert link.span_id == send_span.span_id
 
 
-@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.error.stack", "meta.tracestate"])
+@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.error.stack", "meta.tracestate"], wait_for_num_traces=5)
 def test_subscribe_callback_error(publisher, topic_path, subscriber, subscription_path):
     """Test that the receive span records error info when the user callback raises an exception."""
     received = threading.Event()
@@ -140,7 +140,7 @@ def test_subscribe_callback_error(publisher, topic_path, subscriber, subscriptio
             pass
 
 
-@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.tracestate"])
+@pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES + ["meta.tracestate"], wait_for_num_traces=6)
 def test_subscribe_propagation_disabled(publisher, topic_path, subscriber, subscription_path, test_spans):
     """Test that when propagation is disabled, the receive span still exists but has no span
     links and is not reparented into the producer trace.

--- a/tests/contrib/google_cloud_pubsub/test_pubsub_client.py
+++ b/tests/contrib/google_cloud_pubsub/test_pubsub_client.py
@@ -1,0 +1,56 @@
+from google.pubsub_v1.types import DeleteTopicRequest
+from google.pubsub_v1.types import Topic
+import pytest
+
+
+PROJECT_PATH = "projects/test-project"
+
+
+def _assert_admin_span(span, method, resource_path, project_id="test-project"):
+    assert span.name == "gcp.pubsub.request"
+    assert span.resource == "{} {}".format(method, resource_path)
+    assert span.get_tag("component") == "google_cloud_pubsub"
+    assert span.get_tag("span.kind") == "client"
+    assert span.get_tag("gcloud.project_id") == project_id
+    assert span.get_tag("pubsub.method") == method
+    assert span.get_metric("_dd.measured") == 1
+    assert span.get_tag("messaging.system") is None
+    assert span.get_tag("messaging.operation") is None
+
+
+def _assert_create_delete_spans(test_spans, topic_name):
+    create_span = test_spans.find_span(name="gcp.pubsub.request", resource="createTopic {}".format(topic_name))
+    _assert_admin_span(create_span, "createTopic", topic_name)
+
+    delete_span = test_spans.find_span(name="gcp.pubsub.request", resource="deleteTopic {}".format(topic_name))
+    _assert_admin_span(delete_span, "deleteTopic", topic_name)
+
+
+class TestAdminOperations:
+    def test_flat_kwargs(self, publisher, test_spans):
+        topic_name = "{}/topics/admin-test-flat-kwargs".format(PROJECT_PATH)
+        publisher.create_topic(name=topic_name)
+        publisher.delete_topic(topic=topic_name)
+        _assert_create_delete_spans(test_spans, topic_name)
+
+    def test_positional_request_arg(self, publisher, test_spans):
+        topic_name = "{}/topics/admin-test-positional".format(PROJECT_PATH)
+        publisher.create_topic(Topic(name=topic_name))
+        publisher.delete_topic(DeleteTopicRequest(topic=topic_name))
+        _assert_create_delete_spans(test_spans, topic_name)
+
+    def test_keyword_request_arg(self, publisher, test_spans):
+        topic_name = "{}/topics/admin-test-keyword".format(PROJECT_PATH)
+        publisher.create_topic(request=Topic(name=topic_name))
+        publisher.delete_topic(request=DeleteTopicRequest(topic=topic_name))
+        _assert_create_delete_spans(test_spans, topic_name)
+
+
+class TestErrorHandling:
+    def test_error_records_on_span(self, publisher, test_spans):
+        with pytest.raises(Exception):
+            publisher.get_topic(topic="{}/topics/nonexistent-topic-xyz".format(PROJECT_PATH))
+
+        span = test_spans.find_span(name="gcp.pubsub.request")
+        assert span.error == 1
+        assert span.get_tag("error.type") is not None

--- a/tests/contrib/google_cloud_pubsub/test_pubsub_patch.py
+++ b/tests/contrib/google_cloud_pubsub/test_pubsub_patch.py
@@ -1,5 +1,8 @@
 from google.cloud.pubsub_v1.publisher.client import Client as PublisherClient
 from google.cloud.pubsub_v1.subscriber.client import Client as SubscriberClient
+from google.pubsub_v1.services.publisher.client import PublisherClient as GapicPublisher
+from google.pubsub_v1.services.schema_service.client import SchemaServiceClient
+from google.pubsub_v1.services.subscriber.client import SubscriberClient as GapicSubscriber
 
 from ddtrace.contrib.internal.google_cloud_pubsub.patch import get_version
 from ddtrace.contrib.internal.google_cloud_pubsub.patch import patch
@@ -15,13 +18,31 @@ class TestGoogleCloudPubSubPatch(PatchTestCase.Base):
     __get_version__ = get_version
 
     def assert_module_patched(self, pubsub_v1):
+        # Messaging operations
         self.assert_wrapped(PublisherClient.publish)
         self.assert_wrapped(SubscriberClient.subscribe)
+        # Admin methods
+        self.assert_wrapped(GapicPublisher.create_topic)
+        self.assert_wrapped(GapicPublisher.delete_topic)
+        self.assert_wrapped(GapicPublisher.get_topic)
+        self.assert_wrapped(GapicPublisher.list_topics)
+        self.assert_wrapped(GapicSubscriber.create_subscription)
+        self.assert_wrapped(GapicSubscriber.delete_subscription)
+        self.assert_wrapped(GapicSubscriber.get_subscription)
+        self.assert_wrapped(GapicSubscriber.list_subscriptions)
+        self.assert_wrapped(SchemaServiceClient.create_schema)
+        self.assert_wrapped(SchemaServiceClient.delete_schema)
 
     def assert_not_module_patched(self, pubsub_v1):
         self.assert_not_wrapped(PublisherClient.publish)
         self.assert_not_wrapped(SubscriberClient.subscribe)
+        self.assert_not_wrapped(GapicPublisher.create_topic)
+        self.assert_not_wrapped(GapicSubscriber.create_subscription)
+        self.assert_not_wrapped(SchemaServiceClient.create_schema)
 
     def assert_not_module_double_patched(self, pubsub_v1):
         self.assert_not_double_wrapped(PublisherClient.publish)
         self.assert_not_double_wrapped(SubscriberClient.subscribe)
+        self.assert_not_double_wrapped(GapicPublisher.create_topic)
+        self.assert_not_double_wrapped(GapicSubscriber.create_subscription)
+        self.assert_not_double_wrapped(SchemaServiceClient.create_schema)

--- a/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_publish.json
+++ b/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_publish.json
@@ -1,9 +1,40 @@
 [[
   {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createTopic projects/test-project/topics/test-topic",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96300000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createTopic",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 367613750,
+    "start": 1775040867498898841
+  }],
+[
+  {
     "name": "parent.span",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "parent.span",
-    "trace_id": 0,
+    "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
     "type": "",
@@ -28,7 +59,7 @@
        "name": "gcp.pubsub.send",
        "service": "tests.contrib.google_cloud_pubsub",
        "resource": "test-topic",
-       "trace_id": 0,
+       "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
@@ -47,4 +78,35 @@
        },
        "duration": 26062500,
        "start": 1773674898570682044
-     }]]
+     }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteTopic projects/test-project/topics/test-topic",
+    "trace_id": 2,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96300000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteTopic",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5268750,
+    "start": 1775040867905189508
+  }]]

--- a/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_callback_error.json
+++ b/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_callback_error.json
@@ -1,9 +1,71 @@
 [[
   {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createTopic projects/test-project/topics/test-topic",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createTopic",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 22395875,
+    "start": 1775040868516623633
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createSubscription",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 6577250,
+    "start": 1775040868541369883
+  }],
+[
+  {
     "name": "gcp.pubsub.send",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "test-topic",
-    "trace_id": 0,
+    "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
@@ -36,7 +98,7 @@
        "name": "gcp.pubsub.receive",
        "service": "tests.contrib.google_cloud_pubsub",
        "resource": "test-subscription",
-       "trace_id": 0,
+       "trace_id": 2,
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
@@ -68,4 +130,66 @@
        },
        "duration": 2105917,
        "start": 1773828289539108590
-     }]]
+     }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 3,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteSubscription",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5346833,
+    "start": 1775040868620629925
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteTopic projects/test-project/topics/test-topic",
+    "trace_id": 4,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteTopic",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 3760000,
+    "start": 1775040868626545717
+  }]]

--- a/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_propagation_as_span_links_disabled.json
+++ b/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_propagation_as_span_links_disabled.json
@@ -1,9 +1,71 @@
 [[
   {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createTopic projects/test-project/topics/test-topic",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createTopic",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 20451041,
+    "start": 1775040868200603592
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createSubscription",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5076167,
+    "start": 1775040868223201008
+  }],
+[
+  {
     "name": "gcp.pubsub.send",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "test-topic",
-    "trace_id": 0,
+    "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
@@ -36,7 +98,7 @@
        "name": "gcp.pubsub.receive",
        "service": "tests.contrib.google_cloud_pubsub",
        "resource": "test-subscription",
-       "trace_id": 0,
+       "trace_id": 2,
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
@@ -70,7 +132,7 @@
           "name": "subscriber.span",
           "service": "tests.contrib.google_cloud_pubsub",
           "resource": "subscriber.span",
-          "trace_id": 0,
+          "trace_id": 2,
           "span_id": 3,
           "parent_id": 2,
           "type": "",
@@ -80,4 +142,66 @@
           },
           "duration": 135333,
           "start": 1773828289264058965
-        }]]
+        }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 3,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteSubscription",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5711250,
+    "start": 1775040868323696758
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteTopic projects/test-project/topics/test-topic",
+    "trace_id": 4,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ccf96400000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteTopic",
+      "runtime-id": "04b700d26ed547939d34024f0c1f82a5",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 3593375,
+    "start": 1775040868330095842
+  }]]

--- a/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_propagation_as_span_links_enabled.json
+++ b/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_propagation_as_span_links_enabled.json
@@ -1,9 +1,133 @@
 [[
   {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createTopic projects/test-project/topics/test-topic",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106200000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createTopic",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 18466583,
+    "start": 1775046754506514802
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106200000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createSubscription",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5332792,
+    "start": 1775046754527289843
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 2,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106200000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteSubscription",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5934542,
+    "start": 1775046754653513635
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteTopic projects/test-project/topics/test-topic",
+    "trace_id": 3,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106200000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteTopic",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 9012834,
+    "start": 1775046754660416218
+  }],
+[
+  {
     "name": "gcp.pubsub.send",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "test-topic",
-    "trace_id": 0,
+    "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
@@ -37,7 +161,7 @@
     "name": "gcp.pubsub.receive",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "test-subscription",
-    "trace_id": 1,
+    "trace_id": 5,
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",

--- a/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_propagation_disabled.json
+++ b/tests/snapshots/tests.contrib.google_cloud_pubsub.test_pubsub.test_subscribe_propagation_disabled.json
@@ -1,9 +1,133 @@
 [[
   {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createTopic projects/test-project/topics/test-topic",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106300000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createTopic",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 15225416,
+    "start": 1775046755157559719
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "createSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106300000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "createSubscription",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 6527458,
+    "start": 1775046755175219552
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteSubscription projects/test-project/subscriptions/test-subscription",
+    "trace_id": 2,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106300000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteSubscription",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 5464167,
+    "start": 1775046755275027427
+  }],
+[
+  {
+    "name": "gcp.pubsub.request",
+    "service": "tests.contrib.google_cloud_pubsub",
+    "resource": "deleteTopic projects/test-project/topics/test-topic",
+    "trace_id": 3,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69cd106300000000",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.google_cloud_pubsub",
+      "component": "google_cloud_pubsub",
+      "gcloud.project_id": "test-project",
+      "language": "python",
+      "pubsub.method": "deleteTopic",
+      "runtime-id": "91d463ac53dd47df91b8db0dedeb1390",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 605.0
+    },
+    "duration": 8778333,
+    "start": 1775046755281329302
+  }],
+[
+  {
     "name": "gcp.pubsub.send",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "test-topic",
-    "trace_id": 0,
+    "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
@@ -37,7 +161,7 @@
     "name": "gcp.pubsub.receive",
     "service": "tests.contrib.google_cloud_pubsub",
     "resource": "test-subscription",
-    "trace_id": 1,
+    "trace_id": 5,
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",


### PR DESCRIPTION
## Description

Add tracing for GCP pub/sub admin and management operations. Created `_wrap_methods` to wrap multiple methods in a single call.

## Testing

- Test all GAPIC conventions for a single method
- Updated pub/sub snapshot tests to account for the new admin spans