### PR TITLE
chore(profiling): add internal metric for sampling cpu time

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -46,6 +46,9 @@ class ProfilerStats
     // Number of greenlets currently tracked by the stack profiler
     std::optional<size_t> greenlet_count;
 
+    // Total CPU time (in microseconds) spent by the sampler thread capturing samples
+    size_t sample_capture_cpu_time_us = 0;
+
   public:
     ProfilerStats() = default;
     ~ProfilerStats() = default;
@@ -79,6 +82,9 @@ class ProfilerStats
 
     void set_greenlet_count(size_t count);
     std::optional<size_t> get_greenlet_count() const;
+
+    void add_sample_capture_cpu_time_us(size_t cpu_time_us);
+    size_t get_sample_capture_cpu_time_us() const;
 
     // Returns a JSON string containing relevant Profiler Stats to be included
     // in the libdatadog payload.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -50,6 +50,7 @@ Datadog::ProfilerStats::reset_state()
     heap_tracker_size = std::nullopt;
     asyncio_task_count = std::nullopt;
     greenlet_count = std::nullopt;
+    sample_capture_cpu_time_us = 0;
     // fast_copy_memory_enabled is intentionally not reset: it reflects a static configuration
 }
 
@@ -149,6 +150,18 @@ Datadog::ProfilerStats::get_greenlet_count() const
     return greenlet_count;
 }
 
+void
+Datadog::ProfilerStats::add_sample_capture_cpu_time_us(size_t cpu_time_us)
+{
+    sample_capture_cpu_time_us += cpu_time_us;
+}
+
+size_t
+Datadog::ProfilerStats::get_sample_capture_cpu_time_us() const
+{
+    return sample_capture_cpu_time_us;
+}
+
 std::string
 Datadog::ProfilerStats::get_internal_metadata_json()
 {
@@ -216,6 +229,10 @@ Datadog::ProfilerStats::get_internal_metadata_json()
 
     internal_metadata_json += R"("copy_memory_error_count": )";
     append_to_string(internal_metadata_json, copy_memory_error_count);
+    internal_metadata_json += ",";
+
+    internal_metadata_json += R"("sample_capture_cpu_time_us": )";
+    append_to_string(internal_metadata_json, sample_capture_cpu_time_us);
 
     internal_metadata_json += "}";
 

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -329,21 +329,16 @@ Sampler::sampling_thread(const uint64_t seq_num)
             }
         }
 
-        Sample::profile_borrow().stats().increment_sampling_event_count();
-        Sample::profile_borrow().stats().set_string_table_count(echion->string_table().size());
-        Sample::profile_borrow().stats().set_string_table_ephemeral_count(echion->string_table().ephemeral_size());
-        Sample::profile_borrow().stats().set_fast_copy_memory_enabled(fast_copy_active);
-        Sample::profile_borrow().stats().set_asyncio_task_count(echion->asyncio_task_count());
+        // Collect greenlet count before acquiring the profile lock to avoid
+        // holding two locks simultaneously (greenlet lock then profile lock).
+        size_t greenlet_count;
         {
             const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
-            Sample::profile_borrow().stats().set_greenlet_count(echion->greenlet_info_map().size());
+            greenlet_count = echion->greenlet_info_map().size();
         }
 
-        // Drain copy_memory errors accumulated since the last sampling cycle into ProfilerStats
+        // Drain copy_memory errors accumulated since the last sampling cycle.
         auto copy_errors = g_copy_memory_error_count.exchange(0, std::memory_order_relaxed);
-        if (copy_errors > 0) {
-            Sample::profile_borrow().stats().add_copy_memory_error_count(copy_errors);
-        }
 
         if (do_adaptive_sampling) {
             // Adjust the sampling interval at most every second
@@ -353,16 +348,36 @@ Sampler::sampling_thread(const uint64_t seq_num)
             }
         }
 
+        // Measure CPU time before acquiring the profile lock so lock-wait time is
+        // not counted as sampling overhead.
+        auto sample_capture_cpu_after = get_thread_cpu_time_us();
+
+        // Update all end-of-cycle stats under a single borrow so they always land in
+        // the same upload window as the samples they describe. Without this, the uploader
+        // could swap cur_profiler_stats between two separate borrow calls, silently
+        // shifting some counters (including sample_capture_cpu_time_us) into the next window.
+        {
+            auto borrow = Sample::profile_borrow();
+
+            borrow.stats().increment_sampling_event_count();
+            borrow.stats().set_string_table_count(echion->string_table().size());
+            borrow.stats().set_string_table_ephemeral_count(echion->string_table().ephemeral_size());
+            borrow.stats().set_fast_copy_memory_enabled(fast_copy_active);
+            borrow.stats().set_asyncio_task_count(echion->asyncio_task_count());
+            borrow.stats().set_greenlet_count(greenlet_count);
+
+            if (copy_errors > 0) {
+                borrow.stats().add_copy_memory_error_count(copy_errors);
+            }
+
+            if (sample_capture_cpu_after > sample_capture_cpu_before) {
+                borrow.stats().add_sample_capture_cpu_time_us(sample_capture_cpu_after - sample_capture_cpu_before);
+            }
+        }
+
         // Before sleeping, check whether the user has called for this thread to die.
         if (seq_num != thread_seq_num.load()) {
             break;
-        }
-
-        // Report the CPU time spent capturing samples
-        auto sample_capture_cpu_after = get_thread_cpu_time_us();
-        if (sample_capture_cpu_after > sample_capture_cpu_before) {
-            auto elapsed = sample_capture_cpu_after - sample_capture_cpu_before;
-            Sample::profile_borrow().stats().add_sample_capture_cpu_time_us(elapsed);
         }
 
         // Sleep for the remainder of the interval, get it atomically

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -15,6 +15,7 @@
 #include "echion/threads.h"
 #include "echion/vm.h"
 
