### PR TITLE
test(llmobs): migrate vllm tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/vllm/conftest.py
+++ b/tests/contrib/vllm/conftest.py
@@ -45,11 +45,6 @@ def vllm():
 
 
 @pytest.fixture
-def ddtrace_global_config():
-    return {}
-
-
-@pytest.fixture
 def vllm_llmobs(tracer, monkeypatch):
     # Preserve meta_struct["_llmobs"] on spans so tests can assert against
     # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after

--- a/tests/contrib/vllm/conftest.py
+++ b/tests/contrib/vllm/conftest.py
@@ -50,26 +50,26 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def vllm_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "service": "tests.contrib.vllm",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 @pytest.fixture(scope="module")

--- a/tests/contrib/vllm/conftest.py
+++ b/tests/contrib/vllm/conftest.py
@@ -1,4 +1,5 @@
 import gc
+from unittest import mock
 import weakref
 
 import pytest
@@ -6,8 +7,7 @@ import torch
 
 from ddtrace.contrib.internal.vllm.patch import patch
 from ddtrace.contrib.internal.vllm.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
-from tests.llmobs._utils import TestLLMObsSpanWriter
+from ddtrace.llmobs import LLMObs
 from tests.utils import override_global_config
 
 from ._utils import shutdown_cached_llms
