### PR TITLE
fix(profiling): clean up containers post-fork [backport 4.6]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/cache.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/cache.h
@@ -32,6 +32,17 @@ class LRUCache
         index.clear();
     }
 
+    void postfork_child()
+    {
+        // At fork, the sampling thread may have been modifying the list
+        // mid-operation (e.g., splice in lookup, emplace in store). Traversing
+        // the list to free nodes (as std::list::clear does) can crash on corrupted
+        // pointers. Use placement new to construct fresh empty containers,
+        // abandoning the old data (intentional one-time leak).
+        new (&items) std::list<std::pair<K, std::unique_ptr<V>>>();
+        new (&index) std::unordered_map<K, typename std::list<std::pair<K, std::unique_ptr<V>>>::iterator>();
+    }
+
   private:
     size_t capacity;
     std::list<std::pair<K, std::unique_ptr<V>>> items;

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -99,8 +99,10 @@ class EchionSampler
         // Reset string_table mutex
         string_table_.postfork_child();
 
-        // Clear frame cache after fork (prevent stale pointers)
-        frame_cache_.clear();
+        // Reset frame cache. Use postfork_child (placement new) instead of std::list::clear
+        // because the Sampling Thread may have been modifying the cache when fork
+        // took its snapshot. Traversing a corrupted list to free nodes would crash.
+        frame_cache_.postfork_child();
 
         // Clear stale entries from parent process.
         // No lock needed: only one thread exists in child immediately after fork.

--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -48,7 +48,13 @@ class Sampler
     bool do_adaptive_sampling = true;
     void adapt_sampling_interval();
 
+    // Tracks whether the sampler was running when prefork was called,
+    // so that postfork_parent/restart_after_fork can restore it.
+    bool was_running_at_fork_{ false };
+
     void atfork_child();
+    friend void stack_atfork_prepare();
+    friend void stack_atfork_parent();
     friend void stack_atfork_child();
 
   public:
@@ -82,6 +88,12 @@ class Sampler
 
     // Delegates to the StackRenderer to clear its caches after fork
     void postfork_child();
+
+    // Record whether the Sampler was running before fork
+    void prefork();
+
+    // Restart the sampling thread in the parent after fork
+    void postfork_parent();
 
     // Restart the sampler after fork if it was running
     void restart_after_fork();

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -298,13 +298,39 @@ Sampler::postfork_child()
 }
 
 void
+Sampler::prefork()
+{
+    was_running_at_fork_ = thread_seq_num.load() & 1;
+}
+
+void
+Sampler::postfork_parent()
+{
+    // The parent's sampling thread survives the fork unchanged; no restart needed.
+    // Calling start() here would launch a second thread, corrupt the thread_seq_num
+    // parity invariant used by prefork(), and cause a data race on EchionSampler state.
+}
+
+void
 Sampler::restart_after_fork()
 {
     // Restart the sampler if it was running before fork.
-    // Odd thread_seq_num means the sampler was started and not stopped.
-    if (thread_seq_num.load() & 1) {
+    // We use the saved flag because prefork changed the thread_seq_num parity.
+    if (was_running_at_fork_) {
         start();
     }
+}
+
+static void
+stack_atfork_prepare()
+{
+    Sampler::get().prefork();
+}
+
+static void
+stack_atfork_parent()
+{
+    Sampler::get().postfork_parent();
 }
 
 static void
@@ -343,7 +369,7 @@ Sampler::one_time_setup()
     // It is unlikely, but possible, that the caller has forked since application startup, but before starting echion.
     // Run the cleanup to ensure that we're tracking the correct process.
     stack_postfork_cleanup();
-    pthread_atfork(nullptr, nullptr, stack_atfork_child);
+    pthread_atfork(stack_atfork_prepare, stack_atfork_parent, stack_atfork_child);
 }
 
 void

--- a/releasenotes/notes/fix-profiling-fork-crash-lru-cache-b80e6574fc304037.yaml
+++ b/releasenotes/notes/fix-profiling-fork-crash-lru-cache-b80e6574fc304037.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: A crash that could happen in child processes after fork
+    has been fixed.


### PR DESCRIPTION
Backport of PR #17042 (commit 39a5f2333e91e8d125ebc4f2b4d18bc6e0e2e187) to branch 4.6.

## Description

Fixes a crash in the Profiler (~100/week) when `fork` is called while the Sampling Thread is actively modifying the `LRUCache` for Frames.

The root cause: `postfork_child` called `frame_cache_.clear()`, which traverses the `std::list` to free nodes. If the sampling thread was mid-operation (splice in `lookup`, `emplace_front`/`pop_back` in `store`) at fork time, the list's internal pointers can be in a corrupted state in the child, causing the crash.

Fix: replace `clear()` with `postfork_child()` which uses placement new to construct fresh empty containers, abandoning the old data as an intentional one-time leak.

Also adds `prefork()`/`postfork_parent()` atfork handlers registered via `pthread_atfork` so that `restart_after_fork` uses a pre-saved `was_running_at_fork_` flag instead of relying on `thread_seq_num` parity (which `prefork` itself changes).

## Notes on conflict resolution

No semantic conflicts. The 4.6 branch uses the same `stack_` function-name prefix as `main`, so the changes apply verbatim.