### PR TITLE
chore(ci_visibility): add telemetry for git commit SHA and repository URL discrepancies

### DIFF
--- a/ddtrace/testing/internal/env_tags.py
+++ b/ddtrace/testing/internal/env_tags.py
@@ -13,6 +13,7 @@ from ddtrace.testing.internal.git import get_pr_base_commit_sha
 from ddtrace.testing.internal.git import get_workspace_path
 from ddtrace.testing.internal.offline_mode import get_offline_mode
 from ddtrace.testing.internal.offline_mode import resolve_rlocation
+from ddtrace.testing.internal.telemetry import TelemetryAPI
 from ddtrace.testing.internal.utils import _filter_sensitive_info
 
 
@@ -20,6 +21,11 @@ log = logging.getLogger(__name__)
 
 
 _TagDict = dict[str, t.Optional[str]]
+
+# Provider name constants used in commit SHA consistency telemetry
+_PROVIDER_USER_SUPPLIED = "user_supplied"
+_PROVIDER_CI = "ci_provider"
+_PROVIDER_GIT_CLIENT = "git_client"
 
 
 def merge_tags(target: _TagDict, *tag_dicts: _TagDict) -> None:
@@ -57,6 +63,71 @@ def _read_env_data_file() -> dict[str, str]:
     return {}
 
 
+def _check_commit_sha_consistency(
+    user_supplied_tags: _TagDict,
+    ci_provider_tags: _TagDict,
+    git_client_tags: _TagDict,
+) -> None:
+    """Compare git.commit.sha and git.repository_url values across providers and emit telemetry.
+
+    Checks all provider pairs explicitly, matching the cross-language reference implementation:
+    - Commit SHA: (ci_provider, git_client), (user_supplied, git_client), (user_supplied, ci_provider)
+    - Repository URL: same three pairs
+
+    Each check emits git.commit_sha_discrepancy when both sides are non-empty and differ.
+    Always emits exactly one git.commit_sha_match metric.
+    """
+    if TelemetryAPI._instance is None:
+        return
+
+    u = user_supplied_tags.get
+    c = ci_provider_tags.get
+    g = git_client_tags.get
+
+    checks = [
+        # Commit SHA checks
+        (c(GitTag.COMMIT_SHA), g(GitTag.COMMIT_SHA), "commit_discrepancy", _PROVIDER_CI, _PROVIDER_GIT_CLIENT),
+        (
+            u(GitTag.COMMIT_SHA),
+            g(GitTag.COMMIT_SHA),
+            "commit_discrepancy",
+            _PROVIDER_USER_SUPPLIED,
+            _PROVIDER_GIT_CLIENT,
+        ),
+        (u(GitTag.COMMIT_SHA), c(GitTag.COMMIT_SHA), "commit_discrepancy", _PROVIDER_USER_SUPPLIED, _PROVIDER_CI),
+        # Repository URL checks
+        (
+            c(GitTag.REPOSITORY_URL),
+            g(GitTag.REPOSITORY_URL),
+            "repository_discrepancy",
+            _PROVIDER_CI,
+            _PROVIDER_GIT_CLIENT,
+        ),
+        (
+            u(GitTag.REPOSITORY_URL),
+            g(GitTag.REPOSITORY_URL),
+            "repository_discrepancy",
+            _PROVIDER_USER_SUPPLIED,
+            _PROVIDER_GIT_CLIENT,
+        ),
+        (
+            u(GitTag.REPOSITORY_URL),
+            c(GitTag.REPOSITORY_URL),
+            "repository_discrepancy",
+            _PROVIDER_USER_SUPPLIED,
+            _PROVIDER_CI,
+        ),
+    ]
+
+    has_mismatch = False
+    for left, right, discrepancy_type, expected_provider, discrepant_provider in checks:
+        if left and right and left != right:
+            has_mismatch = True
+            TelemetryAPI.get().record_commit_sha_discrepancy(expected_provider, discrepant_provider, discrepancy_type)
+
+    TelemetryAPI.get().record_commit_sha_match(not has_mismatch)
+
+
 def get_env_tags() -> dict[str, str]:
     # NOTE: In payload-files mode (Bazel sandbox output), CI/Git/OS/runtime tags
     # must NOT be populated from the local environment or git CLI. Instead, the
