### PR TITLE
fix(aap): fix aap enable telemetry report

### DIFF
--- a/ddtrace/appsec/_listeners.py
+++ b/ddtrace/appsec/_listeners.py
@@ -19,6 +19,12 @@ def _abort_appsec(failure_msg: str) -> None:
 
     log.warning("Disabling AppSec: libddwaf failed to load (%s)", failure_msg or "unknown error")
 
+    if asm_config._asm_enabled:
+        from ddtrace.internal.telemetry import telemetry_writer
+        from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
+
+        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
+
     asm_config._asm_enabled = False
     asm_config._asm_can_be_enabled = False
     asm_config._asm_libddwaf_available = False

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -176,12 +176,13 @@ def disable_asm() -> None:
         from ddtrace.appsec._listeners import disable_appsec
 
         disable_appsec(reconfigure_tracer=True)
-        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
+        if not asm_config._asm_enabled:
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
 
 
 def enable_asm() -> None:
     if asm_config._asm_can_be_enabled and not asm_config._asm_enabled:
         from ddtrace.appsec._listeners import load_appsec
 
-        load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC)
-        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
+        if load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC):
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -60,7 +60,8 @@ def enable_appsec_rc() -> None:
 
         load_common_appsec_modules()
 
-    telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
+    if asm_config._asm_enabled:
+        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
     asm_config._rc_client_id = remoteconfig_poller._client.id
 
 
@@ -68,8 +69,6 @@ def disable_appsec_rc() -> None:
     for product_name in APPSEC_PRODUCTS:
         remoteconfig_poller.unregister_callback(product_name)
         remoteconfig_poller.disable_product(product_name)
-
-    telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
 
 
 class AppSecCallback(RCCallback):
@@ -177,6 +176,7 @@ def disable_asm() -> None:
         from ddtrace.appsec._listeners import disable_appsec
 
         disable_appsec(reconfigure_tracer=True)
+        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
 
 
 def enable_asm() -> None:
@@ -184,3 +184,4 @@ def enable_asm() -> None:
         from ddtrace.appsec._listeners import load_appsec
 
         load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC)
+        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)

--- a/releasenotes/notes/fix-appsec-telemetry-product-activation-d2fa33337ab9e4bd.yaml
+++ b/releasenotes/notes/fix-appsec-telemetry-product-activation-d2fa33337ab9e4bd.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    AAP: This fix resolves an issue where Application and API Protection (AAP) was incorrectly reported as an enabled
+    product in internal telemetry for all services by default. Previously, registering remote configuration listeners
+    caused AAP to be reported as activated even when it was not actually enabled. This had no impact on customers as it
+    only affected internal telemetry data. AAP is now only reported as activated when it is explicitly enabled or enabled
+    through remote configuration.

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -21,6 +21,7 @@ from ddtrace.internal.remoteconfig.client import ConfigMetadata
 from ddtrace.internal.remoteconfig.client import TargetFile
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.settings.asm import config as asm_config
+from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
 from ddtrace.internal.utils.formats import asbool
 import tests.appsec.rules as rules
 from tests.appsec.utils import asm_context
@@ -564,3 +565,53 @@ def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
             )
         assert get_triggers(span)
         assert get_waf_addresses("http.request.remote_ip") == "8.8.4.4"
+
+
+def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(tracer, rc_poller):
+    """Regression test: registering RC listeners should not report AppSec as an enabled product in telemetry."""
+    with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
+        with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
+            enable_appsec_rc()
+
+            # RC listeners are registered but AppSec is not enabled
+            assert rc_poller._client._product_callbacks["ASM_FEATURES"]
+            # Telemetry should NOT report AppSec as activated
+            mock_tw.product_activated.assert_not_called()
+
+    disable_appsec_rc()
+
+
+def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller):
+    """When AppSec is explicitly enabled, enable_appsec_rc should report the product as activated."""
+    with override_global_config(dict(_asm_enabled=True, _remote_config_enabled=True)):
+        tracer.configure(appsec_enabled=True)
+        with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
+            enable_appsec_rc()
+
+            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
+
+    disable_appsec_rc()
+
+
+def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller):
+    """When AppSec is enabled/disabled via RC, telemetry should reflect the changes."""
+    with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
+        with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
+            enable_appsec_rc()
+
+            # Initially not activated
+            mock_tw.product_activated.assert_not_called()
+
+            # Simulate RC enabling AppSec
+            enable_config = [build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")]
+            _appsec_callback(enable_config)
+            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
+
+            mock_tw.product_activated.reset_mock()
+
+            # Simulate RC disabling AppSec
+            disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
+            _appsec_callback(disable_config)
+            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)
+
+    disable_appsec_rc()


### PR DESCRIPTION
APPSEC-62332

## Description

`enable_appsec_rc()` unconditionally called `telemetry_writer.product_activated(APPSEC, True)` whenever remote configuration listeners were registered. Since RC listeners are registered by default (to allow remote enablement of AAP), this caused every service to report AAP as an activated product in internal telemetry — even when AAP was not actually enabled.

This PR makes telemetry product activation reporting conditional on the actual state of AAP:

- **`enable_appsec_rc()`**: only reports `True` when `_asm_enabled` is True (AAP explicitly enabled)
- **`enable_asm()` / `disable_asm()`**: reports `True` / `False` when AAP is toggled via remote configuration
- **`_abort_appsec()`**: reports `False` on fatal errors (e.g. libddwaf load failure), only if AAP was previously enabled
- **`disable_appsec_rc()`**: removed the unconditional `product_activated(False)` call — deactivation is now handled by the paths above

This had **no impact on customers** — it only affected internal telemetry data.

## Testing

- 3 regression tests added in `tests/appsec/appsec/test_remoteconfiguration.py`:
  - `test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled` — core regression: RC-only setup must not report AAP as activated
  - `test_rc_activation_reports_appsec_product_when_enabled` — positive case: explicit enablement reports activation
  - `test_rc_enable_then_disable_asm_reports_telemetry` — full RC lifecycle: enable via RC → reports True, disable via RC → reports False
- Verified the first and third tests **fail on old code** and **pass on new code**
- All 58 existing + new tests pass (`appsec::appsec` suite, Python 3.13)

## Risks

None. The change only affects when `product_activated()` is called in internal telemetry. No user-facing behavior changes.

