### PR TITLE
chore(ci): correct the `notify-datadog-release` job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -629,5 +629,5 @@ test-dd-sts:
       aud: rapid-seceng-sit
   script:
     - apt-get update && apt-get install -y curl
-    - 'curl -s -o /dev/null -w "API key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab"'
-    - 'curl -s -o /dev/null -w "APP key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key"'
+    - 'echo "API key policy response code: $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab)"'
+    - 'echo "APP key policy response code: $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key)"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -629,5 +629,5 @@ test-dd-sts:
       aud: rapid-seceng-sit
   script:
     - apt-get update && apt-get install -y curl
-    - 'echo "API key policy response code: $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab)"'
-    - 'echo "APP key policy response code: $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key)"'
+    - 'curl -s -o /dev/null -w "API key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab"'
+    - 'curl -s -o /dev/null -w "APP key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key"'

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -43,37 +43,10 @@ release_pypi_prod:
   variables:
     PYPI_REPOSITORY: pypi
 
-# notify_datadog_release:
-#   extends: .release_base
-#   needs: [ "ddtrace package", "release_pypi_prod" ]
-#   image: ${PYPI_PUBLISH_IMAGE}
-#   id_tokens:
-#     DD_STS_OIDC_TOKEN:
-#       aud: rapid-seceng-sit
-#   tags: [ "arch:amd64" ]
-#   before_script:
-#     - apt-get update && apt-get install --no-install-recommends -y curl jq
-#     - >-
-#       DD_STS_RESPONSE=$(curl -sS
-#       -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
-#       "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key")
-#     - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
-#     - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
-#   script:
-#     - |
-#       echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"
-#       curl --retry 3 --retry-delay 2 --fail -X POST \
-#         -H "Content-Type: application/json" \
-#         -H "DD-API-KEY: ${DD_API_KEY}" \
-#         -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
-#         -d "{\"meta\": {\"payload\": {\"version\": \"${CI_COMMIT_TAG}\", \"git_commit_sha\": \"${CI_COMMIT_SHA}\"}}}" \
-#         https://api.datadoghq.com/api/v2/workflows/dd0d5405-b38c-4f4f-8f4c-c0cd4a65d4d6/instances
-
 notify_datadog_release:
-  stage: release
-  when: manual
+  extends: .release_base
   allow_failure: true
-  needs: []
+  needs: [ "ddtrace package", "release_pypi_prod" ]
   image: ${PYPI_PUBLISH_IMAGE}
   id_tokens:
     DD_STS_OIDC_TOKEN:
@@ -87,14 +60,13 @@ notify_datadog_release:
       "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key")
     - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
     - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
-    - '[ -n "$DD_API_KEY" ] && echo "DD_API_KEY is set (${#DD_API_KEY} chars)" || echo "DD_API_KEY is EMPTY"'
-    - '[ -n "$DD_APP_KEY" ] && echo "DD_APP_KEY is set (${#DD_APP_KEY} chars)" || echo "DD_APP_KEY is EMPTY"'
   script:
+    - sleep 3
     - |
-      echo "Testing workflow API with hardcoded values..."
-      PAYLOAD='{"version": "v0.0.0-dry-run", "git_commit_sha": "0000000000000000000000000000000000000000"}'
+      echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"
+      PAYLOAD="{\"version\": \"${CI_COMMIT_TAG}\", \"git_commit_sha\": \"${CI_COMMIT_SHA}\"}"
       BODY=$(jq -n --arg input "$PAYLOAD" '{"meta": {"payload": {"input": $input}}}')
-      curl --retry 3 --retry-delay 2 -w "\nHTTP status: %{http_code}\n" -X POST \
+      curl --retry 3 --retry-delay 2 --fail -X POST \
         -H "Content-Type: application/json" \
         -H "DD-API-KEY: ${DD_API_KEY}" \
         -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -43,10 +43,37 @@ release_pypi_prod:
   variables:
     PYPI_REPOSITORY: pypi
 