@@ -73,13 +144,13 @@ def get_env_tags() -> dict[str, str]:
 
     tags: _TagDict = {}
 
-    merge_tags(
-        tags,
-        git.get_git_tags_from_git_command(),
-        ci.get_ci_tags(os.environ),
-        git.get_git_tags_from_dd_variables(os.environ),
-        get_custom_dd_tags(os.environ),
-    )
+    local_git_tags = git.get_git_tags_from_git_command()
+    ci_provider_tags = ci.get_ci_tags(os.environ)
+    user_supplied_tags = git.get_git_tags_from_dd_variables(os.environ)
+
+    merge_tags(tags, local_git_tags, ci_provider_tags, user_supplied_tags, get_custom_dd_tags(os.environ))
+
+    _check_commit_sha_consistency(user_supplied_tags, ci_provider_tags, local_git_tags)
 
     if head_sha := tags.get(GitTag.COMMIT_HEAD_SHA):
         merge_tags(tags, git.get_git_head_tags_from_git_command(head_sha))

--- a/ddtrace/testing/internal/env_tags.py
+++ b/ddtrace/testing/internal/env_tags.py
@@ -68,64 +68,36 @@ def _check_commit_sha_consistency(
     ci_provider_tags: _TagDict,
     git_client_tags: _TagDict,
 ) -> None:
-    """Compare git.commit.sha and git.repository_url values across providers and emit telemetry.
+    """Compare git.commit.sha and git.repository_url across all provider pairs and emit telemetry.
 
