### PR TITLE
chore(telemetry): add dependency tracker for SCA telemetry reporting

### DIFF
--- a/benchmarks/packages_update_imported_dependencies/scenario.py
+++ b/benchmarks/packages_update_imported_dependencies/scenario.py
@@ -4,7 +4,12 @@ import bm
 
 from ddtrace.internal.packages import get_module_distribution_versions
 from ddtrace.internal.packages import get_package_distributions
-from ddtrace.internal.telemetry.data import update_imported_dependencies
+
+
+try:
+    from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
+except ImportError:
+    from ddtrace.internal.telemetry.data import update_imported_dependencies
 
 
 class PackagesUpdateImportedDependencies(bm.Scenario):

--- a/ddtrace/internal/telemetry/data.py
+++ b/ddtrace/internal/telemetry/data.py
@@ -1,19 +1,15 @@
 import platform
 import sys
 import sysconfig
-from typing import TYPE_CHECKING  # noqa:F401
-from typing import Iterable  # noqa:F401
 
 from ddtrace.internal import process_tags
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
-from ddtrace.internal.packages import get_module_distribution_versions
 from ddtrace.internal.runtime.container import get_container_info
 from ddtrace.internal.utils.cache import cached
 from ddtrace.version import __version__
 
 from ..hostname import get_hostname
 from ..logger import get_logger
-from .dependency import DependencyEntry
 
 
 log = get_logger(__name__)
@@ -72,30 +68,6 @@ def _get_application(key: tuple[str, str, str]) -> dict:
         application["process_tags"] = p_tags
 
     return application
-
-
-def update_imported_dependencies(
-    already_imported: dict[str, DependencyEntry], new_modules: Iterable[str]
-) -> list[dict[str, str]]:
-    deps = []
-
-    for module_name in new_modules:
-        dists = get_module_distribution_versions(module_name)
-        if not dists:
-            continue
-
-        name, version = dists
-        if name == "ddtrace":
-            continue
-
-        if name in already_imported:
-            continue
-
-        entry = DependencyEntry(name=name, version=version, metadata=None)
-        already_imported[name] = entry
-        deps.append(entry.to_telemetry_dict())
-
-    return deps
 
 
 def get_application(service: str, version: str, env: str) -> dict:

--- a/ddtrace/internal/telemetry/dependency.py
+++ b/ddtrace/internal/telemetry/dependency.py
@@ -8,26 +8,46 @@ dependencies and their associated vulnerability metadata.
 from dataclasses import dataclass
 from dataclasses import field
 import json
-import logging
 from typing import Any
 from typing import Optional
 
+from ddtrace.internal.logger import get_logger
 
-log = logging.getLogger(__name__)
+
+log = get_logger(__name__)
 
 
 @dataclass
 class ReachabilityMetadata:
-    """A single reachability finding for a dependency.
+    """A single reachability finding for a dependency (one per CVE).
 
     Attributes:
         type: Metadata type, always "reachability".
-        value: Dict with keys: id, reached, path, method, line.
+        value: Dict with keys: id, reached (list of hit objects).
     """
 
     type: str
     value: dict
     _sent: bool = field(default=False, repr=False, compare=False)
+
+    _MAX_REACHED_ENTRIES = 1
+
+    @property
+    def cve_id(self) -> Optional[str]:
+        return self.value.get("id")
+
+    def add_reached_entry(self, path: str, symbol: str, line: int) -> bool:
+        """Add a hit entry to the reached list.
+
+        Returns True if the entry was added, False if the list is already
+        at capacity (max 1 per RFC — first hit wins).
+        """
+        reached = self.value["reached"]  # always initialized at construction
+        if len(reached) >= self._MAX_REACHED_ENTRIES:
+            return False
+        reached.append({"path": path, "symbol": symbol, "line": line})
+        self._sent = False
+        return True
 
     def to_telemetry_dict(self) -> dict:
         """Serialize for the telemetry wire format.
@@ -58,31 +78,33 @@ class ReachabilityMetadata:
 class DependencyEntry:
     """Tracks a dependency and its optional reachability metadata.
 
-    Used as the value type in TelemetryWriter._imported_dependencies
-    when SCA runtime reachability is active.  Both telemetry and SCA can
-    interact with this model:
-    - Telemetry creates entries on first import (no metadata).
+    Used as the value type in TelemetryWriter._imported_dependencies.
+    Both telemetry and SCA interact with this model:
+    - Telemetry creates entries on first import.
+    - SCA sets metadata to [] when enabled (signals SCA is active).
     - SCA attaches metadata when a vulnerable symbol executes.
     - Telemetry re-reports the dependency when unsent metadata exists.
 
-    AIDEV-TODO: mark_initial_sent(), to_telemetry_dict(), and the
-    metadata re-reporting logic are intentionally unused in the writer
-    until the follow-up SCA PR wires them behind DD_APPSEC_SCA_ENABLED.
+    The metadata field drives the wire format:
+    - metadata is None  → SCA disabled → no "metadata" key in payload
+    - metadata is []    → SCA enabled, no findings → "metadata": []
+    - metadata has items → SCA enabled with findings → "metadata": [...]
 
     Attributes:
         name: Distribution/package name.
         version: Package version string.
-        metadata: Optional list of reachability metadata entries.
-            None when no metadata has been attached (the common case),
-            avoiding the cost of an empty list per entry.
+        metadata: None when SCA is not active, list (possibly empty) when SCA
+            is active.  The None-vs-list distinction drives wire format.
     """
 
     name: str
     version: str
-    # AIDEV-NOTE: metadata is None (not []) by default to avoid allocating an
-    # empty list for every dependency. Most deps never receive metadata.
+    # NOTE: metadata is None (not []) by default — SCA product sets it
+    # to [] when enabled.  None means SCA is inactive for this entry.
     metadata: Optional[list[ReachabilityMetadata]] = None
     _initial_report_sent: bool = field(default=False, repr=False, compare=False)
+
+    _MAX_METADATA_ENTRIES = 100
 
     def has_unsent_metadata(self) -> bool:
         """True if any metadata entry has not been sent yet."""
@@ -108,22 +130,44 @@ class DependencyEntry:
         for m in self.metadata:
             m._mark_sent()
 
-    def add_metadata(self, meta: ReachabilityMetadata) -> bool:
-        """Add metadata entry, deduplicating by CVE id.
+    def add_metadata(self, cve_id: str, path: str = "", symbol: str = "", line: int = 0) -> bool:
+        """Add or update reachability metadata for a CVE.
+
+        If the CVE exists with reached=[], add the call-site entry.
+        If the CVE doesn't exist, create a new metadata entry.
+
+        Args:
+            cve_id: CVE identifier (required).
+            path: Caller file path (empty for registration-only).
+            symbol: Caller symbol name (empty for registration-only).
+            line: Caller line number (0 for registration-only).
 
         Returns:
