### PR TITLE
test(llmobs): migrate claude_agent_sdk tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch as mock_patch
@@ -18,7 +19,6 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_STRUCTURED_OUTPUT_RESPONSE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_ERROR_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_USE_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_USE_WITH_FOLLOWUP_SEQUENCE
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -29,27 +29,32 @@ def ddtrace_config_claude_agent_sdk():
     return {}
 
 
-def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "unnamed-ml-app", "service": "tests.llmobs"}
+@pytest.fixture
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs(tracer, llmobs_span_writer):
-    with override_global_config(default_global_config()):
-        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
-        LLMObs._instance._llmobs_span_writer = llmobs_span_writer
-        yield LLMObs
-    LLMObs.disable()
-
-
-@pytest.fixture
-def llmobs_events(llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -19,19 +19,8 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_STRUCTURED_OUTPUT_RESPONSE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_ERROR_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_USE_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_USE_WITH_FOLLOWUP_SEQUENCE
-from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
-
-
-@pytest.fixture
-def ddtrace_config_claude_agent_sdk():
-    return {}
-
-
-@pytest.fixture
-def ddtrace_global_config():
-    return {}
 
 
 @pytest.fixture
@@ -53,18 +42,17 @@ def claude_agent_sdk_llmobs(tracer, monkeypatch):
 
 
 @pytest.fixture
-def claude_agent_sdk(ddtrace_config_claude_agent_sdk):
-    with override_config("claude_agent_sdk", ddtrace_config_claude_agent_sdk):
-        with override_env(
-            dict(
-                ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
-            )
-        ):
-            patch()
-            import claude_agent_sdk
+def claude_agent_sdk():
+    with override_env(
+        dict(
+            ANTHROPIC_API_KEY=os.getenv("ANTHROPIC_API_KEY", "<not-a-real-key>"),
+        )
+    ):
+        patch()
+        import claude_agent_sdk
 
-            yield claude_agent_sdk
-            unpatch()
+        yield claude_agent_sdk
+        unpatch()
 
 
 def _create_mock_internal_client(response_sequence):

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -42,7 +42,6 @@ def claude_agent_sdk_llmobs(tracer, monkeypatch):
         {
             "_llmobs_ml_app": "unnamed-ml-app",
             "_dd_api_key": "<not-a-real-key>",
-            "_llmobs_sample_rate": 1.0,
             "service": "tests.llmobs",
         }
     ):

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -35,26 +35,22 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def claude_agent_sdk_llmobs(tracer, monkeypatch):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "unnamed-ml-app",
+            "_dd_api_key": "<not-a-real-key>",
+            "_llmobs_sample_rate": 1.0,
+            "service": "tests.llmobs",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -27,19 +27,10 @@ CLAUDE_AGENT_SDK_VERSION = parse_version(claude_agent_sdk.__version__)
 
 COMMON_TAGS = {"ml_app": "unnamed-ml-app", "service": "tests.llmobs", "integration": "claude_agent_sdk"}
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="unnamed-ml-app",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.llmobs",
-)
 
-
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLLMObsClaudeAgentSdk:
     async def test_llmobs_query_extracts_content_and_usage(
-        self, claude_agent_sdk, mock_internal_client, test_spans
+        self, claude_agent_sdk, mock_internal_client, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "What is 2+2? Reply with just the number."
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -86,7 +77,9 @@ class TestLLMObsClaudeAgentSdk:
             tags=COMMON_TAGS,
         )
 
-    async def test_llmobs_query_with_options(self, claude_agent_sdk, mock_internal_client, test_spans):
+    async def test_llmobs_query_with_options(
+        self, claude_agent_sdk, mock_internal_client, claude_agent_sdk_llmobs, test_spans
+    ):
         prompt = "Test prompt with options"
         options = claude_agent_sdk.ClaudeAgentOptions(max_turns=3)
 
