### PR TITLE
refactor: remove crash in `MetricNamespace`

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -1010,7 +1010,7 @@ experiments:
               - max_rss_usage < 38.00 MB
           - name: telemetryaddmetric-1-gauge-metrics-100-times
             thresholds:
-              - execution_time < 0.15 ms
+              - execution_time < 0.19 ms
               - max_rss_usage < 38.00 MB
           - name: telemetryaddmetric-1-rate-metric-1-times
             thresholds:
@@ -1030,7 +1030,7 @@ experiments:
               - max_rss_usage < 38.00 MB
           - name: telemetryaddmetric-100-gauge-metrics-100-times
             thresholds:
-              - execution_time < 1.55 ms
+              - execution_time < 1.85 ms
               - max_rss_usage < 38.00 MB
           - name: telemetryaddmetric-100-rate-metrics-100-times
             thresholds:

--- a/benchmarks/suitespec.yml
+++ b/benchmarks/suitespec.yml
@@ -146,6 +146,8 @@ suites:
       - '@core'
       - '@tracing'
       - '@vendor'
+      - ddtrace/internal/telemetry/constants.py
+      - ddtrace/internal/telemetry/metrics_namespaces.py*
       - benchmarks/telemetry_add_metric/*
       - benchmarks/suitespec.yml
     cpus_per_run: 1

--- a/ddtrace/internal/telemetry/metrics_namespaces.pyx
+++ b/ddtrace/internal/telemetry/metrics_namespaces.pyx
@@ -106,7 +106,8 @@ cdef class MetricNamespace:
                 else:
                     self._metrics_data[metric_id] = value
         elif metric_type is MetricType.GAUGE:
-            self._metrics_data[metric_id] = value
+            with self._metrics_data_lock:
+                self._metrics_data[metric_id] = value
         else:  # MetricType.DISTRIBUTION
             with self._metrics_data_lock:
                 existing = self._metrics_data.get(metric_id)


### PR DESCRIPTION
## Description

This PR fixes the following crash.

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x00005a87adf31055 dictkeys_get_index (/usr/src/python/Objects/dictobject.c:344:13)
#1   0x00005a87adf31055 unicodekeys_lookup_generic (/usr/src/python/Objects/dictobject.c:876:14)
#2   0x00005a87adf31055 _Py_dict_lookup (/usr/src/python/Objects/dictobject.c:1056:18)
#3   0x00005a87adf31055 PyDict_GetItemWithError (/usr/src/python/Objects/dictobject.c:1789:10)
#4   0x00007b2e6fc1a8e0 __pyx_pw_7ddtrace_8internal_9telemetry_18metrics_namespaces_15MetricNamespace_5add_metric
#5   0x00005a87ae00c955 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#6   0x00005a87ae00c955 PyObject_Vectorcall (/usr/src/python/Objects/call.c:299:12)
#7   0x00005a87ae05ee1d _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:4760:23)
#8   0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#9   0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#10  0x00005a87ae00d587 PyObject_Call
#11  0x00005a87ae061fd8 do_call_core (/usr/src/python/Python/ceval.c:7343:12)
#12  0x00005a87ae061fd8 _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:5367:22)
#13  0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#14  0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#15  0x00005a87ae00e0ba _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#16  0x00005a87ae00e0ba method_vectorcall (/usr/src/python/Objects/classobject.c:59:18)
#17  0x00005a87ae00c955 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#18  0x00005a87ae00c955 PyObject_Vectorcall (/usr/src/python/Objects/call.c:299:12)
#19  0x00005a87ae05ee1d _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:4760:23)
#20  0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#21  0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#22  0x00005a87ae00d02f _PyFunction_Vectorcall (/usr/src/python/Objects/call.c:393:16)
#23  0x00005a87ae00d02f _PyObject_FastCallDictTstate (/usr/src/python/Objects/call.c:141:15)
#24  0x00005a87ae00d02f _PyObject_Call_Prepend (/usr/src/python/Objects/call.c:482:24)
#25  0x00005a87ae0bafd9 slot_tp_call (/usr/src/python/Objects/typeobject.c:7623:15)
#26  0x00005a87ae00c4d9 _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:214:18)
#27  0x00005a87ae05ee1d _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:4760:23)
#28  0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#29  0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#30  0x00005a87ae00d02f _PyFunction_Vectorcall (/usr/src/python/Objects/call.c:393:16)
#31  0x00005a87ae00d02f _PyObject_FastCallDictTstate (/usr/src/python/Objects/call.c:141:15)
#32  0x00005a87ae00d02f _PyObject_Call_Prepend (/usr/src/python/Objects/call.c:482:24)
#33  0x00005a87ae041f7b slot_tp_init (/usr/src/python/Objects/typeobject.c:7854:15)
#34  0x00005a87ae040731 type_call (/usr/src/python/Objects/typeobject.c:1103:19)
#35  0x00005a87ae00c4d9 _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:214:18)
#36  0x00005a87ae05ee1d _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:4760:23)
#37  0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#38  0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#39  0x00005a87ae00e134 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#40  0x00005a87ae00e134 method_vectorcall (/usr/src/python/Objects/classobject.c:89:18)
#41  0x00005a87ae00d587 PyObject_Call
#42  0x00005a87ae061fd8 do_call_core (/usr/src/python/Python/ceval.c:7343:12)
#43  0x00005a87ae061fd8 _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:5367:22)
#44  0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#45  0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#46  0x00005a87ae00d587 PyObject_Call
#47  0x00005a87ae061fd8 do_call_core (/usr/src/python/Python/ceval.c:7343:12)
#48  0x00005a87ae061fd8 _PyEval_EvalFrameDefault (/usr/src/python/Python/ceval.c:5367:22)
#49  0x00005a87ae05e060 _PyEval_EvalFrame (/usr/src/python/./Include/internal/pycore_ceval.h:73:16)
#50  0x00005a87ae05e060 _PyEval_Vector (/usr/src/python/Python/ceval.c:6425:24)
#51  0x00005a87ae00e04b _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:92:11)
#52  0x00005a87ae00e04b method_vectorcall (/usr/src/python/Objects/classobject.c:67:20)
#53  0x00005a87ae00d587 PyObject_Call
#54  0x00005a87ae10e9b3 thread_run (/usr/src/python/./Modules/_threadmodule.c:1124:21)
#55  0x00005a87ae0f1098 pythread_wrapper (/usr/src/python/Python/thread_pthread.h:241:5)
#56  0x00007b2e71c49609 start_thread
#57  0x00007b2e71a14353 clone
```