### PR TITLE
chore(rc): notify product on config unassignment

### DIFF
--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -574,27 +574,28 @@ class RemoteConfigClient:
         payload_list: list[Payload],
         applied_configs: AppliedConfigType,
         client_configs: TargetsType,
-        targets: TargetsType,
     ) -> None:
-        witness = object()
         for target, config in self._applied_configs.items():
-            if client_configs.get(target, witness) == config:
-                # The configuration has not changed.
-                applied_configs[target] = config
-                continue
-            elif target not in targets:
-                callback_action = None
-            else:
-                continue
+            if target not in client_configs:
+                # The target is no longer assigned to this client — either
+                # removed from signed targets entirely, or unassigned from this
+                # client's client_configs. In both cases the product must be
+                # notified by publishing a disable payload (content=None),
+                # otherwise it would keep the removed config active
+                # indefinitely.
+                if config.product_name in self._product_callbacks:
+                    try:
+                        log.debug("[%s][P: %s] Disabling configuration: %s", os.getpid(), os.getppid(), target)
+                        self._accumulate_payload(payload_list, None, target, config)
+                    except Exception:
+                        log.debug("error while removing product %s config %r", config.product_name, config)
 
-            # Check if product is registered
-            if config.product_name in self._product_callbacks:
-                try:
-                    log.debug("[%s][P: %s] Disabling configuration: %s", os.getpid(), os.getppid(), target)
-                    self._accumulate_payload(payload_list, callback_action, target, config)
-                except Exception:
-                    log.debug("error while removing product %s config %r", config.product_name, config)
-                    continue
+            elif client_configs[target] == config:
+                # The configuration has not changed — carry it into the next
+                # snapshot.
+                applied_configs[target] = config
+            # else: the configuration has changed; _load_new_configurations
+            # will publish the updated payload and populate applied_configs.
 
     def _load_new_configurations(
         self,
@@ -726,7 +727,7 @@ class RemoteConfigClient:
         # 2. Remove previously applied configurations
         applied_configs: AppliedConfigType = dict()
         payload_list: list[Payload] = []
-        self._remove_previously_applied_configurations(payload_list, applied_configs, client_configs, targets)
+        self._remove_previously_applied_configurations(payload_list, applied_configs, client_configs)
 
         # 3. Load new configurations
         self._load_new_configurations(payload_list, applied_configs, client_configs, payload)

--- a/tests/internal/remoteconfig/test_remoteconfig_appsec_client.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_appsec_client.py
@@ -264,4 +264,80 @@ def test_remote_config_client_tags_override():
     assert tags["version"] == "bar"
 
 
-# test_apply_default_callback removed - _apply_callback method no longer exists in new architecture
+def test_remove_previously_applied_emits_disable_when_unassigned_from_client():
+    """A target previously applied, still present in signed targets but no longer in
+    client_configs, must generate a disable payload (content=None) so the product
+    callback learns it was removed.
+    """
+    with override_global_config(dict(_remote_config_enabled=True)):
+        mock_callback = MagicMock()
+        applied_config = ConfigMetadata(id="cfg", product_name="ASM_FEATURES", sha256_hash="h", length=1, tuf_version=1)
+
+        rc_client = RemoteConfigClient()
+        rc_client.register_callback("ASM_FEATURES", mock_callback)
+        rc_client._applied_configs = {"datadog/2/ASM_FEATURES/cfg/config": applied_config}
+
+        # client_configs is empty: the config is no longer assigned to this client.
+        applied_configs: dict = {}
+        payload_list: list = []
+        rc_client._remove_previously_applied_configurations(payload_list, applied_configs, client_configs={})
+
+        assert len(payload_list) == 1
+        assert payload_list[0].path == "datadog/2/ASM_FEATURES/cfg/config"
+        assert payload_list[0].content is None
+        assert payload_list[0].metadata is applied_config
+        assert applied_configs == {}
+
+
+def test_remove_previously_applied_emits_disable_when_target_deleted():
+    """A target fully removed from signed targets (not in client_configs either) must
+    still generate a disable payload.
+    """
+    with override_global_config(dict(_remote_config_enabled=True)):
+        mock_callback = MagicMock()
+        applied_config = ConfigMetadata(id="cfg", product_name="ASM_FEATURES", sha256_hash="h", length=1, tuf_version=1)
+
+        rc_client = RemoteConfigClient()
+        rc_client.register_callback("ASM_FEATURES", mock_callback)
+        rc_client._applied_configs = {"datadog/2/ASM_FEATURES/cfg/config": applied_config}
+
+        applied_configs: dict = {}
+        payload_list: list = []
+        rc_client._remove_previously_applied_configurations(payload_list, applied_configs, client_configs={})
+
+        assert len(payload_list) == 1
+        assert payload_list[0].content is None
+
+
+def test_remove_previously_applied_skips_unchanged_and_updated():
+    """Unchanged configs are carried over; updated configs are skipped (to be
+    handled by _load_new_configurations). No disable payloads in either case.
+    """
+    with override_global_config(dict(_remote_config_enabled=True)):
+        mock_callback = MagicMock()
+        unchanged = ConfigMetadata(id="a", product_name="ASM_FEATURES", sha256_hash="h1", length=1, tuf_version=1)
+        old_version = ConfigMetadata(id="b", product_name="ASM_FEATURES", sha256_hash="h2", length=1, tuf_version=1)
+        new_version = ConfigMetadata(id="b", product_name="ASM_FEATURES", sha256_hash="h2-new", length=1, tuf_version=2)
+
+        rc_client = RemoteConfigClient()
+        rc_client.register_callback("ASM_FEATURES", mock_callback)
+        rc_client._applied_configs = {
+            "datadog/2/ASM_FEATURES/a/config": unchanged,
+            "datadog/2/ASM_FEATURES/b/config": old_version,
+        }
+
+        applied_configs: dict = {}
+        payload_list: list = []
+        rc_client._remove_previously_applied_configurations(
+            payload_list,
+            applied_configs,
+            client_configs={
+                "datadog/2/ASM_FEATURES/a/config": unchanged,
+                "datadog/2/ASM_FEATURES/b/config": new_version,
+            },
+        )
+
+        # No disables should have been emitted.
+        assert payload_list == []
+        # Only the unchanged one is carried over to applied_configs.
+        assert applied_configs == {"datadog/2/ASM_FEATURES/a/config": unchanged}


### PR DESCRIPTION
## Description

Previously, when the backend removed a config from this client's client_configs while keeping it in the signed targets bundle, the RC client silently dropped the entry from _applied_configs without publishing a disable payload to the product callback. The product therefore continued applying the stale config indefinitely, even though the client's internal state (and cached_target_files advertised to the agent) reflected the removal.

The removal path gated on `target not in targets`, which only covered the case where the config was deleted from the signed bundle entirely. The common "unassigned from this client" case fell through to `continue` with no product notification.

The check is now `target not in client_configs`, which captures both "deleted from signed targets" and "unassigned from this client" — both result in a disable payload (content=None) being queued for the product callback. The `targets` parameter to
_remove_previously_applied_configurations is no longer needed and has been removed; the branching was also rewritten so the removal path is the first, explicit case (no sentinel).