### PR TITLE
test(llmobs): migrate llama_index tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/llama_index/conftest.py
+++ b/tests/contrib/llama_index/conftest.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 import pytest
 
@@ -6,7 +7,6 @@ from ddtrace.contrib.internal.llama_index.patch import patch
 from ddtrace.contrib.internal.llama_index.patch import unpatch
 from ddtrace.llmobs import LLMObs
 from tests.contrib.llama_index.utils import get_request_vcr
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -23,13 +23,24 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans):
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
     try:
         if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Have to disable and re-enable LLMObs to use to mock tracer.
-            LLMObs.disable()
-            LLMObs.enable(integrations_enabled=False)
-        yield test_spans
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
     finally:
         LLMObs.disable()
 
@@ -54,32 +65,6 @@ def llama_index(ddtrace_global_config, ddtrace_config_llama_index):
 
                 yield llama_index
                 unpatch()
-
-
-@pytest.fixture
-def llama_index_llmobs(tracer, llmobs_span_writer):
-    LLMObs.disable()
-    with override_global_config(
-        {
-            "_dd_api_key": "<not-a-real-api_key>",
-            "_llmobs_ml_app": "<ml-app-name>",
-            "service": "tests.contrib.llama_index",
-        }
-    ):
-        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
-        LLMObs._instance._llmobs_span_writer = llmobs_span_writer
-        yield LLMObs
-    LLMObs.disable()
-
-
-@pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs_events(llama_index_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
 
 
 @pytest.fixture(scope="session")

--- a/tests/contrib/llama_index/conftest.py
+++ b/tests/contrib/llama_index/conftest.py
@@ -7,19 +7,8 @@ from ddtrace.contrib.internal.llama_index.patch import patch
 from ddtrace.contrib.internal.llama_index.patch import unpatch
 from ddtrace.llmobs import LLMObs
 from tests.contrib.llama_index.utils import get_request_vcr
-from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
-
-
-@pytest.fixture
-def ddtrace_config_llama_index():
-    return {}
-
-
-@pytest.fixture
-def ddtrace_global_config():
-    return {}
 
 
 @pytest.fixture
@@ -45,26 +34,19 @@ def llama_index_llmobs(tracer, monkeypatch):
     LLMObs.disable()
 
 
-def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>"}
-
-
 @pytest.fixture
-def llama_index(ddtrace_global_config, ddtrace_config_llama_index):
-    global_config = default_global_config()
-    global_config.update(ddtrace_global_config)
-    with override_global_config(global_config):
-        with override_config("llama_index", ddtrace_config_llama_index):
-            with override_env(
-                dict(
-                    OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
-                )
-            ):
-                patch()
-                import llama_index
+def llama_index():
+    with override_global_config({"_dd_api_key": "<not-a-real-api_key>"}):
+        with override_env(
+            dict(
+                OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
+            )
+        ):
+            patch()
+            import llama_index
 
-                yield llama_index
-                unpatch()
+            yield llama_index
+            unpatch()
 
 
 @pytest.fixture(scope="session")

--- a/tests/contrib/llama_index/conftest.py
+++ b/tests/contrib/llama_index/conftest.py
@@ -36,17 +36,16 @@ def llama_index_llmobs(tracer, monkeypatch):
 
 @pytest.fixture
 def llama_index():
-    with override_global_config({"_dd_api_key": "<not-a-real-api_key>"}):
-        with override_env(
-            dict(
-                OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
-            )
-        ):
-            patch()
-            import llama_index
+    with override_env(
+        dict(
+            OPENAI_API_KEY=os.getenv("OPENAI_API_KEY", "<not-a-real-key>"),
+        )
+    ):
+        patch()
+        import llama_index
 
-            yield llama_index
-            unpatch()
+        yield llama_index
+        unpatch()
 
 
 @pytest.fixture(scope="session")

--- a/tests/contrib/llama_index/conftest.py
+++ b/tests/contrib/llama_index/conftest.py
@@ -23,26 +23,26 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def llama_index_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "service": "tests.contrib.llama_index",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 def default_global_config():

--- a/tests/contrib/llama_index/test_llama_index_llmobs.py
+++ b/tests/contrib/llama_index/test_llama_index_llmobs.py
@@ -4,50 +4,66 @@ from llama_index.core.llms import ChatMessage
 from llama_index.llms.openai import OpenAI
 import pytest
 
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.contrib.llama_index.test_llama_index import _make_mock_embedding
 from tests.contrib.llama_index.test_llama_index import _make_mock_query_engine
 from tests.contrib.llama_index.test_llama_index import _make_mock_retriever
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
 from tests.llmobs._utils import aiterate_stream
 from tests.llmobs._utils import anext_stream
+from tests.llmobs._utils import assert_llmobs_span_data
 from tests.llmobs._utils import iterate_stream
 from tests.llmobs._utils import next_stream
 
 
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.contrib.llama_index",
+)
+
+EXPECTED_TAGS = {
+    "ml_app": "<ml-app-name>",
+    "service": "tests.contrib.llama_index",
+    "integration": "llama_index",
+}
+
+
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLLMObsLlamaIndex:
-    def test_chat_completion(self, llama_index, llmobs_events, test_spans, request_vcr):
+    def test_chat_completion(self, llama_index, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_completion.yaml"):
             llm.chat(messages=[ChatMessage(role="user", content="Hello")])
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
             input_messages=[{"content": "Hello", "role": "user"}],
             output_messages=[{"content": "Hello! How can I assist you today?", "role": "assistant"}],
             metadata={"max_tokens": 100},
-            token_metrics={
+            metrics={
                 "input_tokens": 8,
                 "output_tokens": 9,
                 "total_tokens": 17,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_completion(self, llama_index, llmobs_events, test_spans, request_vcr):
+    def test_completion(self, llama_index, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete.yaml"):
             llm.complete("What is the meaning of life?")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -59,66 +75,65 @@ class TestLLMObsLlamaIndex:
                 }
             ],
             metadata={"max_tokens": 100},
-            token_metrics={
+            metrics={
                 "input_tokens": 14,
                 "output_tokens": 15,
                 "total_tokens": 29,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_chat_stream(self, llama_index, llmobs_events, test_spans, request_vcr, consume_stream):
+    def test_chat_stream(self, llama_index, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_chat_stream.yaml"):
             response = llm.stream_chat(messages=[ChatMessage(role="user", content="Hello")])
             consume_stream(response)
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
             input_messages=[{"content": "Hello", "role": "user"}],
             output_messages=[{"content": "Hello! How can I assist you today?", "role": "assistant"}],
             metadata={"max_tokens": 100},
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_chat_error(self, llama_index, llmobs_events, test_spans, request_vcr):
+    def test_chat_error(self, llama_index, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with pytest.raises(Exception):
             with request_vcr.use_cassette("llama_index_chat_error.yaml"):
                 llm.chat(messages=[ChatMessage(role="user", content="Hello")])
 
-        span = test_spans.pop_traces()[0][0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        span = spans[0]
         # Validate error fields are actually populated (not empty)
         assert span.get_tag("error.type"), "Expected error.type to be set"
         assert span.get_tag("error.message"), "Expected error.message to be set"
         assert span.get_tag("error.stack"), "Expected error.stack to be set"
         assert "AuthenticationError" in span.get_tag("error.type")
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(span),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
             input_messages=[{"content": "Hello", "role": "user"}],
             output_messages=[{"content": "", "role": ""}],
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
+            error={
+                "type": span.get_tag("error.type"),
+                "message": span.get_tag("error.message"),
+                "stack": span.get_tag("error.stack"),
+            },
             metadata={"max_tokens": 100},
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_multi_turn_conversation(self, llama_index, llmobs_events, test_spans, request_vcr):
+    def test_multi_turn_conversation(self, llama_index, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         messages = [
             ChatMessage(role="system", content="You are a helpful assistant."),
@@ -129,9 +144,10 @@ class TestLLMObsLlamaIndex:
         with request_vcr.use_cassette("llama_index_multi_turn.yaml"):
             llm.chat(messages=messages)
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -148,71 +164,68 @@ class TestLLMObsLlamaIndex:
                 }
             ],
             metadata={"max_tokens": 100},
-            token_metrics={
+            metrics={
                 "input_tokens": 39,
                 "output_tokens": 100,
                 "total_tokens": 139,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    async def test_chat_async(self, llama_index, llmobs_events, test_spans, request_vcr):
+    async def test_chat_async(self, llama_index, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_completion.yaml"):
             await llm.achat(messages=[ChatMessage(role="user", content="Hello")])
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
             input_messages=[{"content": "Hello", "role": "user"}],
             output_messages=[{"content": "Hello! How can I assist you today?", "role": "assistant"}],
             metadata={"max_tokens": 100},
-            token_metrics={
+            metrics={
                 "input_tokens": 8,
                 "output_tokens": 9,
                 "total_tokens": 17,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
     @pytest.mark.parametrize("consume_stream", [aiterate_stream, anext_stream])
-    async def test_chat_stream_async(self, llama_index, llmobs_events, test_spans, request_vcr, consume_stream):
+    async def test_chat_stream_async(self, llama_index, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_chat_stream.yaml"):
             response = await llm.astream_chat(messages=[ChatMessage(role="user", content="Hello")])
             await consume_stream(response)
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
             input_messages=[{"content": "Hello", "role": "user"}],
             output_messages=[{"content": "Hello! How can I assist you today?", "role": "assistant"}],
             metadata={"max_tokens": 100},
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_complete_stream(self, llama_index, llmobs_events, test_spans, request_vcr, consume_stream):
+    def test_complete_stream(self, llama_index, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete_stream.yaml"):
             response = llm.stream_complete("What is the meaning of life?")
             consume_stream(response)
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -224,21 +237,20 @@ class TestLLMObsLlamaIndex:
                 }
             ],
             metadata={"max_tokens": 100},
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
     @pytest.mark.parametrize("consume_stream", [aiterate_stream, anext_stream])
-    async def test_complete_stream_async(self, llama_index, llmobs_events, test_spans, request_vcr, consume_stream):
+    async def test_complete_stream_async(self, llama_index, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete_stream.yaml"):
             response = await llm.astream_complete("What is the meaning of life?")
             await consume_stream(response)
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -250,19 +262,18 @@ class TestLLMObsLlamaIndex:
                 }
             ],
             metadata={"max_tokens": 100},
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    async def test_complete_async(self, llama_index, llmobs_events, test_spans, request_vcr):
+    async def test_complete_async(self, llama_index, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete.yaml"):
             await llm.acomplete("What is the meaning of life?")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="llm",
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -274,126 +285,117 @@ class TestLLMObsLlamaIndex:
                 }
             ],
             metadata={"max_tokens": 100},
-            token_metrics={
+            metrics={
                 "input_tokens": 14,
                 "output_tokens": 15,
                 "total_tokens": 29,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_query_engine(self, llama_index, llmobs_events, test_spans):
+    def test_query_engine(self, llama_index, test_spans):
         engine = _make_mock_query_engine()
         engine.query("What is the meaning of life?")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_non_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="workflow",
             input_value="What is the meaning of life?",
             output_value="The answer is 42.",
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    async def test_query_engine_async(self, llama_index, llmobs_events, test_spans):
+    async def test_query_engine_async(self, llama_index, test_spans):
         engine = _make_mock_query_engine()
         await engine.aquery("What is the meaning of life?")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_non_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="workflow",
             input_value="What is the meaning of life?",
             output_value="The answer is 42.",
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_retriever(self, llama_index, llmobs_events, test_spans):
+    def test_retriever(self, llama_index, test_spans):
         retriever = _make_mock_retriever()
         retriever.retrieve("test query")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_non_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="retrieval",
             input_value="test query",
             output_documents=[{"text": "Document text", "score": 0.95, "id": mock.ANY}],
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    async def test_retriever_async(self, llama_index, llmobs_events, test_spans):
+    async def test_retriever_async(self, llama_index, test_spans):
         retriever = _make_mock_retriever()
         await retriever.aretrieve("test query")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_non_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="retrieval",
             input_value="test query",
             output_documents=[{"text": "Document text", "score": 0.95, "id": mock.ANY}],
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_embedding_query(self, llama_index, llmobs_events, test_spans):
+    def test_embedding_query(self, llama_index, test_spans):
         embed = _make_mock_embedding()
         embed.get_query_embedding("test query")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="embedding",
             model_name="mock-embed",
             model_provider="unknown",
             input_documents=[{"text": "test query"}],
             output_value="[1 embedding(s) returned with size 3]",
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    def test_embedding_batch(self, llama_index, llmobs_events, test_spans):
+    def test_embedding_batch(self, llama_index, test_spans):
         embed = _make_mock_embedding()
         embed.get_text_embedding_batch(["doc one", "doc two"])
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="embedding",
             model_name="mock-embed",
             model_provider="unknown",
             input_documents=[{"text": "[2 texts]"}],
             output_value="[2 embedding(s) returned with size 3]",
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
-    async def test_embedding_query_async(self, llama_index, llmobs_events, test_spans):
+    async def test_embedding_query_async(self, llama_index, test_spans):
         embed = _make_mock_embedding()
         await embed.aget_query_embedding("test query")
 
-        span = test_spans.pop_traces()[0][0]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="embedding",
             model_name="mock-embed",
             model_provider="unknown",
             input_documents=[{"text": "test query"}],
             output_value="[1 embedding(s) returned with size 3]",
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.llama_index", "integration": "llama_index"},
+            tags=EXPECTED_TAGS,
         )
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == expected
 
 
 def test_shadow_tags_llm_when_llmobs_disabled(tracer):

--- a/tests/contrib/llama_index/test_llama_index_llmobs.py
+++ b/tests/contrib/llama_index/test_llama_index_llmobs.py
@@ -15,14 +15,6 @@ from tests.llmobs._utils import iterate_stream
 from tests.llmobs._utils import next_stream
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.contrib.llama_index",
-)
-
 EXPECTED_TAGS = {
     "ml_app": "<ml-app-name>",
     "service": "tests.contrib.llama_index",
@@ -30,9 +22,8 @@ EXPECTED_TAGS = {
 }
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLLMObsLlamaIndex:
-    def test_chat_completion(self, llama_index, test_spans, request_vcr):
+    def test_chat_completion(self, llama_index, llama_index_llmobs, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_completion.yaml"):
             llm.chat(messages=[ChatMessage(role="user", content="Hello")])
@@ -55,7 +46,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_completion(self, llama_index, test_spans, request_vcr):
+    def test_completion(self, llama_index, llama_index_llmobs, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete.yaml"):
             llm.complete("What is the meaning of life?")
@@ -84,7 +75,7 @@ class TestLLMObsLlamaIndex:
         )
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_chat_stream(self, llama_index, test_spans, request_vcr, consume_stream):
+    def test_chat_stream(self, llama_index, llama_index_llmobs, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_chat_stream.yaml"):
             response = llm.stream_chat(messages=[ChatMessage(role="user", content="Hello")])
@@ -103,7 +94,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_chat_error(self, llama_index, test_spans, request_vcr):
+    def test_chat_error(self, llama_index, llama_index_llmobs, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with pytest.raises(Exception):
             with request_vcr.use_cassette("llama_index_chat_error.yaml"):
@@ -133,7 +124,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_multi_turn_conversation(self, llama_index, test_spans, request_vcr):
+    def test_multi_turn_conversation(self, llama_index, llama_index_llmobs, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         messages = [
             ChatMessage(role="system", content="You are a helpful assistant."),
@@ -172,7 +163,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    async def test_chat_async(self, llama_index, test_spans, request_vcr):
+    async def test_chat_async(self, llama_index, llama_index_llmobs, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_completion.yaml"):
             await llm.achat(messages=[ChatMessage(role="user", content="Hello")])
@@ -196,7 +187,7 @@ class TestLLMObsLlamaIndex:
         )
 
     @pytest.mark.parametrize("consume_stream", [aiterate_stream, anext_stream])
-    async def test_chat_stream_async(self, llama_index, test_spans, request_vcr, consume_stream):
+    async def test_chat_stream_async(self, llama_index, llama_index_llmobs, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_chat_stream.yaml"):
             response = await llm.astream_chat(messages=[ChatMessage(role="user", content="Hello")])
@@ -216,7 +207,7 @@ class TestLLMObsLlamaIndex:
         )
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_complete_stream(self, llama_index, test_spans, request_vcr, consume_stream):
+    def test_complete_stream(self, llama_index, llama_index_llmobs, test_spans, request_vcr, consume_stream):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete_stream.yaml"):
             response = llm.stream_complete("What is the meaning of life?")
@@ -241,7 +232,9 @@ class TestLLMObsLlamaIndex:
         )
 
     @pytest.mark.parametrize("consume_stream", [aiterate_stream, anext_stream])
-    async def test_complete_stream_async(self, llama_index, test_spans, request_vcr, consume_stream):
+    async def test_complete_stream_async(
+        self, llama_index, llama_index_llmobs, test_spans, request_vcr, consume_stream
+    ):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete_stream.yaml"):
             response = await llm.astream_complete("What is the meaning of life?")
@@ -265,7 +258,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    async def test_complete_async(self, llama_index, test_spans, request_vcr):
+    async def test_complete_async(self, llama_index, llama_index_llmobs, test_spans, request_vcr):
         llm = OpenAI(model="gpt-4o-mini", max_tokens=100)
         with request_vcr.use_cassette("llama_index_complete.yaml"):
             await llm.acomplete("What is the meaning of life?")
@@ -293,7 +286,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_query_engine(self, llama_index, test_spans):
+    def test_query_engine(self, llama_index, llama_index_llmobs, test_spans):
         engine = _make_mock_query_engine()
         engine.query("What is the meaning of life?")
 
@@ -307,7 +300,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    async def test_query_engine_async(self, llama_index, test_spans):
+    async def test_query_engine_async(self, llama_index, llama_index_llmobs, test_spans):
         engine = _make_mock_query_engine()
         await engine.aquery("What is the meaning of life?")
 
@@ -321,7 +314,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_retriever(self, llama_index, test_spans):
+    def test_retriever(self, llama_index, llama_index_llmobs, test_spans):
         retriever = _make_mock_retriever()
         retriever.retrieve("test query")
 
@@ -335,7 +328,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    async def test_retriever_async(self, llama_index, test_spans):
+    async def test_retriever_async(self, llama_index, llama_index_llmobs, test_spans):
         retriever = _make_mock_retriever()
         await retriever.aretrieve("test query")
 
@@ -349,7 +342,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_embedding_query(self, llama_index, test_spans):
+    def test_embedding_query(self, llama_index, llama_index_llmobs, test_spans):
         embed = _make_mock_embedding()
         embed.get_query_embedding("test query")
 
@@ -365,7 +358,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    def test_embedding_batch(self, llama_index, test_spans):
+    def test_embedding_batch(self, llama_index, llama_index_llmobs, test_spans):
         embed = _make_mock_embedding()
         embed.get_text_embedding_batch(["doc one", "doc two"])
 
@@ -381,7 +374,7 @@ class TestLLMObsLlamaIndex:
             tags=EXPECTED_TAGS,
         )
 
-    async def test_embedding_query_async(self, llama_index, test_spans):
+    async def test_embedding_query_async(self, llama_index, llama_index_llmobs, test_spans):
         embed = _make_mock_embedding()
         await embed.aget_query_embedding("test query")
 


### PR DESCRIPTION
Migrates llama_index LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `llama_index_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
