### PR TITLE
fix(kafka): avoid crashes from reentrant calls

### DIFF
--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -1,6 +1,10 @@
 import sys
+from threading import local
 from time import time
 from time import time_ns
+from typing import Any
+from typing import Callable
+from typing import Optional
 
 import confluent_kafka
 
@@ -39,6 +43,7 @@ _DeserializingConsumer = (
 )
 
 log = get_logger(__name__)
+_delivery_callback_state = local()
 
 # Process-wide cache: bootstrap_servers -> cluster_id.
 # Populated by producers (which safely call list_topics); read by consumers
@@ -70,10 +75,11 @@ _MessageField = confluent_kafka.serialization.MessageField if KAFKA_VERSION_TUPL
 
 
 class TracedProducerMixin:
-    def __init__(self, config=None, *args, **kwargs):
+    def __init__(self, config: Optional[dict[str, Any]] = None, *args: Any, **kwargs: Any) -> None:
         if not config:
             config = kwargs
-        super(TracedProducerMixin, self).__init__(config, *args, **kwargs)
+        _wrap_config_on_delivery(config)
+        super(TracedProducerMixin, self).__init__(config, *args, **kwargs)  # type: ignore[call-arg]
         self._dd_bootstrap_servers = (
             config.get("bootstrap.servers")
             if config.get("bootstrap.servers") is not None
@@ -89,10 +95,10 @@ class TracedProducerMixin:
 
 
 class TracedConsumerMixin:
-    def __init__(self, config=None, *args, **kwargs):
+    def __init__(self, config: Optional[dict[str, Any]] = None, *args: Any, **kwargs: Any) -> None:
         if not config:
             config = kwargs
-        super(TracedConsumerMixin, self).__init__(config, *args, **kwargs)
+        super(TracedConsumerMixin, self).__init__(config, *args, **kwargs)  # type: ignore[call-arg]
         self._group_id = config.get("group.id", "")
         self._auto_commit = asbool(config.get("enable.auto.commit", True))
         self._dd_bootstrap_servers = (
@@ -194,6 +200,7 @@ def traced_produce(func, instance, args, kwargs):
     message_key = kwargs.get("key", "") or ""
     partition = kwargs.get("partition", -1)
     headers = get_argument_value(args, kwargs, 6, "headers", optional=True) or {}
+    is_serializing_producer = _SerializingProducer is not None and isinstance(instance, _SerializingProducer)
     with tracer.trace(
         schematize_messaging_operation(kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
         span_type=SpanTypes.WORKER,
@@ -204,7 +211,7 @@ def traced_produce(func, instance, args, kwargs):
         if cluster_id:
             span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
 
-        core.dispatch("kafka.produce.start", (instance, args, kwargs, isinstance(instance, _SerializingProducer), span))
+        core.dispatch("kafka.produce.start", (instance, args, kwargs, is_serializing_producer, span))
 
         span._set_attribute(MESSAGING_SYSTEM, kafkax.SERVICE)
         span._set_attribute(COMPONENT, config.kafka.integration_name)
@@ -214,7 +221,7 @@ def traced_produce(func, instance, args, kwargs):
             # Should fall back to broker id if topic is not provided but it is not readily available here
             span._set_attribute(MESSAGING_DESTINATION_NAME, topic)
 
-        if _SerializingProducer is not None and isinstance(instance, _SerializingProducer):
+        if is_serializing_producer:
             serialized_key = serialize_key(instance, topic, message_key, headers)
             if serialized_key is not None:
                 span._set_attribute(kafkax.MESSAGE_KEY, serialized_key)
@@ -226,6 +233,8 @@ def traced_produce(func, instance, args, kwargs):
         span._set_attribute(_SPAN_MEASURED_KEY, 1)
         if instance._dd_bootstrap_servers is not None:
             span._set_attribute(kafkax.HOST_LIST, instance._dd_bootstrap_servers)
+
+        args, kwargs = _wrap_delivery_callback_in_args(args, kwargs, is_serializing_producer)
 
         # inject headers with Datadog tags if trace propagation is enabled
         if config.kafka.distributed_tracing_enabled:
@@ -389,6 +398,11 @@ def _get_cluster_id(instance, topic):
 
         return ""
 
+    # list_topics can trigger fatal reentrant queue handling when
+    # called from delivery callbacks (e.g., callbacks executed inside flush)
+    if _in_kafka_delivery_callback():
+        return ""
+
     # Check failure cache - skip for 5 minutes if we fail
     last_failure = getattr(instance, "_dd_cluster_id_failure_time", 0)
     if time() - last_failure < 300:
@@ -410,3 +424,54 @@ def _get_cluster_id(instance, topic):
         log.debug("Failed to get Kafka cluster ID, will retry after 5 minutes")
 
     return ""
+
+
+def _wrap_config_on_delivery(config: dict[str, Any]) -> None:
+    on_delivery = config.get("on_delivery")
+    if on_delivery is not None and callable(on_delivery):
+        config["on_delivery"] = _wrap_kafka_delivery_callback(on_delivery)
+
+
+def _wrap_delivery_callback_in_args(args: Any, kwargs: Any, is_serializing: bool) -> tuple[Any, Any]:
+    # Producer.produce and SerializingProducer.produce both place on_delivery at index 4
+    # and timestamp at index 5.
+    callback_arg_pos = 4
+    if is_serializing:
+        callback_kwarg_name = "on_delivery"
+        callback = get_argument_value(args, kwargs, callback_arg_pos, callback_kwarg_name, optional=True)
+    else:
+        callback = get_argument_value(args, kwargs, callback_arg_pos, "callback", optional=True)
+        if callback is None:
+            callback_kwarg_name = "on_delivery"
+            callback = get_argument_value(args, kwargs, callback_arg_pos, callback_kwarg_name, optional=True)
+        else:
+            callback_kwarg_name = "callback"
+
+    if callback is None or not callable(callback):
+        return args, kwargs
+
+    wrapped_callback = _wrap_kafka_delivery_callback(callback)
+    try:
+        return set_argument_value(args, kwargs, callback_arg_pos, callback_kwarg_name, wrapped_callback)
+    except ArgumentError:
+        kwargs[callback_kwarg_name] = wrapped_callback
+        return args, kwargs
+
+
+def _in_kafka_delivery_callback() -> bool:
+    return getattr(_delivery_callback_state, "depth", 0) > 0
+
+
+def _wrap_kafka_delivery_callback(callback: Callable[[Any, Any], Any]) -> Callable[[Any, Any], Any]:
+    def wrapped_callback(err: Any, msg: Any) -> Any:
+        previous_depth = getattr(_delivery_callback_state, "depth", 0)
+        _delivery_callback_state.depth = previous_depth + 1
+        try:
+            return callback(err, msg)
+        finally:
+            if previous_depth:
+                _delivery_callback_state.depth = previous_depth
+            else:
+                delattr(_delivery_callback_state, "depth")
+
+    return wrapped_callback

--- a/releasenotes/notes/fix-kafka-crashes-9d5a3200beab6e7c.yaml
+++ b/releasenotes/notes/fix-kafka-crashes-9d5a3200beab6e7c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    kafka: Fixes crashes that occurred when ``list_topics`` was called from within a Kafka delivery callback.

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -3,6 +3,7 @@ import logging
 import os
 import random
 import time
+from typing import Any
 
 import confluent_kafka
 from confluent_kafka import TopicPartition
@@ -732,3 +733,118 @@ def test_cluster_id_success_caching(kafka_tracer, producer, kafka_topic):
     result2 = _get_cluster_id(producer, kafka_topic)
     assert result2 == result1
     assert call_count == 1  # Should still be 1 (used cache)
+
+
+def test_cluster_id_lookup_skipped_in_delivery_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    from ddtrace._trace.pin import Pin
+    from ddtrace.contrib.internal.kafka import patch as kafka_patch
+
+    class NoClusterMetadata(object):
+        cluster_id = None
+
+    class DummyProducer(object):
+        _dd_bootstrap_servers = None
+
+        def __init__(self):
+            self.list_topics_calls = 0
+
+        def list_topics(self, *args: Any, **kwargs: Any) -> NoClusterMetadata:
+            self.list_topics_calls += 1
+            return NoClusterMetadata()
+
+    producer = DummyProducer()
+    Pin(service="test").onto(producer)
+
+    monkeypatch.setattr(kafka_patch.core, "dispatch", lambda *args, **kwargs: None)
+
+    def nested_func(*args: Any, **kwargs: Any) -> str:
+        return "nested"
+
+    def user_callback(_err: Any, _msg: Any) -> None:
+        kafka_patch.traced_produce(nested_func, producer, ("nested-topic", b"payload"), {})
+
+    def outer_func(*args: Any, **kwargs: Any) -> str:
+        callback = kwargs.get("callback") or kwargs.get("on_delivery")
+        assert callback is not None
+        callback(None, None)
+        return "outer"
+
+    result = kafka_patch.traced_produce(
+        outer_func,
+        producer,
+        ("outer-topic", b"payload"),
+        {"callback": user_callback},
+    )
+
+    assert result == "outer"
+    assert producer.list_topics_calls == 1
+
+
+def test_delivery_callback_wrap_positional_slot() -> None:
+    from ddtrace.contrib.internal.kafka import patch as kafka_patch
+
+    def user_callback(_err: Any, _msg: Any) -> None:
+        pass
+
+    args = ("topic", b"payload", b"key", 0, user_callback, 12345)
+    wrapped_args, _ = kafka_patch._wrap_delivery_callback_in_args(args, {}, is_serializing=False)
+
+    assert wrapped_args[4] is not user_callback
+    assert callable(wrapped_args[4])
+    assert wrapped_args[5] == 12345
+
+    args_without_callback = ("topic", b"payload", b"key", 0, None, 999)
+    unchanged_args, _ = kafka_patch._wrap_delivery_callback_in_args(args_without_callback, {}, is_serializing=False)
+    assert unchanged_args[5] == 999
+    assert unchanged_args[4] is None
+
+
+def test_cluster_id_lookup_skipped_in_config_delivery_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    from ddtrace._trace.pin import Pin
+    from ddtrace.contrib.internal.kafka import patch as kafka_patch
+
+    class NoClusterMetadata(object):
+        cluster_id = None
+
+    class DummyProducer(object):
+        _dd_bootstrap_servers = None
+
+        def __init__(self):
+            self.list_topics_calls = 0
+
+        def list_topics(self, *args: Any, **kwargs: Any) -> NoClusterMetadata:
+            self.list_topics_calls += 1
+            return NoClusterMetadata()
+
+    producer = DummyProducer()
+    Pin(service="test").onto(producer)
+    monkeypatch.setattr(kafka_patch.core, "dispatch", lambda *args, **kwargs: None)
+
+    def nested_func(*args: Any, **kwargs: Any) -> str:
+        return "nested"
+
+    def user_callback(_err: Any, _msg: Any) -> None:
+        kafka_patch.traced_produce(nested_func, producer, ("nested-topic", b"payload"), {})
+
+    config: dict[str, Any] = {"on_delivery": user_callback}
+    kafka_patch._wrap_config_on_delivery(config)
+    config["on_delivery"](None, None)
+
+    assert producer.list_topics_calls == 0
+
+
+def test_config_on_delivery_wraps_callback() -> None:
+    from ddtrace.contrib.internal.kafka import patch as kafka_patch
+
+    state: dict[str, bool] = {}
+
+    def user_callback(_err: Any, _msg: Any) -> None:
+        state["in_callback"] = kafka_patch._in_kafka_delivery_callback()
+
+    config: dict[str, Any] = {"on_delivery": user_callback}
+    kafka_patch._wrap_config_on_delivery(config)
+    assert config["on_delivery"] is not user_callback
+
+    config["on_delivery"](None, None)
+    assert state["in_callback"] is True
+    assert kafka_patch._in_kafka_delivery_callback() is False


### PR DESCRIPTION
## Description

This PR fixes a crash originating from the Kafka integration (attached at the bottom).  The crash trace shows `list_topics` → `c_metadata_to_py` → `rd_kafka_controllerid` → `pthread_mutex_lock` → `SIGSEGV`.  
This is a reentrant `librdkafka` call: `ddtrace`'s `_get_cluster_id` calls `list_topics`, but if that call happens inside a Kafka delivery callback (e.g., one triggered by `flush`), `librdkafka` is already holding its internal mutex, causing the fatal reentrant queue handling crash.

The fix:
- Tracks delivery callback depth via a `threading.local` (`_delivery_callback_state`)
- Wraps user-provided delivery callbacks to set/unset that state `(_wrap_kafka_delivery_callback`)
- In `_get_cluster_id`, skips the `list_topics` call entirely when `_in_kafka_delivery_callback` is true

Note that this is complimentary to #18236. It is not the same crash.

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x00007892da491ff4 pthread_mutex_lock
#1   0x00007892da497abd mtx_lock
#2   0x00007892ab7bf828 rd_kafka_brokers_get_state_version
#3   0x00007892ab7ac618 rd_kafka_controllerid
#4   0x00007892d795f8dd c_metadata_to_py
#5   0x00007892d795fd85 list_topics
#6   0x0000611d199165e0 method_vectorcall_VARARGS_KEYWORDS (/app/Python-3.13.13/Objects/descrobject.c:358:14)
#7   0x0000611d19908034 _PyObject_VectorcallTstate (/app/Python-3.13.13/./Include/internal/pycore_call.h:168:11)
#8   0x0000611d19908034 PyObject_Vectorcall (/app/Python-3.13.13/Objects/call.c:327:12)
#9   0x0000611d1989a800 _PyEval_EvalFrameDefault (/app/Python-3.13.13/Python/generated_cases.c.h:1509:19)
#10  0x0000611d19907b67 _PyObject_VectorcallTstate (/app/Python-3.13.13/./Include/internal/pycore_call.h:168:11)
#11  0x0000611d19907b67 object_vacall (/app/Python-3.13.13/Objects/call.c:820:14)
#12  0x0000611d1990945e PyObject_CallFunctionObjArgs (/app/Python-3.13.13/Objects/call.c:927:14)
#13  0x00007892d9d69c63 WraptBoundFunctionWrapper_call (/project/src/wrapt/_wrappers.c:3024:18)
#14  0x0000611d19907708 _PyObject_MakeTpCall (/app/Python-3.13.13/Objects/call.c:242:18)
#15  0x0000611d1989a800 _PyEval_EvalFrameDefault (/app/Python-3.13.13/Python/generated_cases.c.h:1509:19)
#16  0x0000611d19a65f44 _PyEval_EvalFrame (/app/Python-3.13.13/./Include/internal/pycore_ceval.h:120:16)
#17  0x0000611d19a65f44 _PyEval_Vector (/app/Python-3.13.13/Python/ceval.c:1820:12)
#18  0x0000611d19a65f44 PyEval_EvalCode (/app/Python-3.13.13/Python/ceval.c:604:21)
#19  0x0000611d19a60459 builtin_exec_impl (/app/Python-3.13.13/Python/bltinmodule.c:1142:17)
#20  0x0000611d19a60459 builtin_exec (/app/Python-3.13.13/Python/clinic/bltinmodule.c.h:559:20)
#21  0x0000611d199727f3 cfunction_vectorcall_FASTCALL_KEYWORDS (/app/Python-3.13.13/Objects/methodobject.c:440:24)
#22  0x0000611d19908034 _PyObject_VectorcallTstate (/app/Python-3.13.13/./Include/internal/pycore_call.h:168:11)
#23  0x0000611d19908034 PyObject_Vectorcall (/app/Python-3.13.13/Objects/call.c:327:12)
#24  0x0000611d1989a41c _PyEval_EvalFrameDefault (/app/Python-3.13.13/Python/generated_cases.c.h:813:23)
#25  0x0000611d19afdcf9 pymain_run_module (/app/Python-3.13.13/Modules/main.c:349:14)
#26  0x0000611d19afe49a pymain_run_python (/app/Python-3.13.13/Modules/main.c:690:21)
#27  0x0000611d19aff1de Py_RunMain (/app/Python-3.13.13/Modules/main.c:775:5)
#28  0x0000611d19aff1de pymain_main (/app/Python-3.13.13/Modules/main.c:805:12)
#29  0x0000611d19aff1de Py_BytesMain (/app/Python-3.13.13/Modules/main.c:829:12)
#30  0x00007892da41c28b __libc_start_main
#31  0x0000611d198a6365 _start
```