### PR TITLE
fix(profiling): ensure running loop is not `None` before linking tasks

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -121,9 +121,10 @@ def _(asyncio: ModuleType) -> None:
                 children = get_argument_value(args, kwargs, 1, "children")
                 assert children is not None  # nosec: assert is used for typing
 
-                parent = globals()["current_task"]()
-                for child in children:
-                    stack.link_tasks(parent, child)
+                if globals()["get_running_loop"]() is not None:
+                    parent = globals()["current_task"]()
+                    for child in children:
+                        stack.link_tasks(parent, child)
 
         @partial(wrap, sys.modules["asyncio"].tasks._wait)
         def _(
@@ -136,9 +137,10 @@ def _(asyncio: ModuleType) -> None:
             finally:
                 futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
 
-                parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
-                for future in futures:
-                    stack.link_tasks(parent, future)
+                if globals()["get_running_loop"]() is not None:
+                    parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
+                    for future in futures:
+                        stack.link_tasks(parent, future)
 
         @partial(wrap, sys.modules["asyncio"].tasks.as_completed)
         def _(

--- a/releasenotes/notes/profiling-safer-use-of-task-linking-bfca996e62c5d5b3.yaml
+++ b/releasenotes/notes/profiling-safer-use-of-task-linking-bfca996e62c5d5b3.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: A race condition which could make asyncio code raise exceptions at exit
+    has been fixed.


### PR DESCRIPTION
## Description

This fixes a surprising race condition happening under AnyIO asynchronous testing where we could sometimes end up constructing a `GatheringFuture` without an active event loop. The assumption was that `gather` would always be called with an event loop existing, but that can apparently be not the case at exit with certain additional  `asyncio`-related packages. 