### PR TITLE
test: update database-related snapshots for svc_src tag

### DIFF
--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
@@ -11,29 +11,31 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiomysql",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3400000000",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiomysql",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "5fd399879b2c43628ee3ab3b6470b8b7",
+      "runtime-id": "e9c27f9edafe48a09b7a0d73d6993f15",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 51883
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71795.0
     },
-    "duration": 6833000,
-    "start": 1667240729105451000
+    "duration": 755625,
+    "start": 1776196916216386965
   }],
 [
   {
@@ -48,30 +50,32 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiomysql",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3400000000",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiomysql",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
       "db.user": "test",
       "error.message": "(1146, \"Table 'test.some_non_existant_table' doesn't exist\")",
-      "error.stack": "Traceback (most recent call last):\n  File \"/Users/kverhoog/dev/dd-trace-py/ddtrace/contrib/aiomysql/patch.py\", line 69, in _trace_method\n    result = await method(*args, **kwargs)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/aiomysql/cursors.py\", line 239, in execute\n    await self._query(query)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/aiomysql/cursors.py\", line 457, in _query\n    await conn.query(q)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/aiomysql/connection.py\", line 469, in query\n    await self._read_query_result(unbuffered=unbuffered)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/aiomysql/connection.py\", line 672, in _read_query_result\n    await result.read()\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/aiomysql/connection.py\", line 1157, in read\n    first_packet = await self.connection._read_packet()\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/aiomysql/connection.py\", line 641, in _read_packet\n    packet.raise_for_error()\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/pymysql/protocol.py\", line 221, in raise_for_error\n    err.raise_mysql_exception(self._data)\n  File \"/Users/kverhoog/dev/dd-trace-py/.venv/lib/python3.10/site-packages/pymysql/err.py\", line 143, in raise_mysql_exception\n    raise errorclass(errno, errval)\npymysql.err.ProgrammingError: (1146, \"Table 'test.some_non_existant_table' doesn't exist\")\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/internal/aiomysql/patch.py\", line 101, in _trace_method\n    result = await method(*args, **kwargs)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/aiomysql/cursors.py\", line 239, in execute\n    await self._query(query)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/aiomysql/cursors.py\", line 457, in _query\n    await conn.query(q)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/aiomysql/connection.py\", line 469, in query\n    await self._read_query_result(unbuffered=unbuffered)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/aiomysql/connection.py\", line 672, in _read_query_result\n    await result.read()\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/aiomysql/connection.py\", line 1153, in read\n    first_packet = await self.connection._read_packet()\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/aiomysql/connection.py\", line 641, in _read_packet\n    packet.raise_for_error()\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/pymysql/protocol.py\", line 221, in raise_for_error\n    err.raise_mysql_exception(self._data)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_pytest-asyncio0211_aiomysql~010/lib/python3.9/site-packages/pymysql/err.py\", line 143, in raise_mysql_exception\n    raise errorclass(errno, errval)\npymysql.err.ProgrammingError: (1146, \"Table 'test.some_non_existant_table' doesn't exist\")\n",
       "error.type": "pymysql.err.ProgrammingError",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "5fd399879b2c43628ee3ab3b6470b8b7",
+      "runtime-id": "e9c27f9edafe48a09b7a0d73d6993f15",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 51883
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71795.0
     },
-    "duration": 8135000,
-    "start": 1667240729138420000
+    "duration": 2003708,
+    "start": 1776196916218038549
   }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
@@ -11,27 +11,29 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3500000000",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "10185724725e43958ae66f62b7c6216d",
+      "runtime-id": "fa6d1b49e73b432f91e45122ae8bab86",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 8670
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71937.0
     },
-    "duration": 321000,
-    "start": 1682562112206059292
+    "duration": 358250,
+    "start": 1776196917617991008
   }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3700000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
@@ -19,20 +21,20 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "9f466d3fd1ef4e59ab6d72707e720ecf",
+      "runtime-id": "86c3ecf734be425399b5ebf3ceccc05c",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 8675
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71959.0
     },
-    "duration": 303000,
-    "start": 1682562112974022834
+    "duration": 301708,
+    "start": 1776196919050684217
   }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3600000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
