### PR TITLE
fix(rc): skip shared memory allocation in AWS Lambda

### DIFF
--- a/ddtrace/internal/remoteconfig/_connectors.py
+++ b/ddtrace/internal/remoteconfig/_connectors.py
@@ -43,20 +43,26 @@ class PublisherSubscriberConnector:
     """
 
     def __init__(self):
-        try:
-            self.data = get_mp_context().Array("c", SHARED_MEMORY_SIZE, lock=False)
-        # FileNotFoundError: /dev/shm may not exist or be inaccessible.
-        # ImportError: multiprocessing.Array imports multiprocessing.sharedctypes,
-        # which imports ctypes and requires the _ctypes C extension module. Some
-        # environments (e.g. Alpine Linux, minimal Docker images, or custom
-        # Python builds without libffi) do not provide _ctypes and raise
-        # ModuleNotFoundError.
-        # See: https://app.datadoghq.com/error-tracking/issue/25b34008-bb9f-11f0-abbd-da7ad0900002
-        except (FileNotFoundError, ImportError):
-            log.warning(
-                "Unable to create shared memory. Features relying on remote configuration will not work as expected."
-            )
+        from ddtrace.internal.serverless import in_aws_lambda
+
+        if in_aws_lambda():
             self.data = _DummySharedArray()
+        else:
+            try:
+                self.data = get_mp_context().Array("c", SHARED_MEMORY_SIZE, lock=False)
+            # FileNotFoundError: /dev/shm may not exist or be inaccessible.
+            # ImportError: multiprocessing.Array imports multiprocessing.sharedctypes,
+            # which imports ctypes and requires the _ctypes C extension module. Some
+            # environments (e.g. Alpine Linux, minimal Docker images, or custom
+            # Python builds without libffi) do not provide _ctypes and raise
+            # ModuleNotFoundError.
+            # See: https://app.datadoghq.com/error-tracking/issue/25b34008-bb9f-11f0-abbd-da7ad0900002
+            except (FileNotFoundError, ImportError):
+                log.warning(
+                    "Unable to create shared memory. "
+                    "Features relying on remote configuration will not work as expected."
+                )
+                self.data = _DummySharedArray()
         # Checksum attr validates if the Publisher send new data
         self.checksum = -1
         # shared_data_counter attr validates if the Subscriber send new data

--- a/releasenotes/notes/fix-lambda-shared-memory-warning-4873867125814623.yaml
+++ b/releasenotes/notes/fix-lambda-shared-memory-warning-4873867125814623.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    remote config: Fixes a spurious ``Unable to create shared memory`` warning
+    on every AWS Lambda cold start by skipping the ``multiprocessing.Array``
+    allocation when running in Lambda, where ``/dev/shm`` is unavailable.

--- a/releasenotes/notes/fix-lambda-shared-memory-warning-4873867125814623.yaml
+++ b/releasenotes/notes/fix-lambda-shared-memory-warning-4873867125814623.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    remote config: Fixes a spurious ``Unable to create shared memory`` warning
-    on every AWS Lambda cold start by skipping the ``multiprocessing.Array``
-    allocation when running in Lambda, where ``/dev/shm`` is unavailable.
+    lambda: Fixes a spurious ``Unable to create shared memory`` warning
+    on every AWS Lambda cold start.

--- a/tests/internal/remoteconfig/test_remoteconfig_connector.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_connector.py
@@ -68,6 +68,17 @@ def test_connector_fallback_on_array_creation_failure():
         assert isinstance(connector.data, _DummySharedArray)
 
 
+def test_connector_uses_dummy_shared_array_in_aws_lambda(monkeypatch):
+    """In AWS Lambda, shared memory (/dev/shm) is unavailable. The connector
+    should skip the allocation attempt entirely and use _DummySharedArray
+    without logging a warning."""
+    from ddtrace.internal.remoteconfig._connectors import _DummySharedArray
+
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "my-function")
+    connector = PublisherSubscriberConnector()
+    assert isinstance(connector.data, _DummySharedArray)
+
+
 global_connector = PublisherSubscriberConnector()
 
 

--- a/tests/internal/remoteconfig/test_remoteconfig_connector.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_connector.py
@@ -71,7 +71,8 @@ def test_connector_fallback_on_array_creation_failure():
 def test_connector_uses_dummy_shared_array_in_aws_lambda(monkeypatch):
     """In AWS Lambda, shared memory (/dev/shm) is unavailable. The connector
     should skip the allocation attempt entirely and use _DummySharedArray
-    without logging a warning."""
+    without logging a warning.
+    """
     from ddtrace.internal.remoteconfig._connectors import _DummySharedArray
 
     monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "my-function")


### PR DESCRIPTION
## Summary

Fixes the `Unable to create shared memory. Features relying on remote configuration will not work as expected.` warning that appears on every Lambda cold start since ddtrace v4.5.0.

Closes DataDog/datadog-lambda-python#785

## Root Cause

The [single RC subscriber refactor](https://github.com/DataDog/dd-trace-py/commit/74c3ab43b0) (`v4.5.0`) moved `PublisherSubscriberConnector` creation into `RemoteConfigClient.__init__`, making it eagerly constructed when the module-level `remoteconfig_poller` singleton is instantiated at import time. Before that refactor, connectors were created lazily per-product registration and were never created in Lambda because remote config is disabled there.

AWS Lambda does not provide `/dev/shm`, so the `multiprocessing.Array` allocation always fails with `FileNotFoundError`, logging the warning even though:
- `DD_REMOTE_CONFIGURATION_ENABLED=false` is set
- The ASM settings already disable remote config for Lambda (`asm.py:284`)

Both guards run **after** the singleton is already created — too late to prevent the allocation attempt.

## Changes

- **`ddtrace/internal/remoteconfig/_connectors.py`**: Check `in_aws_lambda()` in `PublisherSubscriberConnector.__init__` before attempting shared memory allocation. When in Lambda, skip directly to `_DummySharedArray` without logging a warning (this is expected behavior, not an error).
- **`tests/internal/remoteconfig/test_remoteconfig_connector.py`**: Add test verifying the connector uses `_DummySharedArray` when `AWS_LAMBDA_FUNCTION_NAME` is set.

## Safety

Using `_DummySharedArray` in Lambda is safe because:
- `.value` is the only attribute accessed on the shared array — `_DummySharedArray` satisfies the full duck-typing contract
- `connector.read()` returns `[]` when `.value` is `b""`, which is handled gracefully by the subscriber dispatch chain (`_dispatch_to_products` calls `periodic()` on callbacks then returns early)
- The RC poller never starts in Lambda (`enable()` returns `False`), so no data is ever written to the connector
- All RC callbacks (ASM, DI, APM Tracing, Tracer Flare, Feature Flags) handle empty/no-op RC data gracefully
- This is the same `_DummySharedArray` already used as the `FileNotFoundError` fallback — we just reach it earlier and without the warning

## Companion PR

Defense-in-depth change in datadog-lambda-python: [DataDog/datadog-lambda-python#797](https://github.com/DataDog/datadog-lambda-python/pull/797) (sets `DD_REMOTE_CONFIGURATION_ENABLED=false` before ddtrace loads)

## Test Plan

- [ ] Existing `test_remoteconfig_connector.py` tests pass (non-Lambda paths unchanged)
- [ ] New `test_connector_uses_dummy_shared_array_in_aws_lambda` test passes
- [ ] Verify no `Unable to create shared memory` warning in Lambda cold start logs