@@ -139,7 +132,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_with_structured_output(
-        self, claude_agent_sdk, mock_internal_client_structured_output, test_spans
+        self, claude_agent_sdk, mock_internal_client_structured_output, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "What is 2+2? Return as JSON."
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -187,7 +180,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_error_no_output(
-        self, claude_agent_sdk, mock_internal_client_error, test_spans
+        self, claude_agent_sdk, mock_internal_client_error, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "This will fail"
 
@@ -234,7 +227,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_assistant_message_error_marks_llm_span_as_error(
-        self, claude_agent_sdk, mock_internal_client_assistant_message_error, test_spans
+        self, claude_agent_sdk, mock_internal_client_assistant_message_error, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "Hello"
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -282,7 +275,7 @@ class TestLLMObsClaudeAgentSdk:
             tags=COMMON_TAGS,
         )
 
-    async def test_llmobs_client_query_captures_prompt(self, mock_client, test_spans):
+    async def test_llmobs_client_query_captures_prompt(self, mock_client, claude_agent_sdk_llmobs, test_spans):
         prompt = "Hello from client!"
 
         await mock_client.query(prompt=prompt)
@@ -339,7 +332,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_with_read_tool_use(
-        self, claude_agent_sdk, mock_internal_client_tool_use, test_spans
+        self, claude_agent_sdk, mock_internal_client_tool_use, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "Read the file at /etc/hostname"
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -420,7 +413,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_with_bash_tool_use(
-        self, claude_agent_sdk, mock_internal_client_bash_tool, test_spans
+        self, claude_agent_sdk, mock_internal_client_bash_tool, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "Run 'echo hello' using the Bash tool"
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -501,7 +494,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_with_grep_tool_use(
-        self, claude_agent_sdk, mock_internal_client_grep_tool, test_spans
+        self, claude_agent_sdk, mock_internal_client_grep_tool, claude_agent_sdk_llmobs, test_spans
     ):
         prompt = "Use the Grep tool to search for 'def test_' in the tests directory"
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -582,7 +575,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_with_async_iterable_prompt(
-        self, claude_agent_sdk, mock_internal_client, test_spans
+        self, claude_agent_sdk, mock_internal_client, claude_agent_sdk_llmobs, test_spans
     ):
         async def prompt_generator():
             yield {"type": "user", "message": {"role": "user", "content": "Hello"}}
@@ -632,7 +625,9 @@ class TestLLMObsClaudeAgentSdk:
             tags=COMMON_TAGS,
         )
 
-    async def test_llmobs_client_query_with_async_iterable_prompt(self, mock_client, test_spans):
+    async def test_llmobs_client_query_with_async_iterable_prompt(
+        self, mock_client, claude_agent_sdk_llmobs, test_spans
+    ):
         async def prompt_generator():
             yield {"type": "user", "message": {"role": "user", "content": "Hello"}}
             yield {"type": "user", "message": {"role": "user", "content": "What is 2+2?"}}
@@ -691,7 +686,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_multi_turn_produces_two_step_spans(
-        self, claude_agent_sdk, mock_internal_client_tool_use_with_followup, test_spans
+        self, claude_agent_sdk, mock_internal_client_tool_use_with_followup, claude_agent_sdk_llmobs, test_spans
     ):
         """Multi-turn with a tool call produces two step spans, one per inference cycle.
         Step 1 contains an llm span and a tool span; step 2 contains only an llm span.
@@ -814,7 +809,7 @@ class TestLLMObsClaudeAgentSdk:
         assert_llmobs_span_data(_get_llmobs_data_metastruct(agent_span), span_kind="agent")
 
     async def test_llmobs_llm_span_includes_token_usage(
-        self, claude_agent_sdk, mock_internal_client_with_usage, test_spans
+        self, claude_agent_sdk, mock_internal_client_with_usage, claude_agent_sdk_llmobs, test_spans
     ):
         """LLM span should include token metrics when AssistantMessage has usage data."""
         prompt = "What is 2+2?"
@@ -849,7 +844,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_tool_error_marks_tool_span_as_error(
-        self, claude_agent_sdk, mock_internal_client_tool_error, test_spans
+        self, claude_agent_sdk, mock_internal_client_tool_error, claude_agent_sdk_llmobs, test_spans
     ):
         """ToolResultBlock with is_error=True should mark the tool span as an error."""
         prompt = "Read the file at /etc/hostname"

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -4,6 +4,7 @@ import claude_agent_sdk
 import pytest
 
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_ASSISTANT_USAGE
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_QUERY_USAGE
@@ -19,35 +20,42 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_READ_TOOL_ID
 from tests.contrib.claude_agent_sdk.utils import MOCK_STRUCTURED_OUTPUT
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_ERROR_MESSAGE
 from tests.contrib.claude_agent_sdk.utils import expected_agent_manifest
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
 
 
 CLAUDE_AGENT_SDK_VERSION = parse_version(claude_agent_sdk.__version__)
 
 COMMON_TAGS = {"ml_app": "unnamed-ml-app", "service": "tests.llmobs", "integration": "claude_agent_sdk"}
 
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="unnamed-ml-app",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.llmobs",
+)
 
+
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLLMObsClaudeAgentSdk:
     async def test_llmobs_query_extracts_content_and_usage(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client, test_spans
+        self, claude_agent_sdk, mock_internal_client, test_spans
     ):
         prompt = "What is 2+2? Reply with just the number."
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -55,15 +63,15 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -74,29 +82,28 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
-    async def test_llmobs_query_with_options(self, claude_agent_sdk, llmobs_events, mock_internal_client, test_spans):
+    async def test_llmobs_query_with_options(self, claude_agent_sdk, mock_internal_client, test_spans):
         prompt = "Test prompt with options"
         options = claude_agent_sdk.ClaudeAgentOptions(max_turns=3)
 
         async for _ in claude_agent_sdk.query(prompt=prompt, options=options):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -104,15 +111,15 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -127,29 +134,28 @@ class TestLLMObsClaudeAgentSdk:
                 "stop_reason": "end_turn",
                 "_dd": {"agent_manifest": expected_agent_manifest(max_iterations=3)},
             },
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
     async def test_llmobs_query_with_structured_output(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_structured_output, test_spans
+        self, claude_agent_sdk, mock_internal_client_structured_output, test_spans
     ):
         prompt = "What is 2+2? Return as JSON."
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -157,15 +163,15 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -176,12 +182,12 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
     async def test_llmobs_query_error_no_output(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_error, test_spans
+        self, claude_agent_sdk, mock_internal_client_error, test_spans
     ):
         prompt = "This will fail"
 
@@ -189,89 +195,79 @@ class TestLLMObsClaudeAgentSdk:
             async for _ in claude_agent_sdk.query(prompt=prompt):
                 pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         assert agent_span.error == 1
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": prompt, "role": "user"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name="unknown",
             model_provider="anthropic",
             input_messages=input_msgs,
             output_messages=[{"content": "", "role": ""}],
-            error="builtins.ValueError",
-            error_message="Connection failed",
-            error_stack=ANY,
+            error={"type": "builtins.ValueError", "message": "Connection failed", "stack": ANY},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json([{"content": ""}]),
-            error="builtins.ValueError",
-            error_message="Connection failed",
-            error_stack=ANY,
+            error={"type": "builtins.ValueError", "message": "Connection failed", "stack": ANY},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json([{"content": ""}]),
             metadata={"_dd": {"agent_manifest": {"framework": "Claude Agent SDK"}}},
-            token_metrics={},
+            metrics={},
             tags=COMMON_TAGS,
-            error="builtins.ValueError",
-            error_message="Connection failed",
-            error_stack=ANY,
+            error={"type": "builtins.ValueError", "message": "Connection failed", "stack": ANY},
         )
 
     async def test_llmobs_assistant_message_error_marks_llm_span_as_error(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_assistant_message_error, test_spans
+        self, claude_agent_sdk, mock_internal_client_assistant_message_error, test_spans
     ):
         prompt = "Hello"
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": prompt, "role": "user"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
             input_messages=input_msgs,
             output_messages=[{"content": "", "role": ""}],
-            error=MOCK_ASSISTANT_MESSAGE_ERROR,
-            error_message=MOCK_ASSISTANT_MESSAGE_ERROR,
+            error={"type": MOCK_ASSISTANT_MESSAGE_ERROR, "message": MOCK_ASSISTANT_MESSAGE_ERROR, "stack": ANY},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json([{"content": ""}]),
-            error=MOCK_ASSISTANT_MESSAGE_ERROR,
-            error_message=MOCK_ASSISTANT_MESSAGE_ERROR,
+            error={"type": MOCK_ASSISTANT_MESSAGE_ERROR, "message": MOCK_ASSISTANT_MESSAGE_ERROR, "stack": ANY},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -281,31 +277,29 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
-            error=MOCK_ASSISTANT_MESSAGE_ERROR,
-            error_message=MOCK_ASSISTANT_MESSAGE_ERROR,
+            metrics=EXPECTED_QUERY_USAGE,
+            error={"type": MOCK_ASSISTANT_MESSAGE_ERROR, "message": MOCK_ASSISTANT_MESSAGE_ERROR, "stack": ANY},
             tags=COMMON_TAGS,
         )
 
-    async def test_llmobs_client_query_captures_prompt(self, mock_client, llmobs_events, test_spans):
+    async def test_llmobs_client_query_captures_prompt(self, mock_client, test_spans):
         prompt = "Hello from client!"
 
         await mock_client.query(prompt=prompt)
         async for _ in mock_client.receive_messages():
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -313,15 +307,15 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -334,7 +328,7 @@ class TestLLMObsClaudeAgentSdk:
                 **({"stop_reason": "end_turn"} if CLAUDE_AGENT_SDK_VERSION >= (0, 1, 49) else {}),
                 "_dd": {"agent_manifest": expected_agent_manifest()},
             },
-            token_metrics={
+            metrics={
                 "input_tokens": 14599,
                 "output_tokens": 5,
                 "total_tokens": 14604,
@@ -345,19 +339,18 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_query_with_read_tool_use(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_tool_use, test_spans
+        self, claude_agent_sdk, mock_internal_client_tool_use, test_spans
     ):
         prompt = "Read the file at /etc/hostname"
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 4
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
         tool_span = next(s for s in spans if "tool" in s.name)
-
-        assert len(llmobs_events) == 4
 
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [
@@ -375,8 +368,8 @@ class TestLLMObsClaudeAgentSdk:
             }
         ]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -384,23 +377,23 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            tool_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(tool_span),
             span_kind="tool",
             input_value=safe_json({"file_path": "/etc/hostname"}),
             output_value="",
             metadata={"tool_id": MOCK_READ_TOOL_ID},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -422,24 +415,23 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
     async def test_llmobs_query_with_bash_tool_use(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_bash_tool, test_spans
+        self, claude_agent_sdk, mock_internal_client_bash_tool, test_spans
     ):
         prompt = "Run 'echo hello' using the Bash tool"
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 4
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
         tool_span = next(s for s in spans if "tool" in s.name)
-
-        assert len(llmobs_events) == 4
 
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [
@@ -457,8 +449,8 @@ class TestLLMObsClaudeAgentSdk:
             }
         ]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -466,23 +458,23 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            tool_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(tool_span),
             span_kind="tool",
             input_value=safe_json(MOCK_BASH_TOOL_INPUT),
             output_value="",
             metadata={"tool_id": MOCK_BASH_TOOL_ID},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -504,24 +496,23 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
     async def test_llmobs_query_with_grep_tool_use(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_grep_tool, test_spans
+        self, claude_agent_sdk, mock_internal_client_grep_tool, test_spans
     ):
         prompt = "Use the Grep tool to search for 'def test_' in the tests directory"
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 4
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
         tool_span = next(s for s in spans if "tool" in s.name)
-
-        assert len(llmobs_events) == 4
 
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [
@@ -539,8 +530,8 @@ class TestLLMObsClaudeAgentSdk:
             }
         ]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -548,23 +539,23 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            tool_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(tool_span),
             span_kind="tool",
             input_value=safe_json(MOCK_GREP_TOOL_INPUT),
             output_value="",
             metadata={"tool_id": MOCK_GREP_TOOL_ID},
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -586,12 +577,12 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
     async def test_llmobs_query_with_async_iterable_prompt(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client, test_spans
+        self, claude_agent_sdk, mock_internal_client, test_spans
     ):
         async def prompt_generator():
             yield {"type": "user", "message": {"role": "user", "content": "Hello"}}
@@ -600,18 +591,17 @@ class TestLLMObsClaudeAgentSdk:
         async for _ in claude_agent_sdk.query(prompt=prompt_generator()):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": "Hello", "role": "user"}, {"content": "What is 2+2?", "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -619,15 +609,15 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -638,11 +628,11 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            token_metrics=EXPECTED_QUERY_USAGE,
+            metrics=EXPECTED_QUERY_USAGE,
             tags=COMMON_TAGS,
         )
 
-    async def test_llmobs_client_query_with_async_iterable_prompt(self, mock_client, llmobs_events, test_spans):
+    async def test_llmobs_client_query_with_async_iterable_prompt(self, mock_client, test_spans):
         async def prompt_generator():
             yield {"type": "user", "message": {"role": "user", "content": "Hello"}}
             yield {"type": "user", "message": {"role": "user", "content": "What is 2+2?"}}
@@ -651,18 +641,17 @@ class TestLLMObsClaudeAgentSdk:
         async for _ in mock_client.receive_messages():
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         agent_span = spans[0]
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
 
-        assert len(llmobs_events) == 3
-
         input_msgs = [{"content": "Hello", "role": "user"}, {"content": "What is 2+2?", "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -670,15 +659,15 @@ class TestLLMObsClaudeAgentSdk:
             output_messages=output_msgs,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            agent_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
             span_kind="agent",
             input_value=safe_json(input_msgs),
             output_value=safe_json(
@@ -691,7 +680,7 @@ class TestLLMObsClaudeAgentSdk:
                 **({"stop_reason": "end_turn"} if CLAUDE_AGENT_SDK_VERSION >= (0, 1, 49) else {}),
                 "_dd": {"agent_manifest": expected_agent_manifest()},
             },
-            token_metrics={
+            metrics={
                 "input_tokens": 14599,
                 "output_tokens": 5,
                 "total_tokens": 14604,
@@ -702,7 +691,7 @@ class TestLLMObsClaudeAgentSdk:
         )
 
     async def test_llmobs_multi_turn_produces_two_step_spans(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_tool_use_with_followup, test_spans
+        self, claude_agent_sdk, mock_internal_client_tool_use_with_followup, test_spans
     ):
         """Multi-turn with a tool call produces two step spans, one per inference cycle.
         Step 1 contains an llm span and a tool span; step 2 contains only an llm span.
@@ -711,14 +700,14 @@ class TestLLMObsClaudeAgentSdk:
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        # 2 step spans + 2 llm spans + 1 tool span + 1 agent span = 6 spans
+        assert len(spans) == 6
         agent_span = spans[0]
         step_spans = [s for s in spans if s.name == "claude_agent_sdk.step"]
         llm_spans = [s for s in spans if s.name == "claude_agent_sdk.llm"]
         tool_span = next(s for s in spans if "tool" in s.name)
 
-        # 2 step spans + 2 llm spans + 1 tool span + 1 agent span = 6 events
-        assert len(llmobs_events) == 6
         assert len(step_spans) == 2
         assert len(llm_spans) == 2
 
@@ -771,9 +760,9 @@ class TestLLMObsClaudeAgentSdk:
         ]
         turn2_output = [{"content": MOCK_FINAL_ASSISTANT_TEXT, "role": "assistant"}]
 
-        # [0] llm span for step 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_spans[0],
+        # llm span for step 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_spans[0]),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -782,9 +771,9 @@ class TestLLMObsClaudeAgentSdk:
             tags=tags,
         )
 
-        # [1] tool span
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            tool_span,
+        # tool span
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(tool_span),
             span_kind="tool",
             input_value=safe_json({"file_path": "/etc/hostname"}),
             output_value="myhost.local",
@@ -792,18 +781,18 @@ class TestLLMObsClaudeAgentSdk:
             tags=tags,
         )
 
