### PR TITLE
test(llmobs): migrate google_adk tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/google_adk/conftest.py
+++ b/tests/contrib/google_adk/conftest.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock
 
 from google.adk.agents.invocation_context import InvocationContext
@@ -17,13 +18,32 @@ from ddtrace.contrib.internal.google_adk.patch import patch as adk_patch
 from ddtrace.contrib.internal.google_adk.patch import unpatch as adk_unpatch
 from ddtrace.llmobs import LLMObs
 from tests.contrib.google_adk.utils import get_request_vcr
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
 
 
 @pytest.fixture
 def ddtrace_global_config():
     return {}
+
+
+@pytest.fixture
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            # Have to disable and re-enable LLMObs to use to mock tracer.
+            LLMObs.disable()
+            LLMObs.enable(integrations_enabled=False)
+            # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+            # background flush thread alive trying to ship spans during the test.
+            LLMObs._instance._llmobs_span_writer.stop()
+            LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 @pytest.fixture
@@ -67,32 +87,6 @@ def mock_invocation_context(test_runner) -> InvocationContext:
         session=mock_session,
         session_service=mock_session_service,
     )
-
-
-@pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def adk_llmobs(tracer, llmobs_span_writer):
-    LLMObs.disable()
-    with override_global_config(
-        {
-            "_dd_api_key": "<not-a-real-api_key>",
-            "_llmobs_ml_app": "<ml-app-name>",
-            "service": "tests.contrib.google_adk",
-        }
-    ):
-        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
-        LLMObs._instance._llmobs_span_writer = llmobs_span_writer
-        yield LLMObs
-    LLMObs.disable()
-
-
-@pytest.fixture
-def llmobs_events(adk_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
 
 
 def search_docs(query: str) -> dict[str, Any]:

--- a/tests/contrib/google_adk/conftest.py
+++ b/tests/contrib/google_adk/conftest.py
@@ -36,7 +36,7 @@ def test_spans(ddtrace_global_config, test_spans, monkeypatch):
             monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
             # Have to disable and re-enable LLMObs to use to mock tracer.
             LLMObs.disable()
-            LLMObs.enable(integrations_enabled=False)
+            LLMObs.enable(integrations_enabled=False, agentless_enabled=False)
             # Replace the real LLMObsSpanWriter with a mock so we don't keep a
             # background flush thread alive trying to ship spans during the test.
             LLMObs._instance._llmobs_span_writer.stop()

--- a/tests/contrib/google_adk/conftest.py
+++ b/tests/contrib/google_adk/conftest.py
@@ -27,23 +27,26 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            # Have to disable and re-enable LLMObs to use to mock tracer.
-            LLMObs.disable()
-            LLMObs.enable(integrations_enabled=False, agentless_enabled=False)
-            # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-            # background flush thread alive trying to ship spans during the test.
-            LLMObs._instance._llmobs_span_writer.stop()
-            LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-        yield test_spans
-    finally:
-        LLMObs.disable()
+def google_adk_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "service": "tests.contrib.google_adk",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -33,13 +33,9 @@ AGENT_MANIFEST_METADATA = {
 }
 
 
-@pytest.mark.parametrize(
-    "ddtrace_global_config",
-    [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")],
-)
 class TestLLMObsGoogleADK:
     @pytest.mark.asyncio
-    async def test_agent_run1(self, test_runner, request_vcr, test_spans):
+    async def test_agent_run1(self, test_runner, request_vcr, test_spans, google_adk_llmobs):
         """Test that a simple agent run creates a valid LLMObs span event."""
         error = None
         with request_vcr.use_cassette("agent_run_async.yaml"):
@@ -104,7 +100,7 @@ class TestLLMObsGoogleADK:
         )
 
     @pytest.mark.asyncio
-    async def test_agent_run_with_tools(self, test_runner, request_vcr, test_spans):
+    async def test_agent_run_with_tools(self, test_runner, request_vcr, test_spans, google_adk_llmobs):
         """Test that an agent run with tool usage creates a valid LLMObs span event."""
         error = None
         with request_vcr.use_cassette("agent_tool_usage.yaml"):
@@ -155,7 +151,7 @@ class TestLLMObsGoogleADK:
             metrics={},
         )
 
