### PR TITLE
refactor(telemetry): dependency tracker performance

### DIFF
--- a/ddtrace/internal/telemetry/dependency_tracker.py
+++ b/ddtrace/internal/telemetry/dependency_tracker.py
@@ -61,16 +61,6 @@ class DependencyTracker:
         self._modules_already_imported: set[str] = set()
         self._lock = Lock()
 
-    def _update_imported(self, new_modules: Iterable[str]) -> list[dict]:
-        """Discover new dependencies from recently imported modules.
-
-        Adds a DependencyEntry for each newly discovered package.
-        Returns serialized dependency dicts ready for the telemetry payload.
-
-        Caller must hold self._lock (called internally from collect_report).
-        """
-        return update_imported_dependencies(self._imported_dependencies, new_modules)
-
     def collect_report(self) -> Optional[list[dict[str, Any]]]:
         """Discover new modules, collect re-reports, mark sent. Return payload or None.
 
@@ -82,14 +72,11 @@ class DependencyTracker:
 
         with self._lock:
             newly_imported_deps = modules.get_newly_imported_modules(self._modules_already_imported)
-            new_deps = self._update_imported(newly_imported_deps)
+            new_deps = update_imported_dependencies(self._imported_dependencies, newly_imported_deps)
 
-            # Mark new deps as initially sent
-            for dep_dict in new_deps:
-                entry = self._imported_dependencies.get(_normalize_dep_name(dep_dict["name"]))
-                if entry:
-                    entry.mark_initial_sent()
-                    entry.mark_all_metadata_sent()
+            # Normalize once; reuse the set for sent-marking and re-report dedup.
+            new_keys = {_normalize_dep_name(d["name"]) for d in new_deps}
+            self._mark_sent(new_keys)
 
             # Skip the re-report scan when SCA is disabled.
             # Without SCA, no entry will ever have unsent metadata, so the
@@ -101,23 +88,52 @@ class DependencyTracker:
             if not tracer_config._sca_enabled:
                 return new_deps if new_deps else None
 
-            # Collect normalized names of deps just reported above to avoid double-reporting.
-            just_reported = {_normalize_dep_name(d["name"]) for d in new_deps}
-
-            # Re-report deps that need it: auto-created by SCA hook (never
-            # reported yet) or already reported but with new unsent metadata.
-            # Include ALL metadata (sent + unsent) per RFC.
-            re_report_deps: list[dict] = []
-            for entry in self._imported_dependencies.values():
-                if _normalize_dep_name(entry.name) in just_reported:
-                    continue
-                if entry.needs_report():
-                    re_report_deps.append(entry.to_telemetry_dict(include_all_metadata=True))
-                    entry.mark_initial_sent()
-                    entry.mark_all_metadata_sent()
-
+            re_report_deps = self._collect_rereports(new_keys)
             all_deps = new_deps + re_report_deps
             return all_deps if all_deps else None
+
+    def _mark_sent(self, keys: Iterable[str]) -> None:
+        """Mark entries at ``keys`` as initially sent with all metadata sent.
+
+        Caller must hold self._lock.
+        """
+        for key in keys:
+            entry = self._imported_dependencies.get(key)
+            if entry is not None:
+                entry.mark_initial_sent()
+                entry.mark_all_metadata_sent()
+
+    def _collect_rereports(self, skip_keys: set[str]) -> list[dict[str, Any]]:
+        """Return serialized dicts for entries needing a re-report.
+
+        Re-report deps that need it: auto-created by SCA hook (never reported
+        yet) or already reported but with new unsent metadata. Include ALL
+        metadata (sent + unsent) per RFC.
+
+        Caller must hold self._lock.
+        """
+        re_report: list[dict[str, Any]] = []
+        for key, entry in self._imported_dependencies.items():
+            if key in skip_keys:
+                continue
+            if entry.needs_report():
+                re_report.append(entry.to_telemetry_dict(include_all_metadata=True))
+                entry.mark_initial_sent()
+                entry.mark_all_metadata_sent()
+        return re_report
+
+    def snapshot_for_heartbeat(self) -> list[dict[str, Any]]:
+        """Return serialized dependency dicts for the extended heartbeat payload.
+
+        Serialization happens under the lock so that concurrent SCA mutations
+        (``attach_metadata`` / ``register_cve``) cannot race the iteration of
+        ``entry.metadata`` or the ``reached`` list inside ``json.dumps``. The
+        payload is a list of fresh dicts safe to hand off to the transport.
+        """
+        with self._lock:
+            return [
+                entry.to_telemetry_dict(include_all_metadata=True) for entry in self._imported_dependencies.values()
+            ]
 
     def _ensure_entry(self, package_name: str) -> None:
         """Auto-create a DependencyEntry if SCA is active and package not yet tracked.
@@ -188,11 +204,6 @@ class DependencyTracker:
             for entry in self._imported_dependencies.values():
                 if entry.metadata is None:
                     entry.metadata = []
