### PR TITLE
test(ai_guard): migrate langchain agent tests to testagent cassettes

### DIFF
--- a/tests/appsec/ai_guard/langchain/test_langchain.py
+++ b/tests/appsec/ai_guard/langchain/test_langchain.py
@@ -172,16 +172,13 @@ async def test_openai_llm_async_block(mock_execute_request, langchain_openai, op
     mock_execute_request.assert_called_once()
 
 
-# TODO use testagent cassettes instead of mocking OpenAI
 @pytest.mark.parametrize("decision", ["DENY", "ABORT"], ids=["deny", "abort"])
-@patch("langchain_openai.chat_models.ChatOpenAI._generate")
 @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
-def test_agent_action_sync_block(mock_execute_request, mock_openai_request, langchain_openai, openai_url, decision):
+def test_agent_action_sync_block(mock_execute_request, langchain_openai, openai_url, decision):
     mock_execute_request.side_effect = [
         mock_evaluate_response("ALLOW"),  # Allow the initial prompt
         mock_evaluate_response(decision),  # Deny/abort the tool call
     ]
-    mock_openai_request.return_value = _mock_openai_tool_response("add", {"a": 1, "b": 1})
 
     @langchain_core.tools.tool
     def add(a: int, b: int) -> int:
@@ -195,7 +192,7 @@ def test_agent_action_sync_block(mock_execute_request, mock_openai_request, lang
 
     tools = [add]
     agent_prompt = ChatPromptTemplate.from_messages([("human", "{input}"), MessagesPlaceholder("agent_scratchpad")])
-    llm = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, n=1, base_url=openai_url)
+    llm = langchain_openai.ChatOpenAI(temperature=0, n=1, base_url=openai_url)
     agent = create_openai_functions_agent(llm, tools, agent_prompt)
 
     agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=False, return_intermediate_steps=False)
@@ -205,22 +202,16 @@ def test_agent_action_sync_block(mock_execute_request, mock_openai_request, lang
         agent_executor.invoke({"input": "1 + 1"})
 
     assert mock_execute_request.call_count == 2  # One for prompt, one for tool
-    assert mock_openai_request.call_count == 1  # Initial prompt that returns a function call result
 
 
-# TODO use testagent cassettes instead of mocking OpenAI
 @pytest.mark.asyncio
 @pytest.mark.parametrize("decision", ["DENY", "ABORT"], ids=["deny", "abort"])
-@patch("langchain_openai.chat_models.ChatOpenAI._agenerate", autospec=True)
 @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
-async def test_agent_action_async_block(
-    mock_execute_request, mock_openai_request, langchain_openai, openai_url, decision
-):
+async def test_agent_action_async_block(mock_execute_request, langchain_openai, openai_url, decision):
     mock_execute_request.side_effect = [
         mock_evaluate_response("ALLOW"),  # Allow the initial prompt
         mock_evaluate_response(decision),  # Deny/abort the tool call
     ]
-    mock_openai_request.return_value = _mock_openai_tool_response("add", {"a": 1, "b": 1})
 
     @langchain_core.tools.tool
     def add(a: int, b: int) -> int:
@@ -234,7 +225,7 @@ async def test_agent_action_async_block(
 
     tools = [add]
     agent_prompt = ChatPromptTemplate.from_messages([("human", "{input}"), MessagesPlaceholder("agent_scratchpad")])
-    llm = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, n=1, base_url=openai_url)
+    llm = langchain_openai.ChatOpenAI(temperature=0, n=1, base_url=openai_url)
     agent = create_openai_functions_agent(llm, tools, agent_prompt)
 
     agent_executor = AgentExecutor(agent=agent, tools=tools)
@@ -244,7 +235,6 @@ async def test_agent_action_async_block(
         await agent_executor.ainvoke({"input": "1 + 1"})
 
     assert mock_execute_request.call_count == 2  # One for prompt, one for tool
-    assert mock_openai_request.call_count == 1  # Initial prompt that returns a function call result
 
 
 @pytest.mark.asyncio

--- a/tests/cassettes/openai/openai_chat_completions_post_23dfb471.json
+++ b/tests/cassettes/openai/openai_chat_completions_post_23dfb471.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "headers": {
+      "Accept-Encoding": "gzip, deflate",
+      "Connection": "keep-alive",
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "OpenAI/Python 1.102.0",
+      "X-Stainless-Lang": "python",
+      "X-Stainless-Package-Version": "1.102.0",
+      "X-Stainless-OS": "Linux",
+      "X-Stainless-Arch": "x64",
+      "X-Stainless-Runtime": "CPython",
+      "X-Stainless-Runtime-Version": "3.11.14",
+      "X-Stainless-Async": "false",
+      "x-stainless-retry-count": "0"
+    },
+    "body": "{\"messages\":[{\"content\":\"1 + 1\",\"role\":\"user\"}],\"model\":\"gpt-3.5-turbo\",\"functions\":[{\"name\":\"add\",\"description\":\"add(a: int, b: int) -> int - Adds a and b.\\n\\n        Args:\\n            a: first int\\n            b: second int\",\"parameters\":{\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"integer\"},\"b\":{\"type\":\"integer\"}},\"required\":[\"a\",\"b\"]}}],\"n\":1,\"stream\":false,\"temperature\":0.0}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "openai-version": "2020-10-01"
+    },
+    "body": "{\n  \"id\": \"chatcmpl-ai-guard-test\",\n  \"object\": \"chat.completion\",\n  \"created\": 1700000000,\n  \"model\": \"gpt-3.5-turbo\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"function_call\": {\n          \"name\": \"add\",\n          \"arguments\": \"{\\\"a\\\": 1, \\\"b\\\": 1}\"\n        }\n      },\n      \"finish_reason\": \"function_call\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 20,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 30\n  }\n}\n"
+  }
+}

