### PR TITLE
chore(profiling): add profiler native allocation analysis skill

### DIFF
--- a/.claude/skills/profiler-allocs/SKILL.md
+++ b/.claude/skills/profiler-allocs/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: profiler-allocs
+description: >
+  Analyze native (C/C++/Rust) memory allocations made by the dd-trace-py
+  profiler. Builds the profiler in Docker, runs it under ddprof to capture
+  allocation profiles, and analyzes allocation count and live heap using
+  go tool pprof. Use this to measure the profiler's fragmentation impact
+  and identify allocation hotspots in profiler code.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+---
+
+# Profiler Native Allocation Analysis
+
+This skill captures and analyzes native memory allocations from the dd-trace-py
+profiler's own code (not the application being profiled). It uses
+[ddprof](https://github.com/DataDog/ddprof) to profile the profiler, then
+`go tool pprof` to analyze the results.
+
+**Primary metric**: allocation count (fragmentation impact), not bytes.
+
+## Prerequisites
+
+- Docker (with `--privileged` capability for `perf_event_open`)
+- `go` (for `go tool pprof`)
+- `zstd` (for decompressing ddprof output)
+
+## Workflow
+
+### Step 1: Build the Docker Image
+
+Check if the image already exists. Only rebuild if profiler source code changed.
+
+```bash
+# Check if image exists
+docker images ddtrace-profiler-allocs --format "{{.ID}}" | head -1
+
+# Build (from repo root)
+docker build -t ddtrace-profiler-allocs -f scripts/profiler-allocs/Dockerfile .
+```
+
+The build takes ~5 minutes (Rust + CMake compilation). It:
+- Installs pyenv + Python 3.12 with `--enable-shared`
+- Installs Rust toolchain
+- Builds dd-trace-py with `DD_FAST_BUILD=1`
+- Downloads ddprof v0.25.0
+
+### Step 2: Capture Profiles
+
+```bash
+mkdir -p artifacts
+docker run --rm --privileged \
+  -e TEST_DURATION=30 \
+  -v $(pwd)/artifacts:/artifacts \
+  ddtrace-profiler-allocs
+```
+
+- `--privileged` is required for ddprof's `perf_event_open`
+- `TEST_DURATION` controls workload duration (default 30s)
+- ddprof writes `.pprof.zst` files to `/artifacts/`
+- Upload period is 10s, so a 30s run produces ~3 steady-state profiles
+
+### Step 3: Analyze
+
+```bash
+scripts/profiler-allocs/analyze.sh [artifacts_dir]
+```
+
+The analysis script:
+1. Decompresses `.pprof.zst` files
+2. Reports profiler allocation count over time (excluding app workload)
+3. Shows cumulative call chains driving allocations
+4. Reports live heap and live object counts
+5. Prints `go tool pprof` commands for interactive flamegraph exploration
+
+### Interpreting Results
+
+**Allocation count** (`alloc-samples`):
+- Focus filter: profiler code paths (dd_wrapper, ddup, libdatadog, etc.)
+- Ignore filter: app workload (bytearray, PyList_Append going through _memalloc hooks)
+- Steady-state rate should be ~2-6 allocs/second
+- Higher rates suggest missing pre-allocation or unnecessary object churn
+
+**Live heap** (`inuse-space`):
+- Shows what's retained — identifies memory that could be freed or pooled
+- `libdd_alloc::VirtualAllocator` is the arena allocator (expected to retain)
+
+**Key code paths to watch**:
+- `UploaderBuilder::build()` — creates exporter + serializes each cycle
+- `ddog_prof_Exporter_new()` — HTTP client + TLS setup (should be reused)
+- `Sampler::sampling_thread()` — stack sampling (should not allocate)
+- `StackRenderer::render_frame()` — frame rendering (should reuse buffers)
+- `intern_string()` — string dedup (grows with unique strings)
+
+### Interactive Exploration
+
+```bash
+# Allocation count flamegraph (profiler only)
+go tool pprof -http=:8080 -sample_index=alloc-samples \
+  -focus='dd_wrapper|ddup|libdatadog|libdd|Datadog::' \
+  -ignore='bytearray|PyByteArray' \
+  artifacts/ddprof*.pprof
+
+# Live heap flamegraph
+go tool pprof -http=:8080 -sample_index=inuse-space \
+  -focus='dd_wrapper|ddup|libdatadog|libdd|Datadog::' \
+  artifacts/ddprof*.pprof
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/profiler-allocs/Dockerfile` | Docker image: dd-trace-py build + ddprof |
+| `scripts/profiler-allocs/test_app.py` | Multi-threaded workload exercising the profiler |
+| `scripts/profiler-allocs/build.sh` | Image build helper |
+| `scripts/profiler-allocs/analyze.sh` | pprof analysis (allocation count + live heap) |
+| `scripts/profiler-allocs/ANALYSIS.md` | Baseline analysis and improvement opportunities |
+
+## Reference: ddprof Flags
+
+```
+ddprof -l notice --preset cpu_live_heap \
+  --debug_pprof_prefix /artifacts/ddprof \
+  -u 10 \
+  -- python3 /app/test_app.py
+```
+
+- `-l notice`: log level
+- `--preset cpu_live_heap`: CPU + allocations + live heap
+- `--debug_pprof_prefix`: saves pprof files locally (zstd compressed)
+- `-u 10`: upload/export period in seconds

--- a/scripts/profiler-allocs/Dockerfile
+++ b/scripts/profiler-allocs/Dockerfile
@@ -1,0 +1,100 @@
+# Dockerfile for analyzing native allocations made by the dd-trace-py profiler.
+# Builds dd-trace-py with profiling extensions and installs ddprof for native
+# heap profiling.
+#
+# Build:
+#   docker build -t ddtrace-profiler-allocs -f scripts/profiler-allocs/Dockerfile .
+#
+# Run:
+#   docker run --rm -v $(pwd)/artifacts:/artifacts ddtrace-profiler-allocs
+
+FROM debian:trixie-slim
+
+ARG TARGETARCH
+ARG DDPROF_VERSION=0.25.0
+
+ENV LANG=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies (mirrors profiling_native CI image)
+# autoconf/automake/libtool needed for libdatadog's libunwind build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      autoconf \
+      automake \
+      build-essential \
+      ca-certificates \
+      cmake \
+      curl \
+      git \
+      libbz2-dev \
+      libffi-dev \
+      liblzma-dev \
+      libncurses5-dev \
+      libncursesw5-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libtool \
+      make \
+      patchelf \
+      pkg-config \
+      wget \
+      xz-utils \
+      zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pyenv + Python 3.12 with --enable-shared (needed for native extensions)
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
+
+RUN git clone --depth 1 --branch "v2.6.17" https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
+    && pyenv install 3.12 \
+    && pyenv global 3.12 \
+    && echo "${PYENV_ROOT}/versions/3.12.12/lib" >> /etc/ld.so.conf.d/pyenv.conf \
+    && ldconfig
+
+# Install Rust
+ENV CARGO_HOME=/root/.cargo
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain stable -y
+
+# Install Python build tools
+RUN pip install --no-cache-dir -U pip setuptools wheel \
+    && pip install --no-cache-dir cmake setuptools_rust cython patchelf pybind11
+
+# Download ddprof
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -L -o /tmp/ddprof.tar.xz \
+      "https://github.com/DataDog/ddprof/releases/download/v${DDPROF_VERSION}/ddprof-${DDPROF_VERSION}-${ARCH}-linux.tar.xz" && \
+    mkdir -p /opt/ddprof && \
+    tar -xf /tmp/ddprof.tar.xz -C /opt/ddprof --strip-components=1 && \
+    rm /tmp/ddprof.tar.xz
+ENV PATH="/opt/ddprof/bin:${PATH}"
+
+# Copy dd-trace-py source and build with profiling extensions
+WORKDIR /dd-trace-py
+COPY . .
+
+# Override .python-version — we only have 3.12 installed
+RUN echo "3.12" > .python-version
+
+# DD_FAST_BUILD=1 disables LTO + Abseil for faster builds
+RUN DD_FAST_BUILD=1 pip install --no-cache-dir -e . -v
+
+# Copy test app
+COPY scripts/profiler-allocs/test_app.py /app/test_app.py
+
+WORKDIR /app
+
+# Run test app under ddprof with cpu_live_heap preset.
+# --debug_pprof_prefix saves pprof files locally (as .pprof.zst).
+# -u 10 sets a short upload period so we get multiple profiles.
+CMD ["ddprof", \
+     "-l", "notice", \
+     "--preset", "cpu_live_heap", \
+     "--debug_pprof_prefix", "/artifacts/ddprof", \
+     "-u", "10", \
+     "--", \
+     "python3", "/app/test_app.py"]

--- a/scripts/profiler-allocs/analyze.sh
+++ b/scripts/profiler-allocs/analyze.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Analyze native allocation pprof files captured by ddprof.
+# Focuses on allocation COUNT (fragmentation impact) from the dd-trace-py
+# profiler's own code, excluding application workload allocations.
+#
+# Usage:
+#   scripts/profiler-allocs/analyze.sh [artifacts_dir]
+
+ARTIFACTS_DIR="${1:-$(pwd)/artifacts}"
+
+# Profiler code paths to focus on
+PROFILER_FOCUS="dd_wrapper|ddup|memalloc|_stack|libdatadog|libdd|sample|profil|echion|_native|uploader|Datadog::|ChainAllocator|SliceSet|intern_string"
+# Application workload paths to exclude (they go through _memalloc hooks but
+# are not the profiler's own allocations)
+APP_IGNORE="bytearray|PyByteArray|PyList_Append|_PyList_Append"
+
+if ! command -v go &>/dev/null; then
+    echo "Error: go is not installed (needed for 'go tool pprof')."
+    exit 1
+fi
+
+# Decompress .pprof.zst files if zstd is available
+if command -v zstd &>/dev/null; then
+    for f in "${ARTIFACTS_DIR}"/*.pprof.zst; do
+        [ -f "$f" ] || continue
+        out="${f%.zst}"
+        if [ ! -f "$out" ] || [ "$f" -nt "$out" ]; then
+            zstd -d "$f" -o "$out" -f --quiet
+        fi
+    done
+else
+    echo "Warning: zstd not found. Cannot decompress .pprof.zst files."
+    echo "Install with: brew install zstd"
+fi
+
+# Collect all plain .pprof files
+pprof_files=()
+while IFS= read -r -d '' f; do
+    pprof_files+=("$f")
+done < <(find "${ARTIFACTS_DIR}" -name "*.pprof" ! -name "*.pprof.zst" -print0 2>/dev/null | sort -z)
+
+if [ ${#pprof_files[@]} -eq 0 ]; then
+    echo "No .pprof files found in ${ARTIFACTS_DIR}"
+    echo ""
+    echo "Run the Docker container first:"
+    echo "  mkdir -p artifacts"
+    echo "  docker run --rm --privileged -v \$(pwd)/artifacts:/artifacts ddtrace-profiler-allocs"
+    exit 1
+fi
+
+echo "========================================================================"
+echo "  Native Allocation Analysis — dd-trace-py profiler"
+echo "  Focus: allocation COUNT (fragmentation impact)"
+echo "========================================================================"
+echo ""
+echo "Found ${#pprof_files[@]} pprof file(s) in ${ARTIFACTS_DIR}"
+echo ""
+
+# --- Section 1: Allocation count per profile (profiler only) ---
+echo "------------------------------------------------------------------------"
+echo "  1. Profiler allocation count over time (alloc-samples)"
+echo "     Excludes application workload (bytearray/list)"
+echo "------------------------------------------------------------------------"
+echo ""
+for f in "${pprof_files[@]}"; do
+    echo "--- $(basename "$f") ---"
+    go tool pprof -top -sample_index=alloc-samples -nodecount=20 \
+        -focus="${PROFILER_FOCUS}" \
+        -ignore="${APP_IGNORE}" \
+        "$f" 2>/dev/null | grep -E "(flat|Total|Duration|Active|Showing|^\s+[0-9])" || true
+    echo ""
+done
+
+# Use the last profile for steady-state deep dives
+if [ ${#pprof_files[@]} -gt 1 ]; then
+    steady_state="${pprof_files[-1]}"
+    echo "(Using last profile for steady-state analysis below)"
+else
+    steady_state="${pprof_files[0]}"
+fi
+echo ""
+
+# --- Section 2: Cumulative call chains driving allocations ---
+echo "------------------------------------------------------------------------"
+echo "  2. Top cumulative call chains (alloc-samples, steady state)"
+echo "     Shows which profiler operations drive the most allocations"
+echo "------------------------------------------------------------------------"
+echo ""
+go tool pprof -top -sample_index=alloc-samples -nodecount=30 -cum \
+    -focus="${PROFILER_FOCUS}" \
+    -ignore="${APP_IGNORE}" \
+    "${steady_state}" 2>/dev/null || true
+echo ""
+
+# --- Section 3: Live heap (what's still held) ---
+echo "------------------------------------------------------------------------"
+echo "  3. Profiler live heap (inuse-space) — retained allocations"
+echo "------------------------------------------------------------------------"
+echo ""
+go tool pprof -top -sample_index=inuse-space -nodecount=25 \
+    -focus="${PROFILER_FOCUS}" \
+    "${steady_state}" 2>/dev/null || true
+echo ""
+
+# --- Section 4: Live object count ---
+echo "------------------------------------------------------------------------"
+echo "  4. Profiler live objects (inuse-objects)"
+echo "------------------------------------------------------------------------"
+echo ""
+go tool pprof -top -sample_index=inuse-objects -nodecount=20 \
+    -focus="${PROFILER_FOCUS}" \
+    "${steady_state}" 2>/dev/null || true
+echo ""
+
+# --- Interactive ---
+echo "========================================================================"
+echo "  Interactive exploration"
+echo "========================================================================"
+echo ""
+echo "Allocation count flamegraph (profiler only, excludes app workload):"
+echo "  go tool pprof -http=:8080 -sample_index=alloc-samples -focus='${PROFILER_FOCUS}' -ignore='${APP_IGNORE}' ${steady_state}"
+echo ""
+echo "Live heap flamegraph (profiler code):"
+echo "  go tool pprof -http=:8080 -sample_index=inuse-space -focus='${PROFILER_FOCUS}' ${steady_state}"
+echo ""
+echo "All profiles:"
+for f in "${pprof_files[@]}"; do
+    echo "  ${f}"
+done
+echo ""

--- a/scripts/profiler-allocs/build.sh
+++ b/scripts/profiler-allocs/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the Docker image for profiler native allocation analysis.
+# Run from the repo root:
+#   scripts/profiler-allocs/build.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE_NAME="ddtrace-profiler-allocs"
+
+cd "${REPO_ROOT}"
+
+echo "==> Building ${IMAGE_NAME} Docker image..."
+echo "    (this builds dd-trace-py with native profiling extensions)"
+
+docker build \
+    -t "${IMAGE_NAME}" \
+    -f scripts/profiler-allocs/Dockerfile \
+    .
+
+echo ""
+echo "==> Build complete: ${IMAGE_NAME}"
+echo ""
+echo "Run with:"
+echo "  mkdir -p artifacts"
+echo "  docker run --rm -v \$(pwd)/artifacts:/artifacts ${IMAGE_NAME}"
+echo ""
+echo "Or with custom duration:"
+echo "  docker run --rm -e TEST_DURATION=60 -v \$(pwd)/artifacts:/artifacts ${IMAGE_NAME}"

--- a/scripts/profiler-allocs/test_app.py
+++ b/scripts/profiler-allocs/test_app.py
@@ -1,0 +1,74 @@
+"""Simple test application that exercises the dd-trace-py profiler.
+
+Starts the profiler with memory + stack collection enabled, then runs
+a workload to trigger profiler activity (sampling, heap tracking, uploads).
+This is meant to be run under ddprof to capture the *profiler's own*
+native allocations.
+"""
+import os
+import time
+import threading
+
+# Disable upload so we don't need a real agent
+os.environ.setdefault("DD_PROFILING_UPLOAD_INTERVAL", "5")
+os.environ.setdefault("DD_PROFILING_ENABLED", "true")
+os.environ.setdefault("DD_PROFILING_MEMORY_ENABLED", "true")
+os.environ.setdefault("DD_PROFILING_STACK_ENABLED", "true")
+os.environ.setdefault("DD_TRACE_AGENT_URL", "http://localhost:18126")  # bogus agent to avoid connection errors
+
+from ddtrace.profiling import Profiler  # noqa: E402
+
+
+DURATION = int(os.environ.get("TEST_DURATION", "30"))  # seconds
+
+
+def cpu_work():
+    """Do some CPU work to trigger stack sampling."""
+    total = 0
+    for i in range(500_000):
+        total += i * i
+    return total
+
+
+def alloc_work():
+    """Do some allocations to trigger heap tracking."""
+    data = []
+    for _ in range(10_000):
+        data.append(bytearray(1024))
+    return data
+
+
+def worker():
+    """Thread worker that alternates CPU and allocation work."""
+    for _ in range(100):
+        cpu_work()
+        alloc_work()
+        time.sleep(0.01)
+
+
+def main():
+    profiler = Profiler()
+    profiler.start()
+
+    print(f"Profiler started, running workload for {DURATION}s...")
+
+    end_time = time.time() + DURATION
+    threads = []
+
+    while time.time() < end_time:
+        # Spawn worker threads to exercise multi-threaded profiling
+        batch = []
+        for _ in range(4):
+            t = threading.Thread(target=worker)
+            t.start()
+            batch.append(t)
+        for t in batch:
+            t.join()
+
+    print("Workload complete, stopping profiler...")
+    profiler.stop(flush=True)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->
Add a skill and tooling to analyze native (C/C++/Rust) memory allocations made by the dd-trace-py profiler using ddprof and go tool pprof.

Includes:
- Docker image that builds dd-trace-py and runs it under ddprof v0.25.0
- Analysis script focusing on allocation count (fragmentation impact)
- Test app exercising the profiler with multi-threaded workload
- Claude Code skill definition for easy invocation

## Testing

<!-- Describe your testing strategy or note what tests are included -->

From claude
Almost all steady-state allocations come from the **upload path**:

```
PeriodicThread__periodic()
  └─ ddup_upload()
       └─ UploaderBuilder::build()       ← 15–23 allocs/cycle
            ├─ ddog_prof_Exporter_new()   ← creates a new HTTP exporter (TLS, tokio, etc.)
            ├─ ddog_Vec_Tag (tag setup)   ← tag vector allocations
            ├─ ddog_prof_Profile_serialize() ← profile encoding
            │    ├─ Rust Vec growth       ← pprof protobuf buffers
            │    └─ Zstd compression      ← compressing serialized profile
            └─ Uploader constructor
       └─ Uploader::upload_unlocked()
            ├─ CancellationToken_new/clone
            └─ ddog_prof_Exporter_send_blocking()
       └─ ~Uploader()                    ← drops exporter, encoded profile
```

Essentially it highlights that we should not be re-creating the uploader at every cycle.


## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
