### PR TITLE
ci(dsm): fix flaky test_data_streams_payload_size bucket-boundary race

### DIFF
--- a/tests/contrib/aiokafka/test_aiokafka_dsm.py
+++ b/tests/contrib/aiokafka/test_aiokafka_dsm.py
@@ -219,18 +219,22 @@ async def test_data_streams_payload_size_tracking(dsm_processor):
         if h_val is not None:
             expected_payload_size += len(h_val)
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
+    # DSM aggregates into 10s wall-clock buckets; produce and consume checkpoints
+    # can land in different buckets when the test straddles a boundary. Iterate
+    # all buckets and assert each recorded sketch matches expected_payload_size.
+    # Hold _lock so the periodic flusher can't mutate _buckets mid-iteration.
+    expected_sketch = DDSketch()
+    expected_sketch.add(expected_payload_size)
+    expected_proto = expected_sketch.to_proto()
 
-    bucket = list(buckets.values())[0]
-    pathway_stats = bucket.pathway_stats
-
-    for stats in pathway_stats.values():
-        assert stats.payload_size.count >= 1
-
-        expected_sketch = DDSketch()
-        expected_sketch.add(expected_payload_size)
-        assert stats.payload_size.to_proto() == expected_sketch.to_proto()
+    pathway_stats_count = 0
+    with dsm_processor._lock:
+        for bucket in dsm_processor._buckets.values():
+            for stats in bucket.pathway_stats.values():
+                pathway_stats_count += 1
+                assert stats.payload_size.count >= 1
+                assert stats.payload_size.to_proto() == expected_proto
+    assert pathway_stats_count >= 1, "no DSM pathway stats recorded for produce/consume"
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -44,15 +44,21 @@ def test_data_streams_payload_size(dsm_processor, consumer, producer, kafka_topi
     producer.produce(kafka_topic, payload, key=key, headers=test_headers)
     producer.flush()
     consumer.poll()
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-    first = list(buckets.values())[0].pathway_stats
-    for _bucket_name, bucket in first.items():
-        assert bucket.payload_size.count >= 1
 
-        expected_sketch = DDSketch()
-        expected_sketch.add(expected_payload_size)
-        assert bucket.payload_size.to_proto() == expected_sketch.to_proto()
+    # DSM aggregates into 10s wall-clock buckets; produce and consume checkpoints
+    # can land in different buckets when the test straddles a boundary. Iterate
+    # all buckets and assert each recorded sketch matches expected_payload_size.
+    expected_sketch = DDSketch()
+    expected_sketch.add(expected_payload_size)
+    expected_proto = expected_sketch.to_proto()
+
+    pathway_stats_count = 0
+    for bucket in dsm_processor._buckets.values():
+        for stats in bucket.pathway_stats.values():
+            pathway_stats_count += 1
+            assert stats.payload_size.count >= 1
+            assert stats.payload_size.to_proto() == expected_proto
+    assert pathway_stats_count >= 1, "no DSM checkpoints recorded for produce/consume"
 
 
 def test_data_streams_kafka_serializing(dsm_processor, deserializing_consumer, serializing_producer, kafka_topic):

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -48,17 +48,19 @@ def test_data_streams_payload_size(dsm_processor, consumer, producer, kafka_topi
     # DSM aggregates into 10s wall-clock buckets; produce and consume checkpoints
     # can land in different buckets when the test straddles a boundary. Iterate
     # all buckets and assert each recorded sketch matches expected_payload_size.
+    # Hold _lock so the periodic flusher can't mutate _buckets mid-iteration.
     expected_sketch = DDSketch()
     expected_sketch.add(expected_payload_size)
     expected_proto = expected_sketch.to_proto()
 
     pathway_stats_count = 0
-    for bucket in dsm_processor._buckets.values():
-        for stats in bucket.pathway_stats.values():
-            pathway_stats_count += 1
-            assert stats.payload_size.count >= 1
-            assert stats.payload_size.to_proto() == expected_proto
-    assert pathway_stats_count >= 1, "no DSM checkpoints recorded for produce/consume"
+    with dsm_processor._lock:
+        for bucket in dsm_processor._buckets.values():
+            for stats in bucket.pathway_stats.values():
+                pathway_stats_count += 1
+                assert stats.payload_size.count >= 1
+                assert stats.payload_size.to_proto() == expected_proto
+    assert pathway_stats_count >= 1, "no DSM pathway stats recorded for produce/consume"
 
 
 def test_data_streams_kafka_serializing(dsm_processor, deserializing_consumer, serializing_producer, kafka_topic):


### PR DESCRIPTION
## Summary

Fixes the `test_data_streams_payload_size` flake in `tests/contrib/kafka/test_kafka_dsm.py` and the matching `test_data_streams_payload_size_tracking` in `tests/contrib/aiokafka/test_aiokafka_dsm.py`. The kafka one has been flaking at 0.66-1.31% across all 27 parametrized variants (3 keys x 3 payloads x 3 Python versions), all currently quarantined under @DataDog/data-streams-monitoring. The aiokafka sibling has the same flake mode and is folded in here.

## Root cause

`DataStreamsProcessor` keys `_buckets` by `now_ns - (now_ns % _bucket_size_ns)` (`ddtrace/internal/datastreams/processor.py:171`) with a 10-second interval. Each test produces one Kafka message and polls it, generating a produce-side and a consume-side checkpoint. When those operations straddle a 10s wall-clock boundary they land in different buckets, breaking `assert len(buckets) == 1`. Probability of straddle is roughly `test_runtime_ms / 10000ms`, which matches the observed flake rate.

The flake has been latent since #7259 (2023-10-18). It only got auto-quarantined when the flaky-test policy was activated for dd-trace-py around 2026-04-24, which produced the visible step change in quarantined-test counts on that day.

## Fix

Iterate all buckets and assert each recorded `pathway_stats` sketch matches `expected_payload_size`. Two safety improvements while in there:

- Hold `dsm_processor._lock` during iteration. The 10s flusher mutates `_buckets` (`_serialize_buckets` deletes keys after serializing), and without the lock the test could hit `RuntimeError: dictionary changed size during iteration`.
- Add `assert pathway_stats_count >= 1`. The original `assert len(buckets) == 1` accepted an empty `pathway_stats` dict and would have silently passed if no checkpoints were recorded.

A product-side fix (monotonic time, or a test-only `_drain_for_testing()` accessor) was considered and rejected: 10s wall-clock buckets are the wire format the agent expects from `/v0.1/pipeline_stats`, and changing it would break the contract with other tracers.

> [!NOTE]
> This fix was developed with the assistance of an LLM (Claude).

## Testing

Reproduced the race in a standalone harness that mirrors the assertion logic against forced bucket states. Confirmed the new logic passes both the happy path and the bucket-straddle case, fails loudly on empty `pathway_stats`, and still catches an incorrect payload size. Local kafka integration tests require a docker-compose Kafka container; relying on CI to exercise all 27 kafka variants plus the aiokafka sibling.

## Unquarantine

After merge, once CI confirms the affected tests are stable, manually unquarantine them in Flaky Management. (Consistent with how other dd-trace-py flaky fixes have shipped recently.)

## Risks

Test-only change. No production code modified.

## Labels

`changelog/no-changelog` test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