@@ -19,20 +21,20 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "f446781b5d244b95abc64fb246064c81",
+      "runtime-id": "ef6181d8e4d142238fc3c6ce52337fe1",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 1959
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71948.0
     },
-    "duration": 336750,
-    "start": 1682181472030042004
+    "duration": 333083,
+    "start": 1776196918322912550
   }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
@@ -11,27 +11,29 @@
     "meta": {
       "_dd.base_service": "my-service-name",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3400000000",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "edd004724e314daf9ff1e51e8234b4df",
+      "runtime-id": "6ccf3914e35749a6882c71d40c3312d8",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 1191
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71904.0
     },
-    "duration": 339958,
-    "start": 1682180471955479013
+    "duration": 350208,
+    "start": 1776196916146532174
   }]]

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de9d3400000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "aiomysql",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "aiomysql",
       "db.name": "test",
       "db.system": "mysql",
@@ -19,20 +21,20 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "ae2b5fb6b2b849ed9a299852cb4df1d5",
+      "runtime-id": "0b5b188a1bc040e38b563c142f925393",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "db.rownumber": 0,
-      "network.destination.port": 3306,
-      "process_id": 1196
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "db.rownumber": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 71926.0
     },
-    "duration": 361500,
-    "start": 1682180472703443222
+    "duration": 311250,
+    "start": 1776196916891916882
   }]]

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.kafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67c62be500000000",
+      "_dd.p.tid": "69de789b00000000",
+      "_dd.svc_src": "tests.contrib.kafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.kafka",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
@@ -22,21 +24,21 @@
       "language": "python",
       "messaging.destination.name": "test_service_override_config",
       "messaging.system": "kafka",
-      "pathway.hash": "12368502031671261057",
-      "runtime-id": "559a40be08084fe3ba6c3dbbe5a60e52",
+      "pathway.hash": "6966110732586201292",
+      "runtime-id": "63d79c760909410187a6bb93c31a9bf4",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "kafka.message_offset": -1,
-      "kafka.partition": 0,
-      "process_id": 20454
+      "_sampling_priority_v1": 1.0,
+      "kafka.message_offset": 1.0,
+      "kafka.partition": 0.0,
+      "process_id": 36820.0
     },
-    "duration": 3640566000,
-    "start": 1741040610249957000
+    "duration": 2849196751,
+    "start": 1776187544735323259
   }],
 [
   {
@@ -51,7 +53,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.kafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67c62be200000000",
+      "_dd.p.tid": "69de789800000000",
+      "_dd.svc_src": "tests.contrib.kafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.kafka",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
@@ -61,18 +65,18 @@
       "messaging.destination.name": "test_service_override_config",
       "messaging.kafka.bootstrap.servers": "127.0.0.1:29092",
       "messaging.system": "kafka",
-      "pathway.hash": "1719926886277470817",
-      "runtime-id": "559a40be08084fe3ba6c3dbbe5a60e52",
+      "pathway.hash": "443645483726763069",
+      "runtime-id": "63d79c760909410187a6bb93c31a9bf4",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "kafka.partition": -1,
-      "process_id": 20454
+      "_sampling_priority_v1": 1.0,
+      "kafka.partition": -1.0,
+      "process_id": 36820.0
     },
-    "duration": 4920000,
-    "start": 1741040610242510000
+    "duration": 1988125,
+    "start": 1776187544481475509
   }]]

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67c62b7600000000",
+      "_dd.p.tid": "69de789f00000000",
+      "_dd.svc_src": "ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
@@ -22,21 +24,21 @@
       "language": "python",
       "messaging.destination.name": "test_service_override_env_var",
       "messaging.system": "kafka",
-      "pathway.hash": "4399795867780198364",
-      "runtime-id": "0f6b6d8734a149b8bcbded06a40e679b",
+      "pathway.hash": "129630962231005456",
+      "runtime-id": "544c6700735a4002b96c60bc06898c32",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "kafka.message_offset": 2,
-      "kafka.partition": 0,
-      "process_id": 20684
+      "_sampling_priority_v1": 1.0,
+      "kafka.message_offset": 1.0,
+      "kafka.partition": 0.0,
+      "process_id": 36852.0
     },
