### PR TITLE
fix(process_tags): process tags raised KeyError instead of AttributeError

### DIFF
--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -155,11 +155,14 @@ _container_tags_hash = ""
 
 
 def __getattr__(name: str) -> Any:
-    if "process_tags" in name:
+    if name in ("process_tags", "process_tags_list"):
         _initialize_process_tags()
         _recompute_base_hash()
         if name == "process_tags":
-            return process_tags  # type: ignore
-        elif name == "process_tags_list":
-            return process_tags_list  # type: ignore
-    return globals()[name]
+            return process_tags
+        return process_tags_list
+
+    try:
+        return globals()[name]
+    except KeyError as e:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from e

--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -159,7 +159,7 @@ def __getattr__(name: str) -> Any:
         _initialize_process_tags()
         _recompute_base_hash()
         if name == "process_tags":
-            return process_tags
-        return process_tags_list
+            return process_tags  # type: ignore
+        return process_tags_list  # type: ignore
 
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from e
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -162,7 +162,4 @@ def __getattr__(name: str) -> Any:
             return process_tags
         return process_tags_list
 
-    try:
-        return globals()[name]
-    except KeyError as e:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from e
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from e

--- a/releasenotes/notes/fix-process-tags-error-1341c4204b8b3f1f.yaml
+++ b/releasenotes/notes/fix-process-tags-error-1341c4204b8b3f1f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: This fix resolves an issue where reading unknown attributes from ``ddtrace.internal.process_tags`` caused a ``KeyError`` instead of raising an ``AttributeError``.

--- a/tests/internal/test_process_tags.py
+++ b/tests/internal/test_process_tags.py
@@ -89,6 +89,11 @@ def test_compute_process_tag_excluded_values(excluded_value):
     assert result is None
 
 
+def test_module_getattr_raises_attribute_error_for_unknown_process_tags_name():
+    with pytest.raises(AttributeError):
+        getattr(process_tags, "process_tags_unknown")
+
+
 @pytest.mark.skipif(sys.version_info[:2] == (3, 9), reason="sys.orig_argv is not available on Python 3.9")
 def test_get_entrypoint_name_module_mode_uses_orig_argv_when_sys_argv_is_incomplete():
     with patch("sys.argv", ["-m"]), patch("sys.orig_argv", ["python", "-m", "myapp"]):


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-py/issues/17563.

TL;DR: if we were trying to retrieve an unknown attributes from `process_tags` module (which should not happen but happened), it was raising the wrong kind of Error.

This PR fixes the issue 