### PR TITLE
feat(ci_visibility): add status_code tag to request error telemetry

### DIFF
--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -55,6 +55,7 @@ class BackendResult:
     is_gzip_response: bool = False
     elapsed_seconds: float = 0.0
     retry_after_seconds: t.Optional[float] = None
+    status_code: t.Optional[int] = None
 
     def on_error_raise_exception(self) -> None:
         if self.error_type:
@@ -295,6 +296,7 @@ class BackendConnector(threading.local):
                 result.response_body = response_body = result.response.read()
 
             if not (200 <= result.response.status <= 299):
+                result.status_code = result.response.status
                 result.error_description = f"{result.response.status} {result.response.reason}"
                 if result.response.status >= 500:
                     result.error_type = ErrorType.CODE_5XX
@@ -379,6 +381,7 @@ class BackendConnector(threading.local):
                     compressed_response=result.is_gzip_response,
                     error=result.error_type,
                     request_bytes=result.request_length,
+                    status_code=result.status_code,
                 )
 
             if result.error_type and result.error_type in RETRIABLE_ERRORS and attempts_so_far < max_attempts:

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -24,6 +24,8 @@ log = logging.getLogger(__name__)
 
 CIVISIBILITY = TELEMETRY_NAMESPACE.CIVISIBILITY
 
+_TRACKED_STATUS_CODES = {400, 401, 403, 404, 408, 429}
+
 
 class ErrorType(str, Enum):
     TIMEOUT = "timeout"
@@ -392,6 +394,7 @@ class TelemetryAPIRequestMetrics:
         compressed_response: bool,
         error: t.Optional[ErrorType],
         request_bytes: t.Optional[int] = None,
+        status_code: t.Optional[int] = None,
     ) -> None:
         self.telemetry_api.add_count_metric(self.count, 1)
         self.telemetry_api.add_distribution_metric(self.duration, seconds)
@@ -404,9 +407,12 @@ class TelemetryAPIRequestMetrics:
             self.telemetry_api.add_distribution_metric(self.request_bytes, request_bytes)
 
         if error is not None:
-            self.record_error(error)
+            self.record_error(error, status_code=status_code)
 
-    def record_error(self, error: ErrorType) -> None:
+    def record_error(self, error: ErrorType, status_code: t.Optional[int] = None) -> None:
         # Map RATE_LIMITED to the same telemetry value as CODE_4XX for cross-language consistency
         error_type = ErrorType.CODE_4XX if error == ErrorType.RATE_LIMITED else error
-        self.telemetry_api.add_count_metric(self.error, 1, {"error_type": error_type})
+        tags: dict[str, t.Any] = {"error_type": error_type}
+        if status_code is not None and status_code in _TRACKED_STATUS_CODES:
+            tags["status_code"] = str(status_code)
+        self.telemetry_api.add_count_metric(self.error, 1, tags)

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -94,6 +94,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=None,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             )
         ]
 
@@ -141,6 +142,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=500,
             ),
             call(
                 seconds=0.0,
@@ -148,6 +150,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=None,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
         ]
 
@@ -195,6 +198,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=500,
             ),
             call(
                 seconds=0.0,
@@ -202,6 +206,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=500,
             ),
             call(
                 seconds=0.0,
@@ -209,6 +214,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=500,
             ),
             call(
                 seconds=0.0,
@@ -216,6 +222,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=500,
             ),
             call(
                 seconds=0.0,
@@ -223,6 +230,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=500,
             ),
         ]
 
@@ -266,6 +274,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -273,6 +282,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -280,6 +290,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -287,6 +298,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -294,6 +306,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
         ]
 
@@ -336,6 +349,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.CODE_4XX,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=400,
             ),
         ]
 
@@ -393,6 +407,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -400,6 +415,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -407,6 +423,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -414,6 +431,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -421,6 +439,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
         ]
 
@@ -461,6 +480,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -468,6 +488,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -475,6 +496,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -482,6 +504,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
             call(
                 seconds=0.0,
@@ -489,6 +512,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
         ]
 
@@ -525,6 +549,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.UNKNOWN,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
         ]
 
@@ -570,6 +595,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=429,
             ),
             call(
                 seconds=0.0,
@@ -577,6 +603,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=None,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=None,
             ),
         ]
 
@@ -620,6 +647,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=429,
             ),
             call(
                 seconds=0.0,
@@ -627,6 +655,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=429,
             ),
             call(
                 seconds=0.0,
@@ -634,6 +663,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=429,
             ),
             call(
                 seconds=0.0,
@@ -641,6 +671,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=429,
             ),
             call(
                 seconds=0.0,
@@ -648,6 +679,7 @@ class TestBackendConnector:
                 compressed_response=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
+                status_code=429,
             ),
         ]
 
@@ -838,6 +870,98 @@ class TestBackendConnector:
         assert b"content1" in body
         assert b"content2" in body
         assert body.count(b"--boundary123") == 3  # 2 file separators + 1 end