-    "duration": 3428082000,
-    "start": 1741040499658821000
+    "duration": 3444094835,
+    "start": 1776187548531880552
   }],
 [
   {
@@ -51,7 +53,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67c62b7300000000",
+      "_dd.p.tid": "69de789c00000000",
+      "_dd.svc_src": "ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
@@ -61,18 +65,18 @@
       "messaging.destination.name": "test_service_override_env_var",
       "messaging.kafka.bootstrap.servers": "127.0.0.1:29092",
       "messaging.system": "kafka",
-      "pathway.hash": "11480763115119589083",
-      "runtime-id": "0f6b6d8734a149b8bcbded06a40e679b",
+      "pathway.hash": "14722941679670948566",
+      "runtime-id": "544c6700735a4002b96c60bc06898c32",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "kafka.partition": -1,
-      "process_id": 20684
+      "_sampling_priority_v1": 1.0,
+      "kafka.partition": -1.0,
+      "process_id": 36852.0
     },
-    "duration": 3524000,
-    "start": 1741040499414765000
+    "duration": 1175375,
+    "start": 1776187548317794469
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_post_1_1.json
@@ -11,24 +11,26 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 126625,
-    "start": 1692647311243494927
+    "duration": 126708,
+    "start": 1776174565493365133
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_pre_1_1.json
@@ -11,24 +11,26 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45ff00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 135834,
-    "start": 1692647267161722878
+    "duration": 350916,
+    "start": 1776174591761022423
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_post_1_1.json
@@ -11,29 +11,31 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 360125,
-    "start": 1692647311232537135
+    "duration": 292708,
+    "start": 1776174564380222466
   }],
 [
   {
@@ -48,28 +50,30 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 216166,
-    "start": 1692647311233205177
+    "duration": 202084,
+    "start": 1776174564380879382
   }],
 [
   {
@@ -84,25 +88,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 53916,
-    "start": 1692647311233482427
+    "duration": 49750,
+    "start": 1776174564381380007
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_pre_1_1.json
@@ -11,29 +11,31 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 320125,
-    "start": 1692647267150049378
+    "duration": 347250,
+    "start": 1776174595218637841
   }],
 [
   {
@@ -48,28 +50,30 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 248167,
-    "start": 1692647267150690253
+    "duration": 223709,
+    "start": 1776174595219399549
   }],
 [
   {
@@ -84,25 +88,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 50167,
-    "start": 1692647267150997670
+    "duration": 55208,
+    "start": 1776174595219770758
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 436542,
-    "start": 1692647311256214093
+    "duration": 363541,
+    "start": 1776174565481512925
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 571875,
-    "start": 1692647267172692545
+    "duration": 486084,
+    "start": 1776174595184300924
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_post_1_1.json
@@ -11,28 +11,30 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 3,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 3.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 244250,
-    "start": 1692647311219557760
+    "duration": 323709,
+    "start": 1776174565462339591
   }],
 [
   {
@@ -47,25 +49,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 3,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 3.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 61667,
-    "start": 1692647311220098218
+    "duration": 104334,
+    "start": 1776174565463066216
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_pre_1_1.json
@@ -11,28 +11,30 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 254209,
-    "start": 1692647267136948628
+    "duration": 367042,
+    "start": 1776174595200983424
   }],
 [
   {
@@ -47,25 +49,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 3,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 3.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 57458,
-    "start": 1692647267137522920
+    "duration": 117625,
+    "start": 1776174595201844299
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 3,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 3.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 309917,
-    "start": 1692647311210920968
+    "duration": 286458,
+    "start": 1776174564401438424
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 403709,
-    "start": 1692647267128257003
+    "duration": 337458,
+    "start": 1776174594016896841
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "ee5f4d9b7b384027b4587b886c75903a",
+      "runtime-id": "7601708c4116426ca4e0806f403f19b3",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19677
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61473.0
     },
-    "duration": 267083,
-    "start": 1692647305352792632
+    "duration": 178292,
+    "start": 1776174562676343090
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460000000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "35ee3b9d62ae4fddb271b990911487ad",
+      "runtime-id": "496c2338c72e4516a9bd4b2e4c57109a",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19553
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62377.0
     },
-    "duration": 232584,
-    "start": 1692647261765025292
+    "duration": 175417,
+    "start": 1776174592411890006
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "dc744e327de747319edc49baa8a17c8e",
+      "runtime-id": "16db8838812f41ee8df13da466e29dd8",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19680
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61589.0
     },
