### PR TITLE
test(appsec): assert SCA dependencies+metadata in app-extended-heartbeat

### DIFF
--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -391,6 +391,70 @@ def _find_dep_with_cve_in_extended(events, dep_name, cve_id):
     return None, None
 
 
+def _wait_for_extended_heartbeat_events(token, min_count=1, timeout=20.0, interval=0.5):
+    """Poll the test agent until ``min_count`` app-extended-heartbeat events have arrived.
+
+    Replaces fixed ``time.sleep`` waits so slow CI runners (where SCA-enabled
+    subprocess startup can eat several seconds) do not race the heartbeat
+    interval. Returns whatever events are available at timeout — callers must
+    still assert on the result.
+    """
+    deadline = time.monotonic() + timeout
+    events: list = []
+    while time.monotonic() < deadline:
+        events = _get_extended_heartbeat_events(token)
+        if len(events) >= min_count:
+            return events
+        time.sleep(interval)
+    return events
+
+
+def _wait_for_cve_reached_in_extended(token, dep_name, cve_id, timeout=20.0, interval=0.5):
+    """Poll until an extended-heartbeat carries ``cve_id`` on ``dep_name`` with a non-empty reached list.
+
+    A heartbeat that fires before the vulnerable call would snapshot the CVE
+    with ``reached=[]``; this waits for a tick that captures the populated
+    entry. Returns ``(events, dep, cve_value)``; ``dep``/``cve_value`` may be
+    ``None`` on timeout so the caller can produce a useful assertion message.
+    """
+    deadline = time.monotonic() + timeout
+    events: list = []
+    while time.monotonic() < deadline:
+        events = _get_extended_heartbeat_events(token)
+        dep, cve_value = _find_dep_with_cve_in_extended(events, dep_name, cve_id)
+        if dep is not None and cve_value and len(cve_value.get("reached", [])) >= 1:
+            return events, dep, cve_value
+        time.sleep(interval)
+    return events, None, None
+
+
+def _wait_for_extended_snapshot_covers_delta(token, timeout=20.0, interval=0.5):
+    """Poll until the latest extended-heartbeat snapshot is a superset of the delta channel.
+
+    Within a single ``periodic()`` tick, ``_report_dependencies`` (delta) and
+    ``_report_heartbeat`` (snapshot) hold the same DependencyTracker lock and
+    run sequentially, so the snapshot is at least as fresh as the delta. This
+    poll waits for at least one such tick to have fired AFTER the in-test
+    requests so the latest snapshot reflects every dep the deltas reported.
+
+    Returns ``(delta_events, extended_events)`` — possibly stale on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    delta_events: list = []
+    extended_events: list = []
+    while time.monotonic() < deadline:
+        delta_events = _get_dependency_events(token)
+        extended_events = _get_extended_heartbeat_events(token)
+        if delta_events and extended_events:
+            delta_names = {d["name"] for d in _collect_all_deps(delta_events) if d.get("name")}
+            latest = extended_events[-1].get("payload", {}).get("dependencies", [])
+            latest_names = {d["name"] for d in latest if d.get("name")}
+            if delta_names and delta_names <= latest_names:
+                return delta_events, extended_events
+        time.sleep(interval)
+    return delta_events, extended_events
+
+
 class TestSCAFlaskExtendedHeartbeat:
     """SCA telemetry e2e tests asserting the app-extended-heartbeat payload.
 
@@ -412,9 +476,10 @@ class TestSCAFlaskExtendedHeartbeat:
             _, flask_client, pid = context
             response = flask_client.get("/", headers={"X-Datadog-Test-Session-Token": iast_test_token})
             assert response.status_code == 200
-            time.sleep(4)
+            # Wait for at least one extended-heartbeat tick — bounded poll
+            # avoids racing slow-CI startup against a fixed sleep window.
+            events = _wait_for_extended_heartbeat_events(iast_test_token, min_count=1, timeout=20.0)
 
-        events = _get_extended_heartbeat_events(iast_test_token)
         assert len(events) > 0, "No app-extended-heartbeat events found"
 
         # Configuration must always be present in the extended payload.
