### PR TITLE
test(llmobs): migrate langgraph tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -56,26 +56,22 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def langgraph_llmobs(tracer, monkeypatch):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "unnamed-ml-app",
+            "_dd_api_key": "<not-a-real-api_key>",
+            "_llmobs_sample_rate": 1.0,
+            "service": "tests.llmobs",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 class State(TypedDict):

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -63,7 +63,6 @@ def langgraph_llmobs(tracer, monkeypatch):
         {
             "_llmobs_ml_app": "unnamed-ml-app",
             "_dd_api_key": "<not-a-real-api_key>",
-            "_llmobs_sample_rate": 1.0,
             "service": "tests.llmobs",
         }
     ):

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -2,6 +2,7 @@ import operator
 import os
 from typing import Annotated
 from typing import TypedDict
+from unittest import mock
 
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
@@ -17,8 +18,7 @@ from ddtrace.contrib.internal.langgraph.patch import patch
 from ddtrace.contrib.internal.langgraph.patch import unpatch
 from ddtrace.contrib.internal.openai.patch import patch as patch_openai
 from ddtrace.contrib.internal.openai.patch import unpatch as unpatch_openai
-from ddtrace.llmobs import LLMObs as llmobs_service
-from tests.llmobs._utils import TestLLMObsSpanWriter
+from ddtrace.llmobs import LLMObs
 from tests.utils import override_global_config
 
 
@@ -50,27 +50,32 @@ def langchain():
     unpatch_langchain()
 
 
-def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "unnamed-ml-app", "service": "tests.llmobs"}
+@pytest.fixture
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs(tracer, llmobs_span_writer):
-    with override_global_config(default_global_config()):
-        llmobs_service.enable(_tracer=tracer)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
-
-
-@pytest.fixture
-def llmobs_events(llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 class State(TypedDict):

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -331,7 +331,9 @@ class TestLangGraphLLMObs:
         assert b_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_simple_graph(self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges):
+    def test_agent_manifest_simple_graph(
+        self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges
+    ):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}
         )
@@ -421,7 +423,9 @@ class TestLangGraphLLMObs:
         assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_populates_tools_from_tool_node(self, langgraph_llmobs, test_spans, custom_agent_with_tool_node):
+    def test_agent_manifest_populates_tools_from_tool_node(
+        self, langgraph_llmobs, test_spans, custom_agent_with_tool_node
+    ):
         custom_agent_with_tool_node.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
 

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -4,308 +4,353 @@ import random
 import pytest
 
 from ddtrace.contrib.internal.langgraph.patch import LANGGRAPH_VERSION
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.llmobs._utils import _assert_span_link
 
 
-def _find_span_by_name(llmobs_events, name):
-    """Find a single span by name."""
-    for event in llmobs_events:
-        if event["name"] == name:
-            return event
-    assert False, f"Span '{name}' not found in llmobs span events"
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="unnamed-ml-app",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.llmobs",
+)
 
 
-def _find_spans_by_name(llmobs_events, names):
-    """Find multiple spans by name, sorting by start_ns."""
-    spans = []
-    for event in llmobs_events:
-        if event["name"] in names:
-            spans.append(event)
-    if len(spans) != len(names):
-        assert False, f"Spans {names} not found in llmobs span events"
-    return sorted(spans, key=lambda x: x["start_ns"])
+def _link_view(span):
+    """Adapt an APM span into the dict shape ``_assert_span_link`` expects.
+
+    ``_assert_span_link`` was written against the wire-event shape; in the
+    meta_struct world span_links live on ``span._meta_struct["_llmobs"]``
+    rather than at the top level of an event.
+    """
+    return {
+        "span_id": str(span.span_id),
+        "span_links": _get_llmobs_data_metastruct(span).get("span_links", []),
+    }
 
 
+def _find_span_by_name(spans, name):
+    """Find a single span by its LLMObs meta_struct name."""
+    for span in spans:
+        if _get_llmobs_data_metastruct(span).get("name") == name:
+            return span
+    assert False, f"Span '{name}' not found in spans"
+
+
+def _find_spans_by_name(spans, names):
+    """Find multiple spans by name, sorted by start_ns."""
+    matched = [span for span in spans if _get_llmobs_data_metastruct(span).get("name") in names]
+    if len(matched) != len(names):
+        assert False, f"Spans {names} not found in spans"
+    return sorted(matched, key=lambda s: s.start_ns)
+
+
+def _collect_spans(test_spans):
+    return [s for trace in test_spans.pop_traces() for s in trace]
+
+
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLangGraphLLMObs:
-    def test_simple_graph(self, llmobs_events, simple_graph):
+    def test_simple_graph(self, test_spans, simple_graph):
         simple_graph.invoke({"a_list": [], "which": "a"}, stream_mode=["values"])
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
         # Check that the graph span has the appropriate output
         # stream_mode=["values"] should result in the last yield being a tuple
