### PR TITLE
ci(hooks): change order of pre-commit hooks for better error coverage

### DIFF
--- a/hooks/autohook.sh
+++ b/hooks/autohook.sh
@@ -79,23 +79,30 @@ main() {
         if [[ $number_of_symlinks -gt 0 ]]
         then
             hook_exit_code=0
+            failed_scripts=()
             for file in "${files[@]}"
             do
                 scriptname=$(basename $file)
                 echo "BEGIN $scriptname"
-                eval "\"$file\""
+                "$file" "$@"
                 script_exit_code="$?"
                 if [[ "$script_exit_code" != 0 ]]
                 then
-                  hook_exit_code=$script_exit_code
+                    hook_exit_code=$script_exit_code
+                    failed_scripts+=("$scriptname (exit $script_exit_code)")
+                    echo "FAILED $scriptname — exited with code $script_exit_code"
                 fi
                 echo "FINISH $scriptname"
             done
             if [[ $hook_exit_code != 0 ]]
             then
-              if [[ $hook_type == "pre-commit" ]]
+              if [[ $hook_type == "pre-commit" || $hook_type == "commit-msg" ]]
               then
-                echo "A $hook_type script exited with non-zero code $hook_exit_code — aborting commit."
+                echo ""
+                echo "The following $hook_type hooks failed — aborting commit:"
+                for s in "${failed_scripts[@]}"; do
+                    echo "  x $s"
+                done
                 exit $hook_exit_code
               else
                 echo "A $hook_type script exited with non-zero code $hook_exit_code (non-blocking, continuing)."

--- a/hooks/scripts/run-fmt.sh
+++ b/hooks/scripts/run-fmt.sh
@@ -14,18 +14,18 @@ if [ -n "$staged_files" ]; then
         hatch -v run lint:ruff check --fix --show-fixes --no-cache $staged_ruff || exit $?
     fi
 
+    # Re-stage ruff's fixes before cython-lint so they're preserved even if cython-lint fails
+    echo "$staged_files" | tr ' ' '\n' | while read -r f; do
+        [ -n "$f" ] || continue
+        echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
+    done
+
     # cython-lint runs on .pyx files only; ruff covers .py/.pyi, and cython-lint's
     # pycodestyle checks would be redundant on .py files
     staged_cython_lint=$(echo "$staged_files" | tr ' ' '\n' | grep '\.pyx$' | grep -v '^$' | tr '\n' ' ')
     if [ -n "$(printf '%s' "$staged_cython_lint" | tr -d ' \t\n')" ]; then
         hatch -v run lint:cython-lint $staged_cython_lint || exit $?
     fi
-
-    # Re-stage only files that had no unstaged changes before ruff (preserves partial staging)
-    echo "$staged_files" | tr ' ' '\n' | while read -r f; do
-        [ -n "$f" ] || continue
-        echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
-    done
 else
     echo 'Format/lint skipped: No Python/stub files were found in `git diff --staged`'
 fi


### PR DESCRIPTION
[PROF-13935](https://datadoghq.atlassian.net/browse/PROF-13935)

## Description

This PR mainly improves error resolution for edge cases. It also improves messaging for *which* of the hooks failed instead of just saying "we failed".

**hooks/autohook.sh**
* Replaces eval "$file" with "$file" "$@" — safer invocation that also forwards hook arguments (needed for commit-msg which receives the message file path)
* Tracks all failed scripts in a failed_scripts array and prints a per-script `FAILED <name>` immediately
* Prints a summary list of which hooks failed (instead of just the exit code)
* Does the same messaging for commit-msg hooks in addition

**hooks/scripts/run-fmt.sh**
* Moves the git add re-staging step to before cython-lint instead of after, so that ruff's auto-fixes are staged in case cython-lint fails

## Testing

tested locally

[PROF-13935]: https://datadoghq.atlassian.net/browse/PROF-13935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