### PR TITLE
ci: add autoconf to local benchmarks Dockerfile

### DIFF
--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -40,6 +40,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   ca-certificates \
   # ddtrace includes c extensions
   build-essential \
+  # libdatadog requires autoconf/automake/libtool to build
+  autoconf \
+  automake \
+  libtool \
   # uuid is used to generate identifier for run if one is not provided
   uuid-runtime \
   # provides ab for testing


### PR DESCRIPTION
## Description

Required change to get benchmarks running locally.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
