### PR TITLE
test: update azure snapshots for svc_src

### DIFF
--- a/tests/snapshots/tests.contrib.azure_cosmos.test_azure_cosmos_snapshot.test_cosmos_async.json
+++ b/tests/snapshots/tests.contrib.azure_cosmos.test_azure_cosmos_snapshot.test_cosmos_async.json
@@ -10,27 +10,27 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 4054666,
-    "start": 1776192325306271338
+    "duration": 2260416,
+    "start": 1776788240589274463
   }],
 [
   {
@@ -44,27 +44,27 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 12308667,
-    "start": 1776192325310958421
+    "duration": 11090833,
+    "start": 1776788240591919588
   }],
 [
   {
@@ -78,7 +78,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -86,20 +86,20 @@
       "cosmosdb.container": "container.azure_cosmos_async",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 4004625,
-    "start": 1776192325323769421
+    "duration": 2391959,
+    "start": 1776788240603340254
   }],
 [
   {
@@ -113,7 +113,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -121,20 +121,20 @@
       "cosmosdb.container": "container.azure_cosmos_async",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2355625,
-    "start": 1776192325328254004
+    "duration": 1384875,
+    "start": 1776788240606041379
   }],
 [
   {
@@ -148,7 +148,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -156,20 +156,20 @@
       "cosmosdb.container": "container.azure_cosmos_async",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 3448125,
-    "start": 1776192325330975796
+    "duration": 1824083,
+    "start": 1776788240607661671
   }],
 [
   {
@@ -183,7 +183,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -191,20 +191,20 @@
       "cosmosdb.container": "container.azure_cosmos_async",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2463083,
-    "start": 1776192325334982338
+    "duration": 2163208,
+    "start": 1776788240609800213
   }],
 [
   {
@@ -218,7 +218,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -226,20 +226,20 @@
       "cosmosdb.container": "container.azure_cosmos_async",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2272875,
-    "start": 1776192325337841671
+    "duration": 1276500,
+    "start": 1776788240612230213
   }],
 [
   {
@@ -253,25 +253,25 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_async",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos-async/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 5562750,
-    "start": 1776192325340499296
+    "duration": 3177041,
+    "start": 1776788240613749213
   }]]

--- a/tests/snapshots/tests.contrib.azure_cosmos.test_azure_cosmos_snapshot.test_cosmos_error.json
+++ b/tests/snapshots/tests.contrib.azure_cosmos.test_azure_cosmos_snapshot.test_cosmos_error.json
@@ -10,27 +10,27 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 3680875,
-    "start": 1776192325361938254
+    "duration": 2107416,
+    "start": 1776788240627206713
   }],
 [
   {
@@ -44,27 +44,27 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 11011792,
-    "start": 1776192325366045129
+    "duration": 13302542,
+    "start": 1776788240629624296
   }],
 [
   {
@@ -78,7 +78,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -86,20 +86,20 @@
       "cosmosdb.container": "container.azure_cosmos_error",
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 6763000,
-    "start": 1776192325377541129
+    "duration": 3312458,
+    "start": 1776788240643252296
   }],
 [
   {
@@ -113,7 +113,7 @@
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -122,23 +122,23 @@
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
       "error.message": "(None) The document already exists in the collection.\nCode: None\nMessage: The document already exists in the collection.",
-      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/internal/azure_cosmos/patch.py\", line 69, in _patched_synchronized_request\n    result = wrapped(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.12/site-packages/azure/cosmos/_synchronized_request.py\", line 214, in SynchronizedRequest\n    return _retry_utility.Execute(\n           ^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.12/site-packages/azure/cosmos/_retry_utility.py\", line 97, in Execute\n    result = ExecuteFunction(function, global_endpoint_manager, *args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.12/site-packages/azure/cosmos/_retry_utility.py\", line 199, in ExecuteFunction\n    return function(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.12/site-packages/azure/cosmos/_synchronized_request.py\", line 150, in _Request\n    raise exceptions.CosmosResourceExistsError(message=data, response=response)\nazure.cosmos.exceptions.CosmosResourceExistsError: (None) The document already exists in the collection.\nCode: None\nMessage: The document already exists in the collection.\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/internal/azure_cosmos/patch.py\", line 69, in _patched_synchronized_request\n    result = wrapped(*args, **kwargs)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.9/site-packages/azure/cosmos/_synchronized_request.py\", line 214, in SynchronizedRequest\n    return _retry_utility.Execute(\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.9/site-packages/azure/cosmos/_retry_utility.py\", line 97, in Execute\n    result = ExecuteFunction(function, global_endpoint_manager, *args, **kwargs)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.9/site-packages/azure/cosmos/_retry_utility.py\", line 199, in ExecuteFunction\n    return function(*args, **kwargs)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurecosmos~490_pytest-asyncio0237_aiohttp_six/lib/python3.9/site-packages/azure/cosmos/_synchronized_request.py\", line 150, in _Request\n    raise exceptions.CosmosResourceExistsError(message=data, response=response)\nazure.cosmos.exceptions.CosmosResourceExistsError: (None) The document already exists in the collection.\nCode: None\nMessage: The document already exists in the collection.\n",
       "error.type": "azure.cosmos.exceptions.CosmosResourceExistsError",
       "http.status_code": "409",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 5121916,
-    "start": 1776192325384705463
+    "duration": 3100542,
+    "start": 1776788240646809504
   }],
 [
   {
@@ -152,7 +152,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -160,20 +160,20 @@
       "cosmosdb.container": "container.azure_cosmos_error",
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2975333,
-    "start": 1776192325390207463
+    "duration": 1694875,
+    "start": 1776788240650194254
   }],
 [
   {
@@ -187,7 +187,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -195,20 +195,20 @@
       "cosmosdb.container": "container.azure_cosmos_error",
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2441250,
-    "start": 1776192325393553421
+    "duration": 1565959,
+    "start": 1776788240652152879
   }],
 [
   {
@@ -222,25 +222,25 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_error",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 5442042,
-    "start": 1776192325396291879
+    "duration": 3659541,
+    "start": 1776788240653922213
   }]]

--- a/tests/snapshots/tests.contrib.azure_cosmos.test_azure_cosmos_snapshot.test_cosmos_sync.json
+++ b/tests/snapshots/tests.contrib.azure_cosmos.test_azure_cosmos_snapshot.test_cosmos_sync.json
@@ -10,27 +10,27 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 3685916,
-    "start": 1776192325128198713
+    "duration": 3907875,
+    "start": 1776788240466024838
   }],
 [
   {
@@ -44,27 +44,27 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 11000500,
-    "start": 1776192325133081671
+    "duration": 14305875,
+    "start": 1776788240470684379
   }],
 [
   {
@@ -78,7 +78,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -86,20 +86,20 @@
       "cosmosdb.container": "container.azure_cosmos_sync",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 3641208,
-    "start": 1776192325144538796
+    "duration": 3400709,
+    "start": 1776788240485570629
   }],
 [
   {
@@ -113,7 +113,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -121,20 +121,20 @@
       "cosmosdb.container": "container.azure_cosmos_sync",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2134542,
-    "start": 1776192325148595004
+    "duration": 1621458,
+    "start": 1776788240489310213
   }],
 [
   {
@@ -148,7 +148,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -156,20 +156,20 @@
       "cosmosdb.container": "container.azure_cosmos_sync",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 3087292,
-    "start": 1776192325151072504
+    "duration": 2432458,
+    "start": 1776788240491192421
   }],
 [
   {
@@ -183,7 +183,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -191,20 +191,20 @@
       "cosmosdb.container": "container.azure_cosmos_sync",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2811333,
-    "start": 1776192325154627421
+    "duration": 2214291,
+    "start": 1776788240494012713
   }],
 [
   {
@@ -218,7 +218,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
@@ -226,20 +226,20 @@
       "cosmosdb.container": "container.azure_cosmos_sync",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 2087667,
-    "start": 1776192325157789504
+    "duration": 1678208,
+    "start": 1776788240496493088
   }],
 [
   {
@@ -253,25 +253,25 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8b4500000000",
+      "_dd.p.tid": "69e7a31000000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_cosmos",
       "component": "azure_cosmos",
       "cosmosdb.connection.mode": "gateway",
       "db.name": "db.azure_cosmos_sync",
       "db.system": "cosmosdb",
-      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.12 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
+      "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.9.25 (Linux-6.12.72-linuxkit-aarch64-with-glibc2.41)",
       "language": "python",
       "out.host": "http://localhost:8081/",
-      "runtime-id": "832dbf54fb9443388fa7e59716751fea",
+      "runtime-id": "8b998d8f904644d898b523907d4d2beb",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 46717.0
+      "process_id": 557.0
     },
-    "duration": 5184375,
-    "start": 1776192325160200338
+    "duration": 4309167,
+    "start": 1776788240498449879
   }]]

--- a/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_activity_trigger_end_to_end.json
+++ b/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_activity_trigger_end_to_end.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6981be8d00000000",
+      "_dd.p.tid": "69e7a81b00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "start_activity",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7072/api/startactivity",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "d9c2e4a35aeb421ca8f4196c7d45a6f1",
+      "runtime-id": "952f361b6987494e889b935cac6a0167",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 1405.0
+      "process_id": 61229.0
     },
-    "duration": 1216397292,
-    "start": 1770110605174766961
+    "duration": 1049920000,
+    "start": 1776789531798186000
   },
      {
        "name": "aiohttp.request",
@@ -40,17 +42,17 @@
        "parent_id": 1,
        "type": "http",
        "meta": {
+         "_dd.svc_src": "aiohttp_client",
          "component": "aiohttp_client",
          "http.method": "POST",
          "http.status_code": "202",
          "http.status_msg": "Accepted",
          "http.url": "http://127.0.0.1:17071/durabletask/orchestrators/activity_orchestrator",
          "out.host": "127.0.0.1",
-         "span.kind": "client",
-         "test.deployment_verification": "pmartinez-aiohttp-test-20260129"
+         "span.kind": "client"
        },
-       "duration": 131553792,
-       "start": 1770110605175859044
+       "duration": 35883000,
+       "start": 1776789531798404000
      },
         {
           "name": "TCPConnector.connect",
@@ -60,11 +62,12 @@
           "span_id": 5,
           "parent_id": 2,
           "meta": {
-            "_dd.p.tid": "6981be8d00000000",
+            "_dd.p.tid": "69e7a81b00000000",
+            "_dd.svc_src": "aiohttp_client",
             "component": "aiohttp"
           },
-          "duration": 1331250,
-          "start": 1770110605178443253
+          "duration": 521000,
+          "start": 1776789531798674000
         },
      {
        "name": "aiohttp.request",
@@ -75,18 +78,18 @@
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.p.tid": "6981be8d00000000",
+         "_dd.p.tid": "69e7a81b00000000",
+         "_dd.svc_src": "aiohttp_client",
          "component": "aiohttp_client",
          "http.method": "GET",
          "http.status_code": "202",
          "http.status_msg": "Accepted",
-         "http.url": "http://127.0.0.1:17071/durabletask/instances/f58cbe129bc4470698155cd7b6edd58d",
+         "http.url": "http://127.0.0.1:17071/durabletask/instances/e9526e0b78dd42a3b4226c2b62dbfb4b",
          "out.host": "127.0.0.1",
-         "span.kind": "client",
-         "test.deployment_verification": "pmartinez-aiohttp-test-20260129"
+         "span.kind": "client"
        },
-       "duration": 60587292,
-       "start": 1770110605309143086
+       "duration": 8038000,
+       "start": 1776789531834711000
      },
         {
           "name": "TCPConnector.connect",
@@ -96,11 +99,12 @@
           "span_id": 6,
           "parent_id": 3,
           "meta": {
-            "_dd.p.tid": "6981be8d00000000",
+            "_dd.p.tid": "69e7a81b00000000",
+            "_dd.svc_src": "aiohttp_client",
             "component": "aiohttp"
           },
-          "duration": 384834,
-          "start": 1770110605309441544
+          "duration": 463000,
+          "start": 1776789531834862000
         },
      {
        "name": "aiohttp.request",
@@ -111,18 +115,18 @@
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.p.tid": "6981be8d00000000",
+         "_dd.p.tid": "69e7a81b00000000",
+         "_dd.svc_src": "aiohttp_client",
          "component": "aiohttp_client",
          "http.method": "GET",
          "http.status_code": "200",
          "http.status_msg": "OK",
-         "http.url": "http://127.0.0.1:17071/durabletask/instances/f58cbe129bc4470698155cd7b6edd58d",
+         "http.url": "http://127.0.0.1:17071/durabletask/instances/e9526e0b78dd42a3b4226c2b62dbfb4b",
          "out.host": "127.0.0.1",
-         "span.kind": "client",
-         "test.deployment_verification": "pmartinez-aiohttp-test-20260129"
+         "span.kind": "client"
        },
-       "duration": 15842791,
-       "start": 1770110606374362420
+       "duration": 3010000,
+       "start": 1776789532844529000
      },
         {
           "name": "TCPConnector.connect",
@@ -132,11 +136,12 @@
           "span_id": 7,
           "parent_id": 4,
           "meta": {
-            "_dd.p.tid": "6981be8d00000000",
+            "_dd.p.tid": "69e7a81b00000000",
+            "_dd.svc_src": "aiohttp_client",
             "component": "aiohttp"
           },
-          "duration": 453125,
-          "start": 1770110606374682628
+          "duration": 480000,
+          "start": 1776789532844777000
         }],
 [
   {
@@ -149,20 +154,22 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6981be8d00000000",
+      "_dd.p.tid": "69e7a81b00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "durable_activity",
       "aas.function.trigger": "Activity",
       "component": "azure_functions",
       "language": "python",
-      "runtime-id": "d9c2e4a35aeb421ca8f4196c7d45a6f1",
+      "runtime-id": "952f361b6987494e889b935cac6a0167",
       "span.kind": "internal"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 1405.0
+      "process_id": 61229.0
     },
-    "duration": 53583,
-    "start": 1770110605603371961
+    "duration": 103000,
+    "start": 1776789531902091000
   }]]

--- a/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_entity_trigger_end_to_end.json
+++ b/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_entity_trigger_end_to_end.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6981be9a00000000",
+      "_dd.p.tid": "69e7a82200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "start_entity",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7072/api/startentity",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "196b6f9036a84b498173f93a69a578a0",
+      "runtime-id": "1b69241f081e4253a3da394677a05d74",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 1802.0
+      "process_id": 61271.0
     },
-    "duration": 1281617334,
-    "start": 1770110618951849051
+    "duration": 1052130000,
+    "start": 1776789538037598000
   },
      {
        "name": "aiohttp.request",
@@ -40,17 +42,17 @@
        "parent_id": 1,
        "type": "http",
        "meta": {
+         "_dd.svc_src": "aiohttp_client",
          "component": "aiohttp_client",
          "http.method": "POST",
          "http.status_code": "202",
          "http.status_msg": "Accepted",
          "http.url": "http://127.0.0.1:17071/durabletask/orchestrators/entity_orchestrator",
          "out.host": "127.0.0.1",
-         "span.kind": "client",
-         "test.deployment_verification": "pmartinez-aiohttp-test-20260129"
+         "span.kind": "client"
        },
-       "duration": 159445500,
-       "start": 1770110618952974051
+       "duration": 36882000,
+       "start": 1776789538037822000
      },
         {
           "name": "TCPConnector.connect",
@@ -60,11 +62,12 @@
           "span_id": 5,
           "parent_id": 2,
           "meta": {
-            "_dd.p.tid": "6981be9a00000000",
+            "_dd.p.tid": "69e7a82200000000",
+            "_dd.svc_src": "aiohttp_client",
             "component": "aiohttp"
           },
-          "duration": 1502250,
-          "start": 1770110618955986217
+          "duration": 538000,
+          "start": 1776789538038080000
         },
      {
        "name": "aiohttp.request",
@@ -75,18 +78,18 @@
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.p.tid": "6981be9a00000000",
+         "_dd.p.tid": "69e7a82200000000",
+         "_dd.svc_src": "aiohttp_client",
          "component": "aiohttp_client",
          "http.method": "GET",
          "http.status_code": "202",
          "http.status_msg": "Accepted",
-         "http.url": "http://127.0.0.1:17071/durabletask/instances/c21ab90e7ff4450b846575faf21cae8d",
+         "http.url": "http://127.0.0.1:17071/durabletask/instances/85bd4673d0c042728048361061549c26",
          "out.host": "127.0.0.1",
-         "span.kind": "client",
-         "test.deployment_verification": "pmartinez-aiohttp-test-20260129"
+         "span.kind": "client"
        },
-       "duration": 93368042,
-       "start": 1770110619114189384
+       "duration": 8918000,
+       "start": 1776789538075123000
      },
         {
           "name": "TCPConnector.connect",
@@ -96,11 +99,12 @@
           "span_id": 6,
           "parent_id": 3,
           "meta": {
-            "_dd.p.tid": "6981be9a00000000",
+            "_dd.p.tid": "69e7a82200000000",
+            "_dd.svc_src": "aiohttp_client",
             "component": "aiohttp"
           },
-          "duration": 512333,
-          "start": 1770110619114727676
+          "duration": 443000,
+          "start": 1776789538075296000
         },
      {
        "name": "aiohttp.request",
@@ -111,18 +115,18 @@
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.p.tid": "6981be9a00000000",
+         "_dd.p.tid": "69e7a82200000000",
+         "_dd.svc_src": "aiohttp_client",
          "component": "aiohttp_client",
          "http.method": "GET",
          "http.status_code": "200",
          "http.status_msg": "OK",
-         "http.url": "http://127.0.0.1:17071/durabletask/instances/c21ab90e7ff4450b846575faf21cae8d",
+         "http.url": "http://127.0.0.1:17071/durabletask/instances/85bd4673d0c042728048361061549c26",
          "out.host": "127.0.0.1",
-         "span.kind": "client",
-         "test.deployment_verification": "pmartinez-aiohttp-test-20260129"
+         "span.kind": "client"
        },
-       "duration": 19974625,
-       "start": 1770110620212754093
+       "duration": 3331000,
+       "start": 1776789539085776000
      },
         {
           "name": "TCPConnector.connect",
@@ -132,11 +136,12 @@
           "span_id": 7,
           "parent_id": 4,
           "meta": {
-            "_dd.p.tid": "6981be9a00000000",
+            "_dd.p.tid": "69e7a82200000000",
+            "_dd.svc_src": "aiohttp_client",
             "component": "aiohttp"
           },
-          "duration": 455375,
-          "start": 1770110620213090801
+          "duration": 469000,
+          "start": 1776789539086037000
         }],
 [
   {
@@ -149,20 +154,22 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6981be9b00000000",
+      "_dd.p.tid": "69e7a82200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "counter",
       "aas.function.trigger": "Entity",
       "component": "azure_functions",
       "language": "python",
-      "runtime-id": "196b6f9036a84b498173f93a69a578a0",
+      "runtime-id": "1b69241f081e4253a3da394677a05d74",
       "span.kind": "internal"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 1802.0
+      "process_id": 61271.0
     },
-    "duration": 448459,
-    "start": 1770110619491400759
+    "duration": 227000,
+    "start": 1776789538153367000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_disabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_disabled_batch_links_disabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4200000000",
+      "_dd.p.tid": "69e92dc400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b5a6803ffb024d98abf10c0d44995907",
+      "runtime-id": "813f3b225cfc4c9dabe617b89b65c3c6",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50393.0
+      "process_id": 72017.0
     },
-    "duration": 12118875,
-    "start": 1776192834275016795
+    "duration": 9226000,
+    "start": 1776889284470915000
   }],
 [
   {
@@ -46,9 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4200000000",
+      "_dd.p.tid": "69e92dc400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -56,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b5a6803ffb024d98abf10c0d44995907",
+      "runtime-id": "813f3b225cfc4c9dabe617b89b65c3c6",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50393.0
+      "process_id": 72017.0
     },
-    "duration": 5349958,
-    "start": 1776192834288183254
+    "duration": 6654000,
+    "start": 1776889284481657000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_disabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_disabled_batch_links_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3f00000000",
+      "_dd.p.tid": "69e92dc100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "04367136055446e5bdc583525e524cf6",
+      "runtime-id": "875072a8bbb749e5888b4be206119512",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50380.0
+      "process_id": 72009.0
     },
-    "duration": 542042,
-    "start": 1776192831327356877
+    "duration": 490000,
+    "start": 1776889281423333000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3f00000000",
+      "_dd.p.tid": "69e92dc100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "339ce1b3-aecb-4e1b-9ad4-d22d834d79a7",
+      "messaging.message_id": "e1700234-8119-4b39-9130-1d73f363f508",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "04367136055446e5bdc583525e524cf6",
+      "runtime-id": "875072a8bbb749e5888b4be206119512",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50380.0
+      "process_id": 72009.0
     },
-    "duration": 421292,
-    "start": 1776192831329648127
+    "duration": 157000,
+    "start": 1776889281424487000
   }],
 [
   {
@@ -80,9 +80,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3f00000000",
+      "_dd.p.tid": "69e92dc100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -90,17 +90,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "04367136055446e5bdc583525e524cf6",
+      "runtime-id": "875072a8bbb749e5888b4be206119512",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50380.0
+      "process_id": 72009.0
     },
-    "duration": 13380959,
-    "start": 1776192831330291877
+    "duration": 6228000,
+    "start": 1776889281424752000
   }],
 [
   {
@@ -115,26 +115,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3f00000000",
+      "_dd.p.tid": "69e92dc100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "04367136055446e5bdc583525e524cf6",
+      "runtime-id": "875072a8bbb749e5888b4be206119512",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50380.0
+      "process_id": 72009.0
     },
-    "duration": 132417,
-    "start": 1776192831343914044
+    "duration": 190000,
+    "start": 1776889281431327000
   }],
 [
   {
@@ -149,27 +149,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3f00000000",
+      "_dd.p.tid": "69e92dc100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "e3e3a644-f1a1-47de-ae8e-7124b8891b79",
+      "messaging.message_id": "f2cfd1e7-f0a5-4e52-b63c-6532eb93dc60",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "04367136055446e5bdc583525e524cf6",
+      "runtime-id": "875072a8bbb749e5888b4be206119512",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50380.0
+      "process_id": 72009.0
     },
-    "duration": 203167,
-    "start": 1776192831344141252
+    "duration": 259000,
+    "start": 1776889281431642000
   }],
 [
   {
@@ -184,9 +184,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3f00000000",
+      "_dd.p.tid": "69e92dc100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -194,15 +194,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "04367136055446e5bdc583525e524cf6",
+      "runtime-id": "875072a8bbb749e5888b4be206119512",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50380.0
+      "process_id": 72009.0
     },
-    "duration": 5189334,
-    "start": 1776192831344430252
+    "duration": 5824000,
+    "start": 1776889281432013000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_enabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_enabled_batch_links_disabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3c00000000",
+      "_dd.p.tid": "69e92dbe00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "75d26090069845ffb21fe641e299ec3e",
+      "runtime-id": "167b183261dd45dfb2f13494ed0bcfe7",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50367.0
+      "process_id": 71978.0
     },
