### PR TITLE
chore(llmobs): store trace/parent IDs as strings

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock_agents.py
+++ b/ddtrace/llmobs/_integrations/bedrock_agents.py
@@ -58,16 +58,14 @@ def _build_span_event(
     if span_id is None:
         span_id = generate_128bit_trace_id()
     apm_trace_id = format_trace_id(root_span.trace_id)
-    llmobs_trace_id = get_llmobs_trace_id(root_span)
-    if llmobs_trace_id is None:
-        llmobs_trace_id = root_span.trace_id
+    llmobs_trace_id_str = get_llmobs_trace_id(root_span) or apm_trace_id
     session_id = get_llmobs_session_id(root_span)
     ml_app = get_llmobs_ml_app(root_span)
     tags = [f"ml_app:{ml_app}", f"session_id:{session_id}", "integration:bedrock_agents"]
     span_event: LLMObsSpanEvent = {
         "name": span_name,
         "span_id": str(span_id),
-        "trace_id": format_trace_id(llmobs_trace_id),
+        "trace_id": llmobs_trace_id_str,
         "parent_id": str(parent_id or root_span.span_id),
         "tags": tags,
         "start_ns": int(start_ns or root_span.start_ns),
@@ -83,7 +81,7 @@ def _build_span_event(
         "metrics": {},
         "_dd": {
             "span_id": str(span_id),
-            "trace_id": format_trace_id(llmobs_trace_id),
+            "trace_id": llmobs_trace_id_str,
             "apm_trace_id": apm_trace_id,
         },
     }

--- a/ddtrace/llmobs/_integrations/crewai.py
+++ b/ddtrace/llmobs/_integrations/crewai.py
@@ -513,6 +513,6 @@ def _get_crew_id(span, operation):
         return f"crew_{span.trace_id}_{span.span_id}"
     if operation == "task":
         parent_id = get_llmobs_parent_id(span)
-        parent_id = str(parent_id) if parent_id is not None else span.parent_id
+        parent_id = parent_id if parent_id is not None else span.parent_id
         return f"crew_{span.trace_id}_{parent_id}"
     return f"{span.trace_id}"

--- a/ddtrace/llmobs/_integrations/crewai.py
+++ b/ddtrace/llmobs/_integrations/crewai.py
@@ -513,6 +513,7 @@ def _get_crew_id(span, operation):
         return f"crew_{span.trace_id}_{span.span_id}"
     if operation == "task":
         parent_id = get_llmobs_parent_id(span)
-        parent_id = parent_id if parent_id is not None else span.parent_id
+        if parent_id is None:
+            parent_id = span.parent_id
         return f"crew_{span.trace_id}_{parent_id}"
     return f"{span.trace_id}"

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -539,7 +539,7 @@ def _default_span_link(span: Span) -> _SpanLink:
     """
     parent_id = get_llmobs_parent_id(span)
     return _SpanLink(
-        span_id=str(parent_id) if parent_id is not None else ROOT_PARENT_ID,
+        span_id=parent_id or ROOT_PARENT_ID,
         trace_id=format_trace_id(span.trace_id),
         attributes={"from": "input", "to": "input"},
     )

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -136,13 +136,13 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         if not trace_info:
             return
         parent_id = get_llmobs_parent_id(llmobs_span)
-        if oai_span.span_type == "agent" and parent_id is not None and str(parent_id) == trace_info.span_id:
+        if oai_span.span_type == "agent" and parent_id == trace_info.span_id:
             trace_info.current_top_level_agent_span_id = str(llmobs_span.span_id)
         if (
             oai_span.span_type == "response"
             and parent_id is not None
             and not trace_info.input_oai_span
-            and str(parent_id) == trace_info.current_top_level_agent_span_id
+            and parent_id == trace_info.current_top_level_agent_span_id
         ):
             trace_info.input_oai_span = oai_span
 
@@ -163,7 +163,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         current_top_level_agent_span_id = trace_info.current_top_level_agent_span_id
         if (
             current_top_level_agent_span_id
-            and str(get_llmobs_parent_id(llmobs_span)) == current_top_level_agent_span_id
+            and get_llmobs_parent_id(llmobs_span) == current_top_level_agent_span_id
         ):
             trace_info.output_oai_span = oai_span
 
@@ -197,7 +197,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         name = None
         parent = _get_nearest_llmobs_ancestor(span)
         trace_info = self._llmobs_get_trace_info(oai_span)
-        if parent and trace_info and str(get_llmobs_parent_id(span)) == trace_info.current_top_level_agent_span_id:
+        if parent and trace_info and get_llmobs_parent_id(span) == trace_info.current_top_level_agent_span_id:
             name = _get_span_name(parent) + " (LLM)"
 
         input_messages = None

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -14,6 +14,7 @@ from ddtrace.llmobs._constants import DISPATCH_ON_OPENAI_AGENT_SPAN_FINISH
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
 from ddtrace.llmobs._constants import OAI_HANDOFF_TOOL_ARG
+from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import LLMObsTraceInfo
 from ddtrace.llmobs._integrations.utils import OaiSpanAdapter
@@ -140,7 +141,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             trace_info.current_top_level_agent_span_id = str(llmobs_span.span_id)
         if (
             oai_span.span_type == "response"
-            and parent_id is not None
+            and parent_id != ROOT_PARENT_ID
             and not trace_info.input_oai_span
             and parent_id == trace_info.current_top_level_agent_span_id
         ):
@@ -161,10 +162,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             return
 
         current_top_level_agent_span_id = trace_info.current_top_level_agent_span_id
-        if (
-            current_top_level_agent_span_id
-            and get_llmobs_parent_id(llmobs_span) == current_top_level_agent_span_id
-        ):
+        if current_top_level_agent_span_id and get_llmobs_parent_id(llmobs_span) == current_top_level_agent_span_id:
             trace_info.output_oai_span = oai_span
 
     def _llmobs_set_trace_attributes(self, span: Span, oai_trace: OaiTraceAdapter) -> None:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1874,19 +1874,21 @@ class LLMObs(Service):
     def _current_trace_context(self) -> Optional[Context]:
         """Returns the context for the current LLMObs trace.
 
-        The returned Context is re-activated as a parent for spans created in another
-        thread/task, so `PROPAGATED_LLMOBS_TRACE_ID_KEY` is written in canonical hex
-        (storage format). Wire-format conversion happens in `_inject_llmobs_context`
-        for outbound HTTP injection only.
+        Invariant: `PROPAGATED_LLMOBS_TRACE_ID_KEY` on `Context._meta` always holds
+        the wire-format (decimal) trace_id. The APM HTTP propagator can serialize
+        this slot directly into the `x-datadog-tags` header, and `_dd.p.*` is
+        dd-trace's namespace for wire-propagated tags. Conversion to canonical hex
+        is deferred to `_activate_llmobs_span` (Context-parent branch) when the
+        value is read into `meta_struct`.
         """
         active = self._llmobs_context_provider.active()
         if isinstance(active, Context):
             return active
         elif isinstance(active, Span):
             context = active.context
-            trace_id = get_llmobs_trace_id(active) or format_trace_id(active.trace_id)
-            if trace_id:
-                context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = trace_id
+            wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active) or format_trace_id(active.trace_id))
+            if wire_trace_id:
+                context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
             return context
         return None
 
@@ -1902,11 +1904,13 @@ class LLMObs(Service):
                 parent_llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
                 fallback_trace_id = format_trace_id(llmobs_parent.trace_id)
             else:
-                # Invariant: writers of PROPAGATED_LLMOBS_TRACE_ID_KEY on a Context used as
-                # an LLMObs parent (`_activate_llmobs_distributed_context`, `_current_trace_context`)
-                # always store canonical hex, so we can read it directly.
+                # `Context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY]` holds wire-format (decimal)
+                # by invariant — it's the slot the APM HTTP propagator (de)serializes. Convert
+                # to canonical hex here at the read boundary into `meta_struct`.
                 # ast-grep-ignore: span-meta-access
-                parent_llmobs_trace_id = llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
+                parent_llmobs_trace_id = _normalize_wire_trace_id_to_hex(
+                    llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
+                )
                 # Context.trace_id is Optional[int]; fall back to a fresh ID rather than an all-zeros placeholder.
                 fallback_trace_id = format_trace_id(llmobs_parent.trace_id or generate_128bit_trace_id())
             llmobs_trace_id = parent_llmobs_trace_id or fallback_trace_id
@@ -2834,21 +2838,22 @@ class LLMObs(Service):
                 log.warning("Failed to parse LLMObs parent ID from request headers.")
                 return
             parent_llmobs_trace_id = context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
+            # `PROPAGATED_LLMOBS_TRACE_ID_KEY` on `Context._meta` is wire-format (decimal).
+            # Store the inbound value as-is and defer normalization to the reader
+            # (`_activate_llmobs_span`, Context-parent branch) so we never apply
+            # `_normalize_wire_trace_id_to_hex` more than once on the same value.
             if parent_llmobs_trace_id is None:
                 log.debug(
                     "Failed to extract LLMObs trace ID from request headers. Expected string, got None. "
                     "Defaulting to the corresponding APM trace ID."
                 )
                 llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
-                llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = format_trace_id(context.trace_id)
+                llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(context.trace_id)
                 cls._instance._llmobs_context_provider.activate(llmobs_context)
                 error = "missing_parent_llmobs_trace_id"
                 return
             llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
-            normalized_trace_id = _normalize_wire_trace_id_to_hex(str(parent_llmobs_trace_id))
-            llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = (
-                normalized_trace_id if normalized_trace_id is not None else format_trace_id(context.trace_id)
-            )
+            llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(parent_llmobs_trace_id)
             cls._instance._llmobs_context_provider.activate(llmobs_context)
         finally:
             telemetry.record_activate_distributed_headers(error)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -123,6 +123,8 @@ from ddtrace.llmobs._utils import _batched
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import _get_parent_prompt
 from ddtrace.llmobs._utils import _get_span_name
+from ddtrace.llmobs._utils import _normalize_trace_id_to_hex
+from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
 from ddtrace.llmobs._utils import add_span_link
 from ddtrace.llmobs._utils import enforce_message_role
@@ -572,8 +574,10 @@ class LLMObs(Service):
         if span.context.get_baggage_item(EXPERIMENT_ID_KEY):
             _dd_attrs["scope"] = "experiments"
 
+        submitted_trace_id = _normalize_trace_id_to_hex(llmobs_trace_id) or llmobs_trace_id
+
         llmobs_span_event: LLMObsSpanEvent = {
-            "trace_id": llmobs_trace_id,
+            "trace_id": submitted_trace_id,
             "span_id": str(span.span_id),
             "parent_id": parent_id,
             "name": _get_span_name(span),
@@ -1858,9 +1862,9 @@ class LLMObs(Service):
             return active
         elif isinstance(active, Span):
             context = active.context
-            context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = get_llmobs_trace_id(active) or format_trace_id(
-                active.trace_id
-            )
+            wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active) or format_trace_id(active.trace_id))
+            if wire_trace_id:
+                context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
             return context
         return None
 
@@ -1872,12 +1876,14 @@ class LLMObs(Service):
         llmobs_parent = self._llmobs_context_provider.active()
         if llmobs_parent:
             parent_id = str(llmobs_parent.span_id)
-            parent_llmobs_trace_id = (
-                get_llmobs_trace_id(llmobs_parent)
-                if isinstance(llmobs_parent, Span)
-                # ast-grep-ignore: span-meta-access
-                else llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
-            )
+            if isinstance(llmobs_parent, Span):
+                parent_llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
+            else:
+                # Upstream wire value may be decimal (older SDKs) or hex; normalize to hex.
+                parent_llmobs_trace_id = _normalize_trace_id_to_hex(
+                    # ast-grep-ignore: span-meta-access
+                    llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
+                )
             llmobs_trace_id = (
                 parent_llmobs_trace_id
                 if parent_llmobs_trace_id is not None
@@ -2740,7 +2746,9 @@ class LLMObs(Service):
             llmobs_trace_id = format_trace_id(generate_128bit_trace_id())
 
         span_context._meta[PROPAGATED_PARENT_ID_KEY] = parent_id
-        span_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = llmobs_trace_id
+        wire_trace_id = _trace_id_to_wire(llmobs_trace_id)
+        if wire_trace_id:
+            span_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
 
         if ml_app is not None:
             span_context._meta[PROPAGATED_ML_APP_KEY] = ml_app
@@ -2816,7 +2824,10 @@ class LLMObs(Service):
                 error = "missing_parent_llmobs_trace_id"
                 return
             llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
-            llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(parent_llmobs_trace_id)
+            normalized_trace_id = _normalize_trace_id_to_hex(str(parent_llmobs_trace_id))
+            llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = (
+                normalized_trace_id if normalized_trace_id is not None else format_trace_id(context.trace_id)
+            )
             cls._instance._llmobs_context_provider.activate(llmobs_context)
         finally:
             telemetry.record_activate_distributed_headers(error)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -125,7 +125,7 @@ from ddtrace.llmobs._utils import _batched
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import _get_parent_prompt
 from ddtrace.llmobs._utils import _get_span_name
-from ddtrace.llmobs._utils import _normalize_trace_id_to_hex
+from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
 from ddtrace.llmobs._utils import add_span_link
@@ -578,10 +578,12 @@ class LLMObs(Service):
         if span.context.get_baggage_item(EXPERIMENT_ID_KEY):
             _dd_attrs["scope"] = "experiments"
 
-        submitted_trace_id = _normalize_trace_id_to_hex(llmobs_trace_id) or llmobs_trace_id
-
+        # llmobs_trace_id is already canonical hex from meta_struct. Do NOT re-normalize:
+        # _normalize_wire_trace_id_to_hex expects wire-format input and is non-idempotent on
+        # the rare 32-char all-[0-9] hex with no leading zero — it would mangle such values
+        # by reinterpreting them as decimal.
         llmobs_span_event: LLMObsSpanEvent = {
-            "trace_id": submitted_trace_id,
+            "trace_id": llmobs_trace_id,
             "span_id": str(span.span_id),
             "parent_id": parent_id,
             "name": _get_span_name(span),
@@ -2843,7 +2845,7 @@ class LLMObs(Service):
                 error = "missing_parent_llmobs_trace_id"
                 return
             llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
-            normalized_trace_id = _normalize_trace_id_to_hex(str(parent_llmobs_trace_id))
+            normalized_trace_id = _normalize_wire_trace_id_to_hex(str(parent_llmobs_trace_id))
             llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = (
                 normalized_trace_id if normalized_trace_id is not None else format_trace_id(context.trace_id)
             )

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1878,17 +1878,18 @@ class LLMObs(Service):
             parent_id = str(llmobs_parent.span_id)
             if isinstance(llmobs_parent, Span):
                 parent_llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
+                # Span.trace_id is always an int.
+                fallback_trace_id = format_trace_id(llmobs_parent.trace_id)
             else:
                 # Upstream wire value may be decimal (older SDKs) or hex; normalize to hex.
                 parent_llmobs_trace_id = _normalize_trace_id_to_hex(
                     # ast-grep-ignore: span-meta-access
                     llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
                 )
-            llmobs_trace_id = (
-                parent_llmobs_trace_id
-                if parent_llmobs_trace_id is not None
-                else format_trace_id(llmobs_parent.trace_id or 0)
-            )
+                # Context.trace_id can be None if the Context was constructed without one;
+                # mint a fresh trace_id rather than emit an all-zeros placeholder.
+                fallback_trace_id = format_trace_id(llmobs_parent.trace_id or generate_128bit_trace_id())
+            llmobs_trace_id = parent_llmobs_trace_id or fallback_trace_id
             if isinstance(llmobs_parent, Span):
                 ml_app = llmobs_parent._get_ctx_item(ML_APP)
                 session_id = llmobs_parent._get_ctx_item(SESSION_ID)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1892,11 +1892,10 @@ class LLMObs(Service):
                 ml_app = llmobs_parent._get_ctx_item(ML_APP)
                 session_id = llmobs_parent._get_ctx_item(SESSION_ID)
             else:
+                parent_ctx = llmobs_parent
                 # We store LLMObs trace ID on span context as decimal strings for distributed context propagation
-                llmobs_trace_id = _normalize_wire_trace_id_to_hex(
-                    llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
-                )
-                ml_app = llmobs_parent._meta.get(PROPAGATED_ML_APP_KEY)
+                llmobs_trace_id = _normalize_wire_trace_id_to_hex(parent_ctx._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY))
+                ml_app = parent_ctx._meta.get(PROPAGATED_ML_APP_KEY)
                 session_id = None
         else:
             parent_id = ROOT_PARENT_ID

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1887,7 +1887,7 @@ class LLMObs(Service):
             llmobs_trace_id = (
                 parent_llmobs_trace_id
                 if parent_llmobs_trace_id is not None
-                else format_trace_id(llmobs_parent.trace_id)
+                else format_trace_id(llmobs_parent.trace_id or 0)
             )
             if isinstance(llmobs_parent, Span):
                 ml_app = llmobs_parent._get_ctx_item(ML_APP)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -542,7 +542,9 @@ class LLMObs(Service):
         if not span_kind:
             raise KeyError("Span kind not found in span context")
 
-        parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID) or ROOT_PARENT_ID
+        parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID)
+        if parent_id is None:
+            raise ValueError("Failed to extract LLMObs parent ID from span context.")
         llmobs_trace_id = llmobs_data.get(LLMOBS_STRUCT.TRACE_ID)
         if llmobs_trace_id is None:
             raise ValueError("Failed to extract LLMObs trace ID from span context.")
@@ -1856,7 +1858,9 @@ class LLMObs(Service):
             return active
         elif isinstance(active, Span):
             context = active.context
-            context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = get_llmobs_trace_id(active) or format_trace_id(active.trace_id)
+            context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = get_llmobs_trace_id(active) or format_trace_id(
+                active.trace_id
+            )
             return context
         return None
 
@@ -1887,7 +1891,8 @@ class LLMObs(Service):
                 session_id = None
         else:
             llmobs_trace_id = format_trace_id(generate_128bit_trace_id())
-            parent_id, ml_app, session_id = None, None, None
+            parent_id = ROOT_PARENT_ID
+            ml_app, session_id = None, None
         ml_app = resolve_ml_app(ml_app or span.context._meta.get(PROPAGATED_ML_APP_KEY))
         _annotate_llmobs_span_data(
             span, parent_id=parent_id, trace_id=llmobs_trace_id, ml_app=ml_app, session_id=session_id
@@ -2726,7 +2731,9 @@ class LLMObs(Service):
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
             _propagated_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or None
             llmobs_trace_id = (
-                _propagated_trace_id if _propagated_trace_id is not None else format_trace_id(generate_128bit_trace_id())
+                _propagated_trace_id
+                if _propagated_trace_id is not None
+                else format_trace_id(generate_128bit_trace_id())
             )
         else:
             ml_app = resolve_ml_app()
@@ -2804,7 +2811,7 @@ class LLMObs(Service):
                     "Defaulting to the corresponding APM trace ID."
                 )
                 llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
-                llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(context.trace_id)
+                llmobs_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = format_trace_id(context.trace_id)
                 cls._instance._llmobs_context_provider.activate(llmobs_context)
                 error = "missing_parent_llmobs_trace_id"
                 return

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -542,8 +542,7 @@ class LLMObs(Service):
         if not span_kind:
             raise KeyError("Span kind not found in span context")
 
-        raw_parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID)
-        parent_id = str(raw_parent_id) if raw_parent_id is not None else ROOT_PARENT_ID
+        parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID) or ROOT_PARENT_ID
         llmobs_trace_id = llmobs_data.get(LLMOBS_STRUCT.TRACE_ID)
         if llmobs_trace_id is None:
             raise ValueError("Failed to extract LLMObs trace ID from span context.")
@@ -572,7 +571,7 @@ class LLMObs(Service):
             _dd_attrs["scope"] = "experiments"
 
         llmobs_span_event: LLMObsSpanEvent = {
-            "trace_id": format_trace_id(llmobs_trace_id),
+            "trace_id": llmobs_trace_id,
             "span_id": str(span.span_id),
             "parent_id": parent_id,
             "name": _get_span_name(span),
@@ -1834,7 +1833,7 @@ class LLMObs(Service):
                 raise LLMObsExportSpanError("Span must be an LLMObs-generated span.")
             return ExportedLLMObsSpan(
                 span_id=str(span.span_id),
-                trace_id=format_trace_id(get_llmobs_trace_id(span) or span.trace_id),
+                trace_id=get_llmobs_trace_id(span) or format_trace_id(span.trace_id),
             )
         except (TypeError, AttributeError):
             error = "invalid_span"
@@ -1857,7 +1856,7 @@ class LLMObs(Service):
             return active
         elif isinstance(active, Span):
             context = active.context
-            context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(get_llmobs_trace_id(active) or active.trace_id)
+            context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = get_llmobs_trace_id(active) or format_trace_id(active.trace_id)
             return context
         return None
 
@@ -1868,7 +1867,7 @@ class LLMObs(Service):
         """
         llmobs_parent = self._llmobs_context_provider.active()
         if llmobs_parent:
-            parent_id = llmobs_parent.span_id
+            parent_id = str(llmobs_parent.span_id)
             parent_llmobs_trace_id = (
                 get_llmobs_trace_id(llmobs_parent)
                 if isinstance(llmobs_parent, Span)
@@ -1876,7 +1875,9 @@ class LLMObs(Service):
                 else llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
             )
             llmobs_trace_id = (
-                int(parent_llmobs_trace_id) if parent_llmobs_trace_id is not None else llmobs_parent.trace_id
+                parent_llmobs_trace_id
+                if parent_llmobs_trace_id is not None
+                else format_trace_id(llmobs_parent.trace_id)
             )
             if isinstance(llmobs_parent, Span):
                 ml_app = llmobs_parent._get_ctx_item(ML_APP)
@@ -1885,7 +1886,7 @@ class LLMObs(Service):
                 ml_app = llmobs_parent._meta.get(PROPAGATED_ML_APP_KEY)  # ast-grep-ignore: span-meta-access
                 session_id = None
         else:
-            llmobs_trace_id = generate_128bit_trace_id()
+            llmobs_trace_id = format_trace_id(generate_128bit_trace_id())
             parent_id, ml_app, session_id = None, None, None
         ml_app = resolve_ml_app(ml_app or span.context._meta.get(PROPAGATED_ML_APP_KEY))
         _annotate_llmobs_span_data(
@@ -1894,7 +1895,7 @@ class LLMObs(Service):
         # Tag the local root so the backend OTel trace processor can connect OTel gen_ai spans
         # to this LLMObs trace
         if span._local_root.get_tag("llmobs_trace_id") is None:
-            span._local_root.set_tag("llmobs_trace_id", format_trace_id(llmobs_trace_id))  # type: ignore[arg-type]
+            span._local_root.set_tag("llmobs_trace_id", llmobs_trace_id)
             span._local_root.set_tag("llmobs_parent_id", str(span.span_id))
         self._llmobs_context_provider.activate(span)
 
@@ -2725,14 +2726,14 @@ class LLMObs(Service):
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
             _propagated_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or None
             llmobs_trace_id = (
-                int(_propagated_trace_id) if _propagated_trace_id is not None else generate_128bit_trace_id()
+                _propagated_trace_id if _propagated_trace_id is not None else format_trace_id(generate_128bit_trace_id())
             )
         else:
             ml_app = resolve_ml_app()
-            llmobs_trace_id = generate_128bit_trace_id()
+            llmobs_trace_id = format_trace_id(generate_128bit_trace_id())
 
         span_context._meta[PROPAGATED_PARENT_ID_KEY] = parent_id
-        span_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = str(llmobs_trace_id)
+        span_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = llmobs_trace_id
 
         if ml_app is not None:
             span_context._meta[PROPAGATED_ML_APP_KEY] = ml_app

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2756,22 +2756,20 @@ class LLMObs(Service):
 
         ml_app = None
         if isinstance(active_span, Span):
+            # meta_struct holds canonical hex; convert to wire format for the header.
             ml_app = get_llmobs_ml_app(active_span)
-            llmobs_trace_id = get_llmobs_trace_id(active_span)
+            wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active_span))
         elif active_context is not None:
+            # Context._meta holds wire format by invariant — read directly.
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
-            _propagated_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or None
-            llmobs_trace_id = (
-                _propagated_trace_id
-                if _propagated_trace_id is not None
-                else format_trace_id(generate_128bit_trace_id())
+            wire_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or str(
+                generate_128bit_trace_id()
             )
         else:
             ml_app = resolve_ml_app()
-            llmobs_trace_id = format_trace_id(generate_128bit_trace_id())
+            wire_trace_id = str(generate_128bit_trace_id())
 
         span_context._meta[PROPAGATED_PARENT_ID_KEY] = parent_id
-        wire_trace_id = _trace_id_to_wire(llmobs_trace_id)
         if wire_trace_id:
             span_context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1892,16 +1892,13 @@ class LLMObs(Service):
             parent_id = str(llmobs_parent.span_id)
             if isinstance(llmobs_parent, Span):
                 parent_llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
-                # Span.trace_id is always an int.
                 fallback_trace_id = format_trace_id(llmobs_parent.trace_id)
             else:
-                # Upstream wire value may be decimal (older SDKs) or hex; normalize to hex.
                 parent_llmobs_trace_id = _normalize_trace_id_to_hex(
                     # ast-grep-ignore: span-meta-access
                     llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
                 )
-                # Context.trace_id can be None if the Context was constructed without one;
-                # mint a fresh trace_id rather than emit an all-zeros placeholder.
+                # Context.trace_id is Optional[int]; fall back to a fresh ID rather than an all-zeros placeholder.
                 fallback_trace_id = format_trace_id(llmobs_parent.trace_id or generate_128bit_trace_id())
             llmobs_trace_id = parent_llmobs_trace_id or fallback_trace_id
             if isinstance(llmobs_parent, Span):

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1870,15 +1870,21 @@ class LLMObs(Service):
         return active if isinstance(active, Span) else None
 
     def _current_trace_context(self) -> Optional[Context]:
-        """Returns the context for the current LLMObs trace."""
+        """Returns the context for the current LLMObs trace.
+
+        The returned Context is re-activated as a parent for spans created in another
+        thread/task, so `PROPAGATED_LLMOBS_TRACE_ID_KEY` is written in canonical hex
+        (storage format). Wire-format conversion happens in `_inject_llmobs_context`
+        for outbound HTTP injection only.
+        """
         active = self._llmobs_context_provider.active()
         if isinstance(active, Context):
             return active
         elif isinstance(active, Span):
             context = active.context
-            wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active) or format_trace_id(active.trace_id))
-            if wire_trace_id:
-                context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
+            trace_id = get_llmobs_trace_id(active) or format_trace_id(active.trace_id)
+            if trace_id:
+                context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = trace_id
             return context
         return None
 