@@ -45,23 +45,31 @@ def vllm():
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com")
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def vllm_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config({"_llmobs_ml_app": "<ml-app-name>", "service": "tests.contrib.vllm"}):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
-
-
-@pytest.fixture
-def llmobs_events(vllm_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 @pytest.fixture(scope="module")

--- a/tests/contrib/vllm/test_api_app.py
+++ b/tests/contrib/vllm/test_api_app.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from unittest import mock
+
 from fastapi.testclient import TestClient
 import pytest
 
 from ddtrace import tracer as ddtracer
-from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.propagation.http import HTTPPropagator
-from tests.utils import override_global_config
+from tests.llmobs._utils import assert_llmobs_span_data
 
 from .api_app import app
 
@@ -21,88 +23,112 @@ IGNORE_FIELDS = [
 ]
 
 
+LLMOBS_GLOBAL_CONFIG = dict(
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    _llmobs_ml_app="<ml-app-name>",
+    service="tests.contrib.vllm",
+)
+
+
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_rag_parent_child(vllm, llmobs_span_writer):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_rag_parent_child(vllm, test_spans):
     """Test RAG endpoint with parent-child span relationships and LLMObs event capture."""
-    # Enable LLMObs on ddtracer with integrations enabled and use test writer
-    llmobs_service.disable()
-    with override_global_config({"_llmobs_ml_app": "<ml-app-name>", "service": "tests.contrib.vllm"}):
-        llmobs_service.enable(_tracer=ddtracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
+    # Create a parent span and inject context into headers. ``ddtracer`` is the same
+    # global tracer wrapped by ``test_spans``; spans land in the same container.
+    with ddtracer.trace("api.rag") as parent_span:
+        headers = {}
+        HTTPPropagator.inject(parent_span.context, headers)
 
-        # Create a parent span and inject context into headers
-        with ddtracer.trace("api.rag") as parent_span:
-            headers = {}
-            HTTPPropagator.inject(parent_span.context, headers)
+        client = TestClient(app)
+        payload = {
+            "query": "What is the capital of France?",
+            "documents": [
+                "Paris is the capital and most populous city of France.",
+                "Berlin is Germany's capital.",
+            ],
+        }
 
-            client = TestClient(app)
-            payload = {
-                "query": "What is the capital of France?",
-                "documents": [
-                    "Paris is the capital and most populous city of France.",
-                    "Berlin is Germany's capital.",
-                ],
-            }
+        res = client.post("/rag", json=payload, headers=headers)
+        assert res.status_code == 200
 
-            res = client.post("/rag", json=payload, headers=headers)
-            assert res.status_code == 200
+    # Should have spans for: embed doc1, embed doc2, embed query, generate text (4 LLMObs spans),
+    # plus the parent ``api.rag`` span which is not an LLMObs span.
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
 
-        llmobs_service.disable()
+    llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
+    assert len(llmobs_spans) == 4
 
-    # Verify LLMObs events were captured
-    # Should have events for: embed doc1, embed doc2, embed query, generate text
-    llmobs_events = llmobs_span_writer.events
-    assert len(llmobs_events) == 4
+    def _kind(span):
+        return _get_llmobs_data_metastruct(span).get("meta", {}).get("span", {}).get("kind")
 
-    # Verify we have both embedding and completion operations
-    span_kinds = [event["meta"]["span"]["kind"] for event in llmobs_events]
-    assert span_kinds.count("embedding") == 3  # 2 docs + 1 query
-    assert span_kinds.count("llm") == 1  # 1 generation
+    embedding_spans = [s for s in llmobs_spans if _kind(s) == "embedding"]
+    generation_spans = [s for s in llmobs_spans if _kind(s) == "llm"]
 
-    # Check embedding events (order may vary)
-    embedding_docs = {
+    assert len(embedding_spans) == 3  # 2 docs + 1 query
+    assert len(generation_spans) == 1
+
+    expected_embedding_docs = {
         "Paris is the capital and most populous city of France.",
         "Berlin is Germany's capital.",
         "What is the capital of France?",
     }
+    captured_docs = set()
+    for span in embedding_spans:
+        meta_struct = _get_llmobs_data_metastruct(span)
+        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        assert len(documents) == 1
+        captured_docs.add(documents[0]["text"])
+    assert captured_docs == expected_embedding_docs
 
-    embedding_events = [e for e in llmobs_events if e["meta"]["span"]["kind"] == "embedding"]
-    generation_events = [e for e in llmobs_events if e["meta"]["span"]["kind"] == "llm"]
+    # Verify all embedding spans have correct structure. Distributed-context propagation
+    # via HTTPPropagator places the request-side spans on the same APM trace as ``api.rag``.
+    for span in embedding_spans:
+        assert span.trace_id == parent_span.trace_id
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(span),
+            span_kind="embedding",
+            model_name="intfloat/e5-small-v2",
+            model_provider="vllm",
+            metadata={"embedding_dim": 384, "num_cached_tokens": 0},
+            metrics={
+                "output_tokens": 0,
+                "time_to_first_token": mock.ANY,
+                "time_in_queue": mock.ANY,
+                "time_in_model_prefill": mock.ANY,
+                "time_in_model_inference": mock.ANY,
+            },
+            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
+        )
+        # input_tokens > 0 sanity check
+        metrics = _get_llmobs_data_metastruct(span).get("metrics", {})
+        assert metrics.get("input_tokens", 0) > 0
 
-    captured_docs = {e["meta"]["input"]["documents"][0]["text"] for e in embedding_events}
-    assert captured_docs == embedding_docs
-
-    # Verify all embedding events have correct structure
-    for event in embedding_events:
-        assert event["meta"]["model_name"] == "intfloat/e5-small-v2"
-        assert event["meta"]["model_provider"] == "vllm"
-        assert event["meta"]["metadata"]["embedding_dim"] == 384
-        assert event["meta"]["metadata"]["num_cached_tokens"] == 0
-        assert event["metrics"]["input_tokens"] > 0
-        assert event["metrics"]["output_tokens"] == 0
-        assert "time_to_first_token" in event["metrics"]
-        assert "time_in_queue" in event["metrics"]
-        assert "time_in_model_prefill" in event["metrics"]
-        assert "time_in_model_inference" in event["metrics"]
-        assert "ml_app:<ml-app-name>" in event["tags"]
-        assert "service:tests.contrib.vllm" in event["tags"]
-
-    # Verify generation event has correct structure
-    assert len(generation_events) == 1
-    gen_event = generation_events[0]
-    assert gen_event["meta"]["model_name"] == "facebook/opt-125m"
-    assert gen_event["meta"]["model_provider"] == "vllm"
-    assert gen_event["meta"]["metadata"]["temperature"] == 0.8
-    assert gen_event["meta"]["metadata"]["top_p"] == 0.95
-    assert gen_event["meta"]["metadata"]["max_tokens"] == 64
-    assert gen_event["meta"]["metadata"]["n"] == 1
-    assert gen_event["meta"]["metadata"]["num_cached_tokens"] == 0
-    assert gen_event["metrics"]["input_tokens"] == 27
-    assert gen_event["metrics"]["output_tokens"] > 0
-    assert "time_to_first_token" in gen_event["metrics"]
-    assert "time_in_queue" in gen_event["metrics"]
-    assert "time_in_model_prefill" in gen_event["metrics"]
-    assert "time_in_model_decode" in gen_event["metrics"]
-    assert "time_in_model_inference" in gen_event["metrics"]
-    assert "ml_app:<ml-app-name>" in gen_event["tags"]
-    assert "service:tests.contrib.vllm" in gen_event["tags"]
+    # Verify generation span has correct structure
+    gen_span = generation_spans[0]
+    assert gen_span.trace_id == parent_span.trace_id
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(gen_span),
+        span_kind="llm",
+        model_name="facebook/opt-125m",
+        model_provider="vllm",
+        metadata={
+            "temperature": 0.8,
+            "top_p": 0.95,
+            "max_tokens": 64,
+            "n": 1,
+            "num_cached_tokens": 0,
+        },
+        metrics={
+            "input_tokens": 27,
+            "time_to_first_token": mock.ANY,
+            "time_in_queue": mock.ANY,
+            "time_in_model_prefill": mock.ANY,
+            "time_in_model_decode": mock.ANY,
+            "time_in_model_inference": mock.ANY,
+        },
+        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
+    )
+    gen_metrics = _get_llmobs_data_metastruct(gen_span).get("metrics", {})
+    assert gen_metrics.get("output_tokens", 0) > 0

--- a/tests/contrib/vllm/test_api_app.py
+++ b/tests/contrib/vllm/test_api_app.py
@@ -7,6 +7,8 @@ import pytest
 
 from ddtrace import tracer as ddtracer
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_metrics
+from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.propagation.http import HTTPPropagator
 from tests.llmobs._utils import assert_llmobs_span_data
 
@@ -51,11 +53,8 @@ def test_rag_parent_child(vllm, vllm_llmobs, test_spans):
     llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
     assert len(llmobs_spans) == 4
 
-    def _kind(span):
-        return _get_llmobs_data_metastruct(span).get("meta", {}).get("span", {}).get("kind")
-
-    embedding_spans = [s for s in llmobs_spans if _kind(s) == "embedding"]
-    generation_spans = [s for s in llmobs_spans if _kind(s) == "llm"]
+    embedding_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "embedding"]
+    generation_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "llm"]
 
     assert len(embedding_spans) == 3  # 2 docs + 1 query
     assert len(generation_spans) == 1