-        # [2] step span for step 1 (container: llm + tool)
-        assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-            step_spans[0],
+        # step span for step 1 (container: llm + tool)
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_spans[0]),
             span_kind="step",
             input_value=safe_json(turn1_input),
             output_value=safe_json(turn1_output),
             tags=tags,
         )
 
-        # [3] llm span for step 2
-        assert llmobs_events[3] == _expected_llmobs_llm_span_event(
-            llm_spans[1],
+        # llm span for step 2
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_spans[1]),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
@@ -812,75 +801,72 @@ class TestLLMObsClaudeAgentSdk:
             tags=tags,
         )
 
-        # [4] step span for step 2
-        assert llmobs_events[4] == _expected_llmobs_non_llm_span_event(
-            step_spans[1],
+        # step span for step 2
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_spans[1]),
             span_kind="step",
             input_value=safe_json(turn2_input),
             output_value=safe_json(turn2_output),
             tags=tags,
         )
 
-        # [5] agent span
-        assert llmobs_events[5]["meta"]["span"]["kind"] == "agent"
+        # agent span
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(agent_span), span_kind="agent")
 
     async def test_llmobs_llm_span_includes_token_usage(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_with_usage, test_spans
+        self, claude_agent_sdk, mock_internal_client_with_usage, test_spans
     ):
         """LLM span should include token metrics when AssistantMessage has usage data."""
         prompt = "What is 2+2?"
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
         step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
         llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
