### PR TITLE
fix(tracing): prevent SCRIPT_NAME doubling in WSGI URL reconstruction

### DIFF
--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -244,20 +244,32 @@ def construct_url(environ):
             if environ["SERVER_PORT"] != "80":
                 url += ":" + environ["SERVER_PORT"]
 
-    url += quote(environ.get("SCRIPT_NAME", ""))
-    # we need the raw uri here for reporting, not the computed one
-    if environ.get("RAW_URI"):
-        url += environ["RAW_URI"]
+    # SCRIPT_NAME composition with RAW_URI / REQUEST_URI is subtle. Two distinct
+    # WSGI flows put a non-empty SCRIPT_NAME in environ:
+    #   1. werkzeug DispatcherMiddleware (and similar in-process mounts) set
+    #      SCRIPT_NAME to the mount prefix AND the original (pre-strip) request
+    #      line is preserved in RAW_URI / REQUEST_URI. Prepending SCRIPT_NAME on
+    #      top of RAW_URI would double the mount prefix (e.g. /asm/asm/...).
+    #   2. A reverse proxy (or upstream WSGI server) strips a path prefix before
+    #      handing the request off, exposing only the post-strip path in
+    #      RAW_URI / REQUEST_URI while the prefix is reported in SCRIPT_NAME.
+    #      Skipping SCRIPT_NAME would lose the prefix from the reported URL.
+    # Distinguish the two by checking whether the raw URI already starts with
+    # SCRIPT_NAME: case (1) starts with it (don't prepend), case (2) doesn't
+    # (prepend). On the PATH_INFO fallback we always prepend SCRIPT_NAME because
+    # PATH_INFO is the stripped value in both cases.
+    script_name = environ.get("SCRIPT_NAME") or ""
+    raw = environ.get("RAW_URI") or environ.get("REQUEST_URI") or ""
+    if raw:
+        if script_name and not raw.startswith(script_name):
+            url += quote(script_name)
+        url += raw
         # on old versions of wsgi, the raw uri does not include the query string
-        if environ.get("QUERY_STRING") and "?" not in environ["RAW_URI"]:
-            url += "?" + environ["QUERY_STRING"]
-    elif environ.get("REQUEST_URI"):
-        url += environ["REQUEST_URI"]
-        # on old versions of wsgi, the raw uri does not include the query string
-        if environ.get("QUERY_STRING") and "?" not in environ["REQUEST_URI"]:
+        if environ.get("QUERY_STRING") and "?" not in raw:
             url += "?" + environ["QUERY_STRING"]
     else:
-        url += quote(environ.get("PATH_INFO", ""))
+        url += quote(script_name)
+        url += quote(environ.get("PATH_INFO") or "")
         if environ.get("QUERY_STRING"):
             url += "?" + environ["QUERY_STRING"]
 

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -249,19 +249,22 @@ def construct_url(environ):
     #   1. werkzeug DispatcherMiddleware (and similar in-process mounts) set
     #      SCRIPT_NAME to the mount prefix AND the original (pre-strip) request
     #      line is preserved in RAW_URI / REQUEST_URI. Prepending SCRIPT_NAME on
-    #      top of RAW_URI would double the mount prefix (e.g. /asm/asm/...).
+    #      top of RAW_URI would double the mount prefix (e.g. /admin/admin/...).
     #   2. A reverse proxy (or upstream WSGI server) strips a path prefix before
     #      handing the request off, exposing only the post-strip path in
     #      RAW_URI / REQUEST_URI while the prefix is reported in SCRIPT_NAME.
     #      Skipping SCRIPT_NAME would lose the prefix from the reported URL.