-    "duration": 10563917,
-    "start": 1776192828489416251
+    "duration": 16107000,
+    "start": 1776889278351863000
   }],
 [
   {
@@ -46,9 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3c00000000",
+      "_dd.p.tid": "69e92dbe00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -56,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "75d26090069845ffb21fe641e299ec3e",
+      "runtime-id": "167b183261dd45dfb2f13494ed0bcfe7",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50367.0
+      "process_id": 71978.0
     },
-    "duration": 7370125,
-    "start": 1776192828501123918
+    "duration": 11551000,
+    "start": 1776889278368560000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_enabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_batch_distributed_tracing_enabled_batch_links_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3900000000",
+      "_dd.p.tid": "69e92dbb00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fd7825936b7d4975b28a5ae02789860e",
+      "runtime-id": "5f422898715546eebad1d18a4fcb4734",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50354.0
+      "process_id": 71974.0
     },
-    "duration": 1280375,
-    "start": 1776192825565209750
+    "duration": 1591000,
+    "start": 1776889275264957000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3900000000",
+      "_dd.p.tid": "69e92dbb00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "109ec711-4954-4098-98a2-b1ad8f258d44",
+      "messaging.message_id": "097ef7b9-bb9c-47f5-84bb-adc0c32eab5f",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fd7825936b7d4975b28a5ae02789860e",
+      "runtime-id": "5f422898715546eebad1d18a4fcb4734",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50354.0
+      "process_id": 71974.0
     },
-    "duration": 1846584,
-    "start": 1776192825567672416
+    "duration": 556000,
+    "start": 1776889275267054000
   }],
 [
   {
@@ -80,10 +80,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3900000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d39000000008ebd943fcb68efae\", \"span_id\": \"de12968b630689ee\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d3900000000\", \"flags\": 1}, {\"trace_id\": \"69de8d3900000000881f6e5e8e30ece6\", \"span_id\": \"fda28ccc1b5dcdca\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d3900000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92dbb00000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92dbb000000000bbf41ae2d47f016\", \"span_id\": \"7c8f7963f20516a4\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dbb00000000\", \"flags\": 1}, {\"trace_id\": \"69e92dbb000000009716c825f8359f40\", \"span_id\": \"16c462c9ee246a8d\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dbb00000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -91,17 +91,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fd7825936b7d4975b28a5ae02789860e",
+      "runtime-id": "5f422898715546eebad1d18a4fcb4734",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50354.0
+      "process_id": 71974.0
     },
-    "duration": 4736208,
-    "start": 1776192825569646208
+    "duration": 7313000,
+    "start": 1776889275267813000
   }],
 [
   {
@@ -116,26 +116,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3900000000",
+      "_dd.p.tid": "69e92dbb00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fd7825936b7d4975b28a5ae02789860e",
+      "runtime-id": "5f422898715546eebad1d18a4fcb4734",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50354.0
+      "process_id": 71974.0
     },
-    "duration": 149417,
-    "start": 1776192825574503416
+    "duration": 379000,
+    "start": 1776889275275530000
   }],
 [
   {
@@ -150,27 +150,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3900000000",
+      "_dd.p.tid": "69e92dbb00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "411494e1-4754-4ae1-b45e-3d5b9ae5be74",
+      "messaging.message_id": "2838e55c-ddef-4c37-8dcb-9f678d718706",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fd7825936b7d4975b28a5ae02789860e",
+      "runtime-id": "5f422898715546eebad1d18a4fcb4734",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50354.0
+      "process_id": 71974.0
     },
-    "duration": 142458,
-    "start": 1776192825574699083
+    "duration": 352000,
+    "start": 1776889275276017000
   }],
 [
   {
@@ -185,10 +185,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3900000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d3900000000fa6b64a29d8d34d5\", \"span_id\": \"20dbeb1b93bafc0e\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d3900000000\", \"flags\": 1}, {\"trace_id\": \"69de8d3900000000dc30c6f3807481c3\", \"span_id\": \"aaeeea70118eccd8\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d3900000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92dbb00000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92dbb00000000471692c17b5450a8\", \"span_id\": \"e873549055bc8383\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dbb00000000\", \"flags\": 1}, {\"trace_id\": \"69e92dbb00000000d5982bbbbc590627\", \"span_id\": \"51c6d347db0fece8\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dbb00000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -196,15 +196,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fd7825936b7d4975b28a5ae02789860e",
+      "runtime-id": "5f422898715546eebad1d18a4fcb4734",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50354.0
+      "process_id": 71974.0
     },
-    "duration": 2967709,
-    "start": 1776192825574879416
+    "duration": 5732000,
+    "start": 1776889275276466000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_list_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_list_distributed_tracing_disabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3600000000",
+      "_dd.p.tid": "69e92db700000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "3accc9d16fd64687a9c70d30e3c605bb",
+      "runtime-id": "4f9fb434da834686983d442a9aef32a5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50341.0
+      "process_id": 71951.0
     },
-    "duration": 499055834,
-    "start": 1776192822105185804
+    "duration": 498818000,
+    "start": 1776889271665666000
   },
      {
        "name": "azure.eventhubs.create",
@@ -52,8 +52,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 178750,
-       "start": 1776192822596435888
+       "duration": 155000,
+       "start": 1776889272155469000
      },
      {
        "name": "azure.eventhubs.create",
@@ -69,14 +69,14 @@
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "767fa003-14e9-46eb-abbc-8a69de360b64",
+         "messaging.message_id": "c96d4bbb-72c6-4657-97f1-9da9996c4979",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 143208,
-       "start": 1776192822596665763
+       "duration": 96000,
+       "start": 1776889272155697000
      }],
 [
   {
@@ -91,9 +91,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3600000000",
+      "_dd.p.tid": "69e92db800000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -101,17 +101,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "3accc9d16fd64687a9c70d30e3c605bb",
+      "runtime-id": "4f9fb434da834686983d442a9aef32a5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50341.0
+      "process_id": 71951.0
     },
-    "duration": 3478500,
-    "start": 1776192822604731971
+    "duration": 5507000,
+    "start": 1776889272164833000
   },
      {
        "name": "azure.eventhubs.create",
@@ -132,8 +132,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 74083,
-       "start": 1776192822604820888
+       "duration": 85000,
+       "start": 1776889272164907000
      },
      {
        "name": "azure.eventhubs.create",
@@ -149,12 +149,12 @@
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "d825935e-cbaa-44f6-a961-7a82cb957d39",
+         "messaging.message_id": "eccfb1d3-a878-402e-982a-585f35930062",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 121292,
-       "start": 1776192822604917304
+       "duration": 111000,
+       "start": 1776889272165018000
      }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_async_list_distributed_tracing_enabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3300000000",
+      "_dd.p.tid": "69e92db400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "1ae737975a7c4c3eae69f9eb4cdee83d",
+      "runtime-id": "6d503bf4fdca4f488a8b6cffbde25882",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50328.0
+      "process_id": 71933.0
     },
-    "duration": 523822459,
-    "start": 1776192819007988344
+    "duration": 500585000,
+    "start": 1776889268577130000
   },
      {
        "name": "azure.eventhubs.create",
@@ -44,7 +44,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d3300000000",
+         "_dd.p.tid": "69e92db400000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -53,8 +53,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 1096667,
-       "start": 1776192819518763636
+       "duration": 904000,
+       "start": 1776889269063053000
      },
      {
        "name": "azure.eventhubs.create",
@@ -67,18 +67,18 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d3300000000",
+         "_dd.p.tid": "69e92db400000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "a460f4e2-d94a-4674-8413-b5c99b4e9fd2",
+         "messaging.message_id": "f436e936-f6a2-4818-93a2-ad5be3183f41",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 411000,
-       "start": 1776192819520040678
+       "duration": 2719000,
+       "start": 1776889269064109000
      }],
 [
   {
@@ -93,9 +93,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d3300000000",
+      "_dd.p.tid": "69e92db500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -103,17 +103,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "1ae737975a7c4c3eae69f9eb4cdee83d",
+      "runtime-id": "6d503bf4fdca4f488a8b6cffbde25882",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50328.0
+      "process_id": 71933.0
     },
-    "duration": 5682583,
-    "start": 1776192819532528303
+    "duration": 6328000,
+    "start": 1776889269078472000
   },
      {
        "name": "azure.eventhubs.create",
@@ -126,7 +126,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d3300000000",
+         "_dd.p.tid": "69e92db500000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -135,8 +135,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 241291,
-       "start": 1776192819532860678
+       "duration": 319000,
+       "start": 1776889269078808000
      },
      {
        "name": "azure.eventhubs.create",
@@ -149,16 +149,16 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d3300000000",
+         "_dd.p.tid": "69e92db500000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "953805d3-34b6-435c-9709-6966f5b7a09d",
+         "messaging.message_id": "40cacc38-cf32-47c9-a13f-3b21efa234a3",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 293583,
-       "start": 1776192819533142136
+       "duration": 346000,
+       "start": 1776889269079179000
      }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_disabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_disabled_batch_links_disabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2f00000000",
+      "_dd.p.tid": "69e92db100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "6905e78bb1dd4b42a20a6aa0c3d5856f",
+      "runtime-id": "387fb509033c435a89f41313ad1d33dd",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50311.0
+      "process_id": 71923.0
     },
-    "duration": 10875292,
-    "start": 1776192815093397842
+    "duration": 12537000,
+    "start": 1776889265486367000
   }],
 [
   {
@@ -46,9 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2f00000000",
+      "_dd.p.tid": "69e92db100000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -56,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "6905e78bb1dd4b42a20a6aa0c3d5856f",
+      "runtime-id": "387fb509033c435a89f41313ad1d33dd",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50311.0
+      "process_id": 71923.0
     },
-    "duration": 3180583,
-    "start": 1776192815104957384
+    "duration": 6421000,
+    "start": 1776889265500542000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_disabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_disabled_batch_links_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2a00000000",
+      "_dd.p.tid": "69e92dad00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9eac12941b024f3c981ed71f61b4a117",
+      "runtime-id": "606f0dd866674480a0616a47e55c91b5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50294.0
+      "process_id": 71901.0
     },
-    "duration": 1509625,
-    "start": 1776192810565918465
+    "duration": 2289000,
+    "start": 1776889261470872000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2a00000000",
+      "_dd.p.tid": "69e92dad00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "4badf654-4e71-424b-983d-b61f211b455e",
+      "messaging.message_id": "376e8698-5cb3-4f2d-bb69-739552534ad6",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9eac12941b024f3c981ed71f61b4a117",
+      "runtime-id": "606f0dd866674480a0616a47e55c91b5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50294.0
+      "process_id": 71901.0
     },
-    "duration": 698750,
-    "start": 1776192810569970298
+    "duration": 505000,
+    "start": 1776889261473838000
   }],
 [
   {
@@ -80,9 +80,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2a00000000",
+      "_dd.p.tid": "69e92dad00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -90,17 +90,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9eac12941b024f3c981ed71f61b4a117",
+      "runtime-id": "606f0dd866674480a0616a47e55c91b5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50294.0
+      "process_id": 71901.0
     },
-    "duration": 11882958,
-    "start": 1776192810571021507
+    "duration": 6079000,
+    "start": 1776889261475330000
   }],
 [
   {
@@ -115,26 +115,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2a00000000",
+      "_dd.p.tid": "69e92dad00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9eac12941b024f3c981ed71f61b4a117",
+      "runtime-id": "606f0dd866674480a0616a47e55c91b5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50294.0
+      "process_id": 71901.0
     },
-    "duration": 121459,
-    "start": 1776192810583121548
+    "duration": 233000,
+    "start": 1776889261481696000
   }],
 [
   {
@@ -149,27 +149,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2a00000000",
+      "_dd.p.tid": "69e92dad00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "0a5412bf-8770-41ee-951c-5459994e7985",
+      "messaging.message_id": "d30dd22a-f082-4ecd-98e6-e6ef836cbcd7",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9eac12941b024f3c981ed71f61b4a117",
+      "runtime-id": "606f0dd866674480a0616a47e55c91b5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50294.0
+      "process_id": 71901.0
     },
-    "duration": 197458,
-    "start": 1776192810583334090
+    "duration": 257000,
+    "start": 1776889261482047000
   }],
 [
   {
@@ -184,9 +184,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2a00000000",
+      "_dd.p.tid": "69e92dad00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -194,15 +194,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9eac12941b024f3c981ed71f61b4a117",
+      "runtime-id": "606f0dd866674480a0616a47e55c91b5",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50294.0
+      "process_id": 71901.0
     },
-    "duration": 5531166,
-    "start": 1776192810583638382
+    "duration": 4131000,
+    "start": 1776889261482406000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_enabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_enabled_batch_links_disabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2500000000",
+      "_dd.p.tid": "69e92da900000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fa54b3d95b3f416e8ab8d4674cee33c2",
+      "runtime-id": "db2fd6d0613a4759a63c38139a11ab01",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50277.0
+      "process_id": 71895.0
     },
-    "duration": 34141250,
-    "start": 1776192805976837338
+    "duration": 12133000,
+    "start": 1776889257358329000
   }],
 [
   {
@@ -46,9 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2600000000",
+      "_dd.p.tid": "69e92da900000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -56,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "fa54b3d95b3f416e8ab8d4674cee33c2",
+      "runtime-id": "db2fd6d0613a4759a63c38139a11ab01",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50277.0
+      "process_id": 71895.0
     },
-    "duration": 3388041,
-    "start": 1776192806011849255
+    "duration": 5740000,
+    "start": 1776889257371599000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_enabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_batch_distributed_tracing_enabled_batch_links_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2100000000",
+      "_dd.p.tid": "69e92da500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b63ccfe23949430f87838f44a18b8fc6",
+      "runtime-id": "9c11e2a29d94429c9a44a766f29eb180",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50260.0
+      "process_id": 71872.0
     },
-    "duration": 5343875,
-    "start": 1776192801333027169
+    "duration": 1189000,
+    "start": 1776889253067904000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2100000000",
+      "_dd.p.tid": "69e92da500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "98152b1c-85ff-4f17-8b60-f736342e43e1",
+      "messaging.message_id": "f5ea690c-f98b-4ae8-b98a-b737c0cbc48f",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b63ccfe23949430f87838f44a18b8fc6",
+      "runtime-id": "9c11e2a29d94429c9a44a766f29eb180",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50260.0
+      "process_id": 71872.0
     },
-    "duration": 711500,
-    "start": 1776192801339563919
+    "duration": 627000,
+    "start": 1776889253069836000
   }],
 [
   {
@@ -80,10 +80,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2100000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d210000000008fca50f0d4e973f\", \"span_id\": \"df993e119c64097c\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d2100000000\", \"flags\": 1}, {\"trace_id\": \"69de8d21000000001513a58bd0b51573\", \"span_id\": \"295d5faaa13fe032\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d2100000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92da500000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92da500000000ee577c91fae10f2d\", \"span_id\": \"a0d5a181827cf683\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92da500000000\", \"flags\": 1}, {\"trace_id\": \"69e92da5000000000297f45d0cafbeef\", \"span_id\": \"1d1dbe5f578a8c1a\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92da500000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -91,17 +91,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b63ccfe23949430f87838f44a18b8fc6",
+      "runtime-id": "9c11e2a29d94429c9a44a766f29eb180",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50260.0
+      "process_id": 71872.0
     },
-    "duration": 14008333,
-    "start": 1776192801340443919
+    "duration": 12075000,
+    "start": 1776889253070649000
   }],
 [
   {
@@ -116,26 +116,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2100000000",
+      "_dd.p.tid": "69e92da500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b63ccfe23949430f87838f44a18b8fc6",
+      "runtime-id": "9c11e2a29d94429c9a44a766f29eb180",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50260.0
+      "process_id": 71872.0
     },
-    "duration": 283542,
-    "start": 1776192801354755002
+    "duration": 449000,
+    "start": 1776889253083608000
   }],
 [
   {
@@ -150,27 +150,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2100000000",
+      "_dd.p.tid": "69e92da500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "ccdaea5d-a938-4f48-b54e-5fa3a34690b7",
+      "messaging.message_id": "073f7ca4-4b56-49ae-8fa4-1c3312774bc3",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b63ccfe23949430f87838f44a18b8fc6",
+      "runtime-id": "9c11e2a29d94429c9a44a766f29eb180",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50260.0
+      "process_id": 71872.0
     },
-    "duration": 288167,
-    "start": 1776192801355127169
+    "duration": 530000,
+    "start": 1776889253084197000
   }],
 [
   {
@@ -185,10 +185,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d2100000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d21000000008cb953c6dcd0b0c6\", \"span_id\": \"4160cd67d11c7050\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d2100000000\", \"flags\": 1}, {\"trace_id\": \"69de8d21000000002ba7f70df2682bfd\", \"span_id\": \"7832381cb58c2b01\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d2100000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92da500000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92da500000000c5ed671f94c3f7e2\", \"span_id\": \"fe447ebc560dab3f\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92da500000000\", \"flags\": 1}, {\"trace_id\": \"69e92da50000000013ece2f08304c542\", \"span_id\": \"a9e14be76d07dc50\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92da500000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -196,15 +196,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b63ccfe23949430f87838f44a18b8fc6",
+      "runtime-id": "9c11e2a29d94429c9a44a766f29eb180",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50260.0
+      "process_id": 71872.0
     },
-    "duration": 4580291,
-    "start": 1776192801355725586
+    "duration": 8558000,
+    "start": 1776889253085098000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_async_batch_distributed_tracing_enabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_async_batch_distributed_tracing_enabled_batch_links_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5700000000",
+      "_dd.p.tid": "69e92ddc00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "87a72e589ac043f2af736bcd21d53ad9",
+      "runtime-id": "a53ebc2098e643449804a36c7c5732a8",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50461.0
+      "process_id": 73035.0
     },
-    "duration": 2228667,
-    "start": 1776192855212100430
+    "duration": 552000,
+    "start": 1776889308231687000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5700000000",
+      "_dd.p.tid": "69e92ddc00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "303b9d37-b5c7-4b47-a61e-7ed8053678fb",
+      "messaging.message_id": "887e0035-5bc9-42d6-8443-3439d0a5a9bb",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "87a72e589ac043f2af736bcd21d53ad9",
+      "runtime-id": "a53ebc2098e643449804a36c7c5732a8",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50461.0
+      "process_id": 73035.0
     },
-    "duration": 670375,
-    "start": 1776192855216041639
+    "duration": 202000,
+    "start": 1776889308232504000
   }],
 [
   {
@@ -80,10 +80,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5700000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d570000000003d8d3b099d375d0\", \"span_id\": \"9c51a3e23aef32c6\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d5700000000\", \"flags\": 1}, {\"trace_id\": \"69de8d5700000000e175dd79945a9d71\", \"span_id\": \"a01790254839b25e\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d5700000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92ddc00000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92ddc00000000ca6e9d32a6b8771a\", \"span_id\": \"05f97ac7a6d16404\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92ddc00000000\", \"flags\": 1}, {\"trace_id\": \"69e92ddc00000000f6922e6912cf5f3a\", \"span_id\": \"c13e5efde64fcd62\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92ddc00000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -91,17 +91,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "87a72e589ac043f2af736bcd21d53ad9",
+      "runtime-id": "a53ebc2098e643449804a36c7c5732a8",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50461.0
+      "process_id": 73035.0
     },
-    "duration": 451122944,
-    "start": 1776192855216895514
+    "duration": 428510000,
+    "start": 1776889308232778000
   }],
 [
   {
@@ -116,26 +116,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5700000000",
+      "_dd.p.tid": "69e92ddc00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "87a72e589ac043f2af736bcd21d53ad9",
+      "runtime-id": "a53ebc2098e643449804a36c7c5732a8",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50461.0
+      "process_id": 73035.0
     },
-    "duration": 505833,
-    "start": 1776192855668480125
+    "duration": 152000,
+    "start": 1776889308661463000
   }],
 [
   {
@@ -150,27 +150,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5700000000",
+      "_dd.p.tid": "69e92ddc00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "3cfaedcd-fe20-426a-8d83-ba906e30c948",
+      "messaging.message_id": "3c5ce20c-dd51-4abe-a0f0-a867f549c4e5",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "87a72e589ac043f2af736bcd21d53ad9",
+      "runtime-id": "a53ebc2098e643449804a36c7c5732a8",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50461.0
+      "process_id": 73035.0
     },
-    "duration": 410583,
-    "start": 1776192855669117625
+    "duration": 131000,
+    "start": 1776889308661663000
   }],
 [
   {
@@ -185,10 +185,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5700000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d57000000006d448ef75bd870c7\", \"span_id\": \"2c7cb6b60a51514b\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d5700000000\", \"flags\": 1}, {\"trace_id\": \"69de8d57000000009d7b60cfcc222133\", \"span_id\": \"8dc0ef30181d5e16\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d5700000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92ddc00000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92ddc00000000ef49c96d0f01092f\", \"span_id\": \"dc0a2d948b4ac23f\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92ddc00000000\", \"flags\": 1}, {\"trace_id\": \"69e92ddc000000004624f43fc638c7e7\", \"span_id\": \"8f1809213bae5ecf\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92ddc00000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -196,15 +196,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "87a72e589ac043f2af736bcd21d53ad9",
+      "runtime-id": "a53ebc2098e643449804a36c7c5732a8",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50461.0
+      "process_id": 73035.0
     },
-    "duration": 586916,
-    "start": 1776192855669680000
+    "duration": 827000,
+    "start": 1776889308661830000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_async_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_async_list_distributed_tracing_enabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5000000000",
+      "_dd.p.tid": "69e92dd500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9c800134aa5747f2a66efefbd4372164",
+      "runtime-id": "8e7fce4dc0b24706a98979a6d47e8f52",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50448.0
+      "process_id": 72957.0
     },