-            True if the metadata was added, False if it was a duplicate or
-            had no CVE id.
+            True if metadata was added or updated, False if duplicate/capped.
         """
-        cve_id = meta.value.get("id")
-        if cve_id is None:
+        if not cve_id:
             log.debug("Ignoring reachability metadata with no CVE id for %s", self.name)
             return False
         if self.metadata is None:
             self.metadata = []
+
+        # Look for existing metadata entry for this CVE
         for existing in self.metadata:
-            if existing.value.get("id") == cve_id:
+            if existing.cve_id == cve_id:
+                # CVE already registered — add hit if call-site info provided
+                if path and existing.add_reached_entry(path, symbol, line):
+                    return True
                 return False
+
+        if len(self.metadata) >= self._MAX_METADATA_ENTRIES:
+            return False
+
+        # Create new metadata entry for this CVE
+        reached = [{"path": path, "symbol": symbol, "line": line}] if path else []
+        meta = ReachabilityMetadata(
+            type="reachability",
+            value={"id": cve_id, "reached": reached},
+        )
         self.metadata.append(meta)
         return True
 
@@ -152,9 +196,8 @@ def attach_reachability_metadata(
     imported_dependencies: dict[str, DependencyEntry],
     package_name: str,
     cve_id: str,
-    reached: bool,
     path: str,
-    method: str,
+    symbol: str,
     line: int,
 ) -> bool:
     """Attach reachability metadata to an already-tracked dependency.
