### PR TITLE
chore(profiling): [3/n] harden asyncio introspection against future CPython versions

### DIFF
--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -1,4 +1,6 @@
 from types import CodeType
+from typing import Final
+from typing import Optional
 
 import bytecode as bc
 
@@ -28,9 +30,9 @@ from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 #     return
 # -----------------------------------------------------------------------------
 
-COROUTINE_ASSEMBLY = Assembly()
-ASYNC_GEN_ASSEMBLY = Assembly()
-ASYNC_HEAD_ASSEMBLY = None
+COROUTINE_ASSEMBLY: Final[Assembly] = Assembly()
+ASYNC_GEN_ASSEMBLY: Final[Assembly] = Assembly()
+ASYNC_HEAD_ASSEMBLY: Optional[Assembly] = None
 
 if PY >= (3, 16):
     raise NotImplementedError("This version of CPython is not supported yet")

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -75,9 +75,9 @@ T = t.TypeVar("T")
 # __wrapped__ attribute. Context-specific values can be stored and retrieved
 # with the set and get methods.
 
-CONTEXT_HEAD = Assembly()
-CONTEXT_RETURN = Assembly()
-CONTEXT_FOOT = Assembly()
+CONTEXT_HEAD: t.Final[Assembly] = Assembly()
+CONTEXT_RETURN: t.Final[Assembly] = Assembly()
+CONTEXT_FOOT: t.Final[Assembly] = Assembly()
 
 if PY >= (3, 16):
     raise NotImplementedError("Python >= 3.16 is not supported yet")

--- a/ddtrace/internal/wrapping/generators.py
+++ b/ddtrace/internal/wrapping/generators.py
@@ -1,4 +1,6 @@
 from types import CodeType
+from typing import Final
+from typing import Optional
 
 import bytecode as bc
 
@@ -27,8 +29,8 @@ from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 # except StopIteration:
 #     return
 # -----------------------------------------------------------------------------
-GENERATOR_ASSEMBLY = Assembly()
-GENERATOR_HEAD_ASSEMBLY = None
+GENERATOR_ASSEMBLY: Final[Assembly] = Assembly()
+GENERATOR_HEAD_ASSEMBLY: Optional[Assembly] = None
 
 if PY >= (3, 16):
     raise NotImplementedError("This version of CPython is not supported yet")

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -39,11 +39,44 @@ def _task_get_name(task: "asyncio.Task[typing.Any]") -> str:
 def _call_init_asyncio(asyncio: ModuleType) -> None:
     from asyncio import tasks as asyncio_tasks
 
+    # AIDEV-NOTE: _scheduled_tasks, _eager_tasks, and _all_tasks are asyncio internals.
+    # They are confirmed present through Python 3.15. On known versions (<=3.15) a missing
+    # attribute is a real bug; on unknown future versions (>=3.16) degrade gracefully.
+    _on_known_version = sys.hexversion < 0x03100000  # < 3.16
+
     if sys.hexversion >= 0x030C0000:
