### PR TITLE
feat(llmobs): auto-tag spans with session/user from RUM OTel baggage

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -104,6 +104,18 @@ EXPERIMENT_PROJECT_ID_KEY = "_ml_obs.experiment_project_id"
 EXPERIMENT_DATASET_NAME_KEY = "_ml_obs.experiment_dataset_name"
 EXPERIMENT_NAME_KEY = "_ml_obs.experiment_name"
 
+# OTel baggage keys propagated by the RUM browser SDK's `propagateTraceBaggage`
+# option. When present on the active trace context (typically extracted from an
+# incoming HTTP request), these values are auto-applied to LLMObs spans so that
+# RUM sessions and users correlate to LLM traces without any manual tagging.
+RUM_BAGGAGE_SESSION_ID_KEY = "session.id"
+RUM_BAGGAGE_USER_ID_KEY = "user.id"
+RUM_BAGGAGE_ACCOUNT_ID_KEY = "account.id"
+
+# LLMObs tag keys aligned with Datadog standard attributes for user identity.
+USER_ID_TAG_KEY = "usr.id"
+USER_ACCOUNT_ID_TAG_KEY = "usr.account_id"
+
 # experiment context keys
 DEFAULT_PROJECT_NAME = "default-project"
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -72,9 +72,14 @@ from ddtrace.llmobs._constants import PROPAGATED_LLMOBS_TRACE_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
+from ddtrace.llmobs._constants import RUM_BAGGAGE_ACCOUNT_ID_KEY
+from ddtrace.llmobs._constants import RUM_BAGGAGE_SESSION_ID_KEY
+from ddtrace.llmobs._constants import RUM_BAGGAGE_USER_ID_KEY
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 from ddtrace.llmobs._constants import SUPPORTED_LLMOBS_INTEGRATIONS
+from ddtrace.llmobs._constants import USER_ACCOUNT_ID_TAG_KEY
+from ddtrace.llmobs._constants import USER_ID_TAG_KEY
 from ddtrace.llmobs._context import LLMObsContextProvider
 from ddtrace.llmobs._evaluators.runner import EvaluatorRunner
 from ddtrace.llmobs._experiment import AsyncEvaluatorType
@@ -560,7 +565,9 @@ class LLMObs(Service):
         # Wait to build meta until after user processors apply and potentially mutate I/O
         meta = _build_span_meta(span, llmobs_span, llmobs_meta, span_kind, input_type, output_type)
         metrics = llmobs_data.get(LLMOBS_STRUCT.METRICS) or {}
-        session_id = get_llmobs_session_id(span)
+        # Fall back to the session.id baggage key propagated by the RUM browser SDK so that
+        # RUM sessions automatically correlate to LLMObs traces without a manual annotate call.
+        session_id = get_llmobs_session_id(span) or span.context.get_baggage_item(RUM_BAGGAGE_SESSION_ID_KEY)
         tags = self._llmobs_tags(span)
         span_links = get_llmobs_span_links(span) or []
         _dd_attrs = {
@@ -612,7 +619,7 @@ class LLMObs(Service):
         err_type = span.get_tag(ERROR_TYPE)
         if err_type:
             tags["error_type"] = err_type
-        session_id = get_llmobs_session_id(span)
+        session_id = get_llmobs_session_id(span) or span.context.get_baggage_item(RUM_BAGGAGE_SESSION_ID_KEY)
         if session_id:
             tags["session_id"] = session_id
 
@@ -637,6 +644,17 @@ class LLMObs(Service):
         dataset_name = span.context.get_baggage_item(EXPERIMENT_DATASET_NAME_KEY)
         if dataset_name and "dataset_name" not in tags:
             tags["dataset_name"] = dataset_name
+
+        # RUM browser SDK propagates user/account identity via OTel baggage when
+        # `propagateTraceBaggage` is enabled. Map onto Datadog standard attribute
+        # names so RUM users correlate to LLMObs traces. Explicit annotate() tags win.
+        user_id = span.context.get_baggage_item(RUM_BAGGAGE_USER_ID_KEY)
+        if user_id and USER_ID_TAG_KEY not in tags:
+            tags[USER_ID_TAG_KEY] = user_id
+
+        account_id = span.context.get_baggage_item(RUM_BAGGAGE_ACCOUNT_ID_KEY)
+        if account_id and USER_ACCOUNT_ID_TAG_KEY not in tags:
+            tags[USER_ACCOUNT_ID_TAG_KEY] = account_id
 
         project_name = span.context.get_baggage_item(EXPERIMENT_PROJECT_NAME_KEY)
         if project_name and "project_name" not in tags:

--- a/releasenotes/notes/llmobs-rum-baggage-auto-tagging-3bf40136cddf27e5.yaml
+++ b/releasenotes/notes/llmobs-rum-baggage-auto-tagging-3bf40136cddf27e5.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    LLM Observability: LLMObs spans are now automatically tagged with
+    ``session_id``, ``usr.id``, and ``usr.account_id`` when OTel baggage is
+    present on the active trace context. This enables automatic correlation
+    between RUM sessions (propagated via the RUM browser SDK's
+    ``propagateTraceBaggage`` option) and LLMObs traces without requiring
+    manual ``LLMObs.annotate`` calls. Values explicitly set via
+    ``LLMObs.annotate`` take precedence over baggage.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -347,6 +347,49 @@ def test_session_id_becomes_top_level_field(llmobs, llmobs_events):
     assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "task", session_id=session_id)
 
 
