### PR TITLE
ci(benchmarks): repair telemetry_dependencies baseline import

### DIFF
--- a/benchmarks/telemetry_dependencies/scenario.py
+++ b/benchmarks/telemetry_dependencies/scenario.py
@@ -209,13 +209,10 @@ class TelemetryDependencies(Scenario):
 
         Only supports first/idle phases since CVE/SCA features don't exist.
         """
-        from ddtrace.internal.telemetry.dependency import DependencyEntry as DE
-
         n = self.num_deps
         phase = self.phase
 
         if phase == "first":
-            # Simulate discovering N new modules
             module_names = ["mod-%d" % i for i in range(n)]
 
             def fake_get_dist(module_name):
@@ -235,11 +232,9 @@ class TelemetryDependencies(Scenario):
             return total
         else:
             # idle / cve_registration / sca_hits all reduce to "nothing to do"
-            # on main since there's no re-report logic
-            already_imported = {}
-            for i in range(n):
-                name = "package-%d" % i
-                already_imported[name] = DE(name=name, version="%d.0.0" % i, metadata=None)
+            # on main since there's no re-report logic. On the old API,
+            # `already_imported` maps name -> version string.
+            already_imported = {"package-%d" % i: "%d.0.0" % i for i in range(n)}
 
             def fake_get_dist(module_name):
                 return None


### PR DESCRIPTION
## Summary

The `telemetry_dependencies` benchmark was failing against the baseline
wheel after #17156 merged, with:

```
ModuleNotFoundError: No module named 'ddtrace.internal.telemetry.dependency'
```

Root cause: `scenario._run_old_api` had a function-scope
`from ddtrace.internal.telemetry.dependency import DependencyEntry as DE`
that Python evaluates on every call. The baseline wheel predates the
SCA-reachability PR, so that module does not exist and the import
crashes before any phase branching. The `else` branch also populated
`already_imported` with `DependencyEntry` instances, but the baseline's
`update_imported_dependencies(already_imported: Dict[str, str], ...)`
expects version strings — it would break if ever exercised.

## Changes

- Drop the broken top-level import.
- Rewrite the idle/fallback branch to populate `already_imported`
  as `{name: version_str}`, matching the baseline contract.

The candidate (new-API) path is unaffected — it runs
`_run_new_api` because `HAS_DEPENDENCY_TRACKER` is True on current
`main`.

## Test plan

- [ ] Re-run the benchmark platform job for `telemetry_dependencies`
      and confirm it completes for both baseline and candidate.
- [ ] Spot-check that the `telemetry_add_metric` job (which was
      already passing) is still unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)