### PR TITLE
fix(profiling): fix crash due to Frame cache eviction [backport 4.5]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -19,7 +19,10 @@
 class EchionSampler;
 
 // ----------------------------------------------------------------------------
-class FrameStack : public std::deque<Frame::Ref>
+// FrameStack owns the Frames so that they stay valid across cache evictions
+// (asyncio unwind_tasks precomputes per-task stacks via Frame::get, which can
+// evict entries still referenced from an earlier thread-stack capture).
+class FrameStack : public std::deque<Frame>
 {
   public:
     using Key = Frame::Key;

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
@@ -11,11 +11,11 @@ FrameStack::render(EchionSampler& echion)
     auto& renderer = echion.renderer();
     for (auto it = this->rbegin(); it != this->rend(); ++it) {
 #if PY_VERSION_HEX >= 0x030c0000
-        if ((*it).get().is_entry)
+        if ((*it).is_entry)
             // This is a shim frame so we skip it.
             continue;
 #endif
-        renderer.render_frame((*it).get());
+        renderer.render_frame(*it);
     }
 }
 
@@ -50,7 +50,7 @@ unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, siz
             continue;
         }
 
-        stack.push_back(*maybe_frame);
+        stack.push_back(maybe_frame->get());
         count++;
 
         if (count >= max_depth) {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -200,7 +200,7 @@ TaskInfo::unwind(EchionSampler& echion, FrameStack& stack, bool using_uvloop)
         }
 
         // Skip the uvloop wrapper frame if present (only at the outermost level of the top-level Task)
-        if (!stack.empty() && is_uvloop_wrapper_frame(echion, using_uvloop, stack.back().get())) {
+        if (!stack.empty() && is_uvloop_wrapper_frame(echion, using_uvloop, stack.back())) {
             stack.pop_back();
             continue;
         }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -47,8 +47,12 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
 
     if (!frame_cache_key) {
         for (size_t i = 0; i < python_stack.size(); i++) {
-            const auto& frame = python_stack[i].get();
-            const auto& frame_name = echion.string_table().lookup(frame.name)->get();
+            const auto& frame = python_stack[i];
+            auto maybe_frame_name = echion.string_table().lookup(frame.name);
+            if (!maybe_frame_name) {
+                continue;
+            }
+            const auto& frame_name = maybe_frame_name->get();
 
             bool is_boundary_frame = false;
 
@@ -96,7 +100,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
         }
     } else {
         for (size_t i = 0; i < python_stack.size(); i++) {
-            const auto& frame = python_stack[i].get();
+            const auto& frame = python_stack[i];
             if (frame.cache_key == *frame_cache_key) {
                 upper_python_stack_size = python_stack.size() - i;
                 break;
@@ -238,7 +242,7 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                     const auto& python_frame = python_stack[frames_to_push - i - 1];
 
                     // Skip the uvloop wrapper frame if present in the Python stack
-                    if (using_uvloop && is_uvloop_wrapper_frame(echion, using_uvloop, python_frame.get())) {
+                    if (is_uvloop_wrapper_frame(echion, using_uvloop, python_frame)) {
                         continue;
                     }
                     stack.push_front(python_frame);

--- a/releasenotes/notes/profiling-fix-asyncio-unwinding-crash-b192aef728433e7d.yaml
+++ b/releasenotes/notes/profiling-fix-asyncio-unwinding-crash-b192aef728433e7d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: A rare crash occurring when profiling asyncio code with many tasks or deep call stacks has been fixed.


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-13112

This fixes a crash in the Profiler codebase.
The crash was caused by `ThreadInfo::unwind_task` trying to use `Frame` objects that it had a reference to (`Frame::Ref`) while those same Frames were being evicted from the cache, which can happen under high load.

```
Error UnixSignal: Process terminated with SI_KERNEL (SIGSEGV)
```

The proposed fix is to change `FrameStack` to extend `std::deque<Frame>` instead of `std::deque<Frame::Ref>`, which means pushing frames to `FrameStack` actually copies them and eliminates that race condition. This should be OK performance-wise because `Frame` is tiny and only has trivial fields to copy (no memory allocations, only integral types).

Another possible fix would be to "lock" certain `Frame` objects in the cache (to prevent them from being evicted while any Task using them is being unwound) but this would be much more complicated to get right and although it would lead to less copies, the performance picture is blurry for more subtle reasons. So I suggest we don't go ahead with the alternative unless we absolutely need to (which we don't seem to).

Running DoE with this change on the Enterprise archetype with asyncio/FastAPI  (n=10) shows no significant difference (either in memory or CPU usage / latency), so I think this is safe to merge performance-wise.

<details>

| Commit | Run | p50 (ms) | p99 (ms) | CPU% | Mem (MB) | |--------|-----|----------|----------|------|----------| | `90de7913` (after) | 1 | 150.43 | 152.88 | 172.68 | 274.9 | | `90de7913` (after) | 2 | 150.45 | 152.38 | 172.17 | 266.2 | | `90de7913` (after) | 3 | 150.43 | 153.91 | 172.92 | 266.2 | | `90de7913` (after) | 4 | 150.46 | 154.16 | 172.83 | 265.8 | | `90de7913` (after) | 5 | 150.44 | 153.01 | 172.80 | 267.4 | | `90de7913` (after) | 6 | 150.43 | 153.28 | 172.70 | 265.8 | | `90de7913` (after) | 7 | 150.54 | 157.48 | 173.32 | 265.8 | | `90de7913` (after) | 8 | 150.51 | 156.61 | 172.18 | 265.5 | | `90de7913` (after) | 9 | 150.53 | 157.05 | 172.18 | 265.8 | | `90de7913` (after) | 10 | 150.45 | 152.84 | 172.08 | 265.5 | | `c26e6181` (before) | 1 | 150.51 | 152.80 | 173.63 | 265.5 | | `c26e6181` (before) | 2 | 150.48 | 152.41 | 173.49 | 265.4 | | `c26e6181` (before) | 3 | 150.47 | 156.31 | 172.53 | 265.9 | | `c26e6181` (before) | 4 | 150.49 | 152.60 | 172.86 | 265.5 | | `c26e6181` (before) | 5 | 150.40 | 152.86 | 172.99 | 266.0 | | `c26e6181` (before) | 6 | 150.46 | 152.66 | 172.53 | 265.5 | | `c26e6181` (before) | 7 | 150.49 | 154.91 | 172.74 | 265.3 | | `c26e6181` (before) | 8 | 150.46 | 152.46 | 171.93 | 265.7 | | `c26e6181` (before) | 9 | 150.52 | 156.70 | 172.96 | 265.7 | | `c26e6181` (before) | 10 | 150.43 | 153.02 | 172.52 | 265.8 |

| Version | p50 (ms) | p99 (ms) | CPU% | Mem (MB) | |---------|----------|----------|------|----------| | `c26e6181` (before)  | 150.470 ± 0.034 | 153.67 ± 1.66 | 172.82 ± 0.50 | 265.6 ± 0.2 | | `90de7913` (after) | 150.465 ± 0.043 | 154.36 ± 1.94 | 172.59 ± 0.41 | 266.9 ± 2.9 | | **Δ (after − before)** | **−0.005ms (0.00%)** | **+0.69ms (+0.45%)** | **−0.23pp (−0.13%)** | **+1.2MB (+0.47%)** |

</details>

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