-    "duration": 280166,
-    "start": 1692647306436758633
+    "duration": 177375,
+    "start": 1776174566127429342
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "683c964c368d4ddfbe882af7e1b889ac",
+      "runtime-id": "5d45b0b9ebe944e59dd4e6e02d47764e",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19556
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62437.0
     },
-    "duration": 323708,
-    "start": 1692647262755043168
+    "duration": 168750,
+    "start": 1776174595048807049
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_post_1_1.json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
@@ -19,19 +21,19 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "8a47d8862dc4498ea44bba0aa2d25612",
+      "runtime-id": "d925cf762116486ea350196aa7dce1c0",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 52045
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61512.0
     },
-    "duration": 328000,
-    "start": 1685619049587872054
+    "duration": 197542,
+    "start": 1776174564224396549
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_pre_1_1.json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460100000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
@@ -19,19 +21,19 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "5f4b7917002a4f0498351a5bddedbcbb",
+      "runtime-id": "6eab37ba8ec54eaab99c63e00d256347",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 51953
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62388.0
     },
-    "duration": 206250,
-    "start": 1685619025014162626
+    "duration": 169458,
+    "start": 1776174593151807465
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "23008368d7b8452b88c0acf73312c93c",
+      "runtime-id": "30f35fe6503b42b0ae754dbbc5180b82",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19686
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61600.0
     },
-    "duration": 247083,
-    "start": 1692647308730645092
+    "duration": 194791,
+    "start": 1776174566867325384
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "bc86c32383d946fca3fc9a9de8dee50d",
+      "runtime-id": "3098400712dd4443a010b0491c9696b3",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19562
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62474.0
     },
-    "duration": 233292,
-    "start": 1692647264697535710
+    "duration": 163333,
+    "start": 1776174595932923883
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "e7f4386aba914e12b8053e6234cda398",
+      "runtime-id": "598771ef1ad44c488812baf37278956f",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19689
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61557.0
     },
-    "duration": 253208,
-    "start": 1692647309773133301
+    "duration": 181667,
+    "start": 1776174565345460216
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b99867c722f44f2680c92721e325bf5a",
+      "runtime-id": "d8c3e847e79d4abdaf56a45f2ab38002",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19565
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62404.0
     },
-    "duration": 251416,
-    "start": 1692647265681358003
+    "duration": 170000,
+    "start": 1776174593907833341
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_post_1_1.json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e300000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
@@ -19,19 +21,19 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "5842268f67714b5aa90fca481d379a4d",
+      "runtime-id": "c75f039a4cdd423193f53053241c83ed",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 52060
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61494.0
     },
-    "duration": 289250,
-    "start": 1685619052784139000
+    "duration": 202625,
+    "start": 1776174563466443424
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_pre_1_1.json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45ff00000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
@@ -19,19 +21,19 @@
       "language": "python",
       "out.host": "127.0.0.1",
       "peer.service": "test",
-      "runtime-id": "b90b1aef18a646e889c4c8ced8707cd8",
+      "runtime-id": "916a151aacfb436fb57ff51e75396209",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 51968
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62354.0
     },
-    "duration": 266208,
-    "start": 1685619028302835086
+    "duration": 159000,
+    "start": 1776174591645923381
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_malformed_query_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_malformed_query_snapshot_post_1_1.json
@@ -11,29 +11,31 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "error.message": "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELEC 1' at line 1",
-      "error.stack": "Traceback (most recent call last):\n  File \"/root/project/ddtrace/contrib/dbapi/__init__.py\", line 124, in _trace_method\n    return method(*args, **kwargs)\n  File \"/root/project/.riot/venv_py3916_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_mariadb~10/lib/python3.9/site-packages/mariadb/cursors.py\", line 312, in execute\n    self._readresponse()\nmariadb.ProgrammingError: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELEC 1' at line 1\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/dbapi.py\", line 136, in _trace_method\n    return method(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-randomly_mariadb~112/lib/python3.12/site-packages/mariadb/cursors.py\", line 351, in execute\n    self._readresponse()\nmariadb.ProgrammingError: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELEC 1' at line 1\n",
       "error.type": "mariadb.ProgrammingError",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": -1,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": -1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 2299125,