+def test_rum_baggage_auto_tags_session_and_user(llmobs, llmobs_events):
+    # Simulates a request where the RUM browser SDK's `propagateTraceBaggage` has
+    # injected session/user/account identifiers into the inbound trace context.
+    with llmobs.task() as span:
+        span.context.set_baggage_item("session.id", "rum-session-123")
+        span.context.set_baggage_item("user.id", "user-abc")
+        span.context.set_baggage_item("account.id", "acct-xyz")
+    assert len(llmobs_events) == 1
+    event = llmobs_events[0]
+    assert event["session_id"] == "rum-session-123"
+    tag_dict = dict(t.split(":", 1) for t in event["tags"])
+    assert tag_dict["session_id"] == "rum-session-123"
+    assert tag_dict["usr.id"] == "user-abc"
+    assert tag_dict["usr.account_id"] == "acct-xyz"
+
+
+def test_rum_baggage_does_not_overwrite_explicit_session_id(llmobs, llmobs_events):
+    with llmobs.task(session_id="explicit-session") as span:
+        span.context.set_baggage_item("session.id", "rum-session-123")
+    assert len(llmobs_events) == 1
+    assert llmobs_events[0]["session_id"] == "explicit-session"
+
+
+def test_rum_baggage_does_not_overwrite_annotated_user_tag(llmobs, llmobs_events):
+    with llmobs.task() as span:
+        span.context.set_baggage_item("user.id", "rum-user")
+        llmobs.annotate(span, tags={"usr.id": "explicit-user"})
+    assert len(llmobs_events) == 1
+    tag_dict = dict(t.split(":", 1) for t in llmobs_events[0]["tags"])
+    assert tag_dict["usr.id"] == "explicit-user"
+
+
+def test_rum_baggage_partial_keys_only_tags_what_is_present(llmobs, llmobs_events):
+    with llmobs.task() as span:
+        span.context.set_baggage_item("user.id", "user-only")
+    assert len(llmobs_events) == 1
+    event = llmobs_events[0]
+    assert "session_id" not in event
+    tag_dict = dict(t.split(":", 1) for t in event["tags"])
+    assert tag_dict["usr.id"] == "user-only"
+    assert "usr.account_id" not in tag_dict
+
+
 def test_llm_span(llmobs, llmobs_events):
     with llmobs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
         assert span.name == "test_llm_call"


### PR DESCRIPTION
## Description

When the RUM browser SDK's `propagateTraceBaggage` option is enabled, it injects `session.id`, `user.id`, and `account.id` as OTel baggage on outbound requests. LLMObs spans now read these values from the active trace context and auto-apply them as `session_id`, `usr.id`, and `usr.account_id` (Datadog standard attributes) on the LLMObs span event, enabling RUM → LLMObs correlation without any manual `LLMObs.annotate()` calls.

Explicit values set via `LLMObs.annotate()` continue to take precedence over baggage-derived values.

Jira: [MLOB-7332](https://datadoghq.atlassian.net/browse/MLOB-7332) (parent epic [MLOB-7330](https://datadoghq.atlassian.net/browse/MLOB-7330))

## Testing

- 4 new unit tests in `tests/llmobs/test_llmobs_service.py`:
  - `test_rum_baggage_auto_tags_session_and_user` — all three keys present
  - `test_rum_baggage_does_not_overwrite_explicit_session_id`
  - `test_rum_baggage_does_not_overwrite_annotated_user_tag`
  - `test_rum_baggage_partial_keys_only_tags_what_is_present`
- Ran local regression across `session_id`, `experiment_baggage`, and `tags` patterns — 66 related tests pass.
- `ruff` format + `mypy` typing clean.

## Risks

Low. The change is additive — LLMObs spans previously ignored baggage, so no existing behavior is overwritten. The baggage fallback only applies when no explicit value is set, so customers currently using `LLMObs.annotate(session_id=...)` see no difference.

The implementation slots into the same `_llmobs_tags` function that already reads experiment baggage (`EXPERIMENT_ID_KEY`, etc.), using the same pattern.

## Additional Notes

This is the first of a multi-repo series tracked under MLOB-7330:
- dd-trace-js (MLOB-7334) — same change in Node.js tracer
- logs-backend (MLOB-7333) — add `usr.id / usr.account_id` to `LlmObsFacets.java` so the tags become queryable
- web-ui (MLOB-7335) — expose `@usr.*` in LLMObs filter UI
- documentation (MLOB-7336) — docs update

RUM baggage keys were verified against `browser-sdk/packages/rum-core/src/domain/tracing/tracer.ts:208-229`. Note: RUM does **not** propagate `user.name` or `user.email` — only `user.id` + `account.id` — so those two are not in scope for auto-tagging.

Claude session: `ff51fe11-3672-4ff3-924f-9595500003dd`
Resume: `claude --resume ff51fe11-3672-4ff3-924f-9595500003dd`

[MLOB-7332]: https://datadoghq.atlassian.net/browse/MLOB-7332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLOB-7330]: https://datadoghq.atlassian.net/browse/MLOB-7330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