### PR TITLE
chore(ci): [1/n] prep testrunner for Python 3.15-dev and bump lockfile job memory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -296,10 +296,13 @@ check_requirements_lockfiles:
   needs: []
   extends: .testrunner
   variables:
-    # Explicit request/limit prevents VPA from clamping below what
-    # scripts/compile-and-prune-test-requirements needs to resolve the full
-    # riot venv matrix. Historical peak was ~6 GiB; 8 GiB gives headroom
-    # for new 3.15 venvs.
+    # DD_DISABLE_VPA is required: without it VPA overrides KUBERNETES_MEMORY_*
+    # (see "overridden by VPA" in runner logs) and clamps the build container
+    # down to ~4 GiB based on its learned model. compile-and-prune-test-
+    # requirements pip-compiles every riot lockfile sequentially and peaks
+    # above that when resolving the full venv matrix (including 3.15 venvs),
+    # causing OOMKilled (exit 137).
+    DD_DISABLE_VPA: "true"
     KUBERNETES_MEMORY_REQUEST: "8Gi"
     KUBERNETES_MEMORY_LIMIT: "8Gi"
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -295,6 +295,13 @@ check_requirements_lockfiles:
   stage: tests
   needs: []
   extends: .testrunner
+  variables:
+    # Explicit request/limit prevents VPA from clamping below what
+    # scripts/compile-and-prune-test-requirements needs to resolve the full
+    # riot venv matrix. Historical peak was ~6 GiB; 8 GiB gives headroom
+    # for new 3.15 venvs.
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "8Gi"
   script:
     - pip install toml==0.10.2
     - scripts/compile-and-prune-test-requirements

--- a/.gitlab/templates/cached-testrunner.yml
+++ b/.gitlab/templates/cached-testrunner.yml
@@ -5,11 +5,11 @@
     EXT_CACHE_VENV: '${{CI_PROJECT_DIR}}/.cache/ext_cache_venv${{PYTHON_VERSION}}'
   before_script: |
     ulimit -c unlimited
-    # AIDEV-NOTE(py315): 3.15 is shipped as the pyenv version "3.15-dev" until
+    # 3.15 is shipped as the pyenv version "3.15-dev" until
     # upstream CPython 3.15 is released. The shim is the usual "python3.15"
     # (no -dev suffix on the binary), so build_base_venvs' `python$PYTHON_VERSION`
-    # works once 3.15-dev is on the `pyenv global` list. Drop the -dev suffix
-    # once the testrunner image installs a GA 3.15.
+    # works once 3.15-dev is on the `pyenv global` list. 
+    # TODO(vlad): Drop the -dev suffix once the testrunner image installs a GA 3.15.
     pyenv global 3.12 3.9 3.10 3.11 3.13 3.14 3.15-dev
     export _CI_DD_AGENT_URL=http://${{HOST_IP}}:8126/
     set -e -o pipefail

--- a/.gitlab/templates/cached-testrunner.yml
+++ b/.gitlab/templates/cached-testrunner.yml
@@ -5,7 +5,12 @@
     EXT_CACHE_VENV: '${{CI_PROJECT_DIR}}/.cache/ext_cache_venv${{PYTHON_VERSION}}'
   before_script: |
     ulimit -c unlimited
-    pyenv global 3.12 3.9 3.10 3.11 3.13 3.14
+    # AIDEV-NOTE(py315): 3.15 is shipped as the pyenv version "3.15-dev" until
+    # upstream CPython 3.15 is released. The shim is the usual "python3.15"
+    # (no -dev suffix on the binary), so build_base_venvs' `python$PYTHON_VERSION`
+    # works once 3.15-dev is on the `pyenv global` list. Drop the -dev suffix
+    # once the testrunner image installs a GA 3.15.
+    pyenv global 3.12 3.9 3.10 3.11 3.13 3.14 3.15-dev
     export _CI_DD_AGENT_URL=http://${{HOST_IP}}:8126/
     set -e -o pipefail
     if [ ! -d $EXT_CACHE_VENV ]; then

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -12,7 +12,7 @@ variables:
   before_script:
     - ulimit -c unlimited
     - git config --global --add safe.directory ${CI_PROJECT_DIR}
-    - pyenv global 3.12 3.9 3.10 3.11 3.13 3.14
+    - pyenv global 3.12 3.9 3.10 3.11 3.13 3.14 3.15-dev
     - export _CI_DD_AGENT_URL=http://${HOST_IP}:8126/
   after_script:
     - bash .gitlab/scripts/generate-core-backtraces.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { text = "LICENSE.BSD3" }
 # ddtrace has many sub-components which can break when CPython internals
 # change over versions, .e.g. profiling. So we explicitly mark incompatibility
 # with versions we don't support yet.
-requires-python = ">=3.9,<3.15"
+requires-python = ">=3.9,<3.16"
 authors = [
     { name = "Datadog, Inc.", email = "dev@datadoghq.com" },
 ]
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 dependencies = [
     "bytecode>=0.17.0,<1; python_version>='3.14.0'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }
 # ddtrace has many sub-components which can break when CPython internals
-# change over versions, .e.g. profiling. So we explicitly mark incompatibility
+# change over versions, e.g. profiling. So we explicitly mark incompatibility
 # with versions we don't support yet.
 requires-python = ">=3.9,<3.16"
 authors = [
@@ -31,7 +31,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.15",
 ]
 dependencies = [
     "bytecode>=0.17.0,<1; python_version>='3.14.0'",


### PR DESCRIPTION
[PROF-14348](https://datadoghq.atlassian.net/browse/PROF-14348)
| [Next PR >](https://github.com/DataDog/dd-trace-py/pull/17531)

## Summary

This is [1/n] in the Python 3.15 support stack for `dd-trace-py`. Two small CI fixes needed for introducing v3.15 builds to the repo.

* add 3.15-dev to pyenv global in `testrunner`** — otherwise builds error with `pyenv: version '3.15' not installed`.
* bump `check_requirements_lockfiles` memory to 8 GiB. Done because `check_requirements_lockfiles` had no explicit Kubernetes resource requests. VPA had learned a 4 GiB limit from past runs, but adding new 3.15 profiling venvs to `riotfile.py` pushes peak memory over that threshold, resulting in OOMKilled; e.g. [job 1622555236](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1622555236).

## Test plan

* CI

[PROF-14348]: https://datadoghq.atlassian.net/browse/PROF-14348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