@@ -1894,10 +1900,11 @@ class LLMObs(Service):
                 parent_llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
                 fallback_trace_id = format_trace_id(llmobs_parent.trace_id)
             else:
-                parent_llmobs_trace_id = _normalize_trace_id_to_hex(
-                    # ast-grep-ignore: span-meta-access
-                    llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
-                )
+                # Invariant: writers of PROPAGATED_LLMOBS_TRACE_ID_KEY on a Context used as
+                # an LLMObs parent (`_activate_llmobs_distributed_context`, `_current_trace_context`)
+                # always store canonical hex, so we can read it directly.
+                # ast-grep-ignore: span-meta-access
+                parent_llmobs_trace_id = llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
                 # Context.trace_id is Optional[int]; fall back to a fresh ID rather than an all-zeros placeholder.
                 fallback_trace_id = format_trace_id(llmobs_parent.trace_id or generate_128bit_trace_id())
             llmobs_trace_id = parent_llmobs_trace_id or fallback_trace_id

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -578,10 +578,6 @@ class LLMObs(Service):
         if span.context.get_baggage_item(EXPERIMENT_ID_KEY):
             _dd_attrs["scope"] = "experiments"
 
-        # llmobs_trace_id is already canonical hex from meta_struct. Do NOT re-normalize:
-        # _normalize_wire_trace_id_to_hex expects wire-format input and is non-idempotent on
-        # the rare 32-char all-[0-9] hex with no leading zero — it would mangle such values
-        # by reinterpreting them as decimal.
         llmobs_span_event: LLMObsSpanEvent = {
             "trace_id": llmobs_trace_id,
             "span_id": str(span.span_id),
@@ -1872,23 +1868,15 @@ class LLMObs(Service):
         return active if isinstance(active, Span) else None
 
     def _current_trace_context(self) -> Optional[Context]:
-        """Returns the context for the current LLMObs trace.
-
-        Invariant: `PROPAGATED_LLMOBS_TRACE_ID_KEY` on `Context._meta` always holds
-        the wire-format (decimal) trace_id. The APM HTTP propagator can serialize
-        this slot directly into the `x-datadog-tags` header, and `_dd.p.*` is
-        dd-trace's namespace for wire-propagated tags. Conversion to canonical hex
-        is deferred to `_activate_llmobs_span` (Context-parent branch) when the
-        value is read into `meta_struct`.
-        """
+        """Returns the context for the current LLMObs trace."""
         active = self._llmobs_context_provider.active()
         if isinstance(active, Context):
             return active
         elif isinstance(active, Span):
+            # We store LLMObs trace ID on span context as decimal strings for distributed context propagation
             context = active.context
-            wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active) or format_trace_id(active.trace_id))
-            if wire_trace_id:
-                context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
+            wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active)) or str(active.trace_id)
+            context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
             return context
         return None
 
