### PR TITLE
fix(internal): crash in ContextVar [backport 4.5]

### DIFF
--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -294,14 +294,18 @@ class BaseWrappingContext(ABC):
 
     def __init__(self, f: FunctionType):
         self.__wrapped__ = f
-        self._storage_stack: ContextVar[list[dict]] = ContextVar(f"{type(self).__name__}__storage_stack", default=[])
+        self._storage: ContextVar[t.Optional[dict]] = ContextVar(f"{type(self).__name__}__storage", default=None)
 
     def __enter__(self) -> "BaseWrappingContext":
-        self._storage_stack.get().append({})
+        prev = self._storage.get()
+        self._storage.set({"__dd_wrapping_context_prev__": prev})
+
         return self
 
     def _pop_storage(self) -> dict[str, t.Any]:
-        return self._storage_stack.get().pop()
+        storage = t.cast(dict, self._storage.get())
+        self._storage.set(storage.pop("__dd_wrapping_context_prev__"))
+        return storage
 
     def __return__(self, value: T) -> T:
         self._pop_storage()
@@ -316,10 +320,10 @@ class BaseWrappingContext(ABC):
         self._pop_storage()
 
     def get(self, key: str) -> t.Any:
-        return self._storage_stack.get()[-1][key]
+        return t.cast(dict, self._storage.get())[key]
 
     def set(self, key: str, value: T) -> T:
-        self._storage_stack.get()[-1][key] = value
+        t.cast(dict, self._storage.get())[key] = value
         return value
 
     @classmethod

--- a/releasenotes/notes/internal-contextvar-crash-fix-53e7b7d0797ba090.yaml
+++ b/releasenotes/notes/internal-contextvar-crash-fix-53e7b7d0797ba090.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    internal: A crash has been fixed.


### PR DESCRIPTION
This is a backport for 4.5.