--- a/tests/cassettes/openai/openai_chat_completions_post_5bb04f9e.json
+++ b/tests/cassettes/openai/openai_chat_completions_post_5bb04f9e.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "headers": {
+      "Accept-Encoding": "gzip, deflate",
+      "Connection": "keep-alive",
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "OpenAI/Python 1.102.0",
+      "X-Stainless-Lang": "python",
+      "X-Stainless-Package-Version": "1.102.0",
+      "X-Stainless-OS": "Linux",
+      "X-Stainless-Arch": "x64",
+      "X-Stainless-Runtime": "CPython",
+      "X-Stainless-Runtime-Version": "3.12.0",
+      "X-Stainless-Async": "false",
+      "x-stainless-retry-count": "0"
+    },
+    "body": "{\"messages\":[{\"content\":\"1 + 1\",\"role\":\"user\"}],\"model\":\"gpt-3.5-turbo\",\"functions\":[{\"name\":\"add\",\"description\":\"Adds a and b.\\n\\n        Args:\\n            a: first int\\n            b: second int\",\"parameters\":{\"properties\":{\"a\":{\"type\":\"integer\"},\"b\":{\"type\":\"integer\"}},\"required\":[\"a\",\"b\"],\"type\":\"object\"}}],\"n\":1,\"stream\":false,\"temperature\":0.0}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "openai-version": "2020-10-01"
+    },
+    "body": "{\n  \"id\": \"chatcmpl-ai-guard-test\",\n  \"object\": \"chat.completion\",\n  \"created\": 1700000000,\n  \"model\": \"gpt-3.5-turbo\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"function_call\": {\n          \"name\": \"add\",\n          \"arguments\": \"{\\\"a\\\": 1, \\\"b\\\": 1}\"\n        }\n      },\n      \"finish_reason\": \"function_call\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 20,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 30\n  }\n}\n"
+  }
+}

--- a/tests/cassettes/openai/openai_chat_completions_post_f9fa0b14.json
+++ b/tests/cassettes/openai/openai_chat_completions_post_f9fa0b14.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "headers": {
+      "Accept-Encoding": "gzip, deflate",
+      "Connection": "keep-alive",
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "OpenAI/Python 2.2.0",
+      "X-Stainless-Lang": "python",
+      "X-Stainless-Package-Version": "2.2.0",
+      "X-Stainless-OS": "Linux",
+      "X-Stainless-Arch": "x64",
+      "X-Stainless-Runtime": "CPython",
+      "X-Stainless-Runtime-Version": "3.13.0",
+      "X-Stainless-Async": "false",
+      "x-stainless-retry-count": "0"
+    },
+    "body": "{\"messages\":[{\"content\":\"1 + 1\",\"role\":\"user\"}],\"model\":\"gpt-3.5-turbo\",\"functions\":[{\"name\":\"add\",\"description\":\"Adds a and b.\\n\\nArgs:\\n    a: first int\\n    b: second int\",\"parameters\":{\"properties\":{\"a\":{\"type\":\"integer\"},\"b\":{\"type\":\"integer\"}},\"required\":[\"a\",\"b\"],\"type\":\"object\"}}],\"n\":1,\"stream\":false,\"temperature\":0.0}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "openai-version": "2020-10-01"
+    },
+    "body": "{\n  \"id\": \"chatcmpl-ai-guard-test\",\n  \"object\": \"chat.completion\",\n  \"created\": 1700000000,\n  \"model\": \"gpt-3.5-turbo\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"function_call\": {\n          \"name\": \"add\",\n          \"arguments\": \"{\\\"a\\\": 1, \\\"b\\\": 1}\"\n        }\n      },\n      \"finish_reason\": \"function_call\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 20,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 30\n  }\n}\n"
+  }
+}


### PR DESCRIPTION
## Description

Migrates `test_agent_action_sync_block` and `test_agent_action_async_block` in `tests/appsec/ai_guard/langchain/test_langchain.py` from mocking `langchain_openai.ChatOpenAI._generate` / `_agenerate` directly to the testagent VCR proxy (`http://localhost:9126/vcr/openai`) with recorded cassettes, consistent with the rest of the suite. Drops the two `# TODO use testagent cassettes instead of mocking OpenAI` comments and the now-unused `mock_openai_request` plumbing.

## Changes

- `tests/appsec/ai_guard/langchain/test_langchain.py`
  - Remove `@patch("langchain_openai.chat_models.ChatOpenAI._generate")` / `_agenerate` and related mock wiring.
  - Remove `max_tokens=256` — langchain-openai 0.3.x rewrites `max_tokens` to `max_completion_tokens` in the outbound body, which would fork the request hash across venvs; dropping it keeps the body stable.
  - Remove the two TODO comments.
- Two new cassettes serving a `function_call` response for `add(a=1, b=1)` so the agent reaches the tool-call step where AI Guard aborts:
  - `tests/cassettes/openai/openai_chat_completions_post_5bb04f9e.json` — langchain-openai ≥ 0.1.7 (description = raw docstring).
  - `tests/cassettes/openai/openai_chat_completions_post_23dfb471.json` — langchain-openai 0.1.6 (description prefixed with function signature).