-    "start": 1692647311188173302
+    "duration": 1338625,
+    "start": 1776174563594583424
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_malformed_query_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_malformed_query_snapshot_pre_1_1.json
@@ -11,29 +11,31 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "error.message": "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELEC 1' at line 1",
-      "error.stack": "Traceback (most recent call last):\n  File \"/root/project/ddtrace/contrib/dbapi/__init__.py\", line 124, in _trace_method\n    return method(*args, **kwargs)\nmariadb.ProgrammingError: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELEC 1' at line 1\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/dbapi.py\", line 136, in _trace_method\n    return method(*args, **kwargs)\nmariadb.ProgrammingError: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'SELEC 1' at line 1\n",
       "error.type": "mariadb.ProgrammingError",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": -1,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": -1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 1391250,
-    "start": 1692647267106458128
+    "duration": 982666,
+    "start": 1776174596059092717
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_post_1_1.json
@@ -11,28 +11,30 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 188875,
-    "start": 1692647311201297635
+    "duration": 201709,
+    "start": 1776174564358473757
   }],
 [
   {
@@ -47,25 +49,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 90458,
-    "start": 1692647311201780260
+    "duration": 80209,
+    "start": 1776174564359068132
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_pre_1_1.json
@@ -11,28 +11,30 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2668100000000",
+      "_dd.p.tid": "69de460400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "a14aa859f9654c0289bca9ccce8681db",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 48692
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 121250,
-    "start": 1722967681609904797
+    "duration": 243792,
+    "start": 1776174596044051633
   }],
 [
   {
@@ -47,25 +49,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2668100000000",
+      "_dd.p.tid": "69de460400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "a14aa859f9654c0289bca9ccce8681db",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 48692
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 36750,
-    "start": 1722967681610223297
+    "duration": 60959,
+    "start": 1776174596044688133
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "b6892bcaa1ca4405a344e37f07fe8a18",
+      "runtime-id": "a1beec7d092b490b94db1a7fa9b813f4",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19671
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61364.0
     },
-    "duration": 299041,
-    "start": 1692647311177222927
+    "duration": 183250,
+    "start": 1776174566984406425
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "tests.contrib.mariadb",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.mariadb",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "82fb0609ae3943fd9aed73ca9abbca8f",
+      "runtime-id": "7db942b23cee4052a1c5d8699e105801",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19547
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62349.0
     },
-    "duration": 264541,
-    "start": 1692647267095817462
+    "duration": 297500,
+    "start": 1776174594327874507
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de45e400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpkpdlb68,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "16331c917bb8464c89c38066736435c9",
+      "runtime-id": "f30e7d5daca44e568855bcea51ae9917",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 3306,
-      "process_id": 19695
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 3306.0,
+      "process_id": 61549.0
     },
-    "duration": 289667,
-    "start": 1692647311107327760
+    "duration": 178708,
+    "start": 1776174564679373216
   }]]

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
@@ -11,26 +11,28 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69de460200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmphbmirkgg,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "mariadb",
       "db.name": "test",
       "db.system": "mariadb",
       "db.user": "test",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "fe4b858f62064273aa9e3dbedd7bcf75",
+      "runtime-id": "599405ee51674cb59aa1722ad22d7e4c",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 0,
-      "network.destination.port": 3306,
-      "process_id": 19571
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 0.0,
+      "network.destination.port": 3306.0,
+      "process_id": 62422.0
     },
-    "duration": 250625,
-    "start": 1692647267027871003
+    "duration": 169459,
+    "start": 1776174594283879132
   }]]

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.psycopg",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bc00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.psycopg",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -19,19 +21,19 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "91b9e07942704e02bd33721f33785cc6",
+      "runtime-id": "c56a9ba77f2d4899b4d299470795a3e3",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75536
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14990.0
     },
-    "duration": 789458,
-    "start": 1692712207066515758
+    "duration": 1393916,
+    "start": 1776109756472501386
   }]]

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_postgres_dbm_propagation_tag.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_postgres_dbm_propagation_tag.json
@@ -12,7 +12,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -20,21 +22,21 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "8f3f46668bbc48e5be37411599b3ba6d",
+      "runtime-id": "352c277eaec24fbc834290e243e6c6ac",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 5432,
-      "process_id": 75560
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14996.0
     },
