### PR TITLE
chore(ci_visibility): implement configuration error tagging for all backend requests

### DIFF
--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -21,6 +21,7 @@ from ddtrace.testing.internal.telemetry import TelemetryAPI
 from ddtrace.testing.internal.test_data import ModuleRef
 from ddtrace.testing.internal.test_data import SuiteRef
 from ddtrace.testing.internal.test_data import TestRef
+from ddtrace.testing.internal.test_data import TestTag
 
 
 log = logging.getLogger(__name__)
@@ -67,6 +68,7 @@ class APIClient:
         self.connector = connector_setup.get_connector_for_subdomain(Subdomain.API)
         self.coverage_connector = connector_setup.get_connector_for_subdomain(Subdomain.CICOVREPRT)
         self.telemetry_api = telemetry_api
+        self.configuration_errors: dict[str, str] = {}
 
     def close(self) -> None:
         self.connector.close()
@@ -100,6 +102,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot fetch settings (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS] = "true"
             return Settings()
 
         try:
@@ -110,6 +113,7 @@ class APIClient:
 
         except Exception as e:
             log.warning("Error getting settings from API: %s", e)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS] = "true"
             return Settings()
 
         try:
@@ -119,6 +123,7 @@ class APIClient:
         except Exception as e:
             log.warning("Error getting settings from API: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS] = "true"
             return Settings()
 
         self.telemetry_api.record_settings(settings)
@@ -159,6 +164,7 @@ class APIClient:
             except KeyError as e:
                 log.warning("Git info not available, cannot fetch known tests (missing key: %s)", e)
                 telemetry.record_error(ErrorType.UNKNOWN)
+                self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                 return set()
 
             try:
@@ -167,6 +173,7 @@ class APIClient:
 
             except Exception as e:
                 log.warning("Error getting known tests from API: %s", e)
+                self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                 return set()
 
             try:
@@ -186,6 +193,7 @@ class APIClient:
                 if not isinstance(page_info, dict):
                     log.warning("Known tests response page_info is not a dict")
                     telemetry.record_error(ErrorType.BAD_JSON)
+                    self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                     return set()
 
                 has_next = page_info.get("has_next")
@@ -196,15 +204,18 @@ class APIClient:
                 if not page_state:
                     log.warning("Known tests response missing pagination cursor on page %d", page_number + 1)
                     telemetry.record_error(ErrorType.BAD_JSON)
+                    self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                     return set()
 
             except Exception:
                 log.warning("Error getting known tests from API")
                 telemetry.record_error(ErrorType.BAD_JSON)
+                self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                 return set()
         else:
             log.warning("Known tests pagination exceeded max pages: %d", max_pages)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
             return set()
 
         self.telemetry_api.record_known_tests_count(len(known_test_ids))
@@ -237,6 +248,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot fetch Test Management properties (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS] = "true"
             return {}
 
         try:
@@ -247,6 +259,7 @@ class APIClient:
 
         except Exception as e:
             log.warning("Error getting Test Management properties from API: %s", e)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS] = "true"
             return {}
 
         try:
@@ -271,6 +284,7 @@ class APIClient:
         except Exception as e:
             log.warning("Failed to parse Test Management tests data from API: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS] = "true"
             return {}
 
         self.telemetry_api.record_test_management_tests_count(len(test_properties))
@@ -395,6 +409,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot get skippable items (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS] = "true"
             return set(), None
 
         try:
@@ -403,6 +418,7 @@ class APIClient:
 
         except Exception as e:
             log.warning("Error getting skippable tests from API: %s", e)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS] = "true"
             return set(), None
 
         try:
