### PR TITLE
perf(profiling): [2/n] cache internal_file path in Lock collector

### DIFF
--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -537,7 +537,7 @@ class LockCollector(collector.CaptureSamplerCollector):
                 if precomputed_internal_file and caller_filename:
                     caller_filename = os.path.normpath(os.path.realpath(caller_filename))
                     is_internal = caller_filename == precomputed_internal_file
-            except OSError:
+            except (ValueError, AttributeError, OSError):
                 pass
 
             return self.PROFILED_LOCK_CLASS(

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -496,6 +496,15 @@ class LockCollector(collector.CaptureSamplerCollector):
 
             internal_module_file = threading_module.__file__
 
+        # Precompute the resolved internal module path once — avoids repeated filesystem syscalls
+        # on every lock allocation.
+        precomputed_internal_file: Optional[str] = None
+        if internal_module_file:
+            try:
+                precomputed_internal_file = os.path.normpath(os.path.realpath(internal_module_file))
+            except OSError:
+                pass
+
         # Precompute module exclusion structures once at patch time (not per lock creation).
         # Two structures for fast matching:
         #   exclude_exact  — frozenset for O(1) exact module name lookup
@@ -512,7 +521,6 @@ class LockCollector(collector.CaptureSamplerCollector):
             """
             cdef bint is_internal = False
             cdef str caller_filename
-            cdef str internal_file
             cdef str caller_module
             try:
                 # In Cython, intermediate frames are invisible; caller is at index 0
@@ -526,11 +534,10 @@ class LockCollector(collector.CaptureSamplerCollector):
                         return original_lock(*args, **kwargs)
 
                 # Internal lock detection (e.g., threading.Semaphore creating a Lock internally)
-                if internal_module_file and caller_filename:
+                if precomputed_internal_file and caller_filename:
                     caller_filename = os.path.normpath(os.path.realpath(caller_filename))
-                    internal_file = os.path.normpath(os.path.realpath(internal_module_file))
-                    is_internal = caller_filename == internal_file
-            except (ValueError, AttributeError, OSError):
+                    is_internal = caller_filename == precomputed_internal_file
+            except OSError:
                 pass
 
             return self.PROFILED_LOCK_CLASS(

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -1949,15 +1949,13 @@ class BaseSemaphoreTest(LockCollectorTestBase):
             )
 
     def test_internal_module_file_realpath_called_once_at_patch_time(self) -> None:
-        """Verify that os.path.realpath() for the internal module file is computed once at patch() time,
+        """Verify that os.path.realpath for the internal module file is computed once at patch time,
         not on every lock allocation.
 
         Regression test for a bug where the constant internal module path was being resolved via
-        os.path.realpath() on every single lock instantiation, causing unnecessary filesystem syscalls
+        os.path.realpath on every single lock instantiation, causing unnecessary filesystem syscalls
         in hot paths (e.g. asyncio Semaphore/Condition allocations per request).
         """
-        import os.path
-
         realpath_call_counts: dict[str, int] = {"patch_time": 0, "alloc_time": 0}
         in_patch: list[bool] = [False]
         original_realpath = os.path.realpath

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -1948,6 +1948,54 @@ class BaseSemaphoreTest(LockCollectorTestBase):
                 "Internal lock from threading stdlib should be a native lock, not a _ProfiledLock"
             )
 
+    def test_internal_module_file_realpath_called_once_at_patch_time(self) -> None:
+        """Verify that os.path.realpath() for the internal module file is computed once at patch() time,
+        not on every lock allocation.
+
+        Regression test for a bug where the constant internal module path was being resolved via
+        os.path.realpath() on every single lock instantiation, causing unnecessary filesystem syscalls
+        in hot paths (e.g. asyncio Semaphore/Condition allocations per request).
+        """
+        import os.path
+
+        realpath_call_counts: dict[str, int] = {"patch_time": 0, "alloc_time": 0}
+        in_patch: list[bool] = [False]
+        original_realpath = os.path.realpath
+
+        def counting_realpath(path: str, **kwargs: object) -> str:
+            if in_patch[0]:
+                realpath_call_counts["patch_time"] += 1
+            else:
+                realpath_call_counts["alloc_time"] += 1
+            return original_realpath(path, **kwargs)  # type: ignore[call-overload]
+
+        with mock.patch("os.path.realpath", side_effect=counting_realpath):
+            in_patch[0] = True
+            collector = self.collector_class(capture_pct=100)
+            collector._start_service()
+            in_patch[0] = False
+
+            try:
+                # Allocate several locks — realpath for the internal module file must NOT be called again
+                for _ in range(5):
+                    lock: LockTypeInst = self.lock_class()
+                    lock.acquire()
+                    lock.release()
+            finally:
+                collector._stop_service()
+
+        # realpath should have been called at least once at patch time (to resolve the internal module file)
+        assert realpath_call_counts["patch_time"] >= 1, (
+            "Expected os.path.realpath to be called at patch() time to precompute the internal module path"
+        )
+        # realpath may still be called at alloc time for the *caller* filename, but NOT for the constant
+        # internal module file. The alloc-time count should be exactly N allocations (one caller realpath each),
+        # not 2*N (which would indicate the internal file is still being resolved per allocation).
+        assert realpath_call_counts["alloc_time"] <= 5, (
+            f"os.path.realpath called {realpath_call_counts['alloc_time']} times during 5 allocations — "
+            "expected at most 5 (one per caller filename). The internal module file path may be recomputed per-call."
+        )
+
     def test_acquire_return_values_preserved(self) -> None:
         """Test that profiling wrapper preserves acquire() return values (transparency test).
 


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/16922) | [Next PR >](https://github.com/DataDog/dd-trace-py/pull/17639)

[SCP-1121](https://datadoghq.atlassian.net/browse/SCP-1121)

## Summary

Hoists `os.path.normpath(os.path.realpath(internal_module_file))` out of the `_profiled_allocate_lock` closure so it is computed once at `patch()` time rather than on every lock allocation.

## Motivation

`os.path.realpath()` involves filesystem syscalls (symlink resolution). With 9 workers each creating asyncio primitives at startup and during requests, the old code was firing this syscall many thousands of times per process lifetime.

## Test plan

* CI

[SCP-1121]: https://datadoghq.atlassian.net/browse/SCP-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