@@ -164,21 +207,34 @@ def attach_reachability_metadata(
 
     Returns:
         True if metadata was attached, False if the package is not tracked
-        or the CVE was already recorded.
+        or the exact finding was already recorded.
     """
     entry = imported_dependencies.get(package_name)
     if entry is None:
         log.debug("Cannot attach metadata: package %r not yet tracked", package_name)
         return False
 
-    meta = ReachabilityMetadata(
-        type="reachability",
-        value={
-            "id": cve_id,
-            "reached": reached,
-            "path": path,
-            "method": method,
-            "line": line,
-        },
-    )
-    return entry.add_metadata(meta)
+    return entry.add_metadata(cve_id, path, symbol, line)
+
+
+def register_cve_metadata(
+    imported_dependencies: dict[str, DependencyEntry],
+    package_name: str,
+    cve_id: str,
+) -> bool:
+    """Register a CVE on a dependency with reached=[].
+
+    Called at CVE load time to report known vulnerabilities before any
+    symbol is actually executed.  The backend sees the CVE with an empty
+    reached list, meaning "known but not yet hit".
+
+    Returns:
+        True if the CVE was registered, False if the package is not tracked
+        or the CVE was already registered.
+    """
+    entry = imported_dependencies.get(package_name)
+    if entry is None:
+        log.debug("Cannot register CVE metadata: package %r not yet tracked", package_name)
+        return False
+
+    return entry.add_metadata(cve_id)

--- a/ddtrace/internal/telemetry/dependency_tracker.py
+++ b/ddtrace/internal/telemetry/dependency_tracker.py
@@ -1,0 +1,240 @@
+"""Encapsulates dependency tracking for telemetry reporting.
+
+Owns the set of imported dependencies, SCA metadata flag, and all logic
+for discovering new dependencies, attaching reachability metadata, and
+producing the ``app-dependencies-loaded`` telemetry payload.
+
+Extracted from TelemetryWriter to separate dependency-tracking
+concerns from the transport/batching layer.  The writer delegates to a
+single DependencyTracker instance.
+"""
+
+from importlib.metadata import PackageNotFoundError
+import re
+from threading import Lock
+from typing import Any
+from typing import Iterable
+from typing import Optional
+
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.packages import get_module_distribution_versions
+from ddtrace.internal.settings._telemetry import config
+
+from . import modules
+from .dependency import DependencyEntry
+from .dependency import attach_reachability_metadata
+from .dependency import register_cve_metadata
+
+
+log = get_logger(__name__)
+
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+
+def _normalize_dep_name(name: str) -> str:
+    """PEP 503 package name canonicalization for consistent dict lookups.
+
+    Distribution metadata may use original casing (e.g. "PyYAML") while
+    SCA CVE data uses lowercased names (e.g. "pyyaml").  Normalizing keys
+    prevents duplicate entries and lookup misses.
+    """
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+class DependencyTracker:
+    """Thread-safe tracker for imported dependencies and SCA metadata.
+
+    All mutable access is protected by an internal lock.
+
+    SCA-enabled state is read from ``tracer_config._sca_enabled`` so
+    it reacts dynamically to Remote Configuration changes instead of
+    relying on a one-time snapshot.  The DependencyEntry.metadata field
+    state drives the wire format:
+    - metadata is None  -> entry serialized without "metadata" key
+    - metadata is not None -> entry serialized with "metadata" key
+    SCA product is responsible for setting metadata to [] on existing
+    entries when it starts (via enable_sca_metadata).
+    """
+
+    def __init__(self) -> None:
+        self._imported_dependencies: dict[str, DependencyEntry] = {}
+        self._modules_already_imported: set[str] = set()
+        self._lock = Lock()
+
+    def _update_imported(self, new_modules: Iterable[str]) -> list[dict]:
+        """Discover new dependencies from recently imported modules.
+
+        Adds a DependencyEntry for each newly discovered package.
+        Returns serialized dependency dicts ready for the telemetry payload.
+
+        Caller must hold self._lock (called internally from collect_report).
+        """
+        return update_imported_dependencies(self._imported_dependencies, new_modules)
+
+    def collect_report(self) -> Optional[list[dict[str, Any]]]:
+        """Discover new modules, collect re-reports, mark sent. Return payload or None.
+
+        When a dependency has unsent metadata (attached by the SCA hook),
+        it is re-reported with ALL metadata (sent + unsent) per the RFC.
+        """
+        if not config.DEPENDENCY_COLLECTION:
+            return None
+
+        with self._lock:
+            newly_imported_deps = modules.get_newly_imported_modules(self._modules_already_imported)
+            new_deps = self._update_imported(newly_imported_deps)
+
+            # Mark new deps as initially sent
+            for dep_dict in new_deps:
+                entry = self._imported_dependencies.get(_normalize_dep_name(dep_dict["name"]))
+                if entry:
+                    entry.mark_initial_sent()
+                    entry.mark_all_metadata_sent()
+
+            # Skip the re-report scan when SCA is disabled.
+            # Without SCA, no entry will ever have unsent metadata, so the
+            # scan over all _imported_dependencies is pure overhead (~887us
+            # at 10K deps).  Only entries created by the SCA hook or with
+            # metadata attached can trigger needs_report() after initial send.
+            from ddtrace.internal.settings._config import config as tracer_config
+
+            if not tracer_config._sca_enabled:
+                return new_deps if new_deps else None
+
+            # Collect normalized names of deps just reported above to avoid double-reporting.
+            just_reported = {_normalize_dep_name(d["name"]) for d in new_deps}
+
+            # Re-report deps that need it: auto-created by SCA hook (never
+            # reported yet) or already reported but with new unsent metadata.
+            # Include ALL metadata (sent + unsent) per RFC.
+            re_report_deps: list[dict] = []
+            for entry in self._imported_dependencies.values():
+                if _normalize_dep_name(entry.name) in just_reported:
+                    continue
+                if entry.needs_report():
+                    re_report_deps.append(entry.to_telemetry_dict(include_all_metadata=True))
+                    entry.mark_initial_sent()
+                    entry.mark_all_metadata_sent()
+
+            all_deps = new_deps + re_report_deps
+            return all_deps if all_deps else None
+
+    def _ensure_entry(self, package_name: str) -> None:
+        """Auto-create a DependencyEntry if SCA is active and package not yet tracked.
+
+        Caller must hold self._lock.
+        """
+        from ddtrace.internal.settings._config import config as tracer_config
+
+        key = _normalize_dep_name(package_name)
+        if key not in self._imported_dependencies and tracer_config._sca_enabled:
+            try:
+                from importlib.metadata import version as importlib_metadata_version
+
+                version = importlib_metadata_version(package_name)
+            except PackageNotFoundError:
+                log.debug("Package %r not found in installed metadata", package_name)
+                version = ""
+            self._imported_dependencies[key] = DependencyEntry(name=package_name, version=version, metadata=[])
+
+    def attach_metadata(
+        self,
+        package_name: str,
+        cve_id: str,
+        path: str,
+        symbol: str,
+        line: int,
+    ) -> bool:
+        """Attach reachability metadata to an imported dependency.
+
+        Called by SCA detection hook when a vulnerable symbol is reached at runtime.
+        Thread-safe: acquires lock before mutating dependency entries.
+
+        If SCA is active and the package isn't tracked yet (telemetry heartbeat
+        hasn't discovered it), auto-creates the entry with metadata=[].
+
+        Returns:
+            True if metadata was attached, False otherwise.
+        """
+        key = _normalize_dep_name(package_name)
+        with self._lock:
+            self._ensure_entry(package_name)
+            return attach_reachability_metadata(self._imported_dependencies, key, cve_id, path, symbol, line)
+
+    def register_cve(self, package_name: str, cve_id: str) -> bool:
+        """Register a CVE on a dependency with reached=[].
+
+        Called at CVE load time to report known vulnerabilities before any
+        symbol is actually executed.  Thread-safe.
+
+        If SCA is active and the package isn't tracked yet, auto-creates the entry.
+
+        Returns:
+            True if the CVE was registered, False otherwise.
+        """
+        key = _normalize_dep_name(package_name)
+        with self._lock:
+            self._ensure_entry(package_name)
+            return register_cve_metadata(self._imported_dependencies, key, cve_id)
+
+    def enable_sca_metadata(self) -> None:
+        """Activate SCA metadata on all currently tracked dependencies.
+
+        Called by the SCA product on start.  Sets metadata from None to []
+        on all existing entries so the wire format includes the "metadata"
+        key.  Future entries pick up the flag from tracer_config._sca_enabled.
+        """
+        with self._lock:
+            for entry in self._imported_dependencies.values():
+                if entry.metadata is None:
+                    entry.metadata = []
+
+    def get_all_dependencies(self) -> list[DependencyEntry]:
+        """Return a snapshot of all dependency entries, safe for unsynchronized iteration."""
+        with self._lock:
+            return list(self._imported_dependencies.values())
+
+    def reset(self) -> None:
+        """Reset all state (used on fork / queue reset)."""
+        with self._lock:
+            self._imported_dependencies = {}
+            self._modules_already_imported = set()
+
+
+def update_imported_dependencies(
+    already_imported: dict[str, DependencyEntry],
+    new_modules: Iterable[str],
+) -> list[dict]:
+    """Standalone version of dependency discovery for backward compatibility.
+
+    Mutates *already_imported* in place, adding a DependencyEntry for each
+    newly discovered package.  Returns the list of serialized dependency
+    dicts ready for the ``app-dependencies-loaded`` telemetry payload.
+
+    SCA-enabled state is read from ``tracer_config._sca_enabled`` so it
+    reacts dynamically to Remote Configuration changes.
+
+    NOTE: This function is kept for backward compatibility with
+    tests and benchmarks that call it directly.  Production code should use
+    DependencyTracker instead.
+    """
+    from ddtrace.internal.settings._config import config as tracer_config
+
+    deps: list[dict] = []
+    for module_name in new_modules:
+        dists = get_module_distribution_versions(module_name)
+        if not dists:
+            continue
+
+        name, version = dists
+        key = _normalize_dep_name(name)
+        if key == "ddtrace":
+            continue
+        if key in already_imported:
+            continue
+
+        metadata: Optional[list] = [] if tracer_config._sca_enabled else None
+        entry = DependencyEntry(name=name, version=version, metadata=metadata)
+        already_imported[key] = entry
+        deps.append(entry.to_telemetry_dict())
+    return deps

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -27,7 +27,6 @@ from ..runtime import get_runtime_id
 from ..service import ServiceStatus
 from ..utils.time import StopWatch
 from ..utils.version import version as tracer_version
-from . import modules
 from .constants import TELEMETRY_APM_PRODUCT
 from .constants import TELEMETRY_EVENT_TYPE
 from .constants import TELEMETRY_LOG_LEVEL
@@ -35,9 +34,7 @@ from .constants import TELEMETRY_NAMESPACE
 from .data import get_application
 from .data import get_host_info
 from .data import get_python_config_vars
-from .data import update_imported_dependencies
-from .dependency import DependencyEntry
-from .dependency import attach_reachability_metadata
+from .dependency_tracker import DependencyTracker
 from .logging import DDTelemetryErrorHandler
 from .metrics_namespaces import MetricNamespace
 from .metrics_namespaces import MetricTagType
@@ -168,8 +165,7 @@ class TelemetryWriter(PeriodicService):
         self._queued_configs: list[dict] = []
         self._sent_configs: list[dict] = []
         self._configuration_queue: list[dict] = []
-        self._imported_dependencies: dict[str, DependencyEntry] = dict()
-        self._modules_already_imported: set[str] = set()
+        self._dependency_tracker = DependencyTracker()
         self._product_enablement: dict[str, bool] = {product.value: False for product in TELEMETRY_APM_PRODUCT}
         self._previous_product_enablement: dict[str, bool] = {}
         self._extended_time = time.monotonic()
@@ -317,7 +313,10 @@ class TelemetryWriter(PeriodicService):
         if time.monotonic() - self._extended_time > self._extended_heartbeat_interval:
             payload["configuration"] = self._sent_configs
             if config.DEPENDENCY_COLLECTION:
-                payload["dependencies"] = [entry.to_telemetry_dict() for entry in self._imported_dependencies.values()]
+                payload["dependencies"] = [
+                    entry.to_telemetry_dict(include_all_metadata=True)
+                    for entry in self._dependency_tracker.get_all_dependencies()
+                ]
             self._extended_time += self._extended_heartbeat_interval
         return payload
 
@@ -337,37 +336,41 @@ class TelemetryWriter(PeriodicService):
         return configurations
 
     def _report_dependencies(self) -> Optional[list[dict[str, Any]]]:
-        """Adds events to report imports done since the last periodic run"""
-        if not config.DEPENDENCY_COLLECTION or not self._enabled:
-            return None
+        """Report newly imported modules and modules with updated SCA metadata.
 
-        with self._service_lock:
-            newly_imported_deps = modules.get_newly_imported_modules(self._modules_already_imported)
-            if not newly_imported_deps:
-                return None
-            return update_imported_dependencies(self._imported_dependencies, newly_imported_deps)
+        Delegates to DependencyTracker.collect_report().
+        """
+        if not self._enabled:
+            return None
+        return self._dependency_tracker.collect_report()
 
     def attach_dependency_metadata(
         self,
         package_name: str,
         cve_id: str,
-        reached: bool,
         path: str,
-        method: str,
+        symbol: str,
         line: int,
     ) -> bool:
         """Attach reachability metadata to an imported dependency.
 
-        Called by SCA detection hook when a vulnerable symbol is reached at runtime.
-        Thread-safe: acquires _service_lock before mutating dependency entries.
-
-        Returns:
-            True if metadata was attached, False if the package is not yet tracked.
+        Delegates to DependencyTracker.attach_metadata().
         """
-        with self._service_lock:
-            return attach_reachability_metadata(
-                self._imported_dependencies, package_name, cve_id, reached, path, method, line
-            )
+        return self._dependency_tracker.attach_metadata(package_name, cve_id, path, symbol, line)
+
+    def register_cve_metadata(self, package_name: str, cve_id: str) -> bool:
+        """Register a CVE on a dependency with reached=[].
+
+        Called at CVE load time. Delegates to DependencyTracker.register_cve().
+        """
+        return self._dependency_tracker.register_cve(package_name, cve_id)
+
+    def enable_sca_metadata(self) -> None:
+        """Activate SCA metadata on all tracked and future dependencies.
+
+        Delegates to DependencyTracker.enable_sca_metadata().
+        """
+        self._dependency_tracker.enable_sca_metadata()
 
     def _report_endpoints(self) -> Optional[dict[str, Any]]:
         """Adds a Telemetry event which sends the list of HTTP endpoints found at startup to the agent"""
@@ -705,7 +708,7 @@ class TelemetryWriter(PeriodicService):
         self._integrations_queue = dict()
         self._namespace.flush()
         self._logs = set()
-        self._imported_dependencies = {}
+        self._dependency_tracker.reset()
         self._queued_configs = []
         self._sent_configs = []
 

--- a/tests/appsec/architectures/mini.py
+++ b/tests/appsec/architectures/mini.py
@@ -13,22 +13,22 @@ import requests  # noqa: E402 F401
 
 from ddtrace import __version__  # noqa: E402
 from ddtrace.internal.settings.asm import config as asm_config  # noqa: E402
-import ddtrace.internal.telemetry.writer  # noqa: E402
+import ddtrace.internal.telemetry.dependency_tracker as dep_tracker  # noqa: E402
 
 
 app = Flask(__name__)
 _TELEMETRY_DEPENDENCIES = []
-update_imported_dependencies = ddtrace.internal.telemetry.writer.update_imported_dependencies
+_original_update_imported_dependencies = dep_tracker.update_imported_dependencies
 
 
 def wrap_update_imported_dependencies(imported_dependencies, newly_imported_deps):
     global _TELEMETRY_DEPENDENCIES
-    dependencies = update_imported_dependencies(imported_dependencies, newly_imported_deps)
+    dependencies = _original_update_imported_dependencies(imported_dependencies, newly_imported_deps)
     _TELEMETRY_DEPENDENCIES.extend(dependencies)
     return dependencies
 
 
-ddtrace.internal.telemetry.writer.update_imported_dependencies = wrap_update_imported_dependencies
+dep_tracker.update_imported_dependencies = wrap_update_imported_dependencies
 
 
 @app.route("/")
@@ -60,7 +60,7 @@ def import_modules():
     if module_name:
         __import__(module_name)
 
-    from ddtrace.internal.telemetry.data import update_imported_dependencies  # noqa: E402
+    from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies  # noqa: E402
 
     newly_loaded = list(sys.modules.keys())
     res = update_imported_dependencies(loaded, newly_loaded)

--- a/tests/telemetry/test_data.py
+++ b/tests/telemetry/test_data.py
@@ -177,7 +177,7 @@ def test_get_container_id_when_container_does_not_exists():
 
 @pytest.mark.subprocess
 def test_update_imported_dependencies_both_empty():
-    from ddtrace.internal.telemetry.data import update_imported_dependencies
+    from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
 
     already_imported = {}
     new_modules = []
@@ -191,7 +191,7 @@ def test_update_imported_dependencies_both_empty():
 def test_update_imported_dependencies():
     import xmltodict
 
-    from ddtrace.internal.telemetry.data import update_imported_dependencies
+    from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
 
     already_imported = {}
     res = update_imported_dependencies(already_imported, [xmltodict.__name__])

--- a/tests/telemetry/test_dependency.py
+++ b/tests/telemetry/test_dependency.py
@@ -2,56 +2,95 @@
 
 import json
 
+import pytest
+
 from ddtrace.internal.telemetry.dependency import DependencyEntry
 from ddtrace.internal.telemetry.dependency import ReachabilityMetadata
 from ddtrace.internal.telemetry.dependency import attach_reachability_metadata
+from ddtrace.internal.telemetry.dependency import register_cve_metadata
+
+
+@pytest.fixture(autouse=True)
+def _restore_sca_config():
+    """Save and restore tracer_config._sca_enabled to prevent cross-test contamination."""
+    from ddtrace.internal.settings._config import config as tracer_config
+
+    saved = tracer_config._sca_enabled
+    yield
+    tracer_config._sca_enabled = saved
 
 
 class TestReachabilityMetadata:
     def test_to_telemetry_dict_serializes_value_as_json_string(self):
         meta = ReachabilityMetadata(
             type="reachability",
-            value={"id": "CVE-2024-1234", "reached": True, "path": "mod.sub", "method": "func", "line": 10},
+            value={"id": "CVE-2024-1234", "reached": [{"path": "mod.sub", "symbol": "func", "line": 10}]},
         )
         result = meta.to_telemetry_dict()
         assert result["type"] == "reachability"
         assert isinstance(result["value"], str)
         parsed = json.loads(result["value"])
         assert parsed["id"] == "CVE-2024-1234"
-        assert parsed["reached"] is True
-        assert parsed["path"] == "mod.sub"
-        assert parsed["method"] == "func"
-        assert parsed["line"] == 10
+        assert isinstance(parsed["reached"], list)
+        assert len(parsed["reached"]) == 1
+        assert parsed["reached"][0]["path"] == "mod.sub"
+        assert parsed["reached"][0]["symbol"] == "func"
+        assert parsed["reached"][0]["line"] == 10
 
     def test_sent_tracking(self):
-        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1"})
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
         assert meta.is_sent is False
         meta._mark_sent()
         assert meta.is_sent is True
 
+    def test_cve_id_property(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.cve_id == "CVE-1"
+
+    def test_cve_id_property_missing(self):
+        meta = ReachabilityMetadata(type="reachability", value={"reached": []})
+        assert meta.cve_id is None
+
+    def test_add_reached_entry_first_hit(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.add_reached_entry("mod.views", "func1", 33) is True
+        assert len(meta.value["reached"]) == 1
+        assert meta.value["reached"][0] == {"path": "mod.views", "symbol": "func1", "line": 33}
+        assert meta.is_sent is False
+
+    def test_add_reached_entry_max_one(self):
+        """RFC says reporting a single occurrence is sufficient — max 1."""
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.add_reached_entry("mod.views", "func1", 33) is True
+        assert meta.add_reached_entry("mod.services", "func2", 44) is False
+        assert len(meta.value["reached"]) == 1
+
+    def test_add_reached_entry_marks_unsent(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        meta._mark_sent()
+        assert meta.is_sent is True
+        meta.add_reached_entry("mod", "func", 1)
+        assert meta.is_sent is False
+
 
 class TestDependencyEntry:
-    def test_to_telemetry_dict_without_metadata(self):
-        """Without metadata, wire format is identical to the old dict[str, str] approach."""
+    def test_to_telemetry_dict_metadata_none(self):
+        """metadata=None -> no metadata key (SCA not active)."""
         entry = DependencyEntry(name="requests", version="2.28.0")
         result = entry.to_telemetry_dict()
         assert result == {"name": "requests", "version": "2.28.0"}
         assert "metadata" not in result
 
+    def test_to_telemetry_dict_metadata_empty_list(self):
+        """metadata=[] -> metadata key with empty list (SCA active, no findings)."""
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        result = entry.to_telemetry_dict()
+        assert result == {"name": "requests", "version": "2.28.0", "metadata": []}
+
     def test_to_telemetry_dict_with_metadata(self):
-        entry = DependencyEntry(name="requests", version="2.28.0")
-        entry.add_metadata(
-            ReachabilityMetadata(
-                type="reachability",
-                value={
-                    "id": "CVE-2024-1234",
-                    "reached": True,
-                    "path": "requests.sessions",
-                    "method": "send",
-                    "line": 1,
-                },
-            )
-        )
+        """metadata with entries -> metadata key with serialized entries."""
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.add_metadata("CVE-2024-1234", "requests.sessions", "send", 1)
         result = entry.to_telemetry_dict()
         assert result["name"] == "requests"
         assert result["version"] == "2.28.0"
@@ -59,22 +98,59 @@ class TestDependencyEntry:
         assert result["metadata"][0]["type"] == "reachability"
         parsed = json.loads(result["metadata"][0]["value"])
         assert parsed["id"] == "CVE-2024-1234"
+        assert isinstance(parsed["reached"], list)
+        assert len(parsed["reached"]) == 1
 
-    def test_add_metadata_deduplicates_by_cve_id(self):
+    def test_add_metadata_same_cve_first_hit_wins(self):
+        """Same CVE from different call sites — first hit wins (max reached=1)."""
         entry = DependencyEntry(name="pkg", version="1.0")
-        meta1 = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": True})
-        meta2 = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": True})
-        meta3 = ReachabilityMetadata(type="reachability", value={"id": "CVE-2", "reached": True})
-        assert entry.add_metadata(meta1) is True
-        assert entry.add_metadata(meta2) is False  # duplicate
-        assert entry.add_metadata(meta3) is True
+        assert entry.add_metadata("CVE-1", "mymodule.views", "func1", 33) is True
+        assert entry.add_metadata("CVE-1", "views.endpoint2", "func2", 456) is False
+        assert len(entry.metadata) == 1
+        assert len(entry.metadata[0].value["reached"]) == 1
+
+    def test_add_metadata_different_cves(self):
+        entry = DependencyEntry(name="pkg", version="1.0")
+        assert entry.add_metadata("CVE-1", "mod", "func", 1) is True
+        assert entry.add_metadata("CVE-2", "mod", "func", 1) is True
         assert len(entry.metadata) == 2
 
     def test_add_metadata_rejects_no_cve_id(self):
         entry = DependencyEntry(name="pkg", version="1.0")
-        meta = ReachabilityMetadata(type="reachability", value={"reached": True})
-        assert entry.add_metadata(meta) is False
+        assert entry.add_metadata("") is False
         assert entry.metadata is None
+
+    def test_add_metadata_initializes_list_from_none(self):
+        """add_metadata on a None-metadata entry initializes the list."""
+        entry = DependencyEntry(name="pkg", version="1.0")
+        assert entry.metadata is None
+        entry.add_metadata("CVE-1")
+        assert entry.metadata is not None
+        assert len(entry.metadata) == 1
+
+    def test_add_metadata_register_cve_empty_reached(self):
+        """Registering a CVE without call-site creates reached=[]."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        assert entry.add_metadata("CVE-1") is True
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value == {"id": "CVE-1", "reached": []}
+
+    def test_add_metadata_register_then_hit(self):
+        """Register CVE with reached=[], then hit fills it."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")  # register with reached=[]
+        assert entry.metadata[0].value["reached"] == []
+        assert entry.add_metadata("CVE-1", "mod.views", "func1", 33) is True
+        assert len(entry.metadata) == 1
+        assert len(entry.metadata[0].value["reached"]) == 1
+        assert entry.metadata[0].value["reached"][0] == {"path": "mod.views", "symbol": "func1", "line": 33}
+
+    def test_add_metadata_duplicate_registration_is_idempotent(self):
+        """Registering the same CVE twice does not create duplicates."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        assert entry.add_metadata("CVE-1") is True
+        assert entry.add_metadata("CVE-1") is False
+        assert len(entry.metadata) == 1
 
     def test_needs_report_new_entry(self):
         entry = DependencyEntry(name="pkg", version="1.0")
@@ -88,125 +164,582 @@ class TestDependencyEntry:
     def test_needs_report_after_initial_send_with_unsent_metadata(self):
         entry = DependencyEntry(name="pkg", version="1.0")
         entry.mark_initial_sent()
-        entry.add_metadata(ReachabilityMetadata(type="reachability", value={"id": "CVE-1"}))
+        entry.add_metadata("CVE-1")
         assert entry.needs_report() is True
 
     def test_needs_report_after_all_metadata_sent(self):
         entry = DependencyEntry(name="pkg", version="1.0")
         entry.mark_initial_sent()
-        entry.add_metadata(ReachabilityMetadata(type="reachability", value={"id": "CVE-1"}))
+        entry.add_metadata("CVE-1")
         entry.mark_all_metadata_sent()
         assert entry.needs_report() is False
 
+    def test_add_metadata_respects_max_cve_cap(self):
+        """add_metadata silently drops CVEs once _MAX_METADATA_ENTRIES is reached."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        for i in range(DependencyEntry._MAX_METADATA_ENTRIES):
+            assert entry.add_metadata(f"CVE-{i}") is True
+        assert len(entry.metadata) == DependencyEntry._MAX_METADATA_ENTRIES
+        assert entry.add_metadata("CVE-overflow") is False
+        assert len(entry.metadata) == DependencyEntry._MAX_METADATA_ENTRIES
+
     def test_get_unsent_metadata(self):
         entry = DependencyEntry(name="pkg", version="1.0")
-        m1 = ReachabilityMetadata(type="reachability", value={"id": "CVE-1"})
-        m2 = ReachabilityMetadata(type="reachability", value={"id": "CVE-2"})
-        entry.add_metadata(m1)
-        entry.add_metadata(m2)
-        m1._mark_sent()
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()  # mark CVE-1 as sent
+        entry.add_metadata("CVE-2")  # CVE-2 is unsent
         unsent = entry.get_unsent_metadata()
         assert len(unsent) == 1
         assert unsent[0].value["id"] == "CVE-2"
 
     def test_to_telemetry_dict_only_unsent(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        m1 = ReachabilityMetadata(type="reachability", value={"id": "CVE-1"})
-        m2 = ReachabilityMetadata(type="reachability", value={"id": "CVE-2"})
-        entry.add_metadata(m1)
-        entry.add_metadata(m2)
-        m1._mark_sent()
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()  # CVE-1 is now sent
+        entry.add_metadata("CVE-2")  # CVE-2 is unsent
         result = entry.to_telemetry_dict(include_all_metadata=False)
         assert len(result["metadata"]) == 1
         parsed = json.loads(result["metadata"][0]["value"])
         assert parsed["id"] == "CVE-2"
 
     def test_to_telemetry_dict_include_all(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        m1 = ReachabilityMetadata(type="reachability", value={"id": "CVE-1"})
-        m2 = ReachabilityMetadata(type="reachability", value={"id": "CVE-2"})
-        entry.add_metadata(m1)
-        entry.add_metadata(m2)
-        m1._mark_sent()
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()  # CVE-1 is now sent
+        entry.add_metadata("CVE-2")  # CVE-2 is unsent
         result = entry.to_telemetry_dict(include_all_metadata=True)
         assert len(result["metadata"]) == 2
 
-    def test_to_telemetry_dict_include_all_metadata_false(self):
-        """When all metadata is sent and include_all_metadata=False, no metadata key."""
-        entry = DependencyEntry(name="pkg", version="1.0")
-        entry.add_metadata(ReachabilityMetadata(type="reachability", value={"id": "CVE-1"}))
+    def test_to_telemetry_dict_all_sent_empty_metadata(self):
+        """When all metadata is sent and include_all_metadata=False, empty list."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")
         entry.mark_all_metadata_sent()
         result = entry.to_telemetry_dict(include_all_metadata=False)
