### PR TITLE
ci: allow notify dd release job to fail

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -45,6 +45,7 @@ release_pypi_prod:
 
 notify_datadog_release:
   extends: .release_base
+  allow_failure: true
   needs: [ "ddtrace package", "release_pypi_prod" ]
   image: ${PYPI_PUBLISH_IMAGE}
   id_tokens:


### PR DESCRIPTION
## Description

Allowing failure to keep release pipelines green

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