@@ -1901,29 +1889,20 @@ class LLMObs(Service):
         if llmobs_parent:
             parent_id = str(llmobs_parent.span_id)
             if isinstance(llmobs_parent, Span):
-                parent_llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
-                fallback_trace_id = format_trace_id(llmobs_parent.trace_id)
-            else:
-                # `Context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY]` holds wire-format (decimal)
-                # by invariant — it's the slot the APM HTTP propagator (de)serializes. Convert
-                # to canonical hex here at the read boundary into `meta_struct`.
-                # ast-grep-ignore: span-meta-access
-                parent_llmobs_trace_id = _normalize_wire_trace_id_to_hex(
-                    llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
-                )
-                # Context.trace_id is Optional[int]; fall back to a fresh ID rather than an all-zeros placeholder.
-                fallback_trace_id = format_trace_id(llmobs_parent.trace_id or generate_128bit_trace_id())
-            llmobs_trace_id = parent_llmobs_trace_id or fallback_trace_id
-            if isinstance(llmobs_parent, Span):
+                llmobs_trace_id = get_llmobs_trace_id(llmobs_parent)
                 ml_app = llmobs_parent._get_ctx_item(ML_APP)
                 session_id = llmobs_parent._get_ctx_item(SESSION_ID)
             else:
-                ml_app = llmobs_parent._meta.get(PROPAGATED_ML_APP_KEY)  # ast-grep-ignore: span-meta-access
+                # We store LLMObs trace ID on span context as decimal strings for distributed context propagation
+                llmobs_trace_id = _normalize_wire_trace_id_to_hex(
+                    llmobs_parent._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
+                )
+                ml_app = llmobs_parent._meta.get(PROPAGATED_ML_APP_KEY)
                 session_id = None
         else:
-            llmobs_trace_id = format_trace_id(generate_128bit_trace_id())
             parent_id = ROOT_PARENT_ID
-            ml_app, session_id = None, None
+            llmobs_trace_id, ml_app, session_id = None, None, None
+        llmobs_trace_id = llmobs_trace_id or format_trace_id(generate_128bit_trace_id())
         ml_app = resolve_ml_app(ml_app or span.context._meta.get(PROPAGATED_ML_APP_KEY))
         _annotate_llmobs_span_data(
             span, parent_id=parent_id, trace_id=llmobs_trace_id, ml_app=ml_app, session_id=session_id
@@ -2762,9 +2741,7 @@ class LLMObs(Service):
         elif active_context is not None:
             # Context._meta holds wire format by invariant — read directly.
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
-            wire_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or str(
-                generate_128bit_trace_id()
-            )
+            wire_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or str(generate_128bit_trace_id())
         else:
             ml_app = resolve_ml_app()
             wire_trace_id = str(generate_128bit_trace_id())

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -548,9 +548,8 @@ class LLMObs(Service):
         if not span_kind:
             raise KeyError("Span kind not found in span context")
 
-        parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID)
-        if parent_id is None:
-            raise ValueError("Failed to extract LLMObs parent ID from span context.")
+        parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID) or ROOT_PARENT_ID
+
         llmobs_trace_id = llmobs_data.get(LLMOBS_STRUCT.TRACE_ID)
         if llmobs_trace_id is None:
             raise ValueError("Failed to extract LLMObs trace ID from span context.")
@@ -2735,11 +2734,11 @@ class LLMObs(Service):
 
         ml_app = None
         if isinstance(active_span, Span):
-            # meta_struct holds canonical hex; convert to wire format for the header.
+            # meta_struct holds canonical hex so have to convert to decimal wire format
             ml_app = get_llmobs_ml_app(active_span)
             wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active_span))
         elif active_context is not None:
