### PR TITLE
test(pytest): stabilize coverage run flake

### DIFF
--- a/tests/contrib/pytest/test_pytest_coverage_upload_v2.py
+++ b/tests/contrib/pytest/test_pytest_coverage_upload_v2.py
@@ -283,6 +283,7 @@ class TestPytestV2CoverageUpload:
 
         mock_session = Mock()
         mock_session.config = Mock()
+        mock_session.exitstatus = 0
 
         with (
             patch("ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled", return_value=True),
@@ -293,6 +294,9 @@ class TestPytestV2CoverageUpload:
             patch("ddtrace.contrib.internal.pytest._plugin_v2.handle_coverage_report") as mock_handle_coverage,
             patch("ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report") as mock_run_coverage,
             patch("ddtrace.contrib.internal.pytest._plugin_v2.get_coverage_percentage", return_value=88.0),
+            patch("ddtrace.contrib.internal.pytest._plugin_v2.InternalTestSession.set_covered_lines_pct"),
+            patch("ddtrace.contrib.internal.pytest._plugin_v2.InternalTestSession.finish"),
+            patch.object(pytest, "global_worker_itr_results", 0, create=True),
         ):
             _pytest_sessionfinish(mock_session, 0)
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"84b8cc9c-850b-4f56-a7ef-e793c285e8ab","source":"chat","resourceId":"aacc0ff1-2f9b-49eb-97c2-86f3528badaf","workflowId":"c424db43-077c-455f-97ad-224583710f9c","codeChangeId":"c424db43-077c-455f-97ad-224583710f9c","sourceType":"test-optimization"} -->
## Description

Fixing `TestPytestV2CoverageUpload::test_coverage_upload_with_coverage_run[py3.10]` • **Questions?** Ask in #code-gen-flaky-tests

This change stabilizes a flaky CI Visibility pytest coverage test by isolating it from shared global/session state in `_pytest_sessionfinish`.

The flake was affecting CI reliability (46.0% flake rate, ~3 hours of CI time wasted, 7 failed pipelines). The test exercised the `coverage run` branch but allowed unrelated global state (`pytest.global_worker_itr_results`) and real `InternalTestSession` side effects to participate, which could vary based on prior test execution.

## Testing

- `scripts/run-tests tests/contrib/pytest/test_pytest_coverage_upload_v2.py --venv 10852ec -- -- tests/contrib/pytest/test_pytest_coverage_upload_v2.py::TestPytestV2CoverageUpload::test_coverage_upload_with_coverage_run -q` *(blocked in this environment: Docker daemon unavailable for required testagent service)*
- `ruff format tests/contrib/pytest/test_pytest_coverage_upload_v2.py`
- `ruff check --fix tests/contrib/pytest/test_pytest_coverage_upload_v2.py`

## Risks

Low. Test-only change with tighter isolation; no production code paths were modified.

## Additional Notes

The test now explicitly sets `mock_session.exitstatus` and patches session/global state touched after the coverage-run path assertion (`InternalTestSession.set_covered_lines_pct`, `InternalTestSession.finish`, and `pytest.global_worker_itr_results`). This keeps the test focused on validating that `_pytest_sessionfinish` invokes `run_coverage_report` and `handle_coverage_report` when `coverage run` is detected.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/aacc0ff1-2f9b-49eb-97c2-86f3528badaf)

Comment @datadog to request changes