### PR TITLE
ci: add s3 artifact metadata to index.html and new metadata.txt files

### DIFF
--- a/.gitlab/scripts/generate-index-html.sh
+++ b/.gitlab/scripts/generate-index-html.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 # Usage: generate-index-html.sh
-# Outputs PEP 503-style index HTML to stdout
+# Outputs PEP 503-style index HTML to stdout.
+# Reads GitLab CI environment variables for build metadata (all optional):
+#   CI_COMMIT_SHA, CI_COMMIT_SHORT_SHA, CI_COMMIT_REF_NAME,
+#   CI_PIPELINE_ID, PACKAGE_VERSION
 
 # Find all wheels
 WHEELS=(pywheels/*.whl)
@@ -11,12 +14,50 @@ if [ ${#WHEELS[@]} -eq 0 ]; then
   exit 1
 fi
 
-# Generate index.html to stdout
-echo '<!DOCTYPE html><html lang="en"><body>'
+# Collect build metadata (fall back gracefully when run outside CI)
+COMMIT_SHA="${CI_COMMIT_SHA:-unknown}"
+COMMIT_SHORT="${CI_COMMIT_SHORT_SHA:-${COMMIT_SHA:0:8}}"
+REF_NAME="${CI_COMMIT_REF_NAME:-unknown}"
+PIPELINE_ID="${CI_PIPELINE_ID:-unknown}"
+PKG_VERSION="${PACKAGE_VERSION:-unknown}"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cat << HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>ddtrace ${PKG_VERSION} — ${REF_NAME}</title>
+  <meta name="dd-commit-sha"       content="${COMMIT_SHA}">
+  <meta name="dd-ref-name"         content="${REF_NAME}">
+  <meta name="dd-pipeline-id"      content="${PIPELINE_ID}">
+  <meta name="dd-package-version"  content="${PKG_VERSION}">
+  <meta name="dd-created-at"       content="${CREATED_AT}">
+  <style>
+    body { font-family: monospace; max-width: 900px; margin: 2em auto; padding: 0 1em; }
+    table { border-collapse: collapse; margin-bottom: 1.5em; }
+    td { padding: 0.15em 1em 0.15em 0; }
+    td:first-child { color: #666; }
+    hr { border: none; border-top: 1px solid #ccc; margin: 1.5em 0; }
+    a { display: block; padding: 0.1em 0; }
+  </style>
+</head>
+<body>
+  <h2>ddtrace build artifacts</h2>
+  <table>
+    <tr><td>Version</td>     <td>${PKG_VERSION}</td></tr>
+    <tr><td>Branch / ref</td><td>${REF_NAME}</td></tr>
+    <tr><td>Commit</td>      <td>${COMMIT_SHA}</td></tr>
+    <tr><td>Pipeline</td>    <td>${PIPELINE_ID}</td></tr>
+    <tr><td>Created</td>     <td>${CREATED_AT}</td></tr>
+  </table>
+  <hr>
+HTML
+
 for w in "${WHEELS[@]}"; do
   fname="$(basename "$w")"
-  # URL-encode special characters (especially +)
   enc_fname="${fname//+/%2B}"
-  echo "<a href=\"${enc_fname}\">${fname}</a><br>"
+  echo "  <a href=\"${enc_fname}\">${fname}</a>"
 done
+
 echo "</body></html>"

--- a/.gitlab/scripts/generate-index-html.sh
+++ b/.gitlab/scripts/generate-index-html.sh
@@ -14,12 +14,23 @@ if [ ${#WHEELS[@]} -eq 0 ]; then
   exit 1
 fi
 
+# HTML-escape a string so it is safe to embed in tag content or attribute values.
+# Uses sed because bash pattern replacement treats & as a backreference on some versions.
+html_escape() {
+  printf '%s' "$1" | sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g' \
+    -e "s/'/\&#39;/g"
+}
+
 # Collect build metadata (fall back gracefully when run outside CI)
-COMMIT_SHA="${CI_COMMIT_SHA:-unknown}"
-COMMIT_SHORT="${CI_COMMIT_SHORT_SHA:-${COMMIT_SHA:0:8}}"
-REF_NAME="${CI_COMMIT_REF_NAME:-unknown}"
-PIPELINE_ID="${CI_PIPELINE_ID:-unknown}"
-PKG_VERSION="${PACKAGE_VERSION:-unknown}"
+COMMIT_SHA="$(html_escape "${CI_COMMIT_SHA:-unknown}")"
+COMMIT_SHORT="$(html_escape "${CI_COMMIT_SHORT_SHA:-${CI_COMMIT_SHA:0:8}}")"
+REF_NAME="$(html_escape "${CI_COMMIT_REF_NAME:-unknown}")"
+PIPELINE_ID="$(html_escape "${CI_PIPELINE_ID:-unknown}")"
+PKG_VERSION="$(html_escape "${PACKAGE_VERSION:-unknown}")"
 CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 cat << HTML
@@ -57,7 +68,8 @@ HTML
 for w in "${WHEELS[@]}"; do
   fname="$(basename "$w")"
   enc_fname="${fname//+/%2B}"
-  echo "  <a href=\"${enc_fname}\">${fname}</a>"
+  esc_fname="$(html_escape "$fname")"
+  echo "  <a href=\"${enc_fname}\">${esc_fname}</a>"
 done
 
 echo "</body></html>"

--- a/.gitlab/scripts/generate-metadata-txt.sh
+++ b/.gitlab/scripts/generate-metadata-txt.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: generate-metadata-txt.sh
+# Outputs key=value build metadata to stdout.
+# Reads GitLab CI environment variables (all optional):
+#   CI_COMMIT_SHA, CI_COMMIT_SHORT_SHA, CI_COMMIT_REF_NAME,
+#   CI_PIPELINE_ID, PACKAGE_VERSION
+
+COMMIT_SHA="${CI_COMMIT_SHA:-unknown}"
+COMMIT_SHORT="${CI_COMMIT_SHORT_SHA:-${COMMIT_SHA:0:8}}"
+REF_NAME="${CI_COMMIT_REF_NAME:-unknown}"
+PIPELINE_ID="${CI_PIPELINE_ID:-unknown}"
+PKG_VERSION="${PACKAGE_VERSION:-unknown}"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cat << EOF
+commit_sha=${COMMIT_SHA}
+commit_short_sha=${COMMIT_SHORT}
+ref_name=${REF_NAME}
+pipeline_id=${PIPELINE_ID}
+package_version=${PKG_VERSION}
+created_at=${CREATED_AT}
+EOF

--- a/.gitlab/scripts/upload-wheels-to-s3.sh
+++ b/.gitlab/scripts/upload-wheels-to-s3.sh
@@ -30,10 +30,12 @@ if [ -n "$SUFFIX" ]; then
   INDEX_FILE="index-${SUFFIX}.html"
   DOWNLOAD_FILE="download-${SUFFIX}.sh"
   INSTALL_FILE="install-${SUFFIX}.sh"
+  METADATA_FILE="metadata-${SUFFIX}.txt"
 else
   INDEX_FILE="index.html"
   DOWNLOAD_FILE="download.sh"
   INSTALL_FILE="install.sh"
+  METADATA_FILE="metadata.txt"
 fi
 
 echo "Uploading ${#WHEELS[@]} package(s) to s3://${BUCKET}/${S3_PATH}/"
@@ -43,16 +45,18 @@ for wheel in "${WHEELS[@]}"; do
   aws s3 cp "$wheel" "s3://${BUCKET}/${S3_PATH}/$(basename "$wheel")"
 done
 
-# Generate and upload index + helper scripts
+# Generate and upload index + helper scripts + metadata
 S3_BASE_URL="https://${BUCKET}.s3.amazonaws.com/${S3_PATH}"
 .gitlab/scripts/generate-index-html.sh | aws s3 cp - "s3://${BUCKET}/${S3_PATH}/${INDEX_FILE}" --content-type text/html
 .gitlab/scripts/generate-download-script.sh "${S3_BASE_URL}" "${INDEX_FILE}" | aws s3 cp - "s3://${BUCKET}/${S3_PATH}/${DOWNLOAD_FILE}" --content-type text/x-shellscript
 .gitlab/scripts/generate-install-script.sh "${S3_BASE_URL}" "${INDEX_FILE}" | aws s3 cp - "s3://${BUCKET}/${S3_PATH}/${INSTALL_FILE}" --content-type text/x-shellscript
+.gitlab/scripts/generate-metadata-txt.sh | aws s3 cp - "s3://${BUCKET}/${S3_PATH}/${METADATA_FILE}" --content-type text/plain
 
 echo "Uploaded to ${S3_PATH}/:"
 echo "  Index:    ${S3_BASE_URL}/${INDEX_FILE}"
 echo "  Download: ${S3_BASE_URL}/${DOWNLOAD_FILE}"
 echo "  Install:  ${S3_BASE_URL}/${INSTALL_FILE}"
+echo "  Metadata: ${S3_BASE_URL}/${METADATA_FILE}"
 
 # Upload debug symbol packages if present
 DEBUG_SYMBOLS=(debugwheelhouse/*.zip)


### PR DESCRIPTION
## Description

It can be nice to know some extra information about the artifacts that were built. Especially on generic S3 paths like `/main/` which are not tied directly to a commit sha or pipeline id.

This PR introduces two changes:

1. Adds metadata about pipeline id, commit sha, timestamp, pacakge version, etc to `index.html` files generated. Both as text and html metadata.
2. Adds a `metadata.txt` file which contains the same information as `key=value` pairs

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
