### PR TITLE
test(llmobs): migrate mcp tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/mcp/conftest.py
+++ b/tests/contrib/mcp/conftest.py
@@ -3,6 +3,7 @@ from http.server import HTTPServer
 import json
 import threading
 import time
+from unittest import mock
 
 from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import create_connected_server_and_client_session
@@ -10,9 +11,8 @@ import pytest
 
 from ddtrace.contrib.internal.mcp.patch import patch
 from ddtrace.contrib.internal.mcp.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._constants import SPAN_ENDPOINT as LLMOBS_SPAN_ENDPOINT
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
 
 
@@ -51,25 +51,31 @@ def mcp_setup():
 
 
 @pytest.fixture
-def mcp_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "mcptest"}
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs_events(mcp_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/mcp/conftest.py
+++ b/tests/contrib/mcp/conftest.py
@@ -56,26 +56,26 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def mcp_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "service": "mcptest",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -6,7 +6,6 @@ import os
 from textwrap import dedent
 
 import mock
-import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
@@ -15,15 +14,6 @@ from tests.utils import override_config
 
 
 MCP_VERSION = parse_version(version("mcp"))
-
-
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="mcptest",
-)
 
 
 def _assert_distributed_trace(test_spans, expected_tool_name):
@@ -43,8 +33,7 @@ def _assert_distributed_trace(test_spans, expected_tool_name):
     return all_spans, client_spans, server_spans
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, mcp_call_tool):
+def test_llmobs_mcp_client_calls_server(mcp_setup, mcp_llmobs, test_spans, mcp_call_tool):
     """Test that LLMObs records are emitted for both client and server MCP operations."""
     asyncio.run(mcp_call_tool("calculator", {"operation": "add", "a": 20, "b": 22}))
 
@@ -173,8 +162,7 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, mcp_call_tool):
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_client_server_tool_error(mcp_setup, test_spans, mcp_call_tool):
+def test_llmobs_client_server_tool_error(mcp_setup, mcp_llmobs, test_spans, mcp_call_tool):
     """Test error handling in both client and server MCP operations."""
     asyncio.run(mcp_call_tool("failing_tool", {"param": "value"}))
 
@@ -258,8 +246,7 @@ def test_llmobs_client_server_tool_error(mcp_setup, test_spans, mcp_call_tool):
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_server_initialization_span_created(mcp_setup, test_spans, mcp_server_initialized):
+def test_server_initialization_span_created(mcp_setup, mcp_llmobs, test_spans, mcp_server_initialized):
     """Test that server initialization creates a span and LLMObs event with custom client info."""
     traces = test_spans.pop_traces()
     all_spans = [span for trace in traces for span in trace]