-    "duration": 881500,
-    "start": 1692712208528994925
+    "duration": 554083,
+    "start": 1776109755972683344
   }],
 [
   {
@@ -50,7 +52,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -58,22 +62,22 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "8f3f46668bbc48e5be37411599b3ba6d",
+      "runtime-id": "352c277eaec24fbc834290e243e6c6ac",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75560
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14996.0
     },
-    "duration": 788750,
-    "start": 1692712208555977092
+    "duration": 406334,
+    "start": 1776109755973522552
   }],
 [
   {
@@ -89,7 +93,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -97,21 +103,21 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "8f3f46668bbc48e5be37411599b3ba6d",
+      "runtime-id": "352c277eaec24fbc834290e243e6c6ac",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 5432,
-      "process_id": 75560
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14996.0
     },
-    "duration": 255875,
-    "start": 1692712208556840925
+    "duration": 181458,
+    "start": 1776109755974022844
   }],
 [
   {
@@ -127,7 +133,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -135,22 +143,22 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "8f3f46668bbc48e5be37411599b3ba6d",
+      "runtime-id": "352c277eaec24fbc834290e243e6c6ac",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75560
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14996.0
     },
-    "duration": 478042,
-    "start": 1692712208557140800
+    "duration": 267708,
+    "start": 1776109755974269969
   }],
 [
   {
@@ -166,7 +174,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -174,21 +184,21 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "8f3f46668bbc48e5be37411599b3ba6d",
+      "runtime-id": "352c277eaec24fbc834290e243e6c6ac",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 5432,
-      "process_id": 75560
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14996.0
     },
-    "duration": 214833,
-    "start": 1692712208557670467
+    "duration": 191917,
+    "start": 1776109755974618552
   }],
 [
   {
@@ -204,7 +214,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48bb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -212,20 +224,20 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "8f3f46668bbc48e5be37411599b3ba6d",
+      "runtime-id": "352c277eaec24fbc834290e243e6c6ac",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75560
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 14996.0
     },
-    "duration": 391333,
-    "start": 1692712208557926717
+    "duration": 245083,
+    "start": 1776109755974877219
   }]]

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced.json
@@ -11,20 +11,22 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd48c200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpbm98qwf6,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "psycopg",
       "db.system": "postgresql",
       "language": "python",
-      "runtime-id": "91b9e07942704e02bd33721f33785cc6",
+      "runtime-id": "fb4c1d3ca70e44649ac00c0e0bcf0913",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 75536
+      "_sampling_priority_v1": 1.0,
+      "process_id": 15231.0
     },
-    "duration": 3814375,
-    "start": 1692712228475612795
+    "duration": 2178459,
+    "start": 1776109762943839916
   }]]

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced_via_env.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced_via_env.json
@@ -11,20 +11,22 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "672bb03d00000000",
+      "_dd.p.tid": "69dd48c200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "psycopg",
       "db.system": "postgresql",
       "language": "python",
-      "runtime-id": "cb42548710de494d94d2000afc8b62e8",
+      "runtime-id": "3509a816c16246998ec848ddc95c387e",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 99101
+      "_sampling_priority_v1": 1.0,
+      "process_id": 15221.0
     },
-    "duration": 12353000,
-    "start": 1730916413457503000
+    "duration": 2127458,
+    "start": 1776109762292844639
   }]]

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_composed_query_encoding.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_composed_query_encoding.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.psycopg2",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd783400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.psycopg2",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -19,19 +21,19 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "5e80c5a691c84329bbe0464d28854fae",
+      "runtime-id": "2dddf211af824f259e536f360a56212d",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75387
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 59607.0
     },
-    "duration": 854333,
-    "start": 1692712137162231545
+    "duration": 1237333,
+    "start": 1776121908868631376
   }]]

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_postgres_dbm_propagation_tag.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_postgres_dbm_propagation_tag.json
@@ -12,7 +12,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd783400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -20,21 +22,21 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "4b04b30d8b3e43eab009a6e5a167f3c1",
+      "runtime-id": "2a7241e1e7e1405ea541c3f80aae900c",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 5432,
-      "process_id": 75405
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 5432.0,
+      "process_id": 59619.0
     },