@@ -423,6 +439,7 @@ class APIClient:
         except Exception as e:
             log.warning("Failed to parse skippable tests data from API: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS] = "true"
             return set(), None
 
         self.telemetry_api.record_skippable_count(count=len(skippable_items), level=self.itr_skipping_level)

--- a/ddtrace/testing/internal/cached_file_provider.py
+++ b/ddtrace/testing/internal/cached_file_provider.py
@@ -34,6 +34,8 @@ class TestOptDataProvider(t.Protocol):
     mypy catches interface drift between the two implementations.
     """
 
+    configuration_errors: dict[str, str]
+
     def get_settings(self) -> Settings: ...
 
     def get_known_tests(self) -> set[TestRef]: ...
@@ -95,6 +97,7 @@ class CachedFileDataProvider:
         self._dir = test_optimization_dir
         self._itr_skipping_level = itr_skipping_level
         self._telemetry_api = telemetry_api
+        self.configuration_errors: dict[str, str] = {}
 
     def _cache_path(self, relative: str) -> str:
         return os.path.join(self._dir, *relative.split("/"))

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -138,6 +138,9 @@ class SessionManager:
             self.settings = self.api_client.get_settings()
             self.override_settings_with_env_vars()
 
+        # Snapshot configuration errors before closing the client.
+        self.configuration_errors = dict(self.api_client.configuration_errors)
+
         self.api_client.close()
 
         # Retry handlers must be set up after collection phase for EFD faulty session logic to work.
@@ -165,6 +168,11 @@ class SessionManager:
             skipping_enabled=self.settings.skipping_enabled,
             skipping_level=self.itr_skipping_level,
         )
+
+        # Propagate configuration errors to the session event and all child events.
+        if self.configuration_errors:
+            self.session.configuration_errors = self.configuration_errors
+            self.session.set_tags(self.configuration_errors)
 
         self.writer.add_metadata("*", self.env_tags)
         self.writer.add_metadata("*", self.platform_tags)
@@ -286,6 +294,8 @@ class SessionManager:
         """
         test_module, created = self.session.get_or_create_child(test_ref.suite.module.name)
         if created:
+            if self.configuration_errors:
+                test_module.set_tags(self.configuration_errors)
             try:
                 on_new_module(test_module)
             except Exception:
@@ -293,6 +303,8 @@ class SessionManager:
 
         test_suite, created = test_module.get_or_create_child(test_ref.suite.name)
         if created:
+            if self.configuration_errors:
+                test_suite.set_tags(self.configuration_errors)
             try:
                 on_new_suite(test_suite)
             except Exception:

--- a/ddtrace/testing/internal/test_data.py
+++ b/ddtrace/testing/internal/test_data.py
@@ -269,6 +269,8 @@ class Test(TestItem["TestSuite", "TestRun"]):
         test_run = TestRun(name=self.name, parent=self)
         test_run.attempt_number = len(self.test_runs)
         test_run.set_service(self.service)
+        if self.session.configuration_errors:
+            test_run.set_tags(self.session.configuration_errors)
         self.test_runs.append(test_run)
         return test_run
 
@@ -362,6 +364,7 @@ class TestSession(TestItem[t.NoReturn, "TestModule"]):
         self.itr_enabled = False
         self.itr_skipping_enabled = False
         self.itr_skipping_level = ITRSkippingLevel.TEST
+        self.configuration_errors: dict[str, str] = {}
 
     def set_session_id(self, session_id: int) -> None:
         self.item_id = session_id
@@ -453,5 +456,11 @@ class TestTag:
     BROWSER_DRIVER = "test.browser.driver"
 
     CODE_COVERAGE_LINES_PCT = "test.code_coverage.lines_pct"
+
+    # Library configuration error tags — set when backend requests fail.
+    LIBRARY_CONFIGURATION_ERROR_SETTINGS = "_dd.ci.library_configuration_error.settings"
+    LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS = "_dd.ci.library_configuration_error.skippable_tests"
+    LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS = "_dd.ci.library_configuration_error.known_tests"
+    LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS = "_dd.ci.library_configuration_error.test_management_tests"
 
     __test__ = False

--- a/ddtrace/testing/internal/test_data.py
+++ b/ddtrace/testing/internal/test_data.py
@@ -269,8 +269,9 @@ class Test(TestItem["TestSuite", "TestRun"]):
         test_run = TestRun(name=self.name, parent=self)
         test_run.attempt_number = len(self.test_runs)
         test_run.set_service(self.service)
-        if self.session.configuration_errors:
-            test_run.set_tags(self.session.configuration_errors)
+        config_errors = getattr(self.session, "configuration_errors", None)
+        if config_errors:
+            test_run.set_tags(config_errors)
         self.test_runs.append(test_run)
         return test_run
 

--- a/ddtrace/testing/internal/test_data.py
+++ b/ddtrace/testing/internal/test_data.py
@@ -270,7 +270,7 @@ class Test(TestItem["TestSuite", "TestRun"]):
         test_run.attempt_number = len(self.test_runs)
         test_run.set_service(self.service)
         config_errors = getattr(self.session, "configuration_errors", None)
-        if config_errors:
+        if isinstance(config_errors, dict) and config_errors:
             test_run.set_tags(config_errors)
         self.test_runs.append(test_run)
         return test_run

--- a/tests/testing/internal/test_api_client.py
+++ b/tests/testing/internal/test_api_client.py
@@ -21,6 +21,7 @@ from ddtrace.testing.internal.test_data import ITRSkippingLevel
 from ddtrace.testing.internal.test_data import ModuleRef
 from ddtrace.testing.internal.test_data import SuiteRef
 from ddtrace.testing.internal.test_data import TestRef
+from ddtrace.testing.internal.test_data import TestTag
 from tests.testing.mocks import mock_backend_connector
 
 
@@ -176,6 +177,8 @@ class TestAPIClientGetSettings:
         assert settings.require_git is False
         assert settings.itr_enabled is False
 
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS: "true"}
+
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.UNKNOWN)
         ]
