### PR TITLE
ci(microbenchmarks): benchmarks-pr-comment explicitly needs microbenchmarks artifacts

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -163,7 +163,9 @@ benchmarks-pr-comment:
   image: $MICROBENCHMARKS_CI_IMAGE
   tags: ["arch:amd64"]
   stage: report
-  needs: [ "check-slo-breaches" ]
+  needs:
+    - check-slo-breaches
+    - microbenchmarks
   when: always
   allow_failure: true
   script: |

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -164,8 +164,9 @@ benchmarks-pr-comment:
   tags: ["arch:amd64"]
   stage: report
   needs:
-    - check-slo-breaches
-    - microbenchmarks
+    - pipeline: $PARENT_PIPELINE_ID
+      job: tests-gen
+    - job: microbenchmarks
   when: always
   allow_failure: true
   script: |


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

`benchmarks-pr-comment` needs `microbenchmarks` artifacts to successfully upload them to the BP UI.

We were seeing instances of jobs with failed uploads to the BP UI, even if artifacts were produced by `microbenchmarks`: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1641457915

This might indicate that `benchmarks-pr-comment` ran without artifacts in some way. 

We can mitigate this by explicitly requiring artifacts.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

None. It is safe to assume that `benchmarks-pr-comments` should require benchmarks to finish to upload their results to the BP UI and to post PR comments.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
