### PR TITLE
perf(tracer): optimize sampling rules tag matching

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -853,11 +853,11 @@ experiments:
           # samplingrules
           - name: samplingrules-average_match
             thresholds:
-              - execution_time < 0.30 ms
+              - execution_time < 0.20 ms
               - max_rss_usage < 38.00 MB
           - name: samplingrules-high_match
             thresholds:
-              - execution_time < 0.48 ms
+              - execution_time < 0.20 ms
               - max_rss_usage < 38.00 MB
           - name: samplingrules-low_match
             thresholds:
@@ -865,7 +865,7 @@ experiments:
               - max_rss_usage < 780.00 MB
           - name: samplingrules-very_low_match
             thresholds:
-              - execution_time < 9.00 ms
+              - execution_time < 4.00 ms
               - max_rss_usage < 85.00 MB
           # sethttpmeta
           - name: sethttpmeta-all-disabled

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -99,29 +99,29 @@ class SamplingRule(object):
         if not self.tags:
             return True
 
-        meta = span._get_str_attributes()
-        metrics = span._get_numeric_attributes()
-        if not meta and not metrics:
-            return False
-
         for tag_key, pattern in self.tags.items():
-            value = meta.get(tag_key, metrics.get(tag_key))
-            if value is None:
-                # If the tag is not present, we failed the match
-                # (Metrics and meta do not support the value None)
-                return False
+            # Check first for an explicit str value
+            value = span._get_str_attribute(tag_key)
 
-            if isinstance(value, float):
-                # Floats: Convert floats that represent integers to int for matching. This is because
-                # SamplingRules only support integers for matfching or glob patterns.
-                if value.is_integer():
-                    value = int(value)
-                elif set(pattern.pattern) - {"?", "*"}:
+            # Otherwise, check for a numeric value
+            if value is None:
+                num_val = span._get_numeric_attribute(tag_key)
+                if num_val is None:
+                    # If the tag is not present as a str or float value, we failed the match
+                    return False
+
+                # SamplingRules only support integers for matching or glob patterns.
+                if num_val.is_integer():
+                    value = str(int(num_val))
+                elif not pattern.wildcards_only:
                     # Only match floats to patterns that only contain wildcards (ex: * or ?*)
                     # This is because we do not want to match floats to patterns like `23.*`.
                     return False
+                else:
+                    # A float and a wildcards-only pattern
+                    value = str(num_val)
 
-            if not pattern.match(str(value)):
+            if not pattern.match(value):
                 return False
 
         return True

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -111,7 +111,7 @@ class SamplingRule(object):
                     return False
 
                 # SamplingRules only support integers for matching or glob patterns.
-                if num_val.is_integer():
+                if isinstance(num_val, int) or num_val.is_integer():
                     value = str(int(num_val))
                 elif not pattern.wildcards_only:
                     # Only match floats to patterns that only contain wildcards (ex: * or ?*)

--- a/ddtrace/internal/glob_matching.py
+++ b/ddtrace/internal/glob_matching.py
@@ -12,6 +12,7 @@ class GlobMatcher(object):
     def __init__(self, pattern):
         # type: (str) -> None
         self.pattern = pattern.lower()
+        self.wildcards_only = not (set(self.pattern) - {"?", "*"})
 
     @cachedmethod()
     def match(self, subject):


### PR DESCRIPTION
## Description

This PR optimizes the logic for `SamplingRule.tags_match`.

1. Avoid unnecessary materialization of meta/metrics as dict
2. Add `GlobMatcher.wildcards_only` precomputed attribute
3. Reduce total number of operations to lookup if tag is present
4. Drop SLOs for sampling rules

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Sampling rule benchmarks:

✅ average_match
Time: ✅ 147.931µs (SLO: <300.000µs 📉 -50.7%) vs baseline: 📉 -13.1%

✅ high_match
Time: ✅ 168.275µs (SLO: <480.000µs 📉 -64.9%) vs baseline: 📉 -22.7%

✅ very_low_match
Time: ✅ 2.688ms (SLO: <9.000ms 📉 -70.1%) vs baseline: 📉 -13.9%
