### PR TITLE
fix(remoteconfig): retry transient poll failures

### DIFF
--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -35,6 +35,7 @@ from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
 from ddtrace.internal.utils.formats import parse_tags_str
+from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.internal.utils.time import StopWatch
 from ddtrace.internal.utils.version import _pep440_to_semver
 
@@ -445,6 +446,18 @@ class RemoteConfigClient:
         self._enabled_products = set()
 
     def _send_request(self, payload: str) -> Optional[Mapping[str, Any]]:
+        try:
+            return self._send_request_with_retry(payload)
+        except OSError as e:
+            log.debug("Unexpected connection error in remote config client request: %s", str(e))
+            return None
+
+    @fibonacci_backoff_with_jitter(
+        attempts=3,
+        initial_wait=0.2,
+        until=lambda result: isinstance(result, Mapping) or result is None,
+    )
+    def _send_request_with_retry(self, payload: str) -> Optional[Mapping[str, Any]]:
         conn = None
         try:
             if config.log_payloads:
@@ -461,9 +474,6 @@ class RemoteConfigClient:
 
             if config.log_payloads:
                 log.debug("[%s][P: %s] RC response payload: %s", os.getpid(), os.getppid(), data.decode("utf-8"))
-        except OSError as e:
-            log.debug("Unexpected connection error in remote config client request: %s", str(e))
-            return None
         finally:
             if conn is not None:
                 conn.close()

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -26,6 +26,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
     """
 
     _enable = True
+    _MAX_CONSECUTIVE_FAILURES = 3
 
     def __init__(self) -> None:
         super(RemoteConfigPoller, self).__init__(
@@ -35,6 +36,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         self._state = self._agent_check
         self._parent_id = os.getpid()
         self._capabilities_map: dict[enum.IntFlag, str] = dict()
+        self._consecutive_failures = 0
 
     def _agent_check(self) -> None:
         try:
@@ -62,10 +64,13 @@ class RemoteConfigPoller(periodic.PeriodicService):
     def _online(self) -> None:
         with StopWatch() as sw:
             if not self._client.request():
-                # An error occurred, so we transition back to the agent check
-                self._state = self._agent_check
+                self._consecutive_failures += 1
+                if self._consecutive_failures >= self._MAX_CONSECUTIVE_FAILURES:
+                    self._state = self._agent_check
+                    self._consecutive_failures = 0
                 return
 
+        self._consecutive_failures = 0
         elapsed = sw.elapsed()
         log.debug(
             "[%d][P: %d] Datadog Remote Config Poller sent request to %s in %.5fs",

--- a/releasenotes/notes/rc-poll-resilience-a4735a9d76f9f603.yaml
+++ b/releasenotes/notes/rc-poll-resilience-a4735a9d76f9f603.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    remote_config: This fix resolves an issue where brief Datadog Agent connection
+    errors could drop Remote Configuration polls, causing products such as Dynamic
+    Instrumentation to temporarily appear disabled.

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -848,3 +848,45 @@ def test_apm_sampling_rules_override():
                 lib_config = call_args[1][0]
                 # After removing configs, we should get an empty dict
                 assert isinstance(lib_config, dict)
+
+
+def test_send_request_retries_once_on_oserror():
+    """First attempt raises OSError; the retry decorator should produce a successful second call."""
+    client = RemoteConfigClient()
+    attempts = []
+
+    def fake_get_connection(*args, **kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise OSError("timed out")
+        mock_conn = mock.MagicMock()
+        mock_conn.getresponse.return_value.status = 200
+        mock_conn.getresponse.return_value.headers.get.return_value = None
+        mock_conn.getresponse.return_value.read.return_value = b'{"ok": true}'
+        return mock_conn
+
+    with mock.patch("ddtrace.internal.agent.get_connection", side_effect=fake_get_connection):
+        result = client._send_request("{}")
+
+    assert len(attempts) == 2
+    assert result == {"ok": True}
+
+
+def test_online_tolerates_transient_failures_before_bouncing(remote_config_worker):
+    """_online should stay in _online for N-1 consecutive failures, and bounce on the Nth."""
+    worker = RemoteConfigPoller()
+    worker._state = worker._online
+    threshold = worker._MAX_CONSECUTIVE_FAILURES
+
+    with mock.patch.object(worker._client, "request", return_value=False):
+        for i in range(threshold - 1):
+            worker._online()
+            assert worker._state == worker._online, f"bounced too early at failure {i + 1}"
+            assert worker._consecutive_failures == i + 1
+
+        worker._online()
+        assert worker._state == worker._agent_check
+        assert worker._consecutive_failures == 0
+
+    worker.stop_subscriber(True)
+    worker.disable()


### PR DESCRIPTION
## Description

Hardens the Remote Configuration poller against brief Datadog Agent stalls that were observable on shared-agent hosts as clusters of simultaneous `timed out` / HTTP 500 errors across all uwsgi workers, followed by backend-side products (e.g., Dynamic Instrumentation) briefly appearing disabled.

Two changes:

1. `RemoteConfigClient._send_request` now retries once with short jitter (up to 3 attempts total, ~200ms initial backoff) on transient `OSError`. Non-error returns (`None` for 404 / empty / 4xx / 5xx, `Mapping` for success) are not retried. Implemented via the existing `fibonacci_backoff_with_jitter` utility.
2. `RemoteConfigPoller._online` tolerates up to 3 consecutive failures before bouncing the FSM back to `_agent_check`. Previously a single failure cost an extra poll tick on `/info`, amplifying heartbeat gaps from one failed poll into two.

Motivation: on a staging host shared with other Datadog-instrumented services, the local Agent periodically stalled for 5-15 seconds (observed ~3 bursts / 24h on the worst day). Each stall caused all 4 workers' poll cycles to fail simultaneously, and the FSM-bounce amplified the gap enough that backend products observed a heartbeat silence and flipped state.

## Testing

- Added `test_send_request_retries_once_on_oserror` in `tests/internal/remoteconfig/test_remoteconfig.py` — confirms that a single transient `OSError` is recovered by the second attempt.
- Added `test_online_tolerates_transient_failures_before_bouncing` — confirms the FSM stays in `_online` for N-1 failures and bounces on the Nth, with the counter resetting after the bounce.
- Decorator semantics (retry on `OSError`, no retry on `None` or `Mapping`, re-raise on exhausted retries) validated standalone because the local dev env currently can't rebuild the dd-trace-py native extensions. Full CI run will cover this.

## Risks

Low. Blast radius is limited to the RC poll path.

- Worst-case poll duration grows from ~2s to ~6.5s (3 × 2s timeout + up to ~0.5s cumulative backoff) when the agent is completely unresponsive. The poll interval is 5s by default, so the next tick fires immediately afterward rather than on schedule — no tighter bound is assumed elsewhere.
- A corrupted JSON response (`ValueError` out of `json.loads`) is now retried once before re-raising. The extra attempt is wasted work but produces no user-visible change, since the existing `except ValueError` in `request()` still swallows it.
- `_consecutive_failures` is a new instance attribute; it does not affect serialized / forked state.

## Additional Notes

This change targets client-side resilience only. The root cause of the agent stalls is upstream (shared host contention) and is being tracked separately.