### PR TITLE
ci(hooks): act on cmakeformat instead of check

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -31,6 +31,9 @@ format_check = [
 cmakeformat_check = [
     "bash scripts/cmake-format.sh"
 ]
+cmakeformat_fix = [
+    "bash scripts/cmake-format.sh --fix"
+]
 cformat_check = [
     "bash scripts/cformat.sh"
 ]

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -29,7 +29,7 @@ Individual pre-commit hooks (run in numeric order):
 | `04-run-clang-format` | Formats staged C/C++ files with clang-format |
 | `05-run-bandit` | Security-scans staged production Python files |
 | `06-check-cython-stubs` | Validates Cython stub files |
-| `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) |
+| `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) in-place and re-stages them |
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
 

--- a/hooks/pre-commit/07-run-cmake-format
+++ b/hooks/pre-commit/07-run-cmake-format
@@ -1,7 +1,17 @@
 #!/usr/bin/env sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '(\.cmake$|CMakeLists\.txt$)')
 if [ -n "$staged_files" ]; then
-    hatch run lint:cmakeformat_check
+    # Capture files with unstaged changes before formatting; we skip re-adding these to preserve partial staging.
+    unstaged_before=$(git diff --name-only)
+
+    # Format staged CMake files in-place.
+    hatch run lint:cmakeformat_fix || exit $?
+
+    # Re-stage only files that had no unstaged changes before formatting (preserves partial staging).
+    echo "$staged_files" | while read -r f; do
+        [ -n "$f" ] || continue
+        echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
+    done
 else
     echo 'Run cmake-format skipped: No CMake files were found in `git diff --staged`'
 fi


### PR DESCRIPTION
[PROF-13935](https://datadoghq.atlassian.net/browse/PROF-13935)

## Description

The `07-run-cmake-format` pre-commit hook was only checking CMake formatting but not fixing it, which caused commits to fail silently when CMake files were out of format.

This PR changes the hook to **auto-format in-place and re-stage** the fixed files, matching the behavior of other hooks.

## Testing
_tested locally_
**BEFORE:** a staged `CMakeLists.txt` with formatting issues would abort the commit, but leave the file unfixed
**AFTER:** hook auto-formats and fixes the error

[PROF-13935]: https://datadoghq.atlassian.net/browse/PROF-13935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