### PR TITLE
ci(iast): fix flaky IAST taint tracking and telemetry tests

### DIFF
--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -8,6 +8,8 @@ import pytest
 from ddtrace.appsec._common_module_patches import patch_common_modules
 from ddtrace.appsec._common_module_patches import unpatch_common_modules
 from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
+from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._overhead_control_engine import oce
 from ddtrace.appsec._iast._patch_modules import _testing_unpatch_iast
 from ddtrace.appsec._iast._patches.json_tainting import patch as json_patch
@@ -70,6 +72,11 @@ def iast_context(env, request_sampling=100.0, deduplication=False, asm_enabled=F
         assert debug_context_array_size() == 2
         assert debug_context_array_free_slots_number() > 0
         span = MockSpan()
+        # Clear any stale IAST context leaked from a previous test. If IAST_CONTEXT holds a
+        # non-None slot ID from a prior test, _iast_start_request() sees is_iast_request_enabled()
+        # as True and skips slot allocation. The stale slot ID then points to a freed C++ taint
+        # map, causing api_taint_pyobject to silently return untainted objects.
+        _iast_finish_request()
         _start_iast_context_and_oce(span)
         weak_hash_patch()
         weak_cipher_patch()
@@ -88,6 +95,11 @@ def iast_context(env, request_sampling=100.0, deduplication=False, asm_enabled=F
             reset_taint_range_limit_cache()
             reset_source_truncation_cache()
             clear_all_request_context_slots()
+            # Keep ContextVar in sync with the freed C++ slots. clear_all_request_context_slots()
+            # frees all taint maps but does NOT update IAST_CONTEXT. If a subsequent test's
+            # _start_iast_context_and_oce still sees is_iast_request_enabled()=True (stale),
+            # it would skip slot allocation, leaving the test with a dangling slot reference.
+            IAST_CONTEXT.set(None)
 
 
 @pytest.fixture

--- a/tests/appsec/iast/iast_utils.py
+++ b/tests/appsec/iast/iast_utils.py
@@ -3,7 +3,6 @@ import json
 import re
 import types
 from typing import Any
-from typing import Optional
 from typing import Text
 from typing import Union
 import zlib
@@ -37,7 +36,7 @@ class IastTestException(Exception):
     pass
 
 
-def get_line(label: Text, filename: Optional[Text] = None):
+def get_line(label: Text, filename: Text):
     """get the line number after the label comment in source file `filename`"""
     with open(filename, "r") as file_in:
         for nb_line, line in enumerate(file_in):
@@ -46,7 +45,7 @@ def get_line(label: Text, filename: Optional[Text] = None):
     raise AssertionError("label %s not found" % label)
 
 
-def get_line_and_hash(label: Text, vuln_type: Text, filename=None, fixed_line=None):
+def get_line_and_hash(label: Text, vuln_type: Text, filename, fixed_line=None):
     """return the line number and the associated vulnerability hash for `label` and source file `filename`"""
 
     if fixed_line is not None:

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -429,9 +429,6 @@ def test_shift_taint_ranges(source, vulnerability_type):
 
 
 def test_are_all_text_all_ranges():
-    if _get_iast_context_id() is None:
-        _start_iast_context_and_oce()
-
     _RANGE1 = TaintRange(0, 2, _SOURCE1)
     _RANGE2 = TaintRange(1, 3, _SOURCE2)
     s1 = "abc123"

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -428,6 +428,7 @@ def test_shift_taint_ranges(source, vulnerability_type):
 
 
 def test_are_all_text_all_ranges():
+    _start_iast_context_and_oce()
     _RANGE1 = TaintRange(0, 2, _SOURCE1)
     _RANGE2 = TaintRange(1, 3, _SOURCE2)
     s1 = "abc123"
@@ -441,9 +442,9 @@ def test_are_all_text_all_ranges():
     assert _num_objects_tainted_in_request() == 0
 
     a_1 = taint_pyobject(
-        "abc1234",
+        "abc1234_unique",
         source_name="test_num_objects_tainted",
-        source_value="abc1234",
+        source_value="abc1234_unique",
         source_origin=OriginType.PARAMETER,
     )
     assert is_pyobject_tainted(a_1)

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -5,7 +5,6 @@ from multiprocessing.pool import ThreadPool
 import random
 import sys
 from time import sleep
-import uuid
 
 import pytest
 
@@ -441,11 +440,10 @@ def test_are_all_text_all_ranges():
     range4 = TaintRange(4, 5, source4)
     assert _num_objects_tainted_in_request() == 0
 
-    unique_str = "abc1234_" + str(uuid.uuid4())
     a_1 = taint_pyobject(
-        unique_str,
+        "abc1234",
         source_name="test_num_objects_tainted",
-        source_value=unique_str,
+        source_value="abc1234",
         source_origin=OriginType.PARAMETER,
     )
     assert is_pyobject_tainted(a_1)
@@ -572,7 +570,8 @@ def reset_contexts_loop():
 async def async_context_loop(task_id: int):
     await asyncio.sleep(0.03)
     a_1 = "abc123"
-    assert _get_iast_context_id() >= 0
+    context_id = _get_iast_context_id()
+    assert context_id is not None and context_id >= 0
     for i in range(25):
         a_1 = taint_pyobject(
             a_1,

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -5,6 +5,7 @@ from multiprocessing.pool import ThreadPool
 import random
 import sys
 from time import sleep
+import uuid
 
 import pytest
 
@@ -428,7 +429,9 @@ def test_shift_taint_ranges(source, vulnerability_type):
 
 
 def test_are_all_text_all_ranges():
-    _start_iast_context_and_oce()
+    if _get_iast_context_id() is None:
+        _start_iast_context_and_oce()
+
     _RANGE1 = TaintRange(0, 2, _SOURCE1)
     _RANGE2 = TaintRange(1, 3, _SOURCE2)
     s1 = "abc123"
@@ -441,10 +444,11 @@ def test_are_all_text_all_ranges():
     range4 = TaintRange(4, 5, source4)
     assert _num_objects_tainted_in_request() == 0
 
+    unique_str = "abc1234_" + str(uuid.uuid4())
     a_1 = taint_pyobject(
-        "abc1234_unique",
+        unique_str,
         source_name="test_num_objects_tainted",
-        source_value="abc1234_unique",
+        source_value=unique_str,
         source_origin=OriginType.PARAMETER,
     )
     assert is_pyobject_tainted(a_1)

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -6,6 +6,7 @@ from ddtrace.appsec._constants import TELEMETRY_INFORMATION_NAME
 from ddtrace.appsec._constants import TELEMETRY_INFORMATION_VERBOSITY
 from ddtrace.appsec._constants import TELEMETRY_MANDATORY_VERBOSITY
 from ddtrace.appsec._iast._handlers import _on_django_patch
+from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._metrics import _set_iast_error_metric
 from ddtrace.appsec._iast._metrics import metric_verbosity
 from ddtrace.appsec._iast._overhead_control_engine import oce
@@ -19,6 +20,7 @@ from ddtrace.appsec._iast.constants import VULN_INSECURE_HASHING_TYPE
 from ddtrace.appsec._iast.constants import VULN_UNTRUSTED_SERIALIZATION
 from ddtrace.appsec._iast.constants import VULN_UNVALIDATED_REDIRECT
 from ddtrace.appsec._iast.constants import VULN_XSS
+from ddtrace.appsec._iast.processor import AppSecIastSpanProcessor
 from ddtrace.appsec._iast.taint_sinks.code_injection import patch as code_injection_patch
 from ddtrace.appsec._iast.taint_sinks.header_injection import patch as header_injection_patch
 from ddtrace.appsec._iast.taint_sinks.untrusted_serialization import patch as untrusted_serialization_patch
@@ -86,17 +88,27 @@ def test_metric_executed_sink(
         weak_hash_patch()
 
         tracer.configure(iast_enabled=True)
+        # Clear any IAST context leaked from a previous test (e.g. tainted objects still in
+        # a slot). Without this, a reused context would make request.tainted > 0 and break
+        # the len == 1 assertion. After clearing, the span processor starts a fresh context
+        # so that is_iast_request_enabled() returns True and executed.sink is emitted.
+        # request.tainted is NOT emitted here because this test taints no objects.
+        _iast_finish_request()
+        AppSecIastSpanProcessor.enable()
 
         telemetry_writer._namespace.flush()
-        with asm_context(tracer=tracer) as span:
-            import hashlib
+        try:
+            with asm_context(tracer=tracer) as span:
+                import hashlib
 
-            m = hashlib.new("md5")
-            m.update(b"Nobody inspects")
-            m.update(b" the spammish repetition")
-            num_vulnerabilities = 10
-            for _ in range(0, num_vulnerabilities):
-                m.digest()
+                m = hashlib.new("md5")
+                m.update(b"Nobody inspects")
+                m.update(b" the spammish repetition")
+                num_vulnerabilities = 10
+                for _ in range(0, num_vulnerabilities):
+                    m.digest()
+        finally:
+            AppSecIastSpanProcessor.disable()
 
         metrics_result = telemetry_writer._namespace.flush()
         _testing_unpatch_iast()
@@ -155,14 +167,21 @@ def test_metric_request_tainted(no_request_sampling, telemetry_writer, tracer):
     ):
         oce.reconfigure()
         tracer.configure(iast_enabled=True)
-
-        with tracer.trace("test", span_type=SpanTypes.WEB) as span:
-            taint_pyobject(
-                pyobject="bar",
-                source_name="test_string_operator_add_two",
-                source_value="bar",
-                source_origin=OriginType.PARAMETER,
-            )
+        # tracer.configure() sets _iast_enabled but does not register AppSecIastSpanProcessor
+        # in SpanProcessor.__processors__. Without this, on_span_start is never called and
+        # no IAST context is created, causing the test to fail non-deterministically depending
+        # on whether a previous test had already enabled the processor.
+        AppSecIastSpanProcessor.enable()
+        try:
+            with tracer.trace("test", span_type=SpanTypes.WEB) as span:
+                taint_pyobject(
+                    pyobject="bar",
+                    source_name="test_string_operator_add_two",
+                    source_value="bar",
+                    source_origin=OriginType.PARAMETER,
+                )
+        finally:
+            AppSecIastSpanProcessor.disable()
 
     metrics_result = telemetry_writer._namespace.flush()
 


### PR DESCRIPTION
## Description

Fix several flaky IAST tests caused by stale `IAST_CONTEXT` ContextVar leaking between tests.

### Root cause

`IAST_CONTEXT` is a module-level `contextvars.ContextVar` holding the current taint map slot ID. When a test left a non-`None` value in `IAST_CONTEXT` (either by not calling `_iast_finish_request()`, or by `clear_all_request_context_slots()` freeing the C++ slots without updating the ContextVar), the next test's `_start_iast_context_and_oce()` would see `is_iast_request_enabled() == True` and **skip slot allocation**. Any subsequent call to `taint_pyobject` would silently return the original untainted object because `safe_get_tainted_object_map_by_ctx_id(stale_id)` returned `null` in C++.

### Fixes

**`tests/appsec/iast/conftest.py`** (`iast_context` fixture):
- Call `_iast_finish_request()` before `_start_iast_context_and_oce()` in setup to clear any stale context from a previous test
- Call `IAST_CONTEXT.set(None)` after `clear_all_request_context_slots()` in teardown to keep the ContextVar in sync with freed C++ slots

**`tests/appsec/iast/test_telemetry.py`**:
- `test_metric_executed_sink`: add `_iast_finish_request()` before `AppSecIastSpanProcessor.enable()` and wrap in try/finally with `disable()`
- `test_metric_request_tainted`: add `AppSecIastSpanProcessor.enable()` / `disable()` around the span to ensure the span processor is registered

**Type fixes** (`iast_utils.py`, `test_native_taint_range.py`):
- Narrow `Optional[Text]` to `Text` in `get_line()` / `get_line_and_hash()` signatures
- Guard `_get_iast_context_id()` result before integer comparison in `async_context_loop`

## Testing

All modified tests are the tests being fixed. The flakiness is order-dependent and manifests under pytest-xdist (`-n auto`) where workers share Python state and run tests in random order.

## Risks

Low — all changes are confined to test files. No production code was modified.

## Changelog

No changelog needed (test-only changes).