-
-        assert len(llmobs_events) == 3
 
         input_msgs = [{"content": prompt, "role": "user"}]
         output_msgs = [{"content": "4", "role": "assistant"}]
 
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            llm_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
             span_kind="llm",
             model_name=MOCK_MODEL,
             model_provider="anthropic",
             input_messages=input_msgs,
             output_messages=output_msgs,
-            token_metrics=EXPECTED_ASSISTANT_USAGE,
+            metrics=EXPECTED_ASSISTANT_USAGE,
             tags=COMMON_TAGS,
         )
-        assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-            step_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
             span_kind="step",
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
-            token_metrics=EXPECTED_ASSISTANT_USAGE,
+            metrics=EXPECTED_ASSISTANT_USAGE,
             tags=COMMON_TAGS,
         )
 
     async def test_llmobs_tool_error_marks_tool_span_as_error(
-        self, claude_agent_sdk, llmobs_events, mock_internal_client_tool_error, test_spans
+        self, claude_agent_sdk, mock_internal_client_tool_error, test_spans
     ):
         """ToolResultBlock with is_error=True should mark the tool span as an error."""
         prompt = "Read the file at /etc/hostname"
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
-        spans = test_spans.pop_traces()[0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
         tool_span = next(s for s in spans if "tool" in s.name)
 
         assert tool_span.error == 1
 
-        tool_event = next(e for e in llmobs_events if e["meta"]["span"]["kind"] == "tool")
-        assert tool_event == _expected_llmobs_non_llm_span_event(
-            tool_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(tool_span),
             span_kind="tool",
             input_value=safe_json({"file_path": "/etc/hostname"}),
             output_value=MOCK_TOOL_ERROR_MESSAGE,
             metadata={"tool_id": MOCK_READ_TOOL_ID},
-            error="ToolError",
-            error_message=MOCK_TOOL_ERROR_MESSAGE,
+            error={"type": "ToolError", "message": MOCK_TOOL_ERROR_MESSAGE, "stack": ANY},
             tags=COMMON_TAGS,
         )


### PR DESCRIPTION
Migrates claude_agent_sdk LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `claude_agent_sdk_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