-    # Distinguish the two by checking whether the raw URI already starts with
-    # SCRIPT_NAME: case (1) starts with it (don't prepend), case (2) doesn't
-    # (prepend). On the PATH_INFO fallback we always prepend SCRIPT_NAME because
-    # PATH_INFO is the stripped value in both cases.
+    # Distinguish the two by checking whether the raw URI starts with SCRIPT_NAME
+    # *at a path boundary* — exact match, ``/``, ``?``, or ``#`` immediately
+    # after — so that ``SCRIPT_NAME=/api`` is not falsely matched against a
+    # ``RAW_URI=/apiary/...`` that just happens to share leading characters.
+    # Case (1) matches at a boundary (don't prepend); case (2) doesn't (prepend).
+    # On the PATH_INFO fallback we always prepend SCRIPT_NAME because PATH_INFO
+    # is the stripped value in both cases.
     script_name = environ.get("SCRIPT_NAME") or ""
     raw = environ.get("RAW_URI") or environ.get("REQUEST_URI") or ""
     if raw:
-        if script_name and not raw.startswith(script_name):
+        if script_name and not _raw_uri_starts_with_script_name(raw, script_name):
             url += quote(script_name)
         url += raw
         # on old versions of wsgi, the raw uri does not include the query string
@@ -274,6 +277,27 @@ def construct_url(environ):
             url += "?" + environ["QUERY_STRING"]
 
     return url
+
+
+def _raw_uri_starts_with_script_name(raw: str, script_name: str) -> bool:
+    """Return True iff ``raw`` begins with ``script_name`` followed by a path
+    boundary (end-of-string, ``/``, ``?``, or ``#``).
+
+    A naive ``raw.startswith(script_name)`` check would mis-classify an
+    in-process-mount setup where the public URL only *shares leading characters*
+    with the mount prefix (e.g. ``SCRIPT_NAME=/api`` vs ``RAW_URI=/apiary/x``)
+    as a doubled-prefix case, dropping the legitimate prefix.
+
+    When ``script_name`` itself ends in ``/`` (notably the root mount ``"/"``),
+    the trailing slash *is* the boundary — any chars after it are inside the
+    next path segment — so no additional boundary check is needed.
+    """
+    if not raw.startswith(script_name):
+        return False
+    if script_name.endswith("/"):
+        return True
+    rest = raw[len(script_name) :]
+    return rest == "" or rest[0] in ("/", "?", "#")
 
 
 def get_request_headers(environ: Mapping[str, str]) -> Mapping[str, str]:

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.trace import Tracer  # noqa:F401
 
 from urllib.parse import quote
+from urllib.parse import unquote_to_bytes
 
 import wrapt
 
@@ -248,23 +249,28 @@ def construct_url(environ):
     # WSGI flows put a non-empty SCRIPT_NAME in environ:
     #   1. werkzeug DispatcherMiddleware (and similar in-process mounts) set
     #      SCRIPT_NAME to the mount prefix AND the original (pre-strip) request
-    #      line is preserved in RAW_URI / REQUEST_URI. Prepending SCRIPT_NAME on
-    #      top of RAW_URI would double the mount prefix (e.g. /admin/admin/...).
+    #      line is preserved in RAW_URI / REQUEST_URI. PATH_INFO is the
+    #      post-strip remainder, so RAW_URI == SCRIPT_NAME + PATH_INFO.
+    #      Prepending SCRIPT_NAME on top would double the mount prefix
+    #      (e.g. /admin/admin/...).
     #   2. A reverse proxy (or upstream WSGI server) strips a path prefix before
     #      handing the request off, exposing only the post-strip path in