-        assert len(result["metadata"]) == 0
-
-    def test_to_telemetry_empty_dict_include_all_metadata_false(self):
-        """When all metadata is sent and include_all_metadata=False, no metadata key."""
-        entry = DependencyEntry(name="pkg", version="1.0")
-        result = entry.to_telemetry_dict(include_all_metadata=False)
-        assert "metadata" not in result
-        assert "name" in result
-        assert "version" in result
+        assert result["metadata"] == []
 
 
 class TestAttachReachabilityMetadata:
     def test_attach_to_existing_dependency(self):
         deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        result = attach_reachability_metadata(deps, "requests", "CVE-2024-1234", True, "requests.sessions", "send", 10)
+        result = attach_reachability_metadata(deps, "requests", "CVE-2024-1234", "requests.sessions", "send", 10)
         assert result is True
         assert len(deps["requests"].metadata) == 1
         assert deps["requests"].metadata[0].value["id"] == "CVE-2024-1234"
+        assert len(deps["requests"].metadata[0].value["reached"]) == 1
 
     def test_attach_to_unknown_package(self):
         deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        result = attach_reachability_metadata(deps, "flask", "CVE-2024-9999", True, "flask.app", "run", 1)
+        result = attach_reachability_metadata(deps, "flask", "CVE-2024-9999", "flask.app", "run", 1)
         assert result is False
 
     def test_attach_multiple_cves_to_same_package(self):
         deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        attach_reachability_metadata(deps, "requests", "CVE-1", True, "mod", "func1", 1)
