### PR TITLE
test(sampling): verify _dd.p.ksr formatting is locale-independent

### DIFF
--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -921,3 +921,22 @@ def test_ksr_formatting(span, sample_rate, expected_ksr):
 
     _set_sampling_tags(span, True, sample_rate, SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE)
     assert span._get_str_attribute(KNUTH_SAMPLE_RATE_KEY) == expected_ksr
+
+
+def test_ksr_formatting_locale_independent():
+    """_dd.p.ksr formatting must use '.' as decimal separator regardless of locale."""
+    import locale
+    from ddtrace.internal.sampling import _format_ksr
+
+    original_locale = locale.getlocale(locale.LC_ALL)
+    try:
+        try:
+            locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+        except locale.Error:
+            pytest.skip("de_DE.UTF-8 locale not available")
+        assert _format_ksr(0.3) == "0.3"
+        assert _format_ksr(0.5) == "0.5"
+        assert _format_ksr(1.0) == "1"
+        assert _format_ksr(0.000001) == "0.000001"
+    finally:
+        locale.setlocale(locale.LC_ALL, original_locale)


### PR DESCRIPTION
## Description

Add a regression test verifying that `_format_ksr` produces locale-independent output (always uses `.` as the decimal separator, never `,`).

This is a cross-tracer hardening effort motivated by [dd-trace-php#3796](https://github.com/DataDog/dd-trace-php/pull/3796), where a German locale caused `_dd.p.ksr` to use `,` instead of `.`, breaking downstream parsing. This test sets `LC_ALL=de_DE.UTF-8` and asserts the formatted value still uses `.`.

## Testing

- New unit test `test_ksr_formatting_locale_independent` in `tests/tracer/test_sampler.py`
- Skips gracefully via `pytest.skip` if the `de_DE.UTF-8` locale is not available on the test runner
- Restores the original locale in a `finally` block to avoid side effects

## Risks

None. Test-only change with no production code modifications.

## Additional Notes

The existing `_format_ksr` implementation in dd-trace-py already uses Python string formatting (`f"{value:.6f}"`) which is locale-independent, so this test should pass today. It serves as a regression guard to prevent future refactors from introducing locale-sensitive formatting (e.g., switching to `locale.format_string` or similar).