### PR TITLE
feat(profiling): [3/n] gate extended Lock primitives with config

### DIFF
--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -375,6 +375,26 @@ class ProfilingConfigLock(DDConfig):
         ),
     )
 
+    primitives = DDConfig.v(
+        frozenset,
+        "primitives",
+        parser=lambda raw: frozenset(p.strip() for p in raw.split(",") if p.strip()),
+        # Deliberately conservative default. After new lock types were added in
+        # v3.5.x, customers with heavy async workloads (many Condition/Semaphore
+        # acquisitions) saw significant latency regressions (SCP-1121). We default
+        # to the original core primitives plus RLock, and let users opt in to
+        # broader coverage via this config.
+        default=frozenset({"threading.Lock", "threading.RLock", "asyncio.Lock"}),
+        help_type="String",
+        help=(
+            "Comma-separated list of lock primitive types to profile. "
+            "Default: ``threading.Lock,threading.RLock,asyncio.Lock``. "
+            "Available primitives: ``threading.Lock``, ``threading.RLock``, ``threading.Semaphore``, "
+            "``threading.BoundedSemaphore``, ``threading.Condition``, ``asyncio.Lock``, "
+            "``asyncio.Semaphore``, ``asyncio.BoundedSemaphore``, ``asyncio.Condition``."
+        ),
+    )
+
 
 class ProfilingConfigMemory(DDConfig):
     __item__ = __prefix__ = "memory"

--- a/ddtrace/internal/settings/profiling.pyi
+++ b/ddtrace/internal/settings/profiling.pyi
@@ -37,6 +37,7 @@ class ProfilingConfigLock(DDConfig):
     enabled: bool
     name_inspect_dir: bool
     exclude_modules: frozenset[str]
+    primitives: frozenset[str]
 
 class ProfilingConfigMemory(DDConfig):
     enabled: bool

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -413,6 +413,13 @@ class TelemetryWriter(PeriodicService):
             configuration_value = ",".join(":".join((k, str(v))) for k, v in configuration_value.items())
         elif isinstance(configuration_value, (list, tuple)):
             configuration_value = ",".join(str(v) for v in configuration_value)
+        elif isinstance(configuration_value, (set, frozenset)):
+            type_name: str = type(configuration_value).__name__
+            if not configuration_value:
+                configuration_value = f"{type_name}()"
+            else:
+                sorted_reprs: str = ", ".join(repr(v) for v in sorted(str(x) for x in configuration_value))
+                configuration_value = f"{type_name}({{{sorted_reprs}}})"
         elif not isinstance(configuration_value, (bool, str, int, float, type(None))):
             # convert unsupported types to strings
             configuration_value = str(configuration_value)

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -34,6 +34,19 @@ from ddtrace.profiling.collector import threading
 LOG = logging.getLogger(__name__)
 
 
