### PR TITLE
ci(benchmarks): bump SLO threshold for span-record-exception

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -956,7 +956,7 @@ experiments:
               - max_rss_usage < 53.00 MB
           - name: span-record-exception
             thresholds:
-              - execution_time < 42.00 ms
+              - execution_time < 43.00 ms
               - max_rss_usage < 53.00 MB
           - name: span-set-status
             thresholds:


### PR DESCRIPTION
## Description

Bumps the `execution_time` SLO threshold for the `span-record-exception` microbenchmark from 42 ms to 43 ms.

The current threshold is causing intermittent CI failures due to natural variance in benchmark execution times. This 1 ms increase keeps the threshold meaningful while reducing noise-driven failures.

<img width="605" height="516" alt="Screenshot 2026-04-22 at 13 10 31" src="https://github.com/user-attachments/assets/cf7f96f4-c563-49d5-a1ba-080eadf0b617" />


## Testing

No functional change — CI benchmark job will validate the updated threshold.

## Risks

None. This is a CI configuration change only; no library code is modified.

## Additional Notes

The `max_rss_usage` threshold (53 MB) is unchanged.