-    "duration": 963091834,
-    "start": 1776192848826961761
+    "duration": 916722000,
+    "start": 1776889301796595000
   },
      {
        "name": "azure.eventhubs.create",
@@ -44,7 +44,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d5000000000",
+         "_dd.p.tid": "69e92dd500000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -53,8 +53,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 519750,
-       "start": 1776192849330680969
+       "duration": 292000,
+       "start": 1776889302278586000
      },
      {
        "name": "azure.eventhubs.create",
@@ -67,18 +67,18 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d5000000000",
+         "_dd.p.tid": "69e92dd500000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "f8f633e2-1d55-4f04-acd3-3b30195ab237",
+         "messaging.message_id": "b3b35d5d-f793-4531-a37e-0b181eb5ce02",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 289375,
-       "start": 1776192849331287053
+       "duration": 183000,
+       "start": 1776889302278924000
      }],
 [
   {
@@ -93,9 +93,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5100000000",
+      "_dd.p.tid": "69e92dd600000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -103,17 +103,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9c800134aa5747f2a66efefbd4372164",
+      "runtime-id": "8e7fce4dc0b24706a98979a6d47e8f52",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50448.0
+      "process_id": 72957.0
     },
-    "duration": 935750,
-    "start": 1776192849790835886
+    "duration": 1002000,
+    "start": 1776889302715655000
   },
      {
        "name": "azure.eventhubs.create",
@@ -126,7 +126,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d5100000000",
+         "_dd.p.tid": "69e92dd600000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -135,8 +135,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 297417,
-       "start": 1776192849791129053
+       "duration": 121000,
+       "start": 1776889302715801000
      },
      {
        "name": "azure.eventhubs.create",
@@ -149,16 +149,16 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d5100000000",
+         "_dd.p.tid": "69e92dd600000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "7d59779e-5541-4195-b10f-de23a630644d",
+         "messaging.message_id": "ca645dff-ed32-4ea7-8ed4-9c49f9440db4",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 201542,
-       "start": 1776192849791472553
+       "duration": 617000,
+       "start": 1776889302715943000
      }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_batch_distributed_tracing_enabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_batch_distributed_tracing_enabled_batch_links_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4a00000000",
+      "_dd.p.tid": "69e92dcf00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "f3db6bdef4b04589bcf590bb5cab0f60",
+      "runtime-id": "e96211f13d2d4c27bde0e944a408dc41",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50427.0
+      "process_id": 72684.0
     },
-    "duration": 678666,
-    "start": 1776192842970114925
+    "duration": 948000,
+    "start": 1776889295712981000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4a00000000",
+      "_dd.p.tid": "69e92dcf00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "7865f461-ca90-4ba9-8733-12c4ccf66441",
+      "messaging.message_id": "5314eaf0-bbd6-49b0-b521-0e8025faccbd",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "f3db6bdef4b04589bcf590bb5cab0f60",
+      "runtime-id": "e96211f13d2d4c27bde0e944a408dc41",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50427.0
+      "process_id": 72684.0
     },
-    "duration": 1111250,
-    "start": 1776192842972166258
+    "duration": 536000,
+    "start": 1776889295714380000
   }],
 [
   {
@@ -80,10 +80,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4a00000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d4a00000000a7c801ef4a0bdad7\", \"span_id\": \"14e85b458c232625\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d4a00000000\", \"flags\": 1}, {\"trace_id\": \"69de8d4a000000008e648c0b29995f00\", \"span_id\": \"33a23c8dc72069f8\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d4a00000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92dcf00000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92dcf00000000d2d48d1aabef9262\", \"span_id\": \"d5b9b16ddb453340\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dcf00000000\", \"flags\": 1}, {\"trace_id\": \"69e92dcf00000000847871ef21314f0d\", \"span_id\": \"4dfd363ef2992b19\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dcf00000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -91,17 +91,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "f3db6bdef4b04589bcf590bb5cab0f60",
+      "runtime-id": "e96211f13d2d4c27bde0e944a408dc41",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50427.0
+      "process_id": 72684.0
     },
-    "duration": 432831667,
-    "start": 1776192842973546966
+    "duration": 449253000,
+    "start": 1776889295715057000
   }],
 [
   {
@@ -116,26 +116,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4b00000000",
+      "_dd.p.tid": "69e92dd000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "f3db6bdef4b04589bcf590bb5cab0f60",
+      "runtime-id": "e96211f13d2d4c27bde0e944a408dc41",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50427.0
+      "process_id": 72684.0
     },
-    "duration": 258500,
-    "start": 1776192843406638383
+    "duration": 888000,
+    "start": 1776889296165283000
   }],
 [
   {
@@ -150,27 +150,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4b00000000",
+      "_dd.p.tid": "69e92dd000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "bfbf82b6-6f78-4a81-817a-07ab3cff4985",
+      "messaging.message_id": "4825ff7d-04a7-4dc4-b133-1af635ebe3c9",
       "messaging.operation": "create",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "f3db6bdef4b04589bcf590bb5cab0f60",
+      "runtime-id": "e96211f13d2d4c27bde0e944a408dc41",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50427.0
+      "process_id": 72684.0
     },
-    "duration": 229500,
-    "start": 1776192843406966550
+    "duration": 434000,
+    "start": 1776889296166331000
   }],
 [
   {
@@ -185,10 +185,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4b00000000",
-      "_dd.span_links": "[{\"trace_id\": \"69de8d4b0000000028a7a70fefbd265c\", \"span_id\": \"1d870c1642cfc616\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d4b00000000\", \"flags\": 1}, {\"trace_id\": \"69de8d4b0000000064b76b88e3dd4d59\", \"span_id\": \"d7a257e7e80185ae\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69de8d4b00000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92dd000000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92dd0000000009a21e6128c88ed90\", \"span_id\": \"51eb191f9e780aa1\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dd000000000\", \"flags\": 1}, {\"trace_id\": \"69e92dd00000000055f882c938f6f10a\", \"span_id\": \"14147bc733b3f75c\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92dd000000000\", \"flags\": 1}]",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -196,15 +196,15 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "f3db6bdef4b04589bcf590bb5cab0f60",
+      "runtime-id": "e96211f13d2d4c27bde0e944a408dc41",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50427.0
+      "process_id": 72684.0
     },
-    "duration": 680417,
-    "start": 1776192843407257383
+    "duration": 683000,
+    "start": 1776889296166870000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_buffered_list_distributed_tracing_enabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4400000000",
+      "_dd.p.tid": "69e92dc700000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "76868de3a34343378e91d87a23a06b67",
+      "runtime-id": "901e0087f5834de5be28e50376ee9077",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50406.0
+      "process_id": 72042.0
     },
-    "duration": 929108792,
-    "start": 1776192836945254047
+    "duration": 971066000,
+    "start": 1776889287927905000
   },
      {
        "name": "azure.eventhubs.create",
@@ -44,7 +44,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d4400000000",
+         "_dd.p.tid": "69e92dc700000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -53,8 +53,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 2262333,
-       "start": 1776192837426029964
+       "duration": 382000,
+       "start": 1776889288448460000
      },
      {
        "name": "azure.eventhubs.create",
@@ -67,18 +67,18 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d4400000000",
+         "_dd.p.tid": "69e92dc700000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "55a6d4bd-92ad-411c-8745-7b69c6c54416",
+         "messaging.message_id": "eb692ceb-d11b-446a-9fda-92bc13db41b9",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 849541,
-       "start": 1776192837428523964
+       "duration": 131000,
+       "start": 1776889288448892000
      }],
 [
   {
@@ -93,9 +93,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d4500000000",
+      "_dd.p.tid": "69e92dc800000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -103,17 +103,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "76868de3a34343378e91d87a23a06b67",
+      "runtime-id": "901e0087f5834de5be28e50376ee9077",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50406.0
+      "process_id": 72042.0
     },
-    "duration": 1237125,
-    "start": 1776192837874765214
+    "duration": 690000,
+    "start": 1776889288899572000
   },
      {
        "name": "azure.eventhubs.create",
@@ -126,7 +126,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d4500000000",
+         "_dd.p.tid": "69e92dc800000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -135,8 +135,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 151125,
-       "start": 1776192837874970756
+       "duration": 139000,
+       "start": 1776889288899749000
      },
      {
        "name": "azure.eventhubs.create",
@@ -149,16 +149,16 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d4500000000",
+         "_dd.p.tid": "69e92dc800000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "9d8dfcd1-3462-4759-a1c5-c348349a2aae",
+         "messaging.message_id": "40f4cc72-50ca-4677-8fae-5042ad8ae94d",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 168542,
-       "start": 1776192837875144964
+       "duration": 144000,
+       "start": 1776889288899921000
      }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_list_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_list_distributed_tracing_disabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1d00000000",
+      "_dd.p.tid": "69e92d9f00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "7e4b295263514d6d9c6ba64bd0805035",
+      "runtime-id": "2c44a493b999486aa0f021f989052116",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50243.0
+      "process_id": 71831.0
     },
-    "duration": 491765251,
-    "start": 1776192797259513625
+    "duration": 538648000,
+    "start": 1776889247296531000
   },
      {
        "name": "azure.eventhubs.create",
@@ -52,8 +52,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 310250,
-       "start": 1776192797743099626
+       "duration": 652000,
+       "start": 1776889247826912000
      },
      {
        "name": "azure.eventhubs.create",
@@ -69,14 +69,14 @@
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "0a98587a-e7d2-400b-8628-d918c48fd9eb",
+         "messaging.message_id": "de4dbf4e-9394-4526-b9d2-1e8ce7681547",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 648834,
-       "start": 1776192797743502167
+       "duration": 277000,
+       "start": 1776889247827715000
      }],
 [
   {
@@ -91,9 +91,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1d00000000",
+      "_dd.p.tid": "69e92d9f00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -101,17 +101,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "7e4b295263514d6d9c6ba64bd0805035",
+      "runtime-id": "2c44a493b999486aa0f021f989052116",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50243.0
+      "process_id": 71831.0
     },
-    "duration": 3568417,
-    "start": 1776192797751772209
+    "duration": 6514000,
+    "start": 1776889247835846000
   },
      {
        "name": "azure.eventhubs.create",
@@ -132,8 +132,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 74292,
-       "start": 1776192797751861292
+       "duration": 173000,
+       "start": 1776889247835991000
      },
      {
        "name": "azure.eventhubs.create",
@@ -149,12 +149,12 @@
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "88e5d9d7-3164-49cf-9eed-34ca05556894",
+         "messaging.message_id": "03f3fcf1-9310-402d-8231-099a82c89743",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 111125,
-       "start": 1776192797751954876
+       "duration": 247000,
+       "start": 1776889247836215000
      }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_batch_list_distributed_tracing_enabled].json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1800000000",
+      "_dd.p.tid": "69e92d9b00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -21,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "4d78cf8eff1a46ccbf0fd4522706c769",
+      "runtime-id": "c1a8997c68084693907ff8de4d66b6b6",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50226.0
+      "process_id": 71808.0
     },
-    "duration": 493537083,
-    "start": 1776192792719230763
+    "duration": 528907000,
+    "start": 1776889243066711000
   },
      {
        "name": "azure.eventhubs.create",
@@ -44,7 +44,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d1800000000",
+         "_dd.p.tid": "69e92d9b00000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -53,8 +53,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 524333,
-       "start": 1776192793201355638
+       "duration": 1189000,
+       "start": 1776889243582462000
      },
      {
        "name": "azure.eventhubs.create",
@@ -67,18 +67,18 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d1800000000",
+         "_dd.p.tid": "69e92d9b00000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "7b901103-78d9-4740-83f7-6765dcadcbf7",
+         "messaging.message_id": "69961c04-1483-4eac-90f7-b5adfae301f5",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 345083,
-       "start": 1776192793201973388
+       "duration": 899000,
+       "start": 1776889243583820000
      }],
 [
   {
@@ -93,9 +93,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1900000000",
+      "_dd.p.tid": "69e92d9b00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.batch_count": "2",
@@ -103,17 +103,17 @@
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "4d78cf8eff1a46ccbf0fd4522706c769",
+      "runtime-id": "c1a8997c68084693907ff8de4d66b6b6",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50226.0
+      "process_id": 71808.0
     },
-    "duration": 5474959,
-    "start": 1776192793213721221
+    "duration": 7095000,
+    "start": 1776889243596180000
   },
      {
        "name": "azure.eventhubs.create",
@@ -126,7 +126,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d1900000000",
+         "_dd.p.tid": "69e92d9b00000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
@@ -135,8 +135,8 @@
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 253750,
-       "start": 1776192793213995221
+       "duration": 353000,
+       "start": 1776889243596508000
      },
      {
        "name": "azure.eventhubs.create",
@@ -149,16 +149,16 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "ddtrace_subprocess_dir",
-         "_dd.p.tid": "69de8d1900000000",
+         "_dd.p.tid": "69e92d9b00000000",
          "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "05805600-f1dc-47d9-810c-90cbf2068310",
+         "messaging.message_id": "7402f1ee-20ee-4834-837e-ffb7318258c7",
          "messaging.operation": "create",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
-       "duration": 271625,
-       "start": 1776192793214286388
+       "duration": 367000,
+       "start": 1776889243596913000
      }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_async_single_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_async_single_distributed_tracing_disabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0900000000",
+      "_dd.p.tid": "69e92d8a00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "5eb00ed392104a0dafbc6f76c52023e1",
+      "runtime-id": "adfbd2f233314ee3a400671acf54312d",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50180.0
+      "process_id": 71736.0
     },
-    "duration": 518541000,
-    "start": 1776192777176769172
+    "duration": 501756000,
+    "start": 1776889226916591000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0900000000",
+      "_dd.p.tid": "69e92d8b00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "6b9aa143-9f5a-4445-aa45-794d76d07b00",
+      "messaging.message_id": "9915215f-147b-46c3-a043-b276dfc1f0dd",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "5eb00ed392104a0dafbc6f76c52023e1",
+      "runtime-id": "adfbd2f233314ee3a400671acf54312d",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50180.0
+      "process_id": 71736.0
     },
-    "duration": 4953167,
-    "start": 1776192777695943672
+    "duration": 8165000,
+    "start": 1776889227418718000
   }],
 [
   {
@@ -80,26 +80,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0900000000",
+      "_dd.p.tid": "69e92d8b00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "5eb00ed392104a0dafbc6f76c52023e1",
+      "runtime-id": "adfbd2f233314ee3a400671acf54312d",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50180.0
+      "process_id": 71736.0
     },
-    "duration": 4164750,
-    "start": 1776192777701071630
+    "duration": 6762000,
+    "start": 1776889227427083000
   }],
 [
   {
@@ -114,25 +114,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0900000000",
+      "_dd.p.tid": "69e92d8b00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "124eb4cd-2780-4a45-9c40-e4525e1ff440",
+      "messaging.message_id": "ab155f83-7e50-4f37-ad4f-569f6c5fd3d0",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "5eb00ed392104a0dafbc6f76c52023e1",
+      "runtime-id": "adfbd2f233314ee3a400671acf54312d",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50180.0
+      "process_id": 71736.0
     },
-    "duration": 3935917,
-    "start": 1776192777705366005
+    "duration": 7794000,
+    "start": 1776889227434006000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_async_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_async_single_distributed_tracing_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0600000000",
+      "_dd.p.tid": "69e92d8700000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "53819980ce7847e786838251a77b7da5",
+      "runtime-id": "eb4d5ab1d35a4da68cd44624bd934225",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50167.0
+      "process_id": 71723.0
     },
-    "duration": 522168834,
-    "start": 1776192774264835837
+    "duration": 504244000,
+    "start": 1776889223775497000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0600000000",
+      "_dd.p.tid": "69e92d8800000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "cf52cea9-b2cc-41c1-b74f-3d4215d05e3a",
+      "messaging.message_id": "6e67bbb9-5749-4b63-aade-99c1438dad95",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "53819980ce7847e786838251a77b7da5",
+      "runtime-id": "eb4d5ab1d35a4da68cd44624bd934225",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50167.0
+      "process_id": 71723.0
     },
-    "duration": 6401750,
-    "start": 1776192774787852671
+    "duration": 13929000,
+    "start": 1776889224280322000
   }],
 [
   {
@@ -80,26 +80,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0600000000",
+      "_dd.p.tid": "69e92d8800000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "53819980ce7847e786838251a77b7da5",
+      "runtime-id": "eb4d5ab1d35a4da68cd44624bd934225",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50167.0
+      "process_id": 71723.0
     },
-    "duration": 4038625,
-    "start": 1776192774794404004
+    "duration": 6265000,
+    "start": 1776889224294400000
   }],
 [
   {
@@ -114,25 +114,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0600000000",
+      "_dd.p.tid": "69e92d8800000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "52b1858d-abd8-4a2d-b2fb-b549bde9cdd8",
+      "messaging.message_id": "efb997c8-8efc-4b0b-a91f-63cbc0e5b430",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "53819980ce7847e786838251a77b7da5",
+      "runtime-id": "eb4d5ab1d35a4da68cd44624bd934225",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50167.0
+      "process_id": 71723.0
     },
-    "duration": 4323584,
-    "start": 1776192774798597587
+    "duration": 5380000,
+    "start": 1776889224300965000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_buffered_async_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_buffered_async_single_distributed_tracing_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1200000000",
+      "_dd.p.tid": "69e92d9400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "baf803bb3aaa4c0e89d1c2c620b66bdd",
+      "runtime-id": "35c39e73593248f7a37f6341b4e14171",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50213.0
+      "process_id": 71800.0
     },
-    "duration": 954525250,
-    "start": 1776192786654695135
+    "duration": 918594000,
+    "start": 1776889236396710000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1300000000",
+      "_dd.p.tid": "69e92d9500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "007f5639-6c41-4a92-9c63-fa06ccd69450",
+      "messaging.message_id": "9b855c4e-8629-480e-aae7-01b720e30f33",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "baf803bb3aaa4c0e89d1c2c620b66bdd",
+      "runtime-id": "35c39e73593248f7a37f6341b4e14171",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50213.0
+      "process_id": 71800.0
     },
-    "duration": 1407834,
-    "start": 1776192787611165093
+    "duration": 1259000,
+    "start": 1776889237316111000
   }],
 [
   {
@@ -80,26 +80,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1300000000",
+      "_dd.p.tid": "69e92d9500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "baf803bb3aaa4c0e89d1c2c620b66bdd",
+      "runtime-id": "35c39e73593248f7a37f6341b4e14171",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50213.0
+      "process_id": 71800.0
     },
-    "duration": 412000,
-    "start": 1776192787612736843
+    "duration": 291000,
+    "start": 1776889237317469000
   }],
 [
   {
@@ -114,25 +114,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d1300000000",
+      "_dd.p.tid": "69e92d9500000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "4296b41c-9b26-478d-807c-49a536359616",
+      "messaging.message_id": "85a74a9b-f545-44de-841a-fdac3566bc45",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "baf803bb3aaa4c0e89d1c2c620b66bdd",
+      "runtime-id": "35c39e73593248f7a37f6341b4e14171",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50213.0
+      "process_id": 71800.0
     },
-    "duration": 421917,
-    "start": 1776192787613263343
+    "duration": 192000,
+    "start": 1776889237317827000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_buffered_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_buffered_single_distributed_tracing_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0c00000000",
+      "_dd.p.tid": "69e92d8e00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c6cc28bc35d421c9bd0f0a05a67721e",
+      "runtime-id": "8a7790d9977a40d7a07a612270acf322",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50193.0
+      "process_id": 71753.0
     },
-    "duration": 918143834,
-    "start": 1776192780304947590
+    "duration": 950297000,
+    "start": 1776889230824278000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0d00000000",
+      "_dd.p.tid": "69e92d8f00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "07da96f1-45f6-4b01-8b0b-85b56f339934",
+      "messaging.message_id": "b7b1d893-a39c-4f00-9799-59e3fee59cd9",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c6cc28bc35d421c9bd0f0a05a67721e",
+      "runtime-id": "8a7790d9977a40d7a07a612270acf322",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50193.0
+      "process_id": 71753.0
     },
-    "duration": 1210000,
-    "start": 1776192781223967465
+    "duration": 1025000,
+    "start": 1776889231775351000
   }],
 [
   {
@@ -80,26 +80,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0d00000000",
+      "_dd.p.tid": "69e92d8f00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c6cc28bc35d421c9bd0f0a05a67721e",
+      "runtime-id": "8a7790d9977a40d7a07a612270acf322",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50193.0
+      "process_id": 71753.0
     },
-    "duration": 439000,
-    "start": 1776192781225350924
+    "duration": 294000,
+    "start": 1776889231776518000
   }],
 [
   {
@@ -114,25 +114,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0d00000000",
+      "_dd.p.tid": "69e92d8f00000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "0f961587-1008-4e50-b278-d212f3e1a65b",
+      "messaging.message_id": "9104a3e3-07a3-4f1f-9383-f00eed68f732",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c6cc28bc35d421c9bd0f0a05a67721e",
+      "runtime-id": "8a7790d9977a40d7a07a612270acf322",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50193.0
+      "process_id": 71753.0
     },
-    "duration": 311625,
-    "start": 1776192781225916257
+    "duration": 204000,
+    "start": 1776889231776879000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_single_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_single_distributed_tracing_disabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0200000000",
+      "_dd.p.tid": "69e92d8400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0bea7340ff1946aaa03e9525d4f6fd26",
+      "runtime-id": "7cfa4051710a407f95ed919bb0e2cea3",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50150.0
+      "process_id": 71692.0
     },
-    "duration": 502296792,
-    "start": 1776192770896520377
+    "duration": 544350000,
+    "start": 1776889220175062000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0300000000",
+      "_dd.p.tid": "69e92d8400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "fd0c4fca-8a34-4edf-921b-dfaae8b7e8e2",
+      "messaging.message_id": "092bb954-6183-4a1d-a3a7-0168a001534f",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0bea7340ff1946aaa03e9525d4f6fd26",
+      "runtime-id": "7cfa4051710a407f95ed919bb0e2cea3",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50150.0
+      "process_id": 71692.0
     },
-    "duration": 6107375,
-    "start": 1776192771400039836
+    "duration": 12457000,
+    "start": 1776889220722607000
   }],
 [
   {
@@ -80,26 +80,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0300000000",
+      "_dd.p.tid": "69e92d8400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0bea7340ff1946aaa03e9525d4f6fd26",
+      "runtime-id": "7cfa4051710a407f95ed919bb0e2cea3",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50150.0
+      "process_id": 71692.0
     },
-    "duration": 5012334,
-    "start": 1776192771406351877
+    "duration": 6313000,
+    "start": 1776889220736069000
   }],
 [
   {
@@ -114,25 +114,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d0300000000",
+      "_dd.p.tid": "69e92d8400000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "643cd5d4-4a2b-4df9-bba3-4eb4957c13fc",
+      "messaging.message_id": "214de796-9a14-4679-9c0a-32b4318ffbe1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0bea7340ff1946aaa03e9525d4f6fd26",
+      "runtime-id": "7cfa4051710a407f95ed919bb0e2cea3",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50150.0
+      "process_id": 71692.0
     },
-    "duration": 4033250,
-    "start": 1776192771411551252
+    "duration": 8647000,
+    "start": 1776889220742651000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer[send_event_single_distributed_tracing_enabled].json
@@ -11,26 +11,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8cfe00000000",
+      "_dd.p.tid": "69e92d8000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c857cd8796446a886162c01f3c381f9",
+      "runtime-id": "64493f05904a4223af5e4f5ccd42b629",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50133.0
+      "process_id": 71671.0
     },
