### PR TITLE
feat(ci_visibility): add rq_compressed and rs_compressed tags to request metrics

### DIFF
--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -53,6 +53,7 @@ class BackendResult:
     response_body: t.Optional[bytes] = None
     parsed_response: t.Any = None
     is_gzip_response: bool = False
+    is_gzip_request: bool = False
     elapsed_seconds: float = 0.0
     retry_after_seconds: t.Optional[float] = None
 
@@ -276,11 +277,14 @@ class BackendConnector(threading.local):
     ) -> BackendResult:
         full_headers = self.default_headers | (headers or {})
 
+        request_compressed = False
         if send_gzip and self.use_gzip and data is not None:
             data = gzip.compress(data, compresslevel=6)
             full_headers["Content-Encoding"] = "gzip"
+            request_compressed = True
 
         result = BackendResult()
+        result.is_gzip_request = request_compressed
         result.request_length = len(data) if data is not None else 0
         start_time = time.perf_counter()
 
@@ -377,6 +381,7 @@ class BackendConnector(threading.local):
                     seconds=result.elapsed_seconds,
                     response_bytes=result.response_length,
                     compressed_response=result.is_gzip_response,
+                    compressed_request=result.is_gzip_request,
                     error=result.error_type,
                     request_bytes=result.request_length,
                 )

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -392,8 +392,15 @@ class TelemetryAPIRequestMetrics:
         compressed_response: bool,
         error: t.Optional[ErrorType],
         request_bytes: t.Optional[int] = None,
+        compressed_request: bool = False,
     ) -> None:
-        self.telemetry_api.add_count_metric(self.count, 1)
+        request_tags: dict[str, t.Any] = {}
+        if compressed_request:
+            request_tags["rq_compressed"] = True
+        if compressed_response:
+            request_tags["rs_compressed"] = True
+
+        self.telemetry_api.add_count_metric(self.count, 1, request_tags if request_tags else None)
         self.telemetry_api.add_distribution_metric(self.duration, seconds)
         if response_bytes is not None and self.response_bytes is not None:
             # We don't always want to record response bytes (for settings requests), so assume that no metric name

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -92,6 +92,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=None,
                 request_bytes=len(b'{"question": 1}'),
             )
@@ -139,6 +140,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -146,6 +148,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=None,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -193,6 +196,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -200,6 +204,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -207,6 +212,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -214,6 +220,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -221,6 +228,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_5XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -264,6 +272,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -271,6 +280,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -278,6 +288,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -285,6 +296,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -292,6 +304,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.BAD_JSON,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -334,6 +347,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.CODE_4XX,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -391,6 +405,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -398,6 +413,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -405,6 +421,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -412,6 +429,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -419,6 +437,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.NETWORK,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -459,6 +478,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -466,6 +486,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -473,6 +494,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -480,6 +502,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -487,6 +510,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.TIMEOUT,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -523,6 +547,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=None,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.UNKNOWN,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -568,6 +593,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -575,6 +601,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=14,
                 compressed_response=False,
+                compressed_request=False,
                 error=None,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -618,6 +645,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -625,6 +653,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -632,6 +661,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -639,6 +669,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -646,6 +677,7 @@ class TestBackendConnector:
                 seconds=0.0,
                 response_bytes=0,
                 compressed_response=False,
+                compressed_request=False,
                 error=ErrorType.RATE_LIMITED,
                 request_bytes=len(b'{"question": 1}'),
             ),