@@ -93,7 +92,7 @@ def test_rag_parent_child(vllm, vllm_llmobs, test_spans):
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
         )
         # input_tokens > 0 sanity check
-        metrics = _get_llmobs_data_metastruct(span).get("metrics", {})
+        metrics = get_llmobs_metrics(span) or {}
         assert metrics.get("input_tokens", 0) > 0
 
     # Verify generation span has correct structure
@@ -121,5 +120,5 @@ def test_rag_parent_child(vllm, vllm_llmobs, test_spans):
         },
         tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
     )
-    gen_metrics = _get_llmobs_data_metastruct(gen_span).get("metrics", {})
+    gen_metrics = get_llmobs_metrics(gen_span) or {}
     assert gen_metrics.get("output_tokens", 0) > 0

--- a/tests/contrib/vllm/test_api_app.py
+++ b/tests/contrib/vllm/test_api_app.py
@@ -23,17 +23,8 @@ IGNORE_FIELDS = [
 ]
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    _llmobs_ml_app="<ml-app-name>",
-    service="tests.contrib.vllm",
-)
-
-
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_rag_parent_child(vllm, test_spans):
+def test_rag_parent_child(vllm, vllm_llmobs, test_spans):
     """Test RAG endpoint with parent-child span relationships and LLMObs event capture."""
     # Create a parent span and inject context into headers. ``ddtracer`` is the same
     # global tracer wrapped by ``test_spans``; spans land in the same container.

