### PR TITLE
test(llmobs): migrate anthropic tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/anthropic/conftest.py
+++ b/tests/contrib/anthropic/conftest.py
@@ -23,23 +23,29 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            # Have to disable and re-enable LLMObs to use to mock tracer.
-            LLMObs.disable()
-            LLMObs.enable(integrations_enabled=False)
-            # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-            # background flush thread alive trying to ship spans during the test.
-            LLMObs._instance._llmobs_span_writer.stop()
-            LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-        yield test_spans
-    finally:
-        LLMObs.disable()
+def anthropic_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+        }
+    ):
+        LLMObs.enable(
+            _tracer=tracer,
+            integrations_enabled=False,
+            instrumented_proxy_urls={"http://localhost:4000"},
+        )
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 def default_global_config():

--- a/tests/contrib/anthropic/conftest.py
+++ b/tests/contrib/anthropic/conftest.py
@@ -23,27 +23,23 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans):
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
     try:
         if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
             # Have to disable and re-enable LLMObs to use to mock tracer.
             LLMObs.disable()
             LLMObs.enable(integrations_enabled=False)
+            # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+            # background flush thread alive trying to ship spans during the test.
+            LLMObs._instance._llmobs_span_writer.stop()
+            LLMObs._instance._llmobs_span_writer = mock.MagicMock()
         yield test_spans
     finally:
         LLMObs.disable()
-
-
-@pytest.fixture
-def mock_llmobs_writer(scope="session"):
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
-    try:
-        LLMObsSpanWriterMock = patcher.start()
-        m = mock.MagicMock()
-        LLMObsSpanWriterMock.return_value = m
-        yield m
-    finally:
-        patcher.stop()
 
 
 def default_global_config():

--- a/tests/contrib/anthropic/conftest.py
+++ b/tests/contrib/anthropic/conftest.py
@@ -7,19 +7,8 @@ from ddtrace.contrib.internal.anthropic.patch import patch
 from ddtrace.contrib.internal.anthropic.patch import unpatch
 from ddtrace.llmobs import LLMObs
 from tests.contrib.anthropic.utils import get_request_vcr
-from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
-
-
-@pytest.fixture
-def ddtrace_config_anthropic():
-    return {}
-
-
-@pytest.fixture
-def ddtrace_global_config():
-    return {}
 
 
 @pytest.fixture
@@ -48,26 +37,19 @@ def anthropic_llmobs(tracer, monkeypatch):
     LLMObs.disable()
 
 
-def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>"}
-
-
 @pytest.fixture
-def anthropic(ddtrace_global_config, ddtrace_config_anthropic):
-    global_config = default_global_config()
-    global_config.update(ddtrace_global_config)
-    with override_global_config(global_config):
-        with override_config("anthropic", ddtrace_config_anthropic):
-            with override_env(
-                dict(
-                    ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
-                )
-            ):
-                patch()
-                import anthropic
+def anthropic():
+    with override_global_config({"_dd_api_key": "<not-a-real-api_key>"}):
+        with override_env(
+            dict(
+                ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
+            )
+        ):
+            patch()
+            import anthropic
 
-                yield anthropic
-                unpatch()
+            yield anthropic
+            unpatch()
 
 
 @pytest.fixture(scope="session")

--- a/tests/contrib/anthropic/test_anthropic.py
+++ b/tests/contrib/anthropic/test_anthropic.py
@@ -12,7 +12,7 @@ from .utils import tools
 ANTHROPIC_VERSION = parse_version(anthropic_module.__version__)
 
 
-def test_global_tags(ddtrace_config_anthropic, anthropic, request_vcr, test_spans):
+def test_global_tags(anthropic, request_vcr, test_spans):
     """
     When the global config UST tags are set
         The service name should be used for all data
@@ -277,7 +277,7 @@ def test_anthropic_llm_sync_tools_full_use(anthropic, request_vcr, snapshot_cont
 
 
 @pytest.mark.asyncio
-async def test_global_tags_async(ddtrace_config_anthropic, anthropic, request_vcr, test_spans):
+async def test_global_tags_async(anthropic, request_vcr, test_spans):
     """
     When the global config UST tags are set
         The service name should be used for all data

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -5,6 +5,8 @@ from mock import patch
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_model_provider
+from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.anthropic.test_anthropic import ANTHROPIC_VERSION
 from tests.contrib.anthropic.test_anthropic import BETA_SKIP_REASON
@@ -366,7 +368,7 @@ class TestLLMObsAnthropic:
         )
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
+        assert get_llmobs_span_kind(spans[0]) == "llm"
 
     @patch("anthropic._base_client.SyncAPIClient.post")
     def test_completion_unknown_provider(self, mock_anthropic_messages_post, anthropic, anthropic_llmobs, test_spans):