-    def test_code_execution(self, mock_invocation_context, test_spans):
+    def test_code_execution(self, mock_invocation_context, test_spans, google_adk_llmobs):
         """Test that code execution creates a valid LLMObs span event."""
         from google.adk.code_executors.code_execution_utils import CodeExecutionInput
         from google.adk.code_executors.unsafe_local_code_executor import UnsafeLocalCodeExecutor

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -2,8 +2,35 @@ from unittest import mock
 
 import pytest
 
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.contrib.google_adk.conftest import create_test_message
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
+
+
+AGENT_MANIFEST_METADATA = {
+    "_dd": {
+        "agent_manifest": {
+            "description": "Test agent for ADK integration testing",
+            "framework": "Google ADK",
+            "instructions": "You are a helpful test agent. You can: "
+            "(1) call tools using the provided "
+            "functions, (2) execute Python code "
+            "blocks when they are provided to you. "
+            "When you see ```python code blocks, "
+            "execute them using your code execution "
+            "capability. Always be helpful and use "
+            "your available capabilities.",
+            "model": "gemini-2.5-pro",
+            "model_configuration": '{"arbitrary_types_allowed": true, "extra": "forbid"}',
+            "name": "test_agent",
+            "session_management": {"session_id": "test-session", "user_id": "test-user"},
+            "tools": [
+                {"description": "A tiny search tool stub.", "name": "search_docs"},
+                {"description": "Simple arithmetic tool.", "name": "multiply"},
+            ],
+        }
+    }
+}
 
 
 @pytest.mark.parametrize(
@@ -12,9 +39,9 @@ from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
 )
 class TestLLMObsGoogleADK:
     @pytest.mark.asyncio
-    async def test_agent_run1(self, test_runner, llmobs_events, request_vcr, test_spans):
+    async def test_agent_run1(self, test_runner, request_vcr, test_spans):
         """Test that a simple agent run creates a valid LLMObs span event."""
-        error_type = mock.ANY
+        error = mock.ANY
         with request_vcr.use_cassette("agent_run_async.yaml"):
             message = create_test_message("Say hello")
             try:
@@ -27,28 +54,59 @@ class TestLLMObsGoogleADK:
             except (TypeError, ValueError) as e:
                 # Handle known ADK library issues with VCR cassettes
                 if any(phrase in str(e) for phrase in ["exec_python", "Function", "JSON serializable", "bytes"]):
-                    error_type = "builtins.TypeError" if isinstance(e, TypeError) else "builtins.ValueError"
+                    error = {
+                        "type": "builtins.TypeError" if isinstance(e, TypeError) else "builtins.ValueError",
+                        "message": mock.ANY,
+                        "stack": mock.ANY,
+                    }
                 else:
                     raise
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
 
-        # We expect 3 events: 2 tool calls and 1 agent run
-        assert len(llmobs_events) == 3
+        # We expect 3 spans: 1 agent run and 2 tool calls
         assert len(spans) == 3
 
         agent_span = spans[0]
         search_tool_span = spans[1]
         multiply_tool_span = spans[2]
 
-        expected_llmobs_tool_span_events_agent_run(
-            llmobs_events, agent_span, search_tool_span, multiply_tool_span, error_type
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(search_tool_span),
+            span_kind="tool",
+            input_value='{"query": "test"}',
+            output_value='{"results": ["Found reference for: test"]}',
+            metadata={"description": "A tiny search tool stub."},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
+            name="search_docs",
+        )
+
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(multiply_tool_span),
+            span_kind="tool",
+            input_value='{"a": 5, "b": 3}',
+            output_value='{"product": 15}',
+            metadata={"description": "Simple arithmetic tool."},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
+            name="multiply",
+        )
+
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
+            span_kind="agent",
+            error=error,
+            input_value="Say hello",
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
+            name="test_agent",
+            metadata=AGENT_MANIFEST_METADATA,
+            output_value=mock.ANY,
+            metrics={},
         )
 
     @pytest.mark.asyncio
-    async def test_agent_run_with_tools(self, test_runner, llmobs_events, request_vcr, test_spans):
+    async def test_agent_run_with_tools(self, test_runner, request_vcr, test_spans):
         """Test that an agent run with tool usage creates a valid LLMObs span event."""
-        error_type = 0
+        error = mock.ANY
         with request_vcr.use_cassette("agent_tool_usage.yaml"):
             message = create_test_message("Can you search for information about recurring revenue?")
             try:
@@ -61,20 +119,43 @@ class TestLLMObsGoogleADK:
             except (TypeError, ValueError) as e:
                 # Handle known ADK library issues with VCR cassettes
                 if any(phrase in str(e) for phrase in ["exec_python", "Function", "JSON serializable", "bytes"]):