-    "duration": 493697126,
-    "start": 1776192766320586958
+    "duration": 599553000,
+    "start": 1776889216130325000
   }],
 [
   {
@@ -45,27 +45,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8cfe00000000",
+      "_dd.p.tid": "69e92d8000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "df537619-8cbb-407a-b45b-f4f334063ac0",
+      "messaging.message_id": "2d70e3b9-9320-4ef8-9990-c43fede63c25",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c857cd8796446a886162c01f3c381f9",
+      "runtime-id": "64493f05904a4223af5e4f5ccd42b629",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50133.0
+      "process_id": 71671.0
     },
-    "duration": 6648291,
-    "start": 1776192766815355084
+    "duration": 16268000,
+    "start": 1776889216730662000
   }],
 [
   {
@@ -80,26 +80,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8cfe00000000",
+      "_dd.p.tid": "69e92d8000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c857cd8796446a886162c01f3c381f9",
+      "runtime-id": "64493f05904a4223af5e4f5ccd42b629",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50133.0
+      "process_id": 71671.0
     },
-    "duration": 4559791,
-    "start": 1776192766822209209
+    "duration": 5344000,
+    "start": 1776889216747264000
   }],
 [
   {
@@ -114,25 +114,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8cfe00000000",
+      "_dd.p.tid": "69e92d8000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_eventhubs",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "d7b86d1c-cda8-430f-b9a3-22ec45d334d8",
+      "messaging.message_id": "beeb5b2e-1793-4dee-bf05-048b8f8828a2",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "0c857cd8796446a886162c01f3c381f9",
+      "runtime-id": "64493f05904a4223af5e4f5ccd42b629",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50133.0
+      "process_id": 71671.0
     },
-    "duration": 7105916,
-    "start": 1776192766826897459
+    "duration": 4865000,
+    "start": 1776889216752865000
   }]]

--- a/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer_error.json
+++ b/tests/snapshots/tests.contrib.azure_eventhubs.test_azure_eventhubs_snapshot.test_producer_error.json
@@ -11,27 +11,27 @@
     "meta": {
       "_dd.base_service": "tests.contrib.azure_eventhubs",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69de8d5b00000000",
+      "_dd.p.tid": "69e92de000000000",
       "_dd.svc_src": "m",
-      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.azure_eventhubs",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:tests.contrib.azure_eventhubs",
       "component": "azure_eventhubs",
       "error.message": "'EventData' object is not iterable",
-      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/internal/azure_eventhubs/patch.py\", line 176, in _patched_send_batch\n    return wrapped(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azureeventhub~5120_pytest-asyncio0237/lib/python3.12/site-packages/azure/eventhub/_producer_client.py\", line 752, in send_batch\n    batch, pid, pkey = self._batch_preparer(\n                       ^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azureeventhub~5120_pytest-asyncio0237/lib/python3.12/site-packages/azure/eventhub/_producer_client.py\", line 293, in _batch_preparer\n    to_send_batch._load_events(  # pylint:disable=protected-access\n  File \"/home/bits/project/.riot/venv_py31212_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azureeventhub~5120_pytest-asyncio0237/lib/python3.12/site-packages/azure/eventhub/_common.py\", line 622, in _load_events\n    for event_data in events:\n                      ^^^^^^\nTypeError: 'EventData' object is not iterable\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/internal/azure_eventhubs/patch.py\", line 176, in _patched_send_batch\n    return wrapped(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azureeventhub~5120_pytest-asyncio0237/lib/python3.11/site-packages/azure/eventhub/_producer_client.py\", line 752, in send_batch\n    batch, pid, pkey = self._batch_preparer(\n                       ^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azureeventhub~5120_pytest-asyncio0237/lib/python3.11/site-packages/azure/eventhub/_producer_client.py\", line 293, in _batch_preparer\n    to_send_batch._load_events(  # pylint:disable=protected-access\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azureeventhub~5120_pytest-asyncio0237/lib/python3.11/site-packages/azure/eventhub/_common.py\", line 622, in _load_events\n    for event_data in events:\nTypeError: 'EventData' object is not iterable\n",
       "error.type": "builtins.TypeError",
       "language": "python",
       "messaging.destination.name": "eh1",
       "messaging.operation": "send",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "044632d074d64488bd74ef11c9fbcc37",
+      "runtime-id": "d8d5dfaa712949fe94263fdd34edd7ee",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 50128.0
+      "process_id": 71667.0
     },
-    "duration": 500723250,
-    "start": 1776192859391740043
+    "duration": 524382000,
+    "start": 1776889312402297000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_distributed_tracing[disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_distributed_tracing[disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69a5ee7500000000",
+      "_dd.p.tid": "69e7b38100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_root",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetroot",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "a61f9ebe0c4242fb80af0faa1d9e4069",
+      "runtime-id": "f0be6a2a10de4ee0a20abca8af5bec11",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 38127.0
+      "process_id": 74558.0
     },
-    "duration": 113403750,
-    "start": 1772482165446939547
+    "duration": 120611000,
+    "start": 1776792449435902000
   },
      {
        "name": "requests.request",
@@ -54,8 +56,8 @@
          "_dd.measured": 1.0,
          "_dd.top_level": 1.0
        },
-       "duration": 109826292,
-       "start": 1772482165450292380
+       "duration": 25670000,
+       "start": 1776792449530673000
      }],
 [
   {
@@ -68,7 +70,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69a5ee7500000000",
+      "_dd.p.tid": "69e7b38100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_child",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -78,15 +82,15 @@
       "http.url": "http://localhost:7071/api/httpgetchild",
       "http.useragent": "python-requests/x.xx.x",
       "language": "python",
-      "runtime-id": "a61f9ebe0c4242fb80af0faa1d9e4069",
+      "runtime-id": "f0be6a2a10de4ee0a20abca8af5bec11",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 38127.0
+      "process_id": 74558.0
     },
-    "duration": 170000,
-    "start": 1772482165468827922
+    "duration": 144000,
+    "start": 1776792449535190000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_distributed_tracing[enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_distributed_tracing[enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69a5ee6900000000",
+      "_dd.p.tid": "69e7b37b00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_root",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetroot",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "9e201ee5d42a461ba76d2d71b9bd10ee",
+      "runtime-id": "3c2d3341bcbb4ac598615be475e047e5",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 37514.0
+      "process_id": 74516.0
     },
-    "duration": 103149625,
-    "start": 1772482153901778014
+    "duration": 109479000,
+    "start": 1776792443628287000
   },
      {
        "name": "requests.request",
@@ -54,8 +56,8 @@
          "_dd.measured": 1.0,
          "_dd.top_level": 1.0
        },
-       "duration": 99076834,
-       "start": 1772482153905629430
+       "duration": 19512000,
+       "start": 1776792443718117000
      },
         {
           "name": "azure.functions.invoke",
@@ -66,7 +68,8 @@
           "parent_id": 2,
           "type": "serverless",
           "meta": {
-            "_dd.p.tid": "69a5ee6900000000",
+            "_dd.p.tid": "69e7b37b00000000",
+            "_dd.svc_src": "m",
             "aas.function.name": "http_get_child",
             "aas.function.trigger": "Http",
             "component": "azure_functions",
@@ -75,13 +78,13 @@
             "http.status_code": "200",
             "http.url": "http://localhost:7071/api/httpgetchild",
             "http.useragent": "python-requests/x.xx.x",
-            "runtime-id": "9e201ee5d42a461ba76d2d71b9bd10ee",
+            "runtime-id": "3c2d3341bcbb4ac598615be475e047e5",
             "span.kind": "server"
           },
           "metrics": {
             "_dd.top_level": 1.0,
-            "process_id": 37514.0
+            "process_id": 74516.0
           },
-          "duration": 151875,
-          "start": 1772482153924515555
+          "duration": 144000,
+          "start": 1776792443722510000
         }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_error.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_error.json
@@ -10,27 +10,29 @@
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6750ad8500000000",
+      "_dd.p.tid": "69e7b35c00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_error",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
       "error.message": "Test Error",
-      "error.stack": "Traceback (most recent call last):\n  File \"/root/project/ddtrace/contrib/internal/azure_functions/patch.py\", line 65, in wrap_function\n    res = func(req)\n          ^^^^^^^^^\n  File \"/root/project/tests/contrib/azure_functions/azure_function_app/function_app.py\", line 19, in http_get_error\n    raise Exception(\"Test Error\")\nException: Test Error\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/rithika.narayan/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/internal/azure_functions/shared.py\", line 72, in wrapper\n    res = func(*args, **kwargs)\n  File \"/Users/rithika.narayan/go/src/github.com/DataDog/dd-trace-py/tests/contrib/azure_functions/azure_function_app/function_app.py\", line 24, in http_get_error\n    raise Exception(\"Test Error\")\nException: Test Error\n",
       "error.type": "builtins.Exception",
       "http.method": "GET",
       "http.route": "/api/httpgeterror",
       "http.url": "http://0.0.0.0:7071/api/httpgeterror",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "d7efb82603894b91af0e18f95bfb40ce",
+      "runtime-id": "8068d2069e7549b1b447df1e8d8e03d5",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 98042
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74293.0
     },
-    "duration": 3862875,
-    "start": 1733340549814399761
+    "duration": 413000,
+    "start": 1776792412156684000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_function_name_decorator.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_function_name_decorator.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67ed73d100000000",
+      "_dd.p.tid": "69e7b36b00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "functionnamedecorator",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetfunctionnamedecorator",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "abb028b298ac4062bfdcd63017f561dd",
+      "runtime-id": "c0e21ecc0a6c474fa819a237ed30b69f",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 49360
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74385.0
     },
-    "duration": 333083,
-    "start": 1743614929143607588
+    "duration": 179000,
+    "start": 1776792427500044000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_function_name_decorator_order.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_function_name_decorator_order.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "684055f800000000",
+      "_dd.p.tid": "69e7b37600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "functionnamedecoratororder",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetfunctionnamedecoratororder",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "e0b373739eb742d29f13fdb6cb71a98e",
+      "runtime-id": "a20708cc764047e5af6d65f6a9f89532",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 53880
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74480.0
     },
-    "duration": 278416,
-    "start": 1749046776355682801
+    "duration": 181000,
+    "start": 1776792438931772000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_function_name_no_decorator.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_function_name_no_decorator.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67ed73ed00000000",
+      "_dd.p.tid": "69e7b37100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_function_name_no_decorator",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetfunctionnamenodecorator",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "a78a08024ea645769371ab213a630386",
+      "runtime-id": "3199909adacc4dd794ac0f352fe19457",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 51797
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74438.0
     },
-    "duration": 315583,
-    "start": 1743614957641418296
+    "duration": 190000,
+    "start": 1776792433225372000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6750ad7d00000000",
+      "_dd.p.tid": "69e7b34900000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_ok",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetok?key=val",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "2dd77b70098048f5a6b7d3a7d53d1082",
+      "runtime-id": "3b714d6672ea4d0cbb6a9453594fc248",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 96455
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74190.0
     },
-    "duration": 1160792,
-    "start": 1733340541444015424
+    "duration": 194000,
+    "start": 1776792393279715000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_async.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_async.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "680bbffe00000000",
+      "_dd.p.tid": "69e7b34d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_ok_async",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetokasync?key=val",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "dc1bd0201db346a887fac16721f3b0e5",
+      "runtime-id": "719cac9ff1e54b36ac6d340dbcf16a5a",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 17518
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74214.0
     },
-    "duration": 794292,
-    "start": 1745600510630485377
+    "duration": 187000,
+    "start": 1776792397998389000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_async_obfuscated.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_async_obfuscated.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68135c0400000000",
+      "_dd.p.tid": "69e7b35700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_ok_async",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetokasync?<redacted>",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "7edd9974ae834236be55679427d26dd1",
+      "runtime-id": "09380f08d18d49afab1a502eb9c70bb9",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 6118
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74259.0
     },
-    "duration": 744750,
-    "start": 1746099204097478012
+    "duration": 181000,
+    "start": 1776792407439882000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_obfuscated.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_obfuscated.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68135be100000000",
+      "_dd.p.tid": "69e7b35200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_ok",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgetok?<redacted>",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "bebb19bc0290454d80b19e0ee5a4546e",
+      "runtime-id": "65f75a094e034e73aeb2c646c362fb82",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 3676
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74240.0
     },
-    "duration": 902208,
-    "start": 1746099169732256385
+    "duration": 189000,
+    "start": 1776792402723669000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_trigger_arg.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_trigger_arg.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67ec4e5e00000000",
+      "_dd.p.tid": "69e7b36600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_get_trigger_arg",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httpgettriggerarg",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "8d8fe775192b47b6b8cc67c801687aef",
+      "runtime-id": "01ff9928a0a94a5db54feed3d4c1cb62",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 66098
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74356.0
     },
-    "duration": 282750,
-    "start": 1743539806219103595
+    "duration": 176000,
+    "start": 1776792422762918000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_post_ok.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_post_ok.json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6750ad8e00000000",
+      "_dd.p.tid": "69e7b36200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "http_post_ok",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,15 +21,15 @@
       "http.url": "http://0.0.0.0:7071/api/httppostok",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "891babf5be3d4b86bd44163cd50c74b0",
+      "runtime-id": "5b62bc46182d4e318c0df195b952b84d",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 99631
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74324.0
     },
-    "duration": 293958,
-    "start": 1733340558198232376
+    "duration": 177000,
+    "start": 1776792418036392000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer.json
@@ -9,20 +9,22 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "67ed8ced00000000",
+      "_dd.p.tid": "69e7b38600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "timer",
       "aas.function.trigger": "Timer",
       "component": "azure_functions",
       "language": "python",
-      "runtime-id": "c20075ab351244ed9d9d5e688777e0b1",
+      "runtime-id": "1a1bb8a423544f12a9506c23dbee81dd",
       "span.kind": "internal"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 30417
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74610.0
     },
-    "duration": 548917,
-    "start": 1743621357729982629
+    "duration": 179000,
+    "start": 1776792454288123000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer_async.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer_async.json
@@ -9,20 +9,22 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "680bbf7f00000000",
+      "_dd.p.tid": "69e7b38a00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "timer_async",
       "aas.function.trigger": "Timer",
       "component": "azure_functions",
       "language": "python",
-      "runtime-id": "60d7e0785b414408a3dafc9fb92d939e",
+      "runtime-id": "9243f2deb41342d3808ddb13f194548c",
       "span.kind": "internal"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 7776
+      "_sampling_priority_v1": 1.0,
+      "process_id": 74632.0
     },
-    "duration": 193000,
-    "start": 1745600383620687347
+    "duration": 102000,
+    "start": 1776792458957931000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_cosmos.test_azure_functions_snapshot.test_cosmos_trigger.json
+++ b/tests/snapshots/tests.contrib.azure_functions_cosmos.test_azure_functions_snapshot.test_cosmos_trigger.json
@@ -10,24 +10,24 @@
     "meta": {
       "_dd.base_service": "x64",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69c599ce00000000",
+      "_dd.p.tid": "69e922f700000000",
       "_dd.svc_src": "azure_functions",
       "_dd.tags.process": "entrypoint.basedir:x64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:x64",
       "aas.function.name": "cosmosdbtrigger",
       "aas.function.trigger": "CosmosDB",
       "component": "azure_functions",
       "language": "python",
-      "runtime-id": "7ee6c4dc0cc54287bb345711236faa28",
+      "runtime-id": "7afbf223626040978acf659312ae2ecd",
       "span.kind": "internal"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 2481.0
+      "process_id": 50064.0
     },
-    "duration": 975417,
-    "start": 1774557646838291758
+    "duration": 107000,
+    "start": 1776886519462165000
   }],
 [
   {
@@ -41,7 +41,7 @@
     "meta": {
       "_dd.base_service": "x64",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69c599ca00000000",
+      "_dd.p.tid": "69e922f300000000",
       "_dd.svc_src": "azure_functions",
       "_dd.tags.process": "entrypoint.basedir:x64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:x64",
       "aas.function.name": "UpsertItem",
@@ -53,17 +53,17 @@
       "http.url": "http://0.0.0.0:7071/api/upsert_item",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "7ee6c4dc0cc54287bb345711236faa28",
+      "runtime-id": "7afbf223626040978acf659312ae2ecd",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 2481.0
+      "process_id": 50064.0
     },
-    "duration": 74000875,
-    "start": 1774557642246782798
+    "duration": 82472000,
+    "start": 1776886515100079000
   },
      {
        "name": "cosmosdb.query",
@@ -75,17 +75,18 @@
        "type": "cosmosdb",
        "meta": {
          "_dd.base_service": "x64",
+         "_dd.svc_src": "m",
          "component": "azure_cosmos",
          "cosmosdb.connection.mode": "gateway",
          "cosmosdb.container": "documents",
          "db.name": "documents-db",
          "db.system": "cosmosdb",
-         "http.useragent": "azsdk-python-cosmos/4.15.0 Python/3.11.13 (Linux-6.12.67-linuxkit-x86_64-with-glibc2.41)",
+         "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.13 (macOS-26.2-arm64-arm-64bit)",
          "out.host": "http://localhost:8081/",
          "span.kind": "client"
        },
-       "duration": 2862417,
-       "start": 1774557642312352881
+       "duration": 7789000,
+       "start": 1776886515167916000
      },
      {
        "name": "cosmosdb.query",
@@ -97,15 +98,16 @@
        "type": "cosmosdb",
        "meta": {
          "_dd.base_service": "x64",
+         "_dd.svc_src": "m",
          "component": "azure_cosmos",
          "cosmosdb.connection.mode": "gateway",
          "cosmosdb.container": "documents",
          "db.name": "documents-db",
          "db.system": "cosmosdb",
-         "http.useragent": "azsdk-python-cosmos/4.15.0 Python/3.11.13 (Linux-6.12.67-linuxkit-x86_64-with-glibc2.41)",
+         "http.useragent": "azsdk-python-cosmos/4.9.0 Python/3.12.13 (macOS-26.2-arm64-arm-64bit)",
          "out.host": "http://localhost:8081/",
          "span.kind": "client"
        },
-       "duration": 4614709,
-       "start": 1774557642315624839
+       "duration": 6326000,
+       "start": 1776886515175958000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_many_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_many_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71e800000000",
+      "_dd.p.tid": "69e92e5d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "72c33ab5276a4895ab368e080b815b58",
+      "runtime-id": "8e55720e64bf4736b0920fc8675e35aa",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 34025
+      "_sampling_priority_v1": 1.0,
+      "process_id": 86503.0
     },
-    "duration": 167375,
-    "start": 1758228968132688846
+    "duration": 223000,
+    "start": 1776889437894093000
   }],
 [
   {
@@ -42,7 +44,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71e700000000",
+      "_dd.p.tid": "69e92e5d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -52,17 +56,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventbatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "72c33ab5276a4895ab368e080b815b58",
+      "runtime-id": "8e55720e64bf4736b0920fc8675e35aa",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 34025
+      "_sampling_priority_v1": 1.0,
+      "process_id": 86503.0
     },
-    "duration": 531330208,
-    "start": 1758228967472768846
+    "duration": 537719000,
+    "start": 1776889437309121000
   },
      {
        "name": "azure.eventhubs.create",
@@ -74,6 +78,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -82,10 +87,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 252916,
-       "start": 1758228967997249638
+       "duration": 317000,
+       "start": 1776889437833602000
      },
      {
        "name": "azure.eventhubs.create",
@@ -97,6 +102,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -105,10 +111,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 94792,
-       "start": 1758228967998357221
+       "duration": 116000,
+       "start": 1776889437834107000
      },
      {
        "name": "azure.eventhubs.send",
@@ -120,6 +126,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.batch_count": "2",
          "messaging.destination.name": "eh1",
@@ -129,8 +136,8 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 4308666,
-       "start": 1758228967998570388
+       "duration": 10735000,
+       "start": 1776889437834323000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_many_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_many_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71dc00000000",
+      "_dd.p.tid": "69e92e5200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
@@ -19,33 +21,33 @@
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "9c4bc93f54b84f159875e6c7a17ca757",
+      "runtime-id": "5f88c43e49d746a0b41529b00e79d790",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 33630
+      "_sampling_priority_v1": 1.0,
+      "process_id": 85103.0
     },
     "span_links": [
       {
         "trace_id": 1,
+        "trace_id_high": 7631681968983244800,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71db00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7551535860605255680
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e5100000000",
+        "flags": 2147483649
       },
       {
         "trace_id": 1,
+        "trace_id_high": 7631681968983244800,
         "span_id": 3,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71db00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7551535860605255680
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e5100000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 399833,
-    "start": 1758228956042088674
+    "duration": 794000,
+    "start": 1776889426545862000
   }],
 [
   {
@@ -58,7 +60,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71db00000000",
+      "_dd.p.tid": "69e92e5100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -68,17 +72,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventbatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "9c4bc93f54b84f159875e6c7a17ca757",
+      "runtime-id": "5f88c43e49d746a0b41529b00e79d790",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 33630
+      "_sampling_priority_v1": 1.0,
+      "process_id": 85103.0
     },
-    "duration": 518065167,
-    "start": 1758228955378548090
+    "duration": 527604000,
+    "start": 1776889425969963000
   },
      {
        "name": "azure.eventhubs.create",
@@ -90,6 +94,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -98,10 +103,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1425875,
-       "start": 1758228955886461590
+       "duration": 689000,
+       "start": 1776889426481829000
      },
      {
        "name": "azure.eventhubs.create",
@@ -113,7 +118,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68cc71db00000000",
+         "_dd.p.tid": "69e92e5100000000",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -122,10 +128,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 246250,
-       "start": 1758228955888524132
+       "duration": 145000,
+       "start": 1776889426482640000
      },
      {
        "name": "azure.eventhubs.send",
@@ -137,7 +143,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68cc71db00000000",
+         "_dd.p.tid": "69e92e5100000000",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.batch_count": "2",
          "messaging.destination.name": "eh1",
@@ -147,24 +154,24 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
        "span_links": [
          {
            "trace_id": 1,
+           "trace_id_high": 7631681968983244800,
            "span_id": 2,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71db00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7551535860605255680
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e5100000000",
+           "flags": 2147483649
          },
          {
            "trace_id": 1,
+           "trace_id_high": 7631681968983244800,
            "span_id": 3,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71db00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7551535860605255680
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e5100000000",
+           "flags": 2147483649
          }
        ],
-       "duration": 5803334,
-       "start": 1758228955888866840
+       "duration": 12284000,
+       "start": 1776889426482860000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_one_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_one_distributed_tracing_disabled].json
@@ -9,27 +9,29 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71d000000000",
+      "_dd.p.tid": "69e92e4700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "e2534dce-cda6-4aeb-bd58-234f88525668",
+      "messaging.message_id": "f86653a1-613d-42c1-b384-1fd2575b1f73",
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "bc64747faba64415bc5f36887dc6fc6c",
+      "runtime-id": "f471827456444119981b3549b4c39919",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 33235
+      "_sampling_priority_v1": 1.0,
+      "process_id": 83581.0
     },