-    Checks all provider pairs explicitly, matching the cross-language reference implementation:
-    - Commit SHA: (ci_provider, git_client), (user_supplied, git_client), (user_supplied, ci_provider)
-    - Repository URL: same three pairs
-
-    Each check emits git.commit_sha_discrepancy when both sides are non-empty and differ.
+    Emits git.commit_sha_discrepancy for each pair where both sides have a value and they differ.
     Always emits exactly one git.commit_sha_match metric.
     """
     if TelemetryAPI._instance is None:
         return
 
-    u = user_supplied_tags.get
-    c = ci_provider_tags.get
-    g = git_client_tags.get
+    telemetry = TelemetryAPI.get()
 
-    checks = [
-        # Commit SHA checks
-        (c(GitTag.COMMIT_SHA), g(GitTag.COMMIT_SHA), "commit_discrepancy", _PROVIDER_CI, _PROVIDER_GIT_CLIENT),
-        (
-            u(GitTag.COMMIT_SHA),
-            g(GitTag.COMMIT_SHA),
-            "commit_discrepancy",
-            _PROVIDER_USER_SUPPLIED,
-            _PROVIDER_GIT_CLIENT,
-        ),
-        (u(GitTag.COMMIT_SHA), c(GitTag.COMMIT_SHA), "commit_discrepancy", _PROVIDER_USER_SUPPLIED, _PROVIDER_CI),
-        # Repository URL checks
-        (
-            c(GitTag.REPOSITORY_URL),
-            g(GitTag.REPOSITORY_URL),
-            "repository_discrepancy",
-            _PROVIDER_CI,
-            _PROVIDER_GIT_CLIENT,
-        ),
-        (
-            u(GitTag.REPOSITORY_URL),
-            g(GitTag.REPOSITORY_URL),
-            "repository_discrepancy",
-            _PROVIDER_USER_SUPPLIED,
-            _PROVIDER_GIT_CLIENT,
-        ),
-        (
-            u(GitTag.REPOSITORY_URL),
-            c(GitTag.REPOSITORY_URL),
-            "repository_discrepancy",
-            _PROVIDER_USER_SUPPLIED,
-            _PROVIDER_CI,
-        ),
+    provider_pairs = [
+        (_PROVIDER_CI, ci_provider_tags, _PROVIDER_GIT_CLIENT, git_client_tags),
+        (_PROVIDER_USER_SUPPLIED, user_supplied_tags, _PROVIDER_GIT_CLIENT, git_client_tags),
+        (_PROVIDER_USER_SUPPLIED, user_supplied_tags, _PROVIDER_CI, ci_provider_tags),
+    ]
+    fields = [
+        (GitTag.COMMIT_SHA, "commit_discrepancy"),
+        (GitTag.REPOSITORY_URL, "repository_discrepancy"),
     ]
 
     has_mismatch = False
-    for left, right, discrepancy_type, expected_provider, discrepant_provider in checks:
-        if left and right and left != right:
-            has_mismatch = True
-            TelemetryAPI.get().record_commit_sha_discrepancy(expected_provider, discrepant_provider, discrepancy_type)
+    for expected_name, expected_tags, discrepant_name, discrepant_tags in provider_pairs:
+        for tag_key, discrepancy_type in fields:
+            left = expected_tags.get(tag_key)
+            right = discrepant_tags.get(tag_key)
+            if left and right and left != right:
+                has_mismatch = True
+                telemetry.record_commit_sha_discrepancy(expected_name, discrepant_name, discrepancy_type)
 
-    TelemetryAPI.get().record_commit_sha_match(not has_mismatch)
+    telemetry.record_commit_sha_match(not has_mismatch)
 
 
 def get_env_tags() -> dict[str, str]:

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -301,6 +301,25 @@ class TelemetryAPI:
         self.add_distribution_metric("git_requests.objects_pack_files", uploaded_files)
         self.add_distribution_metric("git_requests.objects_pack_bytes", uploaded_bytes)
 
+    def record_commit_sha_match(self, matched: bool) -> None:
+        self.add_count_metric("git.commit_sha_match", 1, {"matched": "true" if matched else "false"})
+
+    def record_commit_sha_discrepancy(
+        self,
+        expected_provider: str,
+        discrepant_provider: str,
+        discrepancy_type: str,
+    ) -> None:
+        self.add_count_metric(
+            "git.commit_sha_discrepancy",
+            1,
+            {
+                "expected_provider": expected_provider,
+                "discrepant_provider": discrepant_provider,
+                "type": discrepancy_type,
+            },
+        )
+
 
 class _PayloadFileTelemetryClient:
     """Drop-in replacement for ``_TelemetryClient`` that writes payloads to files.

--- a/tests/testing/internal/test_env_tags.py
+++ b/tests/testing/internal/test_env_tags.py
@@ -8,10 +8,15 @@ from unittest import mock
 import pytest
 
 from ddtrace.testing.internal.ci import CITag
+from ddtrace.testing.internal.env_tags import _PROVIDER_CI
+from ddtrace.testing.internal.env_tags import _PROVIDER_GIT_CLIENT
+from ddtrace.testing.internal.env_tags import _PROVIDER_USER_SUPPLIED
+from ddtrace.testing.internal.env_tags import _check_commit_sha_consistency
 from ddtrace.testing.internal.env_tags import get_env_tags
 from ddtrace.testing.internal.git import Git
 from ddtrace.testing.internal.git import GitTag
 from ddtrace.testing.internal.git import get_git_tags_from_git_command
+from ddtrace.testing.internal.telemetry import TelemetryAPI
 from ddtrace.testing.internal.utils import _filter_sensitive_info
 
 