-                    error_type = "builtins.TypeError" if isinstance(e, TypeError) else "builtins.ValueError"
+                    error = {
+                        "type": "builtins.TypeError" if isinstance(e, TypeError) else "builtins.ValueError",
+                        "message": mock.ANY,
+                        "stack": mock.ANY,
+                    }
                 else:
                     raise
 
-        spans = test_spans.pop_traces()[0]
-        assert len(llmobs_events) == 2
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 2
 
         agent_span = spans[0]
         tool_span = spans[1]
 
-        expected_llmobs_agent_span_event_with_tools(llmobs_events, agent_span, tool_span, error_type)
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(tool_span),
+            span_kind="tool",
+            input_value='{"query": "recurring revenue"}',
+            output_value='{"results": ["Found reference for: recurring revenue"]}',
+            metadata={"description": "A tiny search tool stub."},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
+            name="search_docs",
+        )
 
-    def test_code_execution(self, mock_invocation_context, test_spans, llmobs_events):
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
+            span_kind="agent",
+            error=error,
+            input_value="Can you search for information about recurring revenue?",
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
+            name="test_agent",
+            metadata=AGENT_MANIFEST_METADATA,
+            output_value=mock.ANY,
+            metrics={},
+        )
+
+    def test_code_execution(self, mock_invocation_context, test_spans):
         """Test that code execution creates a valid LLMObs span event."""
         from google.adk.code_executors.code_execution_utils import CodeExecutionInput
         from google.adk.code_executors.unsafe_local_code_executor import UnsafeLocalCodeExecutor
@@ -83,128 +164,14 @@ class TestLLMObsGoogleADK:
         code_input = CodeExecutionInput(code='print("hello world")')
         executor.execute_code(mock_invocation_context, code_input)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        expected_llmobs_code_execution_event(llmobs_events[0], span)
-
-
-def expected_llmobs_tool_span_events_agent_run(
-    llmobs_event, agent_span, search_tool_span, multiply_tool_span, error_type
-):
-    assert llmobs_event[0] == _expected_llmobs_non_llm_span_event(
-        span=search_tool_span,
-        span_kind="tool",
-        input_value='{"query": "test"}',
-        output_value='{"results": ["Found reference for: test"]}',
-        metadata={"description": "A tiny search tool stub."},
-        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
-        name="search_docs",
-    )
-
-    assert llmobs_event[1] == _expected_llmobs_non_llm_span_event(
-        span=multiply_tool_span,
-        span_kind="tool",
-        input_value='{"a": 5, "b": 3}',
-        output_value='{"product": 15}',
-        metadata={"description": "Simple arithmetic tool."},
-        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
-        name="multiply",
-    )
-
-    assert llmobs_event[2] == _expected_llmobs_non_llm_span_event(
-        span=agent_span,
-        span_kind="agent",
-        error_message=mock.ANY,
-        error_stack=mock.ANY,
-        error=error_type,
-        input_value="Say hello",
-        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
-        name="test_agent",
-        metadata={
-            "_dd": {
-                "agent_manifest": {
-                    "description": "Test agent for ADK integration testing",
-                    "framework": "Google ADK",
-                    "instructions": "You are a helpful test agent. You can: "
-                    "(1) call tools using the provided "
-                    "functions, (2) execute Python code "
-                    "blocks when they are provided to you. "
-                    "When you see ```python code blocks, "
-                    "execute them using your code execution "
-                    "capability. Always be helpful and use "
-                    "your available capabilities.",
-                    "model": "gemini-2.5-pro",
-                    "model_configuration": '{"arbitrary_types_allowed": true, "extra": "forbid"}',
-                    "name": "test_agent",
-                    "session_management": {"session_id": "test-session", "user_id": "test-user"},
-                    "tools": [
-                        {"description": "A tiny search tool stub.", "name": "search_docs"},
-                        {"description": "Simple arithmetic tool.", "name": "multiply"},
-                    ],
-                }
-            }
-        },
-        output_value=mock.ANY,
-        token_metrics={},
-    )
-
-
-def expected_llmobs_agent_span_event_with_tools(llmobs_event, agent_span, tool_span, error_type):
-    assert llmobs_event[0] == _expected_llmobs_non_llm_span_event(
-        span=tool_span,
-        span_kind="tool",
-        input_value='{"query": "recurring revenue"}',
-        output_value='{"results": ["Found reference for: recurring revenue"]}',
-        metadata={"description": "A tiny search tool stub."},
-        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
-        name="search_docs",
-    )
-
-    assert llmobs_event[1] == _expected_llmobs_non_llm_span_event(
-        span=agent_span,
-        span_kind="agent",
-        error_message=mock.ANY,
-        error_stack=mock.ANY,
-        error=error_type,
-        input_value="Can you search for information about recurring revenue?",
-        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
-        name="test_agent",
-        metadata={
-            "_dd": {
-                "agent_manifest": {
-                    "description": "Test agent for ADK integration testing",
-                    "framework": "Google ADK",
-                    "instructions": "You are a helpful test agent. You can: "
-                    "(1) call tools using the provided "
-                    "functions, (2) execute Python code "
-                    "blocks when they are provided to you. "
-                    "When you see ```python code blocks, "
-                    "execute them using your code execution "
-                    "capability. Always be helpful and use "
-                    "your available capabilities.",
-                    "model": "gemini-2.5-pro",
-                    "model_configuration": '{"arbitrary_types_allowed": true, "extra": "forbid"}',
-                    "name": "test_agent",
-                    "session_management": {"session_id": "test-session", "user_id": "test-user"},
-                    "tools": [
-                        {"description": "A tiny search tool stub.", "name": "search_docs"},
-                        {"description": "Simple arithmetic tool.", "name": "multiply"},
-                    ],
-                }
-            }
-        },
-        output_value=mock.ANY,
-        token_metrics={},
-    )
-
-
-def expected_llmobs_code_execution_event(llmobs_event, span):
-    assert llmobs_event == _expected_llmobs_non_llm_span_event(
-        span=span,
-        span_kind="code_execute",
-        input_value='print("hello world")',
-        output_value="hello world\n",
-        metadata={},
-        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
-        name="Google ADK Code Execute",
-    )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="code_execute",
+            input_value='print("hello world")',
+            output_value="hello world\n",
+            metadata={},
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.google_adk", "integration": "google_adk"},
+            name="Google ADK Code Execute",
+        )

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -41,7 +41,7 @@ class TestLLMObsGoogleADK:
     @pytest.mark.asyncio
     async def test_agent_run1(self, test_runner, request_vcr, test_spans):
         """Test that a simple agent run creates a valid LLMObs span event."""