-    #      RAW_URI / REQUEST_URI while the prefix is reported in SCRIPT_NAME.
-    #      Skipping SCRIPT_NAME would lose the prefix from the reported URL.
-    # Distinguish the two by checking whether the raw URI starts with SCRIPT_NAME
-    # *at a path boundary* — exact match, ``/``, ``?``, or ``#`` immediately
-    # after — so that ``SCRIPT_NAME=/api`` is not falsely matched against a
-    # ``RAW_URI=/apiary/...`` that just happens to share leading characters.
-    # Case (1) matches at a boundary (don't prepend); case (2) doesn't (prepend).
-    # On the PATH_INFO fallback we always prepend SCRIPT_NAME because PATH_INFO
-    # is the stripped value in both cases.
+    #      RAW_URI / REQUEST_URI; PATH_INFO matches RAW_URI. SCRIPT_NAME carries
+    #      the prefix that was stripped, so RAW_URI != SCRIPT_NAME + PATH_INFO
+    #      (the two differ by exactly the missing prefix). Skipping SCRIPT_NAME
+    #      would lose the prefix from the reported URL — including the case
+    #      where the post-strip path coincidentally starts with the mount
+    #      segment (public URL ``/api/api/users``, RAW_URI ``/api/users``).
+    # Disambiguate by computing the canonical PEP-3333 concatenation
+    # ``SCRIPT_NAME + PATH_INFO`` and comparing it against the raw URI's path
+    # component. Equal → case (1), don't prepend. Different → case (2), prepend.
+    # The PATH_INFO fallback path always prepends SCRIPT_NAME because PATH_INFO
+    # is the stripped value in both flows.
     script_name = environ.get("SCRIPT_NAME") or ""
+    path_info = environ.get("PATH_INFO") or ""
     raw = environ.get("RAW_URI") or environ.get("REQUEST_URI") or ""
     if raw:
-        if script_name and not _raw_uri_starts_with_script_name(raw, script_name):
+        if script_name and not _raw_uri_already_includes_script_name(raw, script_name, path_info):
             url += quote(script_name)
         url += raw
         # on old versions of wsgi, the raw uri does not include the query string
@@ -272,32 +278,64 @@ def construct_url(environ):
             url += "?" + environ["QUERY_STRING"]
     else:
         url += quote(script_name)
-        url += quote(environ.get("PATH_INFO") or "")
+        url += quote(path_info)
         if environ.get("QUERY_STRING"):
             url += "?" + environ["QUERY_STRING"]
 
     return url
 
 
-def _raw_uri_starts_with_script_name(raw: str, script_name: str) -> bool:
-    """Return True iff ``raw`` begins with ``script_name`` followed by a path
-    boundary (end-of-string, ``/``, ``?``, or ``#``).
+def _raw_uri_already_includes_script_name(raw: str, script_name: str, path_info: str) -> bool:
+    """Return True iff ``raw`` already includes ``script_name`` (the
+    DispatcherMiddleware / in-process-mount case), so the caller should not
+    prepend it a second time.
 
-    A naive ``raw.startswith(script_name)`` check would mis-classify an
-    in-process-mount setup where the public URL only *shares leading characters*
-    with the mount prefix (e.g. ``SCRIPT_NAME=/api`` vs ``RAW_URI=/apiary/x``)
-    as a doubled-prefix case, dropping the legitimate prefix.
+    The canonical PEP-3333 reconstruction of the request path is
+    ``SCRIPT_NAME + PATH_INFO``. In an in-process mount, ``RAW_URI`` (the
+    pre-strip request line) matches that concatenation. In a reverse-proxy
+    strip, ``RAW_URI`` matches ``PATH_INFO`` alone (the prefix was stripped
+    upstream and is not in the raw line) — even when ``PATH_INFO`` happens to
+    start with the same first segment as ``SCRIPT_NAME``, which a naive
+    boundary check on ``RAW_URI`` alone could not distinguish.
 