@@ -838,6 +870,80 @@ class TestBackendConnector:
         assert b"content1" in body
         assert b"content2" in body
         assert body.count(b"--boundary123") == 3  # 2 file separators + 1 end
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_post_json_gzip_request(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        """Test that is_gzip_request is set when the request body is compressed."""
+        mock_response = Mock()
+        mock_response.headers = {"Content-Length": 14}
+        mock_response.read.return_value = b'{"answer": 42}'
+        mock_response.status = 200
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        mock_telemetry = Mock()
+
+        connector = BackendConnector(url="https://api.example.com", use_gzip=True)
+
+        result = connector.post_json(
+            "/v1/some-endpoint", data={"question": 1}, send_gzip=True, telemetry=mock_telemetry
+        )
+
+        assert result.error_type is None
+        assert result.is_gzip_request is True
+        assert result.is_gzip_response is False
+
+        assert mock_telemetry.record_request.call_args_list == [
+            call(
+                seconds=0.0,
+                response_bytes=14,
+                compressed_response=False,
+                compressed_request=True,
+                error=None,
+                request_bytes=result.request_length,
+            )
+        ]
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_post_json_no_gzip_request_when_use_gzip_false(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        """Test that is_gzip_request is False when use_gzip is False on the connector."""
+        mock_response = Mock()
+        mock_response.headers = {"Content-Length": 14}
+        mock_response.read.return_value = b'{"answer": 42}'
+        mock_response.status = 200
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com", use_gzip=False)
+
+        result = connector.post_json("/v1/some-endpoint", data={"question": 1}, send_gzip=True)
+
+        assert result.is_gzip_request is False
+
+    @patch("http.client.HTTPSConnection")
+    @patch("time.perf_counter", return_value=0.0)
+    def test_post_json_no_gzip_request_when_send_gzip_false(self, mock_time: Mock, mock_https_connection: Mock) -> None:
+        """Test that is_gzip_request is False when send_gzip is False."""
+        mock_response = Mock()
+        mock_response.headers = {"Content-Length": 14}
+        mock_response.read.return_value = b'{"answer": 42}'
+        mock_response.status = 200
+
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = mock_response
+        mock_https_connection.return_value = mock_conn
+
+        connector = BackendConnector(url="https://api.example.com", use_gzip=True)
+
+        result = connector.post_json("/v1/some-endpoint", data={"question": 1}, send_gzip=False)
+
+        assert result.is_gzip_request is False
 
 
 class TestBackendConnectorSetup:

--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -192,6 +192,89 @@ class TestTelemetry:
             call(CIVISIBILITY, "known_tests.response_bytes", 42, ()),
         ]
 
+    def test_record_request_with_both_compression_tags(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="git_requests.search_commits",
+            duration="git_requests.search_commits_ms",
+            response_bytes=None,
+            error="git_requests.search_commits_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=0.5,
+            response_bytes=None,
+            compressed_response=True,
+            compressed_request=True,
+            error=None,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(
+                CIVISIBILITY,
+                "git_requests.search_commits",
+                1,
+                (("rq_compressed", "true"), ("rs_compressed", "true")),
+            ),
+        ]
+
+    def test_record_request_with_only_request_compression(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="endpoint_payload.requests",
+            duration="endpoint_payload.requests_ms",
+            response_bytes="endpoint_payload.response_bytes",
+            error="endpoint_payload.requests_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=0.5,
+            response_bytes=100,
+            compressed_response=False,
+            compressed_request=True,
+            error=None,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(
+                CIVISIBILITY,
+                "endpoint_payload.requests",
+                1,
+                (("rq_compressed", "true"),),
+            ),
+        ]
+
+    def test_record_request_with_only_response_compression(
+        self, telemetry_api: TelemetryAPI, mock_writer: Mock
+    ) -> None:
+        request_telemetry = telemetry_api.with_request_metric_names(
+            count="git_requests.settings",
+            duration="git_requests.settings_ms",
+            response_bytes="git_requests.settings_response_bytes",
+            error="git_requests.settings_errors",
+        )
+
+        request_telemetry.record_request(
+            seconds=0.5,
+            response_bytes=200,
+            compressed_response=True,
+            compressed_request=False,
+            error=None,
+        )
+
+        assert mock_writer.add_count_metric.call_args_list == [
+            call(
+                CIVISIBILITY,
+                "git_requests.settings",
+                1,
+                (("rs_compressed", "true"),),
+            ),
+        ]
+
+        # Verify response_bytes distribution metric also gets rs_compressed tag
+        assert mock_writer.add_distribution_metric.call_args_list == [
+            call(CIVISIBILITY, "git_requests.settings_ms", 0.5, ()),
+            call(CIVISIBILITY, "git_requests.settings_response_bytes", 200, (("rs_compressed", "true"),)),
+        ]
+
     def test_record_coverage_started(self, telemetry_api: TelemetryAPI, mock_writer: Mock) -> None:
         telemetry_api.record_coverage_started(test_framework="pytest", coverage_library="ddtrace")
 


### PR DESCRIPTION
## Summary
- Adds `rq_compressed` and `rs_compressed` boolean tags to the request count metric
- Tracks whether HTTP request/response bodies were gzip-compressed
- Request compression state flows from `BackendConnector._do_single_request` through `BackendResult.is_gzip_request` to telemetry

## Test plan
- [x] Unit test for both compression tags present
- [x] Unit test for request-only compression
- [x] Unit test for response-only compression
- [x] Integration tests for gzip request detection in BackendConnector
- [x] All existing test_http.py assertions updated with `compressed_request=` parameter

## Motivation
Per CI Visibility telemetry RFC: since gzip support was added for backend requests/responses, we need tags to distinguish compressed vs uncompressed payloads on metrics like `endpoint_payload.requests`, `git_requests.search_commits`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- changelog: no-changelog -->