+#include <cstdint>
 #include <cstring>
 #include <mutex>
 #include <pthread.h>
@@ -72,6 +73,42 @@ create_thread_with_stack(size_t stack_size, Sampler* sampler, uint64_t seq_num)
 #elif defined(__MACH__)
 #include <mach/mach.h>
 #endif
+
+namespace {
+
+// Returns the CPU time of the calling thread in microseconds, or 0 on error.
+uint64_t
+get_thread_cpu_time_us()
+{
+#if defined(__linux__)
+    struct timespec ts
+    {
+        0, 0
+    };
+
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) {
+        return 0;
+    }
+
+    return static_cast<uint64_t>(ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000);
+#elif defined(__MACH__)
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    thread_basic_info_data_t info;
+    thread_port_t thread = mach_thread_self();
+    int kr = thread_info(thread, THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&info), &count);
+    mach_port_deallocate(mach_task_self(), thread);
+    if (kr != KERN_SUCCESS) {
+        return 0;
+    }
+
+    return static_cast<uint64_t>(info.user_time.seconds * 1000000ULL + info.user_time.microseconds +
+                                 info.system_time.seconds * 1000000ULL + info.system_time.microseconds);
+#else
+    return 0;
+#endif
+}
+
+} // namespace
 
 void
 Sampler::adapt_sampling_interval()
@@ -184,6 +221,8 @@ Sampler::sampling_thread(const uint64_t seq_num)
 
     auto* const runtime = &_PyRuntime;
     while (seq_num == thread_seq_num.load()) {
+        auto sample_capture_cpu_before = get_thread_cpu_time_us();
+
         // Clear ephemeral string table entries (task names, greenlet names) periodically.
         // Safe because strings are copied into StringArena during sample construction.
         auto current_upload_seq = ProfilerState::get().upload_seq.load(std::memory_order_relaxed);
@@ -317,6 +356,13 @@ Sampler::sampling_thread(const uint64_t seq_num)
         // Before sleeping, check whether the user has called for this thread to die.
         if (seq_num != thread_seq_num.load()) {
             break;
+        }
+
+        // Report the CPU time spent capturing samples
+        auto sample_capture_cpu_after = get_thread_cpu_time_us();
+        if (sample_capture_cpu_after > sample_capture_cpu_before) {
+            auto elapsed = sample_capture_cpu_after - sample_capture_cpu_before;
+            Sample::profile_borrow().stats().add_sample_capture_cpu_time_us(elapsed);
         }
 
         // Sleep for the remainder of the interval, get it atomically

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -90,7 +90,7 @@ get_thread_cpu_time_us()
         return 0;
     }
 
-    return static_cast<uint64_t>(ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000);
+    return static_cast<uint64_t>(ts.tv_sec * 1'000'000ULL + ts.tv_nsec / 1000);
 #elif defined(__MACH__)
     mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
     thread_basic_info_data_t info;
@@ -101,8 +101,8 @@ get_thread_cpu_time_us()
         return 0;
     }
 
-    return static_cast<uint64_t>(info.user_time.seconds * 1000000ULL + info.user_time.microseconds +
-                                 info.system_time.seconds * 1000000ULL + info.system_time.microseconds);
+    return static_cast<uint64_t>(info.user_time.seconds + info.system_time.seconds) * 1'000'000ULL +
+           info.user_time.microseconds + info.system_time.microseconds;
 #else
     return 0;
 #endif
@@ -120,10 +120,10 @@ Sampler::adapt_sampling_interval()
     };
 
     clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
-    auto new_process_count = static_cast<uint64_t>(ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000);
+    auto new_process_count = static_cast<uint64_t>(ts.tv_sec * 1'000'000ULL + ts.tv_nsec / 1000);
 
     clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
-    auto new_sampler_thread_count = static_cast<uint64_t>(ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000);
+    auto new_sampler_thread_count = static_cast<uint64_t>(ts.tv_sec * 1'000'000ULL + ts.tv_nsec / 1000);
 #elif defined(__MACH__)
     // Get the process CPU time
     task_thread_times_info_data_t task_info_data;
@@ -370,8 +370,9 @@ Sampler::sampling_thread(const uint64_t seq_num)
                 borrow.stats().add_copy_memory_error_count(copy_errors);
             }
 
-            if (sample_capture_cpu_after > sample_capture_cpu_before) {
-                borrow.stats().add_sample_capture_cpu_time_us(sample_capture_cpu_after - sample_capture_cpu_before);
+            size_t cpu_diff = sample_capture_cpu_after - sample_capture_cpu_before;
+            if (cpu_diff > 0) {
+                borrow.stats().add_sample_capture_cpu_time_us(cpu_diff);
             }
         }
 


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-14070

This PR adds an internal metric to profiles to measure the total CPU time we used (per minute) to capture samples in the Stack Profiler. 

On top of this, the PR slightly refactors the logic around reporting `ProfilerStats` to avoid a race condition where we could have a sort of "torn write" where part of the `ProfilerStats` were written in the "current Profile" and some would be written in the "next Profile" -- if the Uploader kicked in in the middle of our calls to methds on `Sample::profile_borrow().stats()`. We now only take `Sample::profile_borrow()` once and keep pushing stuff to it (and to do that, we capture the values we need to push first, and then push them all in a single pass at the end).