@@ -376,7 +378,7 @@ class TestLLMObsAnthropic:
         llm.messages.create(model="claude-3-opus-20240229", max_tokens=15, messages=[{"role": "user", "content": "Hi"}])
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["model_provider"] == "unknown"
+        assert get_llmobs_model_provider(spans[0]) == "unknown"
 
     def test_completion(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured.

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -4,16 +4,16 @@ import mock
 from mock import patch
 import pytest
 
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.anthropic.test_anthropic import ANTHROPIC_VERSION
 from tests.contrib.anthropic.test_anthropic import BETA_SKIP_REASON
 from tests.contrib.anthropic.utils import MOCK_MESSAGES_CREATE_REQUEST
 from tests.contrib.anthropic.utils import tools
 from tests.llmobs._utils import DEEP_TOOL_SCHEMA
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
 from tests.llmobs._utils import aiterate_stream
 from tests.llmobs._utils import anext_stream
+from tests.llmobs._utils import assert_llmobs_span_data
 from tests.llmobs._utils import iterate_stream
 from tests.llmobs._utils import next_stream
 
@@ -72,7 +72,7 @@ class TestLLMObsAnthropic:
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
     def test_beta_server_tool_use_stream(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
+        self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream
     ):
         """Regression test for streamed server-side tool usage/results being captured"""
         llm = anthropic.Anthropic()
@@ -103,84 +103,81 @@ class TestLLMObsAnthropic:
             )
             consume_stream(stream)
 
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-sonnet-4-6",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {
-                        "content": "Let me search for a weather tool to help answer your question!",
-                        "role": "assistant",
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "tool_search_tool_regex",
-                                "arguments": {"pattern": "weather"},
-                                "tool_id": "srvtoolu_01TbRQZ9sz7wNun27iQQ8zKf",
-                                "type": "server_tool_use",
-                            }
-                        ],
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_results": [
-                            {
-                                "result": '{"tool_references": [{"tool_name": "get_weather",'
-                                ' "type": "tool_reference"}],'
-                                ' "type": "tool_search_tool_search_result"}',
-                                "tool_id": "srvtoolu_01TbRQZ9sz7wNun27iQQ8zKf",
-                                "type": "tool_result",
-                            }
-                        ],
-                    },
-                    {"content": "Found it! Let me get the weather for San Francisco, CA now.", "role": "assistant"},
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "arguments": {"location": "San Francisco, CA"},
-                                "tool_id": "toolu_01SHf2kbTahK9zYYPDyvNp5r",
-                                "type": "tool_use",
-                            }
-                        ],
-                    },
-                ],
-                metadata={"max_tokens": 200},
-                token_metrics={
-                    "input_tokens": 1595,
-                    "output_tokens": 143,
-                    "total_tokens": 1738,
-                    "cache_write_input_tokens": 0,
-                    "ephemeral_1h_input_tokens": 0,
-                    "ephemeral_5m_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-6",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {
+                    "content": "Let me search for a weather tool to help answer your question!",
+                    "role": "assistant",
                 },
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=[
-                    {"name": "tool_search_tool_regex", "description": "", "schema": {}},
-                    {
-                        "name": "get_weather",
-                        "description": "",
-                        "schema": {},
-                    },
-                ],
-            )
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "tool_search_tool_regex",
+                            "arguments": {"pattern": "weather"},
+                            "tool_id": "srvtoolu_01TbRQZ9sz7wNun27iQQ8zKf",
+                            "type": "server_tool_use",
+                        }
+                    ],
+                },
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_results": [
+                        {
+                            "result": '{"tool_references": [{"tool_name": "get_weather",'
+                            ' "type": "tool_reference"}],'
+                            ' "type": "tool_search_tool_search_result"}',
+                            "tool_id": "srvtoolu_01TbRQZ9sz7wNun27iQQ8zKf",
+                            "type": "tool_result",
+                        }
+                    ],
+                },
+                {"content": "Found it! Let me get the weather for San Francisco, CA now.", "role": "assistant"},
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                            "tool_id": "toolu_01SHf2kbTahK9zYYPDyvNp5r",
+                            "type": "tool_use",
+                        }
+                    ],
+                },
+            ],
+            metadata={"max_tokens": 200},
+            metrics={
+                "input_tokens": 1595,
+                "output_tokens": 143,
+                "total_tokens": 1738,
+                "cache_write_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=[
+                {"name": "tool_search_tool_regex", "description": "", "schema": {}},
+                {
+                    "name": "get_weather",
+                    "description": "",
+                    "schema": {},
+                },
+            ],
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
-    def test_beta_server_tool_use_non_stream(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
-    ):
+    def test_beta_server_tool_use_non_stream(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion_tools_server_tool_use.yaml"):
             llm.beta.messages.create(
@@ -207,88 +204,85 @@ class TestLLMObsAnthropic:
                 ],
             )
 
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-sonnet-4-6",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {
-                        "content": "Let me search for a weather tool to help answer your question!",
-                        "role": "assistant",
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "tool_search_tool_regex",
-                                "arguments": {"pattern": "weather"},
-                                "tool_id": "srvtoolu_01YBjcsxNhiKh8MPSRLFpXSk",
-                                "type": "server_tool_use",
-                            }
-                        ],
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_results": [
-                            {
-                                "result": '{"tool_references": [{"tool_name": "get_weather",'
-                                ' "type": "tool_reference"}],'
-                                ' "type": "tool_search_tool_search_result"}',
-                                "tool_id": "srvtoolu_01YBjcsxNhiKh8MPSRLFpXSk",
-                                "type": "tool_result",
-                            }
-                        ],
-                    },
-                    {
-                        "content": "I found a weather tool! Let me fetch the current weather for San Francisco, CA.",
-                        "role": "assistant",
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "arguments": {"location": "San Francisco, CA"},
-                                "tool_id": "toolu_013vNgEGWuTc17pHztigU6j2",
-                                "type": "tool_use",
-                            }
-                        ],
-                    },
-                ],
-                metadata={"max_tokens": 200},
-                token_metrics={
-                    "input_tokens": 1595,
-                    "output_tokens": 146,
-                    "total_tokens": 1741,
-                    "cache_write_input_tokens": 0,
-                    "ephemeral_1h_input_tokens": 0,
-                    "ephemeral_5m_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-6",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {
+                    "content": "Let me search for a weather tool to help answer your question!",
+                    "role": "assistant",
                 },
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=[
-                    {"name": "tool_search_tool_regex", "description": "", "schema": {}},
-                    {
-                        "name": "get_weather",
-                        "description": "",
-                        "schema": {},
-                    },
-                ],
-            )
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "tool_search_tool_regex",
+                            "arguments": {"pattern": "weather"},
+                            "tool_id": "srvtoolu_01YBjcsxNhiKh8MPSRLFpXSk",
+                            "type": "server_tool_use",
+                        }
+                    ],
+                },
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_results": [
+                        {
+                            "result": '{"tool_references": [{"tool_name": "get_weather",'
+                            ' "type": "tool_reference"}],'
+                            ' "type": "tool_search_tool_search_result"}',
+                            "tool_id": "srvtoolu_01YBjcsxNhiKh8MPSRLFpXSk",
+                            "type": "tool_result",
+                        }
+                    ],
+                },
+                {
+                    "content": "I found a weather tool! Let me fetch the current weather for San Francisco, CA.",
+                    "role": "assistant",
+                },
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                            "tool_id": "toolu_013vNgEGWuTc17pHztigU6j2",
+                            "type": "tool_use",
+                        }
+                    ],
+                },
+            ],
+            metadata={"max_tokens": 200},
+            metrics={
+                "input_tokens": 1595,
+                "output_tokens": 146,
+                "total_tokens": 1741,
+                "cache_write_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=[
+                {"name": "tool_search_tool_regex", "description": "", "schema": {}},
+                {
+                    "name": "get_weather",
+                    "description": "",
+                    "schema": {},
+                },
+            ],
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 47), reason="Thinking support requires anthropic>=0.47.0")
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_stream_with_thinking(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
-    ):
+    def test_stream_with_thinking(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
         """Ensure thinking blocks are properly captured from streamed responses."""
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion_stream_thinking.yaml"):
@@ -302,30 +296,29 @@ class TestLLMObsAnthropic:
             )
             consume_stream(stream)
 
-            span = test_spans.pop_traces()[0][0]
-            assert mock_llmobs_writer.enqueue.call_count == 1
-            mock_llmobs_writer.enqueue.assert_called_with(
-                _expected_llmobs_llm_span_event(
-                    span,
-                    model_name="claude-sonnet-4-20250514",
-                    model_provider="anthropic",
-                    input_messages=[
-                        {"content": "What is the best selling book of all time?", "role": "user"},
-                    ],
-                    output_messages=[
-                        {
-                            "content": "Let me think about the best selling book.",
-                            "role": "reasoning",
-                        },
-                        {
-                            "content": "The best-selling book of all time is Don Quixote.",
-                            "role": "assistant",
-                        },
-                    ],
-                    metadata={"temperature": 1, "max_tokens": 16000.0},
-                    token_metrics={"input_tokens": 50, "output_tokens": 200, "total_tokens": 250},
-                    tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                )
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 1
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="llm",
+                model_name="claude-sonnet-4-20250514",
+                model_provider="anthropic",
+                input_messages=[
+                    {"content": "What is the best selling book of all time?", "role": "user"},
+                ],
+                output_messages=[
+                    {
+                        "content": "Let me think about the best selling book.",
+                        "role": "reasoning",
+                    },
+                    {
+                        "content": "The best-selling book of all time is Don Quixote.",
+                        "role": "assistant",
+                    },
+                ],
+                metadata={"temperature": 1, "max_tokens": 16000.0},
+                metrics={"input_tokens": 50, "output_tokens": 200, "total_tokens": 250},
+                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
             )
 
     @patch("anthropic._base_client.SyncAPIClient.post")
@@ -334,7 +327,6 @@ class TestLLMObsAnthropic:
         mock_anthropic_messages_post,
         anthropic,
         ddtrace_global_config,
-        mock_llmobs_writer,
         test_spans,
         request_vcr,
     ):