--- a/tests/contrib/vllm/test_api_app.py
+++ b/tests/contrib/vllm/test_api_app.py
@@ -7,6 +7,7 @@ import pytest
 
 from ddtrace import tracer as ddtracer
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_documents
 from ddtrace.llmobs._utils import get_llmobs_metrics
 from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.propagation.http import HTTPPropagator
@@ -66,8 +67,7 @@ def test_rag_parent_child(vllm, vllm_llmobs, test_spans):
     }
     captured_docs = set()
     for span in embedding_spans:
-        meta_struct = _get_llmobs_data_metastruct(span)
-        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        documents = get_llmobs_input_documents(span) or []
         assert len(documents) == 1
         captured_docs.add(documents[0]["text"])
     assert captured_docs == expected_embedding_docs

--- a/tests/contrib/vllm/test_vllm_llmobs.py
+++ b/tests/contrib/vllm/test_vllm_llmobs.py
@@ -2,6 +2,7 @@ import mock
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_documents
 from ddtrace.llmobs.types import Message
 from tests.llmobs._utils import assert_llmobs_span_data
 
@@ -127,8 +128,7 @@ def test_llmobs_classify(vllm_llmobs, test_spans, bge_reranker_llm):
     # Spans may be returned in any order; match by input document text.
     spans_by_prompt = {}
     for span in spans:
-        meta_struct = _get_llmobs_data_metastruct(span)
-        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        documents = get_llmobs_input_documents(span) or []
         assert len(documents) == 1
         spans_by_prompt[documents[0]["text"]] = span
 
@@ -173,8 +173,7 @@ def test_llmobs_embed(vllm_llmobs, test_spans, e5_small_llm):
 
     spans_by_prompt = {}
     for span in spans:
-        meta_struct = _get_llmobs_data_metastruct(span)
-        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        documents = get_llmobs_input_documents(span) or []
         assert len(documents) == 1
         spans_by_prompt[documents[0]["text"]] = span
 
@@ -219,8 +218,7 @@ def test_llmobs_reward(vllm_llmobs, test_spans, bge_reranker_llm):
 
     spans_by_prompt = {}
     for span in spans:
-        meta_struct = _get_llmobs_data_metastruct(span)
-        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        documents = get_llmobs_input_documents(span) or []
         assert len(documents) == 1
         spans_by_prompt[documents[0]["text"]] = span
 
@@ -287,10 +285,9 @@ def test_llmobs_score(vllm_llmobs, test_spans, bge_reranker_llm):
     }
 
     for span in spans:
-        meta_struct = _get_llmobs_data_metastruct(span)
-        token_text = meta_struct["meta"]["input"]["documents"][0]["text"]
+        token_text = get_llmobs_input_documents(span)[0]["text"]
         assert_llmobs_span_data(
-            meta_struct,
+            _get_llmobs_data_metastruct(span),
             span_kind="embedding",
             model_name="BAAI/bge-reranker-v2-m3",
             model_provider="vllm",

--- a/tests/contrib/vllm/test_vllm_llmobs.py
+++ b/tests/contrib/vllm/test_vllm_llmobs.py
@@ -1,8 +1,9 @@
 import mock
 import pytest
 
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs.types import Message
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
 
 from ._utils import get_simple_chat_template
 
@@ -15,19 +16,28 @@ IGNORE_FIELDS = [
     "metrics.vllm.latency.inference",
 ]
 
+LLMOBS_GLOBAL_CONFIG = dict(
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    _llmobs_ml_app="<ml-app-name>",
+    service="tests.contrib.vllm",
+)
+
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_llmobs_basic(llmobs_events, test_spans, opt_125m_llm):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_basic(test_spans, opt_125m_llm):
     from vllm import SamplingParams
 
     llm = opt_125m_llm
     sampling = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=8, seed=42)
     llm.generate("The future of AI is", sampling)
