### PR TITLE
chore(tracer): migrate trace_handlers to Span._set_attribute

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -257,20 +257,20 @@ def _on_web_framework_finish_request(
         span.finish()
 
 
-def _set_inferred_proxy_tags(span, status_code):
+def _set_inferred_proxy_tags(span: Span, status_code):
     if span._parent and span._parent.name in INFERRED_SPAN_NAMES:
         inferred_span = span._parent
-        status_code = status_code if status_code else span.get_tag("http.status_code")
+        status_code = status_code or span._get_attribute("http.status_code")
         if status_code:
             inferred_span._set_attribute("http.status_code", status_code)
         if span.error == 1:
             inferred_span.error = span.error
-            if span._has_attribute(ERROR_MSG):
-                inferred_span.set_tag(ERROR_MSG, span.get_tag(ERROR_MSG))
-            if span._has_attribute(ERROR_TYPE):
-                inferred_span.set_tag(ERROR_TYPE, span.get_tag(ERROR_TYPE))
-            if span._has_attribute(ERROR_STACK):
-                inferred_span.set_tag(ERROR_STACK, span.get_tag(ERROR_STACK))
+            if (error_msg := span._get_attribute(ERROR_MSG)) is not None:
+                inferred_span._set_attribute(ERROR_MSG, error_msg)
+            if (error_type := span._get_attribute(ERROR_TYPE)) is not None:
+                inferred_span._set_attribute(ERROR_TYPE, error_type)
+            if (error_stack := span._get_attribute(ERROR_STACK)) is not None:
+                inferred_span._set_attribute(ERROR_STACK, error_stack)
 
 
 def _set_pubsub_receive_attributes(


### PR DESCRIPTION
## Description

Small optimization to avoid calls to `Span.get_tag`/`Span.set_tag` and avoiding the extra/unnecessary calls to `Span._has_attribute`.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