-
-    def get_all_dependencies(self) -> list[DependencyEntry]:
-        """Return a snapshot of all dependency entries, safe for unsynchronized iteration."""
-        with self._lock:
-            return list(self._imported_dependencies.values())
 
     def reset(self) -> None:
         """Reset all state (used on fork / queue reset)."""

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -313,10 +313,10 @@ class TelemetryWriter(PeriodicService):
         if time.monotonic() - self._extended_time > self._extended_heartbeat_interval:
             payload["configuration"] = self._sent_configs
             if config.DEPENDENCY_COLLECTION:
-                payload["dependencies"] = [
-                    entry.to_telemetry_dict(include_all_metadata=True)
-                    for entry in self._dependency_tracker.get_all_dependencies()
-                ]
+                # Serialize under the tracker lock — concurrent SCA mutations on
+                # DependencyEntry.metadata or ReachabilityMetadata.value["reached"]
+                # would otherwise race list iteration inside json.dumps.
+                payload["dependencies"] = self._dependency_tracker.snapshot_for_heartbeat()
             self._extended_time += self._extended_heartbeat_interval
         return payload
 

--- a/tests/telemetry/test_dependency.py
+++ b/tests/telemetry/test_dependency.py
@@ -795,3 +795,91 @@ class TestTrackerNameNormalization:
         key = _normalize_dep_name("PyYAML")
         assert key in tracker._imported_dependencies
         assert tracker._imported_dependencies[key]._initial_report_sent is True
+
+
+class TestSnapshotForHeartbeat:
+    """Tests for DependencyTracker.snapshot_for_heartbeat — lock-protected extended-heartbeat payload."""
+
+    def test_empty_tracker_returns_empty_list(self):
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        tracker = DependencyTracker()
+        assert tracker.snapshot_for_heartbeat() == []
+
+    def test_returns_all_entries_serialized(self):
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        tracker = DependencyTracker()
+        tracker._imported_dependencies = {
+            "requests": DependencyEntry(name="requests", version="2.28.0", metadata=[]),
+            "flask": DependencyEntry(name="flask", version="3.0.0"),
+        }
+        tracker._imported_dependencies["requests"].add_metadata("CVE-1", "mod", "func", 10)
+
+        snapshot = tracker.snapshot_for_heartbeat()
+
+        assert len(snapshot) == 2
+        by_name = {d["name"]: d for d in snapshot}
+        assert by_name["requests"]["version"] == "2.28.0"
+        assert "metadata" in by_name["requests"]
+        assert len(by_name["requests"]["metadata"]) == 1
+        # flask has metadata=None -> no "metadata" key
+        assert "metadata" not in by_name["flask"]
+
+    def test_includes_already_sent_metadata(self):
+        """Extended heartbeat must re-send sent metadata (include_all_metadata=True)."""
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.add_metadata("CVE-1", "mod", "func", 10)
+        entry.mark_all_metadata_sent()
+
+        tracker = DependencyTracker()
+        tracker._imported_dependencies = {"requests": entry}
+
+        snapshot = tracker.snapshot_for_heartbeat()
+        assert len(snapshot[0]["metadata"]) == 1
+
+    def test_serialization_holds_lock_against_concurrent_mutation(self):
+        """Concurrent attach_metadata must not race iteration inside json.dumps.
+
+        Spawns a writer thread repeatedly adding CVEs to a tracked entry while the
+        heartbeat serializer builds snapshots. Without the lock, the writer thread
+        could append to ReachabilityMetadata.value["reached"] mid-serialization —
+        json.dumps on a list being mutated in another thread is not safe.
+        """
+        import threading
+
+        from ddtrace.internal.settings._config import config as tracer_config
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        tracer_config._sca_enabled = True
+        tracker = DependencyTracker()
+        tracker._imported_dependencies["requests"] = DependencyEntry(
+            name="requests", version="2.28.0", metadata=[]
+        )
+
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                try:
+                    tracker.attach_metadata("requests", f"CVE-{i}", "mod", "func", i)
+                    i += 1
+                except BaseException as exc:  # pragma: no cover — asserted below
+                    errors.append(exc)
+                    return
+
+        t = threading.Thread(target=writer, daemon=True)
+        t.start()
+        try:
+            for _ in range(200):
+                snapshot = tracker.snapshot_for_heartbeat()
+                assert snapshot and snapshot[0]["name"] == "requests"
+        finally:
+            stop.set()
+            t.join(timeout=2)
+
+        assert not errors, errors

--- a/tests/telemetry/test_dependency.py
+++ b/tests/telemetry/test_dependency.py
@@ -855,9 +855,7 @@ class TestSnapshotForHeartbeat:
 
         tracer_config._sca_enabled = True
         tracker = DependencyTracker()
-        tracker._imported_dependencies["requests"] = DependencyEntry(
-            name="requests", version="2.28.0", metadata=[]
-        )
+        tracker._imported_dependencies["requests"] = DependencyEntry(name="requests", version="2.28.0", metadata=[])
 
         stop = threading.Event()
         errors: list[BaseException] = []


### PR DESCRIPTION
## Description

Targeted refactor of `ddtrace/internal/telemetry/dependency_tracker.py` and the writer's heartbeat path, focused on concurrency safety and removing redundant work in `collect_report`. No behavior change on the wire.