-    "duration": 128875,
-    "start": 1758228944939108418
+    "duration": 163000,
+    "start": 1776889415697240000
   }],
 [
   {
@@ -42,7 +44,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71d000000000",
+      "_dd.p.tid": "69e92e4700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_event",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -52,17 +56,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventsingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "bc64747faba64415bc5f36887dc6fc6c",
+      "runtime-id": "f471827456444119981b3549b4c39919",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 33235
+      "_sampling_priority_v1": 1.0,
+      "process_id": 83581.0
     },
-    "duration": 533302667,
-    "start": 1758228944299295668
+    "duration": 520211000,
+    "start": 1776889415155242000
   },
      {
        "name": "azure.eventhubs.send",
@@ -74,17 +78,18 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "e2534dce-cda6-4aeb-bd58-234f88525668",
+         "messaging.message_id": "f86653a1-613d-42c1-b384-1fd2575b1f73",
          "messaging.operation": "send",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 529696375,
-       "start": 1758228944299968460
+       "duration": 518835000,
+       "start": 1776889415155587000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[async_consume_one_distributed_tracing_enabled].json
@@ -9,36 +9,38 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71c500000000",
+      "_dd.p.tid": "69e92e3c00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "703cb3d8-2b1b-4025-add9-f630dc0b3ab8",
+      "messaging.message_id": "2e3400d9-aa1d-415f-ba66-3dcea93400e4",
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "42576f457ef147149e5440b2830ab20e",
+      "runtime-id": "963022503337430e8208fc3cdbf56a5d",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 32839
+      "_sampling_priority_v1": 1.0,
+      "process_id": 82081.0
     },
     "span_links": [
       {
         "trace_id": 1,
+        "trace_id_high": 7631681878788931584,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71c500000000",
-        "flags": 2147483649,
-        "trace_id_high": 7551535766115975168
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e3c00000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 1061125,
-    "start": 1758228933837521469
+    "duration": 378000,
+    "start": 1776889404869010000
   }],
 [
   {
@@ -51,7 +53,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71c500000000",
+      "_dd.p.tid": "69e92e3c00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_event",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -61,17 +65,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventsingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "42576f457ef147149e5440b2830ab20e",
+      "runtime-id": "963022503337430e8208fc3cdbf56a5d",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 32839
+      "_sampling_priority_v1": 1.0,
+      "process_id": 82081.0
     },
-    "duration": 528107792,
-    "start": 1758228933203857719
+    "duration": 536360000,
+    "start": 1776889404306633000
   },
      {
        "name": "azure.eventhubs.send",
@@ -83,17 +87,18 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "703cb3d8-2b1b-4025-add9-f630dc0b3ab8",
+         "messaging.message_id": "2e3400d9-aa1d-415f-ba66-3dcea93400e4",
          "messaging.operation": "send",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 524867792,
-       "start": 1758228933204492219
+       "duration": 534233000,
+       "start": 1776889404307035000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_many_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_many_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71ba00000000",
+      "_dd.p.tid": "69e92e3100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "08ce7f2846ee4ce4967a245a04a5097d",
+      "runtime-id": "9d966a84e5fe4bf6bc515968925d2958",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 32443
+      "_sampling_priority_v1": 1.0,
+      "process_id": 80630.0
     },
-    "duration": 154625,
-    "start": 1758228922795489297
+    "duration": 225000,
+    "start": 1776889393559806000
   }],
 [
   {
@@ -42,7 +44,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71ba00000000",
+      "_dd.p.tid": "69e92e3000000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -52,17 +56,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventbatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "08ce7f2846ee4ce4967a245a04a5097d",
+      "runtime-id": "9d966a84e5fe4bf6bc515968925d2958",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 32443
+      "_sampling_priority_v1": 1.0,
+      "process_id": 80630.0
     },
-    "duration": 516742626,
-    "start": 1758228922146122255
+    "duration": 544564000,
+    "start": 1776889392966493000
   },
      {
        "name": "azure.eventhubs.create",
@@ -74,6 +78,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -82,10 +87,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 241583,
-       "start": 1758228922655677006
+       "duration": 306000,
+       "start": 1776889393495912000
      },
      {
        "name": "azure.eventhubs.create",
@@ -97,6 +102,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -105,10 +111,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 82041,
-       "start": 1758228922656586256
+       "duration": 100000,
+       "start": 1776889393496370000
      },
      {
        "name": "azure.eventhubs.send",
@@ -120,6 +126,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.batch_count": "2",
          "messaging.destination.name": "eh1",
@@ -129,8 +136,8 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 4348667,
-       "start": 1758228922656758714
+       "duration": 13037000,
+       "start": 1776889393496653000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_many_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_many_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71af00000000",
+      "_dd.p.tid": "69e92e2600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
@@ -19,33 +21,33 @@
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "23794c42c55c4f6ab2f7895a57678087",
+      "runtime-id": "0d5ffa456c23469787fe966acfe0921e",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 32047
+      "_sampling_priority_v1": 1.0,
+      "process_id": 79209.0
     },
     "span_links": [
       {
         "trace_id": 1,
+        "trace_id_high": 7631681784299651072,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71ae00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7551535667331727360
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e2600000000",
+        "flags": 2147483649
       },
       {
         "trace_id": 1,
+        "trace_id_high": 7631681784299651072,
         "span_id": 3,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71ae00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7551535667331727360
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e2600000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 419625,
-    "start": 1758228911246453333
+    "duration": 347000,
+    "start": 1776889382702178000
   }],
 [
   {
@@ -58,7 +60,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71ae00000000",
+      "_dd.p.tid": "69e92e2600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -68,17 +72,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventbatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "23794c42c55c4f6ab2f7895a57678087",
+      "runtime-id": "0d5ffa456c23469787fe966acfe0921e",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 32047
+      "_sampling_priority_v1": 1.0,
+      "process_id": 79209.0
     },
-    "duration": 531109917,
-    "start": 1758228910584137791
+    "duration": 556612000,
+    "start": 1776889382090626000
   },
      {
        "name": "azure.eventhubs.create",
@@ -90,6 +94,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -98,10 +103,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1403500,
-       "start": 1758228911106487542
+       "duration": 807000,
+       "start": 1776889382632606000
      },
      {
        "name": "azure.eventhubs.create",
@@ -113,7 +118,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68cc71ae00000000",
+         "_dd.p.tid": "69e92e2600000000",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
          "messaging.operation": "create",
@@ -122,10 +128,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 226542,
-       "start": 1758228911108522500
+       "duration": 254000,
+       "start": 1776889382633622000
      },
      {
        "name": "azure.eventhubs.send",
@@ -137,7 +143,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68cc71ae00000000",
+         "_dd.p.tid": "69e92e2600000000",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.batch_count": "2",
          "messaging.destination.name": "eh1",
@@ -147,24 +154,24 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
        "span_links": [
          {
            "trace_id": 1,
+           "trace_id_high": 7631681784299651072,
            "span_id": 2,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71ae00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7551535667331727360
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e2600000000",
+           "flags": 2147483649
          },
          {
            "trace_id": 1,
+           "trace_id_high": 7631681784299651072,
            "span_id": 3,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc71ae00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7551535667331727360
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e2600000000",
+           "flags": 2147483649
          }
        ],
-       "duration": 5166000,
-       "start": 1758228911108862333
+       "duration": 11434000,
+       "start": 1776889382634012000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_one_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_one_distributed_tracing_disabled].json
@@ -9,27 +9,29 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71a300000000",
+      "_dd.p.tid": "69e92e1b00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "3d9682b6-6d2b-40e2-aec3-cad9f7a82f57",
+      "messaging.message_id": "0d613221-a4e2-46ce-9d7e-c5c87807baf8",
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "b359e920aa524b7a86106903e5541ab2",
+      "runtime-id": "ead0984029d843338a10a2b47cb166eb",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 31652
+      "_sampling_priority_v1": 1.0,
+      "process_id": 76580.0
     },
-    "duration": 142750,
-    "start": 1758228899648788259
+    "duration": 268000,
+    "start": 1776889371299666000
   }],
 [
   {
@@ -42,7 +44,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc71a300000000",
+      "_dd.p.tid": "69e92e1a00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_event",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -52,17 +56,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventsingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "b359e920aa524b7a86106903e5541ab2",
+      "runtime-id": "ead0984029d843338a10a2b47cb166eb",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 31652
+      "_sampling_priority_v1": 1.0,
+      "process_id": 76580.0
     },
-    "duration": 524326000,
-    "start": 1758228899006158217
+    "duration": 536314000,
+    "start": 1776889370741887000
   },
      {
        "name": "azure.eventhubs.send",
@@ -74,17 +78,18 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "3d9682b6-6d2b-40e2-aec3-cad9f7a82f57",
+         "messaging.message_id": "0d613221-a4e2-46ce-9d7e-c5c87807baf8",
          "messaging.operation": "send",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 519475959,
-       "start": 1758228899006772050
+       "duration": 533879000,
+       "start": 1776889370742349000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_eventhubs.test_azure_functions_snapshot.test_event_hubs_trigger[consume_one_distributed_tracing_enabled].json
@@ -9,36 +9,38 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc719800000000",
+      "_dd.p.tid": "69e92e1000000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "eventhub",
       "aas.function.trigger": "EventHubs",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "eh1",
-      "messaging.message_id": "563cbc8e-ec3a-4b5c-b28f-9f2a9eb7143d",
+      "messaging.message_id": "364f4097-f9b3-41c4-ab88-4a1d4066a77c",
       "messaging.operation": "receive",
       "messaging.system": "eventhubs",
       "network.destination.name": "localhost",
-      "runtime-id": "969bca1b0998421a80c39d2169662464",
+      "runtime-id": "868db54ea6c244f8ac826bd23636642f",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 31256
+      "_sampling_priority_v1": 1.0,
+      "process_id": 75145.0
     },
     "span_links": [
       {
         "trace_id": 1,
+        "trace_id_high": 7631681685515403264,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68cc719700000000",
-        "flags": 2147483649,
-        "trace_id_high": 7551535568547479552
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92e0f00000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 1177792,
-    "start": 1758228888547321337
+    "duration": 366000,
+    "start": 1776889360461429000
   }],
 [
   {
@@ -51,7 +53,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68cc719700000000",
+      "_dd.p.tid": "69e92e0f00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "send_event",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -61,17 +65,17 @@
       "http.url": "http://0.0.0.0:7071/api/sendeventsingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "969bca1b0998421a80c39d2169662464",
+      "runtime-id": "868db54ea6c244f8ac826bd23636642f",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 31256
+      "_sampling_priority_v1": 1.0,
+      "process_id": 75145.0
     },
-    "duration": 532820167,
-    "start": 1758228887901005003
+    "duration": 532745000,
+    "start": 1776889359908280000
   },
      {
        "name": "azure.eventhubs.send",
@@ -83,17 +87,18 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_eventhubs",
          "messaging.destination.name": "eh1",
-         "messaging.message_id": "563cbc8e-ec3a-4b5c-b28f-9f2a9eb7143d",
+         "messaging.message_id": "364f4097-f9b3-41c4-ab88-4a1d4066a77c",
          "messaging.operation": "send",
          "messaging.system": "eventhubs",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 528845375,
-       "start": 1758228887901784837
+       "duration": 530473000,
+       "start": 1776889359908688000
      }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_many_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_many_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4448800000000",
+      "_dd.p.tid": "69e92a2700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "c9093bcc39cf49438447885b9e88eeb6",
+      "runtime-id": "3629dc59a41543c6b1b68be0f781ebf5",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 24547
+      "_sampling_priority_v1": 1.0,
+      "process_id": 30097.0
     },
-    "duration": 1027379959,
-    "start": 1757693064664656877
+    "duration": 1027146000,
+    "start": 1776888359722446000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "4fe806b4-a7e8-4784-856c-8d51361ebcdb",
+         "messaging.message_id": "625edaab-9b17-4b54-b374-296ac0a76031",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1471333,
-       "start": 1757693065176034377
+       "duration": 414000,
+       "start": 1776888360247358000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c4448800000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "f83ae125-a10a-437e-bab7-55d62d1ad48b",
+         "messaging.message_id": "e90c03fb-a678-4695-afd6-084fcb445405",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 259208,
-       "start": 1757693065178186252
+       "duration": 103000,
+       "start": 1776888360247938000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +93,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c4448800000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "queue.1",
@@ -100,10 +103,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 7187625,
-       "start": 1757693065178551794
+       "duration": 11817000,
+       "start": 1776888360248107000
      }],
 [
   {
@@ -116,7 +119,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4448900000000",
+      "_dd.p.tid": "69e92a2800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -126,15 +131,15 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "c9093bcc39cf49438447885b9e88eeb6",
+      "runtime-id": "3629dc59a41543c6b1b68be0f781ebf5",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 24547
+      "_sampling_priority_v1": 1.0,
+      "process_id": 30097.0
     },
-    "duration": 159750,
-    "start": 1757693065323525502
+    "duration": 185000,
+    "start": 1776888360322364000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_many_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_many_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4447d00000000",
+      "_dd.p.tid": "69e92a1d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "9994c89dd23f45c3a338314a1ada910e",
+      "runtime-id": "5ab0d506571f4a8eaa24cc5eefaf0e52",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 24153
+      "_sampling_priority_v1": 1.0,
+      "process_id": 28651.0
     },
-    "duration": 1026084917,
-    "start": 1757693053712524928
+    "duration": 1027726000,
+    "start": 1776888349450016000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "f0849b12-776c-4fee-94f8-a8dd6ec47942",
+         "messaging.message_id": "49fe487d-4031-44e5-a6d3-321dd79a24c2",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 4526209,
-       "start": 1757693054216085844
+       "duration": 695000,
+       "start": 1776888349970679000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,21 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c4447d00000000",
+         "_dd.p.tid": "69e92a1d00000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "c95d409f-c354-446d-8215-0d55c0f59f74",
+         "messaging.message_id": "ee386ae4-d86d-4947-ba50-bb471d1ba8f2",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 681000,
-       "start": 1757693054222520219
+       "duration": 167000,
+       "start": 1776888349971529000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +94,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c4447d00000000",
+         "_dd.p.tid": "69e92a1d00000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "queue.1",
@@ -100,26 +105,26 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
        "span_links": [
          {
            "trace_id": 0,
+           "trace_id_high": 7631677347598434304,
            "span_id": 2,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c4447d00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7549234179041394688
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a1d00000000",
+           "flags": 2147483649
          },
          {
            "trace_id": 0,
+           "trace_id_high": 7631677347598434304,
            "span_id": 3,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c4447d00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7549234179041394688
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a1d00000000",
+           "flags": 2147483649
          }
        ],
-       "duration": 14731042,
-       "start": 1757693054223442386
+       "duration": 12324000,
+       "start": 1776888349971765000
      }],
 [
   {
@@ -132,7 +137,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4447e00000000",
+      "_dd.p.tid": "69e92a1e00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -142,31 +149,31 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "9994c89dd23f45c3a338314a1ada910e",
+      "runtime-id": "5ab0d506571f4a8eaa24cc5eefaf0e52",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 24153
+      "_sampling_priority_v1": 1.0,
+      "process_id": 28651.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677347598434304,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c4447d00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7549234179041394688
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a1d00000000",
+        "flags": 2147483649
       },
       {
         "trace_id": 0,
+        "trace_id_high": 7631677347598434304,
         "span_id": 3,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c4447d00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7549234179041394688
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a1d00000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 393792,
-    "start": 1757693054374546636
+    "duration": 301000,
+    "start": 1776888350042620000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_one_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_one_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4447200000000",
+      "_dd.p.tid": "69e92a1200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "9186ba5464c44eaaa9d6781d31ada4d1",
+      "runtime-id": "12dc4c2f7ee842638618337842b3d1b3",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 23755
+      "_sampling_priority_v1": 1.0,
+      "process_id": 27223.0
     },
-    "duration": 1025866250,
-    "start": 1757693042734824464
+    "duration": 1029999000,
+    "start": 1776888338664306000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "d5ffac2a-b39a-4039-840d-f6590ea0e1f5",
+         "messaging.message_id": "5875e14f-989b-46d4-bf84-5d252add32f5",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 8549708,
-       "start": 1757693043245823006
+       "duration": 12481000,
+       "start": 1776888339187185000
      }],
 [
   {
@@ -66,25 +69,27 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4447300000000",
+      "_dd.p.tid": "69e92a1300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "d5ffac2a-b39a-4039-840d-f6590ea0e1f5",
+      "messaging.message_id": "5875e14f-989b-46d4-bf84-5d252add32f5",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "9186ba5464c44eaaa9d6781d31ada4d1",
+      "runtime-id": "12dc4c2f7ee842638618337842b3d1b3",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 23755
+      "_sampling_priority_v1": 1.0,
+      "process_id": 27223.0
     },
-    "duration": 150458,
-    "start": 1757693043343096756
+    "duration": 198000,
+    "start": 1776888339232385000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_async_consume_one_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4446700000000",
+      "_dd.p.tid": "69e92a0700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "8f96ac6bc65540329e7b9bad89695f6d",
+      "runtime-id": "529a24af6ca7479ab44ed0c14c1a92ac",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 23359
+      "_sampling_priority_v1": 1.0,
+      "process_id": 25581.0
     },
-    "duration": 1030611251,
-    "start": 1757693031621019500
+    "duration": 1029268000,
+    "start": 1776888327847838000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "9ede8e39-740a-453b-bd4c-7f41432d9ce6",
+         "messaging.message_id": "22d20676-5b23-4738-8d59-9d27f9ecf1a1",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 7591917,
-       "start": 1757693032131878334
+       "duration": 25176000,
+       "start": 1776888328377574000
      }],
 [
   {
@@ -66,34 +69,36 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4446800000000",
+      "_dd.p.tid": "69e92a0800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "9ede8e39-740a-453b-bd4c-7f41432d9ce6",
+      "messaging.message_id": "22d20676-5b23-4738-8d59-9d27f9ecf1a1",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "8f96ac6bc65540329e7b9bad89695f6d",
+      "runtime-id": "529a24af6ca7479ab44ed0c14c1a92ac",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 23359
+      "_sampling_priority_v1": 1.0,
+      "process_id": 25581.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677253109153792,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c4446700000000",
-        "flags": 2147483649,
-        "trace_id_high": 7549234084552114176
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a0700000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 938375,
-    "start": 1757693032231033126
+    "duration": 392000,
+    "start": 1776888328446115000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_many_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_many_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332cc00000000",
+      "_dd.p.tid": "69e929fd00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "cdda564dbbdd46eeb80690f69af5be5e",
+      "runtime-id": "f70bae2edbf1414f97aba5d268a3ac7c",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 7094
+      "_sampling_priority_v1": 1.0,
+      "process_id": 23973.0
     },
-    "duration": 1025611292,
-    "start": 1757622988816079169
+    "duration": 1024594000,
+    "start": 1776888317059996000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "a2755684-08f2-45b8-94a0-ac41b0d28172",
+         "messaging.message_id": "31a18a59-ff85-4168-8851-1fd421867216",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1518542,
-       "start": 1757622989320127210
+       "duration": 3012000,
+       "start": 1776888317585016000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c332cc00000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "14789e1b-8a6b-450f-9d06-3184a828fc1d",
+         "messaging.message_id": "942c594e-837e-4619-821b-9a2f5c72b6bd",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 273042,
-       "start": 1757622989322330252
+       "duration": 501000,
+       "start": 1776888317588838000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +93,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c332cc00000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "queue.1",
@@ -100,10 +103,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 9228666,
-       "start": 1757622989322707169
+       "duration": 19903000,
+       "start": 1776888317589559000
      }],
 [
   {
@@ -116,7 +119,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332cd00000000",
+      "_dd.p.tid": "69e929fd00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -126,15 +131,15 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "cdda564dbbdd46eeb80690f69af5be5e",
+      "runtime-id": "f70bae2edbf1414f97aba5d268a3ac7c",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 7094
+      "_sampling_priority_v1": 1.0,
+      "process_id": 23973.0
     },
-    "duration": 180542,
-    "start": 1757622989513373419
+    "duration": 198000,
+    "start": 1776888317683921000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_many_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_many_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332c100000000",
+      "_dd.p.tid": "69e929f100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "a32304239262435eaff3c61ac2259134",
+      "runtime-id": "5cb9f4e5d6464a23a41bf08a02d90193",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 6699
+      "_sampling_priority_v1": 1.0,
+      "process_id": 22537.0
     },
-    "duration": 1025491875,
-    "start": 1757622977808263053
+    "duration": 1029364000,
+    "start": 1776888305751655000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "ad794064-f0c9-4ec6-901f-b62f98d66de8",
+         "messaging.message_id": "fff37ac5-e6bc-4b2d-8cf1-fbeb23b1cab3",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1494666,
-       "start": 1757622978323712303
+       "duration": 747000,
+       "start": 1776888306268266000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,21 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c332c100000000",
+         "_dd.p.tid": "69e929f100000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "2808dfe5-2ac5-4100-8c5a-0b04c66f8d57",
+         "messaging.message_id": "007c7dac-7fdc-437d-b6e9-71a6be63e406",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 320625,
-       "start": 1757622978325943803
+       "duration": 178000,
+       "start": 1776888306269167000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +94,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c332c100000000",
+         "_dd.p.tid": "69e929f100000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "queue.1",
@@ -100,26 +105,26 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
        "span_links": [
          {
            "trace_id": 0,
+           "trace_id_high": 7631677158619873280,
            "span_id": 2,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c332c100000000",
-           "flags": 2147483649,
-           "trace_id_high": 7548933204913160192
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e929f100000000",
+           "flags": 2147483649
          },
          {
            "trace_id": 0,
+           "trace_id_high": 7631677158619873280,
            "span_id": 3,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c332c100000000",
-           "flags": 2147483649,
-           "trace_id_high": 7548933204913160192
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e929f100000000",
+           "flags": 2147483649
          }
        ],