@@ -356,26 +348,24 @@ class TestLLMObsAnthropic:
             temperature=0.8,
             messages=messages,
         )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_non_llm_span_event(
-                span,
-                "workflow",
-                input_value=safe_json(
-                    [
-                        {"content": "Respond only in all caps.", "role": "system"},
-                        {"content": "Hello, I am looking for information about some books!", "role": "user"},
-                        {"content": "What is the best selling book?", "role": "user"},
-                    ],
-                    ensure_ascii=False,
-                ),
-                output_value=safe_json(
-                    [{"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON', "role": "assistant"}], ensure_ascii=False
-                ),
-                metadata={"temperature": 0.8, "max_tokens": 15.0},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="workflow",
+            input_value=safe_json(
+                [
+                    {"content": "Respond only in all caps.", "role": "system"},
+                    {"content": "Hello, I am looking for information about some books!", "role": "user"},
+                    {"content": "What is the best selling book?", "role": "user"},
+                ],
+                ensure_ascii=False,
+            ),
+            output_value=safe_json(
+                [{"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON', "role": "assistant"}], ensure_ascii=False
+            ),
+            metadata={"temperature": 0.8, "max_tokens": 15.0},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
         # span created from request with non-proxy URL should result in an LLM span
@@ -387,22 +377,23 @@ class TestLLMObsAnthropic:
             temperature=0.8,
             messages=messages,
         )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
-        assert mock_llmobs_writer.enqueue.call_args_list[1].args[0]["meta"]["span"]["kind"] == "llm"
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
 
     @patch("anthropic._base_client.SyncAPIClient.post")
     def test_completion_unknown_provider(
-        self, mock_anthropic_messages_post, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans
+        self, mock_anthropic_messages_post, anthropic, ddtrace_global_config, test_spans
     ):
         """Ensure model_provider is set to 'unknown' when base_url doesn't match any known provider."""
         mock_anthropic_messages_post.return_value = MOCK_MESSAGES_CREATE_REQUEST
         llm = anthropic.Anthropic(base_url="http://localhost:8000")
         llm.messages.create(model="claude-3-opus-20240229", max_tokens=15, messages=[{"role": "user", "content": "Hi"}])
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        assert mock_llmobs_writer.enqueue.call_args.args[0]["meta"]["model_provider"] == "unknown"
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["model_provider"] == "unknown"
 
-    def test_completion(self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr):
+    def test_completion(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -424,28 +415,25 @@ class TestLLMObsAnthropic:
                     }
                 ],
             )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[
-                    {"content": "Respond only in all caps.", "role": "system"},
-                    {"content": "Hello, I am looking for information about some books!", "role": "user"},
-                    {"content": "What is the best selling book?", "role": "user"},
-                ],
-                output_messages=[{"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON', "role": "assistant"}],
-                metadata={"temperature": 0.8, "max_tokens": 15.0},
-                token_metrics={"input_tokens": 32, "output_tokens": 15, "total_tokens": 47},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[
+                {"content": "Respond only in all caps.", "role": "system"},
+                {"content": "Hello, I am looking for information about some books!", "role": "user"},
+                {"content": "What is the best selling book?", "role": "user"},
+            ],
+            output_messages=[{"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON', "role": "assistant"}],
+            metadata={"temperature": 0.8, "max_tokens": 15.0},
+            metrics={"input_tokens": 32, "output_tokens": 15, "total_tokens": 47},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
-    def test_completion_with_multiple_system_prompts(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
-    ):
+    def test_completion_with_multiple_system_prompts(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints with a list of messages as the system prompt.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -473,38 +461,37 @@ class TestLLMObsAnthropic:
                     }
                 ],
             )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[
-                    {
-                        "content": "You are an AI assistant tasked with analyzing literary works.",
-                        "role": "system",
-                    },
-                    {"content": "only respond in all caps", "role": "system"},
-                    {"content": "Hello, I am looking for information about some books!", "role": "user"},
-                    {"content": "What is the best selling book?", "role": "user"},
-                ],
-                output_messages=[{"content": "HELLO THERE! ACCORDING TO VARIOUS SOURCES, THE", "role": "assistant"}],
-                metadata={"temperature": 0.8, "max_tokens": 15.0},
-                token_metrics={
-                    "input_tokens": 43,
-                    "output_tokens": 15,
-                    "total_tokens": 58,
-                    "cache_write_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
-                    "ephemeral_1h_input_tokens": 0,
-                    "ephemeral_5m_input_tokens": 0,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[
+                {
+                    "content": "You are an AI assistant tasked with analyzing literary works.",
+                    "role": "system",
                 },
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-            )
+                {"content": "only respond in all caps", "role": "system"},
+                {"content": "Hello, I am looking for information about some books!", "role": "user"},
+                {"content": "What is the best selling book?", "role": "user"},
+            ],
+            output_messages=[{"content": "HELLO THERE! ACCORDING TO VARIOUS SOURCES, THE", "role": "assistant"}],
+            metadata={"temperature": 0.8, "max_tokens": 15.0},
+            metrics={
+                "input_tokens": 43,
+                "output_tokens": 15,
+                "total_tokens": 58,
+                "cache_write_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0,
+            },
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
-    def test_error(self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr):
+    def test_error(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an error.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -528,35 +515,34 @@ class TestLLMObsAnthropic:
                     ],
                 )
 
-                span = test_spans.pop_traces()[0][0]
-                assert mock_llmobs_writer.enqueue.call_count == 1
-                mock_llmobs_writer.enqueue.assert_called_with(
-                    _expected_llmobs_llm_span_event(
-                        span,
-                        model_name="claude-3-opus-20240229",
-                        model_provider="anthropic",
-                        input_messages=[
-                            {"content": "Respond only in all caps.", "role": "system"},
-                            {"content": "Hello, I am looking for information about some books!", "role": "user"},
-                            {"content": "What is the best selling book?", "role": "user"},
-                        ],
-                        output_messages=[{"content": ""}],
-                        error="anthropic.AuthenticationError",
-                        error_message=span.get_tag("error.message"),
-                        error_stack=span.get_tag("error.stack"),
-                        metadata={"temperature": 0.8, "max_tokens": 15.0},
-                        tags={
-                            "ml_app": "<ml-app-name>",
-                            "service": "tests.contrib.anthropic",
-                            "integration": "anthropic",
-                        },
-                    )
+                spans = [s for trace in test_spans.pop_traces() for s in trace]
+                assert len(spans) == 1
+                assert_llmobs_span_data(
+                    _get_llmobs_data_metastruct(spans[0]),
+                    span_kind="llm",
+                    model_name="claude-3-opus-20240229",
+                    model_provider="anthropic",
+                    input_messages=[
+                        {"content": "Respond only in all caps.", "role": "system"},
+                        {"content": "Hello, I am looking for information about some books!", "role": "user"},
+                        {"content": "What is the best selling book?", "role": "user"},
+                    ],
+                    output_messages=[{"content": ""}],
+                    error={
+                        "type": "anthropic.AuthenticationError",
+                        "message": spans[0].get_tag("error.message"),
+                        "stack": spans[0].get_tag("error.stack"),
+                    },
+                    metadata={"temperature": 0.8, "max_tokens": 15.0},
+                    tags={
+                        "ml_app": "<ml-app-name>",
+                        "service": "tests.contrib.anthropic",
+                        "integration": "anthropic",
+                    },
                 )
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_stream(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
-    ):
+    def test_stream(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -582,35 +568,32 @@ class TestLLMObsAnthropic:
             )
             consume_stream(stream)
 
-            span = test_spans.pop_traces()[0][0]
-            assert mock_llmobs_writer.enqueue.call_count == 1
-            mock_llmobs_writer.enqueue.assert_called_with(
-                _expected_llmobs_llm_span_event(
-                    span,
-                    model_name="claude-3-opus-20240229",
-                    model_provider="anthropic",
-                    input_messages=[
-                        {
-                            "content": "Can you explain what Descartes meant by 'I think, therefore I am'?",
-                            "role": "user",
-                        },
-                    ],
-                    output_messages=[
-                        {
-                            "content": 'The phrase "I think, therefore I am" (originally in Latin as',
-                            "role": "assistant",
-                        }
-                    ],
-                    metadata={"temperature": 0.8, "max_tokens": 15.0},
-                    token_metrics={"input_tokens": 27, "output_tokens": 15, "total_tokens": 42},
-                    tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                )
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 1
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="llm",
+                model_name="claude-3-opus-20240229",
+                model_provider="anthropic",
+                input_messages=[
+                    {
+                        "content": "Can you explain what Descartes meant by 'I think, therefore I am'?",
+                        "role": "user",
+                    },
+                ],
+                output_messages=[
+                    {
+                        "content": 'The phrase "I think, therefore I am" (originally in Latin as',
+                        "role": "assistant",
+                    }
+                ],
+                metadata={"temperature": 0.8, "max_tokens": 15.0},
+                metrics={"input_tokens": 27, "output_tokens": 15, "total_tokens": 42},
+                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
             )
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_stream_helper(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
-    ):
+    def test_stream_helper(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -641,32 +624,31 @@ class TestLLMObsAnthropic:
             message = stream.get_final_text()
             assert message is not None
 
-            span = test_spans.pop_traces()[0][0]
-            assert mock_llmobs_writer.enqueue.call_count == 1
-            mock_llmobs_writer.enqueue.assert_called_with(
-                _expected_llmobs_llm_span_event(
-                    span,
-                    model_name="claude-3-opus-20240229",
-                    model_provider="anthropic",
-                    input_messages=[
-                        {
-                            "content": "Can you explain what Descartes meant by 'I think, therefore I am'?",
-                            "role": "user",
-                        },
-                    ],
-                    output_messages=[
-                        {
-                            "content": 'The famous philosophical statement "I think, therefore I am" (originally in',
-                            "role": "assistant",
-                        }
-                    ],
-                    metadata={"temperature": 0.8, "max_tokens": 15.0},
-                    token_metrics={"input_tokens": 27, "output_tokens": 15, "total_tokens": 42},
-                    tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                )
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 1
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="llm",
+                model_name="claude-3-opus-20240229",
+                model_provider="anthropic",
+                input_messages=[
+                    {
+                        "content": "Can you explain what Descartes meant by 'I think, therefore I am'?",
+                        "role": "user",
+                    },
+                ],
+                output_messages=[
+                    {
+                        "content": 'The famous philosophical statement "I think, therefore I am" (originally in',
+                        "role": "assistant",
+                    }
+                ],
+                metadata={"temperature": 0.8, "max_tokens": 15.0},
+                metrics={"input_tokens": 27, "output_tokens": 15, "total_tokens": 42},
+                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
             )
 
-    def test_image(self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr):
+    def test_image(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an image input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -698,31 +680,30 @@ class TestLLMObsAnthropic:
                 ],
             )
 
-            span = test_spans.pop_traces()[0][0]
-            assert mock_llmobs_writer.enqueue.call_count == 1
-            mock_llmobs_writer.enqueue.assert_called_with(
-                _expected_llmobs_llm_span_event(
-                    span,
-                    model_name="claude-3-opus-20240229",
-                    model_provider="anthropic",
-                    input_messages=[
-                        {"content": "Hello, what do you see in the following image?", "role": "user"},
-                        {"content": "([IMAGE DETECTED])", "role": "user"},
-                    ],
-                    output_messages=[
-                        {
-                            "content": 'The image shows the logo for a company or product called "Datadog',
-                            "role": "assistant",
-                        }
-                    ],
-                    metadata={"temperature": 0.8, "max_tokens": 15.0},
-                    token_metrics={"input_tokens": 246, "output_tokens": 15, "total_tokens": 261},
-                    tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                )
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 1
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="llm",
+                model_name="claude-3-opus-20240229",
+                model_provider="anthropic",
+                input_messages=[
+                    {"content": "Hello, what do you see in the following image?", "role": "user"},
+                    {"content": "([IMAGE DETECTED])", "role": "user"},
+                ],
+                output_messages=[
+                    {
+                        "content": 'The image shows the logo for a company or product called "Datadog',
+                        "role": "assistant",
+                    }
+                ],
+                metadata={"temperature": 0.8, "max_tokens": 15.0},
+                metrics={"input_tokens": 246, "output_tokens": 15, "total_tokens": 261},
+                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
             )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
-    def test_tools_sync(self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr):
+    def test_tools_sync(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -738,30 +719,28 @@ class TestLLMObsAnthropic:
             )
             assert message is not None
 
-        traces = test_spans.pop_traces()
-        span_1 = traces[0][0]
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_1,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {
-                        "content": WEATHER_OUTPUT_MESSAGE_1,
-                        "role": "assistant",
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL,
-                    },
-                ],
-                metadata={"max_tokens": 200.0},
-                token_metrics={"input_tokens": 599, "output_tokens": 152, "total_tokens": 751},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {
+                    "content": WEATHER_OUTPUT_MESSAGE_1,
+                    "role": "assistant",
+                },
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL,
+                },
+            ],
+            metadata={"max_tokens": 200.0},
+            metrics={"input_tokens": 599, "output_tokens": 152, "total_tokens": 751},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
         tool = next(c for c in message.content if c.type == "tool_use")
@@ -788,43 +767,41 @@ class TestLLMObsAnthropic:
                 )
                 assert response is not None
 
