### PR TITLE
chore(microbenchmarks): bump SLO

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -799,7 +799,7 @@ experiments:
               - max_rss_usage < 46.00 MB
           - name: packagesupdateimporteddependencies-import_one_unknown
             thresholds:
-              - execution_time < 0.05 ms
+              - execution_time < 0.051 ms
               - max_rss_usage < 46.00 MB
           - name: packagesupdateimporteddependencies-import_one_unknown_cache
             thresholds:


### PR DESCRIPTION
## Description

Commit fee55412c9ea8ae202c7b6a0cf5be8fde2c10127 on main broke SLOs, as you can see on this gitlab [job](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1615803272).

This PR bumps the SLO to unblock main.