+_LOCK_PRIMITIVE_COLLECTORS: dict[str, tuple[str, type[collector.Collector]]] = {
+    "threading.Lock": ("threading", threading.ThreadingLockCollector),
+    "threading.RLock": ("threading", threading.ThreadingRLockCollector),
+    "threading.Semaphore": ("threading", threading.ThreadingSemaphoreCollector),
+    "threading.BoundedSemaphore": ("threading", threading.ThreadingBoundedSemaphoreCollector),
+    "threading.Condition": ("threading", threading.ThreadingConditionCollector),
+    "asyncio.Lock": ("asyncio", asyncio.AsyncioLockCollector),
+    "asyncio.Semaphore": ("asyncio", asyncio.AsyncioSemaphoreCollector),
+    "asyncio.BoundedSemaphore": ("asyncio", asyncio.AsyncioBoundedSemaphoreCollector),
+    "asyncio.Condition": ("asyncio", asyncio.AsyncioConditionCollector),
+}
+
+
 class Profiler(object):
     """Run profiling while code is executed.
 
@@ -238,17 +251,19 @@ class _ProfilerInstance(service.Service):
 
                     self._collectors.append(col)
 
-            self._collectors_on_import = [
-                ("threading", lambda _: start_collector(threading.ThreadingLockCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingRLockCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingSemaphoreCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingBoundedSemaphoreCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingConditionCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioLockCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioSemaphoreCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioConditionCollector)),
-            ]
+            def _make_hook(cls: type[collector.Collector]) -> Callable[[Any], None]:
+                def _hook(_: Any) -> None:
+                    start_collector(cls)
+
+                return _hook
+
+            self._collectors_on_import = []
+            for primitive in profiling_config.lock.primitives:
+                if primitive not in _LOCK_PRIMITIVE_COLLECTORS:
+                    LOG.warning("Unknown lock primitive %r in DD_PROFILING_LOCK_PRIMITIVES, skipping", primitive)
+                    continue
+                module, collector_class = _LOCK_PRIMITIVE_COLLECTORS[primitive]
+                self._collectors_on_import.append((module, _make_hook(collector_class)))
 
             for module, hook in self._collectors_on_import:
                 ModuleWatchdog.register_module_hook(module, hook)
@@ -340,6 +355,7 @@ class _ProfilerInstance(service.Service):
         :param flush: Flush a last profile.
         """
         LOG.debug("Stopping profiler")
+
         # Prevent doing more initialisation now that we are shutting down.
         if self._collectors_on_import:
             for module, hook in self._collectors_on_import:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.8.0rc5"
+version = "4.9.0rc1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/releasenotes/notes/profiling-lock-primitives-config-3027207f6c41217a.yaml
+++ b/releasenotes/notes/profiling-lock-primitives-config-3027207f6c41217a.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    profiling: Adds ``DD_PROFILING_LOCK_PRIMITIVES`` to control which lock types are profiled.
+    The default is ``threading.Lock,threading.RLock,asyncio.Lock``, which reduces overhead.
+    Other available primitives are:
+    ``threading.Semaphore``, ``threading.BoundedSemaphore``, ``threading.Condition``,
+    ``asyncio.Semaphore``, ``asyncio.BoundedSemaphore``, or ``asyncio.Condition``.

--- a/riotfile.py
+++ b/riotfile.py
@@ -971,10 +971,13 @@ venv = Venv(
                 "redis": ">=2.10,<2.11",
                 "psycopg2-binary": [">=2.8.6"],  # We need <2.9.0 for Python 2.7, and >2.9.0 for 3.9+
                 "pytest-django[testing]": "==3.10.0",
+                # async ASGI tests (#17404 / #17728) silently skip without it.
+                "pytest-asyncio": latest,
+                # setuptools 80 removed `pkg_resources`, still imported by django-q[2].
+                "setuptools": "<80",
                 "pylibmc": latest,
                 "python-memcached": latest,
                 "pytest-randomly": latest,
-                "django-q": latest,
                 "spyne": latest,
                 "zeep": latest,
                 "bcrypt": "==4.2.1",
@@ -996,6 +999,7 @@ venv = Venv(
                     pkgs={
                         "django": ["~=2.2.0", "~=3.0.0", "~=4.0"],
                         "channels": latest,
+                        "django-q": latest,
                     },
                 ),
                 Venv(
@@ -1005,6 +1009,28 @@ venv = Venv(
                         "django": ["~=4.2"],
                         "psycopg": latest,
                         "channels": latest,
+                        "django-q": latest,
+                    },
+                ),
+                Venv(
+                    # django 5.x (#17728 coverage). Uses django-q2 because django-q imports
+                    # django.utils.baseconv (removed in Django 5.0). Postgres-touching tests
+                    # and Django-4.2-specific test_cached_view are skipped because Django 5.0
+                    # dropped Postgres 12, but the suite's docker-compose still runs Postgres 12.
+                    pys=select_pys(min_version="3.10", max_version="3.13"),
+                    command=(
+                        "pytest {cmdargs} "
+                        "--ignore=tests/contrib/django/test_django_dbm.py "
+                        "--ignore=tests/contrib/django/test_django_snapshots.py "
+                        "-k 'not test_user_name_included and not test_user_name_excluded "
+                        "and not test_cached_view' "
+                        "tests/contrib/django"
+                    ),
+                    pkgs={
+                        "django": ["~=5.1"],
+                        "psycopg": latest,
+                        "channels": latest,
+                        "django-q2": latest,
                     },
                 ),
             ],
