### PR TITLE
fix(profiling): fix crash happening when using Ray [backport 4.6]

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -288,13 +288,25 @@ class _ProfiledLock:
             if value is self:
                 return name
             if config.lock.name_inspect_dir:
-                for attribute in dir(value):
-                    try:
-                        if not attribute.startswith("__") and getattr(value, attribute) is self:
-                            return attribute
-                    except AttributeError:
-                        # Accessing unset attributes in __slots__ raises AttributeError.
-                        pass
+                # Use __dict__ rather than dir + getattr to avoid invoking
+                # arbitrary descriptors. Some third-party descriptors (e.g. Ray's get_actor_name)
+                # crash the process when accessed from a non-actor worker context.
+                instance_dict = getattr(value, "__dict__", None)
+                if instance_dict is None:
+                    # No __dict__ (built-in or __slots__-only). Slot attributes are backed
+                    # by C-level member_descriptors, not arbitrary user descriptors, so
+                    # getattr is safe here.
+                    for klass in type(value).__mro__:
+                        available_attributes = (a for a in getattr(klass, "__slots__", ()) if not a.startswith("__"))
+                        for attribute in available_attributes:
+                            if getattr(value, attribute, None) is self:
+                                return attribute
+
+                    continue
+
+                for attribute, attr_val in instance_dict.items():
+                    if not attribute.startswith("__") and attr_val is self:
+                        return attribute
         return None
 
     def _update_name(self) -> None:

--- a/releasenotes/notes/profiling-lock-use-vars-instead-of-dir-331983a76ccc89b2.yaml
+++ b/releasenotes/notes/profiling-lock-use-vars-instead-of-dir-331983a76ccc89b2.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: A bug in Lock Profiling that could cause crashes when trying to access attributes of
+    custom Lock subclasses (e.g. in Ray) has been fixed.


### PR DESCRIPTION
## Description

Backport of PR #17399 (commit d4fa769d226c17aed16da5573683c7271298dd43) to branch 4.6.

## Notes on conflict resolution

No conflicts. The 4.6 branch uses `_lock.py` (pure Python), which has the same old `dir + getattr` pattern as `main` did before the fix.