### PR TITLE
test(debugger): remove 3.9 exploration runs

### DIFF
--- a/.gitlab/debugging-exploration.yml
+++ b/.gitlab/debugging-exploration.yml
@@ -24,9 +24,6 @@
       parallel:
         matrix:
           - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp39-cp39"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-          - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp310-cp310"
             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
@@ -78,7 +75,7 @@
     DD_DEBUGGER_EXPL_INCLUDE: "boto3"
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+      - PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   script: |
     git clone --depth 1 --branch ${BOTO3_TAG} https://github.com/boto/boto3.git
     cd boto3
@@ -105,7 +102,7 @@
     DD_DEBUGGER_EXPL_COVERAGE_INSTRUMENTATION_RATE: "0.01"
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+      - PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   script: |
     git clone --depth 1 --branch ${BOTO3_TAG} https://github.com/boto/boto3.git
     cd boto3


### PR DESCRIPTION
## Description

The latest releases of boto have dropped support for Python 3.9. Since we haven't made any changes to the bytecode handling for 3.9 in quite some time we can drop the runs for this version from the exploration tests.