### PR TITLE
fix(profiling): ensure running loop is not `None` before linking tasks [backport 4.6]

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -123,14 +123,15 @@ def _(asyncio: ModuleType) -> None:
                 children = get_argument_value(args, kwargs, 1, "children")
                 assert children is not None  # nosec: assert is used for typing
 
-                # Pass an invalid positional index for 'loop'
-                loop = get_argument_value(args, kwargs, -1, "loop")
+                if globals()["get_running_loop"]() is not None:
+                    # Pass an invalid positional index for 'loop'
+                    loop = get_argument_value(args, kwargs, -1, "loop")
 
-                # Link the parent gathering task to the gathered children
-                parent = globals()["current_task"](loop)
+                    # Link the parent gathering task to the gathered children
+                    parent = globals()["current_task"](loop)
 
-                for child in children:
-                    stack.link_tasks(parent, child)
+                    for child in children:
+                        stack.link_tasks(parent, child)
 
         @partial(wrap, sys.modules["asyncio"].tasks._wait)
         def _(
@@ -141,13 +142,14 @@ def _(asyncio: ModuleType) -> None:
             try:
                 return f(*args, **kwargs)
             finally:
-                futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
-                loop = typing.cast("aio.AbstractEventLoop", get_argument_value(args, kwargs, 3, "loop"))
+                if globals()["get_running_loop"]() is not None:
+                    futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
+                    loop = typing.cast("aio.AbstractEventLoop", get_argument_value(args, kwargs, 3, "loop"))
 
-                # Link the parent gathering task to the gathered children
-                parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"](loop))
-                for future in futures:
-                    stack.link_tasks(parent, future)
+                    # Link the parent gathering task to the gathered children
+                    parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"](loop))
+                    for future in futures:
+                        stack.link_tasks(parent, future)
 
         @partial(wrap, sys.modules["asyncio"].tasks.as_completed)
         def _(

--- a/releasenotes/notes/profiling-safer-use-of-task-linking-bfca996e62c5d5b3.yaml
+++ b/releasenotes/notes/profiling-safer-use-of-task-linking-bfca996e62c5d5b3.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: A race condition which could make asyncio code raise exceptions at exit
+    has been fixed.


### PR DESCRIPTION
Backport of PR #17675 (commit d18ef16897aa650b033183f14fcd555ddcf87732) to branch 4.6.

## Description

This fixes a surprising race condition happening under AnyIO asynchronous testing where we could sometimes end up constructing a `GatheringFuture` without an active event loop. The assumption was that `gather` would always be called with an event loop existing, but that can apparently be not the case at exit with certain additional `asyncio`-related packages.

## Notes on conflict resolution

The 4.6 branch uses `current_task(loop)` (with loop argument), which differs from main where it was refactored to `current_task()` (no argument). The fix was applied while preserving the loop-based calling convention of the 4.6 branch.