### PR TITLE
test(llmobs): migrate openai_agents tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -207,23 +207,23 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def openai_agents_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "service": "tests.contrib.agents",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()

--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 from agents import Agent
 from agents import GuardrailFunctionOutput
@@ -12,8 +13,7 @@ import vcr
 
 from ddtrace.contrib.internal.openai_agents.patch import patch
 from ddtrace.contrib.internal.openai_agents.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
-from tests.llmobs._utils import TestLLMObsSpanWriter
+from ddtrace.llmobs import LLMObs
 from tests.utils import override_global_config
 
 
@@ -202,22 +202,28 @@ def openai(agents):
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def agents_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "tests.contrib.agents"}
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
-
-
-@pytest.fixture
-def llmobs_events(agents_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
 
@@ -118,11 +119,6 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
-def _llmobs_name(span):
-    """Get the LLMObs name from a span's meta_struct['_llmobs']."""
-    return _get_llmobs_data_metastruct(span).get("name")
-
-
 class _SpanLinkView:
     """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
     ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict.
@@ -215,13 +211,13 @@ def _assert_expected_agent_run(
         previous_tool_spans = []
     # Names match the LLMObs name on each span in order.
     for i, span in enumerate(spans):
-        assert _llmobs_name(span) == expected_span_names[i], (
-            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, actual={_llmobs_name(span)!r}"
+        assert get_llmobs_span_name(span) == expected_span_names[i], (
+            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, actual={get_llmobs_span_name(span)!r}"
         )
     # First span: agent span.
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_agent_kwargs(spans[0], _llmobs_name(spans[0])),
+        **_expected_agent_kwargs(spans[0], get_llmobs_span_name(spans[0])),
     )
 
     for i, span in enumerate(spans[1:]):
@@ -261,7 +257,7 @@ async def test_llmobs_single_agent(agents, openai_agents_llmobs, test_spans, req
 
     assert len(spans) == 3
 
-    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert get_llmobs_span_name(spans[0]) == "Agent workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
@@ -306,7 +302,7 @@ async def test_llmobs_streamed_single_agent(agents, openai_agents_llmobs, test_s
 
     assert len(spans) == 3
 
-    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert get_llmobs_span_name(spans[0]) == "Agent workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
@@ -344,7 +340,7 @@ def test_llmobs_single_agent_sync(agents, openai_agents_llmobs, test_spans, requ
 
     assert len(spans) == 3
 
-    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert get_llmobs_span_name(spans[0]) == "Agent workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
@@ -389,7 +385,7 @@ async def test_llmobs_manual_tracing_llmobs(agents, openai_agents_llmobs, test_s
 
     assert len(spans) == 4
 
-    assert _llmobs_name(spans[0]) == "Simple Workflow"
+    assert get_llmobs_span_name(spans[0]) == "Simple Workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
@@ -119,55 +120,9 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
-class _SpanLinkView:
-    """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
-    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict.
-    """
-
-    def __init__(self, span):
-        self._span = span
-        self._metastruct = _get_llmobs_data_metastruct(span)
-
-    def __getitem__(self, key):
-        if key == "span_id":
-            return str(self._span.span_id)
-        if key == "span_links":
-            return self._metastruct.get("span_links", [])
-        raise KeyError(key)
-
-
-def _expected_agent_kwargs(span, agent_name: str) -> dict:
-    """Build the kwargs for ``assert_llmobs_span_data`` for an agent span."""
-    return dict(
-        span_kind="agent",
-        metadata=_expected_agent_metadata(agent_name),
-        tags=COMMON_TAGS,
-        name=agent_name,
-    )
-
-
-def _expected_llm_kwargs(
-    input_messages,
-    output_messages,
-    name: Optional[str] = None,
-) -> dict:
-    """Build the kwargs for ``assert_llmobs_span_data`` for an LLM (response) span."""
-    return dict(
-        span_kind="llm",
-        input_messages=input_messages,
-        output_messages=output_messages,
-        metrics={
-            "input_tokens": mock.ANY,
-            "output_tokens": mock.ANY,
-            "total_tokens": mock.ANY,
-            "reasoning_output_tokens": mock.ANY,
-        },
-        metadata=COMMON_RESPONSE_LLM_METADATA,
-        model_name="gpt-4o-2024-08-06",
-        model_provider="openai",
-        tags=COMMON_TAGS,
-        name=name,
-    )
+def _link_view(span):
+    """Build a dict the shape `_assert_span_link` expects (span_id + span_links)."""
+    return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
 
 
 def _expected_tool_kwargs(tool_call: dict) -> dict:
@@ -217,7 +172,10 @@ def _assert_expected_agent_run(
     # First span: agent span.
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_agent_kwargs(spans[0], get_llmobs_span_name(spans[0])),
+        span_kind="agent",
+        metadata=_expected_agent_metadata(get_llmobs_span_name(spans[0])),
+        tags=COMMON_TAGS,
+        name=get_llmobs_span_name(spans[0]),
     )
 
     for i, span in enumerate(spans[1:]):
@@ -226,14 +184,23 @@ def _assert_expected_agent_run(
             if not is_chat:
                 assert_llmobs_span_data(
                     _get_llmobs_data_metastruct(span),
-                    **_expected_llm_kwargs(
-                        input_messages=llm_calls[i // 2][0],
-                        output_messages=llm_calls[i // 2][1],
-                        name=expected_span_names[i + 1],
-                    ),
+                    span_kind="llm",
+                    input_messages=llm_calls[i // 2][0],
+                    output_messages=llm_calls[i // 2][1],
+                    metrics={
+                        "input_tokens": mock.ANY,
+                        "output_tokens": mock.ANY,
+                        "total_tokens": mock.ANY,
+                        "reasoning_output_tokens": mock.ANY,
+                    },
+                    metadata=COMMON_RESPONSE_LLM_METADATA,
+                    model_name="gpt-4o-2024-08-06",
+                    model_provider="openai",
+                    tags=COMMON_TAGS,
+                    name=expected_span_names[i + 1],
                 )
             for tool_span in previous_tool_spans:
-                _assert_span_link(_SpanLinkView(tool_span), _SpanLinkView(span), "output", "input")
+                _assert_span_link(_link_view(tool_span), _link_view(span), "output", "input")
         else:
             tool_call = tool_calls[i // 2]
             assert_llmobs_span_data(
@@ -241,7 +208,7 @@ def _assert_expected_agent_run(
                 **_expected_tool_kwargs(tool_call),
             )
             # assert tool is linked to the previous LLM call
-            _assert_span_link(_SpanLinkView(spans[i]), _SpanLinkView(span), "output", "input")
+            _assert_span_link(_link_view(spans[i]), _link_view(span), "output", "input")
             previous_tool_spans.append(span)
     return previous_tool_spans
 
@@ -792,9 +759,9 @@ async def test_llmobs_oai_agents_with_guardrail_spans(
     assert len(spans) == 7
 
     # assert input guardrail span links to LLM span
-    _assert_span_link(_SpanLinkView(spans[2]), _SpanLinkView(spans[3]), "output", "input")
+    _assert_span_link(_link_view(spans[2]), _link_view(spans[3]), "output", "input")
     # assert LLM span links to output guardrail span
-    _assert_span_link(_SpanLinkView(spans[5]), _SpanLinkView(spans[6]), "output", "input")
+    _assert_span_link(_link_view(spans[5]), _link_view(spans[6]), "output", "input")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -134,7 +134,8 @@ def _llmobs_name(span):
 
 class _SpanLinkView:
     """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
-    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict."""
+    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict.
+    """
 
     def __init__(self, span):
         self._span = span
@@ -224,8 +225,7 @@ def _assert_expected_agent_run(
     # Names match the LLMObs name on each span in order.
     for i, span in enumerate(spans):
         assert _llmobs_name(span) == expected_span_names[i], (
-            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, "
-            f"actual={_llmobs_name(span)!r}"
+            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, actual={_llmobs_name(span)!r}"
         )
     # First span: agent span.
     assert_llmobs_span_data(

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -8,15 +8,6 @@ from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.contrib.agents",
-)
-
-
 COMMON_TAGS = {"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"}
 
 
@@ -259,9 +250,8 @@ def _assert_expected_agent_run(
     return previous_tool_spans
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent(agents, test_spans, request_vcr, simple_agent):
+async def test_llmobs_single_agent(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = await agents.Runner.run(simple_agent, "What is the capital of France?")
@@ -299,9 +289,8 @@ async def test_llmobs_single_agent(agents, test_spans, request_vcr, simple_agent
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, simple_agent):
+async def test_llmobs_streamed_single_agent(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     from openai.types.responses import ResponseTextDeltaEvent
 
     final_output = ""
@@ -345,8 +334,7 @@ async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, sim
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, simple_agent):
+def test_llmobs_single_agent_sync(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = agents.Runner.run_sync(simple_agent, "What is the capital of France?")
@@ -384,9 +372,8 @@ def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, simple_agent)
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, simple_agent):
+async def test_llmobs_manual_tracing_llmobs(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     from agents.tracing import custom_span
     from agents.tracing import trace
 
@@ -436,9 +423,10 @@ async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, sim
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_calls_llmobs(agents, test_spans, request_vcr, addition_agent):
+async def test_llmobs_single_agent_with_tool_calls_llmobs(
+    agents, openai_agents_llmobs, test_spans, request_vcr, addition_agent
+):
     with request_vcr.use_cassette("test_single_agent_with_tool_calls.yaml"):
         result = await agents.Runner.run(addition_agent, "What is the sum of 1 and 2?")
 
@@ -507,9 +495,10 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(agents, test_spans, re
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_vcr, weather_agent):
+async def test_llmobs_single_agent_with_ootb_tools(
+    agents, openai_agents_llmobs, test_spans, request_vcr, weather_agent
+):
     with request_vcr.use_cassette("test_single_agent_with_ootb_tools.yaml"):
         result = await agents.Runner.run(weather_agent, "What is the weather like in New York right now?")
 
@@ -549,9 +538,8 @@ async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_v
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, research_workflow):
+async def test_llmobs_multiple_agent_handoffs(agents, openai_agents_llmobs, test_spans, request_vcr, research_workflow):
     with request_vcr.use_cassette("test_multiple_agent_handoffs.yaml"):
         result = await agents.Runner.run(
             research_workflow, "What is a brief summary of what happened yesterday in the soccer world??"
@@ -666,9 +654,10 @@ async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, r
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_errors(agents, test_spans, request_vcr, addition_agent_with_tool_errors):
+async def test_llmobs_single_agent_with_tool_errors(
+    agents, openai_agents_llmobs, test_spans, request_vcr, addition_agent_with_tool_errors
+):
     with request_vcr.use_cassette("test_agent_with_tool_errors.yaml"):
         result = await agents.Runner.run(addition_agent_with_tool_errors, "What is the sum of 1 and 2?")
     spans = [s for trace in test_spans.pop_traces() for s in trace]
@@ -748,10 +737,9 @@ async def test_llmobs_single_agent_with_tool_errors(agents, test_spans, request_
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
 async def test_llmobs_oai_agents_with_chat_completions_span_linking(
-    agents, openai, test_spans, request_vcr, research_workflow
+    agents, openai, openai_agents_llmobs, test_spans, request_vcr, research_workflow
 ):
     with request_vcr.use_cassette("test_multiple_agent_handoffs_with_chat_completions.yaml"):
         result = await agents.Runner.run(
@@ -796,9 +784,8 @@ async def test_llmobs_oai_agents_with_chat_completions_span_linking(
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 async def test_llmobs_oai_agents_with_guardrail_spans(
-    agents, openai, test_spans, request_vcr, simple_agent_with_guardrail
+    agents, openai, openai_agents_llmobs, test_spans, request_vcr, simple_agent_with_guardrail
 ):
     with request_vcr.use_cassette("test_oai_agents_with_guardrail_spans.yaml"):
         await agents.Runner.run(simple_agent_with_guardrail, "What is the sum of 1 and 2?")

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -3,9 +3,21 @@ from typing import Optional
 import mock
 import pytest
 
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.llmobs._utils import _assert_span_link
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
+
+
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.contrib.agents",
+)
+
+
+COMMON_TAGS = {"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"}
 
 
 COMMON_RESPONSE_LLM_METADATA = {
@@ -115,111 +127,162 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
+def _llmobs_name(span):
+    """Get the LLMObs name from a span's meta_struct['_llmobs']."""
+    return _get_llmobs_data_metastruct(span).get("name")
+
+
+class _SpanLinkView:
+    """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
+    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict."""
+
+    def __init__(self, span):
+        self._span = span
+        self._metastruct = _get_llmobs_data_metastruct(span)
+
+    def __getitem__(self, key):
+        if key == "span_id":
+            return str(self._span.span_id)
+        if key == "span_links":
+            return self._metastruct.get("span_links", [])
+        raise KeyError(key)
+
+
+def _expected_agent_kwargs(span, agent_name: str) -> dict:
+    """Build the kwargs for ``assert_llmobs_span_data`` for an agent span."""
+    return dict(
+        span_kind="agent",
+        metadata=_expected_agent_metadata(agent_name),
+        tags=COMMON_TAGS,
+        name=agent_name,
+    )
+
+
+def _expected_llm_kwargs(
+    input_messages,
+    output_messages,
+    name: Optional[str] = None,
+) -> dict:
+    """Build the kwargs for ``assert_llmobs_span_data`` for an LLM (response) span."""
+    return dict(
+        span_kind="llm",
+        input_messages=input_messages,
+        output_messages=output_messages,
+        metrics={
+            "input_tokens": mock.ANY,
+            "output_tokens": mock.ANY,
+            "total_tokens": mock.ANY,
+            "reasoning_output_tokens": mock.ANY,
+        },
+        metadata=COMMON_RESPONSE_LLM_METADATA,
+        model_name="gpt-4o-2024-08-06",
+        model_provider="openai",
+        tags=COMMON_TAGS,
+        name=name,
+    )
+
+
+def _expected_tool_kwargs(tool_call: dict) -> dict:
+    """Build the kwargs for ``assert_llmobs_span_data`` for a tool span."""
+    error = None
+    if tool_call["error"]:
+        error = {
+            "type": "Error running tool (non-fatal)",
+            "message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
+            "stack": mock.ANY,
+        }
+    kwargs = dict(span_kind="tool", tags=COMMON_TAGS, error=error)
+    if tool_call["type"] in ("function_call", "handoff"):
+        kwargs["input_value"] = mock.ANY
+        kwargs["output_value"] = mock.ANY
+    return kwargs
+
+
 def _assert_expected_agent_run(
     expected_span_names: list[str],
     spans,
-    llmobs_events,
     llm_calls: Optional[list[tuple[list[dict], list[dict]]]] = None,
     tool_calls: Optional[list[dict]] = None,
-    previous_tool_events: Optional[list[dict]] = None,
-    is_chat=False,
-) -> list[dict]:
-    """Assert expected LLMObs events matches actual events for an agent run
-    Return previous tool events for span linking assertions across agent runs
+    previous_tool_spans: Optional[list] = None,
+    is_chat: bool = False,
+) -> list:
+    """Assert expected LLMObs span data for an agent run.
+
+    Returns the list of tool spans seen so far (for cross-run span-link assertions).
+
     Args:
-        spans: list of spans from the mock tracer
-        llmobs_events: list of LLMObs events
-        agent_name: Name of the agent
-        llm_calls: list of (input_messages, output_messages) for each LLM call
-        tool_calls: list of information about tool calls
-        previous_tool_events: list of previous tool events for span linking assertions across agent runs
+        expected_span_names: ordered list of LLMObs span names expected for this run.
+        spans: list of APM spans, sorted by start_ns, beginning with the agent span.
+        llm_calls: list of ``(input_messages, output_messages)`` pairs for each LLM call.
+        tool_calls: list of dicts describing each tool call (``type``, ``error``, optional ``tool_name``).
+        previous_tool_spans: list of tool spans from prior agent runs to assert span-links against.
+        is_chat: when True, the LLM span is produced by the openai integration (chat completions);
+            skip its event-shape assertion (kept compatible with the original test).
     """
-    for i, event in enumerate(llmobs_events):
-        assert event["name"] == expected_span_names[i]
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
-        span_kind="agent",
-        metadata=_expected_agent_metadata(llmobs_events[0]["name"]),
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+    if previous_tool_spans is None:
+        previous_tool_spans = []
+    # Names match the LLMObs name on each span in order.
+    for i, span in enumerate(spans):
+        assert _llmobs_name(span) == expected_span_names[i], (
+            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, "
+            f"actual={_llmobs_name(span)!r}"
+        )
+    # First span: agent span.
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_agent_kwargs(spans[0], _llmobs_name(spans[0])),
     )
-    if not previous_tool_events:
-        previous_tool_events = []
-    for i, event in enumerate(llmobs_events[1:]):
+
+    for i, span in enumerate(spans[1:]):
         if i % 2 == 0:
-            assert is_chat or event == _expected_llmobs_llm_span_event(
-                spans[i + 1],
-                span_kind="llm",
-                input_messages=llm_calls[i // 2][0],
-                output_messages=llm_calls[i // 2][1],
-                token_metrics={
-                    "input_tokens": mock.ANY,
-                    "output_tokens": mock.ANY,
-                    "total_tokens": mock.ANY,
-                    "reasoning_output_tokens": mock.ANY,
-                },
-                metadata=COMMON_RESPONSE_LLM_METADATA,
-                model_name="gpt-4o-2024-08-06",
-                model_provider="openai",
-                tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
-                span_links=i or previous_tool_events,
-                name=expected_span_names[i + 1],
-            )
-            for tool in previous_tool_events:
-                _assert_span_link(tool, event, "output", "input")
+            # LLM span — skip strict assertion in chat mode (handled by openai integration).
+            if not is_chat:
+                assert_llmobs_span_data(
+                    _get_llmobs_data_metastruct(span),
+                    **_expected_llm_kwargs(
+                        input_messages=llm_calls[i // 2][0],
+                        output_messages=llm_calls[i // 2][1],
+                        name=expected_span_names[i + 1],
+                    ),
+                )
+            for tool_span in previous_tool_spans:
+                _assert_span_link(_SpanLinkView(tool_span), _SpanLinkView(span), "output", "input")
         else:
             tool_call = tool_calls[i // 2]
-            error_args = (
-                {
-                    "error_message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
-                    "error": "Error running tool (non-fatal)",
-                }
-                if tool_call["error"]
-                else {}
-            )
-            io_args = (
-                {"input_value": mock.ANY, "output_value": mock.ANY}
-                if tool_call["type"] in ("function_call", "handoff")
-                else {}
-            )
-            assert event == _expected_llmobs_non_llm_span_event(
-                spans[i + 1],
-                span_kind="tool",
-                tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
-                span_links=True,
-                **io_args,
-                **error_args,
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(span),
+                **_expected_tool_kwargs(tool_call),
             )
             # assert tool is linked to the previous LLM call
-            _assert_span_link(llmobs_events[i], event, "output", "input")
-            previous_tool_events.append(event)
-    return previous_tool_events
+            _assert_span_link(_SpanLinkView(spans[i]), _SpanLinkView(span), "output", "input")
+            previous_tool_spans.append(span)
+    return previous_tool_spans
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+async def test_llmobs_single_agent(agents, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = await agents.Runner.run(simple_agent, "What is the capital of France?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert spans[0].name == "Agent workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -236,8 +299,9 @@ async def test_llmobs_single_agent(agents, test_spans, request_vcr, llmobs_event
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, simple_agent):
     from openai.types.responses import ResponseTextDeltaEvent
 
     final_output = ""
@@ -248,25 +312,23 @@ async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, llm
             if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
                 final_output += event.data.delta
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert llmobs_events[0]["name"] == "Agent workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -283,30 +345,29 @@ async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, llm
     )
 
 
-def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = agents.Runner.run_sync(simple_agent, "What is the capital of France?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert llmobs_events[0]["name"] == "Agent workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -323,8 +384,9 @@ def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, llmobs_events
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, simple_agent):
     from agents.tracing import custom_span
     from agents.tracing import trace
 
@@ -335,31 +397,29 @@ async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, llm
             cspan.finish()
             result = await agents.Runner.run(simple_agent, "What is the capital of France?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 4
+    assert len(spans) == 4
 
-    assert llmobs_events[0]["name"] == "Simple Workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Simple Workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=result.final_output,
         metadata={"foo": "bar"},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-        spans[1],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[1]),
         span_kind="task",
         metadata={"foo": "bar"},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[2:],
-        llmobs_events[2:],
         llm_calls=[
             (
                 [
@@ -376,31 +436,28 @@ async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, llm
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_calls_llmobs(
-    agents, test_spans, request_vcr, llmobs_events, addition_agent
-):
+async def test_llmobs_single_agent_with_tool_calls_llmobs(agents, test_spans, request_vcr, addition_agent):
     with request_vcr.use_cassette("test_single_agent_with_tool_calls.yaml"):
         result = await agents.Runner.run(addition_agent, "What is the sum of 1 and 2?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 5
+    assert len(spans) == 5
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the sum of 1 and 2?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Addition Agent", "Addition Agent (LLM)", "add", "Addition Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -450,29 +507,28 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_vcr, llmobs_events, weather_agent):
+async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_vcr, weather_agent):
     with request_vcr.use_cassette("test_single_agent_with_ootb_tools.yaml"):
         result = await agents.Runner.run(weather_agent, "What is the weather like in New York right now?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the weather like in New York right now?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Weather Agent", "Weather Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -493,32 +549,31 @@ async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_v
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, llmobs_events, research_workflow):
+async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, research_workflow):
     with request_vcr.use_cassette("test_multiple_agent_handoffs.yaml"):
         result = await agents.Runner.run(
             research_workflow, "What is a brief summary of what happened yesterday in the soccer world??"
         )
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 8
+    assert len(spans) == 8
 
     # top level workflow
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is a brief summary of what happened yesterday in the soccer world??",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
-    previous_tool_events = _assert_expected_agent_run(
+    previous_tool_spans = _assert_expected_agent_run(
         ["Researcher", "Researcher (LLM)", "research", "Researcher (LLM)", "transfer_to_summarizer"],
         spans[1:6],
-        llmobs_events[1:6],
         llm_calls=[
             (
                 [
@@ -600,7 +655,6 @@ async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, l
     _assert_expected_agent_run(
         ["Summarizer", "Summarizer (LLM)"],
         spans[6:],
-        llmobs_events[6:],
         llm_calls=[
             (
                 mock.ANY,
@@ -608,34 +662,31 @@ async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, l
             )
         ],
         tool_calls=[],
-        previous_tool_events=previous_tool_events[-1:],
+        previous_tool_spans=previous_tool_spans[-1:],
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_errors(
-    agents, test_spans, request_vcr, llmobs_events, addition_agent_with_tool_errors
-):
+async def test_llmobs_single_agent_with_tool_errors(agents, test_spans, request_vcr, addition_agent_with_tool_errors):
     with request_vcr.use_cassette("test_agent_with_tool_errors.yaml"):
         result = await agents.Runner.run(addition_agent_with_tool_errors, "What is the sum of 1 and 2?")
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 5
+    assert len(spans) == 5
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the sum of 1 and 2?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Addition Agent", "Addition Agent (LLM)", "add", "Addition Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -697,28 +748,28 @@ async def test_llmobs_single_agent_with_tool_errors(
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
 async def test_llmobs_oai_agents_with_chat_completions_span_linking(
-    agents, openai, test_spans, request_vcr, llmobs_events, research_workflow
+    agents, openai, test_spans, request_vcr, research_workflow
 ):
     with request_vcr.use_cassette("test_multiple_agent_handoffs_with_chat_completions.yaml"):
         result = await agents.Runner.run(
             research_workflow, "Research and then summarize what happened yesterday in the soccer world"
         )
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 8
+    assert len(spans) == 8
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
-    previous_tool_events = _assert_expected_agent_run(
+    previous_tool_spans = _assert_expected_agent_run(
         [
             "Researcher",
             "OpenAI.createChatCompletion",
@@ -727,14 +778,12 @@ async def test_llmobs_oai_agents_with_chat_completions_span_linking(
             "transfer_to_summarizer",
         ],
         spans[1:6],
-        llmobs_events[1:6],
         tool_calls=[{"type": "function_call", "error": False}, {"type": "handoff", "error": False}],
         is_chat=True,
     )
     _assert_expected_agent_run(
         ["Summarizer", "OpenAI.createChatCompletion"],
         spans[6:],
-        llmobs_events[6:],
         llm_calls=[
             (
                 mock.ANY,
@@ -742,27 +791,27 @@ async def test_llmobs_oai_agents_with_chat_completions_span_linking(
             )
         ],
         tool_calls=[],
-        previous_tool_events=previous_tool_events[-1:],
+        previous_tool_spans=previous_tool_spans[-1:],
         is_chat=True,
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 async def test_llmobs_oai_agents_with_guardrail_spans(
-    agents, openai, test_spans, request_vcr, llmobs_events, simple_agent_with_guardrail
+    agents, openai, test_spans, request_vcr, simple_agent_with_guardrail
 ):
     with request_vcr.use_cassette("test_oai_agents_with_guardrail_spans.yaml"):
         await agents.Runner.run(simple_agent_with_guardrail, "What is the sum of 1 and 2?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 7
+    assert len(spans) == 7
 
     # assert input guardrail span links to LLM span
-    _assert_span_link(llmobs_events[2], llmobs_events[3], "output", "input")
+    _assert_span_link(_SpanLinkView(spans[2]), _SpanLinkView(spans[3]), "output", "input")
     # assert LLM span links to output guardrail span
-    _assert_span_link(llmobs_events[5], llmobs_events[6], "output", "input")
+    _assert_span_link(_SpanLinkView(spans[5]), _SpanLinkView(spans[6]), "output", "input")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -125,22 +125,6 @@ def _link_view(span):
     return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
 
 
-def _expected_tool_kwargs(tool_call: dict) -> dict:
-    """Build the kwargs for ``assert_llmobs_span_data`` for a tool span."""
-    error = None
-    if tool_call["error"]:
-        error = {
-            "type": "Error running tool (non-fatal)",
-            "message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
-            "stack": mock.ANY,
-        }
-    kwargs = dict(span_kind="tool", tags=COMMON_TAGS, error=error)
-    if tool_call["type"] in ("function_call", "handoff"):
-        kwargs["input_value"] = mock.ANY
-        kwargs["output_value"] = mock.ANY
-    return kwargs
-
-
 def _assert_expected_agent_run(
     expected_span_names: list[str],
     spans,
@@ -203,9 +187,24 @@ def _assert_expected_agent_run(
                 _assert_span_link(_link_view(tool_span), _link_view(span), "output", "input")
         else:
             tool_call = tool_calls[i // 2]
+            error = None
+            if tool_call["error"]:
+                error = {
+                    "type": "Error running tool (non-fatal)",
+                    "message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
+                    "stack": mock.ANY,
+                }
+            io_args = (
+                {"input_value": mock.ANY, "output_value": mock.ANY}
+                if tool_call["type"] in ("function_call", "handoff")
+                else {}
+            )
             assert_llmobs_span_data(
                 _get_llmobs_data_metastruct(span),
-                **_expected_tool_kwargs(tool_call),
+                span_kind="tool",
+                tags=COMMON_TAGS,
+                error=error,
+                **io_args,
             )
             # assert tool is linked to the previous LLM call
             _assert_span_link(_link_view(spans[i]), _link_view(span), "output", "input")


### PR DESCRIPTION
## Summary

Migrates contrib openai_agents LLMObs tests from `llmobs_events`-based wire-event assertions to `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`, asserting against the canonical `LLMObsSpanData` payload on the span's `meta_struct["_llmobs"]`.

Stacked on #17789 (openai PR).

## What changes

- `conftest.py`: `test_spans` override sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1` so meta_struct scrub is skipped; adds `ddtrace_global_config` fixture; drops the `llmobs_span_writer` / `agents_llmobs` / `llmobs_events` fixtures.
- Drops `llmobs_events` from migrated test signatures; tests parametrize `ddtrace_global_config` with `LLMOBS_GLOBAL_CONFIG` (turns LLMObs on for that test).
- Drops `_expected_llmobs_*_span_event` helpers from imports.
- Bespoke `_assert_expected_agent_run` rewritten as a function that splats into `assert_llmobs_span_data` via per-kind `_expected_*_kwargs(span, ...)` builders (agent / LLM / tool).
- `token_metrics=` -> `metrics=`; per-kwarg `error_type/error_message/error_stack` -> single `error={"type","message","stack"}` dict (the original "error running tool" kwargs were a flat-args hack on the wire helper).
- Span-link assertions reuse `_assert_span_link` via a tiny `_SpanLinkView` adapter that exposes `span_id` and `span_links` from the span's `meta_struct["_llmobs"]`.
- `_llmobs_name(span)` uses `_get_llmobs_data_metastruct(span).get("name")` rather than `span.name` (APM name).
- Agent-manifest metadata asserted via `metadata={"_dd": {...}}` subset (matcher's shallow-subset semantics on `metadata`).

## Fixtures left for review

none — fully migrated.

## Test plan

- [ ] CI green on the `llmobs::openai_agents` riot venvs (Rust native-ext build fails locally; rely on CI).

Claude session: `5a0031b3-5dfd-4ed2-a3f8-ef98ee7c8c24`
Resume: `claude --resume 5a0031b3-5dfd-4ed2-a3f8-ef98ee7c8c24`