-    When ``script_name`` itself ends in ``/`` (notably the root mount ``"/"``),
-    the trailing slash *is* the boundary — any chars after it are inside the
-    next path segment — so no additional boundary check is needed.
+    ``SCRIPT_NAME == "/"`` is a degenerate root-mount form: there's no real
+    prefix to inject, so we treat it as "already included" to avoid producing
+    a leading double slash.
+
+    If ``PATH_INFO`` is empty we fall back to a path-boundary check on the raw
+    URI; this preserves DispatcherMiddleware correctness in legacy WSGI
+    environs that don't set ``PATH_INFO``, at the cost of regressing the
+    reverse-proxy-with-overlap case which is rare in practice and undetectable
+    without ``PATH_INFO``.
     """
-    if not raw.startswith(script_name):
-        return False
-    if script_name.endswith("/"):
+    sn = script_name.rstrip("/")
+    if not sn:
+        # script_name was "" (caller already gates on this) or "/" — nothing to prepend
         return True
-    rest = raw[len(script_name) :]
-    return rest == "" or rest[0] in ("/", "?", "#")
+    raw_path = raw.split("?", 1)[0].split("#", 1)[0]
+    if path_info:
+        # PATH_INFO and SCRIPT_NAME are WSGI-decoded strings (PEP-3333), but
+        # RAW_URI / REQUEST_URI are the original percent-encoded request line.
+        # Decode the raw path before comparing so benign encoding differences
+        # (e.g. ``%20`` vs literal space) don't flip the decision and cause an
+        # accidental double-prefix. Use ``unquote_to_bytes`` + ``latin-1`` —
+        # the byte-exact lossless round-trip PEP-3333 prescribes for environ
+        # strings — instead of ``unquote``'s default UTF-8/replace, which can
+        # turn a stray ``%FF`` into ``�`` and silently mismatch a PATH_INFO
+        # that the WSGI server passed through as latin-1.
+        try:
+            decoded_raw_path = unquote_to_bytes(raw_path).decode("latin-1")
+        except Exception:
+            decoded_raw_path = raw_path
+        return decoded_raw_path == sn + path_info
+    # Fallback: PATH_INFO is empty / missing. Use a path-segment-boundary check
+    # — DispatcherMiddleware-correct, but the reverse-proxy-with-overlap case
+    # is unrecoverable here without PATH_INFO. ``?`` and ``#`` aren't possible
+    # in ``raw_path`` since we've split them off above.
+    if not raw_path.startswith(sn):
+        return False
+    rest = raw_path[len(sn) :]
+    return rest == "" or rest[0] == "/"
 
 
 def get_request_headers(environ: Mapping[str, str]) -> Mapping[str, str]:

--- a/releasenotes/notes/fix-wsgi-doubling-cc8714d413ac8d80.yaml
+++ b/releasenotes/notes/fix-wsgi-doubling-cc8714d413ac8d80.yaml
@@ -1,12 +1,9 @@
 ---
 fixes:
   - |
-    tracing(wsgi): This fix resolves an issue where the ``http.url`` tag on inbound
-    request spans contained the mount prefix twice (for example ``/admin/admin/users``
-    instead of ``/admin/users``) when a WSGI application was served behind
-    ``werkzeug.middleware.dispatcher.DispatcherMiddleware`` or any other in-process mount
-    that preserves the original request URI in ``RAW_URI`` / ``REQUEST_URI`` while also
-    setting ``SCRIPT_NAME``. URL reconstruction now detects whether the raw request URI
-    already includes ``SCRIPT_NAME`` and prepends it only when a reverse proxy has
-    stripped the prefix, restoring correct URL reporting in both flows. Affects every
-    WSGI-based integration, not only Flask.
+    wsgi: This fix resolves an issue where the ``http.url`` tag on inbound request
+    spans contained the WSGI mount prefix twice (for example ``/admin/admin/users``
+    instead of ``/admin/users``) when the application was served behind
+    ``werkzeug.middleware.dispatcher.DispatcherMiddleware`` or any other in-process
+    mount that preserves the original request URI in ``RAW_URI`` / ``REQUEST_URI``
+    while also setting ``SCRIPT_NAME``.

--- a/releasenotes/notes/fix-wsgi-doubling-cc8714d413ac8d80.yaml
+++ b/releasenotes/notes/fix-wsgi-doubling-cc8714d413ac8d80.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    tracing(wsgi): This fix resolves an issue where the ``http.url`` tag on inbound
+    request spans contained the mount prefix twice (for example ``/admin/admin/users``
+    instead of ``/admin/users``) when a WSGI application was served behind
+    ``werkzeug.middleware.dispatcher.DispatcherMiddleware`` or any other in-process mount
+    that preserves the original request URI in ``RAW_URI`` / ``REQUEST_URI`` while also
+    setting ``SCRIPT_NAME``. URL reconstruction now detects whether the raw request URI
+    already includes ``SCRIPT_NAME`` and prepends it only when a reverse proxy has
+    stripped the prefix, restoring correct URL reporting in both flows. Affects every
+    WSGI-based integration, not only Flask.

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -490,3 +490,146 @@ def test_construct_url_no_script_name_passthrough():
         "QUERY_STRING": "",
     }
     assert construct_url(environ) == "http://localhost:8000/users"
+
+
+def test_construct_url_script_name_absent_from_environ():
+    """SCRIPT_NAME key not present at all (some WSGI servers omit it) is treated
+    as empty — no prefix prepended, raw URI returned as-is.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/users"
+
+
+def test_construct_url_script_name_none_passthrough():
+    """Defensive: a non-spec ``SCRIPT_NAME=None`` is normalized to empty rather
+    than blowing up on string concatenation.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": None,
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/users"
+
+
+def test_construct_url_script_name_prefix_is_not_a_path_segment_match():
+    """``SCRIPT_NAME=/api`` must NOT be considered already-included when the raw
+    URI is ``/apiary/users`` — they share leading characters but the first path
+    segment is different. The reverse-proxy-strip prefix must still be prepended.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/api",
+        "PATH_INFO": "/apiary/users",
+        "RAW_URI": "/apiary/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/api/apiary/users"
+
+
+def test_construct_url_root_script_name_does_not_inject_double_slash():
+    """``SCRIPT_NAME="/"`` (the root mount) must NOT cause a leading double
+    slash in the constructed URL. The trailing ``/`` of the script name itself
+    is the path boundary; we treat it as already-included regardless of the
+    next character in the raw URI.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/users"
+
+
+def test_construct_url_script_name_exact_match_is_not_doubled():
+    """Edge of the boundary check: ``RAW_URI`` is *exactly* ``SCRIPT_NAME``
+    (request hit the bare mount prefix, no path beyond it). The match is at
+    end-of-string — still a path boundary, must not double.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/admin",
+        "PATH_INFO": "",
+        "RAW_URI": "/admin",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/admin"
+
+
+def test_construct_url_raw_uri_takes_precedence_over_request_uri():
+    """When both keys are present, ``RAW_URI`` wins (gunicorn-style preference).
+    Codifies the read order ``RAW_URI`` first, ``REQUEST_URI`` second.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/raw",
+        "REQUEST_URI": "/request",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/raw"
+
+
+def test_construct_url_query_string_already_in_raw_uri_is_not_duplicated():
+    """If the ``?`` is already in ``RAW_URI``, ``QUERY_STRING`` must not be
+    appended a second time. Pairs with the existing case where ``RAW_URI`` lacks
+    the query and ``QUERY_STRING`` is appended to backfill it.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users?a=1&b=2",
+        "QUERY_STRING": "a=1&b=2",
+    }
+    assert construct_url(environ) == "http://localhost:8000/users?a=1&b=2"
+
+
+def test_construct_url_matrix_params_in_raw_uri_treated_as_segment_data():
+    """Matrix-parameter syntax (``;``) is segment-internal data, not a path
+    boundary. With ``SCRIPT_NAME=/api`` and ``RAW_URI=/api;v=1`` (which can only
+    arise from the reverse-proxy-strip flow, since werkzeug DispatcherMiddleware
+    only splits on ``/``), the prefix must still be prepended — yielding the
+    public URL ``/api/api;v=1``.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/api",
+        "PATH_INFO": "/api;v=1",
+        "RAW_URI": "/api;v=1",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/api/api;v=1"
+
+
+def test_construct_url_query_string_backfilled_when_raw_uri_lacks_it():
+    """Older WSGI servers may put just the path in ``RAW_URI`` and the query
+    separately in ``QUERY_STRING``. ``construct_url`` must compose them.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users",
+        "QUERY_STRING": "a=1&b=2",
+    }
+    assert construct_url(environ) == "http://localhost:8000/users?a=1&b=2"

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -537,6 +537,45 @@ def test_construct_url_script_name_prefix_is_not_a_path_segment_match():
     assert construct_url(environ) == "http://localhost:8000/api/apiary/users"
 
 
