### PR TITLE
chore(appsec): skip user block when auto mode resolves to disabled

### DIFF
--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -362,8 +362,11 @@ def block_request_if_user_blocked(userid: str, mode: str = "sdk", session_id: Op
     """
     if mode == LOGIN_EVENTS_MODE.AUTO:
         mode = asm_config._user_event_mode
-    if not asm_config._asm_enabled or mode == LOGIN_EVENTS_MODE.DISABLED:
+    if not asm_config._asm_enabled:
         log.warning("should_block_user call requires ASM to be enabled")
+        return
+    if mode == LOGIN_EVENTS_MODE.DISABLED:
+        log.debug("should_block_user skipped: user instrumentation mode is disabled")
         return
     entry_span = _asm_request_context.get_entry_span()
     if entry_span:

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -360,13 +360,13 @@ def block_request_if_user_blocked(userid: str, mode: str = "sdk", session_id: Op
     :param userid: the ID of the user as registered by `set_user`
     :param mode: the mode of the login event ("sdk" by default, "auto" to simulate auto instrumentation)
     """
+    if not asm_config._asm_enabled:
+        if mode != LOGIN_EVENTS_MODE.AUTO:
+            log.warning("should_block_user call requires ASM to be enabled")
+        return
     if mode == LOGIN_EVENTS_MODE.AUTO:
         mode = asm_config._user_event_mode
-    if not asm_config._asm_enabled:
-        log.warning("should_block_user call requires ASM to be enabled")
-        return
     if mode == LOGIN_EVENTS_MODE.DISABLED:
-        log.debug("should_block_user skipped: user instrumentation mode is disabled")
         return
     entry_span = _asm_request_context.get_entry_span()
     if entry_span:

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -360,11 +360,11 @@ def block_request_if_user_blocked(userid: str, mode: str = "sdk", session_id: Op
     :param userid: the ID of the user as registered by `set_user`
     :param mode: the mode of the login event ("sdk" by default, "auto" to simulate auto instrumentation)
     """
+    if mode == LOGIN_EVENTS_MODE.AUTO:
+        mode = asm_config._user_event_mode
     if not asm_config._asm_enabled or mode == LOGIN_EVENTS_MODE.DISABLED:
         log.warning("should_block_user call requires ASM to be enabled")
         return
-    if mode == LOGIN_EVENTS_MODE.AUTO:
-        mode = asm_config._user_event_mode
     entry_span = _asm_request_context.get_entry_span()
     if entry_span:
         entry_span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, mode)


### PR DESCRIPTION
## Summary

`block_request_if_user_blocked` has a guard-ordering bug: it checks
`mode == DISABLED` **before** resolving `AUTO` to the configured mode.
When called with `mode="auto"` (via `set_user_for_asm`) and
`DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=disabled`, the guard reads
`"auto" == "disabled"` → False and proceeds, calling `should_block_user`
unnecessarily. That WAF call returns `keep=True` and causes the tracer
to force-keep the trace via `_asm_manual_keep` — even though no
automated user event was generated.

Fix: resolve `AUTO` to the configured mode first, then apply the
disabled guard.

```python
# Before (buggy)
if not asm_config._asm_enabled or mode == LOGIN_EVENTS_MODE.DISABLED:
    return
if mode == LOGIN_EVENTS_MODE.AUTO:
    mode = asm_config._user_event_mode   # too late — guard already passed

# After
if mode == LOGIN_EVENTS_MODE.AUTO:
    mode = asm_config._user_event_mode   # resolve first
if not asm_config._asm_enabled or mode == LOGIN_EVENTS_MODE.DISABLED:
    return                               # now correctly catches disabled
```

## How the bug was found

While writing end-to-end tests for the `APPSEC_AUTO_EVENTS_TRACKING=disabled`
scenario in [system-tests](https://github.com/DataDog/system-tests/pull/6750),
login-success traces were unexpectedly force-kept (`_sampling_priority_v1=2`,
`_dd.p.dm=-5`) even though no user event tags were emitted. Debug
tracing confirmed `_asm_manual_keep` was called from `_processor.py:399`
via `should_block_user` → `call_waf_callback(usr.id=...)`, bypassing the
disabled guard due to the ordering bug described above.

## Release notes

> **Note:** Release notes still needed before this can be merged.