-       "duration": 7203333,
-       "start": 1757622978326402553
+       "duration": 9915000,
+       "start": 1776888306269420000
      }],
 [
   {
@@ -132,7 +137,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332c200000000",
+      "_dd.p.tid": "69e929f200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -142,31 +149,31 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a32304239262435eaff3c61ac2259134",
+      "runtime-id": "5cb9f4e5d6464a23a41bf08a02d90193",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 6699
+      "_sampling_priority_v1": 1.0,
+      "process_id": 22537.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677158619873280,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c332c100000000",
-        "flags": 2147483649,
-        "trace_id_high": 7548933204913160192
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e929f100000000",
+        "flags": 2147483649
       },
       {
         "trace_id": 0,
+        "trace_id_high": 7631677158619873280,
         "span_id": 3,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c332c100000000",
-        "flags": 2147483649,
-        "trace_id_high": 7548933204913160192
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e929f100000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 479833,
-    "start": 1757622978468174470
+    "duration": 276000,
+    "start": 1776888306337371000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_one_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_one_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332b600000000",
+      "_dd.p.tid": "69e929e600000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "e62368bce3ba4067a3693958c82c91af",
+      "runtime-id": "587c17e442f3471b861059838904d6a7",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 6301
+      "_sampling_priority_v1": 1.0,
+      "process_id": 21108.0
     },
-    "duration": 1029055958,
-    "start": 1757622966818108006
+    "duration": 1022825000,
+    "start": 1776888294967548000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "queue.1",
-         "messaging.message_id": "12f75303-8e51-4432-8d37-baba56f43abb",
+         "messaging.message_id": "24d949ad-b57b-4a98-84bb-d0dd0b50f85e",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 7160250,
-       "start": 1757622967335385631
+       "duration": 13220000,
+       "start": 1776888295478964000
      }],
 [
   {
@@ -66,25 +69,27 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332b700000000",
+      "_dd.p.tid": "69e929e700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebusqueue",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "12f75303-8e51-4432-8d37-baba56f43abb",
+      "messaging.message_id": "24d949ad-b57b-4a98-84bb-d0dd0b50f85e",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "e62368bce3ba4067a3693958c82c91af",
+      "runtime-id": "587c17e442f3471b861059838904d6a7",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 6301
+      "_sampling_priority_v1": 1.0,
+      "process_id": 21108.0
     },
-    "duration": 176125,
-    "start": 1757622967441064381
+    "duration": 161000,
+    "start": 1776888295522393000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_one_distributed_tracing_enabled].json
@@ -7,93 +7,32 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "serverless",
+    "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332ab00000000",
+      "_dd.p.tid": "69e9293d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
+      "error.message": "Failed to initiate the connection due to exception: [Errno 61] Connection refused Error condition: amqp:socket-error.",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/internal/azure_functions/shared.py\", line 72, in wrapper\n    res = func(*args, **kwargs)\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/tests/contrib/azure_functions_servicebus/azure_function_app/function_app.py\", line 17, in queue_send_single_message\n    with servicebus_client.get_queue_sender(queue_name=\"queue.1\") as queue_sender:\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurefunctions~1101_azureservicebus/lib/python3.11/site-packages/azure/servicebus/_servicebus_sender.py\", line 202, in __enter__\n    self._open_with_retry()\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurefunctions~1101_azureservicebus/lib/python3.11/site-packages/azure/servicebus/_base_handler.py\", line 545, in _open_with_retry\n    return self._do_retryable_operation(self._open)\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurefunctions~1101_azureservicebus/lib/python3.11/site-packages/azure/servicebus/_base_handler.py\", line 413, in _do_retryable_operation\n    raise last_exception from None\nazure.servicebus.exceptions.ServiceBusConnectionError: Failed to initiate the connection due to exception: [Errno 61] Connection refused Error condition: amqp:socket-error.\n",
+      "error.type": "azure.servicebus.exceptions.ServiceBusConnectionError",
       "http.method": "POST",
       "http.route": "/api/queuesendmessagesingle",
-      "http.status_code": "200",
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "81cca026b58743589887188896fc8db4",
+      "runtime-id": "cc6c74fdc64741dd9d58f4d9e225bb50",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 5905
+      "_sampling_priority_v1": 1.0,
+      "process_id": 12672.0
     },
-    "duration": 1025797334,
-    "start": 1757622955835397584
-  },
-     {
-       "name": "azure.servicebus.send",
-       "service": "azure_servicebus",
-       "resource": "queue.1",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "worker",
-       "meta": {
-         "_dd.base_service": "test-func",
-         "component": "azure_servicebus",
-         "messaging.destination.name": "queue.1",
-         "messaging.message_id": "e5869af3-a906-4d80-833e-1957c537eef2",
-         "messaging.operation": "send",
-         "messaging.system": "servicebus",
-         "network.destination.name": "localhost",
-         "span.kind": "producer"
-       },
-       "metrics": {
-         "_dd.top_level": 1
-       },
-       "duration": 7967125,
-       "start": 1757622956349970084
-     }],
-[
-  {
-    "name": "azure.functions.invoke",
-    "service": "test-func",
-    "resource": "ServiceBus servicebusqueue",
-    "trace_id": 1,
-    "span_id": 1,
-    "parent_id": 0,
-    "type": "serverless",
-    "meta": {
-      "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c332ac00000000",
-      "aas.function.name": "servicebusqueue",
-      "aas.function.trigger": "ServiceBus",
-      "component": "azure_functions",
-      "language": "python",
-      "messaging.destination.name": "queue.1",
-      "messaging.message_id": "e5869af3-a906-4d80-833e-1957c537eef2",
-      "messaging.operation": "receive",
-      "messaging.system": "servicebus",
-      "network.destination.name": "localhost",
-      "runtime-id": "81cca026b58743589887188896fc8db4",
-      "span.kind": "consumer"
-    },
-    "metrics": {
-      "_dd.top_level": 1,
-      "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 5905
-    },
-    "span_links": [
-      {
-        "trace_id": 0,
-        "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c332ab00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7548933110423879680
-      }
-    ],
-    "duration": 1011375,
-    "start": 1757622956471232792
+    "duration": 11239862000,
+    "start": 1776888125707609000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[queue_consume_one_distributed_tracing_enabled].json
@@ -7,32 +7,98 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "serverless",
-    "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69e9293d00000000",
+      "_dd.p.tid": "69ea209100000000",
       "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "queue_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
-      "error.message": "Failed to initiate the connection due to exception: [Errno 61] Connection refused Error condition: amqp:socket-error.",
-      "error.stack": "Traceback (most recent call last):\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/internal/azure_functions/shared.py\", line 72, in wrapper\n    res = func(*args, **kwargs)\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/tests/contrib/azure_functions_servicebus/azure_function_app/function_app.py\", line 17, in queue_send_single_message\n    with servicebus_client.get_queue_sender(queue_name=\"queue.1\") as queue_sender:\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurefunctions~1101_azureservicebus/lib/python3.11/site-packages/azure/servicebus/_servicebus_sender.py\", line 202, in __enter__\n    self._open_with_retry()\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurefunctions~1101_azureservicebus/lib/python3.11/site-packages/azure/servicebus/_base_handler.py\", line 545, in _open_with_retry\n    return self._do_retryable_operation(self._open)\n  File \"/Users/emmett.butler/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py31115_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_azurefunctions~1101_azureservicebus/lib/python3.11/site-packages/azure/servicebus/_base_handler.py\", line 413, in _do_retryable_operation\n    raise last_exception from None\nazure.servicebus.exceptions.ServiceBusConnectionError: Failed to initiate the connection due to exception: [Errno 61] Connection refused Error condition: amqp:socket-error.\n",
-      "error.type": "azure.servicebus.exceptions.ServiceBusConnectionError",
       "http.method": "POST",
       "http.route": "/api/queuesendmessagesingle",
+      "http.status_code": "200",
       "http.url": "http://0.0.0.0:7071/api/queuesendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "cc6c74fdc64741dd9d58f4d9e225bb50",
+      "runtime-id": "17a5d8d62242429ca8c2619c2aa46da1",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 12672.0
+      "process_id": 99088.0
     },
-    "duration": 11239862000,
-    "start": 1776888125707609000
+    "duration": 1010795000,
+    "start": 1776951441829350000
+  },
+     {
+       "name": "azure.servicebus.send",
+       "service": "azure_servicebus",
+       "resource": "queue.1",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "worker",
+       "meta": {
+         "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
+         "component": "azure_servicebus",
+         "messaging.destination.name": "queue.1",
+         "messaging.message_id": "b4fcffc0-4e22-4d01-99eb-822e049ace5a",
+         "messaging.operation": "send",
+         "messaging.system": "servicebus",
+         "network.destination.name": "localhost",
+         "span.kind": "producer"
+       },
+       "metrics": {
+         "_dd.top_level": 1.0
+       },
+       "duration": 13398000,
+       "start": 1776951442324297000
+     }],
+[
+  {
+    "name": "azure.functions.invoke",
+    "service": "test-func",
+    "resource": "ServiceBus servicebusqueue",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "serverless",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "69ea209200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
+      "aas.function.name": "servicebusqueue",
+      "aas.function.trigger": "ServiceBus",
+      "component": "azure_functions",
+      "language": "python",
+      "messaging.destination.name": "queue.1",
+      "messaging.message_id": "b4fcffc0-4e22-4d01-99eb-822e049ace5a",
+      "messaging.operation": "receive",
+      "messaging.system": "servicebus",
+      "network.destination.name": "localhost",
+      "runtime-id": "17a5d8d62242429ca8c2619c2aa46da1",
+      "span.kind": "consumer"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 99088.0
+    },
+    "span_links": [
+      {
+        "trace_id": 0,
+        "trace_id_high": 7631948325675073536,
+        "span_id": 2,
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69ea209100000000",
+        "flags": 2147483649
+      }
+    ],
+    "duration": 226000,
+    "start": 1776951442340738000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_many_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_many_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444de00000000",
+      "_dd.p.tid": "69e92b2d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "7bc8c64168fd48038b44fa1a4f706754",
+      "runtime-id": "036b1111bbf54b019dc59ef44d1f3350",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 27714
+      "_sampling_priority_v1": 1.0,
+      "process_id": 65195.0
     },
-    "duration": 1025169375,
-    "start": 1757693150593013917
+    "duration": 1025790000,
+    "start": 1776888621331956000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "261fd5c4-057f-40a3-b857-ac7ca736a581",
+         "messaging.message_id": "862eea0d-29a4-404c-9936-188a8c85f14a",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 2946834,
-       "start": 1757693151121473583
+       "duration": 688000,
+       "start": 1776888621855421000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c444de00000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "74664dd3-3711-41d7-9cba-5af434478090",
+         "messaging.message_id": "31828e7a-09a5-4b62-aec4-33247781b107",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 526000,
-       "start": 1757693151125750083
+       "duration": 200000,
+       "start": 1776888621856418000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +93,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c444de00000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "topic.1",
@@ -100,10 +103,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 10245334,
-       "start": 1757693151126463583
+       "duration": 14111000,
+       "start": 1776888621856759000
      }],
 [
   {
@@ -116,7 +119,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444df00000000",
+      "_dd.p.tid": "69e92b2d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -126,15 +131,15 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "7bc8c64168fd48038b44fa1a4f706754",
+      "runtime-id": "036b1111bbf54b019dc59ef44d1f3350",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 27714
+      "_sampling_priority_v1": 1.0,
+      "process_id": 65195.0
     },
-    "duration": 173875,
-    "start": 1757693151297943250
+    "duration": 191000,
+    "start": 1776888621957474000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_many_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_many_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444d400000000",
+      "_dd.p.tid": "69e92a7200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "b9b3623e4b4248d2840b679c68f31320",
+      "runtime-id": "df16e6a20a594f6992ea0e4eadd9138a",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 27319
+      "_sampling_priority_v1": 1.0,
+      "process_id": 40443.0
     },
-    "duration": 1025033042,
-    "start": 1757693140121650926
+    "duration": 1028248000,
+    "start": 1776888434289340000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "6686def7-beae-48f7-b705-32ec47ef1e2e",
+         "messaging.message_id": "47e5e5ad-ba9f-49e4-8976-784cbb56ab24",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 5319792,
-       "start": 1757693140629205134
+       "duration": 842000,
+       "start": 1776888434818758000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,21 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c444d400000000",
+         "_dd.p.tid": "69e92a7200000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "36b7708f-7b8c-4160-81d2-a03378818efc",
+         "messaging.message_id": "c0d0de64-c1b6-4881-8242-e7500a9540dd",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1247750,
-       "start": 1757693140636104468
+       "duration": 180000,
+       "start": 1776888434819773000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +94,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c444d400000000",
+         "_dd.p.tid": "69e92a7200000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "topic.1",
@@ -100,26 +105,26 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
        "span_links": [
          {
            "trace_id": 0,
+           "trace_id_high": 7631677712670654464,
            "span_id": 2,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c444d400000000",
-           "flags": 2147483649,
-           "trace_id_high": 7549234552703549440
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a7200000000",
+           "flags": 2147483649
          },
          {
            "trace_id": 0,
+           "trace_id_high": 7631677712670654464,
            "span_id": 3,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c444d400000000",
-           "flags": 2147483649,
-           "trace_id_high": 7549234552703549440
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a7200000000",
+           "flags": 2147483649
          }
        ],
-       "duration": 14555750,
-       "start": 1757693140637898343
+       "duration": 13080000,
+       "start": 1776888434820030000
      }],
 [
   {
@@ -132,7 +137,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444d400000000",
+      "_dd.p.tid": "69e92a7200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -142,31 +149,31 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "b9b3623e4b4248d2840b679c68f31320",
+      "runtime-id": "df16e6a20a594f6992ea0e4eadd9138a",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 27319
+      "_sampling_priority_v1": 1.0,
+      "process_id": 40443.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677712670654464,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c444d400000000",
-        "flags": 2147483649,
-        "trace_id_high": 7549234552703549440
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a7200000000",
+        "flags": 2147483649
       },
       {
         "trace_id": 0,
+        "trace_id_high": 7631677712670654464,
         "span_id": 3,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c444d400000000",
-        "flags": 2147483649,
-        "trace_id_high": 7549234552703549440
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a7200000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 354209,
-    "start": 1757693140817381884
+    "duration": 276000,
+    "start": 1776888434901252000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_one_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_one_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444c900000000",
+      "_dd.p.tid": "69e92a6700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "90837f88efbd42c5aa2ca764e6310309",
+      "runtime-id": "5921af3261954964a87064209611e617",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 26923
+      "_sampling_priority_v1": 1.0,
+      "process_id": 38880.0
     },
-    "duration": 1024802251,
-    "start": 1757693129641820087
+    "duration": 1029119000,
+    "start": 1776888423509751000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "93b1001f-b855-4ea6-8b00-d59bf8ac4255",
+         "messaging.message_id": "8fa0a527-f75e-49c7-a8b1-100cf174a8a1",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 8823500,
-       "start": 1757693130160480213
+       "duration": 14881000,
+       "start": 1776888424019531000
      }],
 [
   {
@@ -66,25 +69,27 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444ca00000000",
+      "_dd.p.tid": "69e92a6800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "topic.1",
-      "messaging.message_id": "93b1001f-b855-4ea6-8b00-d59bf8ac4255",
+      "messaging.message_id": "8fa0a527-f75e-49c7-a8b1-100cf174a8a1",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "90837f88efbd42c5aa2ca764e6310309",
+      "runtime-id": "5921af3261954964a87064209611e617",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 26923
+      "_sampling_priority_v1": 1.0,
+      "process_id": 38880.0
     },
-    "duration": 150292,
-    "start": 1757693130271051421
+    "duration": 171000,
+    "start": 1776888424079695000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_async_consume_one_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444be00000000",
+      "_dd.p.tid": "69e92a5c00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "ab6e07e6f53e4142abc9149b26205f6b",
+      "runtime-id": "c6adea0be3d94904812c967b1e1abd1d",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 26525
+      "_sampling_priority_v1": 1.0,
+      "process_id": 37347.0
     },
-    "duration": 1026852751,
-    "start": 1757693118684689638
+    "duration": 1027085000,
+    "start": 1776888412747534000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "837eed20-d733-4d77-a572-4c004e91f959",
+         "messaging.message_id": "78998fcd-6a56-483a-a01c-59c976a32da7",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 8689667,
-       "start": 1757693119199956180
+       "duration": 12922000,
+       "start": 1776888413274749000
      }],
 [
   {
@@ -66,34 +69,36 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c444bf00000000",
+      "_dd.p.tid": "69e92a5d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "topic.1",
-      "messaging.message_id": "837eed20-d733-4d77-a572-4c004e91f959",
+      "messaging.message_id": "78998fcd-6a56-483a-a01c-59c976a32da7",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab6e07e6f53e4142abc9149b26205f6b",
+      "runtime-id": "c6adea0be3d94904812c967b1e1abd1d",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 26525
+      "_sampling_priority_v1": 1.0,
+      "process_id": 37347.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677618181373952,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c444be00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7549234458214268928
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a5c00000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 1003541,
-    "start": 1757693119309663764
+    "duration": 336000,
+    "start": 1776888413331678000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_many_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_many_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c3360700000000",
+      "_dd.p.tid": "69e92a5100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "d0ce6213a1aa41408792fd0211d69bcf",
+      "runtime-id": "feefa751869e4fa6ba4792cccfbd026b",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12372
+      "_sampling_priority_v1": 1.0,
+      "process_id": 35921.0
     },
-    "duration": 1032059667,
-    "start": 1757623815810601177
+    "duration": 1027701000,
+    "start": 1776888401939254000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "a27d08ce-ba5b-4e0d-8469-d422a6aa1d00",
+         "messaging.message_id": "975527b3-a05f-470b-bc51-101716e47b03",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1895708,
-       "start": 1757623816317982677
+       "duration": 493000,
+       "start": 1776888402445362000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c3360700000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "2bd37c2c-a6ff-4d91-987e-ee9ec1cf97a0",
+         "messaging.message_id": "ed40ba17-3791-45bd-972f-21dea98521d4",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 353417,
-       "start": 1757623816320689385
+       "duration": 128000,
+       "start": 1776888402446048000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +93,7 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c3360700000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "topic.1",
@@ -100,10 +103,10 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 7470208,
-       "start": 1757623816321169427
+       "duration": 11499000,
+       "start": 1776888402446254000
      }],
 [
   {
@@ -116,7 +119,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c3360800000000",
+      "_dd.p.tid": "69e92a5200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -126,15 +131,15 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "d0ce6213a1aa41408792fd0211d69bcf",
+      "runtime-id": "feefa751869e4fa6ba4792cccfbd026b",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12372
+      "_sampling_priority_v1": 1.0,
+      "process_id": 35921.0
     },
-    "duration": 173250,
-    "start": 1757623816483666010
+    "duration": 171000,
+    "start": 1776888402529264000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_many_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_many_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c335fc00000000",
+      "_dd.p.tid": "69e92a4700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_message_batch",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagebatch",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "4ec1f90ca2cd45c28e8dbf9723b3c1b4",
+      "runtime-id": "773680eb5998425ca78884667a53a432",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 11978
+      "_sampling_priority_v1": 1.0,
+      "process_id": 34508.0
     },
-    "duration": 1030990667,
-    "start": 1757623804813403546
+    "duration": 1026640000,
+    "start": 1776888391632008000
   },
      {
        "name": "azure.servicebus.create",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "6dcbf430-68f6-42f7-9f85-8d273e4bbafa",
+         "messaging.message_id": "76da5d90-4c83-4801-a3f6-c313247e9320",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 1846000,
-       "start": 1757623805315511380
+       "duration": 4011000,
+       "start": 1776888392162830000
      },
      {
        "name": "azure.servicebus.create",
@@ -65,20 +68,21 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c335fc00000000",
+         "_dd.p.tid": "69e92a4700000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "aa072078-5eec-401a-84a0-4f90dbbf7999",
+         "messaging.message_id": "75657cd4-46f9-4d92-932d-a6eb2bc050e0",
          "messaging.operation": "create",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 339583,
-       "start": 1757623805318220630
+       "duration": 550000,
+       "start": 1776888392167512000
      },
      {
        "name": "azure.servicebus.send",
@@ -90,7 +94,8 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
-         "_dd.p.tid": "68c335fc00000000",
+         "_dd.p.tid": "69e92a4700000000",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.batch_count": "2",
          "messaging.destination.name": "topic.1",
@@ -100,26 +105,26 @@
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
        "span_links": [
          {
            "trace_id": 0,
+           "trace_id_high": 7631677527987060736,
            "span_id": 2,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c335fc00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7548936756851113984
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a4700000000",
+           "flags": 2147483649
          },
          {
            "trace_id": 0,
+           "trace_id_high": 7631677527987060736,
            "span_id": 3,
-           "tracestate": "dd=s:1;t.dm:-0;t.tid:68c335fc00000000",
-           "flags": 2147483649,
-           "trace_id_high": 7548936756851113984
+           "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a4700000000",
+           "flags": 2147483649
          }
        ],
-       "duration": 8163042,
-       "start": 1757623805318692880
+       "duration": 24624000,
+       "start": 1776888392168291000
      }],
 [
   {
@@ -132,7 +137,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c335fd00000000",
+      "_dd.p.tid": "69e92a4800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
@@ -142,31 +149,31 @@
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "4ec1f90ca2cd45c28e8dbf9723b3c1b4",
+      "runtime-id": "773680eb5998425ca78884667a53a432",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 11978
+      "_sampling_priority_v1": 1.0,
+      "process_id": 34508.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677527987060736,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c335fc00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7548936756851113984
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a4700000000",
+        "flags": 2147483649
       },
       {
         "trace_id": 0,
+        "trace_id_high": 7631677527987060736,
         "span_id": 3,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c335fc00000000",
-        "flags": 2147483649,
-        "trace_id_high": 7548936756851113984
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a4700000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 431208,
-    "start": 1757623805482834422
+    "duration": 317000,
+    "start": 1776888392288485000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_one_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_one_distributed_tracing_disabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c335f100000000",
+      "_dd.p.tid": "69e92a3d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "0694dfdfc52147d182203e61cd98dab7",
+      "runtime-id": "b5d4e021d8984c56a30ed7009ca8284b",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 11579
+      "_sampling_priority_v1": 1.0,
+      "process_id": 33081.0
     },
-    "duration": 1030532153,
-    "start": 1757623793331846763
+    "duration": 1031685000,
+    "start": 1776888381312761000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "85165552-7ae7-401f-9709-b2ecd6810f5f",
+         "messaging.message_id": "67c2f855-1a11-4a53-9d18-f071cea296a5",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 11665625,
-       "start": 1757623793852543305
+       "duration": 13202000,
+       "start": 1776888381844130000
      }],
 [
   {
@@ -66,25 +69,27 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c335f100000000",
+      "_dd.p.tid": "69e92a3d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "topic.1",
-      "messaging.message_id": "85165552-7ae7-401f-9709-b2ecd6810f5f",
+      "messaging.message_id": "67c2f855-1a11-4a53-9d18-f071cea296a5",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "0694dfdfc52147d182203e61cd98dab7",
+      "runtime-id": "b5d4e021d8984c56a30ed7009ca8284b",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 11579
+      "_sampling_priority_v1": 1.0,
+      "process_id": 33081.0
     },
-    "duration": 182667,
-    "start": 1757623793976414722
+    "duration": 152000,
+    "start": 1776888381895587000
   }]]