-            # Context._meta holds wire format by invariant — read directly.
+            # Context._meta always holds decimal wire format so we can read directly
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
             wire_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or str(generate_128bit_trace_id())
         else:

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -100,7 +100,7 @@ def record_span_started():
 
 
 def record_span_created(span: Span):
-    is_root_span = get_llmobs_parent_id(span) is None
+    is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
     has_session_id = get_llmobs_session_id(span) is not None
     integration = llmobs_tags.get("integration")
@@ -180,7 +180,7 @@ def record_llmobs_annotate(span: Optional[Span], error: Optional[str]):
     is_root_span = "0"
     if span and isinstance(span, Span):
         span_kind = get_llmobs_span_kind(span) or "N/A"
-        is_root_span = str(int(get_llmobs_parent_id(span) is None))
+        is_root_span = str(int(get_llmobs_parent_id(span) == ROOT_PARENT_ID))
     tags.extend([("span_kind", span_kind), ("is_root_span", is_root_span)])
     telemetry_writer.add_count_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.ANNOTATIONS, value=1, tags=tuple(tags)
@@ -213,7 +213,7 @@ def record_span_exported(span: Optional[Span], error: Optional[str]):
     is_root_span = "0"
     if span and isinstance(span, Span):
         span_kind = get_llmobs_span_kind(span) or "N/A"
-        is_root_span = str(int(get_llmobs_parent_id(span) is None))
+        is_root_span = str(int(get_llmobs_parent_id(span) == ROOT_PARENT_ID))
     tags.extend([("span_kind", span_kind), ("is_root_span", is_root_span)])
     telemetry_writer.add_count_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.SPANS_EXPORTED, value=1, tags=tuple(tags)

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -4,6 +4,7 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import is_dataclass
 import json
+import re
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
@@ -363,6 +364,58 @@ def get_llmobs_trace_id(span: Span) -> Optional[str]:
     llmobs_data = _get_llmobs_data_metastruct(span)
     trace_id = llmobs_data.get(LLMOBS_STRUCT.TRACE_ID)
     return trace_id
+
+
+_HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _normalize_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
+    """Normalize a trace_id into the canonical 32-char lowercase hex storage format.
+
+    - Canonical 32-char lowercase hex → return as-is.
+    - Decimal integer string → convert via ``format_trace_id`` (hex for 128-bit IDs,
+      pass-through for smaller ints).
+    - Empty string or ``None`` → return ``None``.
+    - Anything else (non-numeric custom ID from another SDK or manual user input) →
+      return as-is and log at debug. Cross-SDK trace joining may be affected but we
+      must not raise or corrupt the span.
+    """
+    if value is None or value == "":
+        return None
+    if _HEX_TRACE_ID_RE.match(value):
+        return value
+    try:
+        return format_trace_id(int(value))
+    except (ValueError, TypeError):
+        log.debug(
+            "LLMObs trace_id %r is neither 32-char hex nor a valid decimal integer; "
+            "storing as-is. Cross-SDK trace joining may be affected.",
+            value,
+        )
+        return value
+
+
+def _trace_id_to_wire(value: Optional[str]) -> Optional[str]:
+    """Convert a stored trace_id to the decimal wire format for cross-version compat.
+
+    Older dd-trace-py versions parse the ``_DD_LLMOBS_TRACE_ID`` header via ``int(x)``
+    without a base argument, which fails on any hex string with a-f characters. We
+    therefore keep the wire format as decimal and let each SDK normalize back to hex
+    internally on receive.
+
+    - Canonical 32-char lowercase hex → ``str(int(value, 16))`` → decimal.
+    - Already-decimal or non-hex → return as-is.
+    - Empty / ``None`` → return ``None``.
+    """
+    if not value:
+        return None
+    if _HEX_TRACE_ID_RE.match(value):
+        try:
+            return str(int(value, 16))
+        except ValueError:
+            log.debug("Failed to convert hex LLMObs trace_id %r to decimal; sending as-is.", value)
+            return value
+    return value
 
 
 def get_llmobs_tags(span: Span) -> Optional[dict[str, str]]:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -402,7 +402,7 @@ def _trace_id_to_wire(value: Optional[str]) -> Optional[str]:
     """
     if not value:
         return None
-    if _HEX_TRACE_ID_RE.match(value):
+    if _HEX_TRACE_ID_RE.match(value.lower()):
         try:
             return str(int(value, 16))
         except ValueError:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -370,22 +370,14 @@ _HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 
 
 def _normalize_wire_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
-    """Normalize a wire-format trace_id to canonical 32-char hex storage.
-
-    Safe-to-call inputs: values from `Context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY]`
-    or directly from the wire (HTTP header). By invariant the propagation slot
-    always holds wire-format (decimal); normalize is the read boundary into
-    canonical-hex storage (`meta_struct`).
-
-    Do NOT call on values already in canonical hex form (e.g. read back from
-    `meta_struct`). The function is non-idempotent on the rare 32-char all-[0-9]
-    hex with no leading zero — re-running it would reinterpret such a value as
-    decimal and mangle it.
+    """Normalize a wire-format trace_id to hexadecimal string.
 
     A 32-char all-digit value is ambiguous between hex and a decimal serialization
     of a 128-bit int. Leading ``"0"`` or any ``a-f`` marks it as unambiguous hex;
-    otherwise interpret as decimal (the wire contract). Non-numeric custom IDs
-    pass through.
+    otherwise interpret as decimal (as per the wire contract). Note: some rare (1 in 5 million)
+    cases with 32-char all-[0-9] hex and no leading zero will be incorrectly interpreted as decimal.
+
+    Non-numeric custom IDs pass through unmodified.
     """
     if value is None or value == "":
         return None

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -383,7 +383,7 @@ def _normalize_wire_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
     """
     if value is None or value == "":
         return None
-    if _HEX_TRACE_ID_RE.match(value) and (value[0] == "0" or not value.isdigit()):
+    if _HEX_TRACE_ID_RE.match(value.lower()) and (value[0] == "0" or not value.isdigit()):
         return value
     if value.isdigit():
         try:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -370,21 +370,17 @@ _HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 
 
 def _normalize_wire_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
-    """Normalize an incoming wire trace_id to canonical 32-char hex storage.
+    """Normalize a wire-format trace_id to canonical 32-char hex storage.
 
-    Safe-to-call inputs: values just extracted from the wire — i.e. an
-    inbound HTTP header value, or the value on an inbound `Context._meta`
-    coming straight from the APM HTTP propagator (before
-    `_activate_llmobs_distributed_context` has run on it).
+    Safe-to-call inputs: values from `Context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY]`
+    or directly from the wire (HTTP header). By invariant the propagation slot
+    always holds wire-format (decimal); normalize is the read boundary into
+    canonical-hex storage (`meta_struct`).
 
-    Do NOT call on values already in canonical hex form. That includes
-    values from `meta_struct` and from `Context._meta` on a locally-active
-    LLMObs parent context — both of which already hold canonical hex
-    (post-normalize for activated contexts; written as hex by
-    `_current_trace_context` for cross-thread/async hand-off). Re-running
-    normalize on those values is non-idempotent on the rare 32-char
-    all-[0-9] hex with no leading zero — it would reinterpret them as
-    decimal and mangle them.
+    Do NOT call on values already in canonical hex form (e.g. read back from
+    `meta_struct`). The function is non-idempotent on the rare 32-char all-[0-9]
+    hex with no leading zero — re-running it would reinterpret such a value as
+    decimal and mangle it.
 
     A 32-char all-digit value is ambiguous between hex and a decimal serialization
     of a 128-bit int. Leading ``"0"`` or any ``a-f`` marks it as unambiguous hex;

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -374,10 +374,12 @@ def _normalize_wire_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
 
     A 32-char all-digit value is ambiguous between hex and a decimal serialization
     of a 128-bit int. Leading ``"0"`` or any ``a-f`` marks it as unambiguous hex;
-    otherwise interpret as decimal (as per the wire contract). Note: some rare (1 in 5 million)
-    cases with 32-char all-[0-9] hex and no leading zero will be incorrectly interpreted as decimal.
+    otherwise interpret as decimal (as per the wire contract). Non-numeric custom IDs pass through unmodified.
 
-    Non-numeric custom IDs pass through unmodified.
+    Note: In the case of trace IDs being submitted on request headers as hex strings, some rare values (~ 1/3.78 M)
+    with 32-char all-[0-9] chars and no leading zero will be incorrectly interpreted as decimal. This is only a risk
+    for hand-crafted/forwarded headers.
+
     """
     if value is None or value == "":
         return None

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -369,8 +369,14 @@ def get_llmobs_trace_id(span: Span) -> Optional[str]:
 _HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 
 
-def _normalize_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
+def _normalize_wire_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
     """Normalize an incoming wire trace_id to canonical 32-char hex storage.
+
+    Call only on values sourced from the wire (HTTP header). Do NOT call on
+    values already in canonical hex form (e.g. read back from meta_struct or
+    from Context._meta after an earlier normalize), because this function is
+    non-idempotent on the rare 32-char all-[0-9] hex strings with no leading
+    zero — it would reinterpret them as decimal.
 
     A 32-char all-digit value is ambiguous between hex and a decimal serialization
     of a 128-bit int. Leading ``"0"`` or any ``a-f`` marks it as unambiguous hex;

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -353,13 +353,13 @@ def get_llmobs_span_kind(span: Span) -> Optional[str]:
     return kind
 
 
-def get_llmobs_parent_id(span: Span) -> Optional[int]:
+def get_llmobs_parent_id(span: Span) -> Optional[str]:
     llmobs_data = _get_llmobs_data_metastruct(span)
     parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID)
     return parent_id
 
 
-def get_llmobs_trace_id(span: Span) -> Optional[int]:
+def get_llmobs_trace_id(span: Span) -> Optional[str]:
     llmobs_data = _get_llmobs_data_metastruct(span)
     trace_id = llmobs_data.get(LLMOBS_STRUCT.TRACE_ID)
     return trace_id
@@ -454,8 +454,8 @@ def _annotate_llmobs_span_data(
     experiment_input: Optional[str] = None,
     experiment_output: Optional[str] = None,
     intent: Optional[str] = None,
-    parent_id: Optional[int] = None,
-    trace_id: Optional[int] = None,
+    parent_id: Optional[str] = None,
+    trace_id: Optional[str] = None,
 ) -> None:
     """Annotate llmobs data on span meta_struct field.
 

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -372,11 +372,19 @@ _HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 def _normalize_wire_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
     """Normalize an incoming wire trace_id to canonical 32-char hex storage.
 
-    Call only on values sourced from the wire (HTTP header). Do NOT call on
-    values already in canonical hex form (e.g. read back from meta_struct or
-    from Context._meta after an earlier normalize), because this function is
-    non-idempotent on the rare 32-char all-[0-9] hex strings with no leading
-    zero — it would reinterpret them as decimal.
+    Safe-to-call inputs: values just extracted from the wire — i.e. an
+    inbound HTTP header value, or the value on an inbound `Context._meta`
+    coming straight from the APM HTTP propagator (before
+    `_activate_llmobs_distributed_context` has run on it).
+
+    Do NOT call on values already in canonical hex form. That includes
+    values from `meta_struct` and from `Context._meta` on a locally-active
+    LLMObs parent context — both of which already hold canonical hex
+    (post-normalize for activated contexts; written as hex by
+    `_current_trace_context` for cross-thread/async hand-off). Re-running
+    normalize on those values is non-idempotent on the rare 32-char
+    all-[0-9] hex with no leading zero — it would reinterpret them as
+    decimal and mangle them.
 
     A 32-char all-digit value is ambiguous between hex and a decimal serialization
     of a 128-bit int. Leading ``"0"`` or any ``a-f`` marks it as unambiguous hex;

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -370,25 +370,12 @@ _HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 
 
 def _normalize_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
-    """Normalize a trace_id into the canonical 32-char lowercase hex storage format.
+    """Normalize an incoming wire trace_id to canonical 32-char hex storage.
 
-    The wire format for distributed headers is decimal (``str(int_id)``). A 32-char
-    string matching ``[0-9a-f]`` could be either canonical hex or a 32-digit decimal
-    wire value from a sender that serialized a 128-bit trace_id with ``str(int)``.
-    We disambiguate via two unambiguous hex markers:
-
-    - A leading ``"0"`` in a 32-char hit: ``str(int)`` never emits leading zeros,
-      so this must be zero-padded canonical hex.
-    - At least one ``a-f`` character: can't be decimal.
-
-    Otherwise we prefer decimal interpretation, matching the wire contract.
-
-    - Empty string or ``None`` → ``None``.
-    - Unambiguous canonical hex → return as-is.
-    - Decimal integer string → convert via ``format_trace_id``.
-    - Anything else (non-numeric custom ID from another SDK or manual user input) →
-      return as-is and log at debug. Cross-SDK trace joining may be affected but we
-      must not raise or corrupt the span.
+    A 32-char all-digit value is ambiguous between hex and a decimal serialization
+    of a 128-bit int. Leading ``"0"`` or any ``a-f`` marks it as unambiguous hex;
+    otherwise interpret as decimal (the wire contract). Non-numeric custom IDs
+    pass through.
     """
     if value is None or value == "":
         return None
