### PR TITLE
feat(ci_visibility): add test_session telemetry metric with provider and auto_injected tags

### DIFF
--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -376,6 +376,11 @@ class TestOptPlugin:
             efd_abort_reason=self.session.get_early_flake_detection_abort_reason(),
         )
 
+        TelemetryAPI.get().record_test_session(
+            ci_provider_name=self.manager.env_tags.get(CITag.PROVIDER_NAME),
+            is_auto_injected=self.manager.is_auto_injected,
+        )
+
         if not self.is_xdist_worker:
             # When running with xdist, only the main process writes the session event.
             self.manager.writer.put_item(self.session)

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -297,6 +297,13 @@ class TelemetryAPI:
 
         self.add_count_metric("event_finished", 1, tags)
 
+    def record_test_session(self, ci_provider_name: t.Optional[str], is_auto_injected: bool) -> None:
+        tags = {
+            "provider": ci_provider_name,
+            "auto_injected": is_auto_injected,
+        }
+        self.add_count_metric("test_session", 1, tags)
+
     def record_git_pack_data(self, uploaded_files: int, uploaded_bytes: int) -> None:
         self.add_distribution_metric("git_requests.objects_pack_files", uploaded_files)
         self.add_distribution_metric("git_requests.objects_pack_bytes", uploaded_bytes)

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -628,3 +628,20 @@ class TestTelemetry:
                 ),
             )
         ]
+
+    def test_record_test_session(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        telemetry_api.record_test_session(ci_provider_name="gitlab", is_auto_injected=True)
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(
+                CIVISIBILITY,
+                "test_session",
+                1,
+                (("provider", "gitlab"), ("auto_injected", "true")),
+            )
+        ]
+
+    def test_record_test_session_unsupported_ci(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        telemetry_api.record_test_session(ci_provider_name=None, is_auto_injected=False)
+
+        assert mock_writer.add_count_metric.call_args_list == [call(CIVISIBILITY, "test_session", 1, ())]


### PR DESCRIPTION
## Summary
- Adds a new `test_session` count metric emitted once per test session with `provider` and `auto_injected` tags
- Reduces cardinality versus including these tags on the per-test `event_finished` metric
- Called from the pytest plugin's session finish path alongside `record_session_finished`

## Test plan
- [x] Unit tests for `record_test_session` with provider and auto_injected tags
- [x] Unit test for unsupported CI (None provider, auto_injected=False)
- [ ] Verify metric appears in telemetry intake

## Motivation
Per CI Visibility telemetry RFC: a dedicated low-cardinality `test_session` metric allows tracking CI provider distribution and auto-injection without inflating `event_created`/`event_finished` tag cardinality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- changelog: no-changelog -->