### PR TITLE
fix(llmobs): resolve circular import of ConfigType in _writer

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -3,9 +3,9 @@ import csv
 import json
 import os
 import tempfile
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import TypedDict
 from typing import Union
 from typing import cast
@@ -46,8 +46,8 @@ from ddtrace.llmobs._experiment import RemoteEvaluatorError
 from ddtrace.llmobs._experiment import _TagOperations
 from ddtrace.llmobs._http import get_connection
 from ddtrace.llmobs._utils import safe_json
-from ddtrace.llmobs.types import _Meta
 from ddtrace.llmobs.types import ExperimentConfigType
+from ddtrace.llmobs.types import _Meta
 from ddtrace.version import __version__
 
 

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -3,9 +3,9 @@ import csv
 import json
 import os
 import tempfile
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import TypedDict
 from typing import Union
 from typing import cast
@@ -47,12 +47,13 @@ from ddtrace.llmobs._experiment import _TagOperations
 from ddtrace.llmobs._http import get_connection
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import _Meta
-from ddtrace.llmobs.types import _SpanLink
+from ddtrace.llmobs.types import ExperimentConfigType
 from ddtrace.version import __version__
 
 
 if TYPE_CHECKING:
-    from ddtrace.llmobs._experiment import ConfigType
+    from ddtrace.llmobs.types import ExperimentConfigType
+    from ddtrace.llmobs.types import _SpanLink
 
 
 logger = get_logger(__name__)
@@ -68,8 +69,8 @@ class LLMObsSpanData(TypedDict, total=False):
     session_id: str
     tags: dict[str, str]
     metrics: dict[str, Any]
-    span_links: list[_SpanLink]
-    config: "ConfigType"
+    span_links: list["_SpanLink"]
+    config: "ExperimentConfigType"
     is_evaluation_span: bool
     meta: _Meta
 
@@ -79,8 +80,8 @@ class _LLMObsSpanEventOptional(TypedDict, total=False):
     service: str
     status_message: str
     collection_errors: list[str]
-    span_links: list[_SpanLink]
-    config: "ConfigType"
+    span_links: list["_SpanLink"]
+    config: "ExperimentConfigType"
 
 
 class LLMObsSpanEvent(_LLMObsSpanEventOptional):

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -3,6 +3,7 @@ import csv
 import json
 import os
 import tempfile
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 from typing import TypedDict
@@ -35,7 +36,6 @@ from ddtrace.llmobs._constants import EVAL_SUBDOMAIN_NAME
 from ddtrace.llmobs._constants import EXP_SUBDOMAIN_NAME
 from ddtrace.llmobs._constants import SPAN_ENDPOINT
 from ddtrace.llmobs._constants import SPAN_SUBDOMAIN_NAME
-from ddtrace.llmobs._experiment import ConfigType
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 from ddtrace.llmobs._experiment import DatasetRecordUpdateWithId
@@ -49,6 +49,10 @@ from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import _Meta
 from ddtrace.llmobs.types import _SpanLink
 from ddtrace.version import __version__
+
+
+if TYPE_CHECKING:
+    from ddtrace.llmobs._experiment import ConfigType
 
 
 logger = get_logger(__name__)
@@ -65,7 +69,7 @@ class LLMObsSpanData(TypedDict, total=False):
     tags: dict[str, str]
     metrics: dict[str, Any]
     span_links: list[_SpanLink]
-    config: ConfigType
+    config: "ConfigType"
     is_evaluation_span: bool
     meta: _Meta
 
@@ -76,7 +80,7 @@ class _LLMObsSpanEventOptional(TypedDict, total=False):
     status_message: str
     collection_errors: list[str]
     span_links: list[_SpanLink]
-    config: ConfigType
+    config: "ConfigType"
 
 
 class LLMObsSpanEvent(_LLMObsSpanEventOptional):

--- a/releasenotes/notes/fix-llmobs-writer-configtype-circular-import-bbe5ac187303d8d8.yaml
+++ b/releasenotes/notes/fix-llmobs-writer-configtype-circular-import-bbe5ac187303d8d8.yaml
@@ -1,6 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes a circular import in ``ddtrace.llmobs._writer`` that could cause
-    ``ImportError: cannot import name 'ConfigType' from partially initialized module 'ddtrace.llmobs._experiment'``
-    when ``anthropic`` is installed alongside ``openai`` or ``botocore`` and auto-instrumentation is enabled.
+    LLM Observability: Fixes a circular import in ``ddtrace.llmobs._writer`` when ``anthropic``, ``openai``, and ``botocore`` is installed.

--- a/releasenotes/notes/fix-llmobs-writer-configtype-circular-import-bbe5ac187303d8d8.yaml
+++ b/releasenotes/notes/fix-llmobs-writer-configtype-circular-import-bbe5ac187303d8d8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes a circular import in ``ddtrace.llmobs._writer`` that could cause
+    ``ImportError: cannot import name 'ConfigType' from partially initialized module 'ddtrace.llmobs._experiment'``
+    when ``anthropic`` is installed alongside ``openai`` or ``botocore`` and auto-instrumentation is enabled.


### PR DESCRIPTION
## Description

Fixes #17557.

This PR moves  `ConfigType` import from `ddtrace.llmobs._experiment.py` in the `_writer.py` to `ExperimentConfigType`, and hides it behind a `TYPE_CHECK` flag to avoid any potential circular imports at app runtime.

## Risks

Minimal. The change only affects the form of two type annotations (object → forward-reference string). `TypedDict` accepts string annotations, and `ConfigType` is not referenced at runtime in `_writer.py`.

## Additional Notes

Claude session: `a3853e6b-9ff8-4941-8644-e0728502235d`
Resume: `claude --resume a3853e6b-9ff8-4941-8644-e0728502235d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)