+
+
+class TestBackendResultStatusCode:
+    """Tests for BackendResult.status_code population on non-2xx responses."""
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_status_code_set_on_4xx(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        mock_response = Mock()
+        mock_response.headers = {"Content-Length": "0"}
+        mock_response.read.return_value = b""
+        mock_response.status = 403
+        mock_response.reason = "Forbidden"
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com")
+        result = connector.request("GET", "/test", max_attempts=1)
+
+        assert result.status_code == 403
+        assert result.error_type == ErrorType.CODE_4XX
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_status_code_set_on_5xx(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        mock_response = Mock()
+        mock_response.headers = {"Content-Length": "0"}
+        mock_response.read.return_value = b""
+        mock_response.status = 502
+        mock_response.reason = "Bad Gateway"
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com")
+        result = connector.request("GET", "/test", max_attempts=1)
+
+        assert result.status_code == 502
+        assert result.error_type == ErrorType.CODE_5XX
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_status_code_set_on_429(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_response.read.return_value = b""
+        mock_response.status = 429
+        mock_response.reason = "Too Many Requests"
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com")
+        result = connector.request("GET", "/test", max_attempts=1)
+
+        assert result.status_code == 429
+        assert result.error_type == ErrorType.RATE_LIMITED
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_status_code_none_on_2xx(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        mock_response = Mock()
+        mock_response.headers = {"Content-Length": "2"}
+        mock_response.read.return_value = b"ok"
+        mock_response.status = 200
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com")
+        result = connector.request("GET", "/test", max_attempts=1)
+
+        assert result.status_code is None
+        assert result.error_type is None
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_status_code_none_on_connection_error(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        mock_conn = Mock()
+        mock_conn.getresponse.side_effect = ConnectionRefusedError("refused")
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com")
+        result = connector.request("GET", "/test", max_attempts=1)
+
+        assert result.status_code is None
+        assert result.error_type == ErrorType.NETWORK
 
 
 class TestBackendConnectorSetup:

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -192,6 +192,115 @@ class TestTelemetry:
             call(CIVISIBILITY, "known_tests.response_bytes", 42, ()),
         ]
 
+    def test_record_request_with_tracked_status_code(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="known_tests.request",
+            duration="known_tests.request_ms",
+            response_bytes="known_tests.response_bytes",
+            error="known_tests.request_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=1.41,
+            response_bytes=42,
+            compressed_response=False,
+            error=ErrorType.CODE_4XX,
+            status_code=403,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "known_tests.request", 1, ()),
+            call(
+                CIVISIBILITY,
+                "known_tests.request_errors",
+                1,
+                (("error_type", ErrorType.CODE_4XX.value), ("status_code", "403")),
+            ),
+        ]
+
+    def test_record_request_with_untracked_status_code(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        """Status codes not in the tracked set should not be emitted."""
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="known_tests.request",
+            duration="known_tests.request_ms",
+            response_bytes="known_tests.response_bytes",
+            error="known_tests.request_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=1.41,
+            response_bytes=42,
+            compressed_response=False,
+            error=ErrorType.CODE_4XX,
+            status_code=418,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "known_tests.request", 1, ()),
+            call(
+                CIVISIBILITY,
+                "known_tests.request_errors",
+                1,
+                (("error_type", ErrorType.CODE_4XX.value),),
+            ),
+        ]
+
+    def test_record_request_rate_limited_includes_status_code(
+        self, telemetry_api: TelemetryAPI, mock_writer: Mock
+    ) -> None:
+        """RATE_LIMITED (429) is mapped to CODE_4XX error_type, and 429 is in tracked set."""
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="known_tests.request",
+            duration="known_tests.request_ms",
+            response_bytes="known_tests.response_bytes",
+            error="known_tests.request_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=1.41,
+            response_bytes=42,
+            compressed_response=False,
+            error=ErrorType.RATE_LIMITED,
+            status_code=429,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "known_tests.request", 1, ()),
+            call(
+                CIVISIBILITY,
+                "known_tests.request_errors",
+                1,
+                (("error_type", ErrorType.CODE_4XX.value), ("status_code", "429")),
+            ),
+        ]
+
+    def test_record_request_5xx_with_status_code(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        """5xx errors should not include a status_code tag (only 4xx codes are tracked)."""
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="known_tests.request",
+            duration="known_tests.request_ms",
+            response_bytes="known_tests.response_bytes",
+            error="known_tests.request_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=1.41,
+            response_bytes=42,
+            compressed_response=False,
+            error=ErrorType.CODE_5XX,
+            status_code=500,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(CIVISIBILITY, "known_tests.request", 1, ()),
+            call(
+                CIVISIBILITY,
+                "known_tests.request_errors",
+                1,
+                (("error_type", ErrorType.CODE_5XX.value),),
+            ),
+        ]
+
     def test_record_coverage_started(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_coverage_started(test_framework="pytest", coverage_library="ddtrace")
 


### PR DESCRIPTION
## Summary
- Adds an additive `status_code` tag to error telemetry metrics for specific known 4xx HTTP codes (400, 401, 403, 404, 408, 429)
- The raw status code flows from `BackendResult` through to the telemetry recording layer
- Existing `error_type` tag values remain unchanged (no breaking change to dashboards)

## Test plan
- [x] Unit tests for tracked status codes (403, 429)
- [x] Unit test for untracked status codes (418 — not emitted)
- [x] Unit test for 5xx (status_code tag not emitted)
- [x] Unit test for RATE_LIMITED mapping with status_code
- [x] Integration tests verifying `BackendResult.status_code` population on 4xx, 5xx, 429, 2xx, and connection errors
- [x] All existing test_http.py assertions updated with `status_code=` parameter

## Motivation
Per CI Visibility telemetry RFC: the generic `error_type:status_code_4xx_response` is too coarse — a 400 (bad request) should be distinguishable from a 403 (bad API key). A new `status_code` tag provides this detail without modifying `error_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- changelog: no-changelog -->