@@ -359,8 +346,7 @@ def test_mcp_distributed_tracing_disabled_env(ddtrace_run_python_code_in_subproc
     assert client_trace["spans"][0]["_dd"]["apm_trace_id"] != server_trace["spans"][0]["_dd"]["apm_trace_id"]
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_intent_capture_tool_schema_injection(mcp_setup, test_spans, mcp_server):
+def test_intent_capture_tool_schema_injection(mcp_setup, mcp_llmobs, test_spans, mcp_server):
     """Test that intent capture adds telemetry property to tool input schemas."""
     from mcp.shared.memory import create_connected_server_and_client_session
 
@@ -398,8 +384,7 @@ def test_intent_capture_tool_schema_injection(mcp_setup, test_spans, mcp_server)
     assert "b" in schema["required"]
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_intent_capture_records_intent_on_span_meta(mcp_setup, test_spans, mcp_server):
+def test_intent_capture_records_intent_on_span_meta(mcp_setup, mcp_llmobs, test_spans, mcp_server):
     """Test that intent is recorded on the span meta and telemetry argument is excluded from input."""
     from mcp.shared.memory import create_connected_server_and_client_session
 
@@ -448,8 +433,7 @@ def test_intent_capture_records_intent_on_span_meta(mcp_setup, test_spans, mcp_s
     assert "b" in arguments
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_intent_capture_disabled_by_default(mcp_setup, test_spans, mcp_server):
+def test_intent_capture_disabled_by_default(mcp_setup, mcp_llmobs, test_spans, mcp_server):
     """Test that intent capture is disabled by default and telemetry property is not injected."""
     from mcp.shared.memory import create_connected_server_and_client_session
 

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -418,8 +418,7 @@ def test_intent_capture_records_intent_on_span_meta(mcp_setup, mcp_llmobs, test_
         (
             s
             for s in all_spans
-            if get_llmobs_span_name(s) == "calculator"
-            and (get_llmobs_tags(s) or {}).get("mcp_tool_kind") == "server"
+            if get_llmobs_span_name(s) == "calculator" and (get_llmobs_tags(s) or {}).get("mcp_tool_kind") == "server"
         ),
         None,
     )

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -28,7 +28,8 @@ LLMOBS_GLOBAL_CONFIG = dict(
 
 def _assert_distributed_trace(test_spans, expected_tool_name):
     """Assert that client and server spans have the same trace ID; return spans and the
-    client/server tool-call subsets identified by resource name."""
+    client/server tool-call subsets identified by resource name.
+    """
     traces = test_spans.pop_traces()
     assert len(traces) >= 1
 

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -196,9 +196,14 @@ def test_llmobs_client_server_tool_error(mcp_setup, mcp_llmobs, test_spans, mcp_
         },
         sort_keys=True,
     )
-    assert (
-        _get_llmobs_data_metastruct(client_span).get("meta", {}).get("error", {}).get("message")
-        == "Error executing tool failing_tool: Tool execution failed"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(client_span),
+        span_kind="tool",
+        error={
+            "message": "Error executing tool failing_tool: Tool execution failed",
+            "type": mock.ANY,
+            "stack": mock.ANY,
+        },
     )
 
     expected_params = {

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -9,6 +9,8 @@ import mock
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_span_name
+from ddtrace.llmobs._utils import get_llmobs_tags
 from tests.llmobs._utils import assert_llmobs_span_data
 from tests.utils import override_config
 
@@ -410,8 +412,8 @@ def test_intent_capture_records_intent_on_span_meta(mcp_setup, mcp_llmobs, test_
         (
             s
             for s in all_spans
-            if _get_llmobs_data_metastruct(s).get("name") == "calculator"
-            and _get_llmobs_data_metastruct(s).get("tags", {}).get("mcp_tool_kind") == "server"
+            if get_llmobs_span_name(s) == "calculator"
+            and (get_llmobs_tags(s) or {}).get("mcp_tool_kind") == "server"
         ),
         None,
     )

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -135,7 +135,6 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, mcp_call_tool):
             "mcp_server_title": None,
         },
         name="MCP Client Session",
-        metadata=mock.ANY,
     )
 
     assert_llmobs_span_data(

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -9,6 +9,8 @@ import mock
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_value
+from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from ddtrace.llmobs._utils import get_llmobs_tags
 from tests.llmobs._utils import assert_llmobs_span_data
@@ -179,10 +181,8 @@ def test_llmobs_client_server_tool_error(mcp_setup, mcp_llmobs, test_spans, mcp_
     assert server_span.error
 
     # assert the error client span manually via meta_struct
-    client_metastruct = _get_llmobs_data_metastruct(client_span)
-    client_meta = client_metastruct.get("meta", {})
-    assert client_meta.get("input", {}).get("value") == json.dumps({"param": "value"}, sort_keys=True)
-    assert client_meta.get("output", {}).get("value") == json.dumps(
+    assert get_llmobs_input_value(client_span) == json.dumps({"param": "value"}, sort_keys=True)
+    assert get_llmobs_output_value(client_span) == json.dumps(
         {
             "content": [
                 {
@@ -196,7 +196,10 @@ def test_llmobs_client_server_tool_error(mcp_setup, mcp_llmobs, test_spans, mcp_
         },
         sort_keys=True,
     )
-    assert client_meta.get("error", {}).get("message") == "Error executing tool failing_tool: Tool execution failed"
+    assert (
+        _get_llmobs_data_metastruct(client_span).get("meta", {}).get("error", {}).get("message")
+        == "Error executing tool failing_tool: Tool execution failed"
+    )
 
     expected_params = {
         **({"task": None} if MCP_VERSION >= (1, 26, 0) else {}),
@@ -272,14 +275,12 @@ def test_server_initialization_span_created(mcp_setup, mcp_llmobs, test_spans, m
         },
     )
 
-    init_metastruct = _get_llmobs_data_metastruct(initialize_span)
-    init_meta = init_metastruct.get("meta", {})
-    input_data = json.loads(init_meta.get("input", {}).get("value"))
+    input_data = json.loads(get_llmobs_input_value(initialize_span))
     assert input_data["method"] == "initialize"
     assert input_data["params"]["clientInfo"]["name"] == "test-client"
     assert input_data["params"]["clientInfo"]["version"] == "1.2.3"
 
-    output_data = json.loads(init_meta.get("output", {}).get("value"))
+    output_data = json.loads(get_llmobs_output_value(initialize_span))
     assert "protocolVersion" in output_data
     assert "capabilities" in output_data
     assert "serverInfo" in output_data
@@ -419,15 +420,14 @@ def test_intent_capture_records_intent_on_span_meta(mcp_setup, mcp_llmobs, test_
     )
     assert server_tool_span is not None
 
-    server_tool_metastruct = _get_llmobs_data_metastruct(server_tool_span)
-    server_tool_meta = server_tool_metastruct.get("meta", {})
+    server_tool_meta = _get_llmobs_data_metastruct(server_tool_span).get("meta", {})
 
     # Verify intent is recorded in meta
     assert "intent" in server_tool_meta, f"intent not in meta: {server_tool_meta}"
     assert server_tool_meta["intent"] == "Testing intent capture for adding numbers"
 
     # Verify telemetry argument is NOT in the input value
-    input_value = json.loads(server_tool_meta.get("input", {}).get("value"))
+    input_value = json.loads(get_llmobs_input_value(server_tool_span))
     arguments = input_value.get("params", {}).get("arguments", {})
     assert "telemetry" not in arguments, f"telemetry should not be in arguments: {arguments}"
     assert "operation" in arguments

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -21,7 +21,7 @@ MCP_VERSION = parse_version(version("mcp"))
 
 
 def _assert_distributed_trace(test_spans, expected_tool_name):
-    """Assert that client and server spans have the same trace ID; return spans and the
+    """Assert that client and server spans share APM and LLMObs trace context; return spans and the
     client/server tool-call subsets identified by resource name.
     """
     traces = test_spans.pop_traces()
@@ -33,6 +33,14 @@ def _assert_distributed_trace(test_spans, expected_tool_name):
 
     assert len(client_spans) >= 1 and len(server_spans) >= 1
     assert client_spans[0].trace_id == server_spans[0].trace_id
+
+    # LLMObs has its own context propagation independent of APM (LLMObsContextProvider);
+    # assert the LLMObs trace_id matches and the server tool span's LLMObs parent_id points
+    # at the client tool span so an LLMObs-only propagation regression cannot pass.
+    client_meta = _get_llmobs_data_metastruct(client_spans[0])
+    server_meta = _get_llmobs_data_metastruct(server_spans[0])
+    assert client_meta["trace_id"] == server_meta["trace_id"]
+    assert server_meta["parent_id"] == str(client_spans[0].span_id)
 
     return all_spans, client_spans, server_spans
 

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -6,49 +6,50 @@ import os
 from textwrap import dedent
 
 import mock
+import pytest
 
 from ddtrace.internal.utils.version import parse_version
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from tests.llmobs._utils import assert_llmobs_span_data
 from tests.utils import override_config
 
 
 MCP_VERSION = parse_version(version("mcp"))
 
 
-def _assert_distributed_trace(test_spans, llmobs_events, expected_tool_name):
-    """Assert that client and server spans have the same trace ID and return client/server spans and LLM Obs events."""
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="mcptest",
+)
+
+
+def _assert_distributed_trace(test_spans, expected_tool_name):
+    """Assert that client and server spans have the same trace ID; return spans and the
+    client/server tool-call subsets identified by resource name."""
     traces = test_spans.pop_traces()
     assert len(traces) >= 1
 
     all_spans = [span for trace in traces for span in trace]
     client_spans = [span for span in all_spans if span.resource == "client_tool_call"]
     server_spans = [span for span in all_spans if span.resource == "server_tool_call"]
-    client_events = [event for event in llmobs_events if "MCP Client Tool Call" in event["name"]]
-    server_events = [
-        event
-        for event in llmobs_events
-        if event["name"] == expected_tool_name and "mcp_tool_kind:server" in event.get("tags", [])
-    ]
 
     assert len(client_spans) >= 1 and len(server_spans) >= 1
-    assert len(client_events) >= 1 and len(server_events) >= 1
     assert client_spans[0].trace_id == server_spans[0].trace_id
-    assert client_events[0]["trace_id"] == server_events[0]["trace_id"]
-    assert client_events[0]["_dd"]["apm_trace_id"] == server_events[0]["_dd"]["apm_trace_id"]
 
-    return all_spans, client_events, server_events, client_spans, server_spans
+    return all_spans, client_spans, server_spans
 
 
-def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mcp_call_tool):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, mcp_call_tool):
     """Test that LLMObs records are emitted for both client and server MCP operations."""
     asyncio.run(mcp_call_tool("calculator", {"operation": "add", "a": 20, "b": 22}))
 
