### PR TITLE
ci(internal): accept http git URLs

### DIFF
--- a/tests/sourcecode/test_source_code_link.py
+++ b/tests/sourcecode/test_source_code_link.py
@@ -8,6 +8,6 @@ def test_get_source_code_link():
     reporsitory_url, commit_hash = source_code_link.split("#")
 
     # can be github.com or gitlab.ddbuild.io
-    assert reporsitory_url.startswith("https://git")
+    assert reporsitory_url.startswith(("http://git", "https://git"))
     assert reporsitory_url.endswith("/dd-trace-py")
     assert re.match(r"\b[a-f0-9]{5,40}\b", commit_hash) is not None


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c6908827-05b4-465c-85a6-29fa6f10a0b9","source":"chat","resourceId":"46ec9ae2-804e-4212-b9ff-5a6ea71fffd8","workflowId":"4b0320c2-600d-43b7-ba24-db4f2fad99c4","codeChangeId":"4b0320c2-600d-43b7-ba24-db4f2fad99c4","sourceType":"assistant"} -->
## Description

CI clone infrastructure now provides `http://git...` remotes in some environments, while this test only accepted `https://git...` URLs. `normalize_repository_url()` intentionally preserves HTTP/HTTPS schemes, so the stricter assertion caused a false failure.

- Updated `tests/sourcecode/test_source_code_link.py` to accept both `http://git` and `https://git` prefixes in `test_get_source_code_link`.
- Kept the rest of the test unchanged, including domain-related expectations.

## Testing

## Risks

## Additional Notes