@@ -3024,6 +3050,7 @@ venv = Venv(
                         "langchain-anthropic": "~=0.3.0",
                         "langchain-aws": "~=0.2.0",
                         "langchain-cohere": "~=0.3.0",
+                        "langchain-google-genai": "~=2.0.0",
                     },
                     pys=select_pys(min_version="3.9", max_version="3.12"),
                 ),
@@ -3034,8 +3061,9 @@ venv = Venv(
                         "langchain-anthropic": latest,
                         "langchain-aws": latest,
                         "langchain-cohere": latest,
+                        "langchain-google-genai": latest,
                     },
-                    pys=select_pys(min_version="3.9", max_version="3.12"),
+                    pys=select_pys(min_version="3.10", max_version="3.12"),
                 ),
             ],
         ),

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import sys
@@ -11,9 +12,11 @@ from ddtrace.internal.compat import PYTHON_VERSION_INFO
 from ddtrace.profiling import collector
 from ddtrace.profiling import profiler
 from ddtrace.profiling import scheduler
+from ddtrace.profiling.collector import _lock
 from ddtrace.profiling.collector import asyncio
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading
+from ddtrace.profiling.profiler import _LOCK_PRIMITIVE_COLLECTORS
 
 
 TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT") or False
@@ -148,9 +151,9 @@ def test_default_collectors():
         pass
     else:
         assert any(isinstance(c, asyncio.AsyncioLockCollector) for c in p._profiler._collectors)
-        assert any(isinstance(c, asyncio.AsyncioSemaphoreCollector) for c in p._profiler._collectors)
-        assert any(isinstance(c, asyncio.AsyncioBoundedSemaphoreCollector) for c in p._profiler._collectors)
-        assert any(isinstance(c, asyncio.AsyncioConditionCollector) for c in p._profiler._collectors)
+        assert not any(isinstance(c, asyncio.AsyncioSemaphoreCollector) for c in p._profiler._collectors)
+        assert not any(isinstance(c, asyncio.AsyncioBoundedSemaphoreCollector) for c in p._profiler._collectors)
+        assert not any(isinstance(c, asyncio.AsyncioConditionCollector) for c in p._profiler._collectors)
     p.stop(flush=False)
 
 