@@ -399,25 +386,15 @@ def _normalize_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
             return format_trace_id(int(value))
         except (ValueError, TypeError):
             pass
-    log.debug(
-        "LLMObs trace_id %r is not recognized as canonical hex or a decimal integer; "
-        "storing as-is. Cross-SDK trace joining may be affected.",
-        value,
-    )
+    log.debug("LLMObs trace_id %r is not canonical hex or a decimal integer; storing as-is.", value)
     return value
 
 
 def _trace_id_to_wire(value: Optional[str]) -> Optional[str]:
-    """Convert a stored trace_id to the decimal wire format for cross-version compat.
+    """Convert stored hex trace_id to decimal for the distributed header.
 
-    Older dd-trace-py versions parse the ``_DD_LLMOBS_TRACE_ID`` header via ``int(x)``
-    without a base argument, which fails on any hex string with a-f characters. We
-    therefore keep the wire format as decimal and let each SDK normalize back to hex
-    internally on receive.
-
-    - Canonical 32-char lowercase hex → ``str(int(value, 16))`` → decimal.
-    - Already-decimal or non-hex → return as-is.
-    - Empty / ``None`` → return ``None``.
+    Older dd-trace-py versions parse this header with ``int(x)`` (no base arg),
+    which rejects ``a-f``, so the wire must stay decimal.
     """
     if not value:
         return None

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -372,27 +372,39 @@ _HEX_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 def _normalize_trace_id_to_hex(value: Optional[str]) -> Optional[str]:
     """Normalize a trace_id into the canonical 32-char lowercase hex storage format.
 
-    - Canonical 32-char lowercase hex → return as-is.
-    - Decimal integer string → convert via ``format_trace_id`` (hex for 128-bit IDs,
-      pass-through for smaller ints).
-    - Empty string or ``None`` → return ``None``.
+    The wire format for distributed headers is decimal (``str(int_id)``). A 32-char
+    string matching ``[0-9a-f]`` could be either canonical hex or a 32-digit decimal
+    wire value from a sender that serialized a 128-bit trace_id with ``str(int)``.
+    We disambiguate via two unambiguous hex markers:
+
+    - A leading ``"0"`` in a 32-char hit: ``str(int)`` never emits leading zeros,
+      so this must be zero-padded canonical hex.
+    - At least one ``a-f`` character: can't be decimal.
+
+    Otherwise we prefer decimal interpretation, matching the wire contract.
+
+    - Empty string or ``None`` → ``None``.
+    - Unambiguous canonical hex → return as-is.
+    - Decimal integer string → convert via ``format_trace_id``.
     - Anything else (non-numeric custom ID from another SDK or manual user input) →
       return as-is and log at debug. Cross-SDK trace joining may be affected but we
       must not raise or corrupt the span.
     """
     if value is None or value == "":
         return None
-    if _HEX_TRACE_ID_RE.match(value):
+    if _HEX_TRACE_ID_RE.match(value) and (value[0] == "0" or not value.isdigit()):
         return value
-    try:
-        return format_trace_id(int(value))
-    except (ValueError, TypeError):
-        log.debug(
-            "LLMObs trace_id %r is neither 32-char hex nor a valid decimal integer; "
-            "storing as-is. Cross-SDK trace joining may be affected.",
-            value,
-        )
-        return value
+    if value.isdigit():
+        try:
+            return format_trace_id(int(value))
+        except (ValueError, TypeError):
+            pass
+    log.debug(
+        "LLMObs trace_id %r is not recognized as canonical hex or a decimal integer; "
+        "storing as-is. Cross-SDK trace joining may be affected.",
+        value,
+    )
+    return value
 
 
 def _trace_id_to_wire(value: Optional[str]) -> Optional[str]:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -73,7 +73,6 @@ class LLMObsSpanData(TypedDict, total=False):
     config: "ExperimentConfigType"
     is_evaluation_span: bool
     meta: _Meta
-    _dd: dict[str, str]
 
 
 class _LLMObsSpanEventOptional(TypedDict, total=False):

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -63,8 +63,8 @@ class LLMObsSpanData(TypedDict, total=False):
     """Structure of LLMObs span data attached to APM spans."""
 
     name: str
-    parent_id: Optional[int]
-    trace_id: int
+    parent_id: Optional[str]
+    trace_id: str
     ml_app: str
     session_id: str
     tags: dict[str, str]

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -71,6 +71,7 @@ class LLMObsSpanData(TypedDict, total=False):
     metrics: dict[str, Any]
     span_links: list["_SpanLink"]
     config: "ExperimentConfigType"
+    is_evaluation_span: bool
     meta: _Meta
     _dd: dict[str, str]
 

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -63,7 +63,7 @@ class LLMObsSpanData(TypedDict, total=False):
     """Structure of LLMObs span data attached to APM spans."""
 
     name: str
-    parent_id: Optional[str]
+    parent_id: str
     trace_id: str
     ml_app: str
     session_id: str
@@ -71,8 +71,8 @@ class LLMObsSpanData(TypedDict, total=False):
     metrics: dict[str, Any]
     span_links: list["_SpanLink"]
     config: "ExperimentConfigType"
-    is_evaluation_span: bool
     meta: _Meta
+    _dd: dict[str, str]
 
 
 class _LLMObsSpanEventOptional(TypedDict, total=False):

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -8,8 +8,9 @@ import pytest
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs import LLMObsSpan
-from ddtrace.llmobs import _constants as const
+from ddtrace.llmobs._constants import LANGCHAIN_APM_SPAN_NAME
 from ddtrace.llmobs._constants import LLMOBS_SUBMITTED_TAG_KEY
+from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_trace_id
@@ -52,9 +53,9 @@ def test_set_correct_parent_id(llmobs, tracer):
     with tracer.trace("root"):
         with llmobs.workflow("llm_span") as llm_span:
             pass
-    assert get_llmobs_parent_id(llm_span) is None
+    assert get_llmobs_parent_id(llm_span) == ROOT_PARENT_ID
     with llmobs.workflow("root_llm_span") as root_span:
-        assert get_llmobs_parent_id(root_span) is None
+        assert get_llmobs_parent_id(root_span) == ROOT_PARENT_ID
         with tracer.trace("child_span") as child_span:
             assert get_llmobs_parent_id(child_span) is None
             with llmobs.task("llm_span") as grandchild_span:
@@ -339,7 +340,7 @@ def test_metrics_are_set(tracer, llmobs_events):
 
 def test_langchain_span_name_is_set_to_class_name(tracer, llmobs_events):
     """Test span names for langchain auto-instrumented spans is set correctly."""
-    with tracer.trace(const.LANGCHAIN_APM_SPAN_NAME, resource="expected_name", span_type=SpanTypes.LLM) as llm_span:
+    with tracer.trace(LANGCHAIN_APM_SPAN_NAME, resource="expected_name", span_type=SpanTypes.LLM) as llm_span:
         _annotate_llmobs_span_data(llm_span, kind="llm")
     assert llmobs_events[0]["name"] == "expected_name"
 
@@ -637,7 +638,7 @@ def test_llmobs_trace_id_written_to_local_root_meta(llmobs, llmobs_events):
     # The local root (fastapi.request) should have llmobs_trace_id set as a tag
     assert root.get_tag("llmobs_trace_id") is not None
     # It should match the workflow span's llmobs_trace_id
-    assert root.get_tag("llmobs_trace_id") == format_trace_id(wf_trace_id)
+    assert root.get_tag("llmobs_trace_id") == wf_trace_id
     # llmobs_parent_id should be the workflow span's span_id
     assert root.get_tag("llmobs_parent_id") == str(wf.span_id)
 
@@ -657,7 +658,7 @@ def test_llmobs_trace_id_on_local_root_with_non_llm_child_spans(llmobs, llmobs_e
     # The child span shares the same local root
     assert child._local_root is root
     # So the processor will find llmobs_trace_id on the root span in the same payload
-    assert root.get_tag("llmobs_trace_id") == format_trace_id(wf_trace_id)
+    assert root.get_tag("llmobs_trace_id") == wf_trace_id
 
 
 def test_llmobs_trace_id_not_overwritten_by_sibling_workflows(llmobs, llmobs_events):
@@ -670,7 +671,7 @@ def test_llmobs_trace_id_not_overwritten_by_sibling_workflows(llmobs, llmobs_eve
 
     # The local root should have the first child's trace ID (first-wins)
     assert root.get_tag("llmobs_trace_id") is not None
-    assert root.get_tag("llmobs_trace_id") == format_trace_id(first_trace_id)
+    assert root.get_tag("llmobs_trace_id") == first_trace_id
     # The two workflows should have different trace IDs
     assert first_trace_id != second_trace_id
 

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -58,7 +58,7 @@ def test_set_correct_parent_id(llmobs, tracer):
         with tracer.trace("child_span") as child_span:
             assert get_llmobs_parent_id(child_span) is None
             with llmobs.task("llm_span") as grandchild_span:
-                assert get_llmobs_parent_id(grandchild_span) == root_span.span_id
+                assert get_llmobs_parent_id(grandchild_span) == str(root_span.span_id)
 
 
 class TestSessionId:

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -52,8 +52,7 @@ def test_set_correct_parent_id(llmobs, tracer):
     """Test that the parent_id is set as the span_id of the nearest LLMObs span in the span's ancestor tree."""
     with tracer.trace("root"):
         with llmobs.workflow("llm_span") as llm_span:
