### PR TITLE
chore(native): shutdown exporter background workers when dropping

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -780,7 +780,6 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         :param token: The test session token to use for authentication.
         """
         self._test_session_token = token
-        self._shutdown_exporter()  # 3 seconds timeout
         self._exporter = self._create_exporter()
 
     def recreate(self, appsec_enabled: Optional[bool] = None) -> "NativeWriter":
@@ -1008,14 +1007,11 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         super(NativeWriter, self)._stop_service()
         self.join(timeout=timeout)
 
-    def _shutdown_exporter(self) -> None:
-        self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout
-
     def on_shutdown(self):
         try:
             self.periodic()
         finally:
-            self._shutdown_exporter()
+            self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout
 
 
 def _use_log_writer() -> bool:

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -262,6 +262,14 @@ impl TraceExporterPy {
     }
 }
 
+impl Drop for TraceExporterPy {
+    fn drop(&mut self) {
+        if let Some(exporter) = self.inner.take() {
+            let _ = exporter.shutdown(Some(Duration::from_secs(3)));
+        }
+    }
+}
+
 #[pymodule]
 pub fn register_data_pipeline(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TraceExporterBuilderPy>()?;


### PR DESCRIPTION
## Description

Shutdown all background workers when dropping a trace exporter.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
