### PR TITLE
feat(ci_visibility): send error logs to telemetry endpoint

### DIFF
--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import logging
 from pathlib import Path
+import sys
 import typing as t
 import uuid
 
@@ -102,6 +103,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot fetch settings (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.telemetry_api.record_error_log("Git info not available, cannot fetch settings", sys.exc_info())
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS] = "true"
             return Settings()
 
@@ -123,6 +125,7 @@ class APIClient:
         except Exception as e:
             log.warning("Error getting settings from API: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.telemetry_api.record_error_log("Error getting settings from API", sys.exc_info())
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SETTINGS] = "true"
             return Settings()
 
@@ -164,6 +167,7 @@ class APIClient:
             except KeyError as e:
                 log.warning("Git info not available, cannot fetch known tests (missing key: %s)", e)
                 telemetry.record_error(ErrorType.UNKNOWN)
+                self.telemetry_api.record_error_log("Git info not available, cannot fetch known tests", sys.exc_info())
                 self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                 return set()
 
@@ -193,6 +197,7 @@ class APIClient:
                 if not isinstance(page_info, dict):
                     log.warning("Known tests response page_info is not a dict")
                     telemetry.record_error(ErrorType.BAD_JSON)
+                    self.telemetry_api.record_error_log("Known tests response page_info is not a dict")
                     self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                     return set()
 
@@ -204,17 +209,20 @@ class APIClient:
                 if not page_state:
                     log.warning("Known tests response missing pagination cursor on page %d", page_number + 1)
                     telemetry.record_error(ErrorType.BAD_JSON)
+                    self.telemetry_api.record_error_log("Known tests response missing pagination cursor")
                     self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                     return set()
 
             except Exception:
                 log.warning("Error getting known tests from API")
                 telemetry.record_error(ErrorType.BAD_JSON)
+                self.telemetry_api.record_error_log("Error getting known tests from API", sys.exc_info())
                 self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
                 return set()
         else:
             log.warning("Known tests pagination exceeded max pages: %d", max_pages)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.telemetry_api.record_error_log("Known tests pagination exceeded max pages")
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
             return set()
 
@@ -248,6 +256,9 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot fetch Test Management properties (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.telemetry_api.record_error_log(
+                "Git info not available, cannot fetch Test Management properties", sys.exc_info()
+            )
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS] = "true"
             return {}
 
@@ -284,6 +295,7 @@ class APIClient:
         except Exception as e:
             log.warning("Failed to parse Test Management tests data from API: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.telemetry_api.record_error_log("Failed to parse Test Management tests data from API", sys.exc_info())
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS] = "true"
             return {}
 
@@ -309,6 +321,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot fetch known commits (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.telemetry_api.record_error_log("Git info not available, cannot fetch known commits", sys.exc_info())
             return None
 
         try:
@@ -327,6 +340,7 @@ class APIClient:
         except Exception as e:
             log.warning("Failed to parse search_commits data: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.telemetry_api.record_error_log("Failed to parse search_commits data", sys.exc_info())
             return None
 
         return known_commits
@@ -348,6 +362,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot send git packfile (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.telemetry_api.record_error_log("Git info not available, cannot send git packfile", sys.exc_info())
             return None
 
         try:
@@ -368,6 +383,7 @@ class APIClient:
         except Exception as e:
             log.warning("Error sending Git pack data: %s", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.telemetry_api.record_error_log("Error sending Git pack data", sys.exc_info())
             return None
 
         try:
@@ -409,6 +425,7 @@ class APIClient:
         except KeyError as e:
             log.warning("Git info not available, cannot get skippable items (missing key: %s)", e)
             telemetry.record_error(ErrorType.UNKNOWN)
+            self.telemetry_api.record_error_log("Git info not available, cannot get skippable items", sys.exc_info())
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS] = "true"
             return set(), None
 
@@ -439,6 +456,7 @@ class APIClient:
         except Exception as e:
             log.warning("Failed to parse skippable tests data from API: %s", e)
             telemetry.record_error(ErrorType.BAD_JSON)
+            self.telemetry_api.record_error_log("Failed to parse skippable tests data from API", sys.exc_info())
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS] = "true"
             return set(), None
 

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -425,6 +425,7 @@ class SessionManager:
             git = Git()
         except RuntimeError:
             log.warning("Error calling git binary, skipping metadata upload")
+            TelemetryAPI.get().record_error_log("Error calling git binary, skipping metadata upload")
             return
 
         latest_commits = git.get_latest_commits()

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -93,6 +93,10 @@ class TelemetryAPI:
     def finish(self) -> None:
         self.writer.periodic(force_flush=True)
 
+    def record_error_log(self, message: str, exc_info: t.Optional[tuple] = None) -> None:
+        if hasattr(self.writer, "add_error_log"):
+            self.writer.add_error_log(message, exc_info)
+
     def add_count_metric(self, metric_name: str, value: int, tags: t.Optional[dict[str, t.Any]] = None) -> None:
         log.debug("Recording Test Optimization telemetry count: %r %r %r", metric_name, value, tags)
         self.writer.add_count_metric(self.namespace, metric_name, value, self._make_tags(tags))

--- a/scripts/check_constant_log_message.py
+++ b/scripts/check_constant_log_message.py
@@ -29,6 +29,8 @@ EXCEPTIONS = {
     "ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py:74",
     # _safelog wrapper function dispatches to log methods with variable message
     "ddtrace/internal/writer/writer.py:103",
+    # record_error_log wrapper delegates to add_error_log with caller-validated constant message
+    "ddtrace/testing/internal/telemetry.py:98",
 }
 
 

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -628,3 +628,24 @@ class TestTelemetry:
                 ),
             )
         ]
+
+    def test_record_error_log(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        mock_writer.add_error_log = Mock()
+        telemetry_api.record_error_log("Something went wrong", None)
+        mock_writer.add_error_log.assert_called_once_with("Something went wrong", None)
+
+    def test_record_error_log_with_exc_info(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        mock_writer.add_error_log = Mock()
+        try:
+            raise ValueError("test error")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+            telemetry_api.record_error_log("Caught error", exc_info)
+            mock_writer.add_error_log.assert_called_once_with("Caught error", exc_info)
+
+    def test_record_error_log_noop_writer(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        """When writer doesn't support add_error_log (e.g., NoOp), call is silently ignored."""
+        del mock_writer.add_error_log  # Remove the attribute
+        telemetry_api.record_error_log("Something went wrong", None)  # Should not raise


### PR DESCRIPTION
## Summary
- Adds `record_error_log` method to `TelemetryAPI`, delegating to the ddtrace telemetry writer's `add_error_log`
- Instruments 16 API client error paths and git-missing detection to submit internal errors to the telemetry logs intake
- Uses constant message strings (per `check_constant_log_message.py` guardrail) with `exc_info` for dynamic stack traces

## Test plan
- [x] Unit test for `record_error_log` basic call
- [x] Unit test with `exc_info` tuple
- [x] Unit test for NoOp writer (no `add_error_log` attribute)
- [ ] Verify error logs appear in Datadog Error Tracking via telemetry intake

## Motivation
Per CI Visibility telemetry RFC: internal library errors should be uploaded to the telemetry logs endpoint for visibility in the Logs product and Error Tracking, matching .NET and Node.js tracer behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- changelog: no-changelog -->