-        traces = test_spans.pop_traces()
-        span_2 = traces[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_2,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[
-                    {"content": WEATHER_PROMPT, "role": "user"},
-                    {
-                        "content": WEATHER_OUTPUT_MESSAGE_1,
-                        "role": "assistant",
-                    },
-                    {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
-                    {
-                        "content": "",
-                        "role": "user",
-                        "tool_results": WEATHER_TOOL_RESULT,
-                    },
-                ],
-                output_messages=[
-                    {
-                        "content": WEATHER_OUTPUT_MESSAGE_3,
-                        "role": "assistant",
-                    }
-                ],
-                metadata={"max_tokens": 500.0},
-                token_metrics={"input_tokens": 768, "output_tokens": 29, "total_tokens": 797},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[
+                {"content": WEATHER_PROMPT, "role": "user"},
+                {
+                    "content": WEATHER_OUTPUT_MESSAGE_1,
+                    "role": "assistant",
+                },
+                {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
+                {
+                    "content": "",
+                    "role": "user",
+                    "tool_results": WEATHER_TOOL_RESULT,
+                },
+            ],
+            output_messages=[
+                {
+                    "content": WEATHER_OUTPUT_MESSAGE_3,
+                    "role": "assistant",
+                }
+            ],
+            metadata={"max_tokens": 500.0},
+            metrics={"input_tokens": 768, "output_tokens": 29, "total_tokens": 797},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
-    async def test_tools_async(self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr):
+    async def test_tools_async(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -840,30 +817,28 @@ class TestLLMObsAnthropic:
             )
             assert message is not None
 
-        traces = test_spans.pop_traces()
-        span_1 = traces[0][0]
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_1,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {
-                        "content": WEATHER_OUTPUT_MESSAGE_1,
-                        "role": "assistant",
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL,
-                    },
-                ],
-                metadata={"max_tokens": 200.0},
-                token_metrics={"input_tokens": 599, "output_tokens": 152, "total_tokens": 751},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {
+                    "content": WEATHER_OUTPUT_MESSAGE_1,
+                    "role": "assistant",
+                },
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL,
+                },
+            ],
+            metadata={"max_tokens": 200.0},
+            metrics={"input_tokens": 599, "output_tokens": 152, "total_tokens": 751},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
         tool = next(c for c in message.content if c.type == "tool_use")
@@ -890,41 +865,37 @@ class TestLLMObsAnthropic:
                 )
                 assert response is not None
 
-        traces = test_spans.pop_traces()
-        span_2 = traces[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_2,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[
-                    {"content": WEATHER_PROMPT, "role": "user"},
-                    {
-                        "content": WEATHER_OUTPUT_MESSAGE_1,
-                        "role": "assistant",
-                    },
-                    {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
-                    {"content": "", "role": "user", "tool_results": WEATHER_TOOL_RESULT},
-                ],
-                output_messages=[
-                    {
-                        "content": WEATHER_OUTPUT_MESSAGE_3,
-                        "role": "assistant",
-                    }
-                ],
-                metadata={"max_tokens": 500.0},
-                token_metrics={"input_tokens": 768, "output_tokens": 29, "total_tokens": 797},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[
+                {"content": WEATHER_PROMPT, "role": "user"},
+                {
+                    "content": WEATHER_OUTPUT_MESSAGE_1,
+                    "role": "assistant",
+                },
+                {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
+                {"content": "", "role": "user", "tool_results": WEATHER_TOOL_RESULT},
+            ],
+            output_messages=[
+                {
+                    "content": WEATHER_OUTPUT_MESSAGE_3,
+                    "role": "assistant",
+                }
+            ],
+            metadata={"max_tokens": 500.0},
+            metrics={"input_tokens": 768, "output_tokens": 29, "total_tokens": 797},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_tools_sync_stream(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
-    ):
+    def test_tools_sync_stream(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -958,34 +929,32 @@ class TestLLMObsAnthropic:
             },
         ]
 
-        traces = test_spans.pop_traces()
-        span_1 = traces[0][0]
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_1,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {"content": message[0]["text"], "role": "assistant"},
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "arguments": {"location": "San Francisco, CA"},
-                                "tool_id": "toolu_01DYJo37oETVsCdLTTcCWcdq",
-                                "type": "tool_use",
-                            }
-                        ],
-                    },
-                ],
-                metadata={"max_tokens": 200.0},
-                token_metrics={"input_tokens": 599, "output_tokens": 135, "total_tokens": 734},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {"content": message[0]["text"], "role": "assistant"},
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                            "tool_id": "toolu_01DYJo37oETVsCdLTTcCWcdq",
+                            "type": "tool_use",
+                        }
+                    ],
+                },
+            ],
+            metadata={"max_tokens": 200.0},
+            metrics={"input_tokens": 599, "output_tokens": 135, "total_tokens": 734},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
         with request_vcr.use_cassette("anthropic_completion_tools_call_with_tool_result_stream.yaml"):
@@ -1012,38 +981,36 @@ class TestLLMObsAnthropic:
             for _ in response:
                 pass
 
