### PR TITLE
chore: ignore .omc/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,9 @@ CLAUDE.local.md
 .claude/settings.local.json
 .claude/worktrees/
 
+# oh-my-claudecode
+.omc/
+
 # Riot
 .riot/venv*
 .riot/envs/


### PR DESCRIPTION
## Summary
- Adds `.omc/` to `.gitignore` so oh-my-claudecode local state (e.g. `project-memory.json`) is not tracked.

## Test plan
- [x] `git check-ignore` confirms `.omc/` and its contents are ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)