### PR TITLE
feat(llmobs): support submitting trace and session level evals

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -158,7 +158,6 @@ from ddtrace.version import __version__
 
 log = get_logger(__name__)
 
-
 # requests/concurrent frameworks for distributed injection/extraction
 _INTEGRATIONS_W_PROPAGATION_SUPPORT: dict[str, str] = {
     "requests": "requests",
@@ -2462,7 +2461,7 @@ class LLMObs(Service):
         metadata: Optional[dict[str, object]] = None,
         assessment: Optional[str] = None,
         reasoning: Optional[str] = None,
-        eval_scope: Optional[str] = None,
+        eval_scope: str = "span",
         session_id: Optional[str] = None,
     ) -> None:
         """
@@ -2501,67 +2500,8 @@ class LLMObs(Service):
             return
 
         error = None
-        join_on = {}
-        is_session_scope = False
+        join_on: dict[str, Any] = {}
         try:
-            if eval_scope is not None:
-                eval_scope = eval_scope.lower()
-                if eval_scope not in ("span", "trace", "session"):
-                    error = "invalid_eval_scope"
-                    raise ValueError("eval_scope must be one of 'span', 'trace', or 'session'.")
-
-            is_session_scope = eval_scope == "session"
-
-            if is_session_scope:
-                if span is not None or span_with_tag_value is not None:
-                    error = "invalid_span_for_session_scope"
-                    raise ValueError(
-                        "span and span_with_tag_value must not be provided for session scope evaluations."
-                    )
-                if not session_id or not isinstance(session_id, str):
-                    error = "missing_session_id"
-                    raise ValueError("session_id is required for session scope evaluations.")
-            else:
-                if session_id is not None:
-                    error = "invalid_session_id_for_span_scope"
-                    raise ValueError("session_id must not be provided for span or trace scope evaluations.")
-
-                has_exactly_one_joining_key = (span is not None) ^ (span_with_tag_value is not None)
-
-                if not has_exactly_one_joining_key:
-                    error = "provided_both_span_and_tag_joining_key"
-                    raise ValueError(
-                        "Exactly one of `span` or `span_with_tag_value` must be specified to submit an evaluation metric."
-                    )
-
-                if span is not None:
-                    if (
-                        not isinstance(span, dict)
-                        or not isinstance(span.get("span_id"), str)
-                        or not isinstance(span.get("trace_id"), str)
-                    ):
-                        error = "invalid_span"
-                        raise TypeError(
-                            "`span` must be a dictionary containing both span_id and trace_id keys. "
-                            "LLMObs.export_span() can be used to generate this dictionary from a given span."
-                        )
-                    join_on["span"] = span
-                elif span_with_tag_value is not None:
-                    if (
-                        not isinstance(span_with_tag_value, dict)
-                        or not isinstance(span_with_tag_value.get("tag_key"), str)
-                        or not isinstance(span_with_tag_value.get("tag_value"), str)
-                    ):
-                        error = "invalid_joining_key"
-                        raise TypeError(
-                            "`span_with_tag_value` must be a dict with keys 'tag_key' and 'tag_value' "
-                            "containing string values"
-                        )
-                    join_on["tag"] = {
-                        "key": span_with_tag_value.get("tag_key"),
-                        "value": span_with_tag_value.get("tag_value"),
-                    }
-
             timestamp_ms = timestamp_ms if timestamp_ms else int(time.time() * 1000)
 
             if not isinstance(timestamp_ms, int) or timestamp_ms < 0:
@@ -2626,14 +2566,64 @@ class LLMObs(Service):
                 "{}_value".format(metric_type): value,  # type: ignore
                 "ml_app": ml_app,
                 "tags": ["{}:{}".format(k, v) for k, v in evaluation_tags.items()],
-                "eval_scope": "session",
+                "eval_scope": eval_scope,
             }
-            if eval_scope:
-                evaluation_metric["eval_scope"] = eval_scope
-            if is_session_scope:
-                evaluation_metric["session_id"] = session_id  # type: ignore
+
+            if eval_scope in ("span", "trace"):
+                if session_id is not None:
+                    error = "invalid_session_id_for_span_scope"
+                    raise ValueError("session_id must not be provided for span or trace scope evaluations.")
+
+                has_exactly_one_joining_key = (span is not None) ^ (span_with_tag_value is not None)
+
+                if not has_exactly_one_joining_key:
+                    error = "provided_both_span_and_tag_joining_key"
+                    raise ValueError(
+                        "Exactly one of `span` or `span_with_tag_value` must be specified to submit an evaluation"
+                        " metric."
+                    )
+
+                if span is not None:
+                    if (
+                        not isinstance(span, dict)
+                        or not isinstance(span.get("span_id"), str)
+                        or not isinstance(span.get("trace_id"), str)
+                    ):
+                        error = "invalid_span"
+                        raise TypeError(
+                            "`span` must be a dictionary containing both span_id and trace_id keys. "
+                            "LLMObs.export_span() can be used to generate this dictionary from a given span."
+                        )
+                    join_on["span"] = span
+                    evaluation_metric["join_on"] = join_on
+                elif span_with_tag_value is not None:
+                    if (
+                        not isinstance(span_with_tag_value, dict)
+                        or not isinstance(span_with_tag_value.get("tag_key"), str)
+                        or not isinstance(span_with_tag_value.get("tag_value"), str)
+                    ):
+                        error = "invalid_joining_key"
+                        raise TypeError(
+                            "`span_with_tag_value` must be a dict with keys 'tag_key' and 'tag_value' "
+                            "containing string values"
+                        )
+                    join_on["tag"] = {
+                        "key": span_with_tag_value["tag_key"],
+                        "value": span_with_tag_value["tag_value"],
+                    }
+                    evaluation_metric["join_on"] = join_on
+
+            elif eval_scope == "session":
+                if span is not None or span_with_tag_value is not None:
+                    error = "invalid_span_for_session_scope"
+                    raise ValueError("span and span_with_tag_value must not be provided for session scope evaluations.")
+                if not session_id or not isinstance(session_id, str):
+                    error = "missing_session_id"
+                    raise ValueError("session_id is required for session scope evaluations.")
+                evaluation_metric["session_id"] = session_id
             else:
-                evaluation_metric["join_on"] = join_on
+                error = "invalid_eval_scope"
+                raise ValueError("eval_scope must be one of 'span', 'trace', or 'session'.")
 
             if assessment:
                 if not isinstance(assessment, str) or assessment not in (

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2462,18 +2462,21 @@ class LLMObs(Service):
         metadata: Optional[dict[str, object]] = None,
         assessment: Optional[str] = None,
         reasoning: Optional[str] = None,
+        eval_scope: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> None:
         """