-        assert graph_span["meta"]["output"]["value"] == json.dumps({"a_list": ["a", "b"], "which": "a"})
+        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    async def test_simple_graph_async(self, llmobs_events, simple_graph):
+    async def test_simple_graph_async(self, test_spans, simple_graph):
         await simple_graph.ainvoke({"a_list": [], "which": "a"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
         # Check that the graph span has the appropriate output
         # default stream_mode of "values" should result in the last yield being an object
-        assert graph_span["meta"]["output"]["value"] == json.dumps({"a_list": ["a", "b"], "which": "a"})
+        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    def test_conditional_graph(self, llmobs_events, conditional_graph):
+    def test_conditional_graph(self, test_spans, conditional_graph):
         conditional_graph.invoke({"a_list": [], "which": "c"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        c_span = _find_span_by_name(llmobs_events, "c")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        c_span = _find_span_by_name(spans, "c")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(c_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(c_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
 
-    async def test_conditional_graph_async(self, llmobs_events, conditional_graph):
+    async def test_conditional_graph_async(self, test_spans, conditional_graph):
         await conditional_graph.ainvoke({"a_list": [], "which": "b"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-    def test_subgraph(self, llmobs_events, complex_graph):
+    def test_subgraph(self, test_spans, complex_graph):
         complex_graph.invoke({"a_list": [], "which": "b"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        b1_span = _find_span_by_name(llmobs_events, "b1")
-        b2_span = _find_span_by_name(llmobs_events, "b2")
-        b3_span = _find_span_by_name(llmobs_events, "b3")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        b1_span = _find_span_by_name(spans, "b1")
+        b2_span = _find_span_by_name(spans, "b2")
+        b3_span = _find_span_by_name(spans, "b3")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(b_span, b1_span, "input", "input")
-        _assert_span_link(b1_span, b2_span, "output", "input")
-        _assert_span_link(b2_span, b3_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(b_span), _link_view(b1_span), "input", "input")
+        _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
+        _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    async def test_subgraph_async(self, llmobs_events, complex_graph):
+    async def test_subgraph_async(self, test_spans, complex_graph):
         await complex_graph.ainvoke({"a_list": [], "which": "b"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        b1_span = _find_span_by_name(llmobs_events, "b1")
-        b2_span = _find_span_by_name(llmobs_events, "b2")
-        b3_span = _find_span_by_name(llmobs_events, "b3")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        b1_span = _find_span_by_name(spans, "b1")
+        b2_span = _find_span_by_name(spans, "b2")
+        b3_span = _find_span_by_name(spans, "b3")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(b_span, b1_span, "input", "input")
-        _assert_span_link(b1_span, b2_span, "output", "input")
-        _assert_span_link(b2_span, b3_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(b_span), _link_view(b1_span), "input", "input")
+        _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
+        _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    def test_fanning_graph(self, llmobs_events, fanning_graph):
+    def test_fanning_graph(self, test_spans, fanning_graph):
         fanning_graph.invoke({"a_list": [], "which": ""})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(d_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    async def test_fanning_graph_async(self, llmobs_events, fanning_graph):
+    async def test_fanning_graph_async(self, test_spans, fanning_graph):
         await fanning_graph.ainvoke({"a_list": [], "which": ""})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
 
-        assert graph_span["name"] == "LangGraph"
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(d_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
+        assert _get_llmobs_data_metastruct(graph_span).get("name") == "LangGraph"
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    def test_graph_with_send(self, llmobs_events, graph_with_send):
+    def test_graph_with_send(self, test_spans, graph_with_send):
         graph_with_send.invoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(llmobs_events, ["b", "b", "b"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(spans, ["b", "b", "b"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span_1, graph_span, "output", "output")
-        _assert_span_link(b_span_2, graph_span, "output", "output")
-        _assert_span_link(b_span_3, graph_span, "output", "output")
-        _assert_span_link(a_span, b_span_1, "output", "input")
-        _assert_span_link(a_span, b_span_2, "output", "input")
-        _assert_span_link(a_span, b_span_3, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span_1), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_2), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_3), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_1), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    async def test_graph_with_send_async(self, llmobs_events, graph_with_send):
+    async def test_graph_with_send_async(self, test_spans, graph_with_send):
         await graph_with_send.ainvoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(llmobs_events, ["b", "b", "b"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(spans, ["b", "b", "b"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span_1, graph_span, "output", "output")
-        _assert_span_link(b_span_2, graph_span, "output", "output")
-        _assert_span_link(b_span_3, graph_span, "output", "output")
-        _assert_span_link(a_span, b_span_1, "output", "input")
-        _assert_span_link(a_span, b_span_2, "output", "input")
-        _assert_span_link(a_span, b_span_3, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span_1), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_2), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_3), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_1), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    def test_graph_with_send_complex(self, llmobs_events, graph_with_send_complex):
+    def test_graph_with_send_complex(self, test_spans, graph_with_send_complex):
         graph_with_send_complex.invoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_span_from_send, e_span = _find_spans_by_name(llmobs_events, ["e", "e"])
-        f_span = _find_span_by_name(llmobs_events, "f")
-        g_span = _find_span_by_name(llmobs_events, "g")
-        h_span = _find_span_by_name(llmobs_events, "h")
-        i_span = _find_span_by_name(llmobs_events, "i")
-        j_span = _find_span_by_name(llmobs_events, "j")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_span_from_send, e_span = _find_spans_by_name(spans, ["e", "e"])
+        f_span = _find_span_by_name(spans, "f")
+        g_span = _find_span_by_name(spans, "g")
+        h_span = _find_span_by_name(spans, "h")
+        i_span = _find_span_by_name(spans, "i")
+        j_span = _find_span_by_name(spans, "j")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(b_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span_from_send, "output", "input")
-        _assert_span_link(c_span, f_span, "output", "input")
-        _assert_span_link(c_span, g_span, "output", "input")
-        _assert_span_link(d_span, h_span, "output", "input")
-        _assert_span_link(e_span, h_span, "output", "input")
-        _assert_span_link(e_span_from_send, h_span, "output", "input")
-        _assert_span_link(f_span, i_span, "output", "input")
-        _assert_span_link(g_span, i_span, "output", "input")
-        _assert_span_link(h_span, j_span, "output", "input")
-        _assert_span_link(i_span, j_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span_from_send), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(f_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(g_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span_from_send), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(f_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(g_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
+        _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    async def test_graph_with_send_complex_async(self, llmobs_events, graph_with_send_complex):
+    async def test_graph_with_send_complex_async(self, test_spans, graph_with_send_complex):
         await graph_with_send_complex.ainvoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_span_from_send, e_span = _find_spans_by_name(llmobs_events, ["e", "e"])
-        f_span = _find_span_by_name(llmobs_events, "f")
-        g_span = _find_span_by_name(llmobs_events, "g")
-        h_span = _find_span_by_name(llmobs_events, "h")
-        i_span = _find_span_by_name(llmobs_events, "i")
-        j_span = _find_span_by_name(llmobs_events, "j")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_span_from_send, e_span = _find_spans_by_name(spans, ["e", "e"])
+        f_span = _find_span_by_name(spans, "f")
+        g_span = _find_span_by_name(spans, "g")
+        h_span = _find_span_by_name(spans, "h")
+        i_span = _find_span_by_name(spans, "i")
+        j_span = _find_span_by_name(spans, "j")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(b_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span_from_send, "output", "input")
-        _assert_span_link(c_span, f_span, "output", "input")
-        _assert_span_link(c_span, g_span, "output", "input")
-        _assert_span_link(d_span, h_span, "output", "input")
-        _assert_span_link(e_span, h_span, "output", "input")
-        _assert_span_link(e_span_from_send, h_span, "output", "input")
-        _assert_span_link(f_span, i_span, "output", "input")
-        _assert_span_link(g_span, i_span, "output", "input")
-        _assert_span_link(h_span, j_span, "output", "input")
-        _assert_span_link(i_span, j_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span_from_send), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(f_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(g_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span_from_send), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(f_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(g_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
+        _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    def test_graph_with_uneven_sides(self, llmobs_events, graph_with_uneven_sides):
+    def test_graph_with_uneven_sides(self, test_spans, graph_with_uneven_sides):
         graph_with_uneven_sides.invoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_first_finish, e_second_finish = _find_spans_by_name(llmobs_events, ["e", "e"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_first_finish, e_second_finish = _find_spans_by_name(spans, ["e", "e"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, e_first_finish, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
-        _assert_span_link(d_span, e_second_finish, "output", "input")
-        _assert_span_link(e_first_finish, graph_span, "output", "output")
-        _assert_span_link(e_second_finish, graph_span, "output", "output")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_first_finish), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(e_second_finish), "output", "input")
+        _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_graph_with_uneven_sides_async(self, llmobs_events, graph_with_uneven_sides):
+    async def test_graph_with_uneven_sides_async(self, test_spans, graph_with_uneven_sides):
         await graph_with_uneven_sides.ainvoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_first_finish, e_second_finish = _find_spans_by_name(llmobs_events, ["e", "e"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_first_finish, e_second_finish = _find_spans_by_name(spans, ["e", "e"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, e_first_finish, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
-        _assert_span_link(d_span, e_second_finish, "output", "input")
-        _assert_span_link(e_first_finish, graph_span, "output", "output")
-        _assert_span_link(e_second_finish, graph_span, "output", "output")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_first_finish), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(e_second_finish), "output", "input")
+        _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_astream_events(self, simple_graph, llmobs_events):
+    async def test_astream_events(self, test_spans, simple_graph):
         async for _ in simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2"):
             pass
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-        assert a_span["meta"]["output"]["value"] is not None
-        assert b_span["meta"]["output"]["value"] is not None
+        a_output = _get_llmobs_data_metastruct(a_span).get("meta", {}).get("output", {})
+        b_output = _get_llmobs_data_metastruct(b_span).get("meta", {}).get("output", {})
+        assert a_output.get("value") is not None
+        assert b_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_simple_graph(self, llmobs_events, agentic_graph_with_conditional_and_definitive_edges):
+    def test_agent_manifest_simple_graph(self, test_spans, agentic_graph_with_conditional_and_definitive_edges):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}
         )
+        spans = _collect_spans(test_spans)
 
-        agent_a_span = _find_span_by_name(llmobs_events, "agent_a")
+        agent_a_span = _find_span_by_name(spans, "agent_a")
         try:
-            conditional_agent_span = _find_span_by_name(llmobs_events, "agent_b")
+            conditional_agent_span = _find_span_by_name(spans, "agent_b")
             conditional_agent_name = "agent_b"
         except AssertionError:
-            conditional_agent_span = _find_span_by_name(llmobs_events, "agent_c")
+            conditional_agent_span = _find_span_by_name(spans, "agent_c")
             conditional_agent_name = "agent_c"
 
-        agent_d_span = _find_span_by_name(llmobs_events, "agent_d")
+        agent_d_span = _find_span_by_name(spans, "agent_d")
 
         expected_agent_a_manifest = {
             "framework": "LangGraph",
@@ -331,19 +376,22 @@ class TestLangGraphLLMObs:
             "tools": [],
         }
 
-        assert agent_a_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_a_manifest
-        assert (
-            conditional_agent_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_conditional_agent_manifest
-        )
-        assert agent_d_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_d_manifest
+        agent_a_metadata = _get_llmobs_data_metastruct(agent_a_span).get("meta", {}).get("metadata", {})
+        conditional_metadata = _get_llmobs_data_metastruct(conditional_agent_span).get("meta", {}).get("metadata", {})
+        agent_d_metadata = _get_llmobs_data_metastruct(agent_d_span).get("meta", {}).get("metadata", {})
+
+        assert agent_a_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_a_manifest
+        assert conditional_metadata.get("_dd", {}).get("agent_manifest") == expected_conditional_agent_manifest
+        assert agent_d_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_d_manifest
 
     @pytest.mark.skipif(
         LANGGRAPH_VERSION < (0, 3, 21), reason="create_react_agent has full support after LangGraph 0.3.21"
     )
-    def test_agent_manifest_from_create_react_agent(self, llmobs_events, agent_from_create_react_agent):
+    def test_agent_manifest_from_create_react_agent(self, test_spans, agent_from_create_react_agent):
         agent_from_create_react_agent.invoke({"messages": [{"role": "user", "content": "What is 2 + 2?"}]})
+        spans = _collect_spans(test_spans)
 
-        react_agent_span = _find_span_by_name(llmobs_events, "not_your_average_bostonian")
+        react_agent_span = _find_span_by_name(spans, "not_your_average_bostonian")
 
         expected_agent_manifest = {
             "framework": "LangGraph",
@@ -374,13 +422,15 @@ class TestLangGraphLLMObs:
             "instructions": "You are a helpful assistant who talks with a Boston accent but is also very nice. You speak in full sentences with at least 15 words.",  # noqa: E501
         }
 
-        assert react_agent_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_manifest
+        react_agent_metadata = _get_llmobs_data_metastruct(react_agent_span).get("meta", {}).get("metadata", {})
+        assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_populates_tools_from_tool_node(self, llmobs_events, custom_agent_with_tool_node):
+    def test_agent_manifest_populates_tools_from_tool_node(self, test_spans, custom_agent_with_tool_node):
         custom_agent_with_tool_node.invoke({"a_list": []})
+        spans = _collect_spans(test_spans)
 
-        agent_span = _find_span_by_name(llmobs_events, "custom_agent_with_tool_node")
+        agent_span = _find_span_by_name(spans, "custom_agent_with_tool_node")
 
         expected_agent_manifest = {
             "framework": "LangGraph",
@@ -405,23 +455,26 @@ class TestLangGraphLLMObs:
             ],
         }
 
-        assert agent_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_manifest
+        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        assert agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_manifest_different_recursion_limit(
-        self, llmobs_events, agentic_graph_with_conditional_and_definitive_edges
+        self, test_spans, agentic_graph_with_conditional_and_definitive_edges
     ):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}, {"recursion_limit": 100}
         )
+        spans = _collect_spans(test_spans)
 
-        agent_span = _find_span_by_name(llmobs_events, "agent")
+        agent_span = _find_span_by_name(spans, "agent")
 
-        assert agent_span["meta"]["metadata"]["_dd"]["agent_manifest"]["max_iterations"] == 100
+        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        assert agent_metadata.get("_dd", {}).get("agent_manifest", {}).get("max_iterations") == 100
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_with_tool_calls_integrations_enabled(
-        self, llmobs_events, agent_from_create_react_agent_integrations_enabled
+        self, test_spans, agent_from_create_react_agent_integrations_enabled
     ):
         """
         Test that invoking an agent with tool calls while other integrations are enabled results in
@@ -430,23 +483,35 @@ class TestLangGraphLLMObs:
         agent_from_create_react_agent_integrations_enabled.invoke(
             {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
         )
+        spans = _collect_spans(test_spans)
 
-        assert len(llmobs_events) == 11
+        # Filter to LLMObs-bearing spans (some APM-only spans may be present from langchain/openai patching)
+        llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
+        llmobs_spans.sort(key=lambda s: s.start_ns)
 
-        first_llm_span = llmobs_events[0]
-        tool_span = llmobs_events[4]
-        second_llm_span = llmobs_events[6]
+        assert len(llmobs_spans) == 11
 
-        assert first_llm_span["meta"]["span"]["kind"] == "llm"
-        assert tool_span["meta"]["span"]["kind"] == "tool"
-        assert second_llm_span["meta"]["span"]["kind"] == "llm"
+        first_llm_span = llmobs_spans[0]
+        tool_span = llmobs_spans[4]
+        second_llm_span = llmobs_spans[6]
+
+        first_llm_meta = _get_llmobs_data_metastruct(first_llm_span).get("meta", {})
+        tool_meta = _get_llmobs_data_metastruct(tool_span).get("meta", {})
+        second_llm_meta = _get_llmobs_data_metastruct(second_llm_span).get("meta", {})
+
+        assert first_llm_meta.get("span", {}).get("kind") == "llm"
+        assert tool_meta.get("span", {}).get("kind") == "tool"
+        assert second_llm_meta.get("span", {}).get("kind") == "llm"
+
+        tool_links = _get_llmobs_data_metastruct(tool_span).get("span_links", [])
+        second_llm_links = _get_llmobs_data_metastruct(second_llm_span).get("span_links", [])
 
         # assert llm -> tool span link
-        assert tool_span["span_links"][1]["span_id"] == first_llm_span["span_id"]
-        assert tool_span["span_links"][1]["attributes"]["from"] == "output"
-        assert tool_span["span_links"][1]["attributes"]["to"] == "input"
+        assert tool_links[1]["span_id"] == str(first_llm_span.span_id)
+        assert tool_links[1]["attributes"]["from"] == "output"
+        assert tool_links[1]["attributes"]["to"] == "input"
 
         # assert tool -> llm span link
-        assert second_llm_span["span_links"][0]["span_id"] == tool_span["span_id"]
-        assert second_llm_span["span_links"][0]["attributes"]["from"] == "output"
-        assert second_llm_span["span_links"][0]["attributes"]["to"] == "input"
+        assert second_llm_links[0]["span_id"] == str(tool_span.span_id)
+        assert second_llm_links[0]["attributes"]["from"] == "output"
+        assert second_llm_links[0]["attributes"]["to"] == "input"

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -13,15 +13,6 @@ from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="unnamed-ml-app",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.llmobs",
-)
-
-
 def _link_view(span):
     """Adapt an APM span into the dict shape ``_assert_span_link`` expects.
 
@@ -55,9 +46,8 @@ def _collect_spans(test_spans):
     return [s for trace in test_spans.pop_traces() for s in trace]
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLangGraphLLMObs:
-    def test_simple_graph(self, test_spans, simple_graph):
+    def test_simple_graph(self, langgraph_llmobs, test_spans, simple_graph):
         simple_graph.invoke({"a_list": [], "which": "a"}, stream_mode=["values"])
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -74,7 +64,7 @@ class TestLangGraphLLMObs:
         graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    async def test_simple_graph_async(self, test_spans, simple_graph):
+    async def test_simple_graph_async(self, langgraph_llmobs, test_spans, simple_graph):
         await simple_graph.ainvoke({"a_list": [], "which": "a"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -91,7 +81,7 @@ class TestLangGraphLLMObs:
         graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    def test_conditional_graph(self, test_spans, conditional_graph):
+    def test_conditional_graph(self, langgraph_llmobs, test_spans, conditional_graph):
         conditional_graph.invoke({"a_list": [], "which": "c"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -103,7 +93,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
         _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
 
-    async def test_conditional_graph_async(self, test_spans, conditional_graph):
+    async def test_conditional_graph_async(self, langgraph_llmobs, test_spans, conditional_graph):
         await conditional_graph.ainvoke({"a_list": [], "which": "b"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -115,7 +105,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-    def test_subgraph(self, test_spans, complex_graph):
+    def test_subgraph(self, langgraph_llmobs, test_spans, complex_graph):
         complex_graph.invoke({"a_list": [], "which": "b"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -134,7 +124,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
         _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    async def test_subgraph_async(self, test_spans, complex_graph):
+    async def test_subgraph_async(self, langgraph_llmobs, test_spans, complex_graph):
         await complex_graph.ainvoke({"a_list": [], "which": "b"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -153,7 +143,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
         _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    def test_fanning_graph(self, test_spans, fanning_graph):
+    def test_fanning_graph(self, langgraph_llmobs, test_spans, fanning_graph):
         fanning_graph.invoke({"a_list": [], "which": ""})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -170,7 +160,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
         _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    async def test_fanning_graph_async(self, test_spans, fanning_graph):
+    async def test_fanning_graph_async(self, langgraph_llmobs, test_spans, fanning_graph):
         await fanning_graph.ainvoke({"a_list": [], "which": ""})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -188,7 +178,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
         _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    def test_graph_with_send(self, test_spans, graph_with_send):
+    def test_graph_with_send(self, langgraph_llmobs, test_spans, graph_with_send):
         graph_with_send.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -203,7 +193,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    async def test_graph_with_send_async(self, test_spans, graph_with_send):
+    async def test_graph_with_send_async(self, langgraph_llmobs, test_spans, graph_with_send):
         await graph_with_send.ainvoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -218,7 +208,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    def test_graph_with_send_complex(self, test_spans, graph_with_send_complex):
+    def test_graph_with_send_complex(self, langgraph_llmobs, test_spans, graph_with_send_complex):
         graph_with_send_complex.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -250,7 +240,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
         _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    async def test_graph_with_send_complex_async(self, test_spans, graph_with_send_complex):
+    async def test_graph_with_send_complex_async(self, langgraph_llmobs, test_spans, graph_with_send_complex):
         await graph_with_send_complex.ainvoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -282,7 +272,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
         _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    def test_graph_with_uneven_sides(self, test_spans, graph_with_uneven_sides):
+    def test_graph_with_uneven_sides(self, langgraph_llmobs, test_spans, graph_with_uneven_sides):
         graph_with_uneven_sides.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -302,7 +292,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
         _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_graph_with_uneven_sides_async(self, test_spans, graph_with_uneven_sides):
+    async def test_graph_with_uneven_sides_async(self, langgraph_llmobs, test_spans, graph_with_uneven_sides):
         await graph_with_uneven_sides.ainvoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -322,7 +312,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
         _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_astream_events(self, test_spans, simple_graph):
+    async def test_astream_events(self, langgraph_llmobs, test_spans, simple_graph):
         async for _ in simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2"):
             pass
         spans = _collect_spans(test_spans)
@@ -341,7 +331,7 @@ class TestLangGraphLLMObs:
         assert b_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_simple_graph(self, test_spans, agentic_graph_with_conditional_and_definitive_edges):
+    def test_agent_manifest_simple_graph(self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}
         )
@@ -392,7 +382,7 @@ class TestLangGraphLLMObs:
     @pytest.mark.skipif(
         LANGGRAPH_VERSION < (0, 3, 21), reason="create_react_agent has full support after LangGraph 0.3.21"
     )
-    def test_agent_manifest_from_create_react_agent(self, test_spans, agent_from_create_react_agent):
+    def test_agent_manifest_from_create_react_agent(self, langgraph_llmobs, test_spans, agent_from_create_react_agent):
         agent_from_create_react_agent.invoke({"messages": [{"role": "user", "content": "What is 2 + 2?"}]})
         spans = _collect_spans(test_spans)
 
@@ -431,7 +421,7 @@ class TestLangGraphLLMObs:
         assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_populates_tools_from_tool_node(self, test_spans, custom_agent_with_tool_node):
+    def test_agent_manifest_populates_tools_from_tool_node(self, langgraph_llmobs, test_spans, custom_agent_with_tool_node):
         custom_agent_with_tool_node.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
 
@@ -465,7 +455,7 @@ class TestLangGraphLLMObs:
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_manifest_different_recursion_limit(
-        self, test_spans, agentic_graph_with_conditional_and_definitive_edges
+        self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges
     ):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}, {"recursion_limit": 100}
@@ -479,7 +469,7 @@ class TestLangGraphLLMObs:
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_with_tool_calls_integrations_enabled(
-        self, test_spans, agent_from_create_react_agent_integrations_enabled
+        self, langgraph_llmobs, test_spans, agent_from_create_react_agent_integrations_enabled
     ):
         """
         Test that invoking an agent with tool calls while other integrations are enabled results in

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -5,6 +5,11 @@ import pytest
 
 from ddtrace.contrib.internal.langgraph.patch import LANGGRAPH_VERSION
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_metadata
+from ddtrace.llmobs._utils import get_llmobs_output
+from ddtrace.llmobs._utils import get_llmobs_span_kind
+from ddtrace.llmobs._utils import get_llmobs_span_links
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 
 
@@ -26,21 +31,21 @@ def _link_view(span):
     """
     return {
         "span_id": str(span.span_id),
-        "span_links": _get_llmobs_data_metastruct(span).get("span_links", []),
+        "span_links": get_llmobs_span_links(span) or [],
     }
 
 
 def _find_span_by_name(spans, name):
     """Find a single span by its LLMObs meta_struct name."""
     for span in spans:
-        if _get_llmobs_data_metastruct(span).get("name") == name:
+        if get_llmobs_span_name(span) == name:
             return span
     assert False, f"Span '{name}' not found in spans"
 
 
 def _find_spans_by_name(spans, names):
     """Find multiple spans by name, sorted by start_ns."""
-    matched = [span for span in spans if _get_llmobs_data_metastruct(span).get("name") in names]
+    matched = [span for span in spans if get_llmobs_span_name(span) in names]
     if len(matched) != len(names):
         assert False, f"Spans {names} not found in spans"
     return sorted(matched, key=lambda s: s.start_ns)
@@ -66,7 +71,7 @@ class TestLangGraphLLMObs:
 
         # Check that the graph span has the appropriate output
         # stream_mode=["values"] should result in the last yield being a tuple
-        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
     async def test_simple_graph_async(self, test_spans, simple_graph):
@@ -83,7 +88,7 @@ class TestLangGraphLLMObs:
 
         # Check that the graph span has the appropriate output
         # default stream_mode of "values" should result in the last yield being an object
-        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
     def test_conditional_graph(self, test_spans, conditional_graph):
@@ -174,7 +179,7 @@ class TestLangGraphLLMObs:
         c_span = _find_span_by_name(spans, "c")
         d_span = _find_span_by_name(spans, "d")
 
-        assert _get_llmobs_data_metastruct(graph_span).get("name") == "LangGraph"
+        assert get_llmobs_span_name(graph_span) == "LangGraph"
         _assert_span_link(None, _link_view(graph_span), "input", "input")
         _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
@@ -330,8 +335,8 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-        a_output = _get_llmobs_data_metastruct(a_span).get("meta", {}).get("output", {})
-        b_output = _get_llmobs_data_metastruct(b_span).get("meta", {}).get("output", {})
+        a_output = get_llmobs_output(a_span) or {}
+        b_output = get_llmobs_output(b_span) or {}
         assert a_output.get("value") is not None
         assert b_output.get("value") is not None
 
@@ -376,9 +381,9 @@ class TestLangGraphLLMObs:
             "tools": [],
         }
 
-        agent_a_metadata = _get_llmobs_data_metastruct(agent_a_span).get("meta", {}).get("metadata", {})
-        conditional_metadata = _get_llmobs_data_metastruct(conditional_agent_span).get("meta", {}).get("metadata", {})
-        agent_d_metadata = _get_llmobs_data_metastruct(agent_d_span).get("meta", {}).get("metadata", {})
+        agent_a_metadata = get_llmobs_metadata(agent_a_span) or {}
+        conditional_metadata = get_llmobs_metadata(conditional_agent_span) or {}
+        agent_d_metadata = get_llmobs_metadata(agent_d_span) or {}
 
         assert agent_a_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_a_manifest
         assert conditional_metadata.get("_dd", {}).get("agent_manifest") == expected_conditional_agent_manifest
@@ -422,7 +427,7 @@ class TestLangGraphLLMObs:
             "instructions": "You are a helpful assistant who talks with a Boston accent but is also very nice. You speak in full sentences with at least 15 words.",  # noqa: E501
         }
 
-        react_agent_metadata = _get_llmobs_data_metastruct(react_agent_span).get("meta", {}).get("metadata", {})
+        react_agent_metadata = get_llmobs_metadata(react_agent_span) or {}
         assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
@@ -455,7 +460,7 @@ class TestLangGraphLLMObs:
             ],
         }
 
-        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        agent_metadata = get_llmobs_metadata(agent_span) or {}
         assert agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
@@ -469,7 +474,7 @@ class TestLangGraphLLMObs:
 
         agent_span = _find_span_by_name(spans, "agent")
 
-        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        agent_metadata = get_llmobs_metadata(agent_span) or {}
         assert agent_metadata.get("_dd", {}).get("agent_manifest", {}).get("max_iterations") == 100
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
@@ -495,16 +500,12 @@ class TestLangGraphLLMObs:
         tool_span = llmobs_spans[4]
         second_llm_span = llmobs_spans[6]
 
-        first_llm_meta = _get_llmobs_data_metastruct(first_llm_span).get("meta", {})
-        tool_meta = _get_llmobs_data_metastruct(tool_span).get("meta", {})
-        second_llm_meta = _get_llmobs_data_metastruct(second_llm_span).get("meta", {})
+        assert get_llmobs_span_kind(first_llm_span) == "llm"
+        assert get_llmobs_span_kind(tool_span) == "tool"
+        assert get_llmobs_span_kind(second_llm_span) == "llm"
 
-        assert first_llm_meta.get("span", {}).get("kind") == "llm"
-        assert tool_meta.get("span", {}).get("kind") == "tool"
-        assert second_llm_meta.get("span", {}).get("kind") == "llm"
-
-        tool_links = _get_llmobs_data_metastruct(tool_span).get("span_links", [])
-        second_llm_links = _get_llmobs_data_metastruct(second_llm_span).get("span_links", [])
+        tool_links = get_llmobs_span_links(tool_span) or []
+        second_llm_links = get_llmobs_span_links(second_llm_span) or []
 
         # assert llm -> tool span link
         assert tool_links[1]["span_id"] == str(first_llm_span.span_id)


### PR DESCRIPTION
## Summary

Migrates contrib langgraph LLMObs tests from `llmobs_events`-based wire-event assertions to direct `_get_llmobs_data_metastruct(span)` reads against the canonical `LLMObsSpanData` payload on the span's `meta_struct["_llmobs"]`.

Stacked on #17789 (openai PR — adds the matcher's role normalization and `mock.ANY` whole-value support; this PR uses `_get_llmobs_data_metastruct` and the `_DD_LLMOBS_TEST_KEEP_META_STRUCT` env hook).

## What changes

- `conftest.py`: `test_spans` override sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, re-enables LLMObs against the test tracer, and swaps `LLMObsSpanWriter` for a `mock.MagicMock` so no flush thread runs. Drops `llmobs_span_writer`, `llmobs`, and `llmobs_events` fixtures.
- Test class parametrized once with `LLMOBS_GLOBAL_CONFIG` (mirroring the mcp pattern) so every test enables LLMObs via `ddtrace_global_config`.
- Spans collected via `[s for trace in test_spans.pop_traces() for s in trace]`; lookup helpers (`_find_span_by_name`, `_find_spans_by_name`) walk APM spans and read `meta_struct["_llmobs"].name`.
- Translates raw event-field accesses to meta_struct reads:
  - `event["meta"]["span"]["kind"]` → `meta_struct["_llmobs"]["meta"]["span"]["kind"]`
  - `event["meta"]["output"]["value"]` → `meta_struct["_llmobs"]["meta"]["output"]["value"]`
  - `event["meta"]["metadata"]["_dd"]["agent_manifest"]` → same path under meta_struct
  - `event["span_links"]` → `meta_struct["_llmobs"]["span_links"]`
- Span-link assertions reuse `_assert_span_link` by adapting an APM span via a small `_link_view(span)` helper that exposes the `{span_id, span_links}` shape `_assert_span_link` was designed against.

Notes:
- `assert_llmobs_span_data` is *not* used here — the original tests never used `_expected_llmobs_*_span_event` helpers and instead reach into specific subfields (output.value, metadata._dd.agent_manifest, span_links). Direct meta_struct reads preserve that style.
- `test_agent_with_tool_calls_integrations_enabled` filters to LLMObs-bearing spans before counting (some APM-only spans may surface from langchain/openai patching when integrations are enabled), then keeps the same index-based span-link assertions translated to meta_struct reads.

## Fixtures left for review

none — fully migrated.

Claude session: `5a0031b3-5dfd-4ed2-a3f8-ef98ee7c8c24`
Resume: `claude --resume 5a0031b3-5dfd-4ed2-a3f8-ef98ee7c8c24`