-    "duration": 661458,
-    "start": 1692712138854378004
+    "duration": 475042,
+    "start": 1776121908802563834
   }],
 [
   {
@@ -50,7 +52,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd783400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -58,22 +62,22 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "4b04b30d8b3e43eab009a6e5a167f3c1",
+      "runtime-id": "2a7241e1e7e1405ea541c3f80aae900c",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75405
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 59619.0
     },
-    "duration": 352458,
-    "start": 1692712138878464296
+    "duration": 238959,
+    "start": 1776121908803332042
   }],
 [
   {
@@ -89,7 +93,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd783400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -97,21 +103,21 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "4b04b30d8b3e43eab009a6e5a167f3c1",
+      "runtime-id": "2a7241e1e7e1405ea541c3f80aae900c",
       "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 5432,
-      "process_id": 75405
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 5432.0,
+      "process_id": 59619.0
     },
-    "duration": 120000,
-    "start": 1692712138878880087
+    "duration": 131208,
+    "start": 1776121908803654751
   }],
 [
   {
@@ -127,7 +133,9 @@
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd783400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:python_-m_unittest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:python_-m_unittest",
       "component": "psycopg",
       "db.application": "None",
       "db.name": "postgres",
@@ -135,20 +143,20 @@
       "db.user": "postgres",
       "language": "python",
       "out.host": "127.0.0.1",
-      "runtime-id": "4b04b30d8b3e43eab009a6e5a167f3c1",
+      "runtime-id": "2a7241e1e7e1405ea541c3f80aae900c",
       "server.address": "127.0.0.1",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 5432,
-      "process_id": 75405
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 5432.0,
+      "process_id": 59619.0
     },
-    "duration": 143416,
-    "start": 1692712138879039796
+    "duration": 228375,
+    "start": 1776121908803850542
   }]]

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced.json
@@ -11,20 +11,22 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "69dd784200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpu2ukylf3,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "psycopg",
       "db.system": "postgresql",
       "language": "python",
-      "runtime-id": "5e80c5a691c84329bbe0464d28854fae",
+      "runtime-id": "f641f8e775104c49b6b16e8f16e66681",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 75387
+      "_sampling_priority_v1": 1.0,
+      "process_id": 59863.0
     },
-    "duration": 3607708,
-    "start": 1692712154644657553
+    "duration": 3543167,
+    "start": 1776121922149705882
   }]]

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced_via_env.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced_via_env.json
@@ -11,20 +11,22 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "672bb07300000000",
+      "_dd.p.tid": "69dd784200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "psycopg",
       "db.system": "postgresql",
       "language": "python",
-      "runtime-id": "8166f0c068d04b2f9b5ee065e819d7c0",
+      "runtime-id": "b614f19509404a9f86b2a5347da5b856",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 689
+      "_sampling_priority_v1": 1.0,
+      "process_id": 59884.0
     },
-    "duration": 11286000,
-    "start": 1730916467898579000
+    "duration": 3828459,
+    "start": 1776121922946283257
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema0].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767400000000",
+      "_dd.p.tid": "69dfa96800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "424886c0722748099f7dddfaeb688e3e",
+      "runtime-id": "8c8dfebbe0904597a0fcf52be9fbcb6a",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24468
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98240.0
     },
-    "duration": 477541,
-    "start": 1722971764823021965
+    "duration": 610084,
+    "start": 1776265576252002505
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema1].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2766e00000000",
+      "_dd.p.tid": "69dfa96400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "325846af5de24ba5860027715cde2fc4",
+      "runtime-id": "d1ed4aa6c6c44b289a39072dcc4d6f6e",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24446
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98219.0
     },
-    "duration": 499834,
-    "start": 1722971758706227545
+    "duration": 557500,
+    "start": 1776265572685662379
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema2].json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2766b00000000",
+      "_dd.p.tid": "69dfa95c00000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -22,20 +24,20 @@
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
       "peer.service": "mock-db-name",
-      "runtime-id": "ba41b09acf3d4a35a7cc347c48612832",
+      "runtime-id": "f201d290bd214332bb24417d85bd857a",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24435
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98162.0
     },
-    "duration": 487667,
-    "start": 1722971755864225002
+    "duration": 667583,
+    "start": 1776265564494128000
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema3].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767200000000",
+      "_dd.p.tid": "69dfa95e00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "cb8dc2c3d54147ba98467be35335f8d0",
+      "runtime-id": "5831e0a922b6482287141dcc418874ad",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24457
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98174.0
     },