+# notify_datadog_release:
+#   extends: .release_base
+#   needs: [ "ddtrace package", "release_pypi_prod" ]
+#   image: ${PYPI_PUBLISH_IMAGE}
+#   id_tokens:
+#     DD_STS_OIDC_TOKEN:
+#       aud: rapid-seceng-sit
+#   tags: [ "arch:amd64" ]
+#   before_script:
+#     - apt-get update && apt-get install --no-install-recommends -y curl jq
+#     - >-
+#       DD_STS_RESPONSE=$(curl -sS
+#       -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
+#       "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key")
+#     - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
+#     - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
+#   script:
+#     - |
+#       echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"
+#       curl --retry 3 --retry-delay 2 --fail -X POST \
+#         -H "Content-Type: application/json" \
+#         -H "DD-API-KEY: ${DD_API_KEY}" \
+#         -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+#         -d "{\"meta\": {\"payload\": {\"version\": \"${CI_COMMIT_TAG}\", \"git_commit_sha\": \"${CI_COMMIT_SHA}\"}}}" \
+#         https://api.datadoghq.com/api/v2/workflows/dd0d5405-b38c-4f4f-8f4c-c0cd4a65d4d6/instances
+
 notify_datadog_release:
-  extends: .release_base
+  stage: release
+  when: manual
   allow_failure: true
-  needs: [ "ddtrace package", "release_pypi_prod" ]
+  needs: []
   image: ${PYPI_PUBLISH_IMAGE}
   id_tokens:
     DD_STS_OIDC_TOKEN:
@@ -60,12 +87,16 @@ notify_datadog_release:
       "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key")
     - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
     - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
+    - '[ -n "$DD_API_KEY" ] && echo "DD_API_KEY is set (${#DD_API_KEY} chars)" || echo "DD_API_KEY is EMPTY"'
+    - '[ -n "$DD_APP_KEY" ] && echo "DD_APP_KEY is set (${#DD_APP_KEY} chars)" || echo "DD_APP_KEY is EMPTY"'
   script:
     - |
-      echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"
-      curl --retry 3 --retry-delay 2 --fail -X POST \
+      echo "Testing workflow API with hardcoded values..."
+      PAYLOAD='{"version": "v0.0.0-dry-run", "git_commit_sha": "0000000000000000000000000000000000000000"}'
+      BODY=$(jq -n --arg input "$PAYLOAD" '{"meta": {"payload": {"input": $input}}}')
+      curl --retry 3 --retry-delay 2 -w "\nHTTP status: %{http_code}\n" -X POST \
         -H "Content-Type: application/json" \
         -H "DD-API-KEY: ${DD_API_KEY}" \
         -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
-        -d "{\"meta\": {\"payload\": {\"version\": \"${CI_COMMIT_TAG}\", \"git_commit_sha\": \"${CI_COMMIT_SHA}\"}}}" \
+        -d "$BODY" \
         https://api.datadoghq.com/api/v2/workflows/dd0d5405-b38c-4f4f-8f4c-c0cd4a65d4d6/instances

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -55,15 +55,11 @@ notify_datadog_release:
   before_script:
     - apt-get update && apt-get install --no-install-recommends -y curl jq
     - >-
-      DD_STS_API_KEY=$(curl -sS
-      -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
-      "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab")
-    - >-
-      DD_STS_APP_KEY=$(curl -sS
+      DD_STS_RESPONSE=$(curl -sS
       -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}"
       "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key")
-    - export DD_API_KEY=$(echo "$DD_STS_API_KEY" | jq -re '.api_key')
-    - export DD_APP_KEY=$(echo "$DD_STS_APP_KEY" | jq -re '.application_key')
+    - export DD_API_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.api_key')
+    - export DD_APP_KEY=$(echo "$DD_STS_RESPONSE" | jq -re '.application_key')
   script:
     - |
       echo "Tag: ${CI_COMMIT_TAG} -> Commit SHA: ${CI_COMMIT_SHA}"


### PR DESCRIPTION
## Description

Workflow automation API does not take in a JSON object with arbitrary keys as input body; rather, it takes in a single `input` string. We need to send our data as a JSON string to be parsed by the workflow downstream

## Testing

https://app.datadoghq.com/workflow/dd0d5405-b38c-4f4f-8f4c-c0cd4a65d4d6?debugItem=workflow-data&instance=7b93ae7c-7cfa-419b-b1b3-9b17aac0cbbb

https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1635417293

Did a manual trigger from gitlab CI to verify e2e. Note that this was from a branch trigger, not a tag trigger where this usually needs to run

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

I had claude do the `jq` stuff