-        traces = test_spans.pop_traces()
-        span_2 = traces[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_2,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[
-                    {"content": WEATHER_PROMPT, "role": "user"},
-                    {"content": message[0]["text"], "role": "assistant"},
-                    {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
-                    {"content": "", "role": "user", "tool_results": WEATHER_TOOL_RESULT},
-                ],
-                output_messages=[
-                    {
-                        "content": "\n\n" + WEATHER_OUTPUT_MESSAGE_3[:-1] + " (23°C).",
-                        "role": "assistant",
-                    }
-                ],
-                metadata={"max_tokens": 500.0},
-                token_metrics={"input_tokens": 762, "output_tokens": 33, "total_tokens": 795},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[
+                {"content": WEATHER_PROMPT, "role": "user"},
+                {"content": message[0]["text"], "role": "assistant"},
+                {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
+                {"content": "", "role": "user", "tool_results": WEATHER_TOOL_RESULT},
+            ],
+            output_messages=[
+                {
+                    "content": "\n\n" + WEATHER_OUTPUT_MESSAGE_3[:-1] + " (23°C).",
+                    "role": "assistant",
+                }
+            ],
+            metadata={"max_tokens": 500.0},
+            metrics={"input_tokens": 762, "output_tokens": 33, "total_tokens": 795},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
     @pytest.mark.parametrize("consume_stream", [aiterate_stream, anext_stream])
     async def test_tools_async_stream_helper(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr, consume_stream
+        self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream
     ):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
@@ -1065,34 +1032,32 @@ class TestLLMObsAnthropic:
             raw_message = await stream.get_final_text()
             assert raw_message is not None
 
-        traces = test_spans.pop_traces()
-        span_1 = traces[0][0]
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_1,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {"content": message.content[0].text, "role": "assistant"},
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "arguments": {"location": "San Francisco, CA"},
-                                "tool_id": "toolu_01DYJo37oETVsCdLTTcCWcdq",
-                                "type": "tool_use",
-                            }
-                        ],
-                    },
-                ],
-                metadata={"max_tokens": 200.0},
-                token_metrics={"input_tokens": 599, "output_tokens": 146, "total_tokens": 745},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {"content": message.content[0].text, "role": "assistant"},
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                            "tool_id": "toolu_01DYJo37oETVsCdLTTcCWcdq",
+                            "type": "tool_use",
+                        }
+                    ],
+                },
+            ],
+            metadata={"max_tokens": 200.0},
+            metrics={"input_tokens": 599, "output_tokens": 146, "total_tokens": 745},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
         with request_vcr.use_cassette("anthropic_completion_tools_call_with_tool_result_stream_helper.yaml"):
@@ -1123,36 +1088,32 @@ class TestLLMObsAnthropic:
             raw_message = await stream.get_final_text()
             assert raw_message is not None
 