-            pass
-    assert get_llmobs_parent_id(llm_span) == ROOT_PARENT_ID
+            assert get_llmobs_parent_id(llm_span) == ROOT_PARENT_ID
     with llmobs.workflow("root_llm_span") as root_span:
         assert get_llmobs_parent_id(root_span) == ROOT_PARENT_ID
         with tracer.trace("child_span") as child_span:

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -9,7 +9,7 @@ import pytest
 
 import ddtrace
 from ddtrace.ext import SpanTypes
-from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.internal.service import ServiceStatus
 from ddtrace.llmobs import LLMObs as llmobs_service
 from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import PROMPT_TRACKING_INSTRUMENTATION_METHOD
@@ -984,7 +984,7 @@ def test_export_span_specified_span_returns_span_context(llmobs):
         span_context = llmobs.export_span(span=span)
         assert span_context is not None
         assert span_context["span_id"] == str(span.span_id)
-        assert span_context["trace_id"] == format_trace_id(get_llmobs_trace_id(span))
+        assert span_context["trace_id"] == get_llmobs_trace_id(span)
 
 
 def test_export_span_no_specified_span_no_active_span_raises(llmobs):
@@ -1013,7 +1013,7 @@ def test_export_span_no_specified_span_returns_exported_active_span(llmobs):
         span_context = llmobs.export_span()
         assert span_context is not None
         assert span_context["span_id"] == str(span.span_id)