-    llmobs_events.sort(key=lambda event: event["start_ns"])
-    all_spans, client_events, server_events, client_spans, server_spans = _assert_distributed_trace(
-        test_spans, llmobs_events, "calculator"
-    )
+    all_spans, client_spans, server_spans = _assert_distributed_trace(test_spans, "calculator")
 
-    # Sort all_spans by start_ns to match llmobs_events order
+    # Sort all_spans by start_ns
     all_spans.sort(key=lambda span: span.start_ns)
 
     # session, client initialize, server initialize, client list tools, client tool call, server tool call
@@ -56,11 +57,8 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
     client_span = client_spans[0]
     server_span = server_spans[0]
 
-    assert client_events[0]["name"] == "MCP Client Tool Call: calculator"
-    assert server_events[0]["name"] == "calculator"
-
-    assert client_events[0] == _expected_llmobs_non_llm_span_event(
-        client_span,
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(client_span),
         span_kind="tool",
         input_value=json.dumps({"operation": "add", "a": 20, "b": 22}, sort_keys=True),
         output_value=json.dumps(
@@ -87,9 +85,10 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
         "arguments": {"operation": "add", "a": 20, "b": 22},
     }
 
-    assert server_events[0]["parent_id"] == client_events[0]["span_id"]
-    assert server_events[0] == _expected_llmobs_non_llm_span_event(
-        server_span,
+    # Server tool span is parented to client tool span via apm parent_id
+    assert server_span.parent_id == client_span.span_id
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(server_span),
         span_kind="tool",
         input_value=json.dumps(
             {
@@ -121,9 +120,9 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
         parent_id=mock.ANY,
     )
 
-    # asserting the remaining spans
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        all_spans[0],
+    # asserting the remaining spans (sorted by start_ns)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(all_spans[0]),
         span_kind="workflow",
         input_value=mock.ANY,
         tags={
@@ -138,8 +137,8 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
         metadata=mock.ANY,
     )
 
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-        all_spans[1],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(all_spans[1]),
         span_kind="task",
         output_value=mock.ANY,
         tags={"service": "mcptest", "ml_app": "<ml-app-name>", "integration": "mcp"},
@@ -147,8 +146,8 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
     )
 
     # server initialize
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-        all_spans[2],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(all_spans[2]),
         span_kind="task",
         input_value=mock.ANY,
         output_value=mock.ANY,
@@ -164,8 +163,8 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
     )
 
     # tools/list call
-    assert llmobs_events[5] == _expected_llmobs_non_llm_span_event(
-        all_spans[5],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(all_spans[5]),
         span_kind="task",
         input_value=mock.ANY,
         output_value=mock.ANY,
@@ -174,28 +173,26 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, test_spans, llmobs_events, mc
     )
 
 
-def test_llmobs_client_server_tool_error(mcp_setup, test_spans, llmobs_events, mcp_call_tool):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_client_server_tool_error(mcp_setup, test_spans, mcp_call_tool):
     """Test error handling in both client and server MCP operations."""
     asyncio.run(mcp_call_tool("failing_tool", {"param": "value"}))
 
-    all_spans, client_events, server_events, client_spans, server_spans = _assert_distributed_trace(
-        test_spans, llmobs_events, "failing_tool"
-    )
+    all_spans, client_spans, server_spans = _assert_distributed_trace(test_spans, "failing_tool")
 
     # session, client initialize, server initialize, client tool call, server tool call (no list tools)
     assert len(all_spans) == 5
     client_span = client_spans[0]
     server_span = server_spans[0]
 
-    assert client_events[0]["name"] == "MCP Client Tool Call: failing_tool"
-    assert server_events[0]["name"] == "failing_tool"
-
     assert client_span.error
     assert server_span.error
 
-    # assert the error client span manually
-    assert client_events[0]["meta"]["input"]["value"] == json.dumps({"param": "value"}, sort_keys=True)
-    assert client_events[0]["meta"]["output"]["value"] == json.dumps(
+    # assert the error client span manually via meta_struct
+    client_metastruct = _get_llmobs_data_metastruct(client_span)
+    client_meta = client_metastruct.get("meta", {})
+    assert client_meta.get("input", {}).get("value") == json.dumps({"param": "value"}, sort_keys=True)
+    assert client_meta.get("output", {}).get("value") == json.dumps(
         {
             "content": [
                 {
@@ -209,9 +206,7 @@ def test_llmobs_client_server_tool_error(mcp_setup, test_spans, llmobs_events, m
         },
         sort_keys=True,
     )
-    assert client_events[0]["meta"]["error"]["message"] == "Error executing tool failing_tool: Tool execution failed"
-    assert client_events[0]["status"] == "error"
-    assert "error:1" in client_events[0]["tags"]
+    assert client_meta.get("error", {}).get("message") == "Error executing tool failing_tool: Tool execution failed"
 
     expected_params = {
         **({"task": None} if MCP_VERSION >= (1, 26, 0) else {}),
@@ -220,9 +215,9 @@ def test_llmobs_client_server_tool_error(mcp_setup, test_spans, llmobs_events, m
         "arguments": {"param": "value"},
     }
 
-    assert server_events[0]["parent_id"] == client_events[0]["span_id"]
-    assert server_events[0] == _expected_llmobs_non_llm_span_event(
-        server_span,
+    assert server_span.parent_id == client_span.span_id
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(server_span),
         span_kind="tool",
         input_value=json.dumps(
             {
@@ -257,30 +252,24 @@ def test_llmobs_client_server_tool_error(mcp_setup, test_spans, llmobs_events, m
             "mcp_tool": "failing_tool",
             "mcp_tool_kind": "server",
         },
-        error="ToolError",
-        error_message="tool resulted in an error",
-        error_stack="",
+        error={"type": "ToolError", "message": "tool resulted in an error", "stack": ""},
         name="failing_tool",
         parent_id=mock.ANY,
     )
 
 
-def test_server_initialization_span_created(mcp_setup, test_spans, llmobs_events, mcp_server_initialized):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_server_initialization_span_created(mcp_setup, test_spans, mcp_server_initialized):
     """Test that server initialization creates a span and LLMObs event with custom client info."""
     traces = test_spans.pop_traces()
     all_spans = [span for trace in traces for span in trace]
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
     initialize_spans = [span for span in all_spans if span.name == "mcp.initialize"]
     assert len(initialize_spans) == 1
     initialize_span = initialize_spans[0]
 
-    initialize_events = [event for event in llmobs_events if event["name"] == "mcp.initialize"]
-    assert len(initialize_events) == 1, f"Expected 1 LLMObs event, got {len(initialize_events)}"
-    initialize_event = initialize_events[0]
-
-    assert initialize_event == _expected_llmobs_non_llm_span_event(
-        initialize_span,
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(initialize_span),
         span_kind="task",
         input_value=mock.ANY,
         output_value=mock.ANY,
@@ -294,12 +283,14 @@ def test_server_initialization_span_created(mcp_setup, test_spans, llmobs_events
         },
     )
 
-    input_data = json.loads(initialize_event["meta"]["input"]["value"])
+    init_metastruct = _get_llmobs_data_metastruct(initialize_span)
+    init_meta = init_metastruct.get("meta", {})
+    input_data = json.loads(init_meta.get("input", {}).get("value"))
     assert input_data["method"] == "initialize"
     assert input_data["params"]["clientInfo"]["name"] == "test-client"
     assert input_data["params"]["clientInfo"]["version"] == "1.2.3"
 
-    output_data = json.loads(initialize_event["meta"]["output"]["value"])
+    output_data = json.loads(init_meta.get("output", {}).get("value"))
     assert "protocolVersion" in output_data
     assert "capabilities" in output_data
     assert "serverInfo" in output_data
@@ -368,7 +359,8 @@ def test_mcp_distributed_tracing_disabled_env(ddtrace_run_python_code_in_subproc
     assert client_trace["spans"][0]["_dd"]["apm_trace_id"] != server_trace["spans"][0]["_dd"]["apm_trace_id"]
 
 
-def test_intent_capture_tool_schema_injection(mcp_setup, llmobs_events, mcp_server):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_intent_capture_tool_schema_injection(mcp_setup, test_spans, mcp_server):
     """Test that intent capture adds telemetry property to tool input schemas."""
     from mcp.shared.memory import create_connected_server_and_client_session
 
@@ -406,7 +398,8 @@ def test_intent_capture_tool_schema_injection(mcp_setup, llmobs_events, mcp_serv
     assert "b" in schema["required"]
 
 
-def test_intent_capture_records_intent_on_span_meta(mcp_setup, test_spans, llmobs_events, mcp_server):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_intent_capture_records_intent_on_span_meta(mcp_setup, test_spans, mcp_server):
     """Test that intent is recorded on the span meta and telemetry argument is excluded from input."""
     from mcp.shared.memory import create_connected_server_and_client_session
 
@@ -425,19 +418,29 @@ def test_intent_capture_records_intent_on_span_meta(mcp_setup, test_spans, llmob
     with override_config("mcp", dict(capture_intent=True)):
         asyncio.run(run_test())
 
-    llmobs_events.sort(key=lambda event: event["start_ns"])
-    server_tool_event = next(
-        (e for e in llmobs_events if e["name"] == "calculator" and "mcp_tool_kind:server" in e["tags"]),
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+
+    server_tool_span = next(
+        (
+            s
+            for s in all_spans
+            if _get_llmobs_data_metastruct(s).get("name") == "calculator"
+            and _get_llmobs_data_metastruct(s).get("tags", {}).get("mcp_tool_kind") == "server"
+        ),
         None,
     )
-    assert server_tool_event is not None
+    assert server_tool_span is not None
+
+    server_tool_metastruct = _get_llmobs_data_metastruct(server_tool_span)
+    server_tool_meta = server_tool_metastruct.get("meta", {})
 
     # Verify intent is recorded in meta
-    assert "intent" in server_tool_event["meta"], f"intent not in meta: {server_tool_event['meta']}"
-    assert server_tool_event["meta"]["intent"] == "Testing intent capture for adding numbers"
+    assert "intent" in server_tool_meta, f"intent not in meta: {server_tool_meta}"
+    assert server_tool_meta["intent"] == "Testing intent capture for adding numbers"
 
     # Verify telemetry argument is NOT in the input value
-    input_value = json.loads(server_tool_event["meta"]["input"]["value"])
+    input_value = json.loads(server_tool_meta.get("input", {}).get("value"))
     arguments = input_value.get("params", {}).get("arguments", {})
     assert "telemetry" not in arguments, f"telemetry should not be in arguments: {arguments}"
     assert "operation" in arguments
@@ -445,7 +448,8 @@ def test_intent_capture_records_intent_on_span_meta(mcp_setup, test_spans, llmob
     assert "b" in arguments
 
 
-def test_intent_capture_disabled_by_default(mcp_setup, test_spans, llmobs_events, mcp_server):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_intent_capture_disabled_by_default(mcp_setup, test_spans, mcp_server):
     """Test that intent capture is disabled by default and telemetry property is not injected."""
     from mcp.shared.memory import create_connected_server_and_client_session
 


### PR DESCRIPTION
Migrates mcp LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `llmobs_events` plumbing with an `mcp_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