-        traces = test_spans.pop_traces()
-        span_2 = traces[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span_2,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[
-                    {"content": WEATHER_PROMPT, "role": "user"},
-                    {"content": message.content[0].text, "role": "assistant"},
-                    {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
-                    {"content": "", "role": "user", "tool_results": WEATHER_TOOL_RESULT},
-                ],
-                output_messages=[
-                    {
-                        "content": "\n\nThe current weather in San Francisco, CA is 73°F.",
-                        "role": "assistant",
-                    }
-                ],
-                metadata={"max_tokens": 500.0},
-                token_metrics={"input_tokens": 762, "output_tokens": 18, "total_tokens": 780},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[
+                {"content": WEATHER_PROMPT, "role": "user"},
+                {"content": message.content[0].text, "role": "assistant"},
+                {"content": "", "role": "assistant", "tool_calls": WEATHER_OUTPUT_MESSAGE_2_TOOL_CALL},
+                {"content": "", "role": "user", "tool_results": WEATHER_TOOL_RESULT},
+            ],
+            output_messages=[
+                {
+                    "content": "\n\nThe current weather in San Francisco, CA is 73°F.",
+                    "role": "assistant",
+                }
+            ],
+            metadata={"max_tokens": 500.0},
+            metrics={"input_tokens": 762, "output_tokens": 18, "total_tokens": 780},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
-    def test_completion_prompt_caching(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
-    ):
+    def test_completion_prompt_caching(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         llm = anthropic.Anthropic()
         """Test that prompt caching metrics are properly captured for both cache creation and cache read."""
         large_system_prompt = [
@@ -1176,91 +1137,82 @@ class TestLLMObsAnthropic:
             )
         with request_vcr.use_cassette("anthropic_completion_cache_read.yaml"):
             llm.messages.create(**inference_args, messages=[{"role": "user", "content": "What is a system"}])
-        spans = test_spans.pop_traces()
-        span1, span2 = spans[0][0], spans[1][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 2
 
-        mock_llmobs_writer.enqueue.assert_has_calls(
-            [
-                mock.call(
-                    _expected_llmobs_llm_span_event(
-                        span1,
-                        model_name="claude-sonnet-4-20250514",
-                        model_provider="anthropic",
-                        input_messages=[
-                            {
-                                "content": large_system_prompt[0]["text"],
-                                "role": "system",
-                            },
-                            {
-                                "content": "What are the key principles for designing scalable systems?",
-                                "role": "user",
-                            },
-                        ],
-                        output_messages=[{"content": mock.ANY, "role": "assistant"}],
-                        metadata={
-                            "temperature": 0.1,
-                            "max_tokens": 100.0,
-                        },
-                        token_metrics={
-                            "input_tokens": 2073,
-                            "output_tokens": 100,
-                            "total_tokens": 2173,
-                            "cache_write_input_tokens": 2055,
-                            "cache_read_input_tokens": 0,
-                            "ephemeral_1h_input_tokens": 0,
-                            "ephemeral_5m_input_tokens": 2055,
-                        },
-                        tags={
-                            "ml_app": "<ml-app-name>",
-                            "service": "tests.contrib.anthropic",
-                            "integration": "anthropic",
-                        },
-                    )
-                ),
-                mock.call(
-                    _expected_llmobs_llm_span_event(
-                        span2,
-                        model_name="claude-sonnet-4-20250514",
-                        model_provider="anthropic",
-                        input_messages=[
-                            {
-                                "content": large_system_prompt[0]["text"],
-                                "role": "system",
-                            },
-                            {
-                                "content": "What is a system",
-                                "role": "user",
-                            },
-                        ],
-                        output_messages=[{"content": mock.ANY, "role": "assistant"}],
-                        metadata={
-                            "temperature": 0.1,
-                            "max_tokens": 100.0,
-                        },
-                        token_metrics={
-                            "input_tokens": 2066,
-                            "output_tokens": 100,
-                            "total_tokens": 2166,
-                            "cache_write_input_tokens": 0,
-                            "cache_read_input_tokens": 2055,
-                            "ephemeral_1h_input_tokens": 0,
-                            "ephemeral_5m_input_tokens": 0,
-                        },
-                        tags={
-                            "ml_app": "<ml-app-name>",
-                            "service": "tests.contrib.anthropic",
-                            "integration": "anthropic",
-                        },
-                    )
-                ),
-            ]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[
+                {
+                    "content": large_system_prompt[0]["text"],
+                    "role": "system",
+                },
+                {
+                    "content": "What are the key principles for designing scalable systems?",
+                    "role": "user",
+                },
+            ],
+            output_messages=[{"content": mock.ANY, "role": "assistant"}],
+            metadata={
+                "temperature": 0.1,
+                "max_tokens": 100.0,
+            },
+            metrics={
+                "input_tokens": 2073,
+                "output_tokens": 100,
+                "total_tokens": 2173,
+                "cache_write_input_tokens": 2055,
+                "cache_read_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 2055,
+            },
+            tags={
+                "ml_app": "<ml-app-name>",
+                "service": "tests.contrib.anthropic",
+                "integration": "anthropic",
+            },
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[1]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[
+                {
+                    "content": large_system_prompt[0]["text"],
+                    "role": "system",
+                },
+                {
+                    "content": "What is a system",
+                    "role": "user",
+                },
+            ],
+            output_messages=[{"content": mock.ANY, "role": "assistant"}],
+            metadata={
+                "temperature": 0.1,
+                "max_tokens": 100.0,
+            },
+            metrics={
+                "input_tokens": 2066,
+                "output_tokens": 100,
+                "total_tokens": 2166,
+                "cache_write_input_tokens": 0,
+                "cache_read_input_tokens": 2055,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0,
+            },
+            tags={
+                "ml_app": "<ml-app-name>",
+                "service": "tests.contrib.anthropic",
+                "integration": "anthropic",
+            },
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 66), reason="1h cache TTL not available until 0.66.0, skipping.")
-    def test_completion_prompt_caching_1h_ttl(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
-    ):
+    def test_completion_prompt_caching_1h_ttl(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Test that prompt caching metrics with 1h TTL are properly captured."""
         llm = anthropic.Anthropic()
         large_system_prompt = [
@@ -1278,45 +1230,42 @@ class TestLLMObsAnthropic:
                 temperature=0.1,
                 messages=[{"role": "user", "content": "What are the key principles for designing scalable systems?"}],
             )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
 
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-sonnet-4-20250514",
-                model_provider="anthropic",
-                input_messages=[
-                    {
-                        "content": large_system_prompt[0]["text"],
-                        "role": "system",
-                    },
-                    {
-                        "content": "What are the key principles for designing scalable systems?",
-                        "role": "user",
-                    },
-                ],
-                output_messages=[{"content": mock.ANY, "role": "assistant"}],
-                metadata={
-                    "temperature": 0.1,
-                    "max_tokens": 100.0,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[
+                {
+                    "content": large_system_prompt[0]["text"],
+                    "role": "system",
                 },
-                token_metrics={
-                    "input_tokens": 2073,
-                    "output_tokens": 100,
-                    "total_tokens": 2173,
-                    "cache_write_input_tokens": 2056,
-                    "cache_read_input_tokens": 0,
-                    "ephemeral_1h_input_tokens": 2056,
-                    "ephemeral_5m_input_tokens": 0,
+                {
+                    "content": "What are the key principles for designing scalable systems?",
+                    "role": "user",
                 },
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-            )
+            ],
+            output_messages=[{"content": mock.ANY, "role": "assistant"}],
+            metadata={
+                "temperature": 0.1,
+                "max_tokens": 100.0,
+            },
+            metrics={
+                "input_tokens": 2073,
+                "output_tokens": 100,
+                "total_tokens": 2173,
+                "cache_write_input_tokens": 2056,
+                "cache_read_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 2056,
+                "ephemeral_5m_input_tokens": 0,
+            },
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
-    def test_completion_stream_prompt_caching(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
-    ):
+    def test_completion_stream_prompt_caching(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Test that prompt caching metrics are properly captured for streamed completions."""
         large_system_prompt = [
             {
@@ -1346,89 +1295,82 @@ class TestLLMObsAnthropic:
             for _ in stream2:
                 pass
 
-        spans = test_spans.pop_traces()
-        span1, span2 = spans[0][0], spans[1][0]
-        assert mock_llmobs_writer.enqueue.call_count == 2
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 2
 
-        mock_llmobs_writer.enqueue.assert_has_calls(
-            [
-                mock.call(
-                    _expected_llmobs_llm_span_event(
-                        span1,
-                        model_name="claude-sonnet-4-20250514",
-                        model_provider="anthropic",
-                        input_messages=[
-                            {
-                                "content": large_system_prompt[0]["text"],
-                                "role": "system",
-                            },
-                            {
-                                "content": "What are the key principles for designing scalable systems?",
-                                "role": "user",
-                            },
-                        ],
-                        output_messages=[{"content": mock.ANY, "role": "assistant"}],
-                        metadata={
-                            "temperature": 0.1,
-                            "max_tokens": 100.0,
-                        },
-                        token_metrics={
-                            "input_tokens": 1049,
-                            "output_tokens": 100,
-                            "total_tokens": 1149,
-                            "cache_write_input_tokens": 1031,
-                            "cache_read_input_tokens": 0,
-                            "ephemeral_1h_input_tokens": 0,
-                            "ephemeral_5m_input_tokens": 1031,
-                        },
-                        tags={
-                            "ml_app": "<ml-app-name>",
-                            "service": "tests.contrib.anthropic",
-                            "integration": "anthropic",
-                        },
-                    )
-                ),
-                mock.call(
-                    _expected_llmobs_llm_span_event(
-                        span2,
-                        model_name="claude-sonnet-4-20250514",
-                        model_provider="anthropic",
-                        input_messages=[
-                            {
-                                "content": large_system_prompt[0]["text"],
-                                "role": "system",
-                            },
-                            {
-                                "content": "What is a system",
-                                "role": "user",
-                            },
-                        ],
-                        output_messages=[{"content": mock.ANY, "role": "assistant"}],
-                        metadata={
-                            "temperature": 0.1,
-                            "max_tokens": 100.0,
-                        },
-                        token_metrics={
-                            "input_tokens": 1042,
-                            "output_tokens": 100,
-                            "total_tokens": 1142,
-                            "cache_write_input_tokens": 0,
-                            "cache_read_input_tokens": 1031,
-                            "ephemeral_1h_input_tokens": 0,
-                            "ephemeral_5m_input_tokens": 0,
-                        },
-                        tags={
-                            "ml_app": "<ml-app-name>",
-                            "service": "tests.contrib.anthropic",
-                            "integration": "anthropic",
-                        },
-                    )
-                ),
-            ]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[
+                {
+                    "content": large_system_prompt[0]["text"],
+                    "role": "system",
+                },
+                {
+                    "content": "What are the key principles for designing scalable systems?",
+                    "role": "user",
+                },
+            ],
+            output_messages=[{"content": mock.ANY, "role": "assistant"}],
+            metadata={
+                "temperature": 0.1,
+                "max_tokens": 100.0,
+            },
+            metrics={
+                "input_tokens": 1049,
+                "output_tokens": 100,
+                "total_tokens": 1149,
+                "cache_write_input_tokens": 1031,
+                "cache_read_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 1031,
+            },
+            tags={
+                "ml_app": "<ml-app-name>",
+                "service": "tests.contrib.anthropic",
+                "integration": "anthropic",
+            },
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[1]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[
+                {
+                    "content": large_system_prompt[0]["text"],
+                    "role": "system",
+                },
+                {
+                    "content": "What is a system",
+                    "role": "user",
+                },
+            ],
+            output_messages=[{"content": mock.ANY, "role": "assistant"}],
+            metadata={
+                "temperature": 0.1,
+                "max_tokens": 100.0,
+            },
+            metrics={
+                "input_tokens": 1042,
+                "output_tokens": 100,
+                "total_tokens": 1142,
+                "cache_write_input_tokens": 0,
+                "cache_read_input_tokens": 1031,
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0,
+            },
+            tags={
+                "ml_app": "<ml-app-name>",
+                "service": "tests.contrib.anthropic",
+                "integration": "anthropic",
+            },
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
-    def test_beta_completion(self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr):
+    def test_beta_completion(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Ensure llmobs records are emitted for beta completion endpoints."""
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion.yaml"):
@@ -1437,22 +1379,21 @@ class TestLLMObsAnthropic:
                 max_tokens=15,
                 messages=[{"role": "user", "content": "What does Nietzsche mean by 'God is dead'?"}],
             )
-        span = test_spans.pop_traces()[0][0]
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-3-opus-20240229",
-                model_provider="anthropic",
-                input_messages=[{"content": "What does Nietzsche mean by 'God is dead'?", "role": "user"}],
-                output_messages=[{"content": response.content[0].text, "role": "assistant"}],
-                metadata={"max_tokens": 15.0},
-                token_metrics={
-                    "input_tokens": response.usage.input_tokens,
-                    "output_tokens": response.usage.output_tokens,
-                    "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
-                },
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-3-opus-20240229",
+            model_provider="anthropic",
+            input_messages=[{"content": "What does Nietzsche mean by 'God is dead'?", "role": "user"}],
+            output_messages=[{"content": response.content[0].text, "role": "assistant"}],
+            metadata={"max_tokens": 15.0},
+            metrics={
+                "input_tokens": response.usage.input_tokens,
+                "output_tokens": response.usage.output_tokens,
+                "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+            },
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 47), reason="Thinking support requires anthropic>=0.47.0")
@@ -1460,7 +1401,6 @@ class TestLLMObsAnthropic:
         self,
         anthropic,
         ddtrace_global_config,
-        mock_llmobs_writer,
         test_spans,
         request_vcr,
     ):
@@ -1474,25 +1414,24 @@ class TestLLMObsAnthropic:
                 thinking={"type": "enabled", "budget_tokens": 1024},
                 messages=[{"role": "user", "content": "What is the best selling book of all time?"}],
             )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-sonnet-4-20250514",
-                model_provider="anthropic",
-                input_messages=[{"content": "What is the best selling book of all time?", "role": "user"}],
-                output_messages=[
-                    {
-                        "content": "Let me think about the best selling book of all time.",
-                        "role": "reasoning",
-                    },
-                    {"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON QUIXOTE"', "role": "assistant"},
-                ],
-                metadata={"temperature": 1, "max_tokens": 16000.0},
-                token_metrics={"input_tokens": 50, "output_tokens": 200, "total_tokens": 250},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[{"content": "What is the best selling book of all time?", "role": "user"}],
+            output_messages=[
+                {
+                    "content": "Let me think about the best selling book of all time.",
+                    "role": "reasoning",
+                },
+                {"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON QUIXOTE"', "role": "assistant"},
+            ],
+            metadata={"temperature": 1, "max_tokens": 16000.0},
+            metrics={"input_tokens": 50, "output_tokens": 200, "total_tokens": 250},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 47), reason="Thinking support requires anthropic>=0.47.0")
@@ -1500,7 +1439,6 @@ class TestLLMObsAnthropic:
         self,
         anthropic,
         ddtrace_global_config,
-        mock_llmobs_writer,
         test_spans,
         request_vcr,
     ):
@@ -1515,37 +1453,36 @@ class TestLLMObsAnthropic:
                 messages=[{"role": "user", "content": WEATHER_PROMPT}],
                 tools=tools,
             )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-sonnet-4-20250514",
-                model_provider="anthropic",
-                input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
-                output_messages=[
-                    {
-                        "content": "I need to use the get_weather tool to answer this question.",
-                        "role": "reasoning",
-                    },
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "arguments": {"location": "San Francisco, CA"},
-                                "tool_id": "toolu_thinking_001",
-                                "type": "tool_use",
-                            }
-                        ],
-                    },
-                ],
-                metadata={"max_tokens": 16000.0, "temperature": 1},
-                token_metrics={"input_tokens": 100, "output_tokens": 150, "total_tokens": 250},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[{"content": WEATHER_PROMPT, "role": "user"}],
+            output_messages=[
+                {
+                    "content": "I need to use the get_weather tool to answer this question.",
+                    "role": "reasoning",
+                },
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                            "tool_id": "toolu_thinking_001",
+                            "type": "tool_use",
+                        }
+                    ],
+                },
+            ],
+            metadata={"max_tokens": 16000.0, "temperature": 1},
+            metrics={"input_tokens": 100, "output_tokens": 150, "total_tokens": 250},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 47), reason="Thinking support requires anthropic>=0.47.0")
@@ -1553,7 +1490,6 @@ class TestLLMObsAnthropic:
         self,
         anthropic,
         ddtrace_global_config,
-        mock_llmobs_writer,
         test_spans,
         request_vcr,
     ):
@@ -1592,56 +1528,53 @@ class TestLLMObsAnthropic:
                 ],
                 tools=tools,
             )
-        span = test_spans.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span,
-                model_name="claude-sonnet-4-20250514",
-                model_provider="anthropic",
-                input_messages=[
-                    {"content": WEATHER_PROMPT, "role": "user"},
-                    {"content": "I need to check the weather.", "role": "reasoning"},
-                    {
-                        "content": "",
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "arguments": {"location": "San Francisco, CA"},
-                                "tool_id": "toolu_thinking_001",
-                                "type": "tool_use",
-                            }
-                        ],
-                    },
-                    {
-                        "content": "",
-                        "role": "user",
-                        "tool_results": [
-                            {
-                                "result": "The weather is 73f",
-                                "tool_id": "toolu_thinking_001",
-                                "type": "tool_result",
-                            }
-                        ],
-                    },
-                ],
-                output_messages=[
-                    {
-                        "content": "The weather in San Francisco, CA is currently 73\u00b0F.",
-                        "role": "assistant",
-                    },
-                ],
-                metadata={"max_tokens": 16000.0, "temperature": 1},
-                token_metrics={"input_tokens": 200, "output_tokens": 30, "total_tokens": 230},
-                tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
-                tool_definitions=EXPECTED_TOOL_DEFINITIONS,
-            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            input_messages=[
+                {"content": WEATHER_PROMPT, "role": "user"},
+                {"content": "I need to check the weather.", "role": "reasoning"},
+                {
+                    "content": "",
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                            "tool_id": "toolu_thinking_001",
+                            "type": "tool_use",
+                        }
+                    ],
+                },
+                {
+                    "content": "",
+                    "role": "user",
+                    "tool_results": [
+                        {
+                            "result": "The weather is 73f",
+                            "tool_id": "toolu_thinking_001",
+                            "type": "tool_result",
+                        }
+                    ],
+                },
+            ],
+            output_messages=[
+                {
+                    "content": "The weather in San Francisco, CA is currently 73\u00b0F.",
+                    "role": "assistant",
+                },
+            ],
+            metadata={"max_tokens": 16000.0, "temperature": 1},
+            metrics={"input_tokens": 200, "output_tokens": 30, "total_tokens": 230},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
+            tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
-    def test_deferred_tool_schema_stripped_in_span(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
-    ):
+    def test_deferred_tool_schema_stripped_in_span(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
         """Regression test: deferred tools (defer_loading=True) should have description and schema
         stripped from LLMObs spans to avoid inflating payload size. Non-deferred tools keep their
         full definitions.
@@ -1673,8 +1606,9 @@ class TestLLMObsAnthropic:
                 ],
             )
 
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        span_event = mock_llmobs_writer.enqueue.call_args[0][0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        span_event = _get_llmobs_data_metastruct(spans[0])
         assert span_event["meta"]["tool_definitions"] == [
             {
                 "name": "get_weather",
@@ -1689,7 +1623,7 @@ class TestLLMObsAnthropic:
         ]
 
     def test_tool_with_deep_schema_has_schema_truncated(
-        self, anthropic, ddtrace_global_config, mock_llmobs_writer, test_spans, request_vcr
+        self, anthropic, ddtrace_global_config, test_spans, request_vcr
     ):
         """Tool schemas exceeding MAX_TOOL_SCHEMA_DEPTH should be truncated at the depth limit,
         replacing over-limit containers with empty containers while preserving name, description,
@@ -1717,8 +1651,9 @@ class TestLLMObsAnthropic:
                     },
                 ],
             )
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        span_event = mock_llmobs_writer.enqueue.call_args[0][0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        span_event = _get_llmobs_data_metastruct(spans[0])
         assert span_event["meta"]["tool_definitions"] == [
             {
                 "name": "get_weather",

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -1595,19 +1595,22 @@ class TestLLMObsAnthropic:
 
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        span_event = _get_llmobs_data_metastruct(spans[0])
-        assert span_event["meta"]["tool_definitions"] == [
-            {
-                "name": "get_weather",
-                "description": "Get the weather for a specific location",
-                "schema": {"type": "object", "properties": {"location": {"type": "string"}}},
-            },
-            {
-                "name": "search_logs",
-                "description": "",
-                "schema": {},
-            },
-        ]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            tool_definitions=[
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather for a specific location",
+                    "schema": {"type": "object", "properties": {"location": {"type": "string"}}},
+                },
+                {
+                    "name": "search_logs",
+                    "description": "",
+                    "schema": {},
+                },
+            ],
+        )
 
     def test_tool_with_deep_schema_has_schema_truncated(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Tool schemas exceeding MAX_TOOL_SCHEMA_DEPTH should be truncated at the depth limit,
@@ -1638,42 +1641,45 @@ class TestLLMObsAnthropic:
             )
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        span_event = _get_llmobs_data_metastruct(spans[0])
-        assert span_event["meta"]["tool_definitions"] == [
-            {
-                "name": "get_weather",
-                "description": "Get the weather for a specific location",
-                "schema": {"type": "object", "properties": {"location": {"type": "string"}}},
-            },
-            {
-                "name": "deep_tool",
-                "description": "A tool with a deeply nested schema",
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "l1": {
-                            "type": "object",
-                            "properties": {
-                                "l2": {
-                                    "type": "object",
-                                    "properties": {
-                                        "l3": {
-                                            "type": "object",
-                                            "properties": {
-                                                "l4": {
-                                                    "type": "object",
-                                                    "properties": {"l5": {}},
-                                                }
-                                            },
-                                        }
-                                    },
-                                }
-                            },
-                        }
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
+            tool_definitions=[
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather for a specific location",
+                    "schema": {"type": "object", "properties": {"location": {"type": "string"}}},
+                },
+                {
+                    "name": "deep_tool",
+                    "description": "A tool with a deeply nested schema",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "l1": {
+                                "type": "object",
+                                "properties": {
+                                    "l2": {
+                                        "type": "object",
+                                        "properties": {
+                                            "l3": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "l4": {
+                                                        "type": "object",
+                                                        "properties": {"l5": {}},
+                                                    }
+                                                },
+                                            }
+                                        },
+                                    }
+                                },
+                            }
+                        },
                     },
                 },
-            },
-        ]
+            ],
+        )
 
 
 def test_shadow_tags_chat_when_llmobs_disabled(tracer):

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -50,19 +50,8 @@ EXPECTED_TOOL_DEFINITIONS = [
 ]
 
 
-@pytest.mark.parametrize(
-    "ddtrace_global_config",
-    [
-        dict(
-            _llmobs_enabled=True,
-            _llmobs_sample_rate=1.0,
-            _llmobs_ml_app="<ml-app-name>",
-            _llmobs_instrumented_proxy_urls="http://localhost:4000",
-        )
-    ],
-)
 class TestLLMObsAnthropic:
-    def test_content_block_stop_without_content_does_not_crash(self, ddtrace_global_config):
+    def test_content_block_stop_without_content_does_not_crash(self):
         """Regression test for beta streaming: content_block_stop can arrive without any content blocks."""
         from ddtrace.contrib.internal.anthropic._streaming import _on_content_block_stop_chunk
 
@@ -71,9 +60,7 @@ class TestLLMObsAnthropic:
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_beta_server_tool_use_stream(
-        self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream
-    ):
+    def test_beta_server_tool_use_stream(self, anthropic, anthropic_llmobs, test_spans, request_vcr, consume_stream):
         """Regression test for streamed server-side tool usage/results being captured"""
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion_beta_tools_stream.yaml"):
@@ -177,7 +164,7 @@ class TestLLMObsAnthropic:
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
-    def test_beta_server_tool_use_non_stream(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_beta_server_tool_use_non_stream(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion_tools_server_tool_use.yaml"):
             llm.beta.messages.create(
@@ -282,7 +269,7 @@ class TestLLMObsAnthropic:
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 47), reason="Thinking support requires anthropic>=0.47.0")
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_stream_with_thinking(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
+    def test_stream_with_thinking(self, anthropic, anthropic_llmobs, test_spans, request_vcr, consume_stream):
         """Ensure thinking blocks are properly captured from streamed responses."""
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion_stream_thinking.yaml"):
@@ -326,7 +313,7 @@ class TestLLMObsAnthropic:
         self,
         mock_anthropic_messages_post,
         anthropic,
-        ddtrace_global_config,
+        anthropic_llmobs,
         test_spans,
         request_vcr,
     ):
@@ -382,9 +369,7 @@ class TestLLMObsAnthropic:
         assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
 
     @patch("anthropic._base_client.SyncAPIClient.post")
-    def test_completion_unknown_provider(
-        self, mock_anthropic_messages_post, anthropic, ddtrace_global_config, test_spans
-    ):
+    def test_completion_unknown_provider(self, mock_anthropic_messages_post, anthropic, anthropic_llmobs, test_spans):
         """Ensure model_provider is set to 'unknown' when base_url doesn't match any known provider."""
         mock_anthropic_messages_post.return_value = MOCK_MESSAGES_CREATE_REQUEST
         llm = anthropic.Anthropic(base_url="http://localhost:8000")
@@ -393,7 +378,7 @@ class TestLLMObsAnthropic:
         assert len(spans) == 1
         assert _get_llmobs_data_metastruct(spans[0])["meta"]["model_provider"] == "unknown"
 
-    def test_completion(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_completion(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -433,7 +418,7 @@ class TestLLMObsAnthropic:
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
-    def test_completion_with_multiple_system_prompts(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_completion_with_multiple_system_prompts(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints with a list of messages as the system prompt.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -491,7 +476,7 @@ class TestLLMObsAnthropic:
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
-    def test_error(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_error(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an error.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -542,7 +527,7 @@ class TestLLMObsAnthropic:
                 )
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_stream(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
+    def test_stream(self, anthropic, anthropic_llmobs, test_spans, request_vcr, consume_stream):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -593,7 +578,7 @@ class TestLLMObsAnthropic:
             )
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_stream_helper(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
+    def test_stream_helper(self, anthropic, anthropic_llmobs, test_spans, request_vcr, consume_stream):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -648,7 +633,7 @@ class TestLLMObsAnthropic:
                 tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
             )
 
-    def test_image(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_image(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an image input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -703,7 +688,7 @@ class TestLLMObsAnthropic:
             )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
-    def test_tools_sync(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_tools_sync(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -801,7 +786,7 @@ class TestLLMObsAnthropic:
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
-    async def test_tools_async(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    async def test_tools_async(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -895,7 +880,7 @@ class TestLLMObsAnthropic:
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_tools_sync_stream(self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream):
+    def test_tools_sync_stream(self, anthropic, anthropic_llmobs, test_spans, request_vcr, consume_stream):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
         Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
@@ -1010,7 +995,7 @@ class TestLLMObsAnthropic:
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 27), reason="Anthropic Tools not available until 0.27.0, skipping.")
     @pytest.mark.parametrize("consume_stream", [aiterate_stream, anext_stream])
     async def test_tools_async_stream_helper(
-        self, anthropic, ddtrace_global_config, test_spans, request_vcr, consume_stream
+        self, anthropic, anthropic_llmobs, test_spans, request_vcr, consume_stream
     ):
         """Ensure llmobs records are emitted for completion endpoints when configured and there is an stream input.
 
@@ -1113,7 +1098,7 @@ class TestLLMObsAnthropic:
             tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
-    def test_completion_prompt_caching(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_completion_prompt_caching(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         llm = anthropic.Anthropic()
         """Test that prompt caching metrics are properly captured for both cache creation and cache read."""
         large_system_prompt = [
@@ -1212,7 +1197,7 @@ class TestLLMObsAnthropic:
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 66), reason="1h cache TTL not available until 0.66.0, skipping.")
-    def test_completion_prompt_caching_1h_ttl(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_completion_prompt_caching_1h_ttl(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Test that prompt caching metrics with 1h TTL are properly captured."""
         llm = anthropic.Anthropic()
         large_system_prompt = [
@@ -1265,7 +1250,7 @@ class TestLLMObsAnthropic:
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.anthropic", "integration": "anthropic"},
         )
 
-    def test_completion_stream_prompt_caching(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_completion_stream_prompt_caching(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Test that prompt caching metrics are properly captured for streamed completions."""
         large_system_prompt = [
             {
@@ -1370,7 +1355,7 @@ class TestLLMObsAnthropic:
         )
 
     @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
-    def test_beta_completion(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_beta_completion(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Ensure llmobs records are emitted for beta completion endpoints."""
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion.yaml"):
@@ -1400,7 +1385,7 @@ class TestLLMObsAnthropic:
     def test_completion_with_thinking(
         self,
         anthropic,
-        ddtrace_global_config,
+        anthropic_llmobs,
         test_spans,
         request_vcr,
     ):
@@ -1438,7 +1423,7 @@ class TestLLMObsAnthropic:
     def test_completion_with_thinking_and_tools(
         self,
         anthropic,
-        ddtrace_global_config,
+        anthropic_llmobs,
         test_spans,
         request_vcr,
     ):
@@ -1489,7 +1474,7 @@ class TestLLMObsAnthropic:
     def test_thinking_in_input_messages(
         self,
         anthropic,
-        ddtrace_global_config,
+        anthropic_llmobs,
         test_spans,
         request_vcr,
     ):
@@ -1574,7 +1559,7 @@ class TestLLMObsAnthropic:
             tool_definitions=EXPECTED_TOOL_DEFINITIONS,
         )
 
-    def test_deferred_tool_schema_stripped_in_span(self, anthropic, ddtrace_global_config, test_spans, request_vcr):
+    def test_deferred_tool_schema_stripped_in_span(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Regression test: deferred tools (defer_loading=True) should have description and schema
         stripped from LLMObs spans to avoid inflating payload size. Non-deferred tools keep their
         full definitions.
@@ -1622,9 +1607,7 @@ class TestLLMObsAnthropic:
             },
         ]
 
-    def test_tool_with_deep_schema_has_schema_truncated(
-        self, anthropic, ddtrace_global_config, test_spans, request_vcr
-    ):
+    def test_tool_with_deep_schema_has_schema_truncated(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
         """Tool schemas exceeding MAX_TOOL_SCHEMA_DEPTH should be truncated at the depth limit,
         replacing over-limit containers with empty containers while preserving name, description,
         and all fields within the limit. Tools with shallow schemas are unaffected.


### PR DESCRIPTION
Migrates anthropic LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with an `anthropic_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17767.