-        Submits a custom evaluation metric for a given span.
+        Submits a custom evaluation metric for a given span, trace, or session.
 
         :param str label: The name of the evaluation metric.
         :param str metric_type: The type of the evaluation metric. One of "categorical", "score", "boolean".
         :param value: The value of the evaluation metric.
                       Must be a string (categorical), integer (score), float (score), or boolean (boolean).
         :param dict span: A dictionary of shape {'span_id': str, 'trace_id': str} uniquely identifying
-                            the span associated with this evaluation.
+                            the span associated with this evaluation. Required for span and trace scopes.
         :param dict span_with_tag_value: A dictionary with the format {'tag_key': str, 'tag_value': str}
                             uniquely identifying the span associated with this evaluation.
+                            Required for span and trace scopes (alternative to `span`).
         :param tags: A dictionary of string key-value pairs to tag the evaluation metric with.
         :param str ml_app: The name of the ML application
         :param int timestamp_ms: The unix timestamp in milliseconds when the evaluation metric result was generated.
@@ -2482,6 +2485,13 @@ class LLMObs(Service):
                                 evaluation metric.
         :param str assessment: An assessment of this evaluation. Must be either "pass" or "fail".
         :param str reasoning: An explanation of the evaluation result.
+        :param str eval_scope: The scope of the evaluation. One of "span" (default), "trace", or "session".
+                                Use "trace" to associate the evaluation with an entire trace (the span provided
+                                via `span` should be the root span). Use "session" to associate the evaluation
+                                with a session (requires `session_id`; do not provide `span` or
+                                `span_with_tag_value`).
+        :param str session_id: The session ID to associate the evaluation with. Required when eval_scope
+                                is "session".
         """
         if cls.enabled is False:
             log.debug(
@@ -2492,42 +2502,65 @@ class LLMObs(Service):
 
         error = None
         join_on = {}
+        is_session_scope = False
         try:
-            has_exactly_one_joining_key = (span is not None) ^ (span_with_tag_value is not None)
+            if eval_scope is not None:
+                eval_scope = eval_scope.lower()
+                if eval_scope not in ("span", "trace", "session"):
+                    error = "invalid_eval_scope"
+                    raise ValueError("eval_scope must be one of 'span', 'trace', or 'session'.")
 
-            if not has_exactly_one_joining_key:
-                error = "provided_both_span_and_tag_joining_key"
-                raise ValueError(
-                    "Exactly one of `span` or `span_with_tag_value` must be specified to submit an evaluation metric."
-                )
+            is_session_scope = eval_scope == "session"
 
-            if span is not None:
-                if (
-                    not isinstance(span, dict)
-                    or not isinstance(span.get("span_id"), str)
-                    or not isinstance(span.get("trace_id"), str)
-                ):
-                    error = "invalid_span"
-                    raise TypeError(
-                        "`span` must be a dictionary containing both span_id and trace_id keys. "
-                        "LLMObs.export_span() can be used to generate this dictionary from a given span."
+            if is_session_scope:
+                if span is not None or span_with_tag_value is not None:
+                    error = "invalid_span_for_session_scope"
+                    raise ValueError(
+                        "span and span_with_tag_value must not be provided for session scope evaluations."
                     )
-                join_on["span"] = span
-            elif span_with_tag_value is not None:
-                if (
-                    not isinstance(span_with_tag_value, dict)
-                    or not isinstance(span_with_tag_value.get("tag_key"), str)
-                    or not isinstance(span_with_tag_value.get("tag_value"), str)
-                ):
-                    error = "invalid_joining_key"
-                    raise TypeError(
-                        "`span_with_tag_value` must be a dict with keys 'tag_key' and 'tag_value' "
-                        "containing string values"
+                if not session_id or not isinstance(session_id, str):
+                    error = "missing_session_id"
+                    raise ValueError("session_id is required for session scope evaluations.")
+            else:
+                if session_id is not None:
+                    error = "invalid_session_id_for_span_scope"
+                    raise ValueError("session_id must not be provided for span or trace scope evaluations.")
+
+                has_exactly_one_joining_key = (span is not None) ^ (span_with_tag_value is not None)
+
+                if not has_exactly_one_joining_key:
+                    error = "provided_both_span_and_tag_joining_key"
+                    raise ValueError(
+                        "Exactly one of `span` or `span_with_tag_value` must be specified to submit an evaluation metric."
                     )
-                join_on["tag"] = {
-                    "key": span_with_tag_value.get("tag_key"),
-                    "value": span_with_tag_value.get("tag_value"),
-                }
+
+                if span is not None:
+                    if (
+                        not isinstance(span, dict)
+                        or not isinstance(span.get("span_id"), str)
+                        or not isinstance(span.get("trace_id"), str)
+                    ):
+                        error = "invalid_span"
+                        raise TypeError(
+                            "`span` must be a dictionary containing both span_id and trace_id keys. "
+                            "LLMObs.export_span() can be used to generate this dictionary from a given span."
+                        )
+                    join_on["span"] = span
+                elif span_with_tag_value is not None:
+                    if (
+                        not isinstance(span_with_tag_value, dict)
+                        or not isinstance(span_with_tag_value.get("tag_key"), str)
+                        or not isinstance(span_with_tag_value.get("tag_value"), str)
+                    ):
+                        error = "invalid_joining_key"
+                        raise TypeError(
+                            "`span_with_tag_value` must be a dict with keys 'tag_key' and 'tag_value' "
+                            "containing string values"
+                        )
+                    join_on["tag"] = {
+                        "key": span_with_tag_value.get("tag_key"),
+                        "value": span_with_tag_value.get("tag_value"),
+                    }
 
             timestamp_ms = timestamp_ms if timestamp_ms else int(time.time() * 1000)
 
@@ -2587,14 +2620,20 @@ class LLMObs(Service):
                 evaluation_tags["source"] = "otel"
 
             evaluation_metric: LLMObsEvaluationMetricEvent = {
-                "join_on": join_on,
                 "label": str(label),
                 "metric_type": metric_type,
                 "timestamp_ms": timestamp_ms,
                 "{}_value".format(metric_type): value,  # type: ignore
                 "ml_app": ml_app,
                 "tags": ["{}:{}".format(k, v) for k, v in evaluation_tags.items()],
+                "eval_scope": "session",
             }
+            if eval_scope:
+                evaluation_metric["eval_scope"] = eval_scope
+            if is_session_scope:
+                evaluation_metric["session_id"] = session_id  # type: ignore
+            else:
+                evaluation_metric["join_on"] = join_on
 
             if assessment:
                 if not isinstance(assessment, str) or assessment not in (

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -205,7 +205,7 @@ class BaseLLMObsWriter(PeriodicService):
             # to form http://localhost:8080/foo/bar/buz/baz
             self._endpoint = self.ENDPOINT.lstrip("/")
 
-        self._headers: dict[str, str] = {"Content-Type": "application/json", "test-drive-cadillac-transit-350-cargo-van": 1}
+        self._headers: dict[str, str] = {"Content-Type": "application/json"}
         if is_agentless:
             self._headers["DD-API-KEY"] = self._api_key
             if self._app_key:
@@ -386,7 +386,6 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             "Content-Type": "application/json",
             "DD-API-KEY": self._api_key,
             "DD-APPLICATION-KEY": self._app_key,
-            "test-drive-cadillac-transit-350-cargo-van": 1,
         }
         if not self._agentless:
             headers[EVP_SUBDOMAIN_HEADER_NAME] = self.EVP_SUBDOMAIN_HEADER_VALUE
@@ -395,7 +394,6 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         conn = get_connection(url=self._intake, timeout=timeout)
         try:
             url = self._intake + self._endpoint + path
-            print(f"url: {url}")
             logger.debug("requesting %s", url)
             conn.request(method, url, encoded_body, headers)
             resp = conn.getresponse()

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -106,6 +106,9 @@ class LLMObsEvaluationMetricEvent(TypedDict, total=False):
     tags: list[str]
     assessment: str
     reasoning: str
+    eval_scope: str
+    session_id: str
+    metadata: dict[str, Any]
 
 
 class LLMObsExperimentEvalMetricEvent(TypedDict, total=False):
@@ -202,7 +205,7 @@ class BaseLLMObsWriter(PeriodicService):
             # to form http://localhost:8080/foo/bar/buz/baz
             self._endpoint = self.ENDPOINT.lstrip("/")
 
-        self._headers: dict[str, str] = {"Content-Type": "application/json"}
+        self._headers: dict[str, str] = {"Content-Type": "application/json", "test-drive-cadillac-transit-350-cargo-van": 1}
         if is_agentless:
             self._headers["DD-API-KEY"] = self._api_key
             if self._app_key:
@@ -383,6 +386,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             "Content-Type": "application/json",
             "DD-API-KEY": self._api_key,
             "DD-APPLICATION-KEY": self._app_key,
+            "test-drive-cadillac-transit-350-cargo-van": 1,
         }
         if not self._agentless:
             headers[EVP_SUBDOMAIN_HEADER_NAME] = self.EVP_SUBDOMAIN_HEADER_VALUE
@@ -391,6 +395,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         conn = get_connection(url=self._intake, timeout=timeout)
         try:
             url = self._intake + self._endpoint + path
+            print(f"url: {url}")
             logger.debug("requesting %s", url)
             conn.request(method, url, encoded_body, headers)
             resp = conn.getresponse()

--- a/releasenotes/notes/llmobs-trace-session-level-evals-c5e45391b3e52604.yaml
+++ b/releasenotes/notes/llmobs-trace-session-level-evals-c5e45391b3e52604.yaml
@@ -1,0 +1,8 @@
+features:
+  - |
+    LLM Observability: Adds support for submitting trace-level and session-level evaluation metrics
+    via ``LLMObs.submit_evaluation()``. Two new parameters are introduced: ``eval_scope`` (one of
+    ``"span"`` (default), ``"trace"``, or ``"session"``) and ``session_id`` (required when
+    ``eval_scope="session"``). Use ``eval_scope="trace"`` to associate an evaluation with an entire
+    trace by providing the root span, or ``eval_scope="session"`` to associate an evaluation with a
+    session by providing the ``session_id``.

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -378,24 +378,22 @@ def _expected_llmobs_eval_metric_event(
     metadata=None,
     assessment=None,
     reasoning=None,
-    eval_scope=None,
-    session_id=None,
+    eval_scope="span",
 ):
-    is_session_scope = eval_scope == "session"
     eval_metric_event = {
+        "join_on": {},
         "metric_type": metric_type,
         "label": label,
         "tags": [
             "ddtrace.version:{}".format(ddtrace.__version__),
             "ml_app:{}".format(ml_app if ml_app is not None else "unnamed-ml-app"),
         ],
+        "eval_scope": eval_scope,
     }
-    if not is_session_scope:
-        eval_metric_event["join_on"] = {}
-        if tag_key is not None and tag_value is not None:
-            eval_metric_event["join_on"]["tag"] = {"key": tag_key, "value": tag_value}
-        if span_id is not None and trace_id is not None:
-            eval_metric_event["join_on"]["span"] = {"span_id": span_id, "trace_id": trace_id}
+    if tag_key is not None and tag_value is not None:
+        eval_metric_event["join_on"]["tag"] = {"key": tag_key, "value": tag_value}
+    if span_id is not None and trace_id is not None:
+        eval_metric_event["join_on"]["span"] = {"span_id": span_id, "trace_id": trace_id}
     if categorical_value is not None:
         eval_metric_event["categorical_value"] = categorical_value
     if score_value is not None:
@@ -419,10 +417,6 @@ def _expected_llmobs_eval_metric_event(
         eval_metric_event["ml_app"] = ml_app
     if metadata is not None:
         eval_metric_event["metadata"] = metadata
-    if eval_scope is not None:
-        eval_metric_event["eval_scope"] = eval_scope
-    if session_id is not None:
-        eval_metric_event["session_id"] = session_id
     return eval_metric_event
 
 
@@ -736,6 +730,7 @@ def _dummy_evaluator_eval_metric_event(span_id, trace_id, label=None):
         metric_type="score",
         label=label or "dummy",
         tags=["ddtrace.version:{}".format(ddtrace.__version__), "ml_app:unnamed-ml-app"],
+        eval_scope="span",
     )
 
 

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -378,9 +378,11 @@ def _expected_llmobs_eval_metric_event(
     metadata=None,
     assessment=None,
     reasoning=None,
+    eval_scope=None,
+    session_id=None,
 ):
+    is_session_scope = eval_scope == "session"
     eval_metric_event = {
-        "join_on": {},
         "metric_type": metric_type,
         "label": label,
         "tags": [
@@ -388,10 +390,12 @@ def _expected_llmobs_eval_metric_event(
             "ml_app:{}".format(ml_app if ml_app is not None else "unnamed-ml-app"),
         ],
     }
-    if tag_key is not None and tag_value is not None:
-        eval_metric_event["join_on"]["tag"] = {"key": tag_key, "value": tag_value}
-    if span_id is not None and trace_id is not None:
-        eval_metric_event["join_on"]["span"] = {"span_id": span_id, "trace_id": trace_id}
+    if not is_session_scope:
+        eval_metric_event["join_on"] = {}
+        if tag_key is not None and tag_value is not None:
+            eval_metric_event["join_on"]["tag"] = {"key": tag_key, "value": tag_value}
+        if span_id is not None and trace_id is not None:
+            eval_metric_event["join_on"]["span"] = {"span_id": span_id, "trace_id": trace_id}
     if categorical_value is not None:
         eval_metric_event["categorical_value"] = categorical_value
     if score_value is not None:
@@ -415,6 +419,10 @@ def _expected_llmobs_eval_metric_event(
         eval_metric_event["ml_app"] = ml_app
     if metadata is not None:
         eval_metric_event["metadata"] = metadata
+    if eval_scope is not None:
+        eval_metric_event["eval_scope"] = eval_scope
+    if session_id is not None:
+        eval_metric_event["session_id"] = session_id
     return eval_metric_event
 
 

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -2233,6 +2233,95 @@ def test_submit_evaluation_incorrect_json_value_type_raises_error(llmobs, mock_l
         )
 
 
+def test_submit_evaluation_invalid_eval_scope_raises_error(llmobs):
+    with pytest.raises(ValueError, match="eval_scope must be one of 'span', 'trace', or 'session'."):
+        llmobs.submit_evaluation(
+            span={"span_id": "123", "trace_id": "456"},
+            label="quality",
+            metric_type="score",
+            value=0.9,
+            eval_scope="invalid",
+        )
+
+
+def test_submit_evaluation_trace_scope(llmobs, mock_llmobs_eval_metric_writer):
+    llmobs.submit_evaluation(
+        span={"span_id": "123", "trace_id": "456"},
+        label="quality",
+        metric_type="score",
+        value=0.9,
+        ml_app="test_app",
+        eval_scope="trace",
+    )
+    mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(
+        _expected_llmobs_eval_metric_event(
+            metric_type="score",
+            label="quality",
+            ml_app="test_app",
+            span_id="123",
+            trace_id="456",
+            score_value=0.9,
+            eval_scope="trace",
+        )
+    )
+
+
+def test_submit_evaluation_session_scope(llmobs, mock_llmobs_eval_metric_writer):
+    llmobs.submit_evaluation(
+        label="quality",
+        metric_type="score",
+        value=0.9,
+        ml_app="test_app",
+        eval_scope="session",
+        session_id="test-session-id",
+    )
+    expected = _expected_llmobs_eval_metric_event(
+        metric_type="score",
+        label="quality",
+        ml_app="test_app",
+        score_value=0.9,
+        eval_scope="session",
+        session_id="test-session-id",
+    )
+    mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(expected)
+    # Verify join_on is NOT in the payload
+    actual_event = mock_llmobs_eval_metric_writer.enqueue.call_args[0][0]
+    assert "join_on" not in actual_event
+
+
+def test_submit_evaluation_session_scope_with_span_raises_error(llmobs):
+    with pytest.raises(ValueError, match="span and span_with_tag_value must not be provided for session scope"):
+        llmobs.submit_evaluation(
+            span={"span_id": "123", "trace_id": "456"},
+            label="quality",
+            metric_type="score",
+            value=0.9,
+            eval_scope="session",
+            session_id="test-session-id",
+        )
+
+
+def test_submit_evaluation_session_scope_missing_session_id_raises_error(llmobs):
+    with pytest.raises(ValueError, match="session_id is required for session scope evaluations."):
+        llmobs.submit_evaluation(
+            label="quality",
+            metric_type="score",
+            value=0.9,
+            eval_scope="session",
+        )
+
+
+def test_submit_evaluation_span_scope_with_session_id_raises_error(llmobs):
+    with pytest.raises(ValueError, match="session_id must not be provided for span or trace scope evaluations."):
+        llmobs.submit_evaluation(
+            span={"span_id": "123", "trace_id": "456"},
+            label="quality",
+            metric_type="score",
+            value=0.9,
+            session_id="test-session-id",
+        )
+
+
 class TestBuildSpanEventFromMetaStructE2E:
     def test_llm_span_with_messages(self, llmobs, llmobs_events):
         with llmobs.llm(model_name="test_model", model_provider="test_provider", name="test_llm") as span:

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -2254,15 +2254,19 @@ def test_submit_evaluation_trace_scope(llmobs, mock_llmobs_eval_metric_writer):
         eval_scope="trace",
     )
     mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(
-        _expected_llmobs_eval_metric_event(
-            metric_type="score",
-            label="quality",
-            ml_app="test_app",
-            span_id="123",
-            trace_id="456",
-            score_value=0.9,
-            eval_scope="trace",
-        )
+        {
+            "metric_type": "score",
+            "label": "quality",
+            "tags": [
+                "ddtrace.version:{}".format(ddtrace.__version__),
+                "ml_app:test_app",
+            ],
+            "join_on": {"span": {"span_id": "123", "trace_id": "456"}},
+            "score_value": 0.9,
+            "timestamp_ms": mock.ANY,
+            "ml_app": "test_app",
+            "eval_scope": "trace",
+        }
     )
 
 
@@ -2275,18 +2279,21 @@ def test_submit_evaluation_session_scope(llmobs, mock_llmobs_eval_metric_writer)
         eval_scope="session",
         session_id="test-session-id",
     )
-    expected = _expected_llmobs_eval_metric_event(
-        metric_type="score",
-        label="quality",
-        ml_app="test_app",
-        score_value=0.9,
-        eval_scope="session",
-        session_id="test-session-id",
+    mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(
+        {
+            "metric_type": "score",
+            "label": "quality",
+            "tags": [
+                "ddtrace.version:{}".format(ddtrace.__version__),
+                "ml_app:test_app",
+            ],
+            "score_value": 0.9,
+            "timestamp_ms": mock.ANY,
+            "ml_app": "test_app",
+            "eval_scope": "session",
+            "session_id": "test-session-id",
+        }
     )
-    mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(expected)
-    # Verify join_on is NOT in the payload
-    actual_event = mock_llmobs_eval_metric_writer.enqueue.call_args[0][0]
-    assert "join_on" not in actual_event
 
 
 def test_submit_evaluation_session_scope_with_span_raises_error(llmobs):


### PR DESCRIPTION
## Description

      LLM Observability: Adds support for submitting trace-level and session-level evaluation metrics
      via ``LLMObs.submit_evaluation()``. Two new parameters are introduced: ``eval_scope`` (one of
      ``"span"`` (default), ``"trace"``, or ``"session"``) and ``session_id`` (required when
      ``eval_scope="session"``). Use ``eval_scope="trace"`` to associate an evaluation with an entire
      trace by providing the root span, or ``eval_scope="session"`` to associate an evaluation with a
      session by providing the ``session_id``.

## Testing

Ran test script: https://github.com/DataDog/experimental/blob/main/users/christopher.fox/scripts/emit_eval_metrics.py
- eval_scope set explicitly to "span"
- eval_scope left to default ("span")
- eval_scope "span" + join_on using tag
- eval_scope set to "trace"
- eval_scope set to "session"

Observed in EVP the 5 eval_metric events (3 span-level, 1 trace-level, 1 session-level):
https://dd.datad0g.com/internal/events-ui/queries?index_name=llmobs&query_string=%40event_type%3Aeval-metric%20%40ml_app%3Aemit_eval_metrics&query_type=list&timerange=1775670893207-1776275693207l&track=llmobs


## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
