### PR TITLE
ci: update system-tests pin to post-merge SHA

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -428,7 +428,7 @@ jobs:
 
   tracer-release:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     with:
       library: python
       ref: main

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -388,7 +388,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5
     secrets: inherit
     with:
       library: python_lambda
@@ -418,7 +418,7 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5
     secrets: inherit
     with:
       library: python
@@ -428,7 +428,7 @@ jobs:
 
   tracer-release:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5
     with:
       library: python
       ref: main


### PR DESCRIPTION
Update system-tests pin from 1e5d6b7 to 23941ab (post-merge SHA) to activate dd-sts test optimization.