-        attach_reachability_metadata(deps, "requests", "CVE-2", True, "mod", "func2", 5)
+        attach_reachability_metadata(deps, "requests", "CVE-1", "mod", "func1", 1)
+        attach_reachability_metadata(deps, "requests", "CVE-2", "mod", "func2", 5)
         assert len(deps["requests"].metadata) == 2
 
-    def test_attach_deduplicates_same_cve(self):
+    def test_attach_same_cve_first_hit_wins(self):
+        """Same CVE from different call sites — first hit wins (max reached=1)."""
         deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        assert attach_reachability_metadata(deps, "requests", "CVE-1", True, "mod", "func1", 1) is True
-        assert attach_reachability_metadata(deps, "requests", "CVE-1", True, "mod", "func1", 1) is False
+        assert attach_reachability_metadata(deps, "requests", "CVE-1", "mod.views", "func1", 33) is True
+        assert attach_reachability_metadata(deps, "requests", "CVE-1", "views.ep2", "func2", 456) is False
         assert len(deps["requests"].metadata) == 1
+        assert len(deps["requests"].metadata[0].value["reached"]) == 1
+
+
+class TestRegisterCveMetadata:
+    def test_register_cve_to_tracked_dependency(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        result = register_cve_metadata(deps, "requests", "CVE-1")
+        assert result is True
+        assert len(deps["requests"].metadata) == 1
+        assert deps["requests"].metadata[0].value == {"id": "CVE-1", "reached": []}
+
+    def test_register_cve_to_unknown_package(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
+        result = register_cve_metadata(deps, "flask", "CVE-1")
+        assert result is False
+
+    def test_register_then_hit(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        register_cve_metadata(deps, "requests", "CVE-1")
+        attach_reachability_metadata(deps, "requests", "CVE-1", "mod", "func", 10)
+        assert len(deps["requests"].metadata) == 1
+        assert len(deps["requests"].metadata[0].value["reached"]) == 1
+
+    def test_register_duplicate_is_idempotent(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        assert register_cve_metadata(deps, "requests", "CVE-1") is True
+        assert register_cve_metadata(deps, "requests", "CVE-1") is False
+        assert len(deps["requests"].metadata) == 1
+
+    def test_register_multiple_cves(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        register_cve_metadata(deps, "requests", "CVE-1")
+        register_cve_metadata(deps, "requests", "CVE-2")
+        assert len(deps["requests"].metadata) == 2
+        cve_ids = {m.value["id"] for m in deps["requests"].metadata}
+        assert cve_ids == {"CVE-1", "CVE-2"}
+
+
+def _make_writer_and_tracker(sca_enabled=False, deps=None, enabled=True):
+    """Shared factory for writer-level tests.
+
+    Sets tracer_config._sca_enabled so DependencyTracker reads the live
+    config flag.  Callers should use the _restore_sca_config fixture
+    (autouse in this module) to ensure cleanup.
+    """
+    from unittest.mock import MagicMock
+
+    from ddtrace.internal.settings._config import config as tracer_config
+    from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+    from ddtrace.internal.telemetry.writer import TelemetryWriter
+
+    tracer_config._sca_enabled = sca_enabled
+    writer = TelemetryWriter.__new__(TelemetryWriter)
+    writer._service_lock = MagicMock()
+    writer._enabled = enabled
+    tracker = DependencyTracker()
+    if deps:
+        tracker._imported_dependencies = deps
+    writer._dependency_tracker = tracker
+    return writer, tracker
 
 
 class TestWriterAttachDependencyMetadata:
-    """Writer-level tests for attach_dependency_metadata (with locking)."""
+    """Writer-level tests for attach_dependency_metadata (via DependencyTracker)."""
 
     def test_attach_metadata_to_tracked_dependency(self):
-        from unittest.mock import MagicMock
+        writer, tracker = _make_writer_and_tracker(
+            deps={"requests": DependencyEntry(name="requests", version="2.28.0")}
+        )
 
-        from ddtrace.internal.telemetry.writer import TelemetryWriter
-
-        writer = TelemetryWriter.__new__(TelemetryWriter)
-        writer._service_lock = MagicMock()
-        writer._imported_dependencies = {
-            "requests": DependencyEntry(name="requests", version="2.28.0"),
-        }
-
-        result = writer.attach_dependency_metadata("requests", "CVE-1", True, "mod", "func", 1)
+        result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
 
         assert result is True
-        entry = writer._imported_dependencies["requests"]
+        entry = tracker._imported_dependencies["requests"]
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value["id"] == "CVE-1"
+        assert len(entry.metadata[0].value["reached"]) == 1
+
+    def test_attach_returns_false_for_unknown_package(self):
+        writer, tracker = _make_writer_and_tracker(
+            deps={"requests": DependencyEntry(name="requests", version="2.28.0")}
+        )
+
+        result = writer.attach_dependency_metadata("flask", "CVE-1", "mod", "func", 1)
+
+        assert result is False
+        assert "flask" not in tracker._imported_dependencies
+
+    def test_attach_auto_creates_entry_when_sca_active(self):
+        """When SCA is active and package not tracked, auto-create the entry."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        with patch("importlib.metadata.version", return_value="2.28.0"):
+            result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
+
+        assert result is True
+        assert "requests" in tracker._imported_dependencies
+        entry = tracker._imported_dependencies["requests"]
+        assert entry.version == "2.28.0"
+        assert entry.metadata is not None
         assert len(entry.metadata) == 1
         assert entry.metadata[0].value["id"] == "CVE-1"
 
-    def test_attach_returns_false_for_unknown_package(self):
-        from unittest.mock import MagicMock
+    def test_attach_does_not_auto_create_when_sca_inactive(self):
+        """When SCA is not active, unknown packages return False."""
+        writer, tracker = _make_writer_and_tracker(sca_enabled=False)
 
-        from ddtrace.internal.telemetry.writer import TelemetryWriter
-
-        writer = TelemetryWriter.__new__(TelemetryWriter)
-        writer._service_lock = MagicMock()
-        writer._imported_dependencies = {
-            "requests": DependencyEntry(name="requests", version="2.28.0"),
-        }
-
-        result = writer.attach_dependency_metadata("flask", "CVE-1", True, "mod", "func", 1)
+        result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
 
         assert result is False
-        assert "flask" not in writer._imported_dependencies
+        assert "requests" not in tracker._imported_dependencies
+
+
+class TestWriterEnableScaMetadata:
+    """Tests for enable_sca_metadata method (via DependencyTracker)."""
+
+    def test_enable_sca_metadata_sets_none_to_empty_list(self):
+        writer, tracker = _make_writer_and_tracker(
+            deps={
+                "requests": DependencyEntry(name="requests", version="2.28.0"),
+                "flask": DependencyEntry(name="flask", version="3.0.0"),
+            }
+        )
+        assert tracker._imported_dependencies["requests"].metadata is None
+        assert tracker._imported_dependencies["flask"].metadata is None
+
+        writer.enable_sca_metadata()
+
+        assert tracker._imported_dependencies["requests"].metadata == []
+        assert tracker._imported_dependencies["flask"].metadata == []
+
+    def test_enable_sca_metadata_preserves_existing_metadata(self):
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.add_metadata("CVE-1")
+
+        writer, tracker = _make_writer_and_tracker(deps={"requests": entry})
+
+        writer.enable_sca_metadata()
+
+        # Should not overwrite existing metadata
+        assert len(tracker._imported_dependencies["requests"].metadata) == 1
+
+
+class TestWriterReReporting:
+    """Tests for _report_dependencies re-reporting behavior with metadata."""
+
+    def test_report_dependencies_rereports_on_new_metadata(self):
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        # Pre-populate with an already-reported dep (SCA active: metadata=[])
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        # Attach metadata after initial report
+        writer.attach_dependency_metadata("requests", "CVE-1", "requests.sessions", "send", 10)
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+        ):
+            mock_config.DEPENDENCY_COLLECTION = True
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert len(result[0]["metadata"]) == 1
+        parsed = json.loads(result[0]["metadata"][0]["value"])
+        assert parsed["id"] == "CVE-1"
+        assert isinstance(parsed["reached"], list)
+        assert len(parsed["reached"]) == 1
+
+        # Metadata should be marked as sent now
+        assert entry.has_unsent_metadata() is False
+
+    def test_report_dependencies_no_rereport_without_new_metadata(self):
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker()
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+        ):
+            mock_config.DEPENDENCY_COLLECTION = True
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        # No new deps, no new metadata -> None
+        assert result is None
+
+    def test_rereport_includes_all_metadata_per_rfc(self):
+        """Re-report includes ALL metadata (sent + unsent) per RFC."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        # Attach first CVE and mark as sent
+        writer.attach_dependency_metadata("requests", "CVE-1", "mod.views", "func1", 33)
+        entry.mark_all_metadata_sent()
+
+        # Register second CVE (unsent, with reached=[])
+        writer.register_cve_metadata("requests", "CVE-2")
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+        ):
+            mock_config.DEPENDENCY_COLLECTION = True
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        # Should include ALL metadata (both CVE-1 and CVE-2)
+        assert len(result[0]["metadata"]) == 2
+
+    def test_rereport_on_cve_registration(self):
+        """Registering CVEs after initial dep report triggers re-report with reached=[]."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        entry.mark_all_metadata_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        # Register CVE (simulates CVE load at startup)
+        writer.register_cve_metadata("requests", "CVE-1")
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+        ):
+            mock_config.DEPENDENCY_COLLECTION = True
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert len(result[0]["metadata"]) == 1
+        parsed = json.loads(result[0]["metadata"][0]["value"])
+        assert parsed["id"] == "CVE-1"
+        assert parsed["reached"] == []
+
+    def test_new_deps_without_sca_have_no_metadata_key(self):
+        """New deps created without SCA enabled have no metadata key."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker()
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch(
+                "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
+                return_value=("requests", "2.28.0"),
+            ),
+        ):
+            mock_config.DEPENDENCY_COLLECTION = True
+            mock_modules.get_newly_imported_modules.return_value = {"requests"}
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert "metadata" not in result[0]
+
+
+class TestWriterRegisterCveMetadata:
+    """Writer-level tests for register_cve_metadata (via DependencyTracker)."""
+
+    def test_register_cve_auto_creates_entry_when_sca_active(self):
+        """register_cve_metadata auto-creates an entry when SCA is active and package untracked."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        with patch("importlib.metadata.version", return_value="1.0"):
+            result = writer.register_cve_metadata("flask", "CVE-NEW")
+
+        assert result is True
+        assert "flask" in tracker._imported_dependencies
+        entry = tracker._imported_dependencies["flask"]
+        assert entry.version == "1.0"
+        assert entry.metadata is not None
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value == {"id": "CVE-NEW", "reached": []}
+
+    def test_register_cve_does_not_auto_create_when_sca_inactive(self):
+        writer, tracker = _make_writer_and_tracker(sca_enabled=False)
+        result = writer.register_cve_metadata("flask", "CVE-NEW")
+        assert result is False
+        assert "flask" not in tracker._imported_dependencies
+
+    def test_auto_create_with_version_lookup_failure(self):
+        """When importlib.metadata.version raises PackageNotFoundError, entry is created with version=""."""
+        from importlib.metadata import PackageNotFoundError
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        with patch(
+            "importlib.metadata.version",
+            side_effect=PackageNotFoundError("unknown-pkg"),
+        ):
+            result = writer.register_cve_metadata("unknown-pkg", "CVE-1")
+
+        assert result is True
+        assert tracker._imported_dependencies["unknown-pkg"].version == ""
+
+
+class TestNormalizeDepName:
+    """Tests for PEP 503 package name canonicalization."""
+
+    def test_lowercase(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("PyYAML") == "pyyaml"
+
+    def test_hyphen_passthrough(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("my-package") == "my-package"
+
+    def test_underscore_to_hyphen(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("my_package") == "my-package"
+
+    def test_dot_to_hyphen(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("my.package") == "my-package"
+
+    def test_mixed_separators_collapsed(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("my_.package") == "my-package"
+
+    def test_already_canonical(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("requests") == "requests"
+
+    def test_complex_name(self):
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        assert _normalize_dep_name("Jinja2") == "jinja2"
+
+
+class TestTrackerNameNormalization:
+    """Tests that DependencyTracker normalizes package names to avoid duplicates and lookup misses."""
+
+    def test_ensure_entry_no_duplicate_with_different_casing(self):
+        """_ensure_entry should not create a duplicate when the same package has different casing."""
+        from unittest.mock import patch
+
+        from ddtrace.internal.settings._config import config as tracer_config
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        tracer_config._sca_enabled = True
+        tracker = DependencyTracker()
+
+        with patch("importlib.metadata.version", return_value="6.0"):
+            # Telemetry discovers "PyYAML" first
+            tracker._imported_dependencies["pyyaml"] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
+            # SCA tries to ensure "pyyaml" — should find the existing entry
+            with tracker._lock:
+                tracker._ensure_entry("pyyaml")
+
+        assert len(tracker._imported_dependencies) == 1
+
+    def test_attach_metadata_matches_differently_cased_key(self):
+        """attach_metadata with lowercase name should find an entry stored via telemetry discovery."""
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        tracker = DependencyTracker()
+        # Simulate telemetry discovering "PyYAML" (stored under normalized key)
+        key = _normalize_dep_name("PyYAML")
+        tracker._imported_dependencies[key] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
+
+        # SCA attaches metadata using lowercase name from CVE data
+        result = tracker.attach_metadata("pyyaml", "CVE-2024-1234", "yaml.loader", "load", 10)
+
+        assert result is True
+        entry = tracker._imported_dependencies[key]
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value["id"] == "CVE-2024-1234"
+
+    def test_register_cve_matches_differently_cased_key(self):
+        """register_cve with lowercase name should find an entry stored via telemetry discovery."""
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        tracker = DependencyTracker()
+        key = _normalize_dep_name("PyYAML")
+        tracker._imported_dependencies[key] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
+
+        result = tracker.register_cve("pyyaml", "CVE-2024-5678")
+
+        assert result is True
+        entry = tracker._imported_dependencies[key]
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value == {"id": "CVE-2024-5678", "reached": []}
+
+    def test_update_imported_dependencies_normalizes_keys(self):
+        """update_imported_dependencies should store entries under normalized keys."""
+        from unittest.mock import patch
+
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+        from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
+
+        already_imported = {}
+        with patch(
+            "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
+            return_value=("PyYAML", "6.0"),
+        ):
+            result = update_imported_dependencies(already_imported, ["yaml"])
+
+        assert len(result) == 1
+        assert result[0]["name"] == "PyYAML"  # wire format preserves original name
+        normalized = _normalize_dep_name("PyYAML")
+        assert normalized in already_imported
+        assert already_imported[normalized].name == "PyYAML"
+
+    def test_update_imported_dependencies_deduplicates_with_normalized_keys(self):
+        """A second module mapping to the same dist (different casing) should not create a duplicate."""
+        from unittest.mock import patch
+
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+        from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
+
+        already_imported = {}
+        key = _normalize_dep_name("PyYAML")
+        already_imported[key] = DependencyEntry(name="PyYAML", version="6.0")
+
+        with patch(
+            "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
+            return_value=("pyyaml", "6.0"),
+        ):
+            result = update_imported_dependencies(already_imported, ["yaml.dumper"])
+
+        assert result == []
+        assert len(already_imported) == 1
+
+    def test_collect_report_marks_sent_with_normalized_lookup(self):
+        """collect_report should find entries by normalized key when marking as sent."""
+        from unittest.mock import patch
+
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        tracker = DependencyTracker()
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch(
+                "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
+                return_value=("PyYAML", "6.0"),
+            ),
+        ):
+            mock_config.DEPENDENCY_COLLECTION = True
+            mock_modules.get_newly_imported_modules.return_value = {"yaml"}
+
+            result = tracker.collect_report()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "PyYAML"
+
+        # Entry should be stored under normalized key and marked as sent
+        key = _normalize_dep_name("PyYAML")
+        assert key in tracker._imported_dependencies
+        assert tracker._imported_dependencies[key]._initial_report_sent is True


### PR DESCRIPTION
## Summary

This PR extracts the telemetry dependency tracking changes from the larger SCA PR (#17156) to reduce its size and make review more manageable.

- Introduces `DependencyTracker` to manage dependency state, deduplication, and re-reporting logic for SCA telemetry
- Refactors dependency collection out of the telemetry writer into a dedicated module
- Updates the benchmark scenario for `packages_update_imported_dependencies`
- Adds comprehensive tests for the new dependency tracker and updated dependency logic

**Parent PR:** #17156 — `feat(sca): runtime SCA reachability`

## Test plan
- [ ] Existing telemetry tests pass
- [ ] New `tests/telemetry/test_dependency.py` tests pass
- [ ] `tests/telemetry/test_data.py` tests pass
- [ ] Benchmark scenario runs without errors

## Checklist
- [x] PR description/title adhere to [contributing guidelines](https://ddtrace.readthedocs.io/en/stable/contributing.html)
- [x] Tests provided or no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)