### PR TITLE
fix(llmobs): handle None metadata in experiment dataset records

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1649,7 +1649,7 @@ class Dataset:
                 flat_record[("expected_output", "")] = expected_output
                 column_tuples.add(("expected_output", ""))
 
-            metadata = record.get("metadata", {})
+            metadata = (record.get("metadata") or {})
             if isinstance(metadata, dict):
                 for metadata_col, metadata_val in metadata.items():
                     flat_record[("metadata", metadata_col)] = metadata_val
@@ -2000,7 +2000,7 @@ class Experiment:
             record: DatasetRecord = self._dataset[idx]
             inputs.append(record["input_data"])
             expected_outputs.append(record["expected_output"])
-            record_metadata = record.get("metadata", {})
+            record_metadata = (record.get("metadata") or {})
             metadata_list.append({**record_metadata, "experiment_config": self._config})
 
             eval_result_at_idx_by_name = eval_results[idx]["evaluations"]
@@ -2237,7 +2237,7 @@ class Experiment:
                     tags["dataset_record_canonical_id"] = canonical_id
                 output_data = None
                 last_exc_info = None
-                record_metadata = record.get("metadata", {})
+                record_metadata = (record.get("metadata") or {})
                 task_args: list = [input_data, self._config]
                 if self._task_accepts_metadata:
                     task_args.append(record_metadata)
@@ -2358,7 +2358,7 @@ class Experiment:
         input_data = record["input_data"]
         output_data = task_result["output"]
         expected_output = record["expected_output"]
-        metadata = record.get("metadata", {})
+        metadata = (record.get("metadata") or {})
 
         async def _run_single_evaluator(
             evaluator: Union[EvaluatorType, AsyncEvaluatorType],

--- a/releasenotes/notes/fix-llmobs-experiment-none-metadata-7d4e2f9a8c1b3e5f.yaml
+++ b/releasenotes/notes/fix-llmobs-experiment-none-metadata-7d4e2f9a8c1b3e5f.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes a ``TypeError: 'NoneType' object is not a mapping`` raised
+    when running an experiment over dataset records whose ``metadata`` field is ``None``
+    (a common shape for records serialized with an explicit ``null``). Metadata reads in
+    ``ddtrace/llmobs/_experiment.py`` now fall back to an empty dict for both missing and
+    ``None`` values, so summary evaluators, task argument plumbing, and per-record evaluator
+    context no longer crash on these records.

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -1753,6 +1753,45 @@ def test_experiment_run_summary_evaluators(llmobs, test_dataset_one_record):
     }
 
 
+def test_experiment_run_summary_evaluators_handles_none_metadata(llmobs):
+    """Regression: records whose `metadata` field is explicitly None must not crash
+    the summary evaluator path. `dict.get("metadata", {})` returns the stored None
+    (not the default), which then fails when spread into a dict literal. See
+    _prepare_summary_evaluator_data and the per-record paths that build
+    `{**metadata, "experiment_config": ...}`.
+    """
+    dataset = Dataset(
+        name="test_dataset_none_metadata",
+        project={"name": "test_project", "_id": "proj_123"},
+        dataset_id="ds_none_metadata",
+        records=[
+            {
+                "record_id": "rec_1",
+                "input_data": {"prompt": "What is the capital of France?"},
+                "expected_output": {"answer": "Paris"},
+                "metadata": None,
+            }
+        ],
+        description="Dataset whose records carry metadata=None",
+        latest_version=1,
+        version=1,
+        _dne_client=None,
+    )
+    exp = llmobs.experiment(
+        "test_experiment",
+        dummy_task,
+        dataset,
+        [dummy_evaluator],
+        summary_evaluators=[dummy_summary_evaluator],
+    )
+    task_results = asyncio.run(exp._experiment._run_task(1, run=run_info_with_stable_id(0), raise_errors=False))
+    eval_results = asyncio.run(exp._experiment._run_evaluators(task_results, raise_errors=False))
+    summary_eval_results = asyncio.run(
+        exp._experiment._run_summary_evaluators(task_results, eval_results, raise_errors=True)
+    )
+    assert summary_eval_results[0]["evaluations"]["dummy_summary_evaluator"]["error"] is None
+
+
 def test_experiment_run_evaluators_error(llmobs, test_dataset_one_record):
     exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [faulty_evaluator])
     task_results = asyncio.run(exp._experiment._run_task(1, run=run_info_with_stable_id(0), raise_errors=False))


### PR DESCRIPTION
## Summary

- Handles dataset records whose `metadata` field is explicitly `None` in LLMObs experiments (previously crashed with `TypeError: 'NoneType' object is not a mapping`)
- Root cause: `dict.get("metadata", {})` returns the stored `None` when the key is present, so the subsequent `{**record_metadata, ...}` spread crashes
- Fix: `record.get("metadata") or {}` at every read site in `ddtrace/llmobs/_experiment.py` (four sites)
- Adds a regression test that constructs an in-memory dataset with `metadata=None` and runs the full task → evaluator → summary-evaluator flow

## Context

Several ddeval projects across dd-source currently fail during `ddeval run` with:

```
❌ Evaluation failed: 'NoneType' object is not a mapping
```

The failure reproduces against a bare `ddeval run` (no custom tooling) on `multi-claim-example`, `single-claim-example`, `synthetics-critical-endpoint-selector`, and others. The full stack trace lands at `ddtrace/llmobs/_experiment.py:2004`:

```python
File "ddtrace/llmobs/_experiment.py", line 2004, in _prepare_summary_evaluator_data
    metadata_list.append({**record_metadata, "experiment_config": self._config})
TypeError: 'NoneType' object is not a mapping
```

This cropped up after ddeval `0.0.109272488` (released 2026-04-23) which JSON-decodes pulled dataset records in place. Before that fix, the error was `'str' object is not a mapping` (metadata was the string `"null"`); after, the decoded value is Python `None` — which `dict.get("metadata", {})` happily returns unchanged, and `**None` then crashes.

The upstream ddeval fix was necessary but exposed a latent None-safety bug on this side of the boundary.

## Change details

Every `record.get("metadata", {})` in `_experiment.py` becomes `record.get("metadata") or {}`:

| Line | Site |
|---|---|
| 1652 | `Dataset.as_dataframe()` — previously guarded by `isinstance(metadata, dict)`, now consistent |
| 2003 | `_prepare_summary_evaluator_data` — **the crash site** |
| 2240 | Per-record task argument plumbing (user-visible dict passed to tasks) |
| 2361 | Per-record evaluator context (`combined_metadata` spread) |

## Test plan

- [x] New regression test `test_experiment_run_summary_evaluators_handles_none_metadata` in `tests/llmobs/test_experiments.py`
  - Constructs an in-memory `Dataset` with `metadata=None` (no backend fixture)
  - Runs `_run_task` → `_run_evaluators` → `_run_summary_evaluators` with `raise_errors=True`
  - Asserts no error surfaces from the summary evaluator
- [x] Verified the test **fails on main** at `_experiment.py:2004` with the exact production error, and **passes** with the fix applied
- [x] Backwards-compatible: records with `metadata=None`, missing metadata, and populated metadata all coerce to the same shape downstream
- [ ] Full LLMObs experiment suite (backend-fixture tests skipped locally; CI will cover)

## Release note

Added at `releasenotes/notes/fix-llmobs-experiment-none-metadata-*.yaml`.