### PR TITLE
fix(ci_visibility): align provider pull request metadata

### DIFF
--- a/ddtrace/ext/ci/__init__.py
+++ b/ddtrace/ext/ci/__init__.py
@@ -148,6 +148,7 @@ def tags(environ: Optional[MutableMapping[str, str]] = None, cwd: Optional[str] 
         del tags[git.BRANCH]
     else:
         tags[git.BRANCH] = git.normalize_ref(tags.get(git.BRANCH))
+        tags[git.PULL_REQUEST_BASE_BRANCH] = git.normalize_ref(tags.get(git.PULL_REQUEST_BASE_BRANCH))
         tags[git.TAG] = git.normalize_ref(tags.get(git.TAG))
 
     tags[git.REPOSITORY_URL] = _filter_sensitive_info(tags.get(git.REPOSITORY_URL))
@@ -166,6 +167,7 @@ def extract_appveyor(environ: MutableMapping[str, str]) -> dict[str, Optional[st
     url = "https://ci.appveyor.com/project/{0}/builds/{1}".format(
         environ.get("APPVEYOR_REPO_NAME"), environ.get("APPVEYOR_BUILD_ID")
     )
+    is_pull_request = bool(environ.get("APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH"))
     if environ.get("APPVEYOR_REPO_PROVIDER") == "github":
         repository: Optional[str] = "https://github.com/{0}.git".format(environ.get("APPVEYOR_REPO_NAME"))
         commit: Optional[str] = environ.get("APPVEYOR_REPO_COMMIT")
@@ -186,6 +188,7 @@ def extract_appveyor(environ: MutableMapping[str, str]) -> dict[str, Optional[st
         PROVIDER_NAME: "appveyor",
         git.REPOSITORY_URL: repository,
         git.COMMIT_SHA: commit,
+        git.COMMIT_HEAD_SHA: environ.get("APPVEYOR_PULL_REQUEST_HEAD_COMMIT"),
         WORKSPACE_PATH: environ.get("APPVEYOR_BUILD_FOLDER"),
         PIPELINE_ID: environ.get("APPVEYOR_BUILD_ID"),
         PIPELINE_NAME: environ.get("APPVEYOR_REPO_NAME"),
@@ -193,10 +196,12 @@ def extract_appveyor(environ: MutableMapping[str, str]) -> dict[str, Optional[st
         PIPELINE_URL: url,
         JOB_URL: url,
         git.BRANCH: branch,
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("APPVEYOR_REPO_BRANCH") if is_pull_request else None,
         git.TAG: tag,
         git.COMMIT_MESSAGE: commit_message,
         git.COMMIT_AUTHOR_NAME: environ.get("APPVEYOR_REPO_COMMIT_AUTHOR"),
         git.COMMIT_AUTHOR_EMAIL: environ.get("APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL"),
+        git.PULL_REQUEST_NUMBER: environ.get("APPVEYOR_PULL_REQUEST_NUMBER"),
     }
 
 
@@ -233,6 +238,7 @@ def extract_azure_pipelines(environ: MutableMapping[str, str]) -> dict[str, Opti
         git.BRANCH: environ.get("SYSTEM_PULLREQUEST_SOURCEBRANCH")
         or environ.get("BUILD_SOURCEBRANCH")
         or environ.get("BUILD_SOURCEBRANCHNAME"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("SYSTEM_PULLREQUEST_TARGETBRANCH"),
         git.COMMIT_MESSAGE: environ.get("BUILD_SOURCEVERSIONMESSAGE"),
         git.COMMIT_AUTHOR_NAME: environ.get("BUILD_REQUESTEDFORID"),
         git.COMMIT_AUTHOR_EMAIL: environ.get("BUILD_REQUESTEDFOREMAIL"),
@@ -247,6 +253,7 @@ def extract_azure_pipelines(environ: MutableMapping[str, str]) -> dict[str, Opti
             },
             separators=(",", ":"),
         ),
+        git.PULL_REQUEST_NUMBER: environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"),
     }
 
 
@@ -258,6 +265,7 @@ def extract_bitbucket(environ: MutableMapping[str, str]) -> dict[str, Optional[s
     return {
         git.BRANCH: environ.get("BITBUCKET_BRANCH"),
         git.COMMIT_SHA: environ.get("BITBUCKET_COMMIT"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("BITBUCKET_PR_DESTINATION_BRANCH"),
         git.REPOSITORY_URL: environ.get("BITBUCKET_GIT_SSH_ORIGIN") or environ.get("BITBUCKET_GIT_HTTP_ORIGIN"),
         git.TAG: environ.get("BITBUCKET_TAG"),
         JOB_URL: url,
@@ -267,12 +275,15 @@ def extract_bitbucket(environ: MutableMapping[str, str]) -> dict[str, Optional[s
         PIPELINE_URL: url,
         PROVIDER_NAME: "bitbucket",
         WORKSPACE_PATH: environ.get("BITBUCKET_CLONE_DIR"),
+        git.PULL_REQUEST_NUMBER: environ.get("BITBUCKET_PR_ID"),
     }
 
 
 def extract_buildkite(environ: MutableMapping[str, str]) -> dict[str, Optional[str]]:
     """Extract CI tags from Buildkite environ."""
     # Get all keys which start with BUILDKITE_AGENT_META_DATA_x
+    pull_request_number = environ.get("BUILDKITE_PULL_REQUEST")
+    is_pull_request = pull_request_number not in (None, "", "false")
     node_label_list: list[str] = []
     buildkite_agent_meta_data_prefix = "BUILDKITE_AGENT_META_DATA_"
     for env_variable in environ:
@@ -283,6 +294,7 @@ def extract_buildkite(environ: MutableMapping[str, str]) -> dict[str, Optional[s
     return {
         git.BRANCH: environ.get("BUILDKITE_BRANCH"),
         git.COMMIT_SHA: environ.get("BUILDKITE_COMMIT"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH") if is_pull_request else None,
         git.REPOSITORY_URL: environ.get("BUILDKITE_REPO"),
         git.TAG: environ.get("BUILDKITE_TAG"),
         PIPELINE_ID: environ.get("BUILDKITE_BUILD_ID"),
@@ -307,6 +319,7 @@ def extract_buildkite(environ: MutableMapping[str, str]) -> dict[str, Optional[s
         ),
         NODE_LABELS: json.dumps(node_label_list, separators=(",", ":")),
         NODE_NAME: environ.get("BUILDKITE_AGENT_ID"),
+        git.PULL_REQUEST_NUMBER: pull_request_number if is_pull_request else None,
     }
 
 
@@ -317,6 +330,7 @@ def extract_circle_ci(environ: MutableMapping[str, str]) -> dict[str, Optional[s
         git.COMMIT_SHA: environ.get("CIRCLE_SHA1"),
         git.REPOSITORY_URL: environ.get("CIRCLE_REPOSITORY_URL"),
         git.TAG: environ.get("CIRCLE_TAG"),
+        JOB_ID: environ.get("CIRCLE_BUILD_NUM"),
         PIPELINE_ID: environ.get("CIRCLE_WORKFLOW_ID"),
         PIPELINE_NAME: environ.get("CIRCLE_PROJECT_REPONAME"),
         PIPELINE_NUMBER: environ.get("CIRCLE_BUILD_NUM"),
@@ -325,6 +339,7 @@ def extract_circle_ci(environ: MutableMapping[str, str]) -> dict[str, Optional[s
         JOB_NAME: environ.get("CIRCLE_JOB"),
         PROVIDER_NAME: "circleci",
         WORKSPACE_PATH: environ.get("CIRCLE_WORKING_DIRECTORY"),
+        git.PULL_REQUEST_NUMBER: environ.get("CIRCLE_PR_NUMBER"),
         _CI_ENV_VARS: json.dumps(
             {
                 "CIRCLE_WORKFLOW_ID": environ.get("CIRCLE_WORKFLOW_ID"),
@@ -340,6 +355,7 @@ def extract_codefresh(environ: MutableMapping[str, str]) -> dict[str, Optional[s
     build_id = environ.get("CF_BUILD_ID")
     return {
         git.BRANCH: environ.get("CF_BRANCH"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("CF_PULL_REQUEST_TARGET"),
         PIPELINE_ID: build_id,
         PIPELINE_NAME: environ.get("CF_PIPELINE_NAME"),
         PIPELINE_URL: environ.get("CF_BUILD_URL"),
@@ -349,6 +365,7 @@ def extract_codefresh(environ: MutableMapping[str, str]) -> dict[str, Optional[s
             {"CF_BUILD_ID": build_id},
             separators=(",", ":"),
         ),
+        git.PULL_REQUEST_NUMBER: environ.get("CF_PULL_REQUEST_NUMBER"),
     }
 
 
@@ -369,6 +386,7 @@ def extract_gitlab(environ: MutableMapping[str, str]) -> dict[str, Optional[str]
     return {
         git.BRANCH: environ.get("CI_COMMIT_REF_NAME"),
         git.COMMIT_SHA: environ.get("CI_COMMIT_SHA"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("CI_MERGE_REQUEST_TARGET_BRANCH_NAME"),
         git.REPOSITORY_URL: environ.get("CI_REPOSITORY_URL"),
         git.TAG: environ.get("CI_COMMIT_TAG"),
         STAGE_NAME: environ.get("CI_JOB_STAGE"),
@@ -395,6 +413,10 @@ def extract_gitlab(environ: MutableMapping[str, str]) -> dict[str, Optional[str]
         ),
         NODE_LABELS: environ.get("CI_RUNNER_TAGS"),
         NODE_NAME: environ.get("CI_RUNNER_ID"),
+        git.PULL_REQUEST_BASE_BRANCH_HEAD_SHA: environ.get("CI_MERGE_REQUEST_TARGET_BRANCH_SHA"),
+        git.PULL_REQUEST_BASE_BRANCH_SHA: environ.get("CI_MERGE_REQUEST_DIFF_BASE_SHA"),
+        git.COMMIT_HEAD_SHA: environ.get("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"),
+        git.PULL_REQUEST_NUMBER: environ.get("CI_MERGE_REQUEST_IID"),
     }
 
 
@@ -413,6 +435,7 @@ def extract_jenkins(environ: MutableMapping[str, str]) -> dict[str, Optional[str
     return {
         git.BRANCH: environ.get("GIT_BRANCH"),
         git.COMMIT_SHA: environ.get("GIT_COMMIT"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("CHANGE_TARGET"),
         git.REPOSITORY_URL: environ.get("GIT_URL", environ.get("GIT_URL_1")),
         PIPELINE_ID: environ.get("BUILD_TAG"),
         PIPELINE_NAME: name,
@@ -428,6 +451,7 @@ def extract_jenkins(environ: MutableMapping[str, str]) -> dict[str, Optional[str
         ),
         NODE_LABELS: json.dumps(node_labels_list, separators=(",", ":")),
         NODE_NAME: environ.get("NODE_NAME"),
+        git.PULL_REQUEST_NUMBER: environ.get("CHANGE_ID"),
     }
 
 
@@ -437,14 +461,19 @@ def extract_teamcity(environ: MutableMapping[str, str]) -> dict[str, Optional[st
         JOB_URL: environ.get("BUILD_URL"),
         JOB_NAME: environ.get("TEAMCITY_BUILDCONF_NAME"),
         PROVIDER_NAME: "teamcity",
+        git.PULL_REQUEST_NUMBER: environ.get("TEAMCITY_PULLREQUEST_NUMBER"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("TEAMCITY_PULLREQUEST_TARGET_BRANCH"),
     }
 
 
 def extract_travis(environ: MutableMapping[str, str]) -> dict[str, Optional[str]]:
     """Extract CI tags from Travis environ."""
+    is_pull_request = environ.get("TRAVIS_EVENT_TYPE") == "pull_request"
     return {
         git.BRANCH: environ.get("TRAVIS_PULL_REQUEST_BRANCH") or environ.get("TRAVIS_BRANCH"),
         git.COMMIT_SHA: environ.get("TRAVIS_COMMIT"),
+        git.COMMIT_HEAD_SHA: environ.get("TRAVIS_PULL_REQUEST_SHA") if is_pull_request else None,
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("TRAVIS_BRANCH") if is_pull_request else None,
         git.REPOSITORY_URL: "https://github.com/{0}.git".format(environ.get("TRAVIS_REPO_SLUG")),
         git.TAG: environ.get("TRAVIS_TAG"),
         JOB_URL: environ.get("TRAVIS_JOB_WEB_URL"),
@@ -455,13 +484,14 @@ def extract_travis(environ: MutableMapping[str, str]) -> dict[str, Optional[str]
         PROVIDER_NAME: "travisci",
         WORKSPACE_PATH: environ.get("TRAVIS_BUILD_DIR"),
         git.COMMIT_MESSAGE: environ.get("TRAVIS_COMMIT_MESSAGE"),
+        git.PULL_REQUEST_NUMBER: environ.get("TRAVIS_PULL_REQUEST") if is_pull_request else None,
     }
 
 
 def extract_bitrise(environ: MutableMapping[str, str]) -> dict[str, Optional[str]]:
     """Extract CI tags from Bitrise environ."""
     commit = environ.get("BITRISE_GIT_COMMIT") or environ.get("GIT_CLONE_COMMIT_HASH")
-    branch = environ.get("BITRISEIO_GIT_BRANCH_DEST") or environ.get("BITRISE_GIT_BRANCH")
+    branch = environ.get("BITRISEIO_PULL_REQUEST_HEAD_BRANCH") or environ.get("BITRISE_GIT_BRANCH")
     if environ.get("BITRISE_GIT_MESSAGE"):
         message: Optional[str] = environ.get("BITRISE_GIT_MESSAGE")
     elif environ.get("GIT_CLONE_COMMIT_MESSAGE_SUBJECT") or environ.get("GIT_CLONE_COMMIT_MESSAGE_BODY"):
@@ -481,12 +511,15 @@ def extract_bitrise(environ: MutableMapping[str, str]) -> dict[str, Optional[str
         git.REPOSITORY_URL: environ.get("GIT_REPOSITORY_URL"),
         git.COMMIT_SHA: commit,
         git.BRANCH: branch,
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("BITRISEIO_GIT_BRANCH_DEST"),
         git.TAG: environ.get("BITRISE_GIT_TAG"),
         git.COMMIT_MESSAGE: message,
         git.COMMIT_AUTHOR_NAME: environ.get("GIT_CLONE_COMMIT_AUTHOR_NAME"),
         git.COMMIT_AUTHOR_EMAIL: environ.get("GIT_CLONE_COMMIT_AUTHOR_EMAIL"),
         git.COMMIT_COMMITTER_NAME: environ.get("GIT_CLONE_COMMIT_COMMITER_NAME"),
-        git.COMMIT_COMMITTER_EMAIL: environ.get("GIT_CLONE_COMMIT_COMMITER_NAME"),
+        git.COMMIT_COMMITTER_EMAIL: environ.get("GIT_CLONE_COMMIT_COMMITER_EMAIL")
+        or environ.get("GIT_CLONE_COMMIT_COMMITER_NAME"),
+        git.PULL_REQUEST_NUMBER: environ.get("BITRISE_PULL_REQUEST"),
     }
 
 
@@ -501,10 +534,12 @@ def extract_buddy(environ: MutableMapping[str, str]) -> dict[str, Optional[str]]
         git.REPOSITORY_URL: environ.get("BUDDY_SCM_URL"),
         git.COMMIT_SHA: environ.get("BUDDY_EXECUTION_REVISION"),
         git.BRANCH: environ.get("BUDDY_EXECUTION_BRANCH"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("BUDDY_RUN_PR_BASE_BRANCH"),
         git.TAG: environ.get("BUDDY_EXECUTION_TAG"),
         git.COMMIT_MESSAGE: environ.get("BUDDY_EXECUTION_REVISION_MESSAGE"),
         git.COMMIT_COMMITTER_NAME: environ.get("BUDDY_EXECUTION_REVISION_COMMITTER_NAME"),
         git.COMMIT_COMMITTER_EMAIL: environ.get("BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL"),
+        git.PULL_REQUEST_NUMBER: environ.get("BUDDY_RUN_PR_NO"),
     }
 
 
@@ -520,6 +555,7 @@ def extract_codebuild(environ: MutableMapping[str, str]) -> dict[str, Optional[s
             tags.update(
                 {
                     PROVIDER_NAME: "awscodepipeline",
+                    JOB_ID: environ.get("DD_ACTION_EXECUTION_ID"),
                     PIPELINE_ID: environ.get("DD_PIPELINE_EXECUTION_ID"),
                     _CI_ENV_VARS: json.dumps(
                         {
@@ -533,6 +569,30 @@ def extract_codebuild(environ: MutableMapping[str, str]) -> dict[str, Optional[s
             )
 
     return tags
+
+
+def extract_drone(environ: MutableMapping[str, str]) -> dict[str, Optional[str]]:
+    """Extract CI tags from Drone environ."""
+    repository = environ.get("DRONE_GIT_HTTP_URL")
+    if not repository and environ.get("DRONE_REPO"):
+        repository = "https://github.com/{0}.git".format(environ.get("DRONE_REPO"))
+    return {
+        PROVIDER_NAME: "drone",
+        STAGE_NAME: environ.get("DRONE_STAGE_NAME"),
+        JOB_NAME: environ.get("DRONE_STEP_NAME"),
+        PIPELINE_NUMBER: environ.get("DRONE_BUILD_NUMBER"),
+        PIPELINE_URL: environ.get("DRONE_BUILD_LINK"),
+        WORKSPACE_PATH: environ.get("DRONE_WORKSPACE"),
+        git.BRANCH: environ.get("DRONE_BRANCH") or environ.get("DRONE_COMMIT_BRANCH"),
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("DRONE_TARGET_BRANCH"),
+        git.COMMIT_SHA: environ.get("DRONE_COMMIT_SHA"),
+        git.REPOSITORY_URL: repository,
+        git.TAG: environ.get("DRONE_TAG"),
+        git.COMMIT_AUTHOR_NAME: environ.get("DRONE_COMMIT_AUTHOR_NAME"),
+        git.COMMIT_AUTHOR_EMAIL: environ.get("DRONE_COMMIT_AUTHOR_EMAIL"),
+        git.COMMIT_MESSAGE: environ.get("DRONE_COMMIT_MESSAGE"),
+        git.PULL_REQUEST_NUMBER: environ.get("DRONE_PULL_REQUEST"),
+    }
 
 
 PROVIDERS = (
@@ -550,4 +610,5 @@ PROVIDERS = (
     ("BITRISE_BUILD_SLUG", extract_bitrise),
     ("BUDDY", extract_buddy),
     ("CODEBUILD_INITIATOR", extract_codebuild),
+    ("DRONE", extract_drone),
 )

--- a/ddtrace/ext/ci/__init__.py
+++ b/ddtrace/ext/ci/__init__.py
@@ -148,8 +148,9 @@ def tags(environ: Optional[MutableMapping[str, str]] = None, cwd: Optional[str] 
         del tags[git.BRANCH]
     else:
         tags[git.BRANCH] = git.normalize_ref(tags.get(git.BRANCH))
-        tags[git.PULL_REQUEST_BASE_BRANCH] = git.normalize_ref(tags.get(git.PULL_REQUEST_BASE_BRANCH))
         tags[git.TAG] = git.normalize_ref(tags.get(git.TAG))
+
+    tags[git.PULL_REQUEST_BASE_BRANCH] = git.normalize_ref(tags.get(git.PULL_REQUEST_BASE_BRANCH))
 
     tags[git.REPOSITORY_URL] = _filter_sensitive_info(tags.get(git.REPOSITORY_URL))
 

--- a/ddtrace/ext/ci/github_actions.py
+++ b/ddtrace/ext/ci/github_actions.py
@@ -216,6 +216,7 @@ def extract_github_actions(environ: MutableMapping[str, str]) -> dict[str, Optio
     tags = {
         git.BRANCH: environ.get("GITHUB_HEAD_REF") or environ.get("GITHUB_REF"),
         git.COMMIT_SHA: git_commit_sha,
+        git.PULL_REQUEST_BASE_BRANCH: environ.get("GITHUB_BASE_REF"),
         git.REPOSITORY_URL: "{0}/{1}.git".format(github_server_url, github_repository),
         git.COMMIT_HEAD_SHA: git_commit_head_sha,
         _PIPELINE_ID: github_run_id,

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -28,6 +28,18 @@ GitNotFoundError = FileNotFoundError
 # Git Branch
 BRANCH = "git.branch"
 
+# Git Pull Request Base Branch
+PULL_REQUEST_BASE_BRANCH = "git.pull_request.base_branch"
+
+# Git Pull Request Base Branch SHA
+PULL_REQUEST_BASE_BRANCH_SHA = "git.pull_request.base_branch_sha"
+
+# Git Pull Request Base Branch Head SHA
+PULL_REQUEST_BASE_BRANCH_HEAD_SHA = "git.pull_request.base_branch_head_sha"
+
+# Pull Request Number
+PULL_REQUEST_NUMBER = "pr.number"
+
 # Git Commit SHA
 COMMIT_SHA = "git.commit.sha"
 
@@ -437,6 +449,7 @@ def extract_user_git_metadata(environ: Optional[MutableMapping[str, str]] = None
     environ = env if environ is None else environ
 
     branch = normalize_ref(environ.get("DD_GIT_BRANCH"))
+    pull_request_base_branch = normalize_ref(environ.get("DD_GIT_PULL_REQUEST_BASE_BRANCH"))
     tag = normalize_ref(environ.get("DD_GIT_TAG"))
 
     # if DD_GIT_BRANCH is a tag, we associate its value to TAG instead of BRANCH
@@ -448,6 +461,8 @@ def extract_user_git_metadata(environ: Optional[MutableMapping[str, str]] = None
     tags[REPOSITORY_URL] = environ.get("DD_GIT_REPOSITORY_URL")
     tags[COMMIT_SHA] = environ.get("DD_GIT_COMMIT_SHA")
     tags[BRANCH] = branch
+    tags[PULL_REQUEST_BASE_BRANCH] = pull_request_base_branch
+    tags[PULL_REQUEST_BASE_BRANCH_SHA] = environ.get("DD_GIT_PULL_REQUEST_BASE_BRANCH_SHA")
     tags[TAG] = tag
     tags[COMMIT_MESSAGE] = environ.get("DD_GIT_COMMIT_MESSAGE")
     tags[COMMIT_AUTHOR_DATE] = environ.get("DD_GIT_COMMIT_AUTHOR_DATE")

--- a/ddtrace/internal/test_visibility/coverage_report_utils.py
+++ b/ddtrace/internal/test_visibility/coverage_report_utils.py
@@ -15,7 +15,7 @@ def create_coverage_report_event(
 
     Args:
         coverage_format: The format of the coverage report (e.g., 'lcov', 'cobertura')
-        tags: Tags to include. Only git.* and ci.* prefixed tags are included in the event.
+        tags: Tags to include. Only git.* and ci.* prefixed tags, plus pr.number, are included in the event.
 
     Returns:
         Dictionary with event data ready for upload
@@ -26,14 +26,13 @@ def create_coverage_report_event(
         "timestamp": int(time.time() * 1000),
     }
 
-    # Add only git.* and ci.* tags
+    # Add only git.* and ci.* tags, plus pr.number for PR correlation.
     if tags:
         for key, value in tags.items():
             if not value:
                 continue
 
-            # Handle PR number special case: map to "pr.number"
-            if key == "git.pull_request.number":
+            if key == "pr.number" or key == "git.pull_request.number":
                 event["pr.number"] = value
             # Only include git.* and ci.* prefixed tags
             elif key.startswith(("git.", "ci.")):

--- a/ddtrace/internal/test_visibility/coverage_report_utils.py
+++ b/ddtrace/internal/test_visibility/coverage_report_utils.py
@@ -15,7 +15,7 @@ def create_coverage_report_event(
 
     Args:
         coverage_format: The format of the coverage report (e.g., 'lcov', 'cobertura')
-        tags: Tags to include. Only git.* and ci.* prefixed tags, plus pr.number, are included in the event.
+        tags: Tags to include. Only git.*, ci.*, and pr.* prefixed tags are included in the event.
 
     Returns:
         Dictionary with event data ready for upload
@@ -26,16 +26,13 @@ def create_coverage_report_event(
         "timestamp": int(time.time() * 1000),
     }
 
-    # Add only git.* and ci.* tags, plus pr.number for PR correlation.
+    # Add only git.*, ci.*, and pr.* tags.
     if tags:
         for key, value in tags.items():
             if not value:
                 continue
 
-            if key == "pr.number" or key == "git.pull_request.number":
-                event["pr.number"] = value
-            # Only include git.* and ci.* prefixed tags
-            elif key.startswith(("git.", "ci.")):
+            if key.startswith(("git.", "ci.", "pr.")):
                 event[key] = value
 
     return event

--- a/ddtrace/testing/internal/ci.py
+++ b/ddtrace/testing/internal/ci.py
@@ -99,10 +99,12 @@ def extract_appveyor(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[st
         if extended:
             commit_message += "\n" + extended
 
+    is_pull_request = bool(env.get("APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH"))
     return {
         CITag.PROVIDER_NAME: "appveyor",
         GitTag.REPOSITORY_URL: repository,
         GitTag.COMMIT_SHA: commit,
+        GitTag.COMMIT_HEAD_SHA: env.get("APPVEYOR_PULL_REQUEST_HEAD_COMMIT"),
         CITag.WORKSPACE_PATH: env.get("APPVEYOR_BUILD_FOLDER"),
         CITag.PIPELINE_ID: env.get("APPVEYOR_BUILD_ID"),
         CITag.PIPELINE_NAME: env.get("APPVEYOR_REPO_NAME"),
@@ -110,10 +112,12 @@ def extract_appveyor(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[st
         CITag.PIPELINE_URL: url,
         CITag.JOB_URL: url,
         GitTag.BRANCH: branch,
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("APPVEYOR_REPO_BRANCH") if is_pull_request else None,
         GitTag.TAG: tag,
         GitTag.COMMIT_MESSAGE: commit_message,
         GitTag.COMMIT_AUTHOR_NAME: env.get("APPVEYOR_REPO_COMMIT_AUTHOR"),
         GitTag.COMMIT_AUTHOR_EMAIL: env.get("APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("APPVEYOR_PULL_REQUEST_NUMBER"),
     }
 
 
@@ -144,6 +148,7 @@ def extract_azure_pipelines(env: t.MutableMapping[str, str]) -> dict[str, t.Opti
         GitTag.BRANCH: env.get("SYSTEM_PULLREQUEST_SOURCEBRANCH")
         or env.get("BUILD_SOURCEBRANCH")
         or env.get("BUILD_SOURCEBRANCHNAME"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("SYSTEM_PULLREQUEST_TARGETBRANCH"),
         GitTag.COMMIT_MESSAGE: env.get("BUILD_SOURCEVERSIONMESSAGE"),
         GitTag.COMMIT_AUTHOR_NAME: env.get("BUILD_REQUESTEDFORID"),
         GitTag.COMMIT_AUTHOR_EMAIL: env.get("BUILD_REQUESTEDFOREMAIL"),
@@ -158,6 +163,7 @@ def extract_azure_pipelines(env: t.MutableMapping[str, str]) -> dict[str, t.Opti
             },
             separators=(",", ":"),
         ),
+        GitTag.PULL_REQUEST_NUMBER: env.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"),
     }
 
 
@@ -170,6 +176,7 @@ def extract_bitbucket(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
     return {
         GitTag.BRANCH: env.get("BITBUCKET_BRANCH"),
         GitTag.COMMIT_SHA: env.get("BITBUCKET_COMMIT"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("BITBUCKET_PR_DESTINATION_BRANCH"),
         GitTag.REPOSITORY_URL: env.get("BITBUCKET_GIT_SSH_ORIGIN") or env.get("BITBUCKET_GIT_HTTP_ORIGIN"),
         GitTag.TAG: env.get("BITBUCKET_TAG"),
         CITag.JOB_URL: url,
@@ -179,6 +186,7 @@ def extract_bitbucket(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
         CITag.PIPELINE_URL: url,
         CITag.PROVIDER_NAME: "bitbucket",
         CITag.WORKSPACE_PATH: env.get("BITBUCKET_CLONE_DIR"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("BITBUCKET_PR_ID"),
     }
 
 
@@ -186,6 +194,8 @@ def extract_bitbucket(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
 def extract_buildkite(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]]:
     """Extract CI tags from Buildkite environ."""
     # Get all keys which start with BUILDKITE_AGENT_META_DATA_x
+    pull_request_number = env.get("BUILDKITE_PULL_REQUEST")
+    is_pull_request = pull_request_number not in (None, "", "false")
     node_label_list: list[str] = []
     buildkite_agent_meta_data_prefix = "BUILDKITE_AGENT_META_DATA_"
     for env_variable in env:
@@ -196,6 +206,7 @@ def extract_buildkite(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
     return {
         GitTag.BRANCH: env.get("BUILDKITE_BRANCH"),
         GitTag.COMMIT_SHA: env.get("BUILDKITE_COMMIT"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH") if is_pull_request else None,
         GitTag.REPOSITORY_URL: env.get("BUILDKITE_REPO"),
         GitTag.TAG: env.get("BUILDKITE_TAG"),
         CITag.PIPELINE_ID: env.get("BUILDKITE_BUILD_ID"),
@@ -220,6 +231,7 @@ def extract_buildkite(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
         ),
         CITag.NODE_LABELS: json.dumps(node_label_list, separators=(",", ":")),
         CITag.NODE_NAME: env.get("BUILDKITE_AGENT_ID"),
+        GitTag.PULL_REQUEST_NUMBER: pull_request_number if is_pull_request else None,
     }
 
 
@@ -231,6 +243,7 @@ def extract_circle_ci(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
         GitTag.COMMIT_SHA: env.get("CIRCLE_SHA1"),
         GitTag.REPOSITORY_URL: env.get("CIRCLE_REPOSITORY_URL"),
         GitTag.TAG: env.get("CIRCLE_TAG"),
+        CITag.JOB_ID: env.get("CIRCLE_BUILD_NUM"),
         CITag.PIPELINE_ID: env.get("CIRCLE_WORKFLOW_ID"),
         CITag.PIPELINE_NAME: env.get("CIRCLE_PROJECT_REPONAME"),
         CITag.PIPELINE_NUMBER: env.get("CIRCLE_BUILD_NUM"),
@@ -239,6 +252,7 @@ def extract_circle_ci(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
         CITag.JOB_NAME: env.get("CIRCLE_JOB"),
         CITag.PROVIDER_NAME: "circleci",
         CITag.WORKSPACE_PATH: env.get("CIRCLE_WORKING_DIRECTORY"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("CIRCLE_PR_NUMBER"),
         CITag._CI_ENV_VARS: json.dumps(
             {
                 "CIRCLE_WORKFLOW_ID": env.get("CIRCLE_WORKFLOW_ID"),
@@ -255,6 +269,7 @@ def extract_codefresh(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
     build_id = env.get("CF_BUILD_ID")
     return {
         GitTag.BRANCH: env.get("CF_BRANCH"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("CF_PULL_REQUEST_TARGET"),
         CITag.PIPELINE_ID: build_id,
         CITag.PIPELINE_NAME: env.get("CF_PIPELINE_NAME"),
         CITag.PIPELINE_URL: env.get("CF_BUILD_URL"),
@@ -264,6 +279,7 @@ def extract_codefresh(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
             {"CF_BUILD_ID": build_id},
             separators=(",", ":"),
         ),
+        GitTag.PULL_REQUEST_NUMBER: env.get("CF_PULL_REQUEST_NUMBER"),
     }
 
 
@@ -286,6 +302,7 @@ def extract_gitlab(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]
     return {
         GitTag.BRANCH: env.get("CI_COMMIT_REF_NAME"),
         GitTag.COMMIT_SHA: env.get("CI_COMMIT_SHA"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("CI_MERGE_REQUEST_TARGET_BRANCH_NAME"),
         GitTag.REPOSITORY_URL: env.get("CI_REPOSITORY_URL"),
         GitTag.TAG: env.get("CI_COMMIT_TAG"),
         CITag.STAGE_NAME: env.get("CI_JOB_STAGE"),
@@ -312,6 +329,10 @@ def extract_gitlab(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]
         ),
         CITag.NODE_LABELS: env.get("CI_RUNNER_TAGS"),
         CITag.NODE_NAME: env.get("CI_RUNNER_ID"),
+        GitTag.PULL_REQUEST_BASE_BRANCH_HEAD_SHA: env.get("CI_MERGE_REQUEST_TARGET_BRANCH_SHA"),
+        GitTag.PULL_REQUEST_BASE_BRANCH_SHA: env.get("CI_MERGE_REQUEST_DIFF_BASE_SHA"),
+        GitTag.COMMIT_HEAD_SHA: env.get("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("CI_MERGE_REQUEST_IID"),
     }
 
 
@@ -331,6 +352,7 @@ def extract_jenkins(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str
     return {
         GitTag.BRANCH: env.get("GIT_BRANCH"),
         GitTag.COMMIT_SHA: env.get("GIT_COMMIT"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("CHANGE_TARGET"),
         GitTag.REPOSITORY_URL: env.get("GIT_URL", env.get("GIT_URL_1")),
         CITag.PIPELINE_ID: env.get("BUILD_TAG"),
         CITag.PIPELINE_NAME: name,
@@ -346,6 +368,7 @@ def extract_jenkins(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str
         ),
         CITag.NODE_LABELS: json.dumps(node_labels_list, separators=(",", ":")),
         CITag.NODE_NAME: env.get("NODE_NAME"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("CHANGE_ID"),
     }
 
 
@@ -356,15 +379,20 @@ def extract_teamcity(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[st
         CITag.JOB_URL: env.get("BUILD_URL"),
         CITag.JOB_NAME: env.get("TEAMCITY_BUILDCONF_NAME"),
         CITag.PROVIDER_NAME: "teamcity",
+        GitTag.PULL_REQUEST_NUMBER: env.get("TEAMCITY_PULLREQUEST_NUMBER"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("TEAMCITY_PULLREQUEST_TARGET_BRANCH"),
     }
 
 
 @register_provider("TRAVIS")
 def extract_travis(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]]:
     """Extract CI tags from Travis environ."""
+    is_pull_request = env.get("TRAVIS_EVENT_TYPE") == "pull_request"
     return {
         GitTag.BRANCH: env.get("TRAVIS_PULL_REQUEST_BRANCH") or env.get("TRAVIS_BRANCH"),
         GitTag.COMMIT_SHA: env.get("TRAVIS_COMMIT"),
+        GitTag.COMMIT_HEAD_SHA: env.get("TRAVIS_PULL_REQUEST_SHA") if is_pull_request else None,
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("TRAVIS_BRANCH") if is_pull_request else None,
         GitTag.REPOSITORY_URL: "https://github.com/{0}.git".format(env.get("TRAVIS_REPO_SLUG")),
         GitTag.TAG: env.get("TRAVIS_TAG"),
         CITag.JOB_URL: env.get("TRAVIS_JOB_WEB_URL"),
@@ -375,6 +403,7 @@ def extract_travis(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]
         CITag.PROVIDER_NAME: "travisci",
         CITag.WORKSPACE_PATH: env.get("TRAVIS_BUILD_DIR"),
         GitTag.COMMIT_MESSAGE: env.get("TRAVIS_COMMIT_MESSAGE"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("TRAVIS_PULL_REQUEST") if is_pull_request else None,
     }
 
 
@@ -382,7 +411,7 @@ def extract_travis(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]
 def extract_bitrise(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]]:
     """Extract CI tags from Bitrise environ."""
     commit = env.get("BITRISE_GIT_COMMIT") or env.get("GIT_CLONE_COMMIT_HASH")
-    branch = env.get("BITRISEIO_GIT_BRANCH_DEST") or env.get("BITRISE_GIT_BRANCH")
+    branch = env.get("BITRISEIO_PULL_REQUEST_HEAD_BRANCH") or env.get("BITRISE_GIT_BRANCH")
     if env.get("BITRISE_GIT_MESSAGE"):
         message = env.get("BITRISE_GIT_MESSAGE")
     elif env.get("GIT_CLONE_COMMIT_MESSAGE_SUBJECT") or env.get("GIT_CLONE_COMMIT_MESSAGE_BODY"):
@@ -402,12 +431,15 @@ def extract_bitrise(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str
         GitTag.REPOSITORY_URL: env.get("GIT_REPOSITORY_URL"),
         GitTag.COMMIT_SHA: commit,
         GitTag.BRANCH: branch,
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("BITRISEIO_GIT_BRANCH_DEST"),
         GitTag.TAG: env.get("BITRISE_GIT_TAG"),
         GitTag.COMMIT_MESSAGE: message,
         GitTag.COMMIT_AUTHOR_NAME: env.get("GIT_CLONE_COMMIT_AUTHOR_NAME"),
         GitTag.COMMIT_AUTHOR_EMAIL: env.get("GIT_CLONE_COMMIT_AUTHOR_EMAIL"),
         GitTag.COMMIT_COMMITTER_NAME: env.get("GIT_CLONE_COMMIT_COMMITER_NAME"),
-        GitTag.COMMIT_COMMITTER_EMAIL: env.get("GIT_CLONE_COMMIT_COMMITER_NAME"),
+        GitTag.COMMIT_COMMITTER_EMAIL: env.get("GIT_CLONE_COMMIT_COMMITER_EMAIL")
+        or env.get("GIT_CLONE_COMMIT_COMMITER_NAME"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("BITRISE_PULL_REQUEST"),
     }
 
 
@@ -423,10 +455,12 @@ def extract_buddy(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]]
         GitTag.REPOSITORY_URL: env.get("BUDDY_SCM_URL"),
         GitTag.COMMIT_SHA: env.get("BUDDY_EXECUTION_REVISION"),
         GitTag.BRANCH: env.get("BUDDY_EXECUTION_BRANCH"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("BUDDY_RUN_PR_BASE_BRANCH"),
         GitTag.TAG: env.get("BUDDY_EXECUTION_TAG"),
         GitTag.COMMIT_MESSAGE: env.get("BUDDY_EXECUTION_REVISION_MESSAGE"),
         GitTag.COMMIT_COMMITTER_NAME: env.get("BUDDY_EXECUTION_REVISION_COMMITTER_NAME"),
         GitTag.COMMIT_COMMITTER_EMAIL: env.get("BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("BUDDY_RUN_PR_NO"),
     }
 
 
@@ -442,6 +476,7 @@ def extract_codebuild(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
             tags.update(
                 {
                     CITag.PROVIDER_NAME: "awscodepipeline",
+                    CITag.JOB_ID: env.get("DD_ACTION_EXECUTION_ID"),
                     CITag.PIPELINE_ID: env.get("DD_PIPELINE_EXECUTION_ID"),
                     CITag._CI_ENV_VARS: json.dumps(
                         {
@@ -455,3 +490,28 @@ def extract_codebuild(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[s
             )
 
     return tags
+
+
+@register_provider("DRONE")
+def extract_drone(env: t.MutableMapping[str, str]) -> dict[str, t.Optional[str]]:
+    """Extract CI tags from Drone environ."""
+    repository = env.get("DRONE_GIT_HTTP_URL")
+    if not repository and env.get("DRONE_REPO"):
+        repository = "https://github.com/{0}.git".format(env.get("DRONE_REPO"))
+    return {
+        CITag.PROVIDER_NAME: "drone",
+        CITag.STAGE_NAME: env.get("DRONE_STAGE_NAME"),
+        CITag.JOB_NAME: env.get("DRONE_STEP_NAME"),
+        CITag.PIPELINE_NUMBER: env.get("DRONE_BUILD_NUMBER"),
+        CITag.PIPELINE_URL: env.get("DRONE_BUILD_LINK"),
+        CITag.WORKSPACE_PATH: env.get("DRONE_WORKSPACE"),
+        GitTag.BRANCH: env.get("DRONE_BRANCH") or env.get("DRONE_COMMIT_BRANCH"),
+        GitTag.PULL_REQUEST_BASE_BRANCH: env.get("DRONE_TARGET_BRANCH"),
+        GitTag.COMMIT_SHA: env.get("DRONE_COMMIT_SHA"),
+        GitTag.REPOSITORY_URL: repository,
+        GitTag.TAG: env.get("DRONE_TAG"),
+        GitTag.COMMIT_AUTHOR_NAME: env.get("DRONE_COMMIT_AUTHOR_NAME"),
+        GitTag.COMMIT_AUTHOR_EMAIL: env.get("DRONE_COMMIT_AUTHOR_EMAIL"),
+        GitTag.COMMIT_MESSAGE: env.get("DRONE_COMMIT_MESSAGE"),
+        GitTag.PULL_REQUEST_NUMBER: env.get("DRONE_PULL_REQUEST"),
+    }

--- a/ddtrace/testing/internal/env_tags.py
+++ b/ddtrace/testing/internal/env_tags.py
@@ -69,6 +69,7 @@ def normalize_git_tags(tags: _TagDict) -> None:
         del tags[GitTag.BRANCH]
     else:
         tags[GitTag.BRANCH] = git.normalize_ref(branch)
+        tags[GitTag.PULL_REQUEST_BASE_BRANCH] = git.normalize_ref(tags.get(GitTag.PULL_REQUEST_BASE_BRANCH))
         tags[GitTag.TAG] = git.normalize_ref(tag)
 
     tags[GitTag.REPOSITORY_URL] = _filter_sensitive_info(tags.get(GitTag.REPOSITORY_URL))

--- a/ddtrace/testing/internal/env_tags.py
+++ b/ddtrace/testing/internal/env_tags.py
@@ -69,9 +69,9 @@ def normalize_git_tags(tags: _TagDict) -> None:
         del tags[GitTag.BRANCH]
     else:
         tags[GitTag.BRANCH] = git.normalize_ref(branch)
-        tags[GitTag.PULL_REQUEST_BASE_BRANCH] = git.normalize_ref(tags.get(GitTag.PULL_REQUEST_BASE_BRANCH))
         tags[GitTag.TAG] = git.normalize_ref(tag)
 
+    tags[GitTag.PULL_REQUEST_BASE_BRANCH] = git.normalize_ref(tags.get(GitTag.PULL_REQUEST_BASE_BRANCH))
     tags[GitTag.REPOSITORY_URL] = _filter_sensitive_info(tags.get(GitTag.REPOSITORY_URL))
 
 

--- a/ddtrace/testing/internal/git.py
+++ b/ddtrace/testing/internal/git.py
@@ -26,6 +26,18 @@ class GitTag:
     # Git Branch
     BRANCH = "git.branch"
 
+    # Git Pull Request Base Branch
+    PULL_REQUEST_BASE_BRANCH = "git.pull_request.base_branch"
+
+    # Git Pull Request Base Branch SHA
+    PULL_REQUEST_BASE_BRANCH_SHA = "git.pull_request.base_branch_sha"
+
+    # Git Pull Request Base Branch Head SHA
+    PULL_REQUEST_BASE_BRANCH_HEAD_SHA = "git.pull_request.base_branch_head_sha"
+
+    # Pull Request Number
+    PULL_REQUEST_NUMBER = "pr.number"
+
     # Git Tag
     TAG = "git.tag"
 
@@ -130,7 +142,7 @@ class Git:
     def _git_output(self, args: list[str], telemetry_type: t.Optional[GitTelemetry] = None) -> str:
         result = self._call_git(args)
 
-        if telemetry_type:
+        if telemetry_type and TelemetryAPI._instance is not None:
             TelemetryAPI.get().record_git_command(telemetry_type, result.elapsed_seconds, result.return_code)
 
         if result.return_code != 0:
@@ -277,7 +289,8 @@ class Git:
 
         finally:
             sw.stop()
-            TelemetryAPI.get().record_git_command(GitTelemetry.UNSHALLOW, sw.elapsed(), return_code)
+            if TelemetryAPI._instance is not None:
+                TelemetryAPI.get().record_git_command(GitTelemetry.UNSHALLOW, sw.elapsed(), return_code)
 
     def pack_objects(self, revisions: list[str]) -> t.Iterable[Path]:
         base_name = str(random.randint(1, 1000000))  # nosec: B311
@@ -294,7 +307,10 @@ class Git:
             prefix = f"{output_dir}/{base_name}"
             result = self._call_git(["pack-objects", "--compression=9", "--max-pack-size=3m", prefix], revisions_text)
 
-            TelemetryAPI.get().record_git_command(GitTelemetry.PACK_OBJECTS, result.elapsed_seconds, result.return_code)
+            if TelemetryAPI._instance is not None:
+                TelemetryAPI.get().record_git_command(
+                    GitTelemetry.PACK_OBJECTS, result.elapsed_seconds, result.return_code
+                )
 
             if result.return_code != 0:
                 log.warning("Error calling git pack-objects: %s", result.stderr)
@@ -396,6 +412,8 @@ def get_git_tags_from_dd_variables(env: t.MutableMapping[str, str]) -> dict[str,
         GitTag.REPOSITORY_URL: env.get("_CI_DD_GIT_REPOSITORY_URL") or env.get("DD_GIT_REPOSITORY_URL"),
         GitTag.COMMIT_SHA: env.get("DD_GIT_COMMIT_SHA"),
         GitTag.BRANCH: branch,
+        GitTag.PULL_REQUEST_BASE_BRANCH: normalize_ref(env.get("DD_GIT_PULL_REQUEST_BASE_BRANCH")),
+        GitTag.PULL_REQUEST_BASE_BRANCH_SHA: env.get("DD_GIT_PULL_REQUEST_BASE_BRANCH_SHA"),
         GitTag.TAG: tag,
         GitTag.COMMIT_MESSAGE: env.get("DD_GIT_COMMIT_MESSAGE"),
         GitTag.COMMIT_AUTHOR_DATE: env.get("DD_GIT_COMMIT_AUTHOR_DATE"),

--- a/releasenotes/notes/ci-visibility-provider-pr-metadata-5af55dd9e8a7cf50.yaml
+++ b/releasenotes/notes/ci-visibility-provider-pr-metadata-5af55dd9e8a7cf50.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    CI visibility: This fix resolves issues where CI provider metadata could omit pull request base branch and head commit details or report incorrect pull request values for some providers.

--- a/tests/testing/internal/test_api_client.py
+++ b/tests/testing/internal/test_api_client.py
@@ -1579,7 +1579,7 @@ class TestAPIClientUploadCoverageReport:
         assert event_data["ci.workspace_path"] == "/workspace"
 
     def test_upload_coverage_report_with_pr_number_tag(self, mock_telemetry: Mock) -> None:
-        """Test coverage report upload preserves pr.number tags."""
+        """Test coverage report upload preserves pr.* tags."""
 
         mock_connector = Mock()
         mock_connector.post_files.return_value = BackendResult(response=Mock(status=200))

--- a/tests/testing/internal/test_api_client.py
+++ b/tests/testing/internal/test_api_client.py
@@ -1578,6 +1578,38 @@ class TestAPIClientUploadCoverageReport:
         assert event_data["ci.pipeline.id"] == "123456"
         assert event_data["ci.workspace_path"] == "/workspace"
 
+    def test_upload_coverage_report_with_pr_number_tag(self, mock_telemetry: Mock) -> None:
+        """Test coverage report upload preserves pr.number tags."""
+
+        mock_connector = Mock()
+        mock_connector.post_files.return_value = BackendResult(response=Mock(status=200))
+
+        mock_connector_setup = Mock()
+        mock_connector_setup.get_connector_for_subdomain.return_value = mock_connector
+
+        api_client = APIClient(
+            service="some-service",
+            env="some-env",
+            env_tags={
+                GitTag.REPOSITORY_URL: "http://github.com/DataDog/some-repo.git",
+                GitTag.COMMIT_SHA: "abcd1234",
+                "pr.number": "42",
+            },
+            itr_skipping_level=ITRSkippingLevel.TEST,
+            configurations={},
+            connector_setup=mock_connector_setup,
+            telemetry_api=mock_telemetry,
+        )
+
+        coverage_report = b"SF:test.py\nDA:1,1\nLF:1\nLH:1\nend_of_record\n"
+        api_client.upload_coverage_report(coverage_report, coverage_format="lcov")
+
+        files = mock_connector.post_files.call_args[1]["files"]
+        event_file = files[1]
+        event_data = json.loads(event_file.data.decode("utf-8"))
+
+        assert event_data["pr.number"] == "42"
+
     def test_upload_coverage_report_empty_report(self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture) -> None:
         """Test uploading an empty coverage report."""
         mock_connector = Mock()

--- a/tests/testing/internal/test_env_tags.py
+++ b/tests/testing/internal/test_env_tags.py
@@ -333,3 +333,23 @@ def test_custom_dd_tags(monkeypatch: pytest.MonkeyPatch, git_repo: str) -> None:
 
     assert tags["foo"] == "1"
     assert tags["bar.baz"] == "2"
+
+
+def test_pull_request_base_branch_normalized_when_branch_is_tag(monkeypatch: pytest.MonkeyPatch, git_repo: str) -> None:
+    env = {
+        "APPVEYOR": "true",
+        "APPVEYOR_REPO_PROVIDER": "github",
+        "APPVEYOR_REPO_BRANCH": "refs/heads/main",
+        "APPVEYOR_REPO_TAG_NAME": "refs/tags/v1.2.3",
+        "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH": "refs/tags/v1.2.3",
+    }
+
+    monkeypatch.setattr(os, "environ", env)
+    monkeypatch.chdir(git_repo)
+
+    with mock.patch("ddtrace.testing.internal.git.get_git_tags_from_git_command", return_value={}):
+        tags = get_env_tags()
+
+    assert tags[GitTag.TAG] == "v1.2.3"
+    assert GitTag.BRANCH not in tags
+    assert tags[GitTag.PULL_REQUEST_BASE_BRANCH] == "main"

--- a/tests/tracer/fixtures/ci/appveyor.json
+++ b/tests/tracer/fixtures/ci/appveyor.json
@@ -6,7 +6,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -26,7 +26,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -37,7 +37,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -57,7 +57,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -68,7 +68,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -88,7 +88,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -99,7 +99,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -119,7 +119,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -130,7 +130,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -152,7 +152,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -163,7 +163,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -183,7 +183,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -194,7 +194,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -216,7 +216,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -227,7 +227,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -254,7 +254,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "origin/master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -274,7 +274,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -285,7 +285,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "refs/heads/master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -305,7 +305,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -316,7 +316,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "refs/heads/feature/one",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -336,7 +336,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -346,9 +346,11 @@
       "APPVEYOR_BUILD_FOLDER": "/foo/bar",
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_PULL_REQUEST_HEAD_COMMIT": "724faca55efebf66fc15bfccc34577c64c5480bd",
       "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH": "origin/pr",
+      "APPVEYOR_PULL_REQUEST_NUMBER": "42",
       "APPVEYOR_REPO_BRANCH": "origin/master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -367,9 +369,12 @@
       "git.branch": "pr",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
+      "git.commit.head.sha": "724faca55efebf66fc15bfccc34577c64c5480bd",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
-      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "master",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git",
+      "pr.number": "42"
     }
   ],
   [
@@ -378,9 +383,10 @@
       "APPVEYOR_BUILD_FOLDER": "/foo/bar",
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_PULL_REQUEST_HEAD_COMMIT": "724faca55efebf66fc15bfccc34577c64c5480bd",
       "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH": "refs/heads/pr",
       "APPVEYOR_REPO_BRANCH": "refs/heads/master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -399,8 +405,10 @@
       "git.branch": "pr",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
+      "git.commit.head.sha": "724faca55efebf66fc15bfccc34577c64c5480bd",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "master",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
   ],
@@ -411,7 +419,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "origin/master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -432,7 +440,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git",
       "git.tag": "0.1.0"
     }
@@ -444,7 +452,7 @@
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
       "APPVEYOR_REPO_BRANCH": "refs/heads/master",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -465,7 +473,7 @@
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
       "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
-      "git.commit.sha": "appveyor-repo-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/appveyor-repo-name.git",
       "git.tag": "0.1.0"
     }
@@ -475,7 +483,7 @@
       "APPVEYOR": "true",
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
@@ -516,7 +524,7 @@
       "APPVEYOR": "true",
       "APPVEYOR_BUILD_ID": "appveyor-build-id",
       "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
-      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
       "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",

--- a/tests/tracer/fixtures/ci/awscodepipeline.json
+++ b/tests/tracer/fixtures/ci/awscodepipeline.json
@@ -1,19 +1,9 @@
 [
   [
     {
-      "BUILD_URL": "https://teamcity.com/repo",
-      "TEAMCITY_BUILDCONF_NAME": "Test 1",
-      "TEAMCITY_VERSION": "2022.10 (build 116751)"
-    },
-    {
-      "ci.job.name": "Test 1",
-      "ci.job.url": "https://teamcity.com/repo",
-      "ci.provider.name": "teamcity"
-    }
-  ],
-  [
-    {
-      "BUILD_URL": "https://teamcity.com/repo",
+      "CODEBUILD_BUILD_ARN": "arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19",
+      "CODEBUILD_INITIATOR": "codepipeline/test-pipeline",
+      "DD_ACTION_EXECUTION_ID": "35519dc3-7c45-493c-9ba6-cd78ea11f69d",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
@@ -24,13 +14,13 @@
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
-      "TEAMCITY_BUILDCONF_NAME": "Test 1",
-      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+      "DD_PIPELINE_EXECUTION_ID": "bb1f15ed-fde2-494d-8e13-88785bca9cc0"
     },
     {
-      "ci.job.name": "Test 1",
-      "ci.job.url": "https://teamcity.com/repo",
-      "ci.provider.name": "teamcity",
+      "_dd.ci.env_vars": "{\"CODEBUILD_BUILD_ARN\":\"arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19\",\"DD_PIPELINE_EXECUTION_ID\":\"bb1f15ed-fde2-494d-8e13-88785bca9cc0\",\"DD_ACTION_EXECUTION_ID\":\"35519dc3-7c45-493c-9ba6-cd78ea11f69d\"}",
+      "ci.job.id": "35519dc3-7c45-493c-9ba6-cd78ea11f69d",
+      "ci.pipeline.id": "bb1f15ed-fde2-494d-8e13-88785bca9cc0",
+      "ci.provider.name": "awscodepipeline",
       "git.branch": "user-supplied-branch",
       "git.commit.author.date": "usersupplied-authordate",
       "git.commit.author.email": "usersupplied-authoremail",
@@ -45,7 +35,8 @@
   ],
   [
     {
-      "BUILD_URL": "https://teamcity.com/repo",
+      "CODEBUILD_INITIATOR": "lambdafunction/test-lambda",
+      "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
       "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
@@ -54,15 +45,10 @@
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
-      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
-      "DD_GIT_TAG": "0.0.2",
-      "TEAMCITY_BUILDCONF_NAME": "Test 1",
-      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
-      "ci.job.name": "Test 1",
-      "ci.job.url": "https://teamcity.com/repo",
-      "ci.provider.name": "teamcity",
+      "git.branch": "user-supplied-branch",
       "git.commit.author.date": "usersupplied-authordate",
       "git.commit.author.email": "usersupplied-authoremail",
       "git.commit.author.name": "usersupplied-authorname",
@@ -71,24 +57,7 @@
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
-      "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "git.tag": "0.0.2"
-    }
-  ],
-  [
-    {
-      "BUILD_URL": "https://teamcity.com/repo",
-      "TEAMCITY_BUILDCONF_NAME": "Test 1",
-      "TEAMCITY_PULLREQUEST_NUMBER": "42",
-      "TEAMCITY_PULLREQUEST_TARGET_BRANCH": "target-branch",
-      "TEAMCITY_VERSION": "2022.10 (build 116751)"
-    },
-    {
-      "ci.job.name": "Test 1",
-      "ci.job.url": "https://teamcity.com/repo",
-      "ci.provider.name": "teamcity",
-      "git.pull_request.base_branch": "target-branch",
-      "pr.number": "42"
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/azurepipelines.json
+++ b/tests/tracer/fixtures/ci/azurepipelines.json
@@ -3,12 +3,12 @@
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -18,6 +18,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -29,24 +30,23 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
-      "SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI": "https://azure-pipelines-server-uri.com/pull",
+      "SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI": "https://azure-pipelines-server-uri.com/pull.git",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
       "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
       "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
@@ -54,6 +54,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -65,21 +66,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/pull",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/pull.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -89,6 +89,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -100,21 +101,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar~",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "HOME": "/not-my-home",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
@@ -126,6 +126,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -137,21 +138,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "/foo/~/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "HOME": "/not-my-home",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
@@ -163,6 +163,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -174,21 +175,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "~/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "HOME": "/not-my-home",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
@@ -200,6 +200,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -211,21 +212,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "~foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "HOME": "/not-my-home",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
@@ -237,6 +237,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -248,21 +249,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "~",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "HOME": "/not-my-home",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
@@ -274,6 +274,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -285,21 +286,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -309,6 +309,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -320,21 +321,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "refs/heads/master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -344,6 +344,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -355,21 +356,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "refs/heads/feature/one",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -379,6 +379,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -390,21 +391,20 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/tags/0.1.0",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -414,6 +414,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -424,22 +425,21 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "git.tag": "0.1.0",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git",
+      "git.tag": "0.1.0"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "refs/heads/tags/0.1.0",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
@@ -449,6 +449,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -459,26 +460,25 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commit",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "git.tag": "0.1.0",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git",
+      "git.tag": "0.1.0"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "origin/master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_PULLREQUEST_SOURCEBRANCH": "origin/pr",
-      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "commitPR",
+      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
       "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
       "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
@@ -486,6 +486,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -497,25 +498,24 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commitPR",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "refs/heads/master",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_PULLREQUEST_SOURCEBRANCH": "refs/heads/pr",
-      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "commitPR",
+      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "SYSTEM_STAGEDISPLAYNAME": "azure-pipelines-stage-name",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
       "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
@@ -524,6 +524,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -536,26 +537,25 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commitPR",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build",
+      "BUILD_REPOSITORY_URI": "https://azure-pipelines-server-uri.com/build.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEBRANCH": "refs/heads/feature/one",
       "BUILD_SOURCESDIRECTORY": "/foo/bar",
-      "BUILD_SOURCEVERSION": "commit",
+      "BUILD_SOURCEVERSION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
       "SYSTEM_JOBDISPLAYNAME": "azure-pipelines-job-name",
       "SYSTEM_JOBID": "azure-pipelines-job-id",
       "SYSTEM_PULLREQUEST_SOURCEBRANCH": "refs/heads/pr",
-      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "commitPR",
+      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
       "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
       "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
@@ -563,6 +563,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.name": "azure-pipelines-job-name",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
@@ -575,9 +576,8 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.commit.sha": "commitPR",
-      "git.repository_url": "https://azure-pipelines-server-uri.com/build",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://azure-pipelines-server-uri.com/build.git"
     }
   ],
   [
@@ -605,6 +605,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -620,8 +621,7 @@
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
-      "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ],
   [
@@ -649,6 +649,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -664,15 +665,74 @@
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "git.tag": "0.0.2",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.tag": "0.0.2"
     }
   ],
   [
     {
       "BUILD_BUILDID": "azure-pipelines-build-id",
       "BUILD_DEFINITIONNAME": "azure-pipelines-name",
-      "BUILD_REPOSITORY_URI": "https://user:password@dev.azure.com/fabrikamfiber/",
+      "BUILD_REPOSITORY_URI": "https://dev.azure.com/fabrikamfiber/repo",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://dev.azure.com/fabrikamfiber/repo"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "ssh://host.xz:54321/path/to/repo/",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user:password@dev.azure.com/fabrikamfiber/repo.git",
       "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
       "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
       "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
@@ -684,6 +744,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -693,8 +754,241 @@
       "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
       "git.commit.author.name": "azure-pipelines-commit-author",
       "git.commit.message": "azure-pipelines-commit-message",
-      "git.repository_url": "https://dev.azure.com/fabrikamfiber/",
-      "ci.job.id": "azure-pipelines-job-id"
+      "git.repository_url": "https://dev.azure.com/fabrikamfiber/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user:password@dev.azure.com:1234/fabrikamfiber/repo.git",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://dev.azure.com:1234/fabrikamfiber/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user:password@1.1.1.1:1234/fabrikamfiber/repo.git",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://1.1.1.1:1234/fabrikamfiber/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user:password@1.1.1.1:1234/fabrikamfiber/repo_with_@_yeah.git",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://1.1.1.1:1234/fabrikamfiber/repo_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user@dev.azure.com/fabrikamfiber/repo.git",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://dev.azure.com/fabrikamfiber/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "ssh://user@host.xz:54321/path/to/repo.git/",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "ssh://user:password@host.xz:54321/path/to/repo.git/",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "ssh://user:password@1.1.1.1:54321/path/to/repo.git/",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "ssh://1.1.1.1:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_PULLREQUEST_PULLREQUESTNUMBER": "42",
+      "SYSTEM_PULLREQUEST_TARGETBRANCH": "refs/heads/target-branch",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "https://azure-pipelines-server-uri.com/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
+      "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.pull_request.base_branch": "target-branch",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/bitbucket.json
+++ b/tests/tracer/fixtures/ci/bitbucket.json
@@ -4,8 +4,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -18,8 +18,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -27,8 +27,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -41,8 +41,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -50,7 +50,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_GIT_SSH_ORIGIN": "git@github.com:DataDog/dummy-example.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
@@ -64,7 +65,7 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/dummy-example.git"
     }
   ],
@@ -73,8 +74,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar~",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -87,8 +88,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -96,8 +97,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/~/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -110,8 +111,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -119,8 +120,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "~/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
       "HOME": "/not-my-home",
@@ -135,8 +136,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -144,8 +145,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "~foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -158,8 +159,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -167,8 +168,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "~",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
       "HOME": "/not-my-home",
@@ -183,8 +184,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -192,8 +193,8 @@
       "BITBUCKET_BRANCH": "master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -206,8 +207,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -215,8 +216,8 @@
       "BITBUCKET_BRANCH": "origin/master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -229,8 +230,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -238,8 +239,8 @@
       "BITBUCKET_BRANCH": "refs/heads/master",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -252,8 +253,8 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
@@ -261,8 +262,8 @@
       "BITBUCKET_BRANCH": "refs/heads/feature/one",
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -275,16 +276,16 @@
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git"
     }
   ],
   [
     {
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
       "BITBUCKET_TAG": "origin/tags/0.1.0"
@@ -297,8 +298,8 @@
       "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -306,8 +307,8 @@
     {
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
       "BITBUCKET_CLONE_DIR": "/foo/bar",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
       "BITBUCKET_TAG": "refs/heads/tags/0.1.0"
@@ -320,16 +321,16 @@
       "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
       "ci.provider.name": "bitbucket",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "bitbucket-commit",
-      "git.repository_url": "https://bitbucket-repo-url.com/",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git",
       "git.tag": "0.1.0"
     }
   ],
   [
     {
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
       "DD_GIT_BRANCH": "user-supplied-branch",
@@ -365,8 +366,8 @@
   [
     {
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://bitbucket-repo-url.com/",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
@@ -402,8 +403,48 @@
   [
     {
       "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
-      "BITBUCKET_COMMIT": "bitbucket-commit",
-      "BITBUCKET_GIT_SSH_ORIGIN": "https://user:password@bitbucket.org/DataDog/dogweb.git",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket.org/DataDog/dogweb",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket.org/DataDog/dogweb"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "ssh://host.xz:54321/path/to/repo/",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://user:password@bitbucket.org/DataDog/dogweb.git",
       "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
       "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
     },
@@ -414,8 +455,164 @@
       "ci.pipeline.number": "bitbucket-build-num",
       "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
       "ci.provider.name": "bitbucket",
-      "git.commit.sha": "bitbucket-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://bitbucket.org/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://user@bitbucket.org/DataDog/dogweb.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket.org/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://user:password@bitbucket.org:1234/DataDog/dogweb.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitbucket.org:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://user:password@1.1.1.1/DataDog/dogweb.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://user:password@1.1.1.1:1234/DataDog/dogweb.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://user:password@1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "ssh://user@host.xz:54321/path/to/repo.git/",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "ssh://user:password@host.xz:54321/path/to/repo.git/",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket-repo-url.com/repo.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_PR_DESTINATION_BRANCH": "target-branch",
+      "BITBUCKET_PR_ID": "42",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "git.repository_url": "https://bitbucket-repo-url.com/repo.git",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/bitrise.json
+++ b/tests/tracer/fixtures/ci/bitrise.json
@@ -4,12 +4,12 @@
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
-      "BITRISE_GIT_COMMIT": "gitcommit",
+      "BITRISE_GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -19,8 +19,8 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "gitcommit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -28,11 +28,11 @@
       "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
       "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
       "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
-      "BITRISE_GIT_COMMIT": "gitcommit",
+      "BITRISE_GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_REPOSITORY_URL": "git@github.com:DataDog/dummy-example.git"
     },
     {
@@ -43,7 +43,7 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "gitcommit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/dummy-example.git"
     }
   ],
@@ -56,8 +56,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -68,8 +68,8 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -81,8 +81,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -93,8 +93,8 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -106,8 +106,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar~",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -118,8 +118,8 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -131,8 +131,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/~/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -143,8 +143,8 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -156,8 +156,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "~/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git",
       "HOME": "/not-my-home",
       "USERPROFILE": "/not-my-home"
     },
@@ -170,8 +170,8 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -183,8 +183,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "~foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git",
       "HOME": "/not-my-home",
       "USERPROFILE": "/not-my-home"
     },
@@ -197,8 +197,8 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -210,8 +210,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "~",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git",
       "HOME": "/not-my-home",
       "USERPROFILE": "/not-my-home"
     },
@@ -224,8 +224,8 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -237,8 +237,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -249,8 +249,8 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -262,8 +262,8 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -274,8 +274,8 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git"
     }
   ],
   [
@@ -288,8 +288,8 @@
       "BITRISE_GIT_TAG": "origin/tags/0.1.0",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -299,8 +299,8 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -314,8 +314,8 @@
       "BITRISE_GIT_TAG": "refs/heads/tags/0.1.0",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://bitrise-build-url.com/repo.git"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -325,8 +325,8 @@
       "ci.provider.name": "bitrise",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
-      "git.repository_url": "https://bitrise-build-url.com/",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://bitrise-build-url.com/repo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -339,7 +339,7 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_REPOSITORY_URL": "http://hostname.com/repo.git"
     },
     {
@@ -351,7 +351,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -364,7 +364,7 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_REPOSITORY_URL": "git@hostname.com:org/repo.git"
     },
     {
@@ -376,7 +376,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -389,7 +389,7 @@
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_REPOSITORY_URL": "git@hostname.com:org/repo.git"
     },
     {
@@ -401,7 +401,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "notmaster",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -422,7 +422,7 @@
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -459,7 +459,7 @@
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
       "DD_GIT_TAG": "0.0.2",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit"
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -486,7 +486,51 @@
       "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
       "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
-      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://github.com/DataDog/dogweb"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "ssh://host.xz:54321/path/to/repo/"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git"
     },
     {
@@ -496,8 +540,178 @@
       "ci.pipeline.url": "https://bitrise-build-url.com//",
       "ci.provider.name": "bitrise",
       "git.commit.message": "bitrise-git-commit-message",
-      "git.commit.sha": "bitrise-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://user@github.com/DataDog/dogweb.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://user:password@github.com:1234/DataDog/dogweb.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://user:password@1.1.1.1/DataDog/dogweb.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://user:password@1.1.1.1:1234/DataDog/dogweb.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "https://user:password@1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "ssh://user@host.xz:54321/path/to/repo.git/"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_REPOSITORY_URL": "ssh://user:password@host.xz:54321/path/to/repo.git/"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BITRISEIO_GIT_BRANCH_DEST": "target-branch",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "https://bitrise-build-url.com//",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_PULL_REQUEST": "42",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "https://bitrise-build-url.com//",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/buddy.json
+++ b/tests/tracer/fixtures/ci/buddy.json
@@ -4,7 +4,7 @@
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "master",
       "BUDDY_EXECUTION_ID": "buddy-execution-id",
-      "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
       "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
@@ -12,7 +12,7 @@
       "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "BUDDY_PIPELINE_ID": "456",
       "BUDDY_PIPELINE_NAME": "Deploy to Production",
-      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project"
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project.git"
     },
     {
       "ci.pipeline.id": "456/buddy-execution-id",
@@ -24,8 +24,8 @@
       "git.commit.committer.email": "mikebenson@buddy.works",
       "git.commit.committer.name": "Mike Benson",
       "git.commit.message": "Create buddy.yml",
-      "git.commit.sha": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
-      "git.repository_url": "https://github.com/buddyworks/my-project",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/buddyworks/my-project.git",
       "git.tag": "v1.0"
     }
   ],
@@ -34,7 +34,7 @@
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "my-name-is-rotag/fix-original-bug",
       "BUDDY_EXECUTION_ID": "buddy-execution-id",
-      "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
       "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
@@ -42,7 +42,7 @@
       "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "BUDDY_PIPELINE_ID": "456",
       "BUDDY_PIPELINE_NAME": "Deploy to Production",
-      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project"
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project.git"
     },
     {
       "ci.pipeline.id": "456/buddy-execution-id",
@@ -54,8 +54,8 @@
       "git.commit.committer.email": "mikebenson@buddy.works",
       "git.commit.committer.name": "Mike Benson",
       "git.commit.message": "Create buddy.yml",
-      "git.commit.sha": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
-      "git.repository_url": "https://github.com/buddyworks/my-project",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/buddyworks/my-project.git",
       "git.tag": "v1.0"
     }
   ],
@@ -64,7 +64,7 @@
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "refs/heads/feature/one",
       "BUDDY_EXECUTION_ID": "buddy-execution-id",
-      "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
       "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
@@ -72,7 +72,7 @@
       "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "BUDDY_PIPELINE_ID": "456",
       "BUDDY_PIPELINE_NAME": "Deploy to Production",
-      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project"
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project.git"
     },
     {
       "ci.pipeline.id": "456/buddy-execution-id",
@@ -84,8 +84,8 @@
       "git.commit.committer.email": "mikebenson@buddy.works",
       "git.commit.committer.name": "Mike Benson",
       "git.commit.message": "Create buddy.yml",
-      "git.commit.sha": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
-      "git.repository_url": "https://github.com/buddyworks/my-project",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/buddyworks/my-project.git",
       "git.tag": "0.2.0"
     }
   ],
@@ -94,7 +94,7 @@
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "master",
       "BUDDY_EXECUTION_ID": "buddy-execution-id",
-      "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
       "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
@@ -102,7 +102,7 @@
       "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "BUDDY_PIPELINE_ID": "456",
       "BUDDY_PIPELINE_NAME": "Deploy to Production",
-      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project",
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project.git",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
@@ -139,7 +139,7 @@
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "master",
       "BUDDY_EXECUTION_ID": "buddy-execution-id",
-      "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
       "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
@@ -147,7 +147,7 @@
       "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "BUDDY_PIPELINE_ID": "456",
       "BUDDY_PIPELINE_NAME": "Deploy to Production",
-      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project",
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project.git",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
@@ -176,6 +176,342 @@
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/buddyworks/my-project",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "ssh://host.xz:54321/path/to/repo/",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://user:password@github.com/buddyworks/my-project.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/buddyworks/my-project.git",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://user@github.com/buddyworks/my-project.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/buddyworks/my-project.git",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://user:password@github.com:1234/buddyworks/my-project.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/buddyworks/my-project.git",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://user:password@1.1.1.1/buddyworks/my-project.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/buddyworks/my-project.git",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://user:password@1.1.1.1:1234/buddyworks/my-project.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/buddyworks/my-project.git",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "https://user:password@1.1.1.1:1234/buddyworks/my-project_with_@_yeah.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/buddyworks/my-project_with_@_yeah.git",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "ssh://user@host.xz:54321/path/to/repo.git/"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_SCM_URL": "ssh://user:password@host.xz:54321/path/to/repo.git/"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/",
+      "git.tag": "v1.0"
+    }
+  ],
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
+      "BUDDY_EXECUTION_REVISION": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_RUN_PR_BASE_BRANCH": "target-branch",
+      "BUDDY_RUN_PR_NO": "42",
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project.git"
+    },
+    {
+      "ci.pipeline.id": "456/buddy-execution-id",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "buddy-execution-id",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.branch": "master",
+      "git.commit.committer.email": "mikebenson@buddy.works",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "git.repository_url": "https://github.com/buddyworks/my-project.git",
+      "git.tag": "v1.0",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/buildkite.json
+++ b/tests/tracer/fixtures/ci/buildkite.json
@@ -9,15 +9,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -29,9 +32,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -44,15 +46,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -64,9 +69,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -79,15 +83,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -99,9 +106,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -114,15 +120,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -134,9 +143,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -149,10 +157,12 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": "",
       "HOME": "/not-my-home",
@@ -160,6 +170,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -171,9 +182,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -186,10 +196,12 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": "",
       "HOME": "/not-my-home",
@@ -197,6 +209,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -208,9 +221,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -223,10 +235,12 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": "",
       "HOME": "/not-my-home",
@@ -234,6 +248,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -245,9 +260,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -260,15 +274,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://user@hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -280,9 +297,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -295,15 +311,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://user%E2%82%AC@hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -315,9 +334,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -330,15 +348,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://user:pwd@hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -350,9 +371,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -365,15 +385,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "git@hostname.com:org/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -385,9 +408,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "git@hostname.com:org/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
   [
@@ -400,15 +422,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -420,9 +445,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -435,15 +459,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -455,9 +482,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -470,15 +496,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -490,9 +519,8 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -505,15 +533,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": "0.1.0"
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -524,10 +555,9 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git",
-      "git.tag": "0.1.0",
-      "ci.job.id": "buildkite-job-id"
+      "git.tag": "0.1.0"
     }
   ],
   [
@@ -540,15 +570,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": "origin/tags/0.1.0"
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -559,10 +592,9 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git",
-      "git.tag": "0.1.0",
-      "ci.job.id": "buildkite-job-id"
+      "git.tag": "0.1.0"
     }
   ],
   [
@@ -575,15 +607,18 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_REPO": "http://hostname.com/repo.git",
       "BUILDKITE_TAG": "refs/heads/tags/0.1.0"
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -594,10 +629,9 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git",
-      "git.tag": "0.1.0",
-      "ci.job.id": "buildkite-job-id"
+      "git.tag": "0.1.0"
     }
   ],
   [
@@ -609,10 +643,12 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_TAG": "",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
@@ -627,6 +663,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -642,8 +679,7 @@
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
-      "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ],
   [
@@ -655,10 +691,12 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_TAG": "",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
@@ -673,6 +711,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -688,8 +727,7 @@
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "git.tag": "0.0.2",
-      "ci.job.id": "buildkite-job-id"
+      "git.tag": "0.0.2"
     }
   ],
   [
@@ -701,15 +739,19 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
-      "BUILDKITE_REPO": "https://user:password@github.com/DataDog/dogweb.git",
-      "BUILDKITE_TAG": ""
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://github.com/DataDog/dogweb",
+      "BUILDKITE_TAG": "",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix"
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -719,9 +761,315 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "git.repository_url": "https://github.com/DataDog/dogweb.git",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "ssh://host.xz:54321/path/to/repo/",
+      "BUILDKITE_TAG": "",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix"
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://user:password@github.com/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://user@github.com/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://user:password@github.com:1234/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://user:password@1.1.1.1/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://user:password@1.1.1.1:1234/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "https://user:password@1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "ssh://user@host.xz:54321/path/to/repo.git/",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
+      "BUILDKITE_REPO": "ssh://user:password@host.xz:54321/path/to/repo.git/",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
     }
   ],
   [
@@ -736,14 +1084,17 @@
       "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
       "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
       "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
-      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "BUILDKITE_JOB_ID": "buildkite-job-id",
       "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
       "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "false",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "",
       "BUILDKITE_TAG": ""
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.node.labels": "[\"mytag:my-value\",\"myothertag:my-other-value\"]",
       "ci.node.name": "1a222222-e999-3636-8ddd-802222222222",
@@ -755,8 +1106,41 @@
       "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
       "git.commit.author.name": "buildkite-git-commit-author-name",
       "git.commit.message": "buildkite-git-commit-message",
-      "git.commit.sha": "buildkite-git-commit",
-      "ci.job.id": "buildkite-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "https://buildkite-build-url.com",
+      "BUILDKITE_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_PULL_REQUEST": "42",
+      "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "master",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
+      "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "https://buildkite-build-url.com",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "master",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/circleci.json
+++ b/tests/tracer/fixtures/ci/circleci.json
@@ -7,13 +7,14 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -22,8 +23,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -34,13 +35,14 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -49,8 +51,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -61,13 +63,14 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar~"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -76,8 +79,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -88,13 +91,14 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/~/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -103,8 +107,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -115,8 +119,8 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "~/foo/bar",
       "HOME": "/not-my-home",
@@ -124,6 +128,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -132,8 +137,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -144,8 +149,8 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "~foo/bar",
       "HOME": "/not-my-home",
@@ -153,6 +158,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -161,8 +167,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -173,8 +179,8 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "~",
       "HOME": "/not-my-home",
@@ -182,6 +188,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -190,8 +197,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -202,13 +209,14 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -217,8 +225,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -229,13 +237,14 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -244,8 +253,8 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git"
     }
   ],
   [
@@ -256,14 +265,15 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_TAG": "origin/tags/0.1.0",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -271,8 +281,8 @@
       "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -284,14 +294,15 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_REPOSITORY_URL": "https://circleci-build-url.com/repo.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_TAG": "refs/heads/tags/0.1.0",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -299,8 +310,8 @@
       "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "circleci-git-commit",
-      "git.repository_url": "https://circleci-build-url.com/",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://circleci-build-url.com/repo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -313,12 +324,13 @@
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://hostname.com/repo.git",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -327,7 +339,7 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -340,12 +352,13 @@
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://user@hostname.com/repo.git",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -354,7 +367,7 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -367,12 +380,13 @@
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://user%E2%82%AC@hostname.com/repo.git",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -381,7 +395,7 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -394,12 +408,13 @@
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://user:pwd@hostname.com/repo.git",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -408,7 +423,7 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -421,12 +436,13 @@
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "git@hostname.com:org/repo.git",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -435,7 +451,7 @@
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "circleci-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -446,7 +462,7 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
@@ -461,6 +477,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -486,7 +503,7 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
@@ -501,6 +518,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -526,20 +544,263 @@
       "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
       "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
-      "CIRCLE_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git",
-      "CIRCLE_SHA1": "circleci-git-commit",
-      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+      "CIRCLE_REPOSITORY_URL": "https://github.com/DataDog/dogweb",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix"
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
       "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
-      "git.commit.sha": "circleci-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "ssh://host.xz:54321/path/to/repo/",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user@github.com/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@github.com:1234/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@1.1.1.1/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@1.1.1.1:1234/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "ssh://user@host.xz:54321/path/to/repo.git/",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "ssh://user:password@host.xz:54321/path/to/repo.git/",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "https://circleci-build-url.com/",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_PR_NUMBER": "42",
+      "CIRCLE_SHA1": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "https://circleci-build-url.com/",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/codefresh.json
+++ b/tests/tracer/fixtures/ci/codefresh.json
@@ -158,5 +158,25 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_PULL_REQUEST_NUMBER": "42",
+      "CF_PULL_REQUEST_TARGET": "target-branch",
+      "CF_STEP_NAME": "mah-job-name"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.pull_request.base_branch": "target-branch",
+      "pr.number": "42"
+    }
   ]
 ]

--- a/tests/tracer/fixtures/ci/drone.json
+++ b/tests/tracer/fixtures/ci/drone.json
@@ -1,0 +1,72 @@
+[
+  [
+    {
+      "CI": "true",
+      "DRONE": "true",
+      "DRONE_BRANCH": "master",
+      "DRONE_BUILD_LINK": "https://drone.company.com/octocat/hello-world/42",
+      "DRONE_BUILD_NUMBER": "build-number",
+      "DRONE_COMMIT_AUTHOR_EMAIL": "octocat@github.com",
+      "DRONE_COMMIT_AUTHOR_NAME": "The Octocat",
+      "DRONE_COMMIT_MESSAGE": "Updated README.md",
+      "DRONE_COMMIT_SHA": "bcdd4bf0245c82c060407b3b24b9b87301d15ac1",
+      "DRONE_GIT_HTTP_URL": "https://github.com/octocat/hello-world.git",
+      "DRONE_STAGE_NAME": "build",
+      "DRONE_STEP_NAME": "build_backend",
+      "DRONE_TAG": "v1.0.0",
+      "DRONE_WORKSPACE": "/foo/bar/jenkins/hello-world-job"
+    },
+    {
+      "ci.job.name": "build_backend",
+      "ci.pipeline.number": "build-number",
+      "ci.pipeline.url": "https://drone.company.com/octocat/hello-world/42",
+      "ci.provider.name": "drone",
+      "ci.stage.name": "build",
+      "ci.workspace_path": "/foo/bar/jenkins/hello-world-job",
+      "git.branch": "master",
+      "git.commit.author.email": "octocat@github.com",
+      "git.commit.author.name": "The Octocat",
+      "git.commit.message": "Updated README.md",
+      "git.commit.sha": "bcdd4bf0245c82c060407b3b24b9b87301d15ac1",
+      "git.repository_url": "https://github.com/octocat/hello-world.git",
+      "git.tag": "v1.0.0"
+    }
+  ],
+  [
+    {
+      "CI": "true",
+      "DRONE": "true",
+      "DRONE_BRANCH": "master",
+      "DRONE_BUILD_LINK": "https://drone.company.com/octocat/hello-world/42",
+      "DRONE_BUILD_NUMBER": "build-number",
+      "DRONE_COMMIT_AUTHOR_EMAIL": "octocat@github.com",
+      "DRONE_COMMIT_AUTHOR_NAME": "The Octocat",
+      "DRONE_COMMIT_MESSAGE": "Updated README.md",
+      "DRONE_COMMIT_SHA": "bcdd4bf0245c82c060407b3b24b9b87301d15ac1",
+      "DRONE_GIT_HTTP_URL": "https://github.com/octocat/hello-world.git",
+      "DRONE_PULL_REQUEST": "42",
+      "DRONE_STAGE_NAME": "build",
+      "DRONE_STEP_NAME": "build_backend",
+      "DRONE_TAG": "v1.0.0",
+      "DRONE_TARGET_BRANCH": "target-branch",
+      "DRONE_WORKSPACE": "/foo/bar/jenkins/hello-world-job"
+    },
+    {
+      "ci.job.name": "build_backend",
+      "ci.pipeline.number": "build-number",
+      "ci.pipeline.url": "https://drone.company.com/octocat/hello-world/42",
+      "ci.provider.name": "drone",
+      "ci.stage.name": "build",
+      "ci.workspace_path": "/foo/bar/jenkins/hello-world-job",
+      "git.branch": "master",
+      "git.commit.author.email": "octocat@github.com",
+      "git.commit.author.name": "The Octocat",
+      "git.commit.message": "Updated README.md",
+      "git.commit.sha": "bcdd4bf0245c82c060407b3b24b9b87301d15ac1",
+      "git.pull_request.base_branch": "target-branch",
+      "git.repository_url": "https://github.com/octocat/hello-world.git",
+      "git.tag": "v1.0.0",
+      "pr.number": "42"
+    }
+  ]
+]

--- a/tests/tracer/fixtures/ci/github.json
+++ b/tests/tracer/fixtures/ci/github.json
@@ -5,25 +5,28 @@
       "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://ghenterprise.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://ghenterprise.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://ghenterprise.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://ghenterprise.com/ghactions-repo/actions/runs/ghactions-pipeline-id",
+      "ci.pipeline.url": "https://ghenterprise.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://ghenterprise.com/ghactions-repo.git"
     }
   ],
@@ -37,14 +40,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -52,7 +57,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -66,14 +71,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "foo/bar"
+      "GITHUB_WORKSPACE": "foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -81,7 +88,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -95,14 +102,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar~"
+      "GITHUB_WORKSPACE": "/foo/bar~",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -110,7 +119,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -124,14 +133,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/~/bar"
+      "GITHUB_WORKSPACE": "/foo/~/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -139,7 +150,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -153,16 +164,18 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
       "GITHUB_WORKSPACE": "~/foo/bar",
       "HOME": "/not-my-home",
+      "JOB_CHECK_RUN_ID": "123456",
       "USERPROFILE": "/not-my-home"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -170,7 +183,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -184,16 +197,18 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
       "GITHUB_WORKSPACE": "~foo/bar",
       "HOME": "/not-my-home",
+      "JOB_CHECK_RUN_ID": "123456",
       "USERPROFILE": "/not-my-home"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -201,7 +216,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -215,16 +230,18 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
       "GITHUB_WORKSPACE": "~",
       "HOME": "/not-my-home",
+      "JOB_CHECK_RUN_ID": "123456",
       "USERPROFILE": "/not-my-home"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -232,7 +249,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -246,14 +263,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -261,7 +280,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -275,14 +294,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -290,7 +311,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -304,14 +325,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -319,7 +342,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -333,190 +356,24 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
       "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.tag": "0.1.0"
-    }
-  ],
-  [
-    {
-      "GITHUB_ACTION": "run",
-      "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "origin/tags/0.1.0",
-      "GITHUB_REPOSITORY": "ghactions-repo",
-      "GITHUB_RUN_ID": "ghactions-pipeline-id",
-      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
-      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
-    },
-    {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
-      "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
-      "ci.pipeline.id": "ghactions-pipeline-id",
-      "ci.pipeline.name": "ghactions-pipeline-name",
-      "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id",
-      "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.tag": "0.1.0"
-    }
-  ],
-  [
-    {
-      "GITHUB_ACTION": "run",
-      "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "origin/tags/0.1.0",
-      "GITHUB_REPOSITORY": "ghactions-repo",
-      "GITHUB_RUN_ID": "ghactions-pipeline-id",
-      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://user:password@github.com",
-      "GITHUB_SHA": "ghactions-commit",
-      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
-    },
-    {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
-      "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
-      "ci.pipeline.id": "ghactions-pipeline-id",
-      "ci.pipeline.name": "ghactions-pipeline-name",
-      "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id",
-      "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.tag": "0.1.0"
-    }
-  ],
-  [
-    {
-      "GITHUB_ACTION": "run",
-      "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "origin/tags/0.1.0",
-      "GITHUB_REPOSITORY": "ghactions-repo",
-      "GITHUB_RUN_ID": "ghactions-pipeline-id",
-      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://user@github.com",
-      "GITHUB_SHA": "ghactions-commit",
-      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
-    },
-    {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
-      "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
-      "ci.pipeline.id": "ghactions-pipeline-id",
-      "ci.pipeline.name": "ghactions-pipeline-name",
-      "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id",
-      "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.tag": "0.1.0"
-    }
-  ],
-  [
-    {
-      "GITHUB_ACTION": "run",
-      "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "origin/tags/0.1.0",
-      "GITHUB_REPOSITORY": "ghactions-repo",
-      "GITHUB_RUN_ID": "ghactions-pipeline-id",
-      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://user:password@github.com:1234",
-      "GITHUB_SHA": "ghactions-commit",
-      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
-    },
-    {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
-      "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com:1234/ghactions-repo/commit/ghactions-commit/checks",
-      "ci.pipeline.id": "ghactions-pipeline-id",
-      "ci.pipeline.name": "ghactions-pipeline-name",
-      "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://github.com:1234/ghactions-repo/actions/runs/ghactions-pipeline-id",
-      "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://github.com:1234/ghactions-repo.git",
-      "git.tag": "0.1.0"
-    }
-  ],
-  [
-    {
-      "GITHUB_ACTION": "run",
-      "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "origin/tags/0.1.0",
-      "GITHUB_REPOSITORY": "ghactions-repo",
-      "GITHUB_RUN_ID": "ghactions-pipeline-id",
-      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://user:password@1.1.1.1",
-      "GITHUB_SHA": "ghactions-commit",
-      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
-    },
-    {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
-      "ci.job.name": "github-job-name",
-      "ci.job.url": "https://1.1.1.1/ghactions-repo/commit/ghactions-commit/checks",
-      "ci.pipeline.id": "ghactions-pipeline-id",
-      "ci.pipeline.name": "ghactions-pipeline-name",
-      "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://1.1.1.1/ghactions-repo/actions/runs/ghactions-pipeline-id",
-      "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://1.1.1.1/ghactions-repo.git",
-      "git.tag": "0.1.0"
-    }
-  ],
-  [
-    {
-      "GITHUB_ACTION": "run",
-      "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "origin/tags/0.1.0",
-      "GITHUB_REPOSITORY": "ghactions-repo",
-      "GITHUB_RUN_ID": "ghactions-pipeline-id",
-      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://user:password@1.1.1.1:1234",
-      "GITHUB_SHA": "ghactions-commit",
-      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
-    },
-    {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
-      "ci.job.name": "github-job-name",
-      "ci.job.url": "https://1.1.1.1:1234/ghactions-repo/commit/ghactions-commit/checks",
-      "ci.pipeline.id": "ghactions-pipeline-id",
-      "ci.pipeline.name": "ghactions-pipeline-name",
-      "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://1.1.1.1:1234/ghactions-repo/actions/runs/ghactions-pipeline-id",
-      "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://1.1.1.1:1234/ghactions-repo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -530,21 +387,23 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
       "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git",
       "git.tag": "0.1.0"
     }
@@ -560,14 +419,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -575,7 +436,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "other",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -590,14 +451,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -605,7 +468,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "other",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -620,14 +483,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar"
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -635,7 +500,7 @@
       "ci.provider.name": "github",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/other",
-      "git.commit.sha": "ghactions-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ],
@@ -658,14 +523,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "foo/bar"
+      "GITHUB_WORKSPACE": "foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -703,14 +570,16 @@
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
       "GITHUB_SERVER_URL": "https://github.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "foo/bar"
+      "GITHUB_WORKSPACE": "foo/bar",
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
@@ -733,30 +602,190 @@
     {
       "GITHUB_ACTION": "run",
       "GITHUB_JOB": "github-job-name",
-      "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
       "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
-      "GITHUB_SERVER_URL": "https://ghenterprise.com",
-      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_SERVER_URL": "https://github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GITHUB_WORKFLOW": "ghactions-pipeline-name",
-      "GITHUB_WORKSPACE": "/foo/bar",
-      "JOB_ID": "custom-job-id-123"
+      "JOB_CHECK_RUN_ID": "123456"
     },
     {
-      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+      "ci.job.id": "123456",
       "ci.job.name": "github-job-name",
-      "ci.job.url": "https://ghenterprise.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
       "ci.pipeline.number": "ghactions-pipeline-number",
-      "ci.pipeline.url": "https://ghenterprise.com/ghactions-repo/actions/runs/ghactions-pipeline-id",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id",
       "ci.provider.name": "github",
-      "ci.workspace_path": "/foo/bar",
-      "git.branch": "master",
-      "git.commit.sha": "ghactions-commit",
-      "git.repository_url": "https://ghenterprise.com/ghactions-repo.git",
-      "ci.job.id": "custom-job-id-123"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://user:password@github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "JOB_CHECK_RUN_ID": "123456"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://user@github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "JOB_CHECK_RUN_ID": "123456"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://user:password@github.com:1234",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "JOB_CHECK_RUN_ID": "123456"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com:1234/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com:1234/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://user:password@1.1.1.1",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "JOB_CHECK_RUN_ID": "123456"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://1.1.1.1/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://1.1.1.1/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://user:password@1.1.1.1:1234",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "JOB_CHECK_RUN_ID": "123456"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://1.1.1.1:1234/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://1.1.1.1:1234/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_BASE_REF": "target-branch",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "JOB_CHECK_RUN_ID": "123456"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "123456",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/123456",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/gitlab.json
+++ b/tests/tracer/fixtures/ci/gitlab.json
@@ -4,7 +4,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -21,6 +21,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -35,9 +36,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -45,7 +45,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -62,6 +62,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -76,9 +77,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -86,7 +86,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -103,6 +103,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -117,9 +118,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -127,7 +127,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -146,6 +146,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -160,9 +161,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -170,7 +170,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -189,6 +189,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -203,9 +204,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -213,7 +213,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -232,6 +232,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -246,9 +247,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -256,7 +256,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "refs/heads/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -273,6 +273,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -287,9 +288,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -297,7 +297,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "refs/heads/feature/one",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -314,6 +314,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -328,9 +329,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
     }
   ],
   [
@@ -338,7 +338,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TAG": "origin/tags/0.1.0",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
@@ -356,6 +356,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -370,10 +371,9 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "git.tag": "0.1.0",
-      "ci.job.id": "gitlab-job-id"
+      "git.tag": "0.1.0"
     }
   ],
   [
@@ -381,7 +381,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TAG": "refs/heads/tags/0.1.0",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
@@ -399,6 +399,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -413,10 +414,9 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "git.tag": "0.1.0",
-      "ci.job.id": "gitlab-job-id"
+      "git.tag": "0.1.0"
     }
   ],
   [
@@ -424,7 +424,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TAG": "0.1.0",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
@@ -442,6 +442,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -456,10 +457,9 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "git.tag": "0.1.0",
-      "ci.job.id": "gitlab-job-id"
+      "git.tag": "0.1.0"
     }
   ],
   [
@@ -467,7 +467,91 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "http://hostname.com/repo",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "ssh://host.xz:54321/path/to/repo/",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -484,6 +568,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -498,9 +583,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -508,7 +592,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -525,6 +609,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -539,9 +624,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -549,7 +633,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -566,6 +650,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -580,9 +665,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -590,7 +674,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -607,6 +691,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -621,9 +706,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "http://hostname.com/repo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
   [
@@ -631,7 +715,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -648,6 +732,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -662,9 +747,8 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "git@hostname.com:org/repo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
   [
@@ -672,7 +756,171 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "http://user:pwd@hostname.com:1234/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://hostname.com:1234/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "http://user:pwd@1.1.1.1/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://1.1.1.1/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "http://user:pwd@1.1.1.1:1234/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://1.1.1.1:1234/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "http://user:pwd@1.1.1.1:1234/repo_with_@_yeah.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "http://1.1.1.1:1234/repo_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -699,6 +947,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -717,8 +966,7 @@
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
-      "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ],
   [
@@ -726,7 +974,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -753,6 +1001,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -772,8 +1021,7 @@
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
-      "git.tag": "0.0.2",
-      "ci.job.id": "gitlab-job-id"
+      "git.tag": "0.0.2"
     }
   ],
   [
@@ -781,48 +1029,7 @@
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
-      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
-      "CI_JOB_ID": "gitlab-job-id",
-      "CI_JOB_NAME": "gitlab-job-name",
-      "CI_JOB_STAGE": "gitlab-stage-name",
-      "CI_JOB_URL": "https://gitlab.com/job",
-      "CI_PIPELINE_ID": "gitlab-pipeline-id",
-      "CI_PIPELINE_IID": "gitlab-pipeline-number",
-      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
-      "CI_PROJECT_DIR": "/foo/bar",
-      "CI_PROJECT_PATH": "gitlab-pipeline-name",
-      "CI_PROJECT_URL": "https://gitlab.com/repo",
-      "CI_REPOSITORY_URL": "https://user:password@gitlab.com/DataDog/dogweb.git",
-      "GITLAB_CI": "gitlab"
-    },
-    {
-      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
-      "ci.job.name": "gitlab-job-name",
-      "ci.job.url": "https://gitlab.com/job",
-      "ci.pipeline.id": "gitlab-pipeline-id",
-      "ci.pipeline.name": "gitlab-pipeline-name",
-      "ci.pipeline.number": "gitlab-pipeline-number",
-      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
-      "ci.provider.name": "gitlab",
-      "ci.stage.name": "gitlab-stage-name",
-      "ci.workspace_path": "/foo/bar",
-      "git.branch": "master",
-      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
-      "git.commit.author.email": "john@doe.com",
-      "git.commit.author.name": "John Doe",
-      "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.repository_url": "https://gitlab.com/DataDog/dogweb.git",
-      "ci.job.id": "gitlab-job-id"
-    }
-  ],
-  [
-    {
-      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
-      "CI_COMMIT_REF_NAME": "origin/master",
-      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_ID": "gitlab-job-id",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -841,6 +1048,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.node.labels": "[\"arch:arm64\",\"linux\"]",
@@ -857,9 +1065,57 @@
       "git.commit.author.email": "john@doe.com",
       "git.commit.author.name": "John Doe",
       "git.commit.message": "gitlab-git-commit-message",
-      "git.commit.sha": "gitlab-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://gitlab.com/repo/myrepo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
+      "CI_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "https://gitlab.com/job",
+      "CI_MERGE_REQUEST_DIFF_BASE_SHA": "bf6c156e8c1ec9cf43239162bca38cad22a3f4d2",
+      "CI_MERGE_REQUEST_IID": "42",
+      "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "target-branch",
+      "CI_MERGE_REQUEST_TARGET_BRANCH_SHA": "eb6dda23983998409db832ad675ec18ec32a8205",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "https://gitlab.com/repo",
+      "CI_REPOSITORY_URL": "https://gitlab.com/repo/myrepo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "https://gitlab.com/job",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/-/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "git.pull_request.base_branch_head_sha": "eb6dda23983998409db832ad675ec18ec32a8205",
+      "git.pull_request.base_branch_sha": "bf6c156e8c1ec9cf43239162bca38cad22a3f4d2",
       "git.repository_url": "https://gitlab.com/repo/myrepo.git",
-      "ci.job.id": "gitlab-job-id"
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/jenkins.json
+++ b/tests/tracer/fixtures/ci/jenkins.json
@@ -6,9 +6,9 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL_1": "https://jenkins.com/repo/sample",
-      "GIT_URL_2": "https://jenkins.com/repo/otherSample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://jenkins.com/repo/sample.git",
+      "GIT_URL_2": "https://jenkins.com/repo/otherSample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job"
@@ -21,8 +21,8 @@
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -32,8 +32,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job"
@@ -46,8 +46,8 @@
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -57,8 +57,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job"
@@ -71,8 +71,8 @@
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -82,8 +82,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job",
@@ -98,8 +98,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -109,8 +109,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job",
@@ -125,8 +125,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -136,8 +136,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job",
@@ -152,8 +152,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -163,8 +163,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "HOME": "/not-my-home",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -181,8 +181,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -192,8 +192,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "HOME": "/not-my-home",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -210,8 +210,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -221,8 +221,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "HOME": "/not-my-home",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -239,8 +239,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -250,8 +250,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
       "JOB_URL": "https://jenkins.com/job",
@@ -266,8 +266,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -277,8 +277,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "refs/heads/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName/master",
       "JOB_URL": "https://jenkins.com/job",
@@ -293,8 +293,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -304,8 +304,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "refs/heads/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName/another",
       "JOB_URL": "https://jenkins.com/job",
@@ -320,8 +320,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -331,8 +331,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "refs/heads/feature/one",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName/feature/one",
       "JOB_URL": "https://jenkins.com/job",
@@ -347,8 +347,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -358,8 +358,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "refs/heads/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName/KEY1=VALUE1,KEY2=VALUE2",
       "JOB_URL": "https://jenkins.com/job",
@@ -374,8 +374,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -385,8 +385,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "refs/heads/master",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName/KEY1=VALUE1,KEY2=VALUE2/master",
       "JOB_URL": "https://jenkins.com/job",
@@ -401,8 +401,8 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git"
     }
   ],
   [
@@ -412,8 +412,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/tags/0.1.0",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_URL": "https://jenkins.com/job",
       "WORKSPACE": "/foo/bar"
@@ -425,8 +425,8 @@
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -437,8 +437,8 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "refs/heads/tags/0.1.0",
-      "GIT_COMMIT": "jenkins-git-commit",
-      "GIT_URL": "https://jenkins.com/repo/sample",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL": "https://jenkins.com/repo/sample.git",
       "JENKINS_URL": "jenkins",
       "JOB_URL": "https://jenkins.com/job",
       "WORKSPACE": "/foo/bar"
@@ -450,8 +450,8 @@
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.repository_url": "https://jenkins.com/repo/sample",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://jenkins.com/repo/sample.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -462,7 +462,7 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_URL": "http://hostname.com/repo.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -478,7 +478,7 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -489,7 +489,7 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_URL": "http://user@hostname.com/repo.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -505,7 +505,7 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -516,7 +516,7 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_URL": "http://user%E2%82%AC@hostname.com/repo.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -532,7 +532,7 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -543,7 +543,7 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_URL": "http://user:pwd@hostname.com/repo.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -559,7 +559,7 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "http://hostname.com/repo.git"
     }
   ],
@@ -570,7 +570,7 @@
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
       "GIT_BRANCH": "origin/master",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_URL": "git@hostname.com:org/repo.git",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",
@@ -586,7 +586,7 @@
       "ci.provider.name": "jenkins",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
-      "git.commit.sha": "jenkins-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@hostname.com:org/repo.git"
     }
   ],
@@ -606,7 +606,7 @@
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "JENKINS_URL": "jenkins",
       "JOB_URL": "https://jenkins.com/job"
     },
@@ -644,7 +644,7 @@
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
       "DD_GIT_TAG": "0.0.2",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "JENKINS_URL": "jenkins",
       "JOB_URL": "https://jenkins.com/job"
     },
@@ -672,7 +672,51 @@
       "BUILD_TAG": "jenkins-pipeline-id",
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://github.com/DataDog/dogweb",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "ssh://host.xz:54321/path/to/repo/",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "GIT_URL_1": "https://user:password@github.com/DataDog/dogweb.git",
       "JENKINS_URL": "jenkins",
       "JOB_URL": "https://jenkins.com/job"
@@ -683,7 +727,7 @@
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
-      "git.commit.sha": "jenkins-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/DataDog/dogweb.git"
     }
   ],
@@ -693,7 +737,154 @@
       "BUILD_TAG": "jenkins-pipeline-id",
       "BUILD_URL": "https://jenkins.com/pipeline",
       "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
-      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://user@github.com/DataDog/dogweb.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://user:password@github.com:1234/DataDog/dogweb.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://user:password@1.1.1.1/DataDog/dogweb.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://user:password@1.1.1.1:1234/DataDog/dogweb.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "https://user:password@1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "ssh://user@host.xz:54321/path/to/repo.git/",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GIT_URL_1": "ssh://user:password@host.xz:54321/path/to/repo.git/",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "JENKINS_URL": "jenkins",
       "JOB_URL": "https://jenkins.com/job",
       "NODE_LABELS": "built-in linux",
@@ -707,7 +898,30 @@
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "https://jenkins.com/pipeline",
       "ci.provider.name": "jenkins",
-      "git.commit.sha": "jenkins-git-commit"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "https://jenkins.com/pipeline",
+      "CHANGE_ID": "42",
+      "CHANGE_TARGET": "target-branch",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "https://jenkins.com/job"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "https://jenkins.com/pipeline",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/travisci.json
+++ b/tests/tracer/fixtures/ci/travisci.json
@@ -7,9 +7,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo",
       "TRAVIS_TAG": "origin/tags/0.1.0"
     },
@@ -22,7 +23,7 @@
       "ci.provider.name": "travisci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git",
       "git.tag": "0.1.0"
     }
@@ -35,9 +36,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo",
       "TRAVIS_TAG": "refs/heads/tags/0.1.0"
     },
@@ -50,7 +52,7 @@
       "ci.provider.name": "travisci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git",
       "git.tag": "0.1.0"
     }
@@ -62,9 +64,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -76,7 +79,7 @@
       "ci.provider.name": "travisci",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -88,9 +91,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -103,7 +107,7 @@
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -115,9 +119,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -130,7 +135,7 @@
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -142,9 +147,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -157,7 +163,7 @@
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -170,9 +176,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo",
       "USERPROFILE": "/not-my-home"
     },
@@ -186,7 +193,7 @@
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -198,9 +205,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -213,7 +221,7 @@
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -226,9 +234,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo",
       "USERPROFILE": "/not-my-home"
     },
@@ -242,7 +251,7 @@
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -254,9 +263,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -269,7 +279,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -281,9 +291,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -296,7 +307,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -308,9 +319,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -323,7 +335,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -335,9 +347,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_PULL_REQUEST_BRANCH": "origin/master",
       "TRAVIS_PULL_REQUEST_SLUG": "user/repo",
       "TRAVIS_REPO_SLUG": "user/repo"
@@ -352,7 +365,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -364,9 +377,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_PULL_REQUEST_BRANCH": "refs/heads/master",
       "TRAVIS_PULL_REQUEST_SLUG": "user/repo",
       "TRAVIS_REPO_SLUG": "user/repo"
@@ -381,7 +395,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -393,9 +407,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_PULL_REQUEST_BRANCH": "refs/heads/feature/one",
       "TRAVIS_PULL_REQUEST_SLUG": "user/repo",
       "TRAVIS_REPO_SLUG": "user/repo"
@@ -410,7 +425,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git"
     }
   ],
@@ -430,9 +445,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -470,9 +486,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo"
     },
     {
@@ -502,9 +519,10 @@
       "TRAVIS_BUILD_ID": "travis-pipeline-id",
       "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
       "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
-      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
       "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "false",
       "TRAVIS_REPO_SLUG": "user/repo",
       "TRAVIS_TAG": "origin/tags/0.1.0"
     },
@@ -517,9 +535,41 @@
       "ci.provider.name": "travisci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "travis-commit-message",
-      "git.commit.sha": "travis-git-commit",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/user/repo.git",
       "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "https://travisci.com/pipeline",
+      "TRAVIS_COMMIT": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
+      "TRAVIS_EVENT_TYPE": "pull_request",
+      "TRAVIS_JOB_WEB_URL": "https://travisci.com/job",
+      "TRAVIS_PULL_REQUEST": "42",
+      "TRAVIS_PULL_REQUEST_BRANCH": "pr",
+      "TRAVIS_PULL_REQUEST_SHA": "724faca55efebf66fc15bfccc34577c64c5480bd",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "https://travisci.com/job",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "https://travisci.com/pipeline",
+      "ci.provider.name": "travisci",
+      "git.branch": "pr",
+      "git.commit.head.sha": "724faca55efebf66fc15bfccc34577c64c5480bd",
+      "git.commit.message": "travis-commit-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "master",
+      "git.repository_url": "https://github.com/user/repo.git",
+      "pr.number": "42"
     }
   ]
 ]

--- a/tests/tracer/fixtures/ci/usersupplied.json
+++ b/tests/tracer/fixtures/ci/usersupplied.json
@@ -165,6 +165,56 @@
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://github.com/DataDog/dogweb",
+      "DD_TEST_CASE_NAME": "http-repository-url-no-git-suffix"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "ssh://host.xz:54321/path/to/repo/",
+      "DD_TEST_CASE_NAME": "ssh-repository-url-no-git-suffix"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo/"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git"
     },
     {
@@ -177,6 +227,202 @@
       "git.commit.message": "usersupplied-message",
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user@github.com/DataDog/dogweb.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user:password@github.com:1234/DataDog/dogweb.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user:password@1.1.1.1/DataDog/dogweb.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user:password@1.1.1.1:1234/DataDog/dogweb.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb.git"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user:password@1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://1.1.1.1:1234/DataDog/dogweb_with_@_yeah.git"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "ssh://user@host.xz:54321/path/to/repo.git/"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "ssh://user:password@host.xz:54321/path/to/repo.git/"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "ssh://host.xz:54321/path/to/repo.git/"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_PULL_REQUEST_BASE_BRANCH": "target-branch",
+      "DD_GIT_PULL_REQUEST_BASE_BRANCH_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.pull_request.base_branch": "target-branch",
+      "git.pull_request.base_branch_sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ]
 ]

--- a/tests/tracer/test_ci.py
+++ b/tests/tracer/test_ci.py
@@ -626,6 +626,26 @@ def test_github_pull_request_head_sha():
     )
 
 
+def test_pull_request_base_branch_normalized_when_branch_is_tag():
+    with (
+        mock.patch("ddtrace.ext.ci.git.extract_git_metadata", return_value={}),
+        mock.patch("ddtrace.ext.ci.git.extract_user_git_metadata", return_value={}),
+    ):
+        tags = ci.tags(
+            environ={
+                "APPVEYOR": "true",
+                "APPVEYOR_REPO_PROVIDER": "github",
+                "APPVEYOR_REPO_BRANCH": "refs/heads/main",
+                "APPVEYOR_REPO_TAG_NAME": "refs/tags/v1.2.3",
+                "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH": "refs/tags/v1.2.3",
+            }
+        )
+
+    assert tags[git.TAG] == "v1.2.3"
+    assert git.BRANCH not in tags
+    assert tags[git.PULL_REQUEST_BASE_BRANCH] == "main"
+
+
 def test_extract_git_head_metadata():
     fake_user_info = {
         "author": ("Author", "a@author.com", "date1"),


### PR DESCRIPTION
## Description

Align CI Visibility provider metadata extraction with the Ruby implementation and add missing CI tags across supported providers. This includes pull request base branch and head SHA coverage, missing job identifiers, and provider-specific PR metadata fixes for AppVeyor, Buildkite, Travis, GitLab, Bitrise, Drone, and AWS CodePipeline.

## Testing

- `scripts/run-tests tests/tracer/test_ci.py --pytest-args \"-q\"`
- Targeted env tag validation for CI metadata changes
- `uvx hatch run lint:fmt -- ddtrace/testing/internal/git.py`
- `uvx hatch run lint:checks`
- Individual lint sub-checks were run after `lint:checks` exposed a pre-existing missing script: `scripts/check_profiling_native_coverage.py`

## Risks

Low to moderate. The change is limited to CI metadata extraction paths and mirrored internal testing helpers, but it touches multiple providers and their generated fixture expectations.

## Additional Notes

- Added a release note fragment for the CI Visibility metadata fixes.
- Fixture files were updated as generated outputs for the provider/tag changes.
- `lint:checks` is currently blocked in this checkout by the missing repository script `scripts/check_profiling_native_coverage.py`; other applicable lint checks passed.
