### PR TITLE
chore(crashtracking): receiver side symbolication for tests

### DIFF
--- a/tests/crashtracker/utils.py
+++ b/tests/crashtracker/utils.py
@@ -23,7 +23,7 @@ def start_crashtracker(port: int, stdout: Optional[str] = None, stderr: Optional
         crashtracker_config.debug_url = "http://localhost:%d" % port
         crashtracker_config.stdout_filename = stdout
         crashtracker_config.stderr_filename = stderr
-        crashtracker_config.resolve_frames = "full"
+        crashtracker_config._stacktrace_resolver = "safe"
 
         default_tags = {
             "service": "my_favorite_service",


### PR DESCRIPTION
## Description

This library defaults to symbolicating in the receiver on linux. Our tests should also just default for that for parity.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