--- a/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_one_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_functions_servicebus.test_azure_functions_snapshot.test_service_bus_trigger[topic_consume_one_distributed_tracing_enabled].json
@@ -9,7 +9,9 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c335e600000000",
+      "_dd.p.tid": "69e92a3200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "topic_send_single_message",
       "aas.function.trigger": "Http",
       "component": "azure_functions",
@@ -19,17 +21,17 @@
       "http.url": "http://0.0.0.0:7071/api/topicsendmessagesingle",
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
-      "runtime-id": "cfaf2c798e854cfb946379a60687ba05",
+      "runtime-id": "6136b333a0cd49f08cede9fe24e4c4b7",
       "span.kind": "server"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 11181
+      "_sampling_priority_v1": 1.0,
+      "process_id": 31603.0
     },
-    "duration": 1027043376,
-    "start": 1757623782242818133
+    "duration": 1024453000,
+    "start": 1776888370526648000
   },
      {
        "name": "azure.servicebus.send",
@@ -41,19 +43,20 @@
        "type": "worker",
        "meta": {
          "_dd.base_service": "test-func",
+         "_dd.svc_src": "m",
          "component": "azure_servicebus",
          "messaging.destination.name": "topic.1",
-         "messaging.message_id": "267837d3-0aa8-4585-bee6-e3a36d51452e",
+         "messaging.message_id": "9b8c556a-3c53-4118-8577-4b37dbf3465b",
          "messaging.operation": "send",
          "messaging.system": "servicebus",
          "network.destination.name": "localhost",
          "span.kind": "producer"
        },
        "metrics": {
-         "_dd.top_level": 1
+         "_dd.top_level": 1.0
        },
-       "duration": 29630209,
-       "start": 1757623782749328633
+       "duration": 29033000,
+       "start": 1776888371048531000
      }],
 [
   {
@@ -66,34 +69,36 @@
     "type": "serverless",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c335e600000000",
+      "_dd.p.tid": "69e92a3300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:arm64,entrypoint.name:worker,entrypoint.type:script,entrypoint.workdir:azure_function_app,svc.auto:arm64",
       "aas.function.name": "servicebustopic",
       "aas.function.trigger": "ServiceBus",
       "component": "azure_functions",
       "language": "python",
       "messaging.destination.name": "topic.1",
-      "messaging.message_id": "267837d3-0aa8-4585-bee6-e3a36d51452e",
+      "messaging.message_id": "9b8c556a-3c53-4118-8577-4b37dbf3465b",
       "messaging.operation": "receive",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "cfaf2c798e854cfb946379a60687ba05",
+      "runtime-id": "6136b333a0cd49f08cede9fe24e4c4b7",
       "span.kind": "consumer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 11181
+      "_sampling_priority_v1": 1.0,
+      "process_id": 31603.0
     },
     "span_links": [
       {
         "trace_id": 0,
+        "trace_id_high": 7631677437792747520,
         "span_id": 2,
-        "tracestate": "dd=s:1;t.dm:-0;t.tid:68c335e600000000",
-        "flags": 2147483649,
-        "trace_id_high": 7548936662361833472
+        "tracestate": "dd=s:1;t.dm:-0;t.tid:69e92a3200000000",
+        "flags": 2147483649
       }
     ],
-    "duration": 1049708,
-    "start": 1757623782932002342
+    "duration": 451000,
+    "start": 1776888371168763000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_list_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_list_distributed_tracing_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7b600000000",
+      "_dd.p.tid": "69e92c0400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "25be7898f5224e57b6c46a8cdc37b27a",
+      "runtime-id": "e411dbc9dd4f46138532890f7b3d9ca0",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16652
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67639.0
     },
-    "duration": 543125000,
-    "start": 1757534134563309375
+    "duration": 514261000,
+    "start": 1776888836281071000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7b700000000",
+      "_dd.p.tid": "69e92c0400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "25be7898f5224e57b6c46a8cdc37b27a",
+      "runtime-id": "e411dbc9dd4f46138532890f7b3d9ca0",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16652
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67639.0
     },
-    "duration": 8201250,
-    "start": 1757534135113038084
+    "duration": 12906000,
+    "start": 1776888836796221000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_list_distributed_tracing_enabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7b200000000",
+      "_dd.p.tid": "69e92c0100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "aa449f45aaf044bea1cb732b86e2ddbf",
+      "runtime-id": "f28f05609a014f698076e779ba6898e4",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16645
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67615.0
     },
-    "duration": 545965791,
-    "start": 1757534130865697763
+    "duration": 497036000,
+    "start": 1776888833090657000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7b300000000",
+      "_dd.p.tid": "69e92c0100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "aa449f45aaf044bea1cb732b86e2ddbf",
+      "runtime-id": "f28f05609a014f698076e779ba6898e4",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16645
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67615.0
     },
-    "duration": 6207334,
-    "start": 1757534131416182679
+    "duration": 7975000,
+    "start": 1776888833588024000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_single_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_single_distributed_tracing_disabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7af00000000",
+      "_dd.p.tid": "69e92bfd00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "dd33e42e-52f3-4fe6-87d3-a6366bd022ba",
+      "messaging.message_id": "cf32c3b5-3ec3-463f-b7de-c25c56350a13",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "797508c91a22429790b626ec13de80be",
+      "runtime-id": "6bae67d3001b47159600ecdd1770c6c5",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16638
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67601.0
     },
-    "duration": 540241917,
-    "start": 1757534127423649553
+    "duration": 498602000,
+    "start": 1776888829926008000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7af00000000",
+      "_dd.p.tid": "69e92bfe00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "79afa9bd-d71d-4bce-95a4-2b9a293d7af1",
+      "messaging.message_id": "bb6bec99-5cbd-4113-ad0e-ef120a71a396",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "797508c91a22429790b626ec13de80be",
+      "runtime-id": "6bae67d3001b47159600ecdd1770c6c5",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16638
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67601.0
     },
-    "duration": 9730125,
-    "start": 1757534127968615845
+    "duration": 8331000,
+    "start": 1776888830424931000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7af00000000",
+      "_dd.p.tid": "69e92bfe00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "797508c91a22429790b626ec13de80be",
+      "runtime-id": "6bae67d3001b47159600ecdd1770c6c5",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16638
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67601.0
     },
-    "duration": 7403917,
-    "start": 1757534127978884178
+    "duration": 10209000,
+    "start": 1776888830433548000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7af00000000",
+      "_dd.p.tid": "69e92bfe00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "74ef737a-1c80-4e1c-9692-dccd9f6592db",
+      "messaging.message_id": "f7e8f681-e913-4076-a7a7-6d1b93032088",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "797508c91a22429790b626ec13de80be",
+      "runtime-id": "6bae67d3001b47159600ecdd1770c6c5",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16638
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67601.0
     },
-    "duration": 5469458,
-    "start": 1757534127986591553
+    "duration": 8211000,
+    "start": 1776888830444118000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_async_single_distributed_tracing_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7ab00000000",
+      "_dd.p.tid": "69e92bfa00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "5eefb639-d76b-4a5c-a7c2-ac39d8dd7ed8",
+      "messaging.message_id": "1ae4db0e-9028-46d7-aa96-e1a854b6425f",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "943363ec15ae4ed3982f2068cc3e6230",
+      "runtime-id": "01d1ac7fd4fc4636b0c516f2adba9607",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16631
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67515.0
     },
-    "duration": 541962458,
-    "start": 1757534123933092718
+    "duration": 492646000,
+    "start": 1776888826814410000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7ac00000000",
+      "_dd.p.tid": "69e92bfb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "d91eaff5-01d0-4a06-a2ac-e31d552e8c85",
+      "messaging.message_id": "3719a9d7-1ab4-46a0-9145-26b981c804dd",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "943363ec15ae4ed3982f2068cc3e6230",
+      "runtime-id": "01d1ac7fd4fc4636b0c516f2adba9607",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16631
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67515.0
     },
-    "duration": 9909083,
-    "start": 1757534124481404843
+    "duration": 7208000,
+    "start": 1776888827307379000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7ac00000000",
+      "_dd.p.tid": "69e92bfb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "943363ec15ae4ed3982f2068cc3e6230",
+      "runtime-id": "01d1ac7fd4fc4636b0c516f2adba9607",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16631
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67515.0
     },
-    "duration": 7573625,
-    "start": 1757534124491884301
+    "duration": 8026000,
+    "start": 1776888827314692000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7ac00000000",
+      "_dd.p.tid": "69e92bfb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "ce12c58f-4514-4d9b-9cdd-bc30e0a8eb7f",
+      "messaging.message_id": "40e6cf76-1c7c-4506-83c9-75c80eb76a78",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "943363ec15ae4ed3982f2068cc3e6230",
+      "runtime-id": "01d1ac7fd4fc4636b0c516f2adba9607",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16631
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67515.0
     },
-    "duration": 6929083,
-    "start": 1757534124499687968
+    "duration": 7604000,
+    "start": 1776888827322833000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_list_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_list_distributed_tracing_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a800000000",
+      "_dd.p.tid": "69e92bf700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "04d2aa74aa29471687efcc6b5af4bf33",
+      "runtime-id": "5721b9724a31470c8c7317c521d4d656",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16624
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67504.0
     },
-    "duration": 537728000,
-    "start": 1757534120399533716
+    "duration": 534455000,
+    "start": 1776888823613335000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a800000000",
+      "_dd.p.tid": "69e92bf800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "04d2aa74aa29471687efcc6b5af4bf33",
+      "runtime-id": "5721b9724a31470c8c7317c521d4d656",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16624
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67504.0
     },
-    "duration": 7333000,
-    "start": 1757534120943349883
+    "duration": 12771000,
+    "start": 1776888824148690000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_list_distributed_tracing_enabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a400000000",
+      "_dd.p.tid": "69e92bf400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ea1d8e4095b64728a7ae8fc6dcc553f9",
+      "runtime-id": "0c867ce054754bf7a8a6c2587e7c91f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16617
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67499.0
     },
-    "duration": 537679834,
-    "start": 1757534116941075381
+    "duration": 517061000,
+    "start": 1776888820459712000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a500000000",
+      "_dd.p.tid": "69e92bf400000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ea1d8e4095b64728a7ae8fc6dcc553f9",
+      "runtime-id": "0c867ce054754bf7a8a6c2587e7c91f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16617
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67499.0
     },
-    "duration": 7825875,
-    "start": 1757534117484987256
+    "duration": 9881000,
+    "start": 1776888820977600000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_single_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_single_distributed_tracing_disabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a100000000",
+      "_dd.p.tid": "69e92bf100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "2619e216-a66a-4335-b806-9eb889158ff9",
+      "messaging.message_id": "38679f6c-cf68-4996-a8c5-c952e7cc1508",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "9a81cf0e87bc414e8004d2919566b689",
+      "runtime-id": "8214a8d1b1984cd48afef9c96a38ae9b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16610
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67480.0
     },
-    "duration": 544485917,
-    "start": 1757534113519534004
+    "duration": 533884000,
+    "start": 1776888817297576000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a200000000",
+      "_dd.p.tid": "69e92bf100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "4a35c6a2-de73-49cc-9818-2451d9afa203",
+      "messaging.message_id": "289ed950-c724-40bb-ac56-b05f5ae6246d",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "9a81cf0e87bc414e8004d2919566b689",
+      "runtime-id": "8214a8d1b1984cd48afef9c96a38ae9b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16610
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67480.0
     },
-    "duration": 7305000,
-    "start": 1757534114070004213
+    "duration": 13779000,
+    "start": 1776888817834620000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a200000000",
+      "_dd.p.tid": "69e92bf100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "9a81cf0e87bc414e8004d2919566b689",
+      "runtime-id": "8214a8d1b1984cd48afef9c96a38ae9b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16610
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67480.0
     },
-    "duration": 5443208,
-    "start": 1757534114077671963
+    "duration": 11137000,
+    "start": 1776888817849077000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d7a200000000",
+      "_dd.p.tid": "69e92bf100000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "c671e8b7-f2a1-4e75-89b5-cd40a37c2ddf",
+      "messaging.message_id": "e7f96b33-70ca-4be3-a977-ce69f95b493b",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "9a81cf0e87bc414e8004d2919566b689",
+      "runtime-id": "8214a8d1b1984cd48afef9c96a38ae9b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16610
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67480.0
     },
-    "duration": 4784625,
-    "start": 1757534114083302255
+    "duration": 16078000,
+    "start": 1776888817860824000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[schedule_messages_single_distributed_tracing_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d79e00000000",
+      "_dd.p.tid": "69e92bee00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "8da97d46-4c5c-44de-8bda-76737f3ef270",
+      "messaging.message_id": "98cf7fc8-eb9b-42a1-b6ef-babb42608020",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "27e918920a434f088da3f06ae5a1c8f5",
+      "runtime-id": "6179e4ae3b6b4dbcaaf3e7a9fcbeb298",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16603
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67462.0
     },
-    "duration": 544760625,
-    "start": 1757534110033129961
+    "duration": 546614000,
+    "start": 1776888814127414000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d79e00000000",
+      "_dd.p.tid": "69e92bee00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "d49644d6-e715-49dd-a81f-f01a0750cd8b",
+      "messaging.message_id": "574c1213-8e2d-4a57-871c-af156cfb2c67",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "27e918920a434f088da3f06ae5a1c8f5",
+      "runtime-id": "6179e4ae3b6b4dbcaaf3e7a9fcbeb298",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16603
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67462.0
     },
-    "duration": 7860833,
-    "start": 1757534110583986045
+    "duration": 8170000,
+    "start": 1776888814674905000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d79e00000000",
+      "_dd.p.tid": "69e92bee00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "27e918920a434f088da3f06ae5a1c8f5",
+      "runtime-id": "6179e4ae3b6b4dbcaaf3e7a9fcbeb298",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16603
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67462.0
     },
-    "duration": 6060292,
-    "start": 1757534110592179211
+    "duration": 8064000,
+    "start": 1776888814683400000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d79e00000000",
+      "_dd.p.tid": "69e92bee00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "6ee9bc36-7cc3-4d51-a6df-5ee75a2f8f78",
+      "messaging.message_id": "df1b21ab-06dc-45b4-bd7f-39d67599527f",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "27e918920a434f088da3f06ae5a1c8f5",
+      "runtime-id": "6179e4ae3b6b4dbcaaf3e7a9fcbeb298",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16603
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67462.0
     },
-    "duration": 5126792,
-    "start": 1757534110598398628
+    "duration": 7780000,
+    "start": 1776888814691700000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_disabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_disabled_batch_links_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408e00000000",
+      "_dd.p.tid": "69e92beb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "e7c5a9ceeb2f4eaf951a6881f676841f",
+      "runtime-id": "ca2fe9b87ba54b55beb12e23efb8c34b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12918
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67445.0
     },
-    "duration": 14898917,
-    "start": 1757692046870829253
+    "duration": 18800000,
+    "start": 1776888811551902000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408e00000000",
+      "_dd.p.tid": "69e92beb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "e7c5a9ceeb2f4eaf951a6881f676841f",
+      "runtime-id": "ca2fe9b87ba54b55beb12e23efb8c34b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12918
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67445.0
     },
-    "duration": 6968583,
-    "start": 1757692046890728378
+    "duration": 17046000,
+    "start": 1776888811572923000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_disabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_disabled_batch_links_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408b00000000",
+      "_dd.p.tid": "69e92be800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "b0fbf4b3-2074-4ba3-ab01-281bb5d34a7c",
+      "messaging.message_id": "9a12c4aa-58b6-41b2-91e1-c4843c24e946",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "43054341cd014443b82544007a5120f9",
+      "runtime-id": "f4b057936b6e449dae5996ca2c739db2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12911
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67439.0
     },
-    "duration": 2713542,
-    "start": 1757692043343313793
+    "duration": 572000,
+    "start": 1776888808438833000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408b00000000",
+      "_dd.p.tid": "69e92be800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "e368fe8a-010f-463a-afbc-86578e774171",
+      "messaging.message_id": "2ca1db74-df6e-44da-b874-86a13ff7ac00",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "43054341cd014443b82544007a5120f9",
+      "runtime-id": "f4b057936b6e449dae5996ca2c739db2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12911
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67439.0
     },
-    "duration": 536833,
-    "start": 1757692043355031835
+    "duration": 145000,
+    "start": 1776888808439717000
   }],
 [
   {
@@ -77,7 +81,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408b00000000",
+      "_dd.p.tid": "69e92be800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -85,17 +91,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "43054341cd014443b82544007a5120f9",
+      "runtime-id": "f4b057936b6e449dae5996ca2c739db2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12911
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67439.0
     },
-    "duration": 13082417,
-    "start": 1757692043355939668
+    "duration": 8861000,
+    "start": 1776888808439951000
   }],
 [
   {
@@ -110,24 +116,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408b00000000",
+      "_dd.p.tid": "69e92be800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "43054341cd014443b82544007a5120f9",
+      "runtime-id": "f4b057936b6e449dae5996ca2c739db2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12911
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67439.0
     },
-    "duration": 864334,
-    "start": 1757692043369547251
+    "duration": 150000,
+    "start": 1776888808448978000
   }],
 [
   {
@@ -142,25 +150,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408b00000000",
+      "_dd.p.tid": "69e92be800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "fb17949a-6f38-4ee3-9f4f-c1ef19228adc",
+      "messaging.message_id": "9797a29f-4a97-4ae4-b64a-a86faebf2e0b",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "43054341cd014443b82544007a5120f9",
+      "runtime-id": "f4b057936b6e449dae5996ca2c739db2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12911
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67439.0
     },
-    "duration": 262417,
-    "start": 1757692043370621293
+    "duration": 110000,
+    "start": 1776888808449194000
   }],
 [
   {
@@ -175,7 +185,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408b00000000",
+      "_dd.p.tid": "69e92be800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -183,15 +195,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "43054341cd014443b82544007a5120f9",
+      "runtime-id": "f4b057936b6e449dae5996ca2c739db2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12911
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67439.0
     },
-    "duration": 7188833,
-    "start": 1757692043371020710
+    "duration": 8472000,
+    "start": 1776888808449355000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_enabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_enabled_batch_links_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408700000000",
+      "_dd.p.tid": "69e92be500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "f4d6526ef2364f1c9d9876187d37882e",
+      "runtime-id": "7920484b37e24bf4aa23678993841194",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12904
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67421.0
     },
-    "duration": 15117250,
-    "start": 1757692039830470583
+    "duration": 14590000,
+    "start": 1776888805262492000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408700000000",
+      "_dd.p.tid": "69e92be500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "f4d6526ef2364f1c9d9876187d37882e",
+      "runtime-id": "7920484b37e24bf4aa23678993841194",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12904
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67421.0
     },
-    "duration": 6735334,
-    "start": 1757692039852810291
+    "duration": 7824000,
+    "start": 1776888805278511000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_enabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_batch_distributed_tracing_enabled_batch_links_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408400000000",
+      "_dd.p.tid": "69e92be200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "4b23aa3e-e5cd-4496-940d-5320a0c9fad9",
+      "messaging.message_id": "eef49728-0977-48d7-bd0b-10c8abf3d83e",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab8ada9f14f24e1fa723367401f151a5",
+      "runtime-id": "8bf6098d440b4678ba18aa7003af5adc",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12897
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67414.0
     },
-    "duration": 5401459,
-    "start": 1757692036266226470
+    "duration": 2645000,
+    "start": 1776888802139911000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408400000000",
+      "_dd.p.tid": "69e92be200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "d8cfdb20-7b52-4f72-a718-b78a4ec48b2d",
+      "messaging.message_id": "b71fff20-374d-41c7-bf87-b8a470dd4db2",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab8ada9f14f24e1fa723367401f151a5",
+      "runtime-id": "8bf6098d440b4678ba18aa7003af5adc",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12897
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67414.0
     },
-    "duration": 1001500,
-    "start": 1757692036279843429
+    "duration": 587000,
+    "start": 1776888802143417000
   }],
 [
   {
@@ -77,8 +81,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408400000000",
-      "_dd.span_links": "[{\"trace_id\": \"68c44084000000003a9196ea35ac2747\", \"span_id\": \"065ba32db2ba6bfe\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4408400000000\", \"flags\": 1}, {\"trace_id\": \"68c44084000000002bd91fcae6bbfb25\", \"span_id\": \"7287dc6b29eee3f0\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4408400000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92be200000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92be200000000b8984fde4fbbe180\", \"span_id\": \"85b46a2ac68bf87f\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92be200000000\", \"flags\": 1}, {\"trace_id\": \"69e92be200000000572732b8ab997c49\", \"span_id\": \"785225cd44aa9fb2\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92be200000000\", \"flags\": 1}]",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -86,17 +92,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab8ada9f14f24e1fa723367401f151a5",
+      "runtime-id": "8bf6098d440b4678ba18aa7003af5adc",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12897
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67414.0
     },
-    "duration": 14283333,
-    "start": 1757692036281165762
+    "duration": 23259000,
+    "start": 1776888802144218000
   }],
 [
   {
@@ -111,24 +117,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408400000000",
+      "_dd.p.tid": "69e92be200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab8ada9f14f24e1fa723367401f151a5",
+      "runtime-id": "8bf6098d440b4678ba18aa7003af5adc",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12897
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67414.0
     },
-    "duration": 624875,
-    "start": 1757692036297625262
+    "duration": 1383000,
+    "start": 1776888802168577000
   }],
 [
   {
@@ -143,25 +151,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408400000000",
+      "_dd.p.tid": "69e92be200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "a72cce87-bb3c-4dd1-8339-097785c11391",
+      "messaging.message_id": "86d0d092-e460-4f82-a451-ec19ea5cc31c",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab8ada9f14f24e1fa723367401f151a5",
+      "runtime-id": "8bf6098d440b4678ba18aa7003af5adc",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12897
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67414.0
     },
-    "duration": 377834,
-    "start": 1757692036298410220
+    "duration": 458000,
+    "start": 1776888802170121000
   }],
 [
   {
@@ -176,8 +186,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4408400000000",
-      "_dd.span_links": "[{\"trace_id\": \"68c440840000000005eb06f23f3c3816\", \"span_id\": \"4f336a92573c49e8\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4408400000000\", \"flags\": 1}, {\"trace_id\": \"68c4408400000000c8f49bbcfab14ab5\", \"span_id\": \"0814179dbe4f0e1b\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4408400000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92be200000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92be2000000000cd4296fb60bcd0f\", \"span_id\": \"4204b66a88e79b56\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92be200000000\", \"flags\": 1}, {\"trace_id\": \"69e92be200000000255449a75b5c447a\", \"span_id\": \"605fdfcccd514435\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92be200000000\", \"flags\": 1}]",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -185,15 +197,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "ab8ada9f14f24e1fa723367401f151a5",
+      "runtime-id": "8bf6098d440b4678ba18aa7003af5adc",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12897
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67414.0
     },
-    "duration": 5809292,
-    "start": 1757692036298907720
+    "duration": 16659000,
+    "start": 1776888802170705000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_list_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_list_distributed_tracing_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78c00000000",
+      "_dd.p.tid": "69e92bde00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "c841d58fdc724c5ab68ac87ecd040cd7",
+      "runtime-id": "e68e0b3876f7489896de4cc3ae4d8c8d",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16568
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67396.0
     },
