### PR TITLE
chore: set version to 4.9.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.8.0rc5"
+version = "4.9.0rc1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Part of the normal release process. 4.8 release candidates will continue from the 4.8 branch.