### PR TITLE
ci(gitlab): allow per-service env overrides in suitespec services

### DIFF
--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -42,13 +42,86 @@ class BenchmarkSpec:
     type: str = "benchmark"  # ignored
 
 
+_SERVICE_DEFINITIONS_CACHE: t.Optional[dict] = None
+
+
+def _get_service_definitions() -> dict:
+    """Load and cache the `.services` block from `.gitlab/services.yml`.
+
+    Used to expand services inline when a suite defines per-service env overrides.
+    """
+    global _SERVICE_DEFINITIONS_CACHE
+    if _SERVICE_DEFINITIONS_CACHE is None:
+        import ruamel.yaml as _yaml
+
+        data = _yaml.YAML().load((GITLAB / "services.yml").read_text())
+        _SERVICE_DEFINITIONS_CACHE = data.get(".services", {}) or {}
+    return _SERVICE_DEFINITIONS_CACHE
+
+
+def _render_service_with_env(name: str, env_override: dict, indent: str) -> list[str]:
+    """Render a GitLab service as an expanded list item with the env merged into `variables`.
+
+    `!reference` copies the referenced value verbatim, so we cannot merge into it.
+    To apply per-service env overrides we expand the service definition inline,
+    preserving its other fields (name, alias, command, entrypoint, etc.) and
+    merging the override on top of its existing `variables`.
+    """
+    services = _get_service_definitions()
+    if name not in services:
+        raise ValueError(f"Service '{name}' has env override in suitespec but is not defined in .gitlab/services.yml")
+    service_def = services[name]
+
+    # Merge existing service variables with the per-suite override (override wins).
+    merged_vars = dict(service_def.get("variables") or {})
+    merged_vars.update(env_override)
+
+    lines: list[str] = []
+    first = True
+    for key, value in service_def.items():
+        if key == "variables":
+            continue
+        prefix = f"{indent}- " if first else f"{indent}  "
+        first = False
+        lines.append(f"{prefix}{key}: {_format_yaml_scalar(value)}")
+    if merged_vars:
+        prefix = f"{indent}- " if first else f"{indent}  "
+        lines.append(f"{prefix}variables:")
+        for k, v in merged_vars.items():
+            lines.append(f"{indent}    {k}: {_format_yaml_scalar(v)}")
+    return lines
+
+
+def _format_yaml_scalar(value: t.Any) -> str:
+    """Format a scalar/list for inline YAML emission matching existing output style."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        rendered = ", ".join(_format_yaml_scalar(v) for v in value)
+        return f"[{rendered}]"
+    text = str(value)
+    # Quote strings that contain shell-expanded references or characters YAML may
+    # misinterpret at parse time. Leave plain values unquoted to match the style
+    # used throughout the generated file.
+    needs_quote = any(
+        ch in text
+        for ch in ("$", ":", "#", "{", "}", "[", "]", ",", "&", "*", "!", "?", "|", "<", ">", "=", "%", "@", "`")
+    )
+    if needs_quote or text.strip() != text:
+        escaped = text.replace('"', '\\"')
+        return f'"{escaped}"'
+    return text
+
+
 @dataclass
 class JobSpec:
     name: str
     stage: str
     pattern: t.Optional[str] = None
     snapshot: bool = False
-    services: t.Optional[list[str]] = None
+    services: t.Optional[list[t.Union[str, dict]]] = None
     env: t.Optional[dict[str, str]] = None
     parallelism: t.Optional[int] = None
     venvs_per_job: t.Optional[int] = None
@@ -91,18 +164,30 @@ class JobSpec:
             lines.append("    - job: build_base_venvs")
             lines.append("      artifacts: true")
 
-        services = set(self.services or [])
-        if services:
+        # Normalize services: each entry is either a bare name (str) or a single-key
+        # dict `{name: {env: {...}}}` carrying a per-service env override. The dict
+        # form is expanded inline so the override is scoped to the service container;
+        # bare names keep using `!reference` for minimal diff.
+        service_items: list[tuple[str, dict]] = []
+        for item in self.services or []:
+            if isinstance(item, dict):
+                name, cfg = next(iter(item.items()))
+                service_items.append((name, (cfg or {}).get("env") or {}))
+            else:
+                service_items.append((item, {}))
+
+        service_names = {name for name, _ in service_items}
+        if service_items:
             lines.append("  services:")
-
-            _services = [f"!reference [.services, {_}]" for _ in services]
             if self.snapshot:
-                _services.insert(0, f"!reference [{base}, services]")
+                lines.append(f"    - !reference [{base}, services]")
+            for name, env_override in service_items:
+                if env_override:
+                    lines.extend(_render_service_with_env(name, env_override, indent="    "))
+                else:
+                    lines.append(f"    - !reference [.services, {name}]")
 
-            for service in _services:
-                lines.append(f"    - {service}")
-
-        wait_for = services.copy()
+        wait_for = set(service_names)
         if self.snapshot:
             wait_for.add("testagent")
 

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -177,10 +177,16 @@ class JobSpec:
                 service_items.append((item, {}))
 
         service_names = {name for name, _ in service_items}
+        # A testagent env override would otherwise collide with the default testagent
+        # pulled in by `!reference [{snapshot_base}, services]`, producing two services
+        # with alias=testagent. Inherit from the non-snapshot base (ddagent only) so
+        # the expanded testagent is the sole provider of that alias.
+        testagent_overridden = self.snapshot and any(name == "testagent" and env for name, env in service_items)
+        services_base = base.removesuffix("_snapshot") if testagent_overridden else base
         if service_items:
             lines.append("  services:")
             if self.snapshot:
-                lines.append(f"    - !reference [{base}, services]")
+                lines.append(f"    - !reference [{services_base}, services]")
             for name, env_override in service_items:
                 if env_override:
                     lines.extend(_render_service_with_env(name, env_override, indent="    "))

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -207,14 +207,31 @@ class TestRunner:
 
         return matching
 
+    @staticmethod
+    def _service_names(suite_services) -> set[str]:
+        """Normalize suitespec services (strings or single-key dicts) to service names.
+
+        The dict form ``{name: {env: {...}}}`` carries a per-service env override
+        that only the GitLab generator applies (service container variables).
+        Locally we just need the service name to know which docker-compose
+        service to bring up; the env override is handled via docker-compose
+        (e.g., bind mounts for cassettes).
+        """
+        names: set[str] = set()
+        for item in suite_services or []:
+            if isinstance(item, str):
+                names.add(item)
+            elif isinstance(item, dict) and item:
+                names.add(next(iter(item.keys())))
+        return names
+
     def extract_required_services(self, suites: dict[str, dict]) -> set[str]:
         """Extract all required services from selected suites."""
-        services = set()
+        services: set[str] = set()
         needs_testagent = False
 
         for suite_config in suites.values():
-            suite_services = suite_config.get("services", [])
-            services.update(suite_services)
+            services |= self._service_names(suite_config.get("services"))
 
             # Check if any suite needs testagent (has snapshot: true)
             if suite_config.get("snapshot", False):
@@ -534,8 +551,9 @@ class TestRunner:
             # Get suite config
             suite_config = matching_suites.get(suite_name, {})
 
-            # Extract services for this suite only
-            suite_services = set(suite_config.get("services", []))
+            # Extract services for this suite only (normalize dict-form entries
+            # that carry per-service env overrides — env is a CI-only concern).
+            suite_services = self._service_names(suite_config.get("services"))
             needs_testagent = suite_config.get("snapshot", False)
             if needs_testagent:
                 suite_services.add("testagent")


### PR DESCRIPTION
## Summary

Today, `VCR_CASSETTES_DIRECTORY` is hardcoded in `.gitlab/services.yml`
pointing at `tests/llmobs/llmobs_cassettes`, so every CI job that uses the
shared `testagent` service reads cassettes from the llmobs tree — even
suites that have nothing to do with llmobs.

This PR teaches the suitespec → GitLab generator to accept per-service env
overrides, so a suite can point its testagent at its own cassette root
without touching the shared service definition.

Before (only accepted bare service names):

```yaml
services:
  - testagent
```

After (either form is supported):

```yaml
services:
  - testagent:
      env:
        VCR_CASSETTES_DIRECTORY: "${CI_PROJECT_DIR}/tests/appsec/_cassettes"
```

Bare-name entries keep emitting `!reference [.services, <name>]` (no diff
for existing suites). Dict-form entries expand the service inline and merge
the override into its `variables` block — required because GitLab's
`!reference` copies verbatim and cannot be merged into.

`scripts/run-tests` is also updated to normalize the dict form locally so
`docker compose up <service>` still works.

## Test plan
- [ ] `hatch run lint:style` / `hatch run lint:typing` pass on the changed scripts
- [ ] `scripts/gen_gitlab_config.py` produces unchanged YAML for all existing string-form services (verified: `!reference [.services, testagent]`)
- [ ] A suite using the new dict form renders with merged `variables`

🤖 Generated with [Claude Code](https://claude.com/claude-code)