### PR TITLE
chore(rc): avoid logging error on unsupported agent_config payloads

### DIFF
--- a/ddtrace/internal/flare/_subscribers.py
+++ b/ddtrace/internal/flare/_subscribers.py
@@ -31,6 +31,7 @@ def _process_payloads(flare: Flare, state: TracerFlareState, payloads: t.Sequenc
     for payload in payloads:
         if payload.metadata is None:
             log.debug("Flare: flare payload missing metadata, path=%r", payload.path)
+            continue
         elif isinstance(payload.metadata.id, str) and payload.metadata.id.lower() == "configuration_order":
             continue
 
@@ -73,8 +74,10 @@ def _process_payloads(flare: Flare, state: TracerFlareState, payloads: t.Sequenc
                 flare.clean_up_files()
                 state.current_request_start = None
             else:
-                log.warning(
-                    "Flare: received unexpected product type for tracer flare: %s. Case ID: %r. Skipping...",
+                # none_action is expected when the payload is not relevant to us
+                # (e.g. configuration_order for AGENT_CONFIG, wrong task_type for AGENT_TASK)
+                log.debug(
+                    "Flare: skipping non-actionable payload for product %s. Case ID: %r.",
                     product_type,
                     flare_action.case_id,
                 )

--- a/releasenotes/notes/fix-rc-warning-log-agent-config-ca76bd948e1355b6.yaml
+++ b/releasenotes/notes/fix-rc-warning-log-agent-config-ca76bd948e1355b6.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    remote config: Removes noisy warning log that was being emitted when an unsupported agent config payload was received.

--- a/src/native/tracer_flare.rs
+++ b/src/native/tracer_flare.rs
@@ -168,8 +168,20 @@ impl TracerFlareManagerPy {
             }
         };
 
-        let config_data: RemoteConfigData = RemoteConfigData::try_parse(product, data)
-            .map_err(|e| ParsingError::new_err(format!("Parsing error: {}", e)))?;
+        let config_data: RemoteConfigData = match RemoteConfigData::try_parse(product, data) {
+            Ok(data) => data,
+            Err(e) => {
+                // AGENT_CONFIG has multiple payload shapes; e.g. configuration_order
+                // is valid JSON but not our schema. Valid-JSON parse failures return none_action()
+                // silently; truly malformed JSON propagates as ParsingError.
+                if product == RemoteConfigProduct::AgentConfig
+                    && serde_json::from_slice::<serde_json::Value>(data).is_ok()
+                {
+                    return Ok(FlareActionPy::none_action());
+                }
+                return Err(ParsingError::new_err(format!("Parsing error: {}", e)));
+            }
+        };
 
         Ok(manager
             .handle_remote_config_data(&config_data)

--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -764,6 +764,27 @@ class TracerFlareSubscriberTests(unittest.TestCase):
     def _flare_upload_count(self) -> int:
         return self.tracer_flare_sub.flare._native_manager.zip_and_send.call_count
 
+    def test_configuration_order_payload_is_skipped(self):
+        """
+        AGENT_CONFIG payloads with configuration_order shape (no 'name' field) must be
+        silently skipped — no exception raised, no warning logged, flare state unchanged.
+        """
+        configuration_order_payload = {
+            "internal_order": [],
+            "order": [
+                "flare-log-level-61c7ebea-7129-4e63-9bce-95e61d38493a",
+                "flare-log-level-b9b280f9-bc3a-4d1c-898c-3ba564616241",
+            ],
+        }
+        with mock.patch("ddtrace.internal.flare._subscribers.log") as mock_log:
+            self.connector.write([build_payload("AGENT_CONFIG", configuration_order_payload, "config")])
+            self.get_data_from_connector_and_exec()
+
+        # Flare must not have started
+        assert self.tracer_flare_sub.current_request_start is None
+        # No warning logged — this is an expected payload shape, not an error
+        mock_log.warning.assert_not_called()
+
     def test_process_flare_request_success(self):
         """
         Ensure a successful tracer flare process


### PR DESCRIPTION
## Description                                                                                              
                                                                                                              
  Removes a spurious `WARNING` log triggered when the agent delivers `configuration_order`                    
  payloads alongside regular `AGENT_CONFIG` payloads during a tracer flare request.                           
                                                                                                              
  The agent intentionally forwards `configuration_order` to all `AGENT_CONFIG` subscribers.                   
  The tracer's `metadata.id` filter is the intended guard but can be bypassed if the TUF path                 
  format varies. When it does, the Rust parser fails to deserialize the payload and the error                 
  bubbles up as a noisy warning unrelated to any actual flare failure.                                        
                                                                                                              
  **Changes:**                                                                                                
  - Return `none_action()` silently in `handle_remote_config_data` when an AGENT_CONFIG payload               
    is valid JSON but does not match the expected schema                                                      
  - Downgrade the `_process_payloads` else-branch from `WARNING` → `DEBUG`                                    
  - Add missing `continue` in the `metadata is None` branch (unreachable in practice)


- Gets rid of the following noisy debug log  

```
Received unexpected product type for tracer flare: AGENT_CONFIG
Error handling remote config data for product AGENT_CONFIG: Parsing error: missing field `name` at line 1 column 145
ERROR:ddtrace.internal.flare.flare:Error handling remote config data for product AGENT_CONFIG: Parsing error: missing field `name` at line 1 column 145
```                   
                                                                                                              
## Testing                                                                                                  
                                                                                                              
  Added `TracerFlareSubscriberTests::test_configuration_order_payload_is_skipped`.                            
                                                                                                                                  
                                                                                                              
##  Risks                                                                                                       
                                                                                                              
  None — no behavioral change, log level reduction only.                                                   

## Additional Notes
                                                                                                              
  None 