### PR TITLE
chore: set line numbers in async wrapping

### DIFF
--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -714,12 +714,12 @@ else:
 def wrap_async(instrs: list[bc.Instr], code: CodeType, lineno: int) -> None:
     if (bc.CompilerFlags.ASYNC_GENERATOR | bc.CompilerFlags.COROUTINE) & code.co_flags:
         if ASYNC_HEAD_ASSEMBLY is not None:
-            instrs[0:0] = ASYNC_HEAD_ASSEMBLY.bind()
+            instrs[0:0] = ASYNC_HEAD_ASSEMBLY.bind(lineno=lineno)
 
         if bc.CompilerFlags.COROUTINE & code.co_flags:
             # DEV: This is just
             # >>> return await wrapper(wrapped, args, kwargs)
-            instrs[-1:-1] = COROUTINE_ASSEMBLY.bind()
+            instrs[-1:-1] = COROUTINE_ASSEMBLY.bind(lineno=lineno)
 
         elif bc.CompilerFlags.ASYNC_GENERATOR & code.co_flags:
-            instrs[-1:] = ASYNC_GEN_ASSEMBLY.bind()
+            instrs[-1:] = ASYNC_GEN_ASSEMBLY.bind(lineno=lineno)

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -1123,3 +1123,69 @@ def test_wrapping_context_lazy_unwrap_before_call():
         assert not _UniversalWrappingContext.is_wrapped(foo)
 
     assert wc.count == 0
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_frames_have_valid_linenos():
+    """Regression test: async wrapping must not inject instructions with lineno=None.
+
+    When wrap() is applied to an async function, the injected COROUTINE_ASSEMBLY
+    instructions (GET_AWAITABLE, SEND, YIELD_VALUE, RESUME, ...) were previously
+    emitted without line-number information, leaving f_lineno=None on the
+    suspended trampoline frame.  inspect.stack() / inspect.getframeinfo() does
+    ``lineno - 1 - context//2`` and raises TypeError when lineno is None.  Any
+    code that inspects the call stack from inside or above a wrapped coroutine
+    (e.g. IAST's report_stack) would therefore crash silently.
+    """
+    stack_from_inside = []
+
+    def wrapper(f, args, kwargs):
+        return f(*args, **kwargs)
+
+    async def coro(x):
+        # Capture the full call stack from inside the coroutine body.
+        stack_from_inside.extend(inspect.stack())
+        return x + 1
+
+    wrap(coro, wrapper)
+
+    result = await coro(41)
+    assert result == 42
+
+    # Every frame captured while the wrapped coroutine was running must have a
+    # valid (non-None) line number so that inspect.getframeinfo() cannot crash.
+    for frame_info in stack_from_inside:
+        lineno = frame_info.lineno
+        assert lineno is not None, (
+            f"Frame {frame_info.filename}:{frame_info.function} has lineno=None — "
+            "async wrapping injected instructions without line-number information"
+        )
+
+
+@pytest.mark.asyncio
+async def test_lazy_async_wrapper_frames_have_valid_linenos():
+    """Same lineno regression check for LazyWrappingContext on async functions.
+
+    LazyWrappingContext applies a trampoline on first call, then promotes to
+    full UniversalWrappingContext bytecode wrapping.  Both phases must produce
+    frames with valid linenos.
+    """
+    for call_index in range(2):
+        stack_from_inside = []
+
+        async def coro(x):
+            stack_from_inside.extend(inspect.stack())
+            return x + 1
+
+        DummyLazyWrappingContext(coro).wrap()
+
+        result = await coro(41)
+        assert result == 42
+
+        for frame_info in stack_from_inside:
+            lineno = frame_info.lineno
+            assert lineno is not None, (
+                f"[call {call_index}] Frame {frame_info.filename}:{frame_info.function} "
+                f"has lineno=None — async wrapping injected instructions without "
+                f"line-number information"
+            )


### PR DESCRIPTION
## Description

We make sure that line numbers are set for the opcodes used to implement async function bytecode wrapping. This prevents inspection tools such as inspect.stack to fail (e.g. as used by IAST).

## Testing

This was caught from the system tests running on #17482.