### PR TITLE
fix(telemetry): flush telemetry on sigterm

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -191,6 +191,7 @@ class TelemetryWriter(PeriodicService):
             forksafe.register(self._fork_writer)
             # shutdown the telemetry writer when the application exits
             atexit.register(self.app_shutdown)
+            atexit.register_on_exit_signal(self.app_shutdown)
             # Captures unhandled exceptions during application start up
             self.install_excepthook()
             # In order to support 3.12, we start the writer upon initialization.
@@ -699,6 +700,9 @@ class TelemetryWriter(PeriodicService):
         self._client.send_event(batch_event, payload_types)
 
     def app_shutdown(self) -> None:
+        if not self._enabled:
+            return
+
         if self.started:
             self.periodic(force_flush=True, shutting_down=True)
         self.disable()

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,4 +1,7 @@
 import os
+import signal
+import subprocess
+import sys
 
 import pytest
 
@@ -81,6 +84,52 @@ subprocess.run([sys.executable, "-c", "import ddtrace.auto"], check=True)
     # Only the parent should emit app-started and app-closing
     assert len(test_agent_session.get_events("app-started")) == 1
     assert len(test_agent_session.get_events("app-closing")) == 1
+
+
+def test_enable_sigterm_emits_app_closing(test_agent_session, tmpdir):
+    code = """
+import time
+
+import ddtrace
+
+print("READY", flush=True)
+
+while True:
+    time.sleep(0.1)
+"""
+
+    pyfile = tmpdir.join("test_signal_shutdown.py")
+    pyfile.write(code)
+
+    env = os.environ.copy()
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    env["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"] = "X-Datadog-Test-Session-Token:{}".format(test_agent_session.token)
+
+    proc = subprocess.Popen(
+        [sys.executable, str(pyfile)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=sys.platform != "win32",
+    )
+
+    try:
+        ready = proc.stdout.readline()
+        if b"READY" not in ready:
+            stderr = proc.stderr.read().decode()
+            pytest.fail(f"Subprocess did not signal ready. Got: {ready!r}, stderr: {stderr}")
+
+        os.kill(proc.pid, signal.SIGTERM)
+        stdout, stderr = proc.communicate(timeout=5)
+        assert stdout in (b"",), stdout
+        assert b"RuntimeError: can't create new thread at interpreter shutdown" not in stderr
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    app_closing = test_agent_session.get_events("app-closing")
+    assert len(app_closing) == 1
 
 
 def test_enable_fork_heartbeat(test_agent_session, run_python_code_in_subprocess):


### PR DESCRIPTION
## Description

Telemetry is not flushed when `SIGTERM` is received. Register telemetry shutdown in the exit signal handler, just like the rest of the tracer shutdown.

## Testing

Added a test and checked it failed without the fix.

## Risks

Delaying shutdown on `SIGTERM`.

## Additional Notes


