### PR TITLE
perf(profiling): [2/n] remove one function call per each acquire/release entry point

### DIFF
--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -175,26 +175,37 @@ class _ProfiledLock:
         return bool(self.__wrapped__.locked())
 
     def acquire(self, *args: Any, **kwargs: Any) -> Any:
-        return self._acquire(self.__wrapped__.acquire, *args, **kwargs)
-
-    def __enter__(self, *args: Any, **kwargs: Any) -> Any:
-        return self._acquire(self.__wrapped__.__enter__, *args, **kwargs)
-
-    def __aenter__(self, *args: Any, **kwargs: Any) -> Any:
-        return self._acquire(self.__wrapped__.__aenter__, *args, **kwargs)
-
-    def _acquire(self, inner_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
         if not sampler.capture():
             if config.enable_asserts:
-                # Ensure acquired_time is not set when acquire is not sampled
-                # (else a bogus release sample is produced)
                 assert self.acquired_time is None, (
                     "Expected acquired_time to be None when acquire is not sampled, got %r" % (self.acquired_time,)
                 )  # nosec
+            return self.__wrapped__.acquire(*args, **kwargs)
+        return self._acquire(self.__wrapped__.acquire, *args, **kwargs)
 
-            return inner_func(*args, **kwargs)
+    def __enter__(self, *args: Any, **kwargs: Any) -> Any:
+        cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
+        if not sampler.capture():
+            if config.enable_asserts:
+                assert self.acquired_time is None, (
+                    "Expected acquired_time to be None when acquire is not sampled, got %r" % (self.acquired_time,)
+                )  # nosec
+            return self.__wrapped__.__enter__(*args, **kwargs)
+        return self._acquire(self.__wrapped__.__enter__, *args, **kwargs)
 
+    def __aenter__(self, *args: Any, **kwargs: Any) -> Any:
+        cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
+        if not sampler.capture():
+            if config.enable_asserts:
+                assert self.acquired_time is None, (
+                    "Expected acquired_time to be None when acquire is not sampled, got %r" % (self.acquired_time,)
+                )  # nosec
+            return self.__wrapped__.__aenter__(*args, **kwargs)
+        return self._acquire(self.__wrapped__.__aenter__, *args, **kwargs)
+
+    def _acquire(self, inner_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        # Called only when capture_sampler.capture() already returned True — no re-check needed.
         cdef long long start = time.monotonic_ns()
         result: Any = None
         error_info: Optional[tuple[BaseException, Optional[TracebackType]]] = None
@@ -227,16 +238,24 @@ class _ProfiledLock:
         return result
 
     def release(self, *args: Any, **kwargs: Any) -> Any:
+        if self.acquired_time is None:
+            return self.__wrapped__.release(*args, **kwargs)
         return self._release(self.__wrapped__.release, *args, **kwargs)
 
     def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        if self.acquired_time is None:
+            self.__wrapped__.__exit__(*args, **kwargs)
+            return
         self._release(self.__wrapped__.__exit__, *args, **kwargs)
 
     def __aexit__(self, *args: Any, **kwargs: Any) -> Any:
+        if self.acquired_time is None:
+            return self.__wrapped__.__aexit__(*args, **kwargs)
         return self._release(self.__wrapped__.__aexit__, *args, **kwargs)
 
     def _release(self, inner_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        start: Optional[int] = getattr(self, "acquired_time", None)
+        # All callers *must* check that `self.acquired_time` is not None (i.e. the event was sampled)
+        start: int = self.acquired_time  # type: ignore[assignment]
         self.acquired_time = None
 
         # Note: this can raise an exception. We don't catch it because we
@@ -246,9 +265,6 @@ class _ProfiledLock:
         # What comes next in the function is only code for sampling the lock
         # release, so it is irrelevant if it fails.
         result = inner_func(*args, **kwargs)
-
-        if start is None:
-            return result
 
         if self.is_internal:
             return result

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -174,6 +174,11 @@ class _ProfiledLock:
         """Return True if lock is currently held."""
         return bool(self.__wrapped__.locked())
 
+    # The sampler.capture() check is intentionally duplicated across acquire, __enter__, and
+    # __aenter__ rather than extracted into a shared helper. This eliminates one function-call
+    # frame on the unsampled hot path, which fires on every lock operation. A helper would
+    # reintroduce that overhead. Do NOT refactor. See:
+    # test_unsampled_acquire_bypasses_inner_acquire / test_sampled_acquire_calls_inner_acquire.
     def acquire(self, *args: Any, **kwargs: Any) -> Any:
         cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
         if not sampler.capture():

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -217,7 +217,7 @@ class _ProfiledLock:
         return self._acquire(self.__wrapped__.__aenter__, *args, **kwargs)
 
     def _acquire(self, inner_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        # Called only when capture_sampler.capture() already returned True — no re-check needed.
+        # Called only when capture_sampler.capture already returned True — no re-check needed.
         cdef long long start = time.monotonic_ns()
         result: Any = None
         error_info: Optional[tuple[BaseException, Optional[TracebackType]]] = None

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -182,9 +182,14 @@ class _ProfiledLock:
     def acquire(self, *args: Any, **kwargs: Any) -> Any:
         cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
         if not sampler.capture():
-            if config.enable_asserts:
+            if config.enable_asserts and type(self.__wrapped__).__name__ == "RLock":
+                # For RLock, a re-entrant acquire can arrive here while a previous sampled acquire
+                # is still in progress (acquired_time set). If so, the next release will emit a
+                # sample whose hold time is truncated at this release rather than the true outer
+                # release — the outer hold time is silently lost, skewing the "lock held" time metrics.
                 assert self.acquired_time is None, (
-                    "Expected acquired_time to be None when acquire is not sampled, got %r" % (self.acquired_time,)
+                    "Unsampled re-entrant acquire while a sampled hold is in progress; "
+                    "the next release will emit a truncated hold-time sample. acquired_time=%r" % (self.acquired_time,)
                 )  # nosec
             return self.__wrapped__.acquire(*args, **kwargs)
         return self._acquire(self.__wrapped__.acquire, *args, **kwargs)
@@ -192,9 +197,10 @@ class _ProfiledLock:
     def __enter__(self, *args: Any, **kwargs: Any) -> Any:
         cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
         if not sampler.capture():
-            if config.enable_asserts:
+            if config.enable_asserts and type(self.__wrapped__).__name__ == "RLock":
                 assert self.acquired_time is None, (
-                    "Expected acquired_time to be None when acquire is not sampled, got %r" % (self.acquired_time,)
+                    "Unsampled re-entrant acquire while a sampled hold is in progress; "
+                    "the next release will emit a truncated hold-time sample. acquired_time=%r" % (self.acquired_time,)
                 )  # nosec
             return self.__wrapped__.__enter__(*args, **kwargs)
         return self._acquire(self.__wrapped__.__enter__, *args, **kwargs)
@@ -202,9 +208,10 @@ class _ProfiledLock:
     def __aenter__(self, *args: Any, **kwargs: Any) -> Any:
         cdef CaptureSampler sampler = <CaptureSampler>self.capture_sampler
         if not sampler.capture():
-            if config.enable_asserts:
+            if config.enable_asserts and type(self.__wrapped__).__name__ == "RLock":
                 assert self.acquired_time is None, (
-                    "Expected acquired_time to be None when acquire is not sampled, got %r" % (self.acquired_time,)
+                    "Unsampled re-entrant acquire while a sampled hold is in progress; "
+                    "the next release will emit a truncated hold-time sample. acquired_time=%r" % (self.acquired_time,)
                 )  # nosec
             return self.__wrapped__.__aenter__(*args, **kwargs)
         return self._acquire(self.__wrapped__.__aenter__, *args, **kwargs)
@@ -259,8 +266,11 @@ class _ProfiledLock:
         return self._release(self.__wrapped__.__aexit__, *args, **kwargs)
 
     def _release(self, inner_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        # All callers *must* check that `self.acquired_time` is not None (i.e. the event was sampled)
-        start: int = self.acquired_time  # type: ignore[assignment]
+        # `acquired_time` is guaranteed non-None by all callers, but we check it here anyway to be defensive.
+        if self.acquired_time is None:
+            return inner_func(*args, **kwargs)
+
+        cdef long long start = self.acquired_time
         self.acquired_time = None
 
         # Note: this can raise an exception. We don't catch it because we

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -586,17 +586,17 @@ def test_reentrant_unsampled_acquire_asserts_for_rlock() -> None:
     from ddtrace.profiling.collector._lock import _ProfiledLock
 
     class RLock:  # class name must be exactly "RLock" to trigger the type check
-        def acquire(self, *args, **kwargs):
+        def acquire(self, *args: object, **kwargs: object) -> bool:
             return True
 
-        def __enter__(self, *args, **kwargs):
+        def __enter__(self, *args: object, **kwargs: object) -> bool:
             return True
 
-        def __exit__(self, *args, **kwargs):
+        def __exit__(self, *args: object, **kwargs: object) -> None:
             pass
 
-    sampler = collector.CaptureSampler(capture_pct=0)  # always unsampled
-    profiled = _ProfiledLock(wrapped=RLock(), tracer=None, capture_sampler=sampler)
+    sampler: collector.CaptureSampler = collector.CaptureSampler(capture_pct=0)  # always unsampled
+    profiled: _ProfiledLock = _ProfiledLock(wrapped=RLock(), tracer=None, capture_sampler=sampler)
     profiled.acquired_time = time.monotonic_ns()  # simulate a prior sampled hold in progress
 
     with pytest.raises(AssertionError, match="truncated hold-time sample"):
@@ -615,17 +615,17 @@ def test_reentrant_unsampled_acquire_no_assert_for_non_rlock() -> None:
     from ddtrace.profiling.collector._lock import _ProfiledLock
 
     class Lock:  # any name other than "RLock" — type check must be False
-        def acquire(self, *args, **kwargs):
+        def acquire(self, *args: object, **kwargs: object) -> bool:
             return True
 
-        def __enter__(self, *args, **kwargs):
+        def __enter__(self, *args: object, **kwargs: object) -> bool:
             return True
 
-        def __exit__(self, *args, **kwargs):
+        def __exit__(self, *args: object, **kwargs: object) -> None:
             pass
 
-    sampler = collector.CaptureSampler(capture_pct=0)  # always unsampled
-    profiled = _ProfiledLock(wrapped=Lock(), tracer=None, capture_sampler=sampler)
+    sampler: collector.CaptureSampler = collector.CaptureSampler(capture_pct=0)  # always unsampled
+    profiled: _ProfiledLock = _ProfiledLock(wrapped=Lock(), tracer=None, capture_sampler=sampler)
     profiled.acquired_time = time.monotonic_ns()  # simulate a prior sampled hold in progress
 
     # Must NOT raise — the assertion is RLock-specific
@@ -2176,9 +2176,9 @@ class BaseSemaphoreTest(LockCollectorTestBase):
         If someone refactors acquire/__enter__/__aenter__ back into a shared helper that calls
         _acquire unconditionally, this test will catch it.
         """
-        real_lock = self.lock_class()
-        capture_sampler = CaptureSampler(capture_pct=0)
-        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=0)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
 
         with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
             for _ in range(5):
@@ -2197,9 +2197,9 @@ class BaseSemaphoreTest(LockCollectorTestBase):
         Counterpart to test_unsampled_acquire_bypasses_inner_acquire — ensures we don't accidentally
         drop the _acquire delegation on the sampled path either.
         """
-        real_lock = self.lock_class()
-        capture_sampler = CaptureSampler(capture_pct=100)
-        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=100)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
 
         with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
             for _ in range(3):
@@ -2220,9 +2220,9 @@ class BaseSemaphoreTest(LockCollectorTestBase):
         If someone refactors release/__exit__/__aexit__ back into a shared helper that calls
         _release unconditionally, this test will catch it.
         """
-        real_lock = self.lock_class()
-        capture_sampler = CaptureSampler(capture_pct=0)
-        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=0)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
 
         # Acquire (unsampled — acquired_time stays None)
         profiled_lock.acquire()
@@ -2239,9 +2239,9 @@ class BaseSemaphoreTest(LockCollectorTestBase):
 
     def test_sampled_release_calls_inner_release(self) -> None:
         """Regression: on the sampled path, each release entry point must delegate to _release exactly once."""
-        real_lock = self.lock_class()
-        capture_sampler = CaptureSampler(capture_pct=100)
-        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=100)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
 
         profiled_lock.acquire()
         assert profiled_lock.acquired_time is not None, "precondition: acquired_time must be set after sampled acquire"

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -572,6 +572,66 @@ def test_internal_lock_skips_asserts() -> None:
             raise error[0]
 
 
+@pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLE_ASSERTS="true"))
+def test_reentrant_unsampled_acquire_asserts_for_rlock() -> None:
+    """Unsampled re-entrant acquire on an RLock while a sampled hold is in progress must raise
+    AssertionError — the next release would emit a hold-time sample truncated at this inner
+    release rather than the true outer release.
+    """
+    import time
+
+    import pytest
+
+    from ddtrace.profiling import collector
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+
+    class RLock:  # class name must be exactly "RLock" to trigger the type check
+        def acquire(self, *args, **kwargs):
+            return True
+
+        def __enter__(self, *args, **kwargs):
+            return True
+
+        def __exit__(self, *args, **kwargs):
+            pass
+
+    sampler = collector.CaptureSampler(capture_pct=0)  # always unsampled
+    profiled = _ProfiledLock(wrapped=RLock(), tracer=None, capture_sampler=sampler)
+    profiled.acquired_time = time.monotonic_ns()  # simulate a prior sampled hold in progress
+
+    with pytest.raises(AssertionError, match="truncated hold-time sample"):
+        profiled.acquire()
+
+
+@pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLE_ASSERTS="true"))
+def test_reentrant_unsampled_acquire_no_assert_for_non_rlock() -> None:
+    """The truncated-hold-time assertion is RLock-only. Non-reentrant locks (Lock, Semaphore, …)
+    would deadlock before reaching this path in real usage, so the check is intentionally skipped
+    for them.
+    """
+    import time
+
+    from ddtrace.profiling import collector
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+
+    class Lock:  # any name other than "RLock" — type check must be False
+        def acquire(self, *args, **kwargs):
+            return True
+
+        def __enter__(self, *args, **kwargs):
+            return True
+
+        def __exit__(self, *args, **kwargs):
+            pass
+
+    sampler = collector.CaptureSampler(capture_pct=0)  # always unsampled
+    profiled = _ProfiledLock(wrapped=Lock(), tracer=None, capture_sampler=sampler)
+    profiled.acquired_time = time.monotonic_ns()  # simulate a prior sampled hold in progress
+
+    # Must NOT raise — the assertion is RLock-specific
+    profiled.acquire()
+
+
 @pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLE_ASSERTS="false"))
 def test_profiled_lock_ctor_handles_shallow_stack() -> None:
     """Test that _ProfiledLock.__init__ handles shallow stacks gracefully.

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -1436,9 +1436,13 @@ class TestGenericLockProfiling(LockCollectorTestBase):
         # Capture reference before context manager
         foo_class = Foo
 
-        with self.collector_class(capture_pct=100):
-            foo: Foo = Foo(self.lock_class)
-            foo.foo()
+        with mock.patch(
+            "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
+            True,
+        ):
+            with self.collector_class(capture_pct=100):
+                foo: Foo = Foo(self.lock_class)
+                foo.foo()
 
         ddup.upload()  # pyright: ignore[reportCallIssue]
 
@@ -1550,33 +1554,37 @@ class TestGenericLockProfiling(LockCollectorTestBase):
         foo_func: Optional[Callable[[], None]] = None
         test_bar_class: Optional[type] = None
 
-        with self.collector_class(capture_pct=100):
-            # Create true module-level globals
-            _test_global_lock = self.lock_class()  # !CREATE! _test_global_lock
+        with mock.patch(
+            "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
+            True,
+        ):
+            with self.collector_class(capture_pct=100):
+                # Create true module-level globals
+                _test_global_lock = self.lock_class()  # !CREATE! _test_global_lock
 
-            class TestBar:
-                def __init__(self, lock_class: LockTypeClass) -> None:
-                    self.bar_lock: LockTypeInst = lock_class()  # !CREATE! bar_lock
+                class TestBar:
+                    def __init__(self, lock_class: LockTypeClass) -> None:
+                        self.bar_lock: LockTypeInst = lock_class()  # !CREATE! bar_lock
 
-                def bar(self) -> None:
-                    with self.bar_lock:  # !ACQUIRE! !RELEASE! bar_lock
+                    def bar(self) -> None:
+                        with self.bar_lock:  # !ACQUIRE! !RELEASE! bar_lock
+                            pass
+
+                def foo() -> None:
+                    global _test_global_lock
+                    assert _test_global_lock is not None
+                    with _test_global_lock:  # !ACQUIRE! !RELEASE! _test_global_lock
                         pass
 
-            def foo() -> None:
-                global _test_global_lock
-                assert _test_global_lock is not None
-                with _test_global_lock:  # !ACQUIRE! !RELEASE! _test_global_lock
-                    pass
+                # Capture references before context manager exits
+                foo_func = foo
+                test_bar_class = TestBar
 
-            # Capture references before context manager exits
-            foo_func = foo
-            test_bar_class = TestBar
+                _test_global_bar_instance = TestBar(self.lock_class)  # type: ignore[assignment]
 
-            _test_global_bar_instance = TestBar(self.lock_class)  # type: ignore[assignment]
-
-            # Use the locks
-            foo()
-            _test_global_bar_instance.bar()  # type: ignore[attr-defined]
+                # Use the locks
+                foo()
+                _test_global_bar_instance.bar()  # type: ignore[attr-defined]
 
         ddup.upload()  # pyright: ignore[reportCallIssue]
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -20,6 +20,7 @@ from ddtrace import ext
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.profiling.collector import CaptureSampler
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
@@ -2058,6 +2059,139 @@ class BaseSemaphoreTest(LockCollectorTestBase):
             assert not hasattr(internal_lock, "_ProfiledLock__wrapped"), (
                 "Internal lock from threading stdlib should be a native lock, not a _ProfiledLock"
             )
+
+    def test_internal_module_file_realpath_called_once_at_patch_time(self) -> None:
+        """Verify that os.path.realpath for the internal module file is computed once at patch time,
+        not on every lock allocation.
+
+        Regression test for a bug where the constant internal module path was being resolved via
+        os.path.realpath on every single lock instantiation, causing unnecessary filesystem syscalls
+        in hot paths (e.g. asyncio Semaphore/Condition allocations per request).
+        """
+        realpath_call_counts: dict[str, int] = {"patch_time": 0, "alloc_time": 0}
+        in_patch: list[bool] = [False]
+        original_realpath = os.path.realpath
+
+        def counting_realpath(path: str, **kwargs: object) -> str:
+            if in_patch[0]:
+                realpath_call_counts["patch_time"] += 1
+            else:
+                realpath_call_counts["alloc_time"] += 1
+            return original_realpath(path, **kwargs)  # type: ignore[call-overload]
+
+        with mock.patch("os.path.realpath", side_effect=counting_realpath):
+            in_patch[0] = True
+            collector = self.collector_class(capture_pct=100)
+            collector._start_service()
+            in_patch[0] = False
+
+            try:
+                # Allocate several locks — realpath for the internal module file must NOT be called again
+                for _ in range(5):
+                    lock: LockTypeInst = self.lock_class()
+                    lock.acquire()
+                    lock.release()
+            finally:
+                collector._stop_service()
+
+        # realpath should have been called at least once at patch time (to resolve the internal module file)
+        assert realpath_call_counts["patch_time"] >= 1, (
+            "Expected os.path.realpath to be called at patch() time to precompute the internal module path"
+        )
+        # realpath may still be called at alloc time for the *caller* filename, but NOT for the constant
+        # internal module file. The alloc-time count should be exactly N allocations (one caller realpath each),
+        # not 2*N (which would indicate the internal file is still being resolved per allocation).
+        assert realpath_call_counts["alloc_time"] <= 5, (
+            f"os.path.realpath called {realpath_call_counts['alloc_time']} times during 5 allocations — "
+            "expected at most 5 (one per caller filename). The internal module file path may be recomputed per-call."
+        )
+
+    def test_unsampled_acquire_bypasses_inner_acquire(self) -> None:
+        """Regression: on the unsampled path, acquire/enter entry points must NOT call _acquire.
+
+        The inline-dispatch optimization eliminates one function call per lock operation on the
+        hot (unsampled) path by checking capture_sampler.capture() directly in each entry point
+        and falling through to the wrapped lock without going through _acquire.
+
+        If someone refactors acquire/__enter__/__aenter__ back into a shared helper that calls
+        _acquire unconditionally, this test will catch it.
+        """
+        real_lock = self.lock_class()
+        capture_sampler = CaptureSampler(capture_pct=0)
+        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
+            for _ in range(5):
+                profiled_lock.acquire()
+                profiled_lock.release()
+
+        assert spy.call_count == 0, (
+            f"_acquire was called {spy.call_count} times on the unsampled path (capture_pct=0). "
+            "The inline-dispatch optimization requires that unsampled acquires bypass _acquire entirely. "
+            "Do NOT refactor acquire/__enter__/__aenter__ to call _acquire unconditionally."
+        )
+
+    def test_sampled_acquire_calls_inner_acquire(self) -> None:
+        """Regression: on the sampled path, each entry point must delegate to _acquire exactly once.
+
+        Counterpart to test_unsampled_acquire_bypasses_inner_acquire — ensures we don't accidentally
+        drop the _acquire delegation on the sampled path either.
+        """
+        real_lock = self.lock_class()
+        capture_sampler = CaptureSampler(capture_pct=100)
+        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
+            for _ in range(3):
+                profiled_lock.acquire()
+                profiled_lock.release()
+
+        assert spy.call_count == 3, (
+            f"_acquire was called {spy.call_count} times instead of 3 on the sampled path (capture_pct=100)."
+        )
+
+    def test_unsampled_release_bypasses_inner_release(self) -> None:
+        """Regression: when acquired_time is None (unsampled acquire), release entry points must NOT call _release.
+
+        On the unsampled path, acquired_time is left as None. The inline-dispatch optimization
+        checks this directly in each release entry point and falls through to the wrapped lock
+        without going through _release.
+
+        If someone refactors release/__exit__/__aexit__ back into a shared helper that calls
+        _release unconditionally, this test will catch it.
+        """
+        real_lock = self.lock_class()
+        capture_sampler = CaptureSampler(capture_pct=0)
+        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        # Acquire (unsampled — acquired_time stays None)
+        profiled_lock.acquire()
+        assert profiled_lock.acquired_time is None, "precondition: acquired_time must be None after unsampled acquire"
+
+        with mock.patch.object(type(profiled_lock), "_release", wraps=profiled_lock._release) as spy:
+            profiled_lock.release()
+
+        assert spy.call_count == 0, (
+            f"_release was called {spy.call_count} times when acquired_time was None (unsampled path). "
+            "The inline-dispatch optimization requires that unsampled releases bypass _release entirely. "
+            "Do NOT refactor release/__exit__/__aexit__ to call _release unconditionally."
+        )
+
+    def test_sampled_release_calls_inner_release(self) -> None:
+        """Regression: on the sampled path, each release entry point must delegate to _release exactly once."""
+        real_lock = self.lock_class()
+        capture_sampler = CaptureSampler(capture_pct=100)
+        profiled_lock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        profiled_lock.acquire()
+        assert profiled_lock.acquired_time is not None, "precondition: acquired_time must be set after sampled acquire"
+
+        with mock.patch.object(type(profiled_lock), "_release", wraps=profiled_lock._release) as spy:
+            profiled_lock.release()
+
+        assert spy.call_count == 1, (
+            f"_release was called {spy.call_count} times instead of 1 on the sampled path (capture_pct=100)."
+        )
 
     def test_acquire_return_values_preserved(self) -> None:
         """Test that profiling wrapper preserves acquire() return values (transparency test).


### PR DESCRIPTION
[PROF-14295](https://datadoghq.atlassian.net/browse/PROF-14295)
[SCP-1121](https://datadoghq.atlassian.net/browse/SCP-1121)

## Summary

- Inlines `CaptureSampler.capture()` directly into `acquire`, `__enter__`, `__aenter__` — on the 99% non-sampled path these methods now return after a single C-level call with no Python frame allocation
- Inlines `acquired_time is None` guard directly into `release`, `__exit__`, `__aexit__` — skips `_release` entirely when the acquire was not sampled
- `_acquire` and `_release` become the slow path only (called after sampling decision is already made)

## Motivation

Before this change, every lock operation on the non-sampled path paid:
`_ProfiledLock.__aenter__` → `_acquire(inner_func, ...)` → `CaptureSampler.capture()` → `inner_func()`

The extra Python method dispatch + `*args` repacking fired on 99% of all lock operations. With async Semaphore/Condition primitives hit on every request in a FastAPI/uvicorn app, this compounds into measurable overhead.

## Validation

Micro-benchmark lives on a reference branch (not part of this PR):
[`vlad/lockprof-inline-dispatch-benchmark`](https://github.com/DataDog/dd-trace-py/tree/vlad/lockprof-inline-dispatch-benchmark/scripts/profiles/lockprof_inline_dispatch).

Runs three `Lock` shapes, all wrapping `threading.Lock()` with
`CaptureSampler(capture_pct=0.0)` so every call stays on the unsampled
path:

| Shape      | What it represents                              |
| ---------- | ----------------------------------------------- |
| `INLINE`   | This PR — sampler check inlined into `acquire`  |
| `DISPATCH` | Pre-PR shape — `acquire` → `def _acquire(...)`  |
| `CDEF`     | Hypothetical — `cdef class` + `cdef inline` helper |

Results (Python 3.12.11, macOS arm64, min of 9 × 500,000 ops):

```
acquire()+release() pair:
  NATIVE    :    38.3 ns/op
  INLINE    :   171.7 ns/op    +133.3 ns/pair vs native
  DISPATCH  :   318.5 ns/op    +280.2 ns/pair vs native
  CDEF      :   167.1 ns/op    +128.8 ns/pair vs native

DISPATCH − INLINE (acquire+release pair):  +146.9 ns/pair
DISPATCH − INLINE (acquire only):           +67.6 ns/op
DISPATCH − INLINE (release only):           +78.5 ns/op
```

Takeaways:
1) `acquire/release` pair on the **un-sampled** hot path drops from **318.5 ns → 171.7 ns**, i.e. **~46% reduction**
2) Compiler inlining would help _somewhat_, but it cannot happen because `_ProfiledLock` has to stay a pure-Python class and thus cannot be Cythonized; e.g. due to its lack of dynamic Python attributes like `acquired_time`, `__wrapped__`, `init_location`, etc., which are core to the wrapper.

## Test plan

* CI
* Regression tests in [`tests/profiling/collector/test_threading.py`](https://github.com/DataDog/dd-trace-py/pull/17639/files#diff-a5f6e1e2e3f7c9a8f1f23e1f1c4a2c6a0e3f1e6e0c3e4a2f1e3c1e5a6b4d3e2f) (`test_unsampled_acquire_bypasses_inner_acquire`, `test_sampled_acquire_calls_inner_acquire`) lock in the inlined fast path so a future refactor that collapses the duplication will fail CI.

[PROF-14295]: https://datadoghq.atlassian.net/browse/PROF-14295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCP-1121]: https://datadoghq.atlassian.net/browse/SCP-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