@@ -206,6 +209,21 @@ def test_stop_unregisters_all_import_hooks_for_lock_and_pytorch_collectors(monke
             return None
 
     monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    monkeypatch.setattr(
+        profiler.profiling_config.lock,
+        "primitives",
+        {
+            "threading.Lock",
+            "threading.RLock",
+            "threading.Semaphore",
+            "threading.BoundedSemaphore",
+            "threading.Condition",
+            "asyncio.Lock",
+            "asyncio.Semaphore",
+            "asyncio.BoundedSemaphore",
+            "asyncio.Condition",
+        },
+    )
 
     p = TestProfiler(
         _memory_collector_enabled=False,
@@ -614,3 +632,26 @@ def test_profiler_singleton_after_fork():
         _, status = os.waitpid(pid, 0)
         assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0, f"Child exited with status {status}"
         p.stop(flush=False)
+
+
+def test_lock_primitive_collectors_complete() -> None:
+    """Every LockCollector subclass in the collector modules must be registered in
+    _LOCK_PRIMITIVE_COLLECTORS, and vice versa.  This catches adding a new collector
+    class without wiring it up, or registering a name that has no implementation.
+    """
+    implemented: set[str] = set()
+    for module in (asyncio, threading):
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if (
+                issubclass(cls, _lock.LockCollector)
+                and cls is not _lock.LockCollector
+                and hasattr(cls, "MODULE")
+                and hasattr(cls, "PATCHED_LOCK_NAME")
+            ):
+                implemented.add(f"{cls.MODULE.__name__}.{cls.PATCHED_LOCK_NAME}")
+
+    registered: frozenset[str] = frozenset(_LOCK_PRIMITIVE_COLLECTORS)
+    assert implemented == registered, (
+        f"Implemented but not registered: {implemented - registered}\n"
+        f"Registered but not implemented: {registered - implemented}"
+    )

--- a/tests/profiling/test_profiling_config.py
+++ b/tests/profiling/test_profiling_config.py
@@ -61,7 +61,7 @@ class TestExcludeModulesConfig:
         cfg = ProfilingConfigLock()
         assert isinstance(cfg.exclude_modules, frozenset)
 
-    def test_parsed_value_is_frozenset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_parsed_value_is_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A non-empty env var must produce a frozenset[str], not a raw string."""
         monkeypatch.setenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", "uvicorn,asyncio,sqlalchemy.pool")
         from ddtrace.internal.settings.profiling import ProfilingConfigLock
@@ -77,3 +77,24 @@ class TestExcludeModulesConfig:
 
         cfg = ProfilingConfigLock()
         assert cfg.exclude_modules == frozenset({"uvicorn", "asyncio"})
+
+
+class TestLockConfig:
+    def test_primitives_defaults(self) -> None:
+        config = ProfilingConfig()
+        assert config.lock.primitives == frozenset({"threading.Lock", "threading.RLock", "asyncio.Lock"})
+
+    def test_primitives_custom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "DD_PROFILING_LOCK_PRIMITIVES",
+            "threading.Lock,threading.Semaphore,asyncio.BoundedSemaphore",
+        )
+        config = ProfilingConfig()
+        assert config.lock.primitives == frozenset(
+            {"threading.Lock", "threading.Semaphore", "asyncio.BoundedSemaphore"}
+        )
+
+    def test_primitives_whitespace_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DD_PROFILING_LOCK_PRIMITIVES", " threading.Lock , threading.RLock ")
+        config = ProfilingConfig()
+        assert config.lock.primitives == frozenset({"threading.Lock", "threading.RLock"})


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/17637) | [Next PR >](https://github.com/DataDog/dd-trace-py/pull/17639)

[SCP-1121](https://datadoghq.atlassian.net/browse/SCP-1121)

## Summary

- Replaces the boolean `DD_PROFILING_LOCK_EXTENDED_PRIMITIVES_ENABLED` with a comma-separated string `DD_PROFILING_LOCK_PRIMITIVES`
- Default: `threading.Lock,threading.RLock,asyncio.Lock` — same three that were profiled in ddtrace ≤3.16.2
- Users can opt individual types back in (e.g. `DD_PROFILING_LOCK_PRIMITIVES=threading.Lock,threading.RLock,asyncio.Lock,asyncio.Semaphore`) rather than toggling all-or-nothing
- Available primitives: `threading.{Lock,RLock,Semaphore,BoundedSemaphore,Condition}`, `asyncio.{Lock,Semaphore,BoundedSemaphore,Condition}`

## Motivation

`asyncio.Semaphore`/`Condition` are infrastructure primitives in async web apps — every request touches them (uvicorn connection limits, `asyncio.Queue`, httpx/DB pools). Profiling them by default adds wrapper overhead on every allocation and every acquire. A fine-grained string config lets users add only the types they actually want to observe.

## Test plan

* new unit tests
* CI

[SCP-1121]: https://datadoghq.atlassian.net/browse/SCP-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