+def test_construct_url_dispatcher_middleware_with_percent_encoded_path():
+    """``RAW_URI`` is the original percent-encoded request line; ``PATH_INFO``
+    is the WSGI-decoded form. The DispatcherMiddleware-vs-reverse-proxy
+    disambiguation must not flip on benign encoding differences (here ``%20``
+    in the raw line vs a literal space in ``PATH_INFO``), which would
+    otherwise cause an accidental double-prefix on URLs containing percent-
+    encoded characters.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/admin",
+        "PATH_INFO": "/foo bar",
+        "RAW_URI": "/admin/foo%20bar",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/admin/foo%20bar"
+
+
+def test_construct_url_reverse_proxy_strip_with_path_segment_collision():
+    """A reverse proxy strips a prefix from the public URL ``/api/api/users``
+    yielding ``RAW_URI=/api/users``, ``SCRIPT_NAME=/api``, ``PATH_INFO=/api/users``.
+    Distinguishable from the DispatcherMiddleware case (which would have
+    ``PATH_INFO=/users``) only by comparing the canonical concatenation
+    ``SCRIPT_NAME + PATH_INFO`` (``/api/api/users``) against ``RAW_URI``
+    (``/api/users``); the mismatch flags this as the proxy-strip flow and the
+    prefix must be prepended.
+    """
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/api",
+        "PATH_INFO": "/api/users",
+        "RAW_URI": "/api/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/api/api/users"
+
+
 def test_construct_url_root_script_name_does_not_inject_double_slash():
     """``SCRIPT_NAME="/"`` (the root mount) must NOT cause a leading double
     slash in the constructed URL. The trailing ``/`` of the script name itself

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -6,6 +6,7 @@ from webtest import TestApp
 from ddtrace import config
 from ddtrace.contrib.internal.wsgi.wsgi import DDWSGIMiddleware
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
+from ddtrace.contrib.internal.wsgi.wsgi import construct_url
 from ddtrace.contrib.internal.wsgi.wsgi import get_request_headers
 from tests.utils import override_config
 from tests.utils import override_http_config
