### PR TITLE
feat: add in_azure_app_service() detection and service name default

### DIFF
--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -35,3 +35,13 @@ def in_azure_function():
     # type: () -> bool
     """Returns whether the environment is an Azure Function."""
     return env.get("FUNCTIONS_WORKER_RUNTIME", "") != "" and env.get("FUNCTIONS_EXTENSION_VERSION", "") != ""
+
+
+def in_azure_app_service():
+    # type: () -> bool
+    """Returns whether the environment is an Azure App Service (not an Azure Function).
+
+    Azure App Services set WEBSITE_SITE_NAME but do not set FUNCTIONS_WORKER_RUNTIME,
+    which distinguishes them from Azure Functions (which set both).
+    """
+    return env.get("WEBSITE_SITE_NAME", "") != "" and env.get("FUNCTIONS_WORKER_RUNTIME", "") == ""

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -26,6 +26,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import config as _native_config
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.serverless import in_aws_lambda
+from ddtrace.internal.serverless import in_azure_app_service
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.settings import env
@@ -511,7 +512,7 @@ class Config(object):
             self.service = _get_config("AWS_LAMBDA_FUNCTION_NAME", DEFAULT_SPAN_SERVICE_NAME)
         if self.service is None and in_gcp_function():
             self.service = _get_config(["K_SERVICE", "FUNCTION_NAME"], DEFAULT_SPAN_SERVICE_NAME)
-        if self.service is None and in_azure_function():
+        if self.service is None and (in_azure_function() or in_azure_app_service()):
             self.service = _get_config("WEBSITE_SITE_NAME", DEFAULT_SPAN_SERVICE_NAME)
         if self.service is None and DEFAULT_SPAN_SERVICE_NAME:
             self.service = _get_config("DD_SERVICE", DEFAULT_SPAN_SERVICE_NAME)

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ddtrace.internal.serverless import in_azure_app_service
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from tests.utils import override_env
@@ -26,6 +27,23 @@ def test_is_azure_function():
 
 def test_not_azure_function():
     assert in_azure_function() is False
+
+
+def test_is_azure_app_service():
+    with override_env(dict(WEBSITE_SITE_NAME="my-app")):
+        assert in_azure_app_service() is True
+
+
+def test_not_azure_app_service_without_site_name():
+    assert in_azure_app_service() is False
+
+
+def test_not_azure_app_service_when_azure_function():
+    # Azure Functions also set WEBSITE_SITE_NAME — must NOT be classified as App Service
+    with override_env(
+        dict(WEBSITE_SITE_NAME="my-func", FUNCTIONS_WORKER_RUNTIME="python", FUNCTIONS_EXTENSION_VERSION="~4")
+    ):
+        assert in_azure_app_service() is False
 
 
 standard_blocklist = [


### PR DESCRIPTION
## Summary

Adds Azure App Services detection to dd-trace-py and extends the service name default logic to cover App Services. No RC or DI changes are needed — dd-trace-py does not disable RC for Azure App Services, so when a customer runs the Datadog Agent as a sidecar with `DD_DYNAMIC_INSTRUMENTATION_ENABLED=true`, DI already activates via the products manager.

The key discriminator: both App Services and Azure Functions set `WEBSITE_SITE_NAME`, but only Azure Functions sets `FUNCTIONS_WORKER_RUNTIME`. The new `in_azure_app_service()` function checks `WEBSITE_SITE_NAME != ""` AND `FUNCTIONS_WORKER_RUNTIME == ""`.

## Changes

- `ddtrace/internal/serverless/__init__.py`: Add `in_azure_app_service()` function (analogous to `in_azure_function()` at line 34)
- `ddtrace/internal/settings/_config.py`: Extend service name default at line 515 to use `WEBSITE_SITE_NAME` for App Services customers (same as Azure Functions already does)
- `tests/internal/test_serverless.py`: Add 3 tests: `test_is_azure_app_service`, `test_not_azure_app_service_without_site_name`, `test_not_azure_app_service_when_azure_function`

## Testing

- Standalone logic tests (3/3 PASS): `in_azure_app_service()` correctly returns True for App Services, False for no env vars, False when Azure Functions env vars present
- Full pytest requires native extension build — CI will run

## Context

Phase 1 of Live Debugger on Azure (App Services). Azure Functions Consumption deferred.