-        assert span_context["trace_id"] == format_trace_id(get_llmobs_trace_id(span))
+        assert span_context["trace_id"] == get_llmobs_trace_id(span)
 
 
 def test_flush_does_not_call_periodic_when_llmobs_is_disabled(
@@ -1950,7 +1950,7 @@ def test_submit_evaluation_enqueues_writer_with_categorical_metric(llmobs, mock_
             _expected_llmobs_eval_metric_event(
                 ml_app="dummy",
                 span_id=str(span.span_id),
-                trace_id=format_trace_id(get_llmobs_trace_id(span)),
+                trace_id=get_llmobs_trace_id(span),
                 label="toxicity",
                 metric_type="categorical",
                 categorical_value="high",
@@ -1979,7 +1979,7 @@ def test_submit_evaluation_enqueues_writer_with_score_metric(llmobs, mock_llmobs
         mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
             _expected_llmobs_eval_metric_event(
                 span_id=str(span.span_id),
-                trace_id=format_trace_id(get_llmobs_trace_id(span)),
+                trace_id=get_llmobs_trace_id(span),
                 label="sentiment",
                 metric_type="score",
                 score_value=0.9,
@@ -2204,7 +2204,7 @@ def test_submit_evaluation_enqueues_writer_with_boolean_metric(llmobs, mock_llmo
         mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
             _expected_llmobs_eval_metric_event(
                 span_id=str(span.span_id),
-                trace_id=format_trace_id(get_llmobs_trace_id(span)),
+                trace_id=get_llmobs_trace_id(span),
                 label="is_toxic",
                 metric_type="boolean",
                 boolean_value=False,

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -9,7 +9,6 @@ import pytest
 
 import ddtrace
 from ddtrace.ext import SpanTypes
-from ddtrace.internal.service import ServiceStatus
 from ddtrace.llmobs import LLMObs as llmobs_service
 from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import PROMPT_TRACKING_INSTRUMENTATION_METHOD

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -7,6 +7,7 @@ from ddtrace.contrib.internal.asyncio.patch import patch as patch_asyncio
 from ddtrace.contrib.internal.asyncio.patch import unpatch as unpatch_asyncio
 from ddtrace.contrib.internal.futures.patch import patch as patch_futures
 from ddtrace.contrib.internal.futures.patch import unpatch as unpatch_futures
+from ddtrace.llmobs._constants import PROPAGATED_LLMOBS_TRACE_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
@@ -447,3 +448,63 @@ async def test_asyncio_create_task(llmobs, llmobs_events, patched_asyncio):
     assert main_task_span["trace_id"] == side_task_span["trace_id"]
     assert main_task_span["_dd"]["apm_trace_id"] == side_task_span["_dd"]["apm_trace_id"]
     assert main_task_span["trace_id"] != main_task_span["_dd"]["apm_trace_id"]
+
+
+_HEX_TRACE_ID = "ef017ddb6db557ea44fb6ce732fd0687"
+_DECIMAL_TRACE_ID = str(int(_HEX_TRACE_ID, 16))
+
+
+def _make_upstream_llmobs_context(trace_id_value, parent_id="987654321"):
+    from ddtrace.trace import Context
+
+    ctx = Context(trace_id=123456789, span_id=int(parent_id))
+    ctx._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = trace_id_value
+    ctx._meta[PROPAGATED_PARENT_ID_KEY] = parent_id
+    return ctx
+
+
+def test_injected_trace_id_is_decimal_on_the_wire(llmobs):
+    """Wire must stay decimal so older SDKs that do int(header) keep working."""
+    with llmobs.workflow("w") as span:
+        llmobs._inject_llmobs_context(span.context, {})
+    wire_value = span.context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
+    assert wire_value and wire_value.isdigit()
+
+
+def test_activate_decimal_header_stores_canonical_hex(llmobs):
+    ctx = _make_upstream_llmobs_context(_DECIMAL_TRACE_ID)
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.workflow("w") as span:
+        assert get_llmobs_trace_id(span) == _HEX_TRACE_ID
+
+
+def test_activate_hex_header_stores_canonical_hex(llmobs):
+    ctx = _make_upstream_llmobs_context(_HEX_TRACE_ID)
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.workflow("w") as span:
+        assert get_llmobs_trace_id(span) == _HEX_TRACE_ID
+
+
+def test_activate_non_numeric_header_passthrough_does_not_raise(llmobs):
+    custom_tid = "my-custom-trace-id-not-numeric"
+    ctx = _make_upstream_llmobs_context(custom_tid)
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.workflow("w") as span:
+        assert get_llmobs_trace_id(span) == custom_tid
+
+
+def test_submitted_event_trace_id_is_hex_when_upstream_sent_decimal(llmobs, llmobs_events):
+    """Backend must always see hex so trace joining works even across mixed-version upstreams."""
+    ctx = _make_upstream_llmobs_context(_DECIMAL_TRACE_ID)
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.workflow("w"):
+        pass
+    assert len(llmobs_events) == 1
+    assert llmobs_events[0]["trace_id"] == _HEX_TRACE_ID
+
+
+def test_inject_skips_header_when_trace_id_is_empty(llmobs, monkeypatch):
+    monkeypatch.setattr("ddtrace.llmobs._llmobs._trace_id_to_wire", lambda _v: None)
+    with llmobs.workflow("w") as span:
+        llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) != ""

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -508,3 +508,26 @@ def test_inject_skips_header_when_trace_id_is_empty(llmobs, monkeypatch):
     with llmobs.workflow("w") as span:
         llmobs._inject_llmobs_context(span.context, {})
         assert PROPAGATED_LLMOBS_TRACE_ID_KEY not in span.context._meta
+
+
+# Ambiguous trace_id class: 32-char hex composed only of [0-9] with no leading zero.
+# Indistinguishable by shape from a 32-digit decimal, which is why
+# _normalize_wire_trace_id_to_hex is non-idempotent on these values and must only ever be
+# called on wire-sourced inputs. The wire-decimal form is the int's decimal representation
+# (~38 digits for 128-bit), so wire-in/hex-out round-trips cleanly.
+_AMBIGUOUS_HEX_TRACE_ID = "12345678901234567890123456789012"
+_AMBIGUOUS_WIRE_TRACE_ID = str(int(_AMBIGUOUS_HEX_TRACE_ID, 16))
+
+
+def test_submitted_event_trace_id_matches_stored_for_ambiguous_hex(llmobs, llmobs_events):
+    """Regression: submit must not re-normalize the stored hex. A trace_id whose 32-char hex
+    form is all-[0-9] with no leading zero would otherwise be mangled by
+    _normalize_wire_trace_id_to_hex reinterpreting it as decimal."""
+    ctx = _make_upstream_llmobs_context(_AMBIGUOUS_WIRE_TRACE_ID)
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.workflow("w") as span:
+        stored = get_llmobs_trace_id(span)
+    assert stored == _AMBIGUOUS_HEX_TRACE_ID
+    assert len(llmobs_events) == 1
+    assert llmobs_events[0]["trace_id"] == _AMBIGUOUS_HEX_TRACE_ID
+    assert llmobs_events[0]["trace_id"] == stored

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -100,7 +100,7 @@ print(json.dumps(headers))
     llmobs.activate_distributed_headers(headers)
     with llmobs.workflow("LLMObs span") as span:
         assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert get_llmobs_parent_id(span) == int(headers["_DD_LLMOBS_SPAN_ID"])
+        assert get_llmobs_parent_id(span) == headers["_DD_LLMOBS_SPAN_ID"]
 
 
 def test_propagate_llmobs_parent_id_complex(ddtrace_run_python_code_in_subprocess, llmobs):
@@ -134,7 +134,7 @@ print(json.dumps(headers))
         with llmobs.llm(model_name="llm_model", name="LLMObs span") as llm_span:
             assert str(span.parent_id) == headers["x-datadog-parent-id"]
             assert get_llmobs_parent_id(span) is None
-            assert get_llmobs_parent_id(llm_span) == int(headers["_DD_LLMOBS_SPAN_ID"])
+            assert get_llmobs_parent_id(llm_span) == headers["_DD_LLMOBS_SPAN_ID"]
 
 
 def test_no_llmobs_parent_id_propagated_if_no_llmobs_spans(ddtrace_run_python_code_in_subprocess, llmobs):
@@ -216,7 +216,7 @@ with LLMObs.workflow("LLMObs span") as root_span:
     with tracer.trace("Non-LLMObs span") as child_span:
         headers = {
             "_DD_LLMOBS_SPAN_ID": str(root_span.span_id),
-            "_DD_LLMOBS_TRACE_ID": str(get_llmobs_trace_id(root_span))
+            "_DD_LLMOBS_TRACE_ID": get_llmobs_trace_id(root_span)
         }
         headers = LLMObs.inject_distributed_headers(headers, span=child_span)
 
@@ -231,9 +231,9 @@ print(json.dumps(headers))
     llmobs_no_ml_app.activate_distributed_headers(headers)
     with llmobs_no_ml_app.workflow("LLMObs span") as span:
         assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert get_llmobs_parent_id(span) == int(headers["_DD_LLMOBS_SPAN_ID"])
+        assert get_llmobs_parent_id(span) == headers["_DD_LLMOBS_SPAN_ID"]
         assert get_llmobs_ml_app(span) == "test-app"  # should have been propagated
-        assert get_llmobs_trace_id(span) == int(headers["_DD_LLMOBS_TRACE_ID"])
+        assert get_llmobs_trace_id(span) == headers["_DD_LLMOBS_TRACE_ID"]
 
 
 def test_activate_distributed_headers_propagate_complex(ddtrace_run_python_code_in_subprocess, llmobs):
@@ -268,7 +268,7 @@ print(json.dumps(headers))
         with llmobs.llm(model_name="llm_model", name="LLMObs span") as llm_span:
             assert str(span.parent_id) == headers["x-datadog-parent-id"]
             assert get_llmobs_parent_id(span) is None
-            assert get_llmobs_parent_id(llm_span) == int(headers["_DD_LLMOBS_SPAN_ID"])
+            assert get_llmobs_parent_id(llm_span) == headers["_DD_LLMOBS_SPAN_ID"]
             assert get_llmobs_ml_app(llm_span) == "test-app"  # should be the one set by `llmobs` fixture
 
 

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -522,7 +522,8 @@ _AMBIGUOUS_WIRE_TRACE_ID = str(int(_AMBIGUOUS_HEX_TRACE_ID, 16))
 def test_submitted_event_trace_id_matches_stored_for_ambiguous_hex(llmobs, llmobs_events):
     """Regression: submit must not re-normalize the stored hex. A trace_id whose 32-char hex
     form is all-[0-9] with no leading zero would otherwise be mangled by
-    _normalize_wire_trace_id_to_hex reinterpreting it as decimal."""
+    _normalize_wire_trace_id_to_hex reinterpreting it as decimal.
+    """
     ctx = _make_upstream_llmobs_context(_AMBIGUOUS_WIRE_TRACE_ID)
     llmobs._instance._activate_llmobs_distributed_context({}, ctx)
     with llmobs.workflow("w") as span:

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -166,7 +166,7 @@ print(json.dumps(headers))
     llmobs.activate_distributed_headers(headers)
     with llmobs.workflow("LLMObs span") as span:
         assert str(span.parent_id) == headers.get("x-datadog-parent-id")
-        assert get_llmobs_parent_id(span) is None
+        assert get_llmobs_parent_id(span) == ROOT_PARENT_ID
 
 
 def test_inject_distributed_headers_simple(llmobs):
@@ -366,7 +366,7 @@ print(json.dumps(headers))
     llmobs.activate_distributed_headers(headers)
     with llmobs.task("LLMObs span") as span:
         assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert get_llmobs_parent_id(span) is None
+        assert get_llmobs_parent_id(span) == ROOT_PARENT_ID
         assert get_llmobs_ml_app(span) == "test-app"
 
 

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -507,4 +507,4 @@ def test_inject_skips_header_when_trace_id_is_empty(llmobs, monkeypatch):
     monkeypatch.setattr("ddtrace.llmobs._llmobs._trace_id_to_wire", lambda _v: None)
     with llmobs.workflow("w") as span:
         llmobs._inject_llmobs_context(span.context, {})
-    assert span.context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) != ""
+        assert PROPAGATED_LLMOBS_TRACE_ID_KEY not in span.context._meta

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 import pytest
 
+from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _normalize_trace_id_to_hex
@@ -409,7 +410,7 @@ class TestTraceIdNormalization:
 
         caplog.set_level(logging.DEBUG, logger="ddtrace.llmobs._utils")
         assert _normalize_trace_id_to_hex("custom-trace-id-abc") == "custom-trace-id-abc"
-        assert any("neither 32-char hex nor a valid decimal" in r.message for r in caplog.records)
+        assert any("not recognized as canonical hex or a decimal integer" in r.message for r in caplog.records)
 
     def test_normalize_uppercase_hex_passthrough(self):
         up = self.HEX_TRACE_ID.upper()
@@ -418,6 +419,29 @@ class TestTraceIdNormalization:
     def test_normalize_none_and_empty(self):
         assert _normalize_trace_id_to_hex(None) is None
         assert _normalize_trace_id_to_hex("") is None
+
+    def test_normalize_32_digit_decimal_wire_value_not_misclassified_as_hex(self):
+        # Older SDKs may emit `str(int_128bit)` on the wire; for int values in
+        # [10**31, 10**32 - 1] the result is 32 decimal digits and would match
+        # the hex regex. The refined normalizer must interpret these as decimal
+        # (wire contract) rather than pass through as hex, or the next hop's
+        # `_trace_id_to_wire` would re-parse the string as base-16 and corrupt
+        # the trace_id.
+        decimal_wire = "50000000000000000000000000000000"  # 5 * 10^31, 32 digits, no leading zero
+        assert not decimal_wire[0] == "0"
+        assert decimal_wire.isdigit()
+        normalized = _normalize_trace_id_to_hex(decimal_wire)
+        assert normalized == format_trace_id(int(decimal_wire))
+        # Round-trip: storage -> wire -> same original decimal
+        assert _trace_id_to_wire(normalized) == decimal_wire
+
+    def test_normalize_zero_padded_hex_passthrough_even_if_all_digits(self):
+        # A 32-char hit starting with "0" cannot be a decimal integer (str(int)
+        # never has leading zeros), so even if every character is 0-9 we must
+        # treat it as canonical hex.
+        padded_hex_all_digits = "00000000000000001234567890123456"
+        normalized = _normalize_trace_id_to_hex(padded_hex_all_digits)
+        assert normalized == padded_hex_all_digits
 
     def test_wire_hex_to_decimal(self):
         assert _trace_id_to_wire(self.HEX_TRACE_ID) == self.DECIMAL_TRACE_ID

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -3,6 +3,8 @@ import pytest
 
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
+from ddtrace.llmobs._utils import _normalize_trace_id_to_hex
+from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.utils import Documents
 from ddtrace.llmobs.utils import Messages
@@ -346,7 +348,7 @@ class TestAnnotateLLMObsSpanData:
                 model_provider="openai",
                 session_id="sess-1",
                 parent_id="parent-1",
-                trace_id=12345,
+                trace_id="12345",
                 input_messages=messages_in,
                 output_messages=messages_out,
                 metadata={"temperature": 0.5},
@@ -360,7 +362,7 @@ class TestAnnotateLLMObsSpanData:
             assert data[LLMOBS_STRUCT.ML_APP] == "test-app"
             assert data[LLMOBS_STRUCT.SESSION_ID] == "sess-1"
             assert data[LLMOBS_STRUCT.PARENT_ID] == "parent-1"
-            assert data[LLMOBS_STRUCT.TRACE_ID] == 12345
+            assert data[LLMOBS_STRUCT.TRACE_ID] == "12345"
             assert data[LLMOBS_STRUCT.METRICS] == {"input_tokens": 10}
             assert data[LLMOBS_STRUCT.TAGS] == {"env": "prod"}
             assert data[LLMOBS_STRUCT.SPAN_LINKS] == links
@@ -386,3 +388,50 @@ class TestAnnotateLLMObsSpanData:
             assert data[LLMOBS_STRUCT.META][LLMOBS_STRUCT.METADATA] == {"key1": "val1", "key2": "val2"}
             assert data[LLMOBS_STRUCT.METRICS] == {"input_tokens": 10, "output_tokens": 5}
             assert data[LLMOBS_STRUCT.TAGS] == {"env": "prod", "version": "1.0"}
+
+
+class TestTraceIdNormalization:
+    HEX_TRACE_ID = "ef017ddb6db557ea44fb6ce732fd0687"
+    DECIMAL_TRACE_ID = str(int(HEX_TRACE_ID, 16))
+
+    def test_normalize_canonical_hex_passthrough(self):
+        assert _normalize_trace_id_to_hex(self.HEX_TRACE_ID) == self.HEX_TRACE_ID
+
+    def test_normalize_decimal_converts_to_hex(self):
+        assert _normalize_trace_id_to_hex(self.DECIMAL_TRACE_ID) == self.HEX_TRACE_ID
+
+    def test_normalize_small_decimal_identity(self):
+        # format_trace_id returns str(int) for values <= 2^64, so small ints stay decimal.
+        assert _normalize_trace_id_to_hex("12345") == "12345"
+
+    def test_normalize_non_numeric_custom_id_passthrough(self, caplog):
+        import logging
+
+        caplog.set_level(logging.DEBUG, logger="ddtrace.llmobs._utils")
+        assert _normalize_trace_id_to_hex("custom-trace-id-abc") == "custom-trace-id-abc"
+        assert any("neither 32-char hex nor a valid decimal" in r.message for r in caplog.records)
+
+    def test_normalize_uppercase_hex_passthrough(self):
+        up = self.HEX_TRACE_ID.upper()
+        assert _normalize_trace_id_to_hex(up) == up
+
+    def test_normalize_none_and_empty(self):
+        assert _normalize_trace_id_to_hex(None) is None
+        assert _normalize_trace_id_to_hex("") is None
+
+    def test_wire_hex_to_decimal(self):
+        assert _trace_id_to_wire(self.HEX_TRACE_ID) == self.DECIMAL_TRACE_ID
+
+    def test_wire_decimal_passthrough(self):
+        assert _trace_id_to_wire(self.DECIMAL_TRACE_ID) == self.DECIMAL_TRACE_ID
+
+    def test_wire_custom_passthrough(self):
+        assert _trace_id_to_wire("custom-trace-id-abc") == "custom-trace-id-abc"
+
+    def test_wire_none_and_empty(self):
+        assert _trace_id_to_wire(None) is None
+        assert _trace_id_to_wire("") is None
+
+    def test_normalize_after_wire_recovers_hex(self):
+        wire = _trace_id_to_wire(self.HEX_TRACE_ID)
+        assert _normalize_trace_id_to_hex(wire) == self.HEX_TRACE_ID

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -410,7 +410,7 @@ class TestTraceIdNormalization:
 
         caplog.set_level(logging.DEBUG, logger="ddtrace.llmobs._utils")
         assert _normalize_trace_id_to_hex("custom-trace-id-abc") == "custom-trace-id-abc"
-        assert any("not recognized as canonical hex or a decimal integer" in r.message for r in caplog.records)
+        assert any("not canonical hex or a decimal integer" in r.message for r in caplog.records)
 
     def test_normalize_uppercase_hex_passthrough(self):
         up = self.HEX_TRACE_ID.upper()
@@ -421,27 +421,17 @@ class TestTraceIdNormalization:
         assert _normalize_trace_id_to_hex("") is None
 
     def test_normalize_32_digit_decimal_wire_value_not_misclassified_as_hex(self):
-        # Older SDKs may emit `str(int_128bit)` on the wire; for int values in
-        # [10**31, 10**32 - 1] the result is 32 decimal digits and would match
-        # the hex regex. The refined normalizer must interpret these as decimal
-        # (wire contract) rather than pass through as hex, or the next hop's
-        # `_trace_id_to_wire` would re-parse the string as base-16 and corrupt
-        # the trace_id.
-        decimal_wire = "50000000000000000000000000000000"  # 5 * 10^31, 32 digits, no leading zero
-        assert not decimal_wire[0] == "0"
-        assert decimal_wire.isdigit()
+        # 32-digit decimals (older-SDK str(int128) output) must round-trip as decimal,
+        # otherwise _trace_id_to_wire would re-parse as base-16 on the next hop.
+        decimal_wire = "50000000000000000000000000000000"
         normalized = _normalize_trace_id_to_hex(decimal_wire)
         assert normalized == format_trace_id(int(decimal_wire))
-        # Round-trip: storage -> wire -> same original decimal
         assert _trace_id_to_wire(normalized) == decimal_wire
 
     def test_normalize_zero_padded_hex_passthrough_even_if_all_digits(self):
-        # A 32-char hit starting with "0" cannot be a decimal integer (str(int)
-        # never has leading zeros), so even if every character is 0-9 we must
-        # treat it as canonical hex.
+        # Leading "0" disambiguates as hex: str(int) can't emit leading zeros.
         padded_hex_all_digits = "00000000000000001234567890123456"
-        normalized = _normalize_trace_id_to_hex(padded_hex_all_digits)
-        assert normalized == padded_hex_all_digits
+        assert _normalize_trace_id_to_hex(padded_hex_all_digits) == padded_hex_all_digits
 
     def test_wire_hex_to_decimal(self):
         assert _trace_id_to_wire(self.HEX_TRACE_ID) == self.DECIMAL_TRACE_ID

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
-from ddtrace.llmobs._utils import _normalize_trace_id_to_hex
+from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.utils import Documents
@@ -396,42 +396,42 @@ class TestTraceIdNormalization:
     DECIMAL_TRACE_ID = str(int(HEX_TRACE_ID, 16))
 
     def test_normalize_canonical_hex_passthrough(self):
-        assert _normalize_trace_id_to_hex(self.HEX_TRACE_ID) == self.HEX_TRACE_ID
+        assert _normalize_wire_trace_id_to_hex(self.HEX_TRACE_ID) == self.HEX_TRACE_ID
 
     def test_normalize_decimal_converts_to_hex(self):
-        assert _normalize_trace_id_to_hex(self.DECIMAL_TRACE_ID) == self.HEX_TRACE_ID
+        assert _normalize_wire_trace_id_to_hex(self.DECIMAL_TRACE_ID) == self.HEX_TRACE_ID
 
     def test_normalize_small_decimal_identity(self):
         # format_trace_id returns str(int) for values <= 2^64, so small ints stay decimal.
-        assert _normalize_trace_id_to_hex("12345") == "12345"
+        assert _normalize_wire_trace_id_to_hex("12345") == "12345"
 
     def test_normalize_non_numeric_custom_id_passthrough(self, caplog):
         import logging
 
         caplog.set_level(logging.DEBUG, logger="ddtrace.llmobs._utils")
-        assert _normalize_trace_id_to_hex("custom-trace-id-abc") == "custom-trace-id-abc"
+        assert _normalize_wire_trace_id_to_hex("custom-trace-id-abc") == "custom-trace-id-abc"
         assert any("not canonical hex or a decimal integer" in r.message for r in caplog.records)
 
     def test_normalize_uppercase_hex_passthrough(self):
         up = self.HEX_TRACE_ID.upper()
-        assert _normalize_trace_id_to_hex(up) == up
+        assert _normalize_wire_trace_id_to_hex(up) == up
 
     def test_normalize_none_and_empty(self):
-        assert _normalize_trace_id_to_hex(None) is None
-        assert _normalize_trace_id_to_hex("") is None
+        assert _normalize_wire_trace_id_to_hex(None) is None
+        assert _normalize_wire_trace_id_to_hex("") is None
 
     def test_normalize_32_digit_decimal_wire_value_not_misclassified_as_hex(self):
         # 32-digit decimals (older-SDK str(int128) output) must round-trip as decimal,
         # otherwise _trace_id_to_wire would re-parse as base-16 on the next hop.
         decimal_wire = "50000000000000000000000000000000"
-        normalized = _normalize_trace_id_to_hex(decimal_wire)
+        normalized = _normalize_wire_trace_id_to_hex(decimal_wire)
         assert normalized == format_trace_id(int(decimal_wire))
         assert _trace_id_to_wire(normalized) == decimal_wire
 
     def test_normalize_zero_padded_hex_passthrough_even_if_all_digits(self):
         # Leading "0" disambiguates as hex: str(int) can't emit leading zeros.
         padded_hex_all_digits = "00000000000000001234567890123456"
-        assert _normalize_trace_id_to_hex(padded_hex_all_digits) == padded_hex_all_digits
+        assert _normalize_wire_trace_id_to_hex(padded_hex_all_digits) == padded_hex_all_digits
 
     def test_wire_hex_to_decimal(self):
         assert _trace_id_to_wire(self.HEX_TRACE_ID) == self.DECIMAL_TRACE_ID
@@ -448,4 +448,4 @@ class TestTraceIdNormalization:
 
     def test_normalize_after_wire_recovers_hex(self):
         wire = _trace_id_to_wire(self.HEX_TRACE_ID)
-        assert _normalize_trace_id_to_hex(wire) == self.HEX_TRACE_ID
+        assert _normalize_wire_trace_id_to_hex(wire) == self.HEX_TRACE_ID


### PR DESCRIPTION
[MLOB-6633]

Extracted from #17235 to narrow review scope.

## Description

This PR stores LLMObs trace/parent IDs as hexadecimal strings internally on `span._meta_struct`, with decimal wire values only for distributed request/context propagation.

Note: this PR preserves wire-format (distributed header) compatibility with older SDK versions by keeping headers decimal.

### Context on LLMObs trace IDs

A trace ID is generated SDK-side as a random 128-bit integer (or, for distributed/OTel/custom-instrumented sources, supplied by the upstream as a string). It lives in two places at runtime:                     

  | Location | Format | Purpose |                                                                                                        
  |---|---|---|
  | `span.meta_struct[LLMOBS_STRUCT.KEY][LLMOBS_STRUCT.TRACE_ID]` | **canonical hex** (32-char lowercase) | source of truth for a locally-active span |  
  | `span.context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY]` (`_dd.p.llmobs_trace_id`) | **wire decimal** | propagation across HTTP, threads,   asyncio tasks |                                                                                                                     
                                                                                                                                      
  Everywhere else that emits or reads a trace ID — `LLMObsSpanEvent.trace_id`, the `llmobs_trace_id` local-root tag, `export_span()`, 
  eval submission — pulls from the span.meta_struct trace ID and uses the value verbatim. The span context trace ID is only ever used for distributed context propagation.           
                                                         
  ## Why two formats                                                                                                                  
  
Ideally we would use hex everywhere to simplify, since the backend stores and joins on hex strings. However to ensure backwards compatibility when propagating requests from/to older ddtrace SDKs we need to ensure a decimal wire trace ID format. (Older dd-trace-py versions parse `_dd.p.llmobs_trace_id` via `int(header)` (no 
  base argument), which rejects `a-f`. If we sent hex, an older upstream/downstream peer would crash.)

This PR attempts to simplify things as much as possible to avoid unnecessary/redundant conversions, and keep things simple and straightforward - store and use trace ID as hex string, and only use wire decimal format for distributed requests (context).                                
  
  ## Conversion: only at the wire boundary                                                                                            
                                                         
  Conversion happens at exactly two call sites:                                                                                       
  
  1. **receive distributed request** — `_activate_llmobs_span` (Context-parent branch): when a new LLMObs span inherits from a propagated `Context`, normalize the wire-decimal value via `_normalize_wire_trace_id_to_hex` before writing it to `meta_struct`.
  2. **send distributed request/context** — `_inject_llmobs_context` (outbound HTTP) and `_current_trace_context` (cross-thread/async hand-off when 
  copying meta_struct → `Context._meta`): convert via `_trace_id_to_wire`.                                                              

Note: `_activate_llmobs_span()` via `_normalize_wire_trace_id_to_hex()` technically now also allows converting hex string trace IDs on distributed requests, where previously we would only accept integer trace IDs (this is to unblock a future potential change to the wire format to hex strings). The one caveat here is the rare 32-char       
  all-`[0-9]`-with-no-leading-zero hex class — those values are shape-indistinguishable from a 32-digit decimal, and we take decimal precedence for now, so these will be marked incorrect. **This is not a new bug on existing trace IDs, this only affects new hex str trace IDs manually sent by non-SDK users**

  ## What changes                                                                                                                     
  
  ### Before (on `main`)                                                                                                              
                                                         
  - `LLMObsSpanData.trace_id: int`, `parent_id: Optional[int]`; root spans had `parent_id = None`.                                    
  - Stored value was an `int`; rendering happened at every consumer:
    - submitted event: `format_trace_id(int)` → hex                                                                                   
    - wire header: `str(int)` → decimal                                                                                               
    - wire activation: `int(header)` → int                                                                                            
  - No support for non-numeric (custom) upstream trace IDs — `int(header)` would raise.                                               
  - Every callsite that read the parent had to reason about `None`, then `str(...)` it.                                               
                                                                                                                                      
  ### After (this PR)                                                                                                                 
                                                                                                                                      
  - `LLMObsSpanData.trace_id: str`, `parent_id: str`; root spans carry `ROOT_PARENT_ID = "undefined"` (matches the sentinel the       
  backend already uses for root-span queries).
  - `meta_struct` holds canonical hex; submission, `export_span()`, and the local-root tag pass that string through verbatim.         
  - `Context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY]` always holds wire decimal — both the inbound value (stored as-received) and the   
  value written by `_current_trace_context` for async/thread hand-off. The format is no longer lifecycle-dependent.                   
  - `_normalize_wire_trace_id_to_hex(value)` runs only on wire-sourced reads. Disambiguates 32-char ambiguous strings via leading zero
   / `a-f` presence; passes non-numeric custom IDs through unchanged.                                                                 
  - `_trace_id_to_wire(value)` converts stored hex back to decimal at the propagation boundary.
  - Integration callsites (`bedrock_agents.py`, `crewai.py`, `langgraph.py`, `openai_agents.py`, `_telemetry.py`) drop `str(...)`     
  wrapping and `is None` checks; compare against `ROOT_PARENT_ID` instead.                                                            
                                                                                                                                      
  ## Why this is better                                  
                                                                                                                                      
  - Stored value is the value the backend stores — `export_span()` returns exactly the trace_id the backend will index, so user code  
  that round-trips through it stops being lossy.
  - Each value is converted at most once per boundary crossing, in one place. No more `format_trace_id(...)` / `int(...)` sprinkled at
   every consumer.                                                                                                                    
                                                                                      
## Testing

Manually [tested older/new versions](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Aml-app%20%40event_type%3Aspan%20%40parent_id%3Aundefined%20service%3Allmobs-distrib%2A&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ3PbBz0eN3mkwAAABhBWjNQYkJ6MEFBQWxUaVdDODZBb0FBQUEAAAAkZjE5ZGNmNmMtNDU5Yy00ZGY2LWIzODctODMzMjBmMjliYTNlAAAFRA%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=7556807551033922194&start=1777298067807&end=1777301667807&paused=false) of the SDK to ensure distributed tracing is unbroken.
                                                                                                        
  ## Related                                                                                                                          
                                                         
  3-PR split of #17235:                                                                                                               
  1. #17683 — default model=unknown (XS) — merged
  2. **This PR** — trace/parent IDs as strings + `_dd.scope` at span start (M)                                                        
  3. #17685 — initialize tags and span name at span start (L, stacked on this PR)                                                     
                                                                                                                                      
  Claude session: `da6fb254-912e-4d04-aec2-ed09cd1980ac`                                                                              
  Resume: `claude --resume da6fb254-912e-4d04-aec2-ed09cd1980ac`      

[MLOB-6633]: https://datadoghq.atlassian.net/browse/MLOB-6633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