-    span = test_spans.pop_traces()[0][0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
 
-    assert len(llmobs_events) == 1
-    expected = _expected_llmobs_llm_span_event(
-        span,
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
         model_name="facebook/opt-125m",
         model_provider="vllm",
         input_messages=[Message(content="The future of AI is")],
@@ -40,7 +50,7 @@ def test_llmobs_basic(llmobs_events, test_spans, opt_125m_llm):
             "finish_reason": "length",
             "num_cached_tokens": 0,
         },
-        token_metrics={
+        metrics={
             "input_tokens": 6,
             "output_tokens": 8,
             "total_tokens": 14,
@@ -52,11 +62,11 @@ def test_llmobs_basic(llmobs_events, test_spans, opt_125m_llm):
         },
         tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
     )
-    assert llmobs_events[0] == expected
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_llmobs_chat(llmobs_events, test_spans, opt_125m_llm):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_chat(test_spans, opt_125m_llm):
     from vllm import SamplingParams
 
     llm = opt_125m_llm
@@ -70,11 +80,12 @@ def test_llmobs_chat(llmobs_events, test_spans, opt_125m_llm):
     ]
 
     llm.chat(conversation, sampling_params, chat_template=get_simple_chat_template(), use_tqdm=False)
-    span = test_spans.pop_traces()[0][0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
 
-    assert len(llmobs_events) == 1
-    expected = _expected_llmobs_llm_span_event(
-        span,
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
         model_name="facebook/opt-125m",
         model_provider="vllm",
         input_messages=[
@@ -92,7 +103,7 @@ def test_llmobs_chat(llmobs_events, test_spans, opt_125m_llm):
             "finish_reason": "length",
             "num_cached_tokens": mock.ANY,
         },
-        token_metrics={
+        metrics={
             "input_tokens": mock.ANY,
             "output_tokens": 16,
             "total_tokens": mock.ANY,
@@ -104,11 +115,11 @@ def test_llmobs_chat(llmobs_events, test_spans, opt_125m_llm):
         },
         tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
     )
-    assert llmobs_events[0] == expected
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_llmobs_classify(llmobs_events, test_spans, bge_reranker_llm):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_classify(test_spans, bge_reranker_llm):
     llm = bge_reranker_llm
 
     prompts = [
@@ -120,21 +131,29 @@ def test_llmobs_classify(llmobs_events, test_spans, bge_reranker_llm):
     traces = test_spans.pop_traces()
     spans = [s for t in traces for s in t]
 
-    # Expect one event per input prompt
-    assert len(llmobs_events) == len(prompts) == len(spans)
-    span_by_id = {s.span_id: s for s in spans}
+    # Expect one span per input prompt
+    assert len(spans) == len(prompts)
 
-    for prompt, event in zip(prompts, llmobs_events):
-        span = span_by_id[int(event["span_id"])]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+    # Spans may be returned in any order; match by input document text.
+    spans_by_prompt = {}
+    for span in spans:
+        meta_struct = _get_llmobs_data_metastruct(span)
+        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        assert len(documents) == 1
+        spans_by_prompt[documents[0]["text"]] = span
+
+    assert set(spans_by_prompt.keys()) == set(prompts)
+
+    for prompt in prompts:
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans_by_prompt[prompt]),
             span_kind="embedding",
             model_name="BAAI/bge-reranker-v2-m3",
             model_provider="vllm",
             input_documents=[{"text": prompt}],
             output_value="[1 embedding(s) returned with size 1]",
             metadata={"embedding_dim": 1, "num_cached_tokens": 0},
-            token_metrics={
+            metrics={
                 "input_tokens": 7,
                 "output_tokens": 0,
                 "total_tokens": 7,
@@ -145,11 +164,11 @@ def test_llmobs_classify(llmobs_events, test_spans, bge_reranker_llm):
             },
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
         )
-        assert event == expected
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_llmobs_embed(llmobs_events, test_spans, e5_small_llm):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_embed(test_spans, e5_small_llm):
     llm = e5_small_llm
 
     prompts = [
@@ -161,21 +180,27 @@ def test_llmobs_embed(llmobs_events, test_spans, e5_small_llm):
     traces = test_spans.pop_traces()
     spans = [s for t in traces for s in t]
 
-    # Expect one event per input prompt
-    assert len(llmobs_events) == len(prompts) == len(spans)
-    span_by_id = {s.span_id: s for s in spans}
+    assert len(spans) == len(prompts)
 
-    for prompt, event in zip(prompts, llmobs_events):
-        span = span_by_id[int(event["span_id"])]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+    spans_by_prompt = {}
+    for span in spans:
+        meta_struct = _get_llmobs_data_metastruct(span)
+        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        assert len(documents) == 1
+        spans_by_prompt[documents[0]["text"]] = span
+
+    assert set(spans_by_prompt.keys()) == set(prompts)
+
+    for prompt in prompts:
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans_by_prompt[prompt]),
             span_kind="embedding",
             model_name="intfloat/e5-small",
             model_provider="vllm",
             input_documents=[{"text": prompt}],
             output_value="[1 embedding(s) returned with size 384]",
             metadata={"embedding_dim": 384, "num_cached_tokens": 0},
-            token_metrics={
+            metrics={
                 "input_tokens": 7,
                 "output_tokens": 0,
                 "total_tokens": 7,
@@ -186,11 +211,11 @@ def test_llmobs_embed(llmobs_events, test_spans, e5_small_llm):
             },
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
         )
-        assert event == expected
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_llmobs_reward(llmobs_events, test_spans, bge_reranker_llm):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_reward(test_spans, bge_reranker_llm):
     llm = bge_reranker_llm
 
     prompts = [
@@ -202,21 +227,27 @@ def test_llmobs_reward(llmobs_events, test_spans, bge_reranker_llm):
     traces = test_spans.pop_traces()
     spans = [s for t in traces for s in t]
 
-    # Expect one event per input prompt
-    assert len(llmobs_events) == len(prompts) == len(spans)
-    span_by_id = {s.span_id: s for s in spans}
+    assert len(spans) == len(prompts)
 
-    for prompt, event in zip(prompts, llmobs_events):
-        span = span_by_id[int(event["span_id"])]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+    spans_by_prompt = {}
+    for span in spans:
+        meta_struct = _get_llmobs_data_metastruct(span)
+        documents = meta_struct.get("meta", {}).get("input", {}).get("documents", [])
+        assert len(documents) == 1
+        spans_by_prompt[documents[0]["text"]] = span
+
+    assert set(spans_by_prompt.keys()) == set(prompts)
+
+    for prompt in prompts:
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans_by_prompt[prompt]),
             span_kind="embedding",
             model_name="BAAI/bge-reranker-v2-m3",
             model_provider="vllm",
             input_documents=[{"text": prompt}],
             output_value="[1 embedding(s) returned with size 7]",
             metadata={"embedding_dim": 7, "num_cached_tokens": 0},
-            token_metrics={
+            metrics={
                 "input_tokens": 7,
                 "output_tokens": 0,
                 "total_tokens": 7,
@@ -227,11 +258,11 @@ def test_llmobs_reward(llmobs_events, test_spans, bge_reranker_llm):
             },
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
         )
-        assert event == expected
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-def test_llmobs_score(llmobs_events, test_spans, bge_reranker_llm):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_score(test_spans, bge_reranker_llm):
     llm = bge_reranker_llm
 
     text_1 = "What is the capital of France?"
@@ -244,9 +275,8 @@ def test_llmobs_score(llmobs_events, test_spans, bge_reranker_llm):
     traces = test_spans.pop_traces()
     spans = [s for t in traces for s in t]
 
-    # Expect one event per candidate document
-    assert len(llmobs_events) == len(texts_2) == len(spans)
-    span_by_id = {s.span_id: s for s in spans}
+    # Expect one span per candidate document
+    assert len(spans) == len(texts_2)
 
     expected_token_metrics_by_text = {
         "[0, 4865, 83, 70, 10323, 111, 9942, 32, 2, 2, 581, 10323, 111, 30089, 83, 8233, 399, 5, 2]": {
@@ -269,21 +299,20 @@ def test_llmobs_score(llmobs_events, test_spans, bge_reranker_llm):
         },
     }
 
-    for event in llmobs_events:
-        span = span_by_id[int(event["span_id"])]
-        token_text = event["meta"]["input"]["documents"][0]["text"]
-        expected = _expected_llmobs_llm_span_event(
-            span,
+    for span in spans:
+        meta_struct = _get_llmobs_data_metastruct(span)
+        token_text = meta_struct["meta"]["input"]["documents"][0]["text"]
+        assert_llmobs_span_data(
+            meta_struct,
             span_kind="embedding",
             model_name="BAAI/bge-reranker-v2-m3",
             model_provider="vllm",
             input_documents=[{"text": token_text}],
             output_value="[1 embedding(s) returned with size 1]",
             metadata={"embedding_dim": 1, "num_cached_tokens": 0},
-            token_metrics=expected_token_metrics_by_text[token_text],
+            metrics=expected_token_metrics_by_text[token_text],
             tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.vllm", "integration": "vllm"},
         )
-        assert event == expected
 
 
 def test_shadow_tags_completion_when_llmobs_disabled(tracer):

--- a/tests/contrib/vllm/test_vllm_llmobs.py
+++ b/tests/contrib/vllm/test_vllm_llmobs.py
@@ -16,17 +16,9 @@ IGNORE_FIELDS = [
     "metrics.vllm.latency.inference",
 ]
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    _llmobs_ml_app="<ml-app-name>",
-    service="tests.contrib.vllm",
-)
-
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_basic(test_spans, opt_125m_llm):
+def test_llmobs_basic(vllm_llmobs, test_spans, opt_125m_llm):
     from vllm import SamplingParams
 
     llm = opt_125m_llm
@@ -65,8 +57,7 @@ def test_llmobs_basic(test_spans, opt_125m_llm):
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_chat(test_spans, opt_125m_llm):
+def test_llmobs_chat(vllm_llmobs, test_spans, opt_125m_llm):
     from vllm import SamplingParams
 
     llm = opt_125m_llm
@@ -118,8 +109,7 @@ def test_llmobs_chat(test_spans, opt_125m_llm):
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_classify(test_spans, bge_reranker_llm):
+def test_llmobs_classify(vllm_llmobs, test_spans, bge_reranker_llm):
     llm = bge_reranker_llm
 
     prompts = [
@@ -167,8 +157,7 @@ def test_llmobs_classify(test_spans, bge_reranker_llm):
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_embed(test_spans, e5_small_llm):
+def test_llmobs_embed(vllm_llmobs, test_spans, e5_small_llm):
     llm = e5_small_llm
 
     prompts = [
@@ -214,8 +203,7 @@ def test_llmobs_embed(test_spans, e5_small_llm):
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_reward(test_spans, bge_reranker_llm):
+def test_llmobs_reward(vllm_llmobs, test_spans, bge_reranker_llm):
     llm = bge_reranker_llm
 
     prompts = [
@@ -261,8 +249,7 @@ def test_llmobs_reward(test_spans, bge_reranker_llm):
 
 
 @pytest.mark.snapshot(ignores=IGNORE_FIELDS)
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_score(test_spans, bge_reranker_llm):
+def test_llmobs_score(vllm_llmobs, test_spans, bge_reranker_llm):
     llm = bge_reranker_llm
 
     text_1 = "What is the capital of France?"


### PR DESCRIPTION
Migrates vllm LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `vllm_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