-        error = mock.ANY
+        error = None
         with request_vcr.use_cassette("agent_run_async.yaml"):
             message = create_test_message("Say hello")
             try:
@@ -106,7 +106,7 @@ class TestLLMObsGoogleADK:
     @pytest.mark.asyncio
     async def test_agent_run_with_tools(self, test_runner, request_vcr, test_spans):
         """Test that an agent run with tool usage creates a valid LLMObs span event."""
-        error = mock.ANY
+        error = None
         with request_vcr.use_cassette("agent_tool_usage.yaml"):
             message = create_test_message("Can you search for information about recurring revenue?")
             try:

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -1069,8 +1069,11 @@ def assert_llmobs_span_data(
     """Assert against an LLMObsSpanData payload from ``meta_struct['_llmobs']``.
 
     Structural fields (``span_kind``, ``name``, ``parent_id``, ``model_name``,
-    ``model_provider``, input/output messages/values/documents, ``error``,
+    ``model_provider``, input/output messages/values/documents,
     ``tool_definitions``) are strict-equality, checked only when provided.
+
+    ``error`` defaults to asserting no error payload is present. Pass
+    ``error=mock.ANY`` to skip the check.
 
     ``metadata``, ``tags``, ``metrics`` are top-level subset only: declared
     top-level keys must equal exactly, extras tolerated. Nested values compare
@@ -1148,7 +1151,13 @@ def assert_llmobs_span_data(
         _check_eq("meta.output.value", output_value, actual_output.get(LLMOBS_STRUCT.VALUE))
     if output_documents is not None:
         _check_eq("meta.output.documents", output_documents, actual_output.get(LLMOBS_STRUCT.DOCUMENTS))
-    if error is not None:
+    if error is None:
+        actual_error = actual_meta.get(LLMOBS_STRUCT.ERROR)
+        if actual_error:
+            failures.append(
+                "meta.error unexpectedly present:\n    expected=<absent>\n    actual={!r}".format(actual_error)
+            )
+    else:
         _check_eq("meta.error", error, actual_meta.get(LLMOBS_STRUCT.ERROR))
     if tool_definitions is not None:
         _check_eq("meta.tool_definitions", tool_definitions, actual_meta.get(LLMOBS_STRUCT.TOOL_DEFINITIONS))


### PR DESCRIPTION
Migrates google_adk LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `google_adk_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
