### PR TITLE
chore(snapshots): wrong service was provided in TracingSubscriber

### DIFF
--- a/ddtrace/_trace/subscribers/_base.py
+++ b/ddtrace/_trace/subscribers/_base.py
@@ -38,7 +38,7 @@ def _finish_span(
     if not span:
         return
 
-    set_service_and_source(span, ctx.get_item("service"), ctx.event.integration_config or dict())
+    set_service_and_source(span, ctx.event.service or "", ctx.event.integration_config or dict())
 
     exc_type, exc_value, exc_traceback = exc_info
     if exc_type and exc_value and exc_traceback:
@@ -97,7 +97,7 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
     if event.measured:
         span._set_attribute(_SPAN_MEASURED_KEY, 1)
 
-    set_service_and_source(span, ctx.get_item("service"), integration_config or dict())
+    set_service_and_source(span, ctx.event.service or "", integration_config or dict())
     ctx.span = span
 
     if config._inferred_proxy_services_enabled:


### PR DESCRIPTION
In `TracingSubscriber`, we were using `ctx.get_item("service")` in `set_service_and_source`.  However, this field is never populated.

Replaced it with `event.service` which is populated.