@@ -220,6 +223,8 @@ class TestAPIClientGetSettings:
         assert settings.skipping_enabled is False
         assert settings.require_git is False
         assert settings.itr_enabled is False
+
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == []
 
@@ -266,9 +271,65 @@ class TestAPIClientGetSettings:
         assert settings.require_git is False
         assert settings.itr_enabled is False
 
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS: "true"}
+
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)
         ]
+
+    def test_get_settings_no_error_on_success(self, mock_telemetry: Mock) -> None:
+        mock_connector = (
+            mock_backend_connector()
+            .with_post_json_response(
+                endpoint="/api/v2/libraries/tests/services/setting",
+                response_data={
+                    "data": {
+                        "attributes": {
+                            "code_coverage": False,
+                            "coverage_report_upload_enabled": False,
+                            "di_enabled": False,
+                            "early_flake_detection": {
+                                "enabled": False,
+                                "faulty_session_threshold": 30,
+                                "slow_test_retries": {"10s": 5, "30s": 3, "5m": 2, "5s": 10},
+                            },
+                            "flaky_test_retries_enabled": False,
+                            "impacted_tests_enabled": False,
+                            "itr_enabled": False,
+                            "known_tests_enabled": False,
+                            "require_git": False,
+                            "test_management": {"attempt_to_fix_retries": 20, "enabled": False},
+                            "tests_skipping": False,
+                        },
+                        "id": "00000000-0000-0000-0000-000000000000",
+                        "type": "ci_app_tracers_test_service_settings",
+                    }
+                },
+            )
+            .build()
+        )
+        mock_connector_setup = Mock()
+        mock_connector_setup.get_connector_for_subdomain.return_value = mock_connector
+
+        api_client = APIClient(
+            service="some-service",
+            env="some-env",
+            env_tags={
+                GitTag.REPOSITORY_URL: "http://github.com/DataDog/some-repo.git",
+                GitTag.COMMIT_SHA: "abcd1234",
+                GitTag.BRANCH: "some-branch",
+                GitTag.COMMIT_MESSAGE: "I am a commit",
+            },
+            itr_skipping_level=ITRSkippingLevel.TEST,
+            configurations={"os.platform": "Linux"},
+            connector_setup=mock_connector_setup,
+            telemetry_api=mock_telemetry,
+        )
+
+        with patch("uuid.uuid4", return_value=uuid.UUID("00000000-0000-0000-0000-000000000000")):
+            api_client.get_settings()
+
+        assert api_client.configuration_errors == {}
 
 
 class TestAPIClientGetKnownTests:
