### PR TITLE
fix(tracer): reduce tracer shutdown message verbosity

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -444,16 +444,11 @@ class SpanAggregator(SpanProcessor):
         self._queue_span_count_metrics("spans_finished", "integration_name", 1)
         # Log a warning if the tracer is shutdown before spans are finished
         if log.isEnabledFor(logging.WARNING):
-            unsent_spans = [
-                f"trace_id={s.trace_id} parent_id={s.parent_id} span_id={s.span_id} name={s.name} resource={s.resource} started={s.start} sampling_priority={s.context.sampling_priority}"  # noqa: E501
-                for t in self._traces.values()
-                for s in t.spans
-            ]
-            if unsent_spans:
+            unsent_span_count = sum(len(t.spans) for t in self._traces.values())
+            if unsent_span_count:
                 log.warning(
-                    "Shutting down tracer with %d spans. These spans will not be sent to Datadog: %s",
-                    len(unsent_spans),
-                    ", ".join(unsent_spans),
+                    "Shutting down tracer with %d spans. These spans will not be sent to Datadog.",
+                    unsent_span_count,
                 )
 
         try:

--- a/releasenotes/notes/shorter-span-shutdown-logs-a9027e1097e5e7b0.yaml
+++ b/releasenotes/notes/shorter-span-shutdown-logs-a9027e1097e5e7b0.yaml
@@ -1,0 +1,30 @@
+---
+#instructions:
+#    The style guide below provides explanations, instructions, and templates to write your own release note.
+#    Once finished, all irrelevant sections (including this instruction section) should be removed,
+#    and the release note should be committed with the rest of the changes.
+#
+#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
+#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
+#
+#    The release note should also clearly distinguish between announcements and user instructions. Use:
+#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
+#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
+#    * Active present infinitive for user instructions (ex: ``set, use, add``)
+#
+#    Release notes should:
+#    * Use plain language
+#    * Be concise
+#    * Include actionable steps with the necessary code changes
+#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
+#    * Use full sentences with sentence-casing and punctuation.
+#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
+#
+#    Release notes should not:
+#    * Be vague. Example: ``fixes an issue in tracing``.
+#    * Use overly technical language
+#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
+fixes:
+  - |
+    fix(tracing): Decrease amount of overly-verbose logging emitted during some shutdowns.
+

--- a/releasenotes/notes/shorter-span-shutdown-logs-a9027e1097e5e7b0.yaml
+++ b/releasenotes/notes/shorter-span-shutdown-logs-a9027e1097e5e7b0.yaml
@@ -1,29 +1,4 @@
 ---
-#instructions:
-#    The style guide below provides explanations, instructions, and templates to write your own release note.
-#    Once finished, all irrelevant sections (including this instruction section) should be removed,
-#    and the release note should be committed with the rest of the changes.
-#
-#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
-#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
-#
-#    The release note should also clearly distinguish between announcements and user instructions. Use:
-#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
-#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
-#    * Active present infinitive for user instructions (ex: ``set, use, add``)
-#
-#    Release notes should:
-#    * Use plain language
-#    * Be concise
-#    * Include actionable steps with the necessary code changes
-#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
-#    * Use full sentences with sentence-casing and punctuation.
-#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
-#
-#    Release notes should not:
-#    * Be vague. Example: ``fixes an issue in tracing``.
-#    * Use overly technical language
-#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
 fixes:
   - |
     fix(tracing): Decrease amount of overly-verbose logging emitted during some shutdowns.


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

Currently, [millions](https://app.datadoghq.com/logs?query=%40sampling_priority%3A%2A%20%22These%20spans%20will%20not%20be%20sent%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=sunburst&from_ts=1775759379759&to_ts=1776364179759&live=true) of logs are being sent to Datadog org 2 with this message. This PR makes the message only print the length of the collection, not the full contents.

It will take up less space in our logs backend, and make it easier for browsers to open the log message if it has hundreds+ spans.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

I did not test this. I don't typically work in the agent, and am just a bystander whose log made the browser slow to a crawl 😅. Happy to test though if there's a doc on how to do so.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

Some people may depend on the content of the log to debug or look for specific spans. I _expect_ not since they're so verbose & I'm not sure what they'd be used for, but technically it's possible.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
