### PR TITLE
fix: raise AttributeError instead of KeyError in module __getattr__ (PEP 562)

### DIFF
--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -162,4 +162,4 @@ def __getattr__(name: str) -> Any:
             return process_tags  # type: ignore
         elif name == "process_tags_list":
             return process_tags_list  # type: ignore
-    return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Bug

`process_tags/__init__.py` `__getattr__` falls through to `return globals()[name]`, which raises `KeyError` for missing attributes. Per [PEP 562](https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access), module `__getattr__` must raise `AttributeError` — raising anything else breaks `hasattr()`, `getattr()` with defaults, and introspection tools like `torch.compile`.

## Fix

Replace `return globals()[name]` with `raise AttributeError(...)`.

Introduced in #16593.

Closes #17563