### PR TITLE
fix(llmobs): default model_name/model_provider to "unknown"

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -75,6 +75,8 @@ from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 from ddtrace.llmobs._constants import SUPPORTED_LLMOBS_INTEGRATIONS
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._context import LLMObsContextProvider
 from ddtrace.llmobs._evaluators.runner import EvaluatorRunner
 from ddtrace.llmobs._experiment import AsyncEvaluatorType
@@ -368,8 +370,10 @@ def _build_span_meta(
         metadata=llmobs_meta.get(LLMOBS_STRUCT.METADATA) or {},
     )
     if span_kind in ("llm", "embedding"):
-        meta[LLMOBS_STRUCT.MODEL_NAME] = llmobs_meta.get(LLMOBS_STRUCT.MODEL_NAME) or ""
-        meta[LLMOBS_STRUCT.MODEL_PROVIDER] = (llmobs_meta.get(LLMOBS_STRUCT.MODEL_PROVIDER) or "custom").lower()
+        meta[LLMOBS_STRUCT.MODEL_NAME] = llmobs_meta.get(LLMOBS_STRUCT.MODEL_NAME) or UNKNOWN_MODEL_NAME
+        meta[LLMOBS_STRUCT.MODEL_PROVIDER] = (
+            llmobs_meta.get(LLMOBS_STRUCT.MODEL_PROVIDER) or UNKNOWN_MODEL_PROVIDER
+        ).lower()
     tool_definitions = llmobs_meta.get(LLMOBS_STRUCT.TOOL_DEFINITIONS)
     if tool_definitions:
         meta[LLMOBS_STRUCT.TOOL_DEFINITIONS] = tool_definitions

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1950,10 +1950,10 @@ class LLMObs(Service):
         """
         Trace an invocation call to an LLM where inputs and outputs are represented as text.
 
-        :param str model_name: The name of the invoked LLM. If not provided, a default value of "custom" will be set.
+        :param str model_name: The name of the invoked LLM. If not provided, a default value of "unknown" will be set.
         :param str name: The name of the traced operation. If not provided, a default value of "llm" will be set.
         :param str model_provider: The name of the invoked LLM provider (ex: openai, bedrock).
-                                   If not provided, a default value of "custom" will be set.
+                                   If not provided, a default value of "unknown" will be set.
         :param str session_id: The ID of the underlying user session. Required for tracking sessions.
         :param str ml_app: The name of the ML application that the agent is orchestrating. If not provided, the default
                            value will be set to the value of `DD_LLMOBS_ML_APP`.
@@ -1963,9 +1963,9 @@ class LLMObs(Service):
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
         if model_name is None:
-            model_name = "custom"
+            model_name = UNKNOWN_MODEL_NAME
         if model_provider is None:
-            model_provider = "custom"
+            model_provider = UNKNOWN_MODEL_PROVIDER
         return cls._instance._start_span(
             "llm",
             name,
@@ -2102,10 +2102,10 @@ class LLMObs(Service):
         Trace a call to an embedding model or function to create an embedding.
 
         :param str model_name: The name of the invoked embedding model.
-                               If not provided, a default value of "custom" will be set.
+                               If not provided, a default value of "unknown" will be set.
         :param str name: The name of the traced operation. If not provided, a default value of "embedding" will be set.
         :param str model_provider: The name of the invoked LLM provider (ex: openai, bedrock).
-                                   If not provided, a default value of "custom" will be set.
+                                   If not provided, a default value of "unknown" will be set.
         :param str session_id: The ID of the underlying user session. Required for tracking sessions.
         :param str ml_app: The name of the ML application that the agent is orchestrating. If not provided, the default
                            value will be set to the value of `DD_LLMOBS_ML_APP`.
@@ -2115,9 +2115,9 @@ class LLMObs(Service):
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
         if model_name is None:
-            model_name = "custom"
+            model_name = UNKNOWN_MODEL_NAME
         if model_provider is None:
-            model_provider = "custom"
+            model_provider = UNKNOWN_MODEL_PROVIDER
         return cls._instance._start_span(
             "embedding",
             name,

--- a/ddtrace/llmobs/decorators.py
+++ b/ddtrace/llmobs/decorators.py
@@ -11,6 +11,7 @@ from typing import OrderedDict
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
 from ddtrace.llmobs._llmobs import LLMObsAnnotateSpanError
 from ddtrace.llmobs._utils import get_llmobs_output_messages
 from ddtrace.llmobs._utils import get_llmobs_output_value
@@ -22,7 +23,7 @@ log = get_logger(__name__)
 def _get_llmobs_span_options(name, model_name, func):
     traced_model_name = model_name
     if traced_model_name is None:
-        traced_model_name = "custom"
+        traced_model_name = UNKNOWN_MODEL_NAME
 
     span_name = name
     if span_name is None:

--- a/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
+++ b/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM spans to ``unknown`` if not provided or empty.

--- a/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
+++ b/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans to ``unknown`` if not provided or empty.
+    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans to ``unknown`` if not provided or empty. This applies to auto-instrumented spans, the ``LLMObs.llm()`` / ``LLMObs.embedding()`` manual instrumentation APIs, and the ``@llm`` / ``@embedding`` decorators. Previously these defaulted to ``custom``; any monitors or dashboards filtering on ``model_provider:custom`` against spans that relied on the default will need to be updated.

--- a/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
+++ b/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans from ``custom`` to ``unknown`` if not provided or empty.
+    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans from ``custom`` to ``unknown`` if not provided or empty. This applies to both auto-instrumented spans and manual instrumentation via ``LLMObs.llm()`` / ``LLMObs.embedding()`` and the ``@llm`` / ``@embedding`` decorators.

--- a/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
+++ b/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans to ``unknown`` if not provided or empty. This applies to auto-instrumented spans, the ``LLMObs.llm()`` / ``LLMObs.embedding()`` manual instrumentation APIs, and the ``@llm`` / ``@embedding`` decorators. Previously these defaulted to ``custom``; any monitors or dashboards filtering on ``model_provider:custom`` against spans that relied on the default will need to be updated.
+    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans from ``custom`` to ``unknown`` if not provided or empty.

--- a/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
+++ b/releasenotes/notes/fix-llmobs-model-default-cebbde303bbae020.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM spans to ``unknown`` if not provided or empty.
+    LLM Observability: Changes the default ``model_name`` and ``model_provider`` of LLM and embedding spans to ``unknown`` if not provided or empty.

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -183,7 +183,7 @@ class TestLLMObsClaudeAgentSdk:
         expected_llm_event = _expected_llmobs_llm_span_event(
             llm_span,
             span_kind="llm",
-            model_name="",
+            model_name="unknown",
             model_provider="anthropic",
             input_messages=[{"content": prompt, "role": "user"}],
             output_messages=[{"content": "", "role": ""}],

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -15,6 +15,8 @@ except ImportError:
 import ddtrace
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_span_name
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
@@ -221,11 +223,11 @@ def _expected_llmobs_llm_span_event(
     if not meta_dict["output"]:
         meta_dict.pop("output")
     if span_kind in ("llm", "embedding"):
-        meta_dict["model_name"] = model_name if model_name is not None else ""
-        meta_dict["model_provider"] = (model_provider or "custom").lower()
+        meta_dict["model_name"] = model_name if model_name is not None else UNKNOWN_MODEL_NAME
+        meta_dict["model_provider"] = (model_provider or UNKNOWN_MODEL_PROVIDER).lower()
     elif model_name is not None:
         meta_dict["model_name"] = model_name
-        meta_dict["model_provider"] = (model_provider or "custom").lower()
+        meta_dict["model_provider"] = (model_provider or UNKNOWN_MODEL_PROVIDER).lower()
     if tool_definitions is not None:
         meta_dict["tool_definitions"] = tool_definitions
     meta_dict.update({"metadata": metadata or {}})

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -10,6 +10,7 @@ from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs import LLMObsSpan
 from ddtrace.llmobs import _constants as const
 from ddtrace.llmobs._constants import LLMOBS_SUBMITTED_TAG_KEY
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_trace_id
@@ -356,13 +357,13 @@ def test_error_is_set(tracer, llmobs_events):
     assert 'raise ValueError("error")' in span_event["meta"]["error"]["stack"]
 
 
-def test_model_provider_defaults_to_custom(tracer, llmobs_events):
-    """Test that model provider defaults to "custom" if not provided."""
+def test_model_provider_defaults_to_unknown(tracer, llmobs_events):
+    """Test that model provider defaults to "unknown" if not provided."""
     with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
         _annotate_llmobs_span_data(llm_span, kind="llm", model_name="model_name")
     span_event = llmobs_events[0]
     assert span_event["meta"]["model_name"] == "model_name"
-    assert span_event["meta"]["model_provider"] == "custom"
+    assert span_event["meta"]["model_provider"] == UNKNOWN_MODEL_PROVIDER
 
 
 def test_model_not_set_if_not_llm_kind_span(tracer, llmobs_events):

--- a/tests/llmobs/test_llmobs_decorators.py
+++ b/tests/llmobs/test_llmobs_decorators.py
@@ -4,6 +4,8 @@ import mock
 import pytest
 
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs.decorators import agent
 from ddtrace.llmobs.decorators import embedding
 from ddtrace.llmobs.decorators import llm
@@ -82,7 +84,7 @@ def test_llm_decorator_no_model_name_sets_default(llmobs, llmobs_events, test_sp
     assert llmobs_events[0] == _expected_llmobs_llm_span_event(
         span,
         "llm",
-        model_name="custom",
+        model_name=UNKNOWN_MODEL_NAME,
         model_provider="test_provider",
         session_id="test_session_id",
         is_decorator=True,
@@ -97,7 +99,7 @@ def test_llm_decorator_default_kwargs(llmobs, llmobs_events, test_spans):
     f()
     span = test_spans.pop()[0]
     assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        span, "llm", model_name="custom", model_provider="custom", is_decorator=True
+        span, "llm", model_name=UNKNOWN_MODEL_NAME, model_provider=UNKNOWN_MODEL_PROVIDER, is_decorator=True
     )
 
 
@@ -130,7 +132,7 @@ def test_embedding_decorator_no_model_name_sets_default(llmobs, llmobs_events, t
     assert llmobs_events[0] == _expected_llmobs_llm_span_event(
         span,
         "embedding",
-        model_name="custom",
+        model_name=UNKNOWN_MODEL_NAME,
         model_provider="test_provider",
         session_id="test_session_id",
         is_decorator=True,
@@ -145,7 +147,7 @@ def test_embedding_decorator_default_kwargs(llmobs, llmobs_events, test_spans):
     f()
     span = test_spans.pop()[0]
     assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        span, "embedding", model_name="custom", model_provider="custom", is_decorator=True
+        span, "embedding", model_name=UNKNOWN_MODEL_NAME, model_provider=UNKNOWN_MODEL_PROVIDER, is_decorator=True
     )
 
 
@@ -504,7 +506,12 @@ def test_ml_app_override(llmobs, llmobs_events, test_spans):
     g()
     span = test_spans.pop()[0]
     assert llmobs_events[-1] == _expected_llmobs_llm_span_event(
-        span, "llm", model_name="test_model", model_provider="custom", tags={"ml_app": "test_ml_app"}, is_decorator=True
+        span,
+        "llm",
+        model_name="test_model",
+        model_provider=UNKNOWN_MODEL_PROVIDER,
+        tags={"ml_app": "test_ml_app"},
+        is_decorator=True,
     )
 
     @embedding(model_name="test_model", ml_app="test_ml_app")
@@ -517,7 +524,7 @@ def test_ml_app_override(llmobs, llmobs_events, test_spans):
         span,
         "embedding",
         model_name="test_model",
-        model_provider="custom",
+        model_provider=UNKNOWN_MODEL_PROVIDER,
         tags={"ml_app": "test_ml_app"},
         is_decorator=True,
     )
@@ -674,8 +681,8 @@ def test_generator_sync(llmobs, llmobs_events, test_spans):
                 decorator_name,
                 input_messages=[{"content": "hello"}],
                 output_messages=[{"content": "world"}],
-                model_name="custom",
-                model_provider="custom",
+                model_name=UNKNOWN_MODEL_NAME,
+                model_provider=UNKNOWN_MODEL_PROVIDER,
                 is_decorator=True,
             )
         elif decorator_name == "embedding":
@@ -684,8 +691,8 @@ def test_generator_sync(llmobs, llmobs_events, test_spans):
                 decorator_name,
                 input_documents=[{"text": "hello"}],
                 output_value="world",
-                model_name="custom",
-                model_provider="custom",
+                model_name=UNKNOWN_MODEL_NAME,
+                model_provider=UNKNOWN_MODEL_PROVIDER,
                 is_decorator=True,
             )
         elif decorator_name == "retrieval":
@@ -737,8 +744,8 @@ async def test_generator_async(llmobs, llmobs_events, test_spans):
                 decorator_name,
                 input_messages=[{"content": "hello"}],
                 output_messages=[{"content": "world"}],
-                model_name="custom",
-                model_provider="custom",
+                model_name=UNKNOWN_MODEL_NAME,
+                model_provider=UNKNOWN_MODEL_PROVIDER,
                 is_decorator=True,
             )
         elif decorator_name == "embedding":
@@ -747,8 +754,8 @@ async def test_generator_async(llmobs, llmobs_events, test_spans):
                 decorator_name,
                 input_documents=[{"text": "hello"}],
                 output_value="world",
-                model_name="custom",
-                model_provider="custom",
+                model_name=UNKNOWN_MODEL_NAME,
+                model_provider=UNKNOWN_MODEL_PROVIDER,
                 is_decorator=True,
             )
         elif decorator_name == "retrieval":

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -19,6 +19,8 @@ from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 from ddtrace.llmobs._constants import SUPPORTED_LLMOBS_INTEGRATIONS
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
+from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import get_llmobs_input_documents
 from ddtrace.llmobs._utils import get_llmobs_input_messages
@@ -350,21 +352,21 @@ def test_llm_span(llmobs, llmobs_events):
 
 def test_llm_span_no_model_sets_default(llmobs, llmobs_events):
     with llmobs.llm(name="test_llm_call", model_provider="test_provider") as span:
-        assert get_llmobs_model_name(span) == "custom"
+        assert get_llmobs_model_name(span) == UNKNOWN_MODEL_NAME
     assert len(llmobs_events) == 1
     assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        span, "llm", model_name="custom", model_provider="test_provider"
+        span, "llm", model_name=UNKNOWN_MODEL_NAME, model_provider="test_provider"
     )
 
 
-def test_default_model_provider_set_to_custom(llmobs):
+def test_default_model_provider_set_to_unknown(llmobs):
     with llmobs.llm(model_name="test_model", name="test_llm_call") as span:
         assert span.name == "test_llm_call"
         assert span.resource == "llm"
         assert span.span_type == "llm"
         assert get_llmobs_span_kind(span) == "llm"
         assert get_llmobs_model_name(span) == "test_model"
-        assert get_llmobs_model_provider(span) == "custom"
+        assert get_llmobs_model_provider(span) == UNKNOWN_MODEL_PROVIDER
 
 
 def test_tool_span(llmobs, llmobs_events):
@@ -409,21 +411,21 @@ def test_agent_span(llmobs, llmobs_events):
 
 def test_embedding_span_no_model_sets_default(llmobs, llmobs_events):
     with llmobs.embedding(name="test_embedding", model_provider="test_provider") as span:
-        assert get_llmobs_model_name(span) == "custom"
+        assert get_llmobs_model_name(span) == UNKNOWN_MODEL_NAME
     assert len(llmobs_events) == 1
     assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        span, "embedding", model_name="custom", model_provider="test_provider"
+        span, "embedding", model_name=UNKNOWN_MODEL_NAME, model_provider="test_provider"
     )
 
 
-def test_embedding_default_model_provider_set_to_custom(llmobs):
+def test_embedding_default_model_provider_set_to_unknown(llmobs):
     with llmobs.embedding(model_name="test_model", name="test_embedding") as span:
         assert span.name == "test_embedding"
         assert span.resource == "embedding"
         assert span.span_type == "llm"
         assert get_llmobs_span_kind(span) == "embedding"
         assert get_llmobs_model_name(span) == "test_model"
-        assert get_llmobs_model_provider(span) == "custom"
+        assert get_llmobs_model_provider(span) == UNKNOWN_MODEL_PROVIDER
 
 
 def test_embedding_span(llmobs, llmobs_events):
@@ -944,13 +946,13 @@ def test_ml_app_override(llmobs, llmobs_events):
         pass
     assert len(llmobs_events) == 3
     assert llmobs_events[2] == _expected_llmobs_llm_span_event(
-        span, "llm", model_name="model_name", model_provider="custom", tags={"ml_app": "test_app"}
+        span, "llm", model_name="model_name", model_provider=UNKNOWN_MODEL_PROVIDER, tags={"ml_app": "test_app"}
     )
     with llmobs.embedding(model_name="model_name", name="test_embedding", ml_app="test_app") as span:
         pass
     assert len(llmobs_events) == 4
     assert llmobs_events[3] == _expected_llmobs_llm_span_event(
-        span, "embedding", model_name="model_name", model_provider="custom", tags={"ml_app": "test_app"}
+        span, "embedding", model_name="model_name", model_provider=UNKNOWN_MODEL_PROVIDER, tags={"ml_app": "test_app"}
     )
     with llmobs.workflow(name="test_workflow", ml_app="test_app") as span:
         pass


### PR DESCRIPTION
[MLOB-6633]

## Description

Extracted from #17235 to narrow review scope. This PR changes the default `model_name` and `model_provider` for LLM and embedding spans from `""` / `"custom"` to the shared `UNKNOWN_MODEL_NAME` / `UNKNOWN_MODEL_PROVIDER` constants (both `"unknown"`) consistently across every entry point:

- Auto-instrumentation fallback in `_build_span_meta` (`ddtrace/llmobs/_llmobs.py`)
- Manual instrumentation APIs `LLMObs.llm()` and `LLMObs.embedding()`
- Decorator helper `_get_llmobs_span_options` used by `@llm` and `@embedding`

Previously these sites independently defaulted to `""` or `"custom"`; unifying them prevents the inconsistency where the same "no provider specified" signal would surface as `"custom"` through the manual APIs but `"unknown"` through the auto-instrumentation path.

## Testing

- `tests/llmobs/test_llmobs_service.py`: renamed `test_default_model_provider_set_to_custom` → `..._unknown` (same for embedding), updated `test_llm_span_no_model_sets_default` / `test_embedding_span_no_model_sets_default` / `test_ml_app_override` to assert the new default via the `UNKNOWN_MODEL_NAME` / `UNKNOWN_MODEL_PROVIDER` constants.
- `tests/llmobs/test_llmobs.py`: renamed `test_model_provider_defaults_to_custom` → `..._unknown`, updated to use the constant.
- `tests/llmobs/test_llmobs_decorators.py`: updated 8 assertion sites to use the constants.
- `tests/llmobs/_utils.py`: helper uses the constants.
- `tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py`: assertion fix for auto-instrumented default.

## Risks

**Customer-visible behavior change.** Any monitor or dashboard filtering `model_provider:custom` against spans that relied on the default — whether from auto-instrumentation, manual `LLMObs.llm()` / `LLMObs.embedding()` calls, or the `@llm` / `@embedding` decorators — will stop matching once those spans start emitting `"unknown"`. The release note calls this out; users filtering explicitly by a non-default provider value are unaffected.

Public API docstrings on `LLMObs.llm()` and `LLMObs.embedding()` are updated to document the new default, but the function signatures are unchanged (no caller code needs to change).

## Additional Notes

Part of a 3-PR split of #17235. Order:
1. **This PR** — default model=unknown (S)
2. #17684 — trace/parent IDs as strings (M)
3. #17685 — initialize tags and span name at span start (L, stacked on #17684)

Claude session: `da6fb254-912e-4d04-aec2-ed09cd1980ac`
Resume: `claude --resume da6fb254-912e-4d04-aec2-ed09cd1980ac`

[MLOB-6633]: https://datadoghq.atlassian.net/browse/MLOB-6633