### PR TITLE
fix(llmobs): handle null metadata on dataset records in experiments

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -2000,7 +2000,7 @@ class Experiment:
             record: DatasetRecord = self._dataset[idx]
             inputs.append(record["input_data"])
             expected_outputs.append(record["expected_output"])
-            record_metadata = record.get("metadata", {})
+            record_metadata = record.get("metadata") or {}
             metadata_list.append({**record_metadata, "experiment_config": self._config})
 
             eval_result_at_idx_by_name = eval_results[idx]["evaluations"]
@@ -2237,7 +2237,7 @@ class Experiment:
                     tags["dataset_record_canonical_id"] = canonical_id
                 output_data = None
                 last_exc_info = None
-                record_metadata = record.get("metadata", {})
+                record_metadata = record.get("metadata") or {}
                 task_args: list = [input_data, self._config]
                 if self._task_accepts_metadata:
                     task_args.append(record_metadata)

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -625,7 +625,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
                     "canonical_id": attrs.get("canonical_id"),
                     "input_data": attrs["input"],
                     "expected_output": attrs.get("expected_output"),
-                    "metadata": attrs.get("metadata", {}),
+                    "metadata": attrs.get("metadata") or {},
                     "tags": attrs.get("tags", []),
                 }
                 class_records.append(dataset_record)

--- a/releasenotes/notes/fix-llmobs-experiment-null-metadata-6422fbcfa197f328.yaml
+++ b/releasenotes/notes/fix-llmobs-experiment-null-metadata-6422fbcfa197f328.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where running an experiment with a dataset
+    whose records had ``null`` metadata caused the summary evaluator to crash with a
+    ``TypeError`` while preparing evaluator inputs.

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -39,6 +39,7 @@ from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 from ddtrace.llmobs._experiment import DatasetRecordNew
 from ddtrace.llmobs._experiment import EvaluatorResult
+from ddtrace.llmobs._experiment import Experiment
 from ddtrace.llmobs._experiment import ExperimentRun
 from ddtrace.llmobs._experiment import RemoteEvaluator
 from ddtrace.llmobs._experiment import RemoteEvaluatorError
@@ -4795,3 +4796,34 @@ def test_csv_dataset_as_dataframe(llmobs, tmp_csv_file_for_upload):
         finally:
             if dataset_id:
                 llmobs._delete_dataset(dataset_id=dataset_id)
+
+
+def test_prepare_summary_evaluator_data_handles_none_metadata():
+    """Records with metadata=None (e.g. from API returning null) must not crash data prep."""
+    dataset = _make_dataset_with_records(
+        [
+            {"input_data": {"prompt": "hi"}, "expected_output": "hello", "metadata": None},
+        ]
+    )
+    exp = Experiment(
+        name="test",
+        task=dummy_task,
+        dataset=dataset,
+        evaluators=[dummy_evaluator],
+        project_name="test-project",
+        summary_evaluators=[dummy_summary_evaluator],
+    )
+    task_results = [
+        {
+            "idx": 0,
+            "span_id": "1",
+            "trace_id": "1",
+            "timestamp": 0,
+            "output": "hello",
+            "metadata": {},
+            "error": {"message": None, "type": None, "stack": None},
+        }
+    ]
+    eval_results = [{"idx": 0, "evaluations": {"dummy_evaluator": {"value": True, "error": None}}}]
+    _, _, _, metadata_list, _ = exp._prepare_summary_evaluator_data(task_results, eval_results)
+    assert metadata_list == [{"experiment_config": {}}]


### PR DESCRIPTION
## Summary

When a dataset record had `metadata: null` (the LLMObs API may return `null` for missing metadata), `record.get("metadata", {})` returned `None` instead of the `{}` default — the default only kicks in when the key is absent. The summary evaluator then crashed with:

```
TypeError: argument of type 'NoneType' is not iterable
```

at `_prepare_summary_evaluator_data` in `ddtrace/llmobs/_experiment.py`, where it does `{**record_metadata, "experiment_config": self._config}`.

### Changes

- `ddtrace/llmobs/_experiment.py` — Coerce `None` to `{}` in both spots that read `record.get("metadata", ...)` (summary evaluator data prep + per-record task argument).
- `ddtrace/llmobs/_writer.py` — Same coercion when materialising records from API responses, so a `null` metadata field never propagates into the in-memory `Dataset`.
- `tests/llmobs/test_experiments.py` — Regression test that constructs a `Dataset` with `metadata=None` and asserts `_prepare_summary_evaluator_data` no longer raises.

## Test plan

- [x] New regression test `test_prepare_summary_evaluator_data_handles_none_metadata` passes.
- [x] Existing `test_experiment_run_summary_evaluators` and tag-operation unit tests still pass.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described
- [x] Risk is outlined (low — narrowing default-coercion behavior; no API change)
- [x] Library release note included