**Concurrency fix (heartbeat):**
`writer._report_heartbeat` previously called `tracker.get_all_dependencies()` and then serialized each `DependencyEntry` outside the tracker lock. The returned list was a snapshot, but entries themselves remained live — concurrent SCA hooks (`attach_metadata` / `register_cve`) mutate `DependencyEntry.metadata` and `ReachabilityMetadata.value["reached"]`. In particular, `json.dumps(self.value)` iterates the `reached` list, and a concurrent `append` is not safe. Now the heartbeat calls a new `DependencyTracker.snapshot_for_heartbeat()` that builds telemetry dicts while holding `self._lock`.

**collect_report cleanup:**
- Removed the thin `_update_imported` wrapper (single caller, pure pass-through).
- Normalized new-dep names exactly once; the resulting set is reused both for sent-marking and for skipping just-reported deps in the re-report scan. The previous code normalized each new dep twice and also called `_normalize_dep_name(entry.name)` for every tracked entry on every flush.
- Split `collect_report` into `_mark_sent(keys)` and `_collect_rereports(skip_keys)` helpers for clarity (SRP). Public API unchanged.
- Dropped unused `get_all_dependencies()`.

**Split out:** the `data.get_host_info` `@cached()` migration is tracked separately in #17669 to keep this PR focused on the tracker.

**Context:** Findings from a pragmatic code review (L5) of the telemetry dependency tracker on an earlier branch. These are internal-only changes; nothing externally observable shifts. The three standalone helpers (`update_imported_dependencies`, `attach_reachability_metadata`, `register_cve_metadata`) are preserved untouched — they are called from benchmarks, tests, and monkey-patched by `tests/appsec/architectures/mini.py`. The deferred `tracer_config` imports are also preserved: `settings/_config.py` imports telemetry at module top, so a top-level import in the tracker would create a circular import.

## Performance

Isolated A/B microbenchmark of `collect_report()`'s body — byte-for-byte reproduction of `main` vs. this branch, same mocked distribution lookups on both sides, 33 interleaved samples per case. Times are the best of the run; medians track the same direction.

| Scenario (SCA enabled unless noted) | Before (main) | After (this PR) | Δ |
|---|---:|---:|---:|
| 2 000 tracked deps, 50 new imports | 2 695 µs | 1 981 µs | **+26.5 % faster** |
| 5 000 tracked deps, 50 new imports | 6 567 µs | 4 752 µs | **+27.6 % faster** |
| 10 000 tracked deps, 50 new imports | 13 075 µs | 9 539 µs | **+27.0 % faster** |
| **Idle tick**, 5 000 deps, 0 new | 1 880 µs | 148 µs | **+92.1 % faster** |
| **Idle tick**, 10 000 deps, 0 new | 3 790 µs | 298 µs | **+92.1 % faster** |
| SCA **disabled**, 2 000 deps, 50 new | 1 767 µs | 1 783 µs | ~flat (−0.9 %) |

**Where the speedup comes from:** the previous re-report scan called `_normalize_dep_name(entry.name)` (a regex substitution) on every tracked entry, every tick. The refactor iterates `imported.items()` and uses the already-normalized dict key directly, eliminating N regex calls per heartbeat. The idle-path win is large because with no new modules the only work done is that re-report scan.

The SCA-disabled fast path was not touched and is statistically flat, as expected.

## Testing

- `hatch run lint:fmt -- ...` — clean
- `pytest tests/telemetry/test_dependency.py` — **69 passed**, including a new `TestSnapshotForHeartbeat` class:
  - Empty-tracker case returns `[]`
  - All entries serialized correctly; `metadata=None` entries omit the `"metadata"` key
  - Already-sent metadata is still included in the heartbeat payload
  - **Concurrency test**: a writer thread repeatedly calls `attach_metadata` while the main thread builds 200 snapshots. Without the lock, the writer races `json.dumps` iteration over `reached`; with the lock, the test is clean.
- `pytest tests/telemetry/test_data.py` — 15 passed, 2 failures that are pre-existing and unrelated (subprocess-marked tests that assume docker paths in `conftest.py`; verified identical failure on clean `origin/main`).
- `pytest tests/telemetry/test_writer.py` — same pre-existing subprocess-path failures on both clean `main` and this branch; no new regressions.

## Risks

Low — internal refactor with no wire-format or public-API changes.

- `snapshot_for_heartbeat()` holds the tracker lock during a list comprehension that calls `to_telemetry_dict(include_all_metadata=True)` per entry, which includes a `json.dumps` per `ReachabilityMetadata`. On an app with 10k+ tracked deps this is marginally longer than the previous lock-then-serialize-outside pattern, but in exchange we get correctness. Heartbeats run at most once per extended-interval (default 24h), so this is not hot.
- `collect_report` helper split is a pure refactor; `_mark_sent` and `_collect_rereports` remain private and require the caller to hold `self._lock`.

## Additional Notes

- Added `changelog/no-changelog` — the SCA-related telemetry (reachability metadata on `DependencyEntry`) is unreleased, and the rest of this PR is internal refactor.
