### PR TITLE
chore(riot): delete useless sub venvs

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -412,11 +412,7 @@ venv = Venv(
                 "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "0",
             },
             venvs=[
-                Venv(
-                    venvs=[
-                        Venv(pys=select_pys()),
-                    ]
-                ),
+                Venv(pys=select_pys()),
                 # This test variant ensures tracer tests are compatible with both 64bit trace ids.
                 # 128bit trace ids are tested by the default case above.
                 Venv(
@@ -638,15 +634,11 @@ venv = Venv(
         Venv(
             name="lib_injection",
             command="pytest {cmdargs} tests/lib_injection/",
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={
-                        "PyYAML": latest,
-                        "pytest-randomly": latest,
-                    },
-                ),
-            ],
+            pys=select_pys(),
+            pkgs={
+                "PyYAML": latest,
+                "pytest-randomly": latest,
+            },
         ),
         Venv(
             name="gevent",
@@ -700,38 +692,26 @@ venv = Venv(
         Venv(
             name="runtime",
             command="pytest {cmdargs} tests/runtime/",
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={
-                        "msgpack": latest,
-                        "pytest-randomly": latest,
-                    },
-                )
-            ],
+            pys=select_pys(),
+            pkgs={
+                "msgpack": latest,
+                "pytest-randomly": latest,
+            },
         ),
         Venv(
             name="smoke_test",
             command="python tests/smoke_test.py {cmdargs}",
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                )
-            ],
+            pys=select_pys(),
         ),
         Venv(
             name="ddtracerun",
             command="pytest {cmdargs} --no-cov tests/commands/test_runner.py",
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={
-                        "redis": latest,
-                        "gevent": latest,
-                        "pytest-randomly": latest,
-                    },
-                ),
-            ],
+            pys=select_pys(),
+            pkgs={
+                "redis": latest,
+                "gevent": latest,
+                "pytest-randomly": latest,
+            },
         ),
         Venv(
             name="debugger",
@@ -864,22 +844,14 @@ venv = Venv(
             venvs=[
                 Venv(
                     command="pytest {cmdargs} --ignore='tests/contrib/bottle/test_autopatch.py' tests/contrib/bottle/",
-                    venvs=[
-                        Venv(
-                            pys=select_pys(max_version="3.9"),
-                            pkgs={"bottle": [">=0.12,<0.13", latest]},
-                        ),
-                    ],
+                    pys=select_pys(max_version="3.9"),
+                    pkgs={"bottle": [">=0.12,<0.13", latest]},
                 ),
                 Venv(
                     command="python tests/ddtrace_run.py pytest {cmdargs} tests/contrib/bottle/test_autopatch.py",
                     env={"DD_SERVICE": "bottle-app"},
-                    venvs=[
-                        Venv(
-                            pys=select_pys(max_version="3.9"),
-                            pkgs={"bottle": [">=0.12,<0.13", latest]},
-                        ),
-                    ],
+                    pys=select_pys(max_version="3.9"),
+                    pkgs={"bottle": [">=0.12,<0.13", latest]},
                 ),
             ],
         ),
@@ -1176,32 +1148,24 @@ venv = Venv(
         Venv(
             name="elasticsearch:multi",
             command="pytest {cmdargs} tests/contrib/elasticsearch/test_elasticsearch_multi.py",
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={
-                        "elasticsearch": latest,
-                        "elasticsearch7": latest,
-                        "pytest-randomly": latest,
-                    },
-                ),
-            ],
+            pys=select_pys(),
+            pkgs={
+                "elasticsearch": latest,
+                "elasticsearch7": latest,
+                "pytest-randomly": latest,
+            },
         ),
         Venv(
             name="elasticsearch:async",
             command="pytest {cmdargs} tests/contrib/elasticsearch/test_async.py",
             env={"AIOHTTP_NO_EXTENSIONS": "1"},  # needed until aiohttp is updated to support python 3.12
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={
-                        "elasticsearch[async]": latest,
-                        "elasticsearch7[async]": latest,
-                        "opensearch-py[async]": latest,
-                        "pytest-randomly": latest,
-                    },
-                ),
-            ],
+            pys=select_pys(),
+            pkgs={
+                "elasticsearch[async]": latest,
+                "elasticsearch7[async]": latest,
+                "opensearch-py[async]": latest,
+                "pytest-randomly": latest,
+            },
         ),
         Venv(
             name="elasticsearch:opensearch",
@@ -1301,6 +1265,10 @@ venv = Venv(
             },
             venvs=[
                 Venv(
+                    env={
+                        "DD_PYTEST_USE_NEW_PLUGIN": "false",
+                    },
+                    pys=["3.9"],
                     pkgs={
                         "flask": "~=0.12.0",
                         "Werkzeug": ["<1.0"],
@@ -1317,12 +1285,7 @@ venv = Venv(
                         # https://github.com/pallets/markupsafe/issues/282
                         # DEV: Breaking change made in 2.1.0 release
                         "markupsafe": "<2.0",
-                    },
-                    venvs=[
-                        Venv(pys=["3.9"], pkgs={"exceptiongroup": latest}),
-                    ],
-                    env={
-                        "DD_PYTEST_USE_NEW_PLUGIN": "false",
+                        "exceptiongroup": latest,
                     },
                 ),
                 Venv(
@@ -1429,15 +1392,11 @@ venv = Venv(
         Venv(
             name="psycopg:psycopg2",
             command="pytest {cmdargs} tests/contrib/psycopg2",
+            pys=select_pys(),
             pkgs={
                 "pytest-randomly": latest,
+                "psycopg2-binary": ["~=2.9.2", latest],
             },
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                    pkgs={"psycopg2-binary": ["~=2.9.2", latest]},
-                ),
-            ],
         ),
         Venv(
             name="psycopg",
@@ -1544,19 +1503,15 @@ venv = Venv(
             name="pynamodb",
             command="pytest -n 8 {cmdargs} tests/contrib/pynamodb",
             # TODO: Py312 requires changes to test code
-            venvs=[
-                Venv(
-                    pys=select_pys(min_version="3.9", max_version="3.11"),
-                    pkgs={
-                        "pynamodb": ["~=5.3", "<6.0"],
-                        "moto": ">=1.0,<2.0",
-                        "cfn-lint": "~=0.53.1",
-                        "Jinja2": "~=2.10.0",
-                        "pytest-randomly": latest,
-                        "pytest-xdist": latest,
-                    },
-                ),
-            ],
+            pys=select_pys(min_version="3.9", max_version="3.11"),
+            pkgs={
+                "pynamodb": ["~=5.3", "<6.0"],
+                "moto": ">=1.0,<2.0",
+                "cfn-lint": "~=0.53.1",
+                "Jinja2": "~=2.10.0",
+                "pytest-randomly": latest,
+                "pytest-xdist": latest,
+            },
         ),
         Venv(
             name="starlette",
@@ -1727,11 +1682,7 @@ venv = Venv(
             venvs=[
                 Venv(
                     pkgs={"botocore": "==1.34.49", "boto3": "==1.34.49"},
-                    venvs=[
-                        Venv(
-                            pys=select_pys(),
-                        ),
-                    ],
+                    pys=select_pys(),
                 ),
                 Venv(
                     pkgs={
@@ -1739,11 +1690,7 @@ venv = Venv(
                         "botocore": "==1.38.26",
                         "boto3": "==1.38.26",
                     },
-                    venvs=[
-                        Venv(
-                            pys=select_pys(),
-                        ),
-                    ],
+                    pys=select_pys(),
                 ),
             ],
         ),
@@ -2087,21 +2034,15 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/asynctest/",
             pkgs={
                 "pytest-randomly": latest,
+                "pytest": [
+                    ">=6.0,<7.0",
+                ],
+                "asynctest": "==0.13.0",
             },
             env={
                 "DD_PYTEST_USE_NEW_PLUGIN": "false",
             },
-            venvs=[
-                Venv(
-                    pys="3.9",
-                    pkgs={
-                        "pytest": [
-                            ">=6.0,<7.0",
-                        ],
-                        "asynctest": "==0.13.0",
-                    },
-                ),
-            ],
+            pys="3.9",
         ),
         Venv(
             name="pytest_bdd",
@@ -2144,19 +2085,13 @@ venv = Venv(
             pkgs={
                 "msgpack": latest,
                 "pytest-randomly": latest,
+                "pytest-benchmark": [
+                    ">=3.1.0,<=4.0.0",
+                ],
             },
             env={
                 "DD_PYTEST_USE_NEW_PLUGIN": "false",
             },
-            venvs=[
-                Venv(
-                    pkgs={
-                        "pytest-benchmark": [
-                            ">=3.1.0,<=4.0.0",
-                        ]
-                    },
-                ),
-            ],
         ),
         Venv(
             name="pytest:flaky",
@@ -2369,14 +2304,8 @@ venv = Venv(
         Venv(
             name="algoliasearch",
             command="pytest {cmdargs} tests/contrib/algoliasearch",
-            pkgs={"urllib3": "~=1.26.15", "pytest-randomly": latest},
-            venvs=[
-                Venv(
-                    # algoliasearch added support for Python 3.9, 3.10, 3.11 in 3.0
-                    pys=select_pys(),
-                    pkgs={"algoliasearch": "~=2.6"},
-                ),
-            ],
+            pys=select_pys(),
+            pkgs={"urllib3": "~=1.26.15", "pytest-randomly": latest, "algoliasearch": "~=2.6"},
         ),
         Venv(
             name="aiopg",
@@ -2495,13 +2424,8 @@ venv = Venv(
         Venv(
             name="rediscluster",
             command="pytest {cmdargs} tests/contrib/rediscluster",
-            pkgs={"pytest-randomly": latest},
-            venvs=[
-                Venv(
-                    pys=select_pys(max_version="3.11"),
-                    pkgs={"redis-py-cluster": [">=2.0,<2.1", latest]},
-                ),
-            ],
+            pys=select_pys(max_version="3.11"),
+            pkgs={"pytest-randomly": latest, "redis-py-cluster": [">=2.0,<2.1", latest]},
         ),
         Venv(
             name="redis",
@@ -2511,21 +2435,15 @@ venv = Venv(
             venvs=[
                 Venv(
                     command="pytest {cmdargs} tests/contrib/redis",
+                    pys=select_pys(min_version="3.9", max_version="3.10"),
                     pkgs={
                         "redis": [
                             "~=4.1",
                             "~=4.3",
                             "==5.0.1",
                         ],
+                        "pytest-asyncio": "==0.23.7",
                     },
-                    venvs=[
-                        Venv(
-                            pys=select_pys(min_version="3.9", max_version="3.10"),
-                            pkgs={
-                                "pytest-asyncio": "==0.23.7",
-                            },
-                        ),
-                    ],
                 ),
                 Venv(
                     # redis added support for Python 3.11 in 4.3
@@ -2748,16 +2666,12 @@ venv = Venv(
             command="pytest {cmdargs} tests/contrib/sqlite3",
             pkgs={
                 "pytest-randomly": latest,
+                "pysqlite3-binary": [latest],
             },
-            venvs=[
-                # sqlite3 is tied to the Python version and is not installable via pip
-                # To test a range of versions without updating Python, we use Linux only pysqlite3-binary package
-                # Remove pysqlite3-binary on Python 3.9+ locally on non-linux machines
-                Venv(
-                    pys=select_pys(min_version="3.9", max_version="3.12"),
-                    pkgs={"pysqlite3-binary": [latest]},
-                ),
-            ],
+            # sqlite3 is tied to the Python version and is not installable via pip
+            # To test a range of versions without updating Python, we use Linux only pysqlite3-binary package
+            # Remove pysqlite3-binary on Python 3.9+ locally on non-linux machines
+            pys=select_pys(min_version="3.9", max_version="3.12"),
         ),
         Venv(
             name="dbapi",
@@ -2870,13 +2784,9 @@ venv = Venv(
             pkgs={
                 "pytest-randomly": latest,
                 "mock": latest,
+                # Test against openfeature-sdk 0.8.0+ (required for finally_after hook details parameter)
+                "openfeature-sdk": ["~=0.8.0", latest],
             },
-            venvs=[
-                Venv(
-                    # Test against openfeature-sdk 0.8.0+ (required for finally_after hook details parameter)
-                    pkgs={"openfeature-sdk": ["~=0.8.0", latest]},
-                ),
-            ],
         ),
         Venv(
             name="asyncio",
@@ -3071,17 +2981,13 @@ venv = Venv(
         Venv(
             name="openai_agents",
             command="pytest {cmdargs} tests/contrib/openai_agents",
-            venvs=[
-                Venv(
-                    pys=select_pys(min_version="3.9", max_version="3.13"),
-                    pkgs={
-                        "vcrpy": latest,
-                        "pytest-asyncio": latest,
-                        "openai": latest,
-                        "openai-agents": ["~=0.0.0", latest],
-                    },
-                )
-            ],
+            pys=select_pys(min_version="3.9", max_version="3.13"),
+            pkgs={
+                "vcrpy": latest,
+                "pytest-asyncio": latest,
+                "openai": latest,
+                "openai-agents": ["~=0.0.0", latest],
+            },
         ),
         Venv(
             name="langchain",
@@ -3227,6 +3133,7 @@ venv = Venv(
         Venv(
             name="google_adk",
             command="pytest -n auto {cmdargs} tests/contrib/google_adk",
+            pys=select_pys(),
             pkgs={
                 "pytest-asyncio": latest,
                 "pytest-xdist": latest,
@@ -3234,24 +3141,15 @@ venv = Venv(
                 "vcrpy": latest,
                 "deprecated": latest,
             },
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                ),
-            ],
         ),
         Venv(
             name="google_genai",
             command="pytest {cmdargs} tests/contrib/google_genai",
+            pys=select_pys(),
             pkgs={
                 "pytest-asyncio": latest,
                 "google-genai": latest,
             },
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                ),
-            ],
         ),
         Venv(
             name="crewai",
@@ -3551,11 +3449,7 @@ venv = Venv(
                 "DD_AGENT_PORT": "9126",
                 "DD_PYTEST_USE_NEW_PLUGIN": "false",
             },
-            venvs=[
-                Venv(
-                    pys=select_pys(min_version="3.9", max_version="3.13"),
-                ),
-            ],
+            pys=select_pys(min_version="3.9", max_version="3.13"),
         ),
         Venv(
             name="subprocess",
@@ -3860,23 +3754,17 @@ venv = Venv(
                     pys=select_pys(),
                     env={
                         "DD_PROFILING_MEMALLOC_ASSERT_ON_REENTRY": "1",
+                        # standard allocators
+                        "PYTHONMALLOC": [
+                            "malloc",
+                            "pymalloc",
+                            "malloc_debug",
+                            "pymalloc_debug",
+                        ],
                     },
                     pkgs={
                         "protobuf": latest,
                     },
-                    venvs=[
-                        # standard allocators
-                        Venv(
-                            env={
-                                "PYTHONMALLOC": [
-                                    "malloc",
-                                    "pymalloc",
-                                    "malloc_debug",
-                                    "pymalloc_debug",
-                                ],
-                            },
-                        ),
-                    ],
                 ),
             ],
         ),
@@ -4125,6 +4013,7 @@ venv = Venv(
             pkgs={
                 "requests": latest,
                 "httpx": latest,
+                "django": "~=5.1",
             },
             env={
                 "DD_TRACE_AGENT_URL": "http://testagent:9126",
@@ -4134,14 +4023,7 @@ venv = Venv(
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
                 "DD_PATCH_MODULES": "unittest:false",
             },
-            venvs=[
-                Venv(
-                    pys=["3.10", "3.13"],
-                    pkgs={
-                        "django": "~=5.1",
-                    },
-                ),
-            ],
+            pys=["3.10", "3.13"],
         ),
         Venv(
             name="appsec_threats_flask_no_iast",
@@ -4244,6 +4126,7 @@ venv = Venv(
                 "requests": latest,
                 "hypothesis": latest,
                 "httpx": latest,
+                "flask": "~=3.0",
             },
             env={
                 "DD_TRACE_AGENT_URL": "http://testagent:9126",
@@ -4253,14 +4136,7 @@ venv = Venv(
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
                 "DD_PATCH_MODULES": "unittest:false",
             },
-            venvs=[
-                Venv(
-                    pys=["3.11", "3.13"],
-                    pkgs={
-                        "flask": "~=3.0",
-                    },
-                ),
-            ],
+            pys=["3.11", "3.13"],
         ),
         Venv(
             name="appsec_threats_fastapi_no_iast",
@@ -4351,6 +4227,7 @@ venv = Venv(
                 "requests": latest,
                 "hypothesis": latest,
                 "httpx": "<0.28.0",
+                "fastapi": "~=0.114.2",
             },
             env={
                 "DD_TRACE_AGENT_URL": "http://testagent:9126",
@@ -4360,14 +4237,7 @@ venv = Venv(
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
                 "DD_PATCH_MODULES": "unittest:false",
             },
-            venvs=[
-                Venv(
-                    pys=["3.10", "3.13"],
-                    pkgs={
-                        "fastapi": "~=0.114.2",
-                    },
-                ),
-            ],
+            pys=["3.10", "3.13"],
         ),
         Venv(
             name="appsec_threats_tornado_no_iast",
@@ -4445,6 +4315,7 @@ venv = Venv(
             pkgs={
                 "requests": latest,
                 "httpx": latest,
+                "tornado": "~=6.5",
             },
             env={
                 "DD_TRACE_AGENT_URL": "http://testagent:9126",
@@ -4454,14 +4325,7 @@ venv = Venv(
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
                 "DD_PATCH_MODULES": "unittest:false",
             },
-            venvs=[
-                Venv(
-                    pys=["3.10", "3.14"],
-                    pkgs={
-                        "tornado": "~=6.5",
-                    },
-                ),
-            ],
+            pys=["3.10", "3.14"],
         ),
         Venv(
             name="appsec_iast_native",
@@ -4488,11 +4352,7 @@ venv = Venv(
             pkgs={
                 "requests": latest,
             },
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                ),
-            ],
+            pys=select_pys(),
         ),
         Venv(
             name="ai_guard_langchain",
@@ -4545,11 +4405,7 @@ venv = Venv(
             pkgs={
                 "strands-agents": ">=1.29.0",
             },
-            venvs=[
-                Venv(
-                    pys=select_pys(min_version="3.10"),
-                ),
-            ],
+            pys=select_pys(min_version="3.10"),
         ),
         Venv(
             name="ai_guard_litellm_guardrail",
@@ -4575,11 +4431,7 @@ venv = Venv(
         Venv(
             name="sca",
             command="pytest {cmdargs} tests/appsec/sca/",
-            venvs=[
-                Venv(
-                    pys=select_pys(),
-                ),
-            ],
+            pys=select_pys(),
         ),
     ],
 )


### PR DESCRIPTION
## Description

A lots of integration are creating sub venvs which are actually useless.

I'm creating a subscript to be able to update riotfile tested version programmatically (more to come soon) and it makes everything harder. 

This PR fixes the issue