-    "duration": 545070501,
-    "start": 1757534092621417550
+    "duration": 514361000,
+    "start": 1776888798449469000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78d00000000",
+      "_dd.p.tid": "69e92bde00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "c841d58fdc724c5ab68ac87ecd040cd7",
+      "runtime-id": "e68e0b3876f7489896de4cc3ae4d8c8d",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16568
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67396.0
     },
-    "duration": 8116584,
-    "start": 1757534093172579717
+    "duration": 8854000,
+    "start": 1776888798964207000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_list_distributed_tracing_enabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78900000000",
+      "_dd.p.tid": "69e92bdb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "2a32d08d43d84de1a75713d1f883f7eb",
+      "runtime-id": "67125d36b51b468689166c4a60f57438",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16561
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67391.0
     },
-    "duration": 543648125,
-    "start": 1757534089144524049
+    "duration": 505561000,
+    "start": 1776888795312834000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78900000000",
+      "_dd.p.tid": "69e92bdb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "2a32d08d43d84de1a75713d1f883f7eb",
+      "runtime-id": "67125d36b51b468689166c4a60f57438",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16561
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67391.0
     },
-    "duration": 5128125,
-    "start": 1757534089691485466
+    "duration": 8516000,
+    "start": 1776888795819334000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_single_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_single_distributed_tracing_disabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78500000000",
+      "_dd.p.tid": "69e92bd800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "59fd18b7-9add-4a2b-8a81-6b622287aaf7",
+      "messaging.message_id": "7077a848-41f2-467a-bd04-f28db70c11f1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "2dc72a1361cf416889735ceafab2be50",
+      "runtime-id": "4512556568e14a839e10e4cce1e0bcf9",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16554
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67385.0
     },
-    "duration": 540886583,
-    "start": 1757534085640484214
+    "duration": 492887000,
+    "start": 1776888792198886000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78600000000",
+      "_dd.p.tid": "69e92bd800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "e30e4125-c5e3-49ff-9ffb-af3423912374",
+      "messaging.message_id": "4862415f-d425-44b7-bf69-1896483464ea",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "2dc72a1361cf416889735ceafab2be50",
+      "runtime-id": "4512556568e14a839e10e4cce1e0bcf9",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16554
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67385.0
     },
-    "duration": 9716833,
-    "start": 1757534086188438464
+    "duration": 7620000,
+    "start": 1776888792692346000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78600000000",
+      "_dd.p.tid": "69e92bd800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "2dc72a1361cf416889735ceafab2be50",
+      "runtime-id": "4512556568e14a839e10e4cce1e0bcf9",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16554
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67385.0
     },
-    "duration": 7792500,
-    "start": 1757534086198866006
+    "duration": 18655000,
+    "start": 1776888792700305000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78600000000",
+      "_dd.p.tid": "69e92bd800000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "7611e0eb-c592-499a-bc37-1dadb8af49ac",
+      "messaging.message_id": "d8c77b64-84da-4ae1-bd9f-984b9ca49f8e",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "2dc72a1361cf416889735ceafab2be50",
+      "runtime-id": "4512556568e14a839e10e4cce1e0bcf9",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16554
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67385.0
     },
-    "duration": 5778916,
-    "start": 1757534086206988256
+    "duration": 9273000,
+    "start": 1776888792719245000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_async_single_distributed_tracing_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78200000000",
+      "_dd.p.tid": "69e92bd500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "549b7502-e954-4001-891c-219c5816407b",
+      "messaging.message_id": "31640fe7-cf78-456f-b486-f08176aed96b",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "1a3deac69c7249818b38c53d3b642639",
+      "runtime-id": "b34fdc73d7a74f07beead5bbc58babd8",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16547
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67374.0
     },
-    "duration": 535752709,
-    "start": 1757534082116262462
+    "duration": 518218000,
+    "start": 1776888789080803000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78200000000",
+      "_dd.p.tid": "69e92bd500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "00faf436-d1a9-4144-8c65-f0e8a9f53a84",
+      "messaging.message_id": "6d3caf97-3c47-4f32-aaa9-f9739fab021f",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "1a3deac69c7249818b38c53d3b642639",
+      "runtime-id": "b34fdc73d7a74f07beead5bbc58babd8",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16547
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67374.0
     },
-    "duration": 8635084,
-    "start": 1757534082657032212
+    "duration": 8397000,
+    "start": 1776888789599646000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78200000000",
+      "_dd.p.tid": "69e92bd500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "1a3deac69c7249818b38c53d3b642639",
+      "runtime-id": "b34fdc73d7a74f07beead5bbc58babd8",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16547
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67374.0
     },
-    "duration": 7362500,
-    "start": 1757534082666083004
+    "duration": 7241000,
+    "start": 1776888789608314000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d78200000000",
+      "_dd.p.tid": "69e92bd500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "243928cb-5938-434a-a008-9b06fa0fb36e",
+      "messaging.message_id": "9e106b7e-5ec3-4261-9202-40b78ff45540",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "1a3deac69c7249818b38c53d3b642639",
+      "runtime-id": "b34fdc73d7a74f07beead5bbc58babd8",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16547
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67374.0
     },
-    "duration": 8388166,
-    "start": 1757534082673737171
+    "duration": 7456000,
+    "start": 1776888789615784000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_disabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_disabled_batch_links_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4402200000000",
+      "_dd.p.tid": "69e92bd200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "f3c55db96b3d47bf96633e2d0aa56a94",
+      "runtime-id": "b8d5bcce354b4307bc7c14ca49a9f9c8",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12306
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67370.0
     },
-    "duration": 14948292,
-    "start": 1757691938194506133
+    "duration": 11401000,
+    "start": 1776888786462527000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4402200000000",
+      "_dd.p.tid": "69e92bd200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "f3c55db96b3d47bf96633e2d0aa56a94",
+      "runtime-id": "b8d5bcce354b4307bc7c14ca49a9f9c8",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12306
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67370.0
     },
-    "duration": 6576916,
-    "start": 1757691938217577092
+    "duration": 6376000,
+    "start": 1776888786475170000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_disabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_disabled_batch_links_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401e00000000",
+      "_dd.p.tid": "69e92bcf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "78fa810e-b024-4c32-b624-737eacb2492d",
+      "messaging.message_id": "183afe58-770c-4c03-9562-dbc2ca3165f8",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "49191e0bf2694e0b9f5479717ed51720",
+      "runtime-id": "13f53ef5f0a148799abcf6e951ce9955",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12298
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67328.0
     },
-    "duration": 1629417,
-    "start": 1757691934724831548
+    "duration": 877000,
+    "start": 1776888783309498000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401e00000000",
+      "_dd.p.tid": "69e92bcf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "ccd143c8-54fc-46f3-9cf1-5796e728286c",
+      "messaging.message_id": "ecc18185-01aa-43f3-881d-e0affcc59f2b",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "49191e0bf2694e0b9f5479717ed51720",
+      "runtime-id": "13f53ef5f0a148799abcf6e951ce9955",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12298
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67328.0
     },
-    "duration": 407708,
-    "start": 1757691934733772257
+    "duration": 348000,
+    "start": 1776888783311419000
   }],
 [
   {
@@ -77,7 +81,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401e00000000",
+      "_dd.p.tid": "69e92bcf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -85,17 +91,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "49191e0bf2694e0b9f5479717ed51720",
+      "runtime-id": "13f53ef5f0a148799abcf6e951ce9955",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12298
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67328.0
     },
-    "duration": 12486417,
-    "start": 1757691934734442465
+    "duration": 12394000,
+    "start": 1776888783311955000
   }],
 [
   {
@@ -110,24 +116,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401e00000000",
+      "_dd.p.tid": "69e92bcf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "49191e0bf2694e0b9f5479717ed51720",
+      "runtime-id": "13f53ef5f0a148799abcf6e951ce9955",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12298
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67328.0
     },
-    "duration": 853292,
-    "start": 1757691934747506423
+    "duration": 461000,
+    "start": 1776888783324805000
   }],
 [
   {
@@ -142,25 +150,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401e00000000",
+      "_dd.p.tid": "69e92bcf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "05040d13-f53a-4dbb-b84e-4659a0b80027",
+      "messaging.message_id": "c19ce9a1-bd97-406a-a44b-1e047962a4d5",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "49191e0bf2694e0b9f5479717ed51720",
+      "runtime-id": "13f53ef5f0a148799abcf6e951ce9955",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12298
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67328.0
     },
-    "duration": 381958,
-    "start": 1757691934748572257
+    "duration": 395000,
+    "start": 1776888783325456000
   }],
 [
   {
@@ -175,7 +185,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401e00000000",
+      "_dd.p.tid": "69e92bcf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -183,15 +195,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "49191e0bf2694e0b9f5479717ed51720",
+      "runtime-id": "13f53ef5f0a148799abcf6e951ce9955",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12298
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67328.0
     },
-    "duration": 6641417,
-    "start": 1757691934749181048
+    "duration": 7491000,
+    "start": 1776888783326099000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_enabled_batch_links_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_enabled_batch_links_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401b00000000",
+      "_dd.p.tid": "69e92bcc00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a6230f92b06f433bb939c559739e2297",
+      "runtime-id": "61749981c55c47da8dabdbfc3cc8e1fb",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12290
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67321.0
     },
-    "duration": 14289541,
-    "start": 1757691931311713297
+    "duration": 19708000,
+    "start": 1776888780212096000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401b00000000",
+      "_dd.p.tid": "69e92bcc00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a6230f92b06f433bb939c559739e2297",
+      "runtime-id": "61749981c55c47da8dabdbfc3cc8e1fb",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12290
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67321.0
     },
-    "duration": 6198167,
-    "start": 1757691931333198130
+    "duration": 12885000,
+    "start": 1776888780235473000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_enabled_batch_links_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_batch_distributed_tracing_enabled_batch_links_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401700000000",
+      "_dd.p.tid": "69e92bc900000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "1886fab3-4023-4027-ad1a-93ca2a2cea39",
+      "messaging.message_id": "d6584270-f66d-4b85-9bfe-b50cb64bacc7",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "59f3c49fafba4c62879ad49dbccdafd2",
+      "runtime-id": "53a7f92e374c4171b1940c4b96aee9f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12282
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67310.0
     },
-    "duration": 5089333,
-    "start": 1757691927756432212
+    "duration": 2510000,
+    "start": 1776888777033558000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401700000000",
+      "_dd.p.tid": "69e92bc900000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "ec67f9e2-aafc-4013-b8cd-be5159a1e7d6",
+      "messaging.message_id": "000e5fd4-1782-48ac-963c-f5eb5cd4b803",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "59f3c49fafba4c62879ad49dbccdafd2",
+      "runtime-id": "53a7f92e374c4171b1940c4b96aee9f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12282
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67310.0
     },
-    "duration": 808083,
-    "start": 1757691927769353670
+    "duration": 390000,
+    "start": 1776888777036616000
   }],
 [
   {
@@ -77,8 +81,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401700000000",
-      "_dd.span_links": "[{\"trace_id\": \"68c44017000000001bbd12f58c419ee5\", \"span_id\": \"8b4501284983f86c\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4401700000000\", \"flags\": 1}, {\"trace_id\": \"68c4401700000000185b7708e863d8e3\", \"span_id\": \"3e3805196f5c7486\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4401700000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92bc900000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92bc90000000004f5d3257352d47e\", \"span_id\": \"915a82c1fe1f2661\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92bc900000000\", \"flags\": 1}, {\"trace_id\": \"69e92bc900000000d10b541b869f9617\", \"span_id\": \"db0e6a3ce2103e06\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92bc900000000\", \"flags\": 1}]",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -86,17 +92,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "59f3c49fafba4c62879ad49dbccdafd2",
+      "runtime-id": "53a7f92e374c4171b1940c4b96aee9f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12282
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67310.0
     },
-    "duration": 12197875,
-    "start": 1757691927770398337
+    "duration": 23313000,
+    "start": 1776888777037143000
   }],
 [
   {
@@ -111,24 +117,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401700000000",
+      "_dd.p.tid": "69e92bc900000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "59f3c49fafba4c62879ad49dbccdafd2",
+      "runtime-id": "53a7f92e374c4171b1940c4b96aee9f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12282
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67310.0
     },
-    "duration": 890083,
-    "start": 1757691927784499045
+    "duration": 954000,
+    "start": 1776888777061477000
   }],
 [
   {
@@ -143,25 +151,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401700000000",
+      "_dd.p.tid": "69e92bc900000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "52863d23-2e6d-4b72-a170-7cdba5eeae29",
+      "messaging.message_id": "ac796801-e592-4fd9-83e5-d1f2386e9bbb",
       "messaging.operation": "create",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "59f3c49fafba4c62879ad49dbccdafd2",
+      "runtime-id": "53a7f92e374c4171b1940c4b96aee9f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12282
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67310.0
     },
-    "duration": 400417,
-    "start": 1757691927785558253
+    "duration": 598000,
+    "start": 1776888777062586000
   }],
 [
   {
@@ -176,8 +186,10 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c4401700000000",
-      "_dd.span_links": "[{\"trace_id\": \"68c4401700000000ac7d7984057128da\", \"span_id\": \"bc9e3de1271c9abe\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4401700000000\", \"flags\": 1}, {\"trace_id\": \"68c440170000000068381c0e0384f8ba\", \"span_id\": \"0c73e3391deda087\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:68c4401700000000\", \"flags\": 1}]",
+      "_dd.p.tid": "69e92bc900000000",
+      "_dd.span_links": "[{\"trace_id\": \"69e92bc90000000083f997b1355900a8\", \"span_id\": \"6edead9cc3c0e813\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92bc900000000\", \"flags\": 1}, {\"trace_id\": \"69e92bc9000000000dbed37a4186fe2b\", \"span_id\": \"01e4a034be8e238b\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:69e92bc900000000\", \"flags\": 1}]",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -185,15 +197,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "59f3c49fafba4c62879ad49dbccdafd2",
+      "runtime-id": "53a7f92e374c4171b1940c4b96aee9f6",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 12282
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67310.0
     },
-    "duration": 5903083,
-    "start": 1757691927786100170
+    "duration": 14779000,
+    "start": 1776888777063311000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_list_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_list_distributed_tracing_disabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d77000000000",
+      "_dd.p.tid": "69e92bc500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "523e462b378b4ecc851933bb5a7ae315",
+      "runtime-id": "fb8f5a6612c5493cb3ab12cbfe9ba665",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16512
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67155.0
     },
-    "duration": 546131542,
-    "start": 1757534064710902010
+    "duration": 527592000,
+    "start": 1776888773260036000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d77100000000",
+      "_dd.p.tid": "69e92bc500000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "523e462b378b4ecc851933bb5a7ae315",
+      "runtime-id": "fb8f5a6612c5493cb3ab12cbfe9ba665",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16512
+      "_sampling_priority_v1": 1.0,
+      "process_id": 67155.0
     },
-    "duration": 7704042,
-    "start": 1757534065263791260
+    "duration": 6370000,
+    "start": 1776888773787963000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_list_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_list_distributed_tracing_enabled].json
@@ -11,7 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76d00000000",
+      "_dd.p.tid": "69e92bc200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -19,17 +21,17 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "63daef539cbc4629b4e21e42ffb7a8a9",
+      "runtime-id": "f619025fdc68490195d4880ff43ec1d2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16505
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66945.0
     },
-    "duration": 531543834,
-    "start": 1757534061253268716
+    "duration": 513758000,
+    "start": 1776888770033345000
   }],
 [
   {
@@ -44,7 +46,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76d00000000",
+      "_dd.p.tid": "69e92bc200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.batch_count": "2",
@@ -52,15 +56,15 @@
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "63daef539cbc4629b4e21e42ffb7a8a9",
+      "runtime-id": "f619025fdc68490195d4880ff43ec1d2",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16505
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66945.0
     },
-    "duration": 4978833,
-    "start": 1757534061788785217
+    "duration": 7987000,
+    "start": 1776888770547952000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_single_distributed_tracing_disabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_single_distributed_tracing_disabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76900000000",
+      "_dd.p.tid": "69e92bbe00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "6a46af62-0366-4f75-a3a2-1eebfdde4aea",
+      "messaging.message_id": "4313454b-680c-48bd-afd1-a438b5f82aa7",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a27a425a24294ea0b36295730ab196d8",
+      "runtime-id": "b6c2c28124164c939c9c4ec0862c6659",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16498
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66846.0
     },
-    "duration": 552578875,
-    "start": 1757534057730533090
+    "duration": 505190000,
+    "start": 1776888766860640000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76a00000000",
+      "_dd.p.tid": "69e92bbf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "71f81232-0d3c-4313-a04c-f280aab4882c",
+      "messaging.message_id": "206b8c92-807d-426c-948a-221ac3faa393",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a27a425a24294ea0b36295730ab196d8",
+      "runtime-id": "b6c2c28124164c939c9c4ec0862c6659",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16498
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66846.0
     },
-    "duration": 7029875,
-    "start": 1757534058289521340
+    "duration": 6908000,
+    "start": 1776888767366155000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76a00000000",
+      "_dd.p.tid": "69e92bbf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a27a425a24294ea0b36295730ab196d8",
+      "runtime-id": "b6c2c28124164c939c9c4ec0862c6659",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16498
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66846.0
     },
-    "duration": 5993583,
-    "start": 1757534058296938715
+    "duration": 6740000,
+    "start": 1776888767373193000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76a00000000",
+      "_dd.p.tid": "69e92bbf00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "b33b414e-7059-4c2e-a114-fb1d5563502b",
+      "messaging.message_id": "4c2db42d-3f66-470d-84ac-ebfaf7e1cf57",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "a27a425a24294ea0b36295730ab196d8",
+      "runtime-id": "b6c2c28124164c939c9c4ec0862c6659",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16498
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66846.0
     },
-    "duration": 5056458,
-    "start": 1757534058303234382
+    "duration": 7048000,
+    "start": 1776888767380069000
   }]]

--- a/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_single_distributed_tracing_enabled].json
+++ b/tests/snapshots/tests.contrib.azure_servicebus.test_azure_servicebus_snapshot.test_producer[send_messages_single_distributed_tracing_enabled].json
@@ -11,25 +11,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76600000000",
+      "_dd.p.tid": "69e92bbb00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "061e2b65-4cc1-4138-939b-395ba20487e3",
+      "messaging.message_id": "a5ce1ed6-4ce4-49b8-b91a-9b474220d838",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "135121aa8da74f3ca97abaf9816b8289",
+      "runtime-id": "92993f0216ce463dbd6afc413eb0bc0b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16491
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66837.0
     },
-    "duration": 552660000,
-    "start": 1757534054134645130
+    "duration": 531310000,
+    "start": 1776888763718404000
   }],
 [
   {
@@ -44,25 +46,27 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76600000000",
+      "_dd.p.tid": "69e92bbc00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "5eae45f5-7a86-45d6-beb9-c574e6bcd0fc",
+      "messaging.message_id": "50c60a39-82e3-4b08-bfe1-8189726f2548",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "135121aa8da74f3ca97abaf9816b8289",
+      "runtime-id": "92993f0216ce463dbd6afc413eb0bc0b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16491
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66837.0
     },
-    "duration": 7807333,
-    "start": 1757534054693857880
+    "duration": 13152000,
+    "start": 1776888764250900000
   }],
 [
   {
@@ -77,24 +81,26 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76600000000",
+      "_dd.p.tid": "69e92bbc00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "135121aa8da74f3ca97abaf9816b8289",
+      "runtime-id": "92993f0216ce463dbd6afc413eb0bc0b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16491
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66837.0
     },
-    "duration": 5892291,
-    "start": 1757534054702405797
+    "duration": 12345000,
+    "start": 1776888764265086000
   }],
 [
   {
@@ -109,23 +115,25 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68c1d76600000000",
+      "_dd.p.tid": "69e92bbc00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:ddtrace_subprocess_dir",
       "component": "azure_servicebus",
       "language": "python",
       "messaging.destination.name": "queue.1",
-      "messaging.message_id": "eaf39d71-071a-4e17-9ca1-46d00bfd1e7c",
+      "messaging.message_id": "30809224-7866-45a4-819a-14d92cc23a5e",
       "messaging.operation": "send",
       "messaging.system": "servicebus",
       "network.destination.name": "localhost",
-      "runtime-id": "135121aa8da74f3ca97abaf9816b8289",
+      "runtime-id": "92993f0216ce463dbd6afc413eb0bc0b",
       "span.kind": "producer"
     },
     "metrics": {
-      "_dd.top_level": 1,
+      "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
-      "_sampling_priority_v1": 1,
-      "process_id": 16491
+      "_sampling_priority_v1": 1.0,
+      "process_id": 66837.0
     },
-    "duration": 4774334,
-    "start": 1757534054708523463
+    "duration": 9815000,
+    "start": 1776888764277748000
   }]]


### PR DESCRIPTION
## Description

This change commits the result of running the azure-related test suites on my laptop from https://github.com/DataDog/dd-trace-py/pull/17502. That change removes the tag `meta._dd.svc_src` from the list of attributes ignored during snapshot testing. The change here is a small, easier-to-review subset of that change.