@@ -469,6 +530,7 @@ class TestAPIClientGetKnownTests:
         assert mock_connector.post_json.call_count == 2, "should stop after max_pages=2, not request page 3"
         assert "Known tests pagination exceeded max pages: 2" in caplog.text
         assert known_tests == set()
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
 
     def test_get_known_tests_max_pages_zero_uses_default(
         self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
@@ -549,6 +611,7 @@ class TestAPIClientGetKnownTests:
                 known_tests = api_client.get_known_tests()
         assert "page_info is not a dict" in caplog.text
         assert known_tests == set()
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)
         ]
@@ -578,6 +641,7 @@ class TestAPIClientGetKnownTests:
         assert mock_connector.post_json.call_args_list == []
 
         assert known_tests == set()
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.UNKNOWN)
@@ -615,6 +679,7 @@ class TestAPIClientGetKnownTests:
         assert "Error getting known tests from API: No can do" in caplog.text
 
         assert known_tests == set()
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == []
 
     def test_get_known_tests_errors_in_response(self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture) -> None:
@@ -650,6 +715,7 @@ class TestAPIClientGetKnownTests:
         assert "Error getting known tests from API" in caplog.text
 
         assert known_tests == set()
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)
@@ -837,6 +903,7 @@ class TestAPIClientGetTestManagementTests:
         assert mock_connector.post_json.call_args_list == []
 
         assert properties == {}
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.UNKNOWN)
@@ -876,6 +943,7 @@ class TestAPIClientGetTestManagementTests:
         assert "Error getting Test Management properties from API" in caplog.text
 
         assert properties == {}
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS: "true"}
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == []
 
     def test_get_test_management_tests_errors_in_response(
@@ -914,6 +982,7 @@ class TestAPIClientGetTestManagementTests:
         assert "'data'" in caplog.text
 
         assert properties == {}
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)
@@ -1180,6 +1249,7 @@ class TestAPIClientGetSkippableTests:
 
         assert skippable_tests == set()
         assert correlation_id is None
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.UNKNOWN)
@@ -1220,6 +1290,7 @@ class TestAPIClientGetSkippableTests:
 
         assert skippable_tests == set()
         assert correlation_id is None
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == []
 
@@ -1260,6 +1331,7 @@ class TestAPIClientGetSkippableTests:
 
         assert skippable_tests == set()
         assert correlation_id is None
+        assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS: "true"}
 
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -316,6 +316,7 @@ class TestSessionManagerEnvVarOverrides:
         mock_client.send_git_pack_file.return_value = None
         mock_client.get_skippable_tests.return_value = (set(), None)
         mock_client.close.return_value = None
+        mock_client.configuration_errors = {}
 
         monkeypatch.setenv(env_var, env_value)
 

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -195,6 +195,7 @@ class SessionManagerMockBuilder:
             mock_client.get_known_commits.return_value = self._known_commits
             mock_client.send_git_pack_file.return_value = None
             mock_client.get_skippable_tests.return_value = (self._skippable_items, None)
+            mock_client.configuration_errors = {}
             mock_api_client.return_value = mock_client
 
             with (
@@ -426,6 +427,8 @@ class APIClientMockBuilder:
 
         # Always add upload_coverage_report method that returns True (mocked success)
         mock_client.upload_coverage_report = Mock(return_value=True)
+
+        mock_client.configuration_errors = {}
 
         return mock_client
 


### PR DESCRIPTION
## Description

Replace the single `_dd.ci.library_configuration_error` tag with per-request error tags so each backend request failure is tracked individually:
- `_dd.ci.library_configuration_error.settings`
- `_dd.ci.library_configuration_error.skippable_tests`
- `_dd.ci.library_configuration_error.known_tests`
- `_dd.ci.library_configuration_error.test_management_tests`

Error tags are propagated to all child spans (modules, suites, test runs) so failures are visible at every level.

This will help us surface warnings in the UI when any of our features didn't work as expected due to a failure in our backend.

Jira ticket: [SDTEST-3520]

## Testing

Unit tests added for all error paths in `api_client.py` — covering missing git data, HTTP request failures, and bad JSON responses for each endpoint.

## Risks

None — tags are only added on error paths and do not affect nominal test run behavior.

[SDTEST-3520]: https://datadoghq.atlassian.net/browse/SDTEST-3520