@@ -456,15 +521,14 @@ class TestSCAFlaskExtendedHeartbeat:
             response = flask_client.get("/sca-test-requests", headers={"X-Datadog-Test-Session-Token": iast_test_token})
             assert response.status_code == 200
 
-            # Allow at least one heartbeat tick AFTER the vulnerable call so the
-            # extended heartbeat payload re-snapshots tracked deps with the new
-            # metadata.
-            time.sleep(5)
+            # Wait for a heartbeat tick AFTER the vulnerable call that captures
+            # the populated reached entry. Polls instead of sleeping a fixed
+            # window so a slow CI runner doesn't miss the post-call tick.
+            events, dep, cve_value = _wait_for_cve_reached_in_extended(
+                iast_test_token, "requests", "CVE-2024-35195", timeout=20.0
+            )
 
-        events = _get_extended_heartbeat_events(iast_test_token)
         assert len(events) > 0, "No app-extended-heartbeat events found"
-
-        dep, cve_value = _find_dep_with_cve_in_extended(events, "requests", "CVE-2024-35195")
         assert dep is not None, (
             "CVE-2024-35195 not present in any app-extended-heartbeat dependency metadata. "
             f"Extended events: {json.dumps(events, indent=2)[:2000]}"
@@ -510,10 +574,12 @@ class TestSCAFlaskExtendedHeartbeat:
             response = flask_client.get("/sca-test-requests", headers={"X-Datadog-Test-Session-Token": iast_test_token})
             assert response.status_code == 200
 
-            time.sleep(5)
-
-        delta_events = _get_dependency_events(iast_test_token)
-        extended_events = _get_extended_heartbeat_events(iast_test_token)
+            # Poll for a heartbeat tick AFTER the request that already shows
+            # delta ⊆ latest extended snapshot. Within a tick, both reports run
+            # under the same DependencyTracker lock, so this is the natural
+            # synchronization point — superior to a fixed sleep that can miss
+            # the post-request tick on slow runners.
+            delta_events, extended_events = _wait_for_extended_snapshot_covers_delta(iast_test_token, timeout=20.0)
 
         assert len(delta_events) > 0, "No app-dependencies-loaded events to compare against"
         assert len(extended_events) > 0, "No app-extended-heartbeat events found"

--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -368,14 +368,6 @@ _SCA_EXTENDED_HEARTBEAT_ENV = {
 }
 
 
-def _collect_all_deps_extended(events):
-    """Flatten dependencies from app-extended-heartbeat events."""
-    all_deps = []
-    for event in events:
-        all_deps.extend(event.get("payload", {}).get("dependencies", []))
-    return all_deps
-
-
 def _find_dep_with_cve_in_extended(events, dep_name, cve_id):
     """Find a dependency carrying a specific CVE in the most recent extended-heartbeat event.
 
@@ -431,7 +423,7 @@ class TestSCAFlaskExtendedHeartbeat:
                 f"app-extended-heartbeat missing configuration: {event['payload']}"
             )
 
-        all_deps = _collect_all_deps_extended(events)
+        all_deps = _collect_all_deps(events)
         assert len(all_deps) > 0, (
             f"Expected dependencies in app-extended-heartbeat with SCA enabled, got none. Events: {events[:1]}"
         )
@@ -489,16 +481,17 @@ class TestSCAFlaskExtendedHeartbeat:
         assert hit.get("line", 0) > 0
 
     def test_extended_heartbeat_dependency_list_is_full_snapshot(self, iast_test_token):
-        """The extended-heartbeat dependency list must be a full snapshot, not a delta.
+        """The extended-heartbeat dependency list must be a superset of the delta channel.
 
         Compares the union of dependencies seen across app-dependencies-loaded
         (the per-tick delta) against a single app-extended-heartbeat payload
         (the latest one received). The contract is that one extended-heartbeat
-        event re-sends the *full* dependency snapshot, so the backend can
-        reconcile state from any single such payload without needing to
-        accumulate prior deltas. Asserting against the aggregate of all
-        extended events would mask the exact regression we want to catch:
-        per-event partial slices would still union to the full set.
+        event must contain at least every dep ever reported via the delta
+        channel, so the backend can reconcile state from any single such
+        payload without needing to accumulate prior deltas. Asserting against
+        the aggregate of all extended events would mask the exact regression
+        we want to catch: per-event partial slices would still union to the
+        full set.
         """
         with flask_server(
             appsec_enabled="false",

--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -51,6 +51,26 @@ def _get_dependency_events(token):
     return events
 
 
+def _get_extended_heartbeat_events(token):
+    """Extract app-extended-heartbeat events from the test agent session."""
+    requests = _get_telemetry_requests(token)
+    events = []
+    for req in requests:
+        if "apmtelemetry" not in req.get("url", ""):
+            continue
+        try:
+            body = json.loads(base64.b64decode(req["body"]))
+        except Exception:
+            continue
+        if body.get("request_type") == "message-batch":
+            for sub in body.get("payload", []):
+                if sub.get("request_type") == "app-extended-heartbeat":
+                    events.append(sub)
+        elif body.get("request_type") == "app-extended-heartbeat":
+            events.append({"payload": body["payload"], "request_type": body["request_type"]})
+    return events
+
+
 def _collect_all_deps(events):
     """Flatten all dependencies from all events into a single list."""
     all_deps = []
@@ -335,4 +355,177 @@ class TestSCAFlaskTelemetry:
         # reached should be empty — no vulnerable endpoint was called
         assert len(cve_value["reached"]) == 0, (
             f"Expected reached=[] for CVE registered at load time (no vulnerable call), got: {cve_value['reached']}"
+        )
+
+
+_SCA_EXTENDED_HEARTBEAT_ENV = {
+    "DD_APPSEC_SCA_ENABLED": "true",
+    "_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED": "true",
+    "DD_TELEMETRY_HEARTBEAT_INTERVAL": "2",
+    # Force the extended-heartbeat payload to fire on every heartbeat tick so we
+    # can inspect it within the test's lifetime instead of waiting 24h.
+    "_DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL": "1",
+}
+
+
+def _collect_all_deps_extended(events):
+    """Flatten dependencies from app-extended-heartbeat events."""
+    all_deps = []
+    for event in events:
+        all_deps.extend(event.get("payload", {}).get("dependencies", []))
+    return all_deps
+
+
+def _find_dep_with_cve_in_extended(events, dep_name, cve_id):
+    """Find a dependency carrying a specific CVE in any extended-heartbeat event."""
+    for dep in _collect_all_deps_extended(events):
+        if dep.get("name") != dep_name:
+            continue
+        for meta_entry in dep.get("metadata", []):
+            if meta_entry.get("type") != "reachability":
+                continue
+            try:
+                value = json.loads(meta_entry["value"])
+            except (json.JSONDecodeError, KeyError, TypeError):
+                continue
+            if value.get("id") == cve_id:
+                return dep, value
+    return None, None
+
+
+class TestSCAFlaskExtendedHeartbeat:
+    """SCA telemetry e2e tests asserting the app-extended-heartbeat payload.
+
+    The extended heartbeat is meant to be a *complete* snapshot of the
+    application's dependencies and SCA reachability findings, re-sent on a
+    long interval so the backend can recover from missed deltas. These tests
+    pin down that contract end-to-end.
+    """
+
+    def test_extended_heartbeat_includes_dependencies_with_metadata_key(self, iast_test_token):
+        """SCA on: extended heartbeat carries dependencies and metadata key is preserved."""
+        with flask_server(
+            appsec_enabled="false",
+            iast_enabled="false",
+            token=iast_test_token,
+            port=8056,
+            env=_SCA_EXTENDED_HEARTBEAT_ENV,
+        ) as context:
+            _, flask_client, pid = context
+            response = flask_client.get("/", headers={"X-Datadog-Test-Session-Token": iast_test_token})
+            assert response.status_code == 200
+            time.sleep(4)
+
+        events = _get_extended_heartbeat_events(iast_test_token)
+        assert len(events) > 0, "No app-extended-heartbeat events found"
+
+        # Configuration must always be present in the extended payload.
+        for event in events:
+            assert "configuration" in event["payload"], (
+                f"app-extended-heartbeat missing configuration: {event['payload']}"
+            )
+
+        all_deps = _collect_all_deps_extended(events)
+        assert len(all_deps) > 0, (
+            f"Expected dependencies in app-extended-heartbeat with SCA enabled, got none. Events: {events[:1]}"
+        )
+
+        deps_with_metadata_key = [d for d in all_deps if "metadata" in d]
+        assert len(deps_with_metadata_key) > 0, (
+            f"Expected SCA-tracked deps to carry the 'metadata' key in extended heartbeat. Sample deps: {all_deps[:3]}"
+        )
+
+    def test_extended_heartbeat_includes_cve_metadata_after_vulnerable_call(self, iast_test_token):
+        """After a vulnerable call, CVE reachability shows up in app-extended-heartbeat too.
+
+        This is the contract-critical scenario: even if the backend missed the
+        original app-dependencies-loaded delta, the next extended heartbeat
+        must re-send the full snapshot including the attached CVE metadata.
+        """
+        with flask_server(
+            appsec_enabled="false",
+            iast_enabled="false",
+            token=iast_test_token,
+            port=8057,
+            env=_SCA_EXTENDED_HEARTBEAT_ENV,
+        ) as context:
+            _, flask_client, pid = context
+
+            response = flask_client.get("/", headers={"X-Datadog-Test-Session-Token": iast_test_token})
+            assert response.status_code == 200
+
+            # Trigger the vulnerable code path to attach reachability metadata.
+            response = flask_client.get("/sca-test-requests", headers={"X-Datadog-Test-Session-Token": iast_test_token})
+            assert response.status_code == 200
+
+            # Allow at least one heartbeat tick AFTER the vulnerable call so the
+            # extended heartbeat payload re-snapshots tracked deps with the new
+            # metadata.
+            time.sleep(5)
+
+        events = _get_extended_heartbeat_events(iast_test_token)
+        assert len(events) > 0, "No app-extended-heartbeat events found"
+
+        dep, cve_value = _find_dep_with_cve_in_extended(events, "requests", "CVE-2024-35195")
+        assert dep is not None, (
+            "CVE-2024-35195 not present in any app-extended-heartbeat dependency metadata. "
+            f"Extended events: {json.dumps(events, indent=2)[:2000]}"
+        )
+        assert dep["name"] == "requests"
+        assert cve_value["id"] == "CVE-2024-35195"
+        assert isinstance(cve_value["reached"], list)
+        assert len(cve_value["reached"]) >= 1, (
+            f"Expected reached entry in extended heartbeat after vulnerable call, got: {cve_value['reached']}"
+        )
+        hit = cve_value["reached"][0]
+        assert "app.py" in hit["path"], f"Expected caller path containing 'app.py', got: {hit['path']}"
+        assert "sca_test_requests" in hit.get("symbol", "")
+        assert hit.get("line", 0) > 0
+
+    def test_extended_heartbeat_dependency_list_is_full_snapshot(self, iast_test_token):
+        """The extended-heartbeat dependency list must be a full snapshot, not a delta.
+
+        Compares the union of dependencies seen across app-dependencies-loaded
+        (the per-tick delta) against the list emitted in app-extended-heartbeat.
+        Every dep ever reported via the delta channel must show up at least once
+        in an extended-heartbeat snapshot, since the snapshot is meant to let the
+        backend reconcile state without relying on every delta being received.
+        """
+        with flask_server(
+            appsec_enabled="false",
+            iast_enabled="false",
+            token=iast_test_token,
+            port=8058,
+            env=_SCA_EXTENDED_HEARTBEAT_ENV,
+        ) as context:
+            _, flask_client, pid = context
+
+            response = flask_client.get("/", headers={"X-Datadog-Test-Session-Token": iast_test_token})
+            assert response.status_code == 200
+
+            # Hit a route that imports more modules so the dep set grows over
+            # time, increasing the chance of catching a delta-vs-snapshot drift.
+            response = flask_client.get("/sca-test-requests", headers={"X-Datadog-Test-Session-Token": iast_test_token})
+            assert response.status_code == 200
+
+            time.sleep(5)
+
+        delta_events = _get_dependency_events(iast_test_token)
+        extended_events = _get_extended_heartbeat_events(iast_test_token)
+
+        assert len(delta_events) > 0, "No app-dependencies-loaded events to compare against"
+        assert len(extended_events) > 0, "No app-extended-heartbeat events found"
+
+        delta_names = {d["name"] for d in _collect_all_deps(delta_events) if d.get("name")}
+        snapshot_names = {d["name"] for d in _collect_all_deps_extended(extended_events) if d.get("name")}
+
+        # The latest extended heartbeat is meant to be a complete snapshot.
+        # The delta channel may include deps the snapshot also includes, but
+        # the snapshot must cover the union of what was reported, so any delta
+        # name absent from every snapshot is a contract violation.
+        missing = delta_names - snapshot_names
+        assert not missing, (
+            f"Dependencies reported via app-dependencies-loaded are missing from every "
+            f"app-extended-heartbeat snapshot — extended heartbeat is not a full snapshot. "
+            f"Missing: {sorted(missing)[:20]}"
         )

--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -377,19 +377,25 @@ def _collect_all_deps_extended(events):
 
 
 def _find_dep_with_cve_in_extended(events, dep_name, cve_id):
-    """Find a dependency carrying a specific CVE in any extended-heartbeat event."""
-    for dep in _collect_all_deps_extended(events):
-        if dep.get("name") != dep_name:
-            continue
-        for meta_entry in dep.get("metadata", []):
-            if meta_entry.get("type") != "reachability":
+    """Find a dependency carrying a specific CVE in the most recent extended-heartbeat event.
+
+    Iterates events newest-first so an early heartbeat that snapshots the CVE
+    pre-vulnerable-call (with reached=[]) does not shadow a later heartbeat
+    that captured the populated reached entry.
+    """
+    for event in reversed(events):
+        for dep in event.get("payload", {}).get("dependencies", []):
+            if dep.get("name") != dep_name:
                 continue
-            try:
-                value = json.loads(meta_entry["value"])
-            except (json.JSONDecodeError, KeyError, TypeError):
-                continue
-            if value.get("id") == cve_id:
-                return dep, value
+            for meta_entry in dep.get("metadata", []):
+                if meta_entry.get("type") != "reachability":
+                    continue
+                try:
+                    value = json.loads(meta_entry["value"])
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    continue
+                if value.get("id") == cve_id:
+                    return dep, value
     return None, None
 
 
@@ -486,10 +492,13 @@ class TestSCAFlaskExtendedHeartbeat:
         """The extended-heartbeat dependency list must be a full snapshot, not a delta.
 
         Compares the union of dependencies seen across app-dependencies-loaded
-        (the per-tick delta) against the list emitted in app-extended-heartbeat.
-        Every dep ever reported via the delta channel must show up at least once
-        in an extended-heartbeat snapshot, since the snapshot is meant to let the
-        backend reconcile state without relying on every delta being received.
+        (the per-tick delta) against a single app-extended-heartbeat payload
+        (the latest one received). The contract is that one extended-heartbeat
+        event re-sends the *full* dependency snapshot, so the backend can
+        reconcile state from any single such payload without needing to
+        accumulate prior deltas. Asserting against the aggregate of all
+        extended events would mask the exact regression we want to catch:
+        per-event partial slices would still union to the full set.
         """
         with flask_server(
             appsec_enabled="false",
@@ -517,15 +526,16 @@ class TestSCAFlaskExtendedHeartbeat:
         assert len(extended_events) > 0, "No app-extended-heartbeat events found"
 
         delta_names = {d["name"] for d in _collect_all_deps(delta_events) if d.get("name")}
-        snapshot_names = {d["name"] for d in _collect_all_deps_extended(extended_events) if d.get("name")}
 
-        # The latest extended heartbeat is meant to be a complete snapshot.
-        # The delta channel may include deps the snapshot also includes, but
-        # the snapshot must cover the union of what was reported, so any delta
-        # name absent from every snapshot is a contract violation.
-        missing = delta_names - snapshot_names
+        # Pick the latest extended heartbeat — by contract, it alone must be a
+        # complete snapshot of what was reported via the delta channel.
+        latest_snapshot = extended_events[-1]
+        latest_snapshot_deps = latest_snapshot.get("payload", {}).get("dependencies", [])
+        latest_snapshot_names = {d["name"] for d in latest_snapshot_deps if d.get("name")}
+
+        missing = delta_names - latest_snapshot_names
         assert not missing, (
-            f"Dependencies reported via app-dependencies-loaded are missing from every "
-            f"app-extended-heartbeat snapshot — extended heartbeat is not a full snapshot. "
+            f"Dependencies reported via app-dependencies-loaded are missing from the latest "
+            f"app-extended-heartbeat payload — extended heartbeat is not a full snapshot. "
             f"Missing: {sorted(missing)[:20]}"
         )


### PR DESCRIPTION
## Description

Adds end-to-end test coverage for the SCA runtime reachability snapshot
inside the `app-extended-heartbeat` telemetry event.

The existing `tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py`
suite only inspected `app-dependencies-loaded` events. The extended
heartbeat is a separate event that is meant to re-send the *full*
dependency snapshot (including SCA reachability metadata) on a long
interval so the backend can reconcile state without relying on every
delta being received. That contract was previously asserted only at the
unit level (`tests/telemetry/test_dependency.py::TestSnapshotForHeartbeat`);
nothing wired SCA + extended heartbeat together end-to-end.

This PR adds a new `TestSCAFlaskExtendedHeartbeat` class with three
tests, plus the helpers needed to extract `app-extended-heartbeat`
events from the test agent session.

## Testing

The new tests:

1. `test_extended_heartbeat_includes_dependencies_with_metadata_key`
   — boots Flask with `DD_APPSEC_SCA_ENABLED=true` and a 1s
   `_DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL`, then asserts the
   resulting `app-extended-heartbeat` payload carries `configuration`,
   non-empty `dependencies`, and the `metadata` key on SCA-tracked deps.
2. `test_extended_heartbeat_includes_cve_metadata_after_vulnerable_call`
   — triggers `/sca-test-requests` (CVE-2024-35195) and asserts the
   extended heartbeat re-emits the CVE with a populated `reached`
   array, including caller `path` / `symbol` / `line`.
3. `test_extended_heartbeat_dependency_list_is_full_snapshot`
   — cross-checks the union of deps reported via
   `app-dependencies-loaded` against what shows up in
   `app-extended-heartbeat`, asserting the snapshot is a superset
   (i.e. a full snapshot, not a delta).

Local validation note: the new tests follow the established pattern in
this file 1:1 and reuse the same helpers (`_collect_all_deps`,
`_find_dep_with_cve`, etc.). I ran them via `scripts/run-tests --venv 42964a4`
locally; both my new tests and the pre-existing `TestSCAFlaskTelemetry`
tests in this file errored with `socket.gaierror: [Errno -3] Temporary failure in name resolution`
inside the Docker testagent network, so end-to-end pass requires CI.
The Python file itself passes `hatch run lint:fmt`.

## Risks

None — test-only addition. No production code changes. Existing tests
in this file are untouched.

## Additional Notes

- This is a test-only change → `changelog/no-changelog` label.
- Related unit-level coverage already exists at
  `tests/telemetry/test_dependency.py::TestSnapshotForHeartbeat`
  (snapshot builder under lock, re-includes already-sent metadata).
- Source contract under test:
  `ddtrace/internal/telemetry/writer.py::_report_heartbeat`
  +`ddtrace/internal/telemetry/dependency_tracker.py::snapshot_for_heartbeat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)