@@ -409,3 +410,83 @@ app.get("/")"""
         env["DD_SERVICE"] = service_name
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, stderr
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for construct_url SCRIPT_NAME composition.
+#
+# Two distinct WSGI flows leave a non-empty ``SCRIPT_NAME`` in ``environ``:
+#   1. In-process mounts (e.g. ``werkzeug.middleware.dispatcher.DispatcherMiddleware``)
+#      preserve the original request URI in ``RAW_URI`` / ``REQUEST_URI`` while
+#      also setting ``SCRIPT_NAME`` to the mount prefix. Naively prepending
+#      ``SCRIPT_NAME`` would double the prefix in ``http.url``.
+#   2. A reverse proxy strips a path prefix before forwarding, exposing only
+#      the post-strip path in ``RAW_URI`` while reporting the prefix via
+#      ``SCRIPT_NAME``. Skipping ``SCRIPT_NAME`` would lose the prefix.
+# ``construct_url`` distinguishes the two by checking whether the raw URI
+# already starts with ``SCRIPT_NAME``. These tests pin that behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_construct_url_dispatcher_middleware_does_not_double_prefix():
+    """RAW_URI already includes the mount prefix → SCRIPT_NAME must NOT be prepended."""
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/admin",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/admin/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/admin/users"
+
+
+def test_construct_url_reverse_proxy_prepends_script_name():
+    """RAW_URI lacks the prefix (proxy stripped it) → SCRIPT_NAME must be prepended."""
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/api/v2",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/api/v2/users"
+
+
+def test_construct_url_request_uri_dispatcher_middleware_does_not_double_prefix():
+    """Same as the RAW_URI case but exercising the REQUEST_URI fallback (uWSGI)."""
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/admin",
+        "PATH_INFO": "/users",
+        "REQUEST_URI": "/admin/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/admin/users"
+
+
+def test_construct_url_path_info_fallback_uses_script_name():
+    """Without RAW_URI / REQUEST_URI, the fallback always composes SCRIPT_NAME + PATH_INFO."""
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "/admin",
+        "PATH_INFO": "/users",
+        "QUERY_STRING": "x=1",
+    }
+    assert construct_url(environ) == "http://localhost:8000/admin/users?x=1"
+
+
+def test_construct_url_no_script_name_passthrough():
+    """Empty SCRIPT_NAME is the common case (flat apps): the raw URI is returned as-is."""
+    environ = {
+        "wsgi.url_scheme": "http",
+        "HTTP_HOST": "localhost:8000",
+        "SCRIPT_NAME": "",
+        "PATH_INFO": "/users",
+        "RAW_URI": "/users",
+        "QUERY_STRING": "",
+    }
+    assert construct_url(environ) == "http://localhost:8000/users"


### PR DESCRIPTION
APPSEC-62528

## Summary

The shared `construct_url` helper in `ddtrace/contrib/internal/wsgi/wsgi.py` unconditionally prepended `SCRIPT_NAME` to `RAW_URI` / `REQUEST_URI`, which is wrong under werkzeug's `DispatcherMiddleware` (and similar in-process mounts) where the raw request URI **already contains** the mount prefix — yielding doubled URLs like `/admin/admin/users` on the `http.url` span tag.

### What changed

`construct_url` now distinguishes the two real-world WSGI flows that put a non-empty `SCRIPT_NAME` in `environ`:

1. **In-process mount (DispatcherMiddleware, etc.)** — the raw request URI is preserved pre-strip in `RAW_URI` / `REQUEST_URI` and already contains the mount prefix. `SCRIPT_NAME` is set to that same prefix. Prepending again would double it.
2. **Reverse proxy strip** — the proxy strips a path prefix before forwarding, exposing only the post-strip path in `RAW_URI` while reporting the prefix via `SCRIPT_NAME`. Skipping `SCRIPT_NAME` would lose the prefix from the reported URL.

The new logic checks whether the raw URI already starts with `SCRIPT_NAME`: case (1) does (don't prepend), case (2) doesn't (prepend). The `PATH_INFO` fallback path always prepends `SCRIPT_NAME` — `PATH_INFO` is the stripped value in both cases.

This bug pre-dates the Flask sub-app work but was surfaced by it. The fix affects **every WSGI-based integration**, not only Flask.

## Test plan

Five regression tests in `tests/contrib/wsgi/test_wsgi.py`, run as part of `contrib::wsgi`:

- [x] `test_construct_url_dispatcher_middleware_does_not_double_prefix` — pins the bug fix (RAW_URI includes prefix, must not double)
- [x] `test_construct_url_request_uri_dispatcher_middleware_does_not_double_prefix` — same coverage via the REQUEST_URI fallback (uWSGI)
- [x] `test_construct_url_reverse_proxy_prepends_script_name` — pins the reverse-proxy case (raw lacks prefix, must prepend)
- [x] `test_construct_url_path_info_fallback_uses_script_name` — canonical PEP-3333 reconstruction (no raw URI)
- [x] `test_construct_url_no_script_name_passthrough` — flat-app baseline

I verified the two DM regression tests **fail without the fix** with exactly the doubled-prefix behavior:
```
assert 'http://localhost:8000/admin/admin/users' == 'http://localhost:8000/admin/users'
```

Local validation (`scripts/run-tests --venv 5ec239b`, py3.13):
- `contrib::wsgi`: **32 passed** (27 prior + 5 new).

## Risks

- `construct_url` is shared infrastructure across all WSGI integrations. The behavior change is localized to the `SCRIPT_NAME != ""` cases:
  - **Flat apps** (empty `SCRIPT_NAME`, the common case): identical output.
  - **Reverse-proxy strip flow**: identical output (prefix was already correct pre-PR).
  - **In-process mount flow**: was producing doubled prefix, now produces correct path. Span `http.url` tag values change for users of `DispatcherMiddleware` or similar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)