-        scheduled_tasks = asyncio_tasks._scheduled_tasks.data  # type: ignore[attr-defined]
-        eager_tasks = asyncio_tasks._eager_tasks  # type: ignore[attr-defined]
+        if not hasattr(asyncio_tasks, "_scheduled_tasks"):
+            if _on_known_version:
+                raise RuntimeError(
+                    "ddtrace profiler: asyncio.tasks._scheduled_tasks not found on "
+                    "Python %s. asyncio task tracking will not work. "
+                    "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+                )
+            else:
+                log.warning(
+                    "ddtrace profiler: asyncio.tasks._scheduled_tasks not found on "
+                    "Python %s. asyncio task tracking will be incomplete.",
+                    sys.version,
+                )
+                return
+        scheduled_tasks = getattr(asyncio_tasks, "_scheduled_tasks").data
+        eager_tasks = getattr(asyncio_tasks, "_eager_tasks", None)
     else:
-        scheduled_tasks = asyncio_tasks._all_tasks.data  # type: ignore[attr-defined]
+        if not hasattr(asyncio_tasks, "_all_tasks"):
+            if _on_known_version:
+                raise RuntimeError(
+                    "ddtrace profiler: asyncio.tasks._all_tasks not found on "
+                    "Python %s. asyncio task tracking will not work. "
+                    "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+                )
+            else:
+                log.warning(
+                    "ddtrace profiler: asyncio.tasks._all_tasks not found on "
+                    "Python %s. asyncio task tracking will be incomplete.",
+                    sys.version,
+                )
+                return
+        scheduled_tasks = getattr(asyncio_tasks, "_all_tasks").data
         eager_tasks = None
 
     stack.init_asyncio(scheduled_tasks, eager_tasks)
@@ -179,9 +212,9 @@ def _(asyncio: ModuleType) -> None:
 
         elif _on_known_version:
             raise RuntimeError(
-                "ddtrace profiler: asyncio.tasks._wait not found on Python %s. "
+                f"ddtrace profiler: asyncio.tasks._wait not found on Python {sys.version}. "
                 "asyncio.wait() task-parent linking will not work. "
-                "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+                "Please report this at https://github.com/DataDog/dd-trace-py/issues."
             )
         else:
             log.warning(

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -90,8 +90,11 @@ def _(asyncio: ModuleType) -> None:
 
     init_stack: bool = config.stack.enabled and stack.is_available
 
-    # Python 3.14+: BaseDefaultEventLoopPolicy was renamed to _BaseDefaultEventLoopPolicy
-    # Try both names for compatibility
+    # Python 3.14+: BaseDefaultEventLoopPolicy was renamed to _BaseDefaultEventLoopPolicy.
+    # AIDEV-TODO: The entire asyncio policy system is deprecated in 3.15 (CPython #127949)
+    # and scheduled for removal in 3.16. When porting to 3.16, this block needs to be
+    # replaced — the policy hook won't exist. Use asyncio.run(loop_factory=...) instead.
+    # See docs/contributing-profiling-new-cpython.rst for migration guidance.
     events_module = sys.modules["asyncio.events"]
     if sys.hexversion >= 0x030E0000:
         # Python 3.14+: Use _BaseDefaultEventLoopPolicy
@@ -112,32 +115,41 @@ def _(asyncio: ModuleType) -> None:
             return f(*args, **kwargs)
 
     if init_stack:
+        # AIDEV-NOTE: _GatheringFuture and _wait are asyncio internals with no stability
+        # guarantee. Guard with hasattr so removal/rename in a future CPython release
+        # degrades gracefully (task linking skipped) rather than raising AttributeError.
+        # AIDEV-TODO: asyncio policy system deprecated in 3.15 (CPython #127949), removed
+        # in 3.16. When porting to 3.16, revisit this whole block — _GatheringFuture and
+        # _wait may also be gone. Replace with asyncio.run(loop_factory=...) pattern.
+        if hasattr(sys.modules["asyncio"].tasks, "_GatheringFuture"):
 
-        @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
-        def _(f: typing.Callable[..., None], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]) -> None:
-            try:
-                return f(*args, **kwargs)
-            finally:
-                children = get_argument_value(args, kwargs, 1, "children")
-                assert children is not None  # nosec: assert is used for typing
+            @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
+            def _wrap_gathering_future(
+                f: typing.Callable[..., None], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
+            ) -> None:
+                try:
+                    return f(*args, **kwargs)
+                finally:
+                    children = get_argument_value(args, kwargs, 1, "children")
+                    assert children is not None  # nosec: assert is used for typing
 
-                if globals()["get_running_loop"]() is not None:
                     parent = globals()["current_task"]()
                     for child in children:
                         stack.link_tasks(parent, child)
 
-        @partial(wrap, sys.modules["asyncio"].tasks._wait)
-        def _(
-            f: typing.Callable[..., tuple[set["aio.Future[typing.Any]"], set["aio.Future[typing.Any]"]]],
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            try:
-                return f(*args, **kwargs)
-            finally:
-                futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
+        if hasattr(sys.modules["asyncio"].tasks, "_wait"):
 
-                if globals()["get_running_loop"]() is not None:
+            @partial(wrap, sys.modules["asyncio"].tasks._wait)
+            def _wrap_wait(
+                f: typing.Callable[..., tuple[set["aio.Future[typing.Any]"], set["aio.Future[typing.Any]"]]],
+                args: tuple[typing.Any, ...],
+                kwargs: dict[str, typing.Any],
+            ) -> typing.Any:
+                try:
+                    return f(*args, **kwargs)
+                finally:
+                    futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
+
                     parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
                     for future in futures:
                         stack.link_tasks(parent, future)

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -169,15 +169,20 @@ def _(asyncio: ModuleType) -> None:
             def _wrap_gathering_future(
                 f: typing.Callable[..., None], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
             ) -> None:
-                try:
-                    return f(*args, **kwargs)
-                finally:
-                    children = get_argument_value(args, kwargs, 1, "children")
-                    assert children is not None  # nosec: assert is used for typing
+                f(*args, **kwargs)
+                children = get_argument_value(args, kwargs, 1, "children")
+                assert children is not None  # nosec: assert is used for typing
 
+                # AIDEV-NOTE: current_task() raises RuntimeError if there is no running
+                # event loop (e.g. asyncio.gather() called outside an async context to
+                # build a coroutine for later scheduling). In that case there is no parent
+                # task to link from, so we skip link_tasks entirely.
+                try:
                     parent = globals()["current_task"]()
-                    for child in children:
-                        stack.link_tasks(parent, child)
+                except RuntimeError:
+                    return
+                for child in children:
+                    stack.link_tasks(parent, child)
 
         elif _on_known_version:
             raise RuntimeError(
@@ -201,14 +206,19 @@ def _(asyncio: ModuleType) -> None:
                 args: tuple[typing.Any, ...],
                 kwargs: dict[str, typing.Any],
             ) -> typing.Any:
-                try:
-                    return f(*args, **kwargs)
-                finally:
-                    futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
+                result = f(*args, **kwargs)
+                futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
 
+                # AIDEV-NOTE: same guard as _wrap_gathering_future — _wait may also be
+                # invoked outside a running loop (e.g. building the coroutine before
+                # scheduling). Skip link_tasks when there is no current task.
+                try:
                     parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
-                    for future in futures:
-                        stack.link_tasks(parent, future)
+                except RuntimeError:
+                    return result
+                for future in futures:
+                    stack.link_tasks(parent, future)
+                return result
 
         elif _on_known_version:
             raise RuntimeError(

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -11,10 +11,14 @@ if typing.TYPE_CHECKING:
 
 from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace.internal.datadog.profiling import stack
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.settings.profiling import config
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.wrapping import wrap
+
+
+log = get_logger(__name__)
 
 
 ASYNCIO_IMPORTED: bool = False
@@ -116,11 +120,16 @@ def _(asyncio: ModuleType) -> None:
 
     if init_stack:
         # AIDEV-NOTE: _GatheringFuture and _wait are asyncio internals with no stability
-        # guarantee. Guard with hasattr so removal/rename in a future CPython release
-        # degrades gracefully (task linking skipped) rather than raising AttributeError.
+        # guarantee. On Python <= 3.15 (versions we've explicitly validated), we raise
+        # immediately if they're missing — that's a real bug, not a graceful degradation.
+        # On Python >= 3.16 (where the asyncio policy system is being removed and these
+        # may go too), we degrade gracefully with a warning instead of crashing.
         # AIDEV-TODO: asyncio policy system deprecated in 3.15 (CPython #127949), removed
         # in 3.16. When porting to 3.16, revisit this whole block — _GatheringFuture and
         # _wait may also be gone. Replace with asyncio.run(loop_factory=...) pattern.
+        # See docs/contributing-profiling-new-cpython.rst.
+        _on_known_version = sys.hexversion < 0x03100000  # < 3.16
+
         if hasattr(sys.modules["asyncio"].tasks, "_GatheringFuture"):
 
             @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
@@ -136,6 +145,20 @@ def _(asyncio: ModuleType) -> None:
                     parent = globals()["current_task"]()
                     for child in children:
                         stack.link_tasks(parent, child)
+
+        elif _on_known_version:
+            raise RuntimeError(
+                "ddtrace profiler: asyncio.tasks._GatheringFuture not found on Python %s. "
+                "asyncio.gather() task-parent linking will not work. "
+                "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+            )
+        else:
+            log.warning(
+                "ddtrace profiler: asyncio.tasks._GatheringFuture not found on Python %s. "
+                "asyncio.gather() task-parent links will be missing from profiler data. "
+                "This may be caused by asyncio internals changing in this Python version.",
+                sys.version,
+            )
 
         if hasattr(sys.modules["asyncio"].tasks, "_wait"):
 
@@ -153,6 +176,20 @@ def _(asyncio: ModuleType) -> None:
                     parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
                     for future in futures:
                         stack.link_tasks(parent, future)
+
+        elif _on_known_version:
+            raise RuntimeError(
+                "ddtrace profiler: asyncio.tasks._wait not found on Python %s. "
+                "asyncio.wait() task-parent linking will not work. "
+                "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+            )
+        else:
+            log.warning(
+                "ddtrace profiler: asyncio.tasks._wait not found on Python %s. "
+                "asyncio.wait() task-parent links will be missing from profiler data. "
+                "This may be caused by asyncio internals changing in this Python version.",
+                sys.version,
+            )
 
         @partial(wrap, sys.modules["asyncio"].tasks.as_completed)
         def _(

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 from functools import partial
 import sys
-import types
+from types import FunctionType
 from types import ModuleType
 import typing
 
@@ -27,6 +27,16 @@ log = get_logger(__name__)
 _ON_KNOWN_VERSION: bool = sys.hexversion < 0x03100000  # < 3.16
 
 ASYNCIO_IMPORTED: bool = False
+
+
+# AIDEV-NOTE: Structural Protocols for introspected asyncio/uvloop classes. getattr() returns Any, so
+# these annotations document the contract we actually depend on rather than accepting any `type`.
+class _HasSetEventLoop(typing.Protocol):
+    set_event_loop: typing.Callable[..., typing.Any]
+
+
+class _HasCreateTask(typing.Protocol):
+    create_task: typing.Callable[..., typing.Any]
 
 
 def current_task() -> typing.Optional["asyncio.Task[typing.Any]"]:
@@ -136,7 +146,7 @@ def _(asyncio: ModuleType) -> None:
     # replaced — the policy hook won't exist. Use asyncio.run(loop_factory=...) instead.
     # See docs/contributing-profiling-new-cpython.rst for migration guidance.
     events_module: ModuleType = sys.modules["asyncio.events"]
-    policy_class: typing.Optional[type]
+    policy_class: typing.Optional[type[_HasSetEventLoop]]
     if sys.hexversion >= 0x030E0000:
         # Python 3.14+: Use _BaseDefaultEventLoopPolicy
         policy_class = getattr(events_module, "_BaseDefaultEventLoopPolicy", None)
@@ -292,10 +302,10 @@ def _(asyncio: ModuleType) -> None:
         if sys.hexversion >= 0x030B0000:  # Python 3.11+
             taskgroups_module: typing.Optional[ModuleType] = sys.modules.get("asyncio.taskgroups")
             if taskgroups_module is not None:
-                taskgroup_class: typing.Optional[type] = getattr(taskgroups_module, "TaskGroup", None)
+                taskgroup_class: typing.Optional[type[_HasCreateTask]] = getattr(taskgroups_module, "TaskGroup", None)
                 if taskgroup_class is not None and hasattr(taskgroup_class, "create_task"):
 
-                    @partial(wrap, taskgroup_class.create_task)
+                    @partial(wrap, typing.cast(FunctionType, taskgroup_class.create_task))
                     def _(
                         f: typing.Callable[..., "aio.Task[typing.Any]"],
                         args: tuple[typing.Any, ...],
@@ -353,10 +363,12 @@ def _(uvloop: ModuleType) -> None:
     init_stack: bool = config.stack.enabled and stack.is_available
 
     # Wrap uvloop.new_event_loop to track loops when they're created
-    new_event_loop_func: typing.Optional[types.FunctionType] = getattr(uvloop, "new_event_loop", None)
+    new_event_loop_func: typing.Optional[typing.Callable[..., "asyncio.AbstractEventLoop"]] = getattr(
+        uvloop, "new_event_loop", None
+    )
     if new_event_loop_func is not None:
 
-        @partial(wrap, new_event_loop_func)
+        @partial(wrap, typing.cast(FunctionType, new_event_loop_func))
         def _(
             f: typing.Callable[..., "asyncio.AbstractEventLoop"],
             args: tuple[typing.Any, ...],
@@ -374,10 +386,10 @@ def _(uvloop: ModuleType) -> None:
             return loop
 
     # Wrap uvloop.EventLoopPolicy.set_event_loop for uvloop.install() + asyncio.run() pattern
-    uvloop_policy_class: typing.Optional[type] = getattr(uvloop, "EventLoopPolicy", None)
+    uvloop_policy_class: typing.Optional[type[_HasSetEventLoop]] = getattr(uvloop, "EventLoopPolicy", None)
     if uvloop_policy_class is not None and hasattr(uvloop_policy_class, "set_event_loop"):
 
-        @partial(wrap, uvloop_policy_class.set_event_loop)
+        @partial(wrap, typing.cast(FunctionType, uvloop_policy_class.set_event_loop))
         def _(
             f: typing.Callable[..., typing.Any], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
         ) -> typing.Any:

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 from functools import partial
 import sys
+import types
 from types import ModuleType
 import typing
 
@@ -20,6 +21,10 @@ from ddtrace.internal.wrapping import wrap
 
 log = get_logger(__name__)
 
+# True for every Python version we have explicitly validated (< 3.16).
+# Used to decide whether a missing asyncio internal is a hard bug (raise) or
+# a graceful degradation (warn + continue) for future, unvalidated versions.
+_ON_KNOWN_VERSION: bool = sys.hexversion < 0x03100000  # < 3.16
 
 ASYNCIO_IMPORTED: bool = False
 
@@ -42,15 +47,13 @@ def _call_init_asyncio(asyncio: ModuleType) -> None:
     # AIDEV-NOTE: _scheduled_tasks, _eager_tasks, and _all_tasks are asyncio internals.
     # They are confirmed present through Python 3.15. On known versions (<=3.15) a missing
     # attribute is a real bug; on unknown future versions (>=3.16) degrade gracefully.
-    _on_known_version = sys.hexversion < 0x03100000  # < 3.16
-
     if sys.hexversion >= 0x030C0000:
         if not hasattr(asyncio_tasks, "_scheduled_tasks"):
-            if _on_known_version:
+            if _ON_KNOWN_VERSION:
                 raise RuntimeError(
-                    "ddtrace profiler: asyncio.tasks._scheduled_tasks not found on "
-                    "Python %s. asyncio task tracking will not work. "
-                    "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+                    f"ddtrace profiler: asyncio.tasks._scheduled_tasks not found on "
+                    f"Python {sys.version}. asyncio task tracking will not work. "
+                    "Please report this at https://github.com/DataDog/dd-trace-py/issues"
                 )
             else:
                 log.warning(
@@ -59,15 +62,15 @@ def _call_init_asyncio(asyncio: ModuleType) -> None:
                     sys.version,
                 )
                 return
-        scheduled_tasks = getattr(asyncio_tasks, "_scheduled_tasks").data
-        eager_tasks = getattr(asyncio_tasks, "_eager_tasks", None)
+        scheduled_tasks: typing.Any = getattr(asyncio_tasks, "_scheduled_tasks").data
+        eager_tasks: typing.Any = getattr(asyncio_tasks, "_eager_tasks", None)
     else:
         if not hasattr(asyncio_tasks, "_all_tasks"):
-            if _on_known_version:
+            if _ON_KNOWN_VERSION:
                 raise RuntimeError(
-                    "ddtrace profiler: asyncio.tasks._all_tasks not found on "
-                    "Python %s. asyncio task tracking will not work. "
-                    "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+                    f"ddtrace profiler: asyncio.tasks._all_tasks not found on "
+                    f"Python {sys.version}. asyncio task tracking will not work. "
+                    "Please report this at https://github.com/DataDog/dd-trace-py/issues"
                 )
             else:
                 log.warning(
@@ -132,7 +135,8 @@ def _(asyncio: ModuleType) -> None:
     # and scheduled for removal in 3.16. When porting to 3.16, this block needs to be
     # replaced — the policy hook won't exist. Use asyncio.run(loop_factory=...) instead.
     # See docs/contributing-profiling-new-cpython.rst for migration guidance.
-    events_module = sys.modules["asyncio.events"]
+    events_module: ModuleType = sys.modules["asyncio.events"]
+    policy_class: typing.Optional[type]
     if sys.hexversion >= 0x030E0000:
         # Python 3.14+: Use _BaseDefaultEventLoopPolicy
         policy_class = getattr(events_module, "_BaseDefaultEventLoopPolicy", None)
@@ -161,8 +165,6 @@ def _(asyncio: ModuleType) -> None:
         # in 3.16. When porting to 3.16, revisit this whole block — _GatheringFuture and
         # _wait may also be gone. Replace with asyncio.run(loop_factory=...) pattern.
         # See docs/contributing-profiling-new-cpython.rst.
-        _on_known_version = sys.hexversion < 0x03100000  # < 3.16
-
         if hasattr(sys.modules["asyncio"].tasks, "_GatheringFuture"):
 
             @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
@@ -184,11 +186,11 @@ def _(asyncio: ModuleType) -> None:
                 for child in children:
                     stack.link_tasks(parent, child)
 
-        elif _on_known_version:
+        elif _ON_KNOWN_VERSION:
             raise RuntimeError(
-                "ddtrace profiler: asyncio.tasks._GatheringFuture not found on Python %s. "
+                f"ddtrace profiler: asyncio.tasks._GatheringFuture not found on Python {sys.version}. "
                 "asyncio.gather() task-parent linking will not work. "
-                "Please report this at https://github.com/DataDog/dd-trace-py/issues" % sys.version
+                "Please report this at https://github.com/DataDog/dd-trace-py/issues"
             )
         else:
             log.warning(
@@ -220,7 +222,7 @@ def _(asyncio: ModuleType) -> None:
                     stack.link_tasks(parent, future)
                 return result
 
-        elif _on_known_version:
+        elif _ON_KNOWN_VERSION:
             raise RuntimeError(
                 f"ddtrace profiler: asyncio.tasks._wait not found on Python {sys.version}. "
                 "asyncio.wait() task-parent linking will not work. "
@@ -288,9 +290,9 @@ def _(asyncio: ModuleType) -> None:
 
         # Wrap asyncio.TaskGroup.create_task to link parent task to created tasks (Python 3.11+)
         if sys.hexversion >= 0x030B0000:  # Python 3.11+
-            taskgroups_module = sys.modules.get("asyncio.taskgroups")
+            taskgroups_module: typing.Optional[ModuleType] = sys.modules.get("asyncio.taskgroups")
             if taskgroups_module is not None:
-                taskgroup_class = getattr(taskgroups_module, "TaskGroup", None)
+                taskgroup_class: typing.Optional[type] = getattr(taskgroups_module, "TaskGroup", None)
                 if taskgroup_class is not None and hasattr(taskgroup_class, "create_task"):
 
                     @partial(wrap, taskgroup_class.create_task)
@@ -351,7 +353,7 @@ def _(uvloop: ModuleType) -> None:
     init_stack: bool = config.stack.enabled and stack.is_available
 
     # Wrap uvloop.new_event_loop to track loops when they're created
-    new_event_loop_func = getattr(uvloop, "new_event_loop", None)
+    new_event_loop_func: typing.Optional[types.FunctionType] = getattr(uvloop, "new_event_loop", None)
     if new_event_loop_func is not None:
 
         @partial(wrap, new_event_loop_func)
@@ -360,9 +362,9 @@ def _(uvloop: ModuleType) -> None:
             args: tuple[typing.Any, ...],
             kwargs: dict[str, typing.Any],
         ) -> "asyncio.AbstractEventLoop":
-            loop = f(*args, **kwargs)
+            loop: "asyncio.AbstractEventLoop" = f(*args, **kwargs)
             if init_stack:
-                thread_id = typing.cast(int, ddtrace_threading.current_thread().ident)
+                thread_id: int = typing.cast(int, ddtrace_threading.current_thread().ident)
                 stack.set_uvloop_mode(thread_id, True)
 
                 stack.track_asyncio_loop(thread_id, loop)
@@ -372,14 +374,14 @@ def _(uvloop: ModuleType) -> None:
             return loop
 
     # Wrap uvloop.EventLoopPolicy.set_event_loop for uvloop.install() + asyncio.run() pattern
-    policy_class = getattr(uvloop, "EventLoopPolicy", None)
-    if policy_class is not None and hasattr(policy_class, "set_event_loop"):
+    uvloop_policy_class: typing.Optional[type] = getattr(uvloop, "EventLoopPolicy", None)
+    if uvloop_policy_class is not None and hasattr(uvloop_policy_class, "set_event_loop"):
 
-        @partial(wrap, policy_class.set_event_loop)
+        @partial(wrap, uvloop_policy_class.set_event_loop)
         def _(
             f: typing.Callable[..., typing.Any], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
         ) -> typing.Any:
-            thread_id = typing.cast(int, ddtrace_threading.current_thread().ident)
+            thread_id: int = typing.cast(int, ddtrace_threading.current_thread().ident)
             if init_stack:
                 stack.set_uvloop_mode(thread_id, True)
 


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/17531) | [Next PR >](https://github.com/DataDog/dd-trace-py/pull/17624)

## Summary

Peels the defensive asyncio introspection hardening out of #17624 into its own standalone PR. These guards are independent of Python 3.15 — they harden `ddtrace/profiling/_asyncio.py` against future CPython internal API changes (3.16+) and against runtime edge cases that also apply to 3.10–3.14.

## Stack

- `main`
  - #17531 — `chore(tracing): [2/n] support Python 3.15 coroutine and generator wrapping`
    - **this PR** — defensive hardening of asyncio introspection
      - #17624 — `chore(profiling): [3/n] support Python 3.15 for profiling`

## Changes

- `ddtrace/profiling/_asyncio.py`:
  - Guard `hasattr` access to every asyncio private API we introspect: `_scheduled_tasks`, `_eager_tasks`, `_all_tasks`, `_GatheringFuture`, `_wait`, task `WeakSet` internals. On known versions <3.16 a missing attribute raises with a GitHub issue link; on unknown versions >=3.16 we warn and degrade gracefully.
  - Wrap `asyncio.get_running_loop` / `asyncio.current_task` calls inside our task-link wrappers with `try`/`except RuntimeError` so a task completing outside of a running loop — observed on 3.15 — no longer propagates an exception into user code.
  - Introduce structural `Protocol` classes `_HasSetEventLoop`, `_HasCreateTask` and explicit type annotations for the attributes we introspect, so the contract we depend on is documented.
- `ddtrace/internal/wrapping/{asyncs,context,generators}.py`:
  - Matching type-annotation polish on the wrapping helpers touched by the new guards.

## Why split this out

- Independent of 3.15: these defenses are correct and desirable on 3.10–3.14 as well.
- Different review lens: pure profiling-asyncio hardening; no bytecode manipulation like #17531, no CPython internal headers / riot matrix expansion like #17624.
- Shrinks #17624's diff, which had grown to ~1K LoC.

## Testing

- Syntax check of the touched file.
- Downstream #17624 CI exercises these guards on Python 3.10 / 3.12 / 3.13 / 3.14 / 3.15 via the profiler's standard asyncio tests; the guards fire on import so any profiler test exercises them.

## Release notes

No user-facing behavior change beyond graceful handling of future-version attribute removals. Tagging `changelog/no-changelog` to match the rest of the 3.15 PR stack (#17531, #17624).

