### PR TITLE
refactor(profiling): remove `VmReader`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/vm.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/vm.h
@@ -11,9 +11,6 @@
 #include <echion/danger.h>
 
 #if defined PL_LINUX
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -75,60 +72,6 @@ inline ssize_t (*safe_copy)(pid_t,
                             const struct iovec*,
                             unsigned long,
                             unsigned long) = process_vm_readv;
-
-class VmReader
-{
-    void* buffer{ nullptr };
-    size_t sz{ 0 };
-    int fd{ -1 };
-    inline static VmReader* instance{ nullptr }; // Prevents having to set this in implementation
-
-    VmReader(size_t _sz, void* _buffer, int _fd)
-      : buffer(_buffer)
-      , sz{ _sz }
-      , fd{ _fd }
-    {
-    }
-
-    static VmReader* create(size_t sz);
-
-    bool is_valid() const { return buffer != nullptr; }
-
-  public:
-    static VmReader* get_instance();
-
-    ssize_t safe_copy(pid_t pid,
-                      const struct iovec* local_iov,
-                      unsigned long liovcnt,
-                      const struct iovec* remote_iov,
-                      unsigned long riovcnt,
-                      unsigned long flags);
-
-    ~VmReader()
-    {
-        if (buffer) {
-            munmap(buffer, sz);
-        }
-        if (fd != -1) {
-            close(fd);
-        }
-        instance = nullptr;
-    }
-};
-
-/**
- * Initialize the safe copy operation on Linux
- */
-bool
-read_process_vm_init();
-
-ssize_t
-vmreader_safe_copy(pid_t pid,
-                   const struct iovec* local_iov,
-                   unsigned long liovcnt,
-                   const struct iovec* remote_iov,
-                   unsigned long riovcnt,
-                   unsigned long flags);
 
 /**
  * Initialize the safe copy operation on Linux

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/vm.cc
@@ -4,8 +4,6 @@
 #include <array>
 #include <string>
 
-#include <cstdint>
-
 bool
 is_truthy(const char* s)
 {
@@ -30,127 +28,6 @@ use_alternative_copy_memory()
 }
 
 #if defined PL_LINUX
-VmReader*
-VmReader::create(size_t sz)
-{
-    // Makes a temporary file and ftruncates it to the specified size
-    std::array<std::string, 3> tmp_dirs = { "/dev/shm", "/tmp", "/var/tmp" };
-    std::string tmp_suffix = "/echion-XXXXXX";
-
-    int fd = -1;
-    void* ret = nullptr;
-
-    for (auto& tmp_dir : tmp_dirs) {
-        // Reset the file descriptor, just in case
-        close(fd);
-
-        // Create the temporary file
-        std::string tmpfile = tmp_dir + tmp_suffix;
-        fd = mkstemp(tmpfile.data());
-        if (fd == -1)
-            continue;
-
-        // Unlink might fail if delete is blocked on the VFS, but currently no action is taken
-        unlink(tmpfile.data());
-
-        // Make sure we have enough size
-        if (ftruncate(fd, static_cast<off_t>(sz)) == -1) {
-            continue;
-        }
-
-        // Map the file
-        ret = mmap(NULL, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
-        if (ret == MAP_FAILED) {
-            ret = nullptr;
-            continue;
-        }
-
-        // Successful.  Break.
-        break;
-    }
-
-    return new VmReader(sz, ret, fd);
-}
-
-namespace {
-constexpr size_t KB = 1024;
-constexpr size_t MB = KB * KB;
-} // namespace
-
-VmReader*
-VmReader::get_instance()
-{
-    if (instance == nullptr) {
-        instance = VmReader::create(MB);
-        if (!instance) {
-            std::cerr << "Failed to initialize VmReader" << std::endl;
-            return nullptr;
-        }
-    }
-
-    return instance;
-}
-
-ssize_t
-VmReader::safe_copy(pid_t process_id,
-                    const struct iovec* local_iov,
-                    unsigned long liovcnt,
-                    const struct iovec* remote_iov,
-                    unsigned long riovcnt,
-                    unsigned long flags)
-{
-    (void)process_id;
-    (void)flags;
-    if (liovcnt != 1 || riovcnt != 1) {
-        // Unsupported
-        return 0;
-    }
-
-    // Check to see if we need to resize the buffer
-    if (remote_iov[0].iov_len > sz) {
-        if (ftruncate(fd, static_cast<off_t>(remote_iov[0].iov_len)) == -1) {
-            return 0;
-        } else {
-            void* tmp = mremap(buffer, sz, remote_iov[0].iov_len, MREMAP_MAYMOVE);
-            if (tmp == MAP_FAILED) {
-                return 0;
-            }
-            buffer = tmp; // no need to munmap
-            sz = remote_iov[0].iov_len;
-        }
-    }
-
-    ssize_t ret = pwritev(fd, remote_iov, static_cast<int>(riovcnt), 0);
-    if (ret == -1) {
-        return ret;
-    }
-
-    // Copy the data from the buffer to the remote process
-    std::memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
-    return ret;
-}
-
-bool
-read_process_vm_init()
-{
-    VmReader* _ = VmReader::get_instance();
-    return !!_;
-}
-
-ssize_t
-vmreader_safe_copy(pid_t process_id,
-                   const struct iovec* local_iov,
-                   unsigned long liovcnt,
-                   const struct iovec* remote_iov,
-                   unsigned long riovcnt,
-                   unsigned long flags)
-{
-    auto reader = VmReader::get_instance();
-    if (!reader)
-        return 0;
-    return reader->safe_copy(process_id, local_iov, liovcnt, remote_iov, riovcnt, flags);
-}
-
 __attribute__((constructor)) void
 init_safe_copy()
 {
@@ -171,31 +48,19 @@ init_safe_copy()
         dst[i] = ~0x42;
     }
 
-    // Check to see that process_vm_readv works, unless it's overridden
-    const char force_override_str[] = "ECHION_ALT_VM_READ_FORCE";
-    const char* force_override = std::getenv(force_override_str);
-    if (!force_override || !is_truthy(force_override)) {
-        struct iovec iov_dst = { dst, sizeof(dst) };
-        struct iovec iov_src = { src, sizeof(src) };
-        ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
+    struct iovec iov_dst = { dst, sizeof(dst) };
+    struct iovec iov_src = { src, sizeof(src) };
+    ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
 
-        // If we succeed, then use process_vm_readv
-        if (result == sizeof(src)) {
-            safe_copy = process_vm_readv;
-            return;
-        }
-    }
-
-    // Else, we have to setup the writev method
-    if (!read_process_vm_init()) {
-        // std::cerr might not have been fully initialized at this point, so use
-        // fprintf instead.
-        fprintf(stderr, "Failed to initialize all safe copy interfaces\n");
-        failed_safe_copy = true;
+    if (result == sizeof(src)) {
+        safe_copy = process_vm_readv;
         return;
     }
 
-    safe_copy = vmreader_safe_copy;
+    // std::cerr might not have been fully initialized at this point, so use
+    // fprintf instead.
+    fprintf(stderr, "Failed to initialize safe copy interface\n");
+    failed_safe_copy = true;
 }
 #endif // PL_LINUX
 

--- a/releasenotes/notes/remove-alt-vmreader-07cb63ec874c8111.yaml
+++ b/releasenotes/notes/remove-alt-vmreader-07cb63ec874c8111.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    profiling: The ``ECHION_ALT_VM_READ_FORCE`` configuration flag has been removed
+    and support for the associated feature has been dropped.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-14386

(no previous PR) | [Next PR (17757) >](https://github.com/DataDog/dd-trace-py/pull/17757) 

**Please do not merge this PR for me.**

This PR removes the alternative memory copying implementation from the Python Profiler, which was previously supposedly used in case `process_vm_readv` was not available. In practice, the few cases where we saw it used proved ineffective (it would lead to crashes) and we are removing it as part of our work to move away from `process_vm_readv` to `memcpy`. 