### PR TITLE
chore(internal): honor positional timeout in PeriodicThread.join

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -742,7 +742,12 @@ PeriodicThread_join(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 
     PyObject* timeout = Py_None;
 
-    if (args != NULL && kwargs != NULL) {
+    // CPython passes kwargs = NULL when the caller uses only positional
+    // arguments. The previous guard skipped parsing in that case, silently
+    // dropping the timeout: join(0.1) fell through to the Py_None branch and
+    // waited forever. PyArg_ParseTupleAndKeywords accepts kwargs == NULL, so
+    // we only need args to be non-NULL to attempt parsing.
+    if (args != NULL) {
         static const char* argnames[] = { "timeout", NULL };
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", (char**)argnames, &timeout))
             return NULL;

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -683,7 +683,12 @@ PeriodicThread_join(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 
     PyObject* timeout = Py_None;
 
-    if (args != NULL && kwargs != NULL) {
+    // CPython passes kwargs = NULL when the caller uses only positional
+    // arguments. The previous guard skipped parsing in that case, silently
+    // dropping the timeout: join(0.1) fell through to the Py_None branch and
+    // waited forever. PyArg_ParseTupleAndKeywords accepts kwargs == NULL, so
+    // we only need args to be non-NULL to attempt parsing.
+    if (args != NULL) {
         static const char* argnames[] = { "timeout", NULL };
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", (char**)argnames, &timeout))
             return NULL;

--- a/releasenotes/notes/fix-periodic-thread-join-positional-timeout-d5145d3aafb16129.yaml
+++ b/releasenotes/notes/fix-periodic-thread-join-positional-timeout-d5145d3aafb16129.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    internal: ``PeriodicThread.join(timeout)`` now honors the timeout when
+    passed positionally. Previously, only the keyword form
+    (``join(timeout=...)``) respected the value; positional calls silently fell
+    through to an infinite wait. This affected
+    ``PeriodicService.join(timeout=...)`` and ``Timer.join(timeout=...)``,
+    whose wrappers forward positionally — callers expecting a bounded wait
+    would instead block until the underlying thread exited on its own.

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -48,6 +48,38 @@ def test_periodic_double_start():
     t.join()
 
 
+def test_periodic_join_positional_timeout_is_honored():
+    """Regression: PeriodicThread.join(timeout) passed positionally was ignored.
+
+    The native PeriodicThread_join skipped argument parsing whenever kwargs was
+    NULL — which is the normal case for positional calls — so the timeout was
+    dropped and execution fell through to the Py_None infinite-wait branch.
+    PeriodicService.join(timeout=...) forwards positionally to its worker, so
+    every user of that wrapper was silently waiting forever instead of
+    honoring the timeout. This test pins the positional form (and the kwarg
+    form) to actually return within the requested timeout.
+    """
+    t = periodic.PeriodicThread(60.0, lambda: None)
+    t.start()
+    try:
+        start = monotonic()
+        t.join(0.1)  # positional
+        elapsed_pos = monotonic() - start
+        assert elapsed_pos < 1.0, (
+            "positional join(0.1) blocked for %.2fs — timeout was ignored" % elapsed_pos
+        )
+
+        start = monotonic()
+        t.join(timeout=0.1)  # keyword
+        elapsed_kw = monotonic() - start
+        assert elapsed_kw < 1.0, (
+            "keyword join(timeout=0.1) blocked for %.2fs — timeout was ignored" % elapsed_kw
+        )
+    finally:
+        t.stop()
+        t.join()
+
+
 def test_periodic_error():
     x = {"OK": False}
 

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -48,6 +48,34 @@ def test_periodic_double_start():
     t.join()
 
 
+def test_periodic_join_positional_timeout_is_honored():
+    """Regression: PeriodicThread.join(timeout) passed positionally was ignored.
+
+    The native PeriodicThread_join skipped argument parsing whenever kwargs was
+    NULL — which is the normal case for positional calls — so the timeout was
+    dropped and execution fell through to the Py_None infinite-wait branch.
+    PeriodicService.join(timeout=...) forwards positionally to its worker, so
+    every user of that wrapper was silently waiting forever instead of
+    honoring the timeout. This test pins the positional form (and the kwarg
+    form) to actually return within the requested timeout.
+    """
+    t = periodic.PeriodicThread(60.0, lambda: None)
+    t.start()
+    try:
+        start = monotonic()
+        t.join(0.1)  # positional
+        elapsed_pos = monotonic() - start
+        assert elapsed_pos < 1.0, "positional join(0.1) blocked for %.2fs — timeout was ignored" % elapsed_pos
+
+        start = monotonic()
+        t.join(timeout=0.1)  # keyword
+        elapsed_kw = monotonic() - start
+        assert elapsed_kw < 1.0, "keyword join(timeout=0.1) blocked for %.2fs — timeout was ignored" % elapsed_kw
+    finally:
+        t.stop()
+        t.join()
+
+
 def test_periodic_error():
     x = {"OK": False}
 


### PR DESCRIPTION
## Description

`PeriodicThread_join` (native, in `ddtrace/internal/_threads.cpp`) guarded its
argument parsing with `args != NULL && kwargs != NULL`. CPython passes
`kwargs == NULL` whenever the caller uses only positional arguments, so
`t.join(0.1)` skipped parsing and `timeout` stayed `Py_None`, falling through
to `self->_stopped->wait()` — an unbounded wait.

Both `PeriodicService.join` (`ddtrace/internal/periodic.py:64`) and
`Timer.join` (`ddtrace/internal/periodic.py:151`) forward to the underlying
worker positionally, so every caller that did `service.join(timeout=...)` was
silently waiting for the thread to exit on its own instead of honoring the
requested timeout. The telemetry writer shutdown path (`self.join(timeout=2)`)
is one user-visible example.

The fix drops the spurious `kwargs != NULL` check: `PyArg_ParseTupleAndKeywords`
already accepts `kwargs == NULL`.

This bug has been in the file since `PeriodicThread_join` was first
introduced; it was found by a randomized lifecycle stress test targeting the
native `_threads.cpp` that I'm prototyping separately.

## Testing

New regression test in `tests/internal/test_periodic.py`:
`test_periodic_join_positional_timeout_is_honored` — asserts both
`t.join(0.1)` and `t.join(timeout=0.1)` return within 1s against a long-interval
thread. Before the fix, the positional form hangs forever; after the fix both
forms return in ~0.1s.

Quick standalone verification on a Linux workspace:

Before:
```
kwarg join(timeout=0.1):  elapsed=0.100s
WATCHDOG: positional join hung past 2s — killing
```

After:
```
positional join(0.1):  elapsed=0.100s
keyword   join(t=0.1): elapsed=0.100s
```

## Risks

Very low. Behavior change is scoped to `PeriodicThread.join(X)` called
positionally — previously an unbounded wait, now bounded by `X`. Callers that
were relying on the (undocumented) infinite-wait-when-passing-a-number
behavior would be affected, but that matches no documented contract and all
existing positional callsites in the repo already want the timeout honored
(they are `service.join(timeout=...)` wrappers forwarding positionally).

No API surface change. Release note included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)