-    "duration": 488750,
-    "start": 1722971762725292172
+    "duration": 576625,
+    "start": 1776265566179919376
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema4].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767700000000",
+      "_dd.p.tid": "69dfa96200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "031c8a7369614c7e930854e5fbe6c960",
+      "runtime-id": "3310167c055c439c8492c5e821f71a75",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24478
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98204.0
     },
-    "duration": 618375,
-    "start": 1722971767470728758
+    "duration": 544875,
+    "start": 1776265570565627878
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema5].json
@@ -10,8 +10,10 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767a00000000",
+      "_dd.p.tid": "69dfa95f00000000",
       "_dd.peer.service.source": "db.name",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.user:true",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -22,20 +24,20 @@
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
       "peer.service": "mock-db-name",
-      "runtime-id": "ed909cc6637545a28bee17e3794b346e",
+      "runtime-id": "fbf390c0672747809bb35ca020cc509b",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24488
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98186.0
     },
-    "duration": 489666,
-    "start": 1722971770484891218
+    "duration": 563208,
+    "start": 1776265567844002418
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_commit.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_commit.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767800000000",
+      "_dd.p.tid": "69dfa96300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,17 +23,17 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 818250,
-    "start": 1722971768604165925
+    "duration": 885417,
+    "start": 1776265571218017461
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_executemany_insert.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_executemany_insert.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767500000000",
+      "_dd.p.tid": "69dfa95a00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,21 +23,21 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client",
       "sql.executemany": "true"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 803958,
-    "start": 1722971765425873007
+    "duration": 1288417,
+    "start": 1776265562175630346
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767800000000",
+      "_dd.p.tid": "69dfa96600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 856041,
-    "start": 1722971768087295675
+    "duration": 1035833,
+    "start": 1776265574090715921
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall_multiple_rows.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall_multiple_rows.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767b00000000",
+      "_dd.p.tid": "69dfa96500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 2,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 2.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 790625,
-    "start": 1722971771070745718
+    "duration": 914334,
+    "start": 1776265573362696837
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchone.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchone.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767000000000",
+      "_dd.p.tid": "69dfa96600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 779125,
-    "start": 1722971760316620254
+    "duration": 885042,
+    "start": 1776265574612243713
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_rollback.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_rollback.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2766f00000000",
+      "_dd.p.tid": "69dfa96900000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,17 +23,17 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 810125,
-    "start": 1722971759268462671
+    "duration": 1028375,
+    "start": 1776265577005953506
   }]]

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_settings_override.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_settings_override.json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.snowflake",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "66b2767b00000000",
+      "_dd.p.tid": "69dfa95a00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.snowflake",
       "component": "snowflake",
       "db.application": "PythonConnector",
       "db.name": "mock-db-name",
@@ -21,20 +23,20 @@
       "db.warehouse": "mock-warehouse-name",
       "language": "python",
       "out.host": "mock-account.snowflakecomputing.com",
-      "runtime-id": "056d559a15d34e5cb47f66c18ccbe086",
+      "runtime-id": "e4ae4bcd07844a3fb0c654591b8ad34b",
       "server.address": "mock-account.snowflakecomputing.com",
       "sfqid": "mocksfqid-29244a72-90a0-4309-9168-9dcf67721f6d",
       "span.kind": "client"
     },
     "metrics": {
-      "_dd.measured": 1,
-      "_dd.top_level": 1,
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "db.row_count": 1,
-      "network.destination.port": 443,
-      "process_id": 24423
+      "_sampling_priority_v1": 1.0,
+      "db.row_count": 1.0,
+      "network.destination.port": 443.0,
+      "process_id": 98149.0
     },
-    "duration": 765709,
-    "start": 1722971771608533801
+    "duration": 994375,
+    "start": 1776265562777022680
   }]]


### PR DESCRIPTION
## Description

This change commits the result of running some database-related test suites in my local `testrunner` container from https://github.com/DataDog/dd-trace-py/pull/17502. That change removes the tag `meta._dd.svc_src` from the list of attributes ignored during snapshot testing. The change here is a small, easier-to-review subset of that change.