@@ -446,3 +451,129 @@ def test_github_actions_base_branch_sha_not_overwritten_when_already_set(
 
     mock_merge_base.assert_not_called()
     assert tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == existing_base_sha
+
+
+class TestCheckCommitShaConsistency:
+    """Tests for _check_commit_sha_consistency telemetry helper."""
+
+    SHA1 = "aaaa1111"
+    SHA2 = "bbbb2222"
+    SHA3 = "cccc3333"
+    REPO1 = "https://github.com/org/repo-a.git"
+    REPO2 = "https://github.com/org/repo-b.git"
+    REPO3 = "https://github.com/org/repo-c.git"
+
+    def _call(self, user=None, ci=None, git=None, user_repo=None, ci_repo=None, git_repo=None):
+        return _check_commit_sha_consistency(
+            {GitTag.COMMIT_SHA: user, GitTag.REPOSITORY_URL: user_repo},
+            {GitTag.COMMIT_SHA: ci, GitTag.REPOSITORY_URL: ci_repo},
+            {GitTag.COMMIT_SHA: git, GitTag.REPOSITORY_URL: git_repo},
+        )
+
+    def test_all_match_emits_matched_true(self, mock_telemetry: mock.Mock) -> None:
+        self._call(user=self.SHA1, ci=self.SHA1, git=self.SHA1)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(True)
+        mock_telemetry.record_commit_sha_discrepancy.assert_not_called()
+
+    def test_no_providers_have_sha_emits_matched_true(self, mock_telemetry: mock.Mock) -> None:
+        self._call()
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(True)
+        mock_telemetry.record_commit_sha_discrepancy.assert_not_called()
+
+    def test_only_one_provider_has_sha_emits_matched_true(self, mock_telemetry: mock.Mock) -> None:
+        self._call(ci=self.SHA1)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(True)
+        mock_telemetry.record_commit_sha_discrepancy.assert_not_called()
+
+    def test_ci_vs_git_client_sha_mismatch(self, mock_telemetry: mock.Mock) -> None:
+        self._call(ci=self.SHA1, git=self.SHA2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        mock_telemetry.record_commit_sha_discrepancy.assert_called_once_with(
+            _PROVIDER_CI, _PROVIDER_GIT_CLIENT, "commit_discrepancy"
+        )
+
+    def test_user_supplied_vs_git_client_sha_mismatch(self, mock_telemetry: mock.Mock) -> None:
+        self._call(user=self.SHA1, git=self.SHA2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        mock_telemetry.record_commit_sha_discrepancy.assert_called_once_with(
+            _PROVIDER_USER_SUPPLIED, _PROVIDER_GIT_CLIENT, "commit_discrepancy"
+        )
+
+    def test_user_supplied_vs_ci_sha_mismatch(self, mock_telemetry: mock.Mock) -> None:
+        self._call(user=self.SHA1, ci=self.SHA2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        mock_telemetry.record_commit_sha_discrepancy.assert_called_once_with(
+            _PROVIDER_USER_SUPPLIED, _PROVIDER_CI, "commit_discrepancy"
+        )
+
+    def test_all_three_sha_different_emits_three_discrepancies(self, mock_telemetry: mock.Mock) -> None:
+        self._call(user=self.SHA1, ci=self.SHA2, git=self.SHA3)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        calls = mock_telemetry.record_commit_sha_discrepancy.call_args_list
+        assert len(calls) == 3
+        assert mock.call(_PROVIDER_CI, _PROVIDER_GIT_CLIENT, "commit_discrepancy") in calls
+        assert mock.call(_PROVIDER_USER_SUPPLIED, _PROVIDER_GIT_CLIENT, "commit_discrepancy") in calls
+        assert mock.call(_PROVIDER_USER_SUPPLIED, _PROVIDER_CI, "commit_discrepancy") in calls
+
+    def test_ci_vs_git_client_url_mismatch(self, mock_telemetry: mock.Mock) -> None:
+        self._call(ci_repo=self.REPO1, git_repo=self.REPO2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        mock_telemetry.record_commit_sha_discrepancy.assert_called_once_with(
+            _PROVIDER_CI, _PROVIDER_GIT_CLIENT, "repository_discrepancy"
+        )
+
+    def test_user_supplied_vs_git_client_url_mismatch(self, mock_telemetry: mock.Mock) -> None:
+        self._call(user_repo=self.REPO1, git_repo=self.REPO2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        mock_telemetry.record_commit_sha_discrepancy.assert_called_once_with(
+            _PROVIDER_USER_SUPPLIED, _PROVIDER_GIT_CLIENT, "repository_discrepancy"
+        )
+
+    def test_user_supplied_vs_ci_url_mismatch(self, mock_telemetry: mock.Mock) -> None:
+        self._call(user_repo=self.REPO1, ci_repo=self.REPO2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        mock_telemetry.record_commit_sha_discrepancy.assert_called_once_with(
+            _PROVIDER_USER_SUPPLIED, _PROVIDER_CI, "repository_discrepancy"
+        )
+
+    def test_sha_and_url_mismatch_emits_both_types(self, mock_telemetry: mock.Mock) -> None:
+        self._call(ci=self.SHA1, git=self.SHA2, ci_repo=self.REPO1, git_repo=self.REPO2)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+        calls = mock_telemetry.record_commit_sha_discrepancy.call_args_list
+        assert mock.call(_PROVIDER_CI, _PROVIDER_GIT_CLIENT, "commit_discrepancy") in calls
+        assert mock.call(_PROVIDER_CI, _PROVIDER_GIT_CLIENT, "repository_discrepancy") in calls
+
+    def test_all_six_discrepancies_when_all_differ(self, mock_telemetry: mock.Mock) -> None:
+        self._call(
+            user=self.SHA1,
+            ci=self.SHA2,
+            git=self.SHA3,
+            user_repo=self.REPO1,
+            ci_repo=self.REPO2,
+            git_repo=self.REPO3,
+        )
+
+        assert mock_telemetry.record_commit_sha_discrepancy.call_count == 6
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(False)
+
+    def test_empty_string_treated_as_absent(self, mock_telemetry: mock.Mock) -> None:
+        self._call(ci="", git=self.SHA1)
+
+        mock_telemetry.record_commit_sha_match.assert_called_once_with(True)
+        mock_telemetry.record_commit_sha_discrepancy.assert_not_called()
+
+    def test_no_telemetry_when_instance_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(TelemetryAPI, "_instance", None)
+        # Should not raise
+        self._call(ci=self.SHA1, git=self.SHA2)

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -594,3 +594,37 @@ class TestTelemetry:
             call(CIVISIBILITY, "git_requests.objects_pack_files", 5, ()),
             call(CIVISIBILITY, "git_requests.objects_pack_bytes", 200, ()),
         ]
+
+    def test_record_commit_sha_match_true(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        telemetry_api.record_commit_sha_match(matched=True)
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "git.commit_sha_match", 1, (("matched", "true"),))
+        ]
+
+    def test_record_commit_sha_match_false(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        telemetry_api.record_commit_sha_match(matched=False)
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "git.commit_sha_match", 1, (("matched", "false"),))
+        ]
+
+    def test_record_commit_sha_discrepancy(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        telemetry_api.record_commit_sha_discrepancy(
+            expected_provider="ci_provider",
+            discrepant_provider="local_git",
+            discrepancy_type="commit_discrepancy",
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(
+                CIVISIBILITY,
+                "git.commit_sha_discrepancy",
+                1,
+                (
+                    ("expected_provider", "ci_provider"),
+                    ("discrepant_provider", "local_git"),
+                    ("type", "commit_discrepancy"),
+                ),
+            )
+        ]


### PR DESCRIPTION
## Description

Adds telemetry metrics to track when git commit SHA or repository URL values differ across providers (user-supplied `DD_GIT_*` env vars, CI provider, local git client). This helps understand how common these discrepancies are in customer setups.

Two new count metrics:
- `git.commit_sha_match` — emitted every time git info is built, with tag `matched: "true"|"false"`
- `git.commit_sha_discrepancy` — emitted for each mismatched pair, with tags `expected_provider`, `discrepant_provider`, and `type` (`commit_discrepancy` or `repository_discrepancy`)

All 6 provider-pair × field combinations are checked explicitly, matching the cross-language reference implementation (Ruby: DataDog/datadog-ci-rb#360).

## Testing

Unit tests covering:
- All 6 check combinations (3 provider pairs × 2 fields)
- Edge cases: empty strings, missing values, no telemetry instance
- Telemetry method serialization (`test_telemetry.py`)

## Risks

Low — telemetry-only change, no impact on tag values or test execution behavior.