### PR TITLE
ci(benchmarks): integrate parallel macrobenchmarks from apm-sdks-benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - package
+  # These benchmarks are planned to replace the legacy macrobenchmarks in the future
   - python-flask-realworld-parallel
   - python-flask-realworld-parallel-slo
   - tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ include:
   - local: ".gitlab/fuzz.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-python-flask-realworld-parallel.yml'
-    ref: 'fayssal/integrate'
+    ref: 'main'
 
 "pipeline variables":
   stage: .pre

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 stages:
   - package
+  - python-flask-realworld-parallel
+  - python-flask-realworld-parallel-slo
   - tests
   - fuzz
   - shared-pipeline
@@ -61,6 +63,9 @@ include:
   - local: ".gitlab/benchmarks/serverless.yml"
   - local: ".gitlab/native.yml"
   - local: ".gitlab/fuzz.yml"
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-python-flask-realworld-parallel.yml'
+    ref: 'fayssal/integrate'
 
 "pipeline variables":
   stage: .pre


### PR DESCRIPTION
## Description
Integrates new parallel macrobenchmarks from `DataDog/apm-reliability/apm-sdks-benchmarks` via GitLab `include: project:` directive. Both old and new benchmarks run alongside each other during a transition period before switching over exclusively.
<!-- Provide an overview of the change and motivation for the change -->

## Testing
Existing benchmark suite runs as before; new benchmarks from `apm-sdks-benchmarks` run in parallel with old benchmarks to verify compatibility and correctness.
<!-- Describe your testing strategy or note what tests are included -->

## Risks
None — both benchmark suites coexist during transition.
<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes
`apm-sdks-benchmarks` is now the single repository for all macrobenchmark configuration changes related to these benchmarks.
<!-- Any other information that would be helpful for reviewers -->
