### PR TITLE
test(llmobs): migrate bedrock tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -97,7 +97,6 @@ def bedrock_llmobs(tracer, monkeypatch, llmobs_span_writer):
         {
             "_llmobs_ml_app": "<ml-app-name>",
             "_dd_api_key": "<not-a-real-key>",
-            "_llmobs_sample_rate": 1.0,
         }
     ):
         LLMObs.enable(_tracer=tracer, integrations_enabled=False, agentless_enabled=False)

--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -7,7 +7,7 @@ from ddtrace.contrib.internal.botocore.patch import patch
 from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.contrib.internal.urllib3.patch import patch as urllib3_patch
 from ddtrace.contrib.internal.urllib3.patch import unpatch as urllib3_unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs import LLMObs
 from tests.contrib.botocore.bedrock_utils import get_request_vcr
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
@@ -35,7 +35,7 @@ def aws_credentials():
 
 
 @pytest.fixture
-def boto3(aws_credentials, llmobs_span_writer, ddtrace_global_config):
+def boto3(aws_credentials, ddtrace_global_config):
     global_config = {"_dd_api_key": "<not-a-real-api_key>"}
     global_config.update(ddtrace_global_config)
     with override_global_config(global_config):
@@ -90,19 +90,38 @@ def llmobs_span_writer():
 
 
 @pytest.fixture
-def bedrock_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "tests.llmobs"}
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
+def test_spans(ddtrace_global_config, test_spans, llmobs_span_writer, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use the test tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False, agentless_enabled=False)
+                # Replace the real LLMObsSpanWriter with a TestLLMObsSpanWriter so we
+                # don't keep a background flush thread alive trying to ship spans during
+                # the test, and so the bedrock_agents integration's synthetic span
+                # events (no backing APM span) are still observable via ``llmobs_events``.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = llmobs_span_writer
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 @pytest.fixture
-def llmobs_events(bedrock_llmobs, llmobs_span_writer):
+def llmobs_events(test_spans, llmobs_span_writer):
+    """Wire-format LLMObsSpanEvents enqueued to the writer.
+
+    Used by ``test_bedrock_agents_llmobs.py`` because the bedrock_agents
+    integration synthesizes span events without backing APM spans (the
+    enqueued events are not derivable from ``meta_struct``).
+    """
     return llmobs_span_writer.events
 
 

--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -100,7 +100,7 @@ def bedrock_llmobs(tracer, monkeypatch):
             "_dd_api_key": "<not-a-real-key>",
         }
     ):
-        LLMObs.enable(_tracer=tracer, integrations_enabled=False, agentless_enabled=False)
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
         LLMObs._instance._llmobs_span_writer.stop()
         LLMObs._instance._llmobs_span_writer = mock.MagicMock()
         yield LLMObs

--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import botocore
+import mock
 import pytest
 
 from ddtrace.contrib.internal.botocore.patch import patch
@@ -90,8 +91,31 @@ def llmobs_span_writer():
 
 
 @pytest.fixture
-def bedrock_llmobs(tracer, monkeypatch, llmobs_span_writer):
+def bedrock_llmobs(tracer, monkeypatch):
     monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False, agentless_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
+
+
+@pytest.fixture
+def bedrock_agents_llmobs(tracer, llmobs_span_writer):
+    """LLMObs fixture for bedrock_agents tests.
+
+    Keeps the real ``TestLLMObsSpanWriter`` (instead of a mock) because the
+    bedrock_agents integration synthesizes span events without a backing APM
+    span — the enqueued events are not derivable from ``meta_struct`` and must
+    be read out of the writer via ``llmobs_events``.
+    """
     LLMObs.disable()
     with override_global_config(
         {
@@ -107,13 +131,7 @@ def bedrock_llmobs(tracer, monkeypatch, llmobs_span_writer):
 
 
 @pytest.fixture
-def llmobs_events(test_spans, llmobs_span_writer):
-    """Wire-format LLMObsSpanEvents enqueued to the writer.
-
-    Used by ``test_bedrock_agents_llmobs.py`` because the bedrock_agents
-    integration synthesizes span events without backing APM spans (the
-    enqueued events are not derivable from ``meta_struct``).
-    """
+def llmobs_events(llmobs_span_writer):
     return llmobs_span_writer.events
 
 

--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -90,28 +90,21 @@ def llmobs_span_writer():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, llmobs_span_writer, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use the test tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False, agentless_enabled=False)
-                # Replace the real LLMObsSpanWriter with a TestLLMObsSpanWriter so we
-                # don't keep a background flush thread alive trying to ship spans during
-                # the test, and so the bedrock_agents integration's synthetic span
-                # events (no backing APM span) are still observable via ``llmobs_events``.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = llmobs_span_writer
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def bedrock_llmobs(tracer, monkeypatch, llmobs_span_writer):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "_llmobs_sample_rate": 1.0,
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False, agentless_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = llmobs_span_writer
+        yield LLMObs
+    LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -107,7 +107,7 @@ def _assert_inner_spans(inner_spans, trace_step_spans):
 
 
 def test_agent_invoke(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
@@ -131,7 +131,7 @@ def test_agent_invoke(
 
 
 def test_agent_invoke_stream(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
@@ -156,7 +156,7 @@ def test_agent_invoke_stream(
 
 
 def test_agent_invoke_trace_disabled(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):
@@ -174,7 +174,7 @@ def test_agent_invoke_trace_disabled(
 
 
 def test_agent_invoke_stream_trace_disabled(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -6,9 +6,18 @@ from tests.contrib.botocore.bedrock_utils import AGENT_INPUT
 from tests.contrib.botocore.bedrock_utils import BOTO_VERSION
 
 
-pytestmark = pytest.mark.skipif(
-    BOTO_VERSION < (1, 38, 0), reason="LLMObs bedrock agent traces are only supported for boto3 > 1.36.0"
-)
+pytestmark = [
+    pytest.mark.skipif(
+        BOTO_VERSION < (1, 38, 0), reason="LLMObs bedrock agent traces are only supported for boto3 > 1.36.0"
+    ),
+    # Bedrock agent traces are synthesized into wire-format LLMObsSpanEvents (no
+    # backing APM span), so these tests still read events out of the writer via
+    # the ``llmobs_events`` fixture rather than asserting on ``meta_struct``.
+    pytest.mark.parametrize(
+        "ddtrace_global_config",
+        [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")],
+    ),
+]
 
 EXPECTED_OUTPUT = (
     "Based on your preferences for a beach vacation with nature and outdoor adventures, I recommend a "
@@ -97,7 +106,7 @@ def _assert_inner_spans(inner_spans, trace_step_spans):
         assert len(inner_spans_by_trace_step[trace_step_span["span_id"]]) == expected_inner_spans_per_step[i]
 
 
-def test_agent_invoke(bedrock_agent_client, request_vcr, llmobs_events):
+def test_agent_invoke(ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
             agentAliasId=AGENT_ALIAS_ID,
@@ -119,7 +128,7 @@ def test_agent_invoke(bedrock_agent_client, request_vcr, llmobs_events):
     _assert_inner_spans(inner_spans, trace_step_spans)
 
 
-def test_agent_invoke_stream(bedrock_agent_client, request_vcr, llmobs_events):
+def test_agent_invoke_stream(ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
             agentAliasId=AGENT_ALIAS_ID,
@@ -142,7 +151,9 @@ def test_agent_invoke_stream(bedrock_agent_client, request_vcr, llmobs_events):
     _assert_inner_spans(inner_spans, trace_step_spans)
 
 
-def test_agent_invoke_trace_disabled(bedrock_agent_client, request_vcr, llmobs_events):
+def test_agent_invoke_trace_disabled(
+    ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events
+):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):
         response = bedrock_agent_client.invoke_agent(
@@ -158,7 +169,9 @@ def test_agent_invoke_trace_disabled(bedrock_agent_client, request_vcr, llmobs_e
     assert llmobs_events[0]["name"] == "Bedrock Agent {}".format(AGENT_ID)
 
 
-def test_agent_invoke_stream_trace_disabled(bedrock_agent_client, request_vcr, llmobs_events):
+def test_agent_invoke_stream_trace_disabled(
+    ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events
+):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):
         response = bedrock_agent_client.invoke_agent(

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -97,9 +97,7 @@ def _assert_inner_spans(inner_spans, trace_step_spans):
         assert len(inner_spans_by_trace_step[trace_step_span["span_id"]]) == expected_inner_spans_per_step[i]
 
 
-def test_agent_invoke(
-    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
-):
+def test_agent_invoke(bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
             agentAliasId=AGENT_ALIAS_ID,
@@ -121,9 +119,7 @@ def test_agent_invoke(
     _assert_inner_spans(inner_spans, trace_step_spans)
 
 
-def test_agent_invoke_stream(
-    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
-):
+def test_agent_invoke_stream(bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
             agentAliasId=AGENT_ALIAS_ID,

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -106,7 +106,9 @@ def _assert_inner_spans(inner_spans, trace_step_spans):
         assert len(inner_spans_by_trace_step[trace_step_span["span_id"]]) == expected_inner_spans_per_step[i]
 
 
-def test_agent_invoke(ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events):
+def test_agent_invoke(
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
+):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
             agentAliasId=AGENT_ALIAS_ID,
@@ -128,7 +130,9 @@ def test_agent_invoke(ddtrace_global_config, bedrock_agent_client, request_vcr, 
     _assert_inner_spans(inner_spans, trace_step_spans)
 
 
-def test_agent_invoke_stream(ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events):
+def test_agent_invoke_stream(
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
+):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
             agentAliasId=AGENT_ALIAS_ID,
@@ -152,7 +156,7 @@ def test_agent_invoke_stream(ddtrace_global_config, bedrock_agent_client, reques
 
 
 def test_agent_invoke_trace_disabled(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
 ):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):
@@ -170,7 +174,7 @@ def test_agent_invoke_trace_disabled(
 
 
 def test_agent_invoke_stream_trace_disabled(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, test_spans, llmobs_events
+    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_llmobs, test_spans, llmobs_events
 ):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -15,7 +15,7 @@ pytestmark = [
     # the ``llmobs_events`` fixture rather than asserting on ``meta_struct``.
     pytest.mark.parametrize(
         "ddtrace_global_config",
-        [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")],
+        [dict(_llmobs_enabled=True, _llmobs_ml_app="<ml-app-name>")],
     ),
 ]
 

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -6,18 +6,9 @@ from tests.contrib.botocore.bedrock_utils import AGENT_INPUT
 from tests.contrib.botocore.bedrock_utils import BOTO_VERSION
 
 
-pytestmark = [
-    pytest.mark.skipif(
-        BOTO_VERSION < (1, 38, 0), reason="LLMObs bedrock agent traces are only supported for boto3 > 1.36.0"
-    ),
-    # Bedrock agent traces are synthesized into wire-format LLMObsSpanEvents (no
-    # backing APM span), so these tests still read events out of the writer via
-    # the ``llmobs_events`` fixture rather than asserting on ``meta_struct``.
-    pytest.mark.parametrize(
-        "ddtrace_global_config",
-        [dict(_llmobs_enabled=True, _llmobs_ml_app="<ml-app-name>")],
-    ),
-]
+pytestmark = pytest.mark.skipif(
+    BOTO_VERSION < (1, 38, 0), reason="LLMObs bedrock agent traces are only supported for boto3 > 1.36.0"
+)
 
 EXPECTED_OUTPUT = (
     "Based on your preferences for a beach vacation with nature and outdoor adventures, I recommend a "
@@ -107,7 +98,7 @@ def _assert_inner_spans(inner_spans, trace_step_spans):
 
 
 def test_agent_invoke(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
+    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
@@ -131,7 +122,7 @@ def test_agent_invoke(
 
 
 def test_agent_invoke_stream(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
+    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     with request_vcr.use_cassette("agent_invoke.yaml"):
         response = bedrock_agent_client.invoke_agent(
@@ -156,7 +147,7 @@ def test_agent_invoke_stream(
 
 
 def test_agent_invoke_trace_disabled(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
+    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):
@@ -174,7 +165,7 @@ def test_agent_invoke_trace_disabled(
 
 
 def test_agent_invoke_stream_trace_disabled(
-    ddtrace_global_config, bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
+    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
 ):
     """Test that we only get the agent span when enableTrace is set to False."""
     with request_vcr.use_cassette("agent_invoke_trace_disabled.yaml"):

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -6,6 +6,8 @@ import pytest
 
 from ddtrace.llmobs import LLMObs as llmobs_service
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_messages
+from ddtrace.llmobs._utils import get_llmobs_span_kind
 from tests.contrib.botocore.bedrock_utils import _MODELS
 from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
 from tests.contrib.botocore.bedrock_utils import BOTO_VERSION
@@ -606,7 +608,7 @@ class TestLLMObsBedrock:
 
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["messages"] == [
+        assert get_llmobs_input_messages(spans[0]) == [
             {"tool_results": [{"result": "bar", "tool_id": "foo", "type": "toolResult"}], "role": "user"}
         ]
 
@@ -628,7 +630,7 @@ class TestLLMObsBedrock:
 
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["messages"] == [
+        assert get_llmobs_input_messages(spans[0]) == [
             {"tool_results": [{"result": '{"result": "bar"}', "tool_id": "foo", "type": "toolResult"}], "role": "user"}
         ]
 
@@ -664,7 +666,7 @@ class TestLLMObsBedrock:
 
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["messages"] == [
+        assert get_llmobs_input_messages(spans[0]) == [
             {
                 "tool_results": [
                     {"result": "[Unsupported content type(s): image]", "tool_id": "foo", "type": "toolResult"}
@@ -728,7 +730,7 @@ class TestLLMObsBedrockProxy:
                 tags=BEDROCK_TAGS,
             )
         else:
-            assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
+            assert get_llmobs_span_kind(spans[0]) == "llm"
 
     @classmethod
     def _test_llmobs_invoke_stream_proxy(
@@ -775,7 +777,7 @@ class TestLLMObsBedrockProxy:
                 tags=BEDROCK_TAGS,
             )
         else:
-            assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
+            assert get_llmobs_span_kind(spans[0]) == "llm"
 
     def test_llmobs_ai21_invoke_proxy(
         self,

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -142,13 +142,9 @@ class TestLLMObsBedrock:
     def test_llmobs_cohere_single_output_invoke(
         self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
     ):
-        self._test_llmobs_invoke(
-            "cohere", bedrock_client, test_spans, cassette_name="cohere_invoke_single_output.yaml"
-        )
+        self._test_llmobs_invoke("cohere", bedrock_client, test_spans, cassette_name="cohere_invoke_single_output.yaml")
 
-    def test_llmobs_cohere_multi_output_invoke(
-        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
-    ):
+    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke(
             "cohere",
             bedrock_client,

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -139,9 +139,7 @@ class TestLLMObsBedrock:
     def test_llmobs_anthropic_message(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("anthropic_message", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_single_output_invoke(
-        self, bedrock_client, bedrock_llmobs, test_spans
-    ):
+    def test_llmobs_cohere_single_output_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("cohere", bedrock_client, test_spans, cassette_name="cohere_invoke_single_output.yaml")
 
     def test_llmobs_cohere_multi_output_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
@@ -178,14 +176,10 @@ class TestLLMObsBedrock:
     def test_llmobs_anthropic_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("anthropic", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_message_invoke_stream(
-        self, bedrock_client, bedrock_llmobs, test_spans
-    ):
+    def test_llmobs_anthropic_message_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_single_output_invoke_stream(
-        self, bedrock_client, bedrock_llmobs, test_spans
-    ):
+    def test_llmobs_cohere_single_output_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
@@ -193,9 +187,7 @@ class TestLLMObsBedrock:
             cassette_name="cohere_invoke_stream_single_output.yaml",
         )
 
-    def test_llmobs_cohere_multi_output_invoke_stream(
-        self, bedrock_client, bedrock_llmobs, test_spans
-    ):
+    def test_llmobs_cohere_multi_output_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -684,10 +684,9 @@ class TestLLMObsBedrock:
 @pytest.mark.parametrize(
     "ddtrace_global_config",
     [
-        dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>"),
+        dict(_llmobs_enabled=True, _llmobs_ml_app="<ml-app-name>"),
         dict(
             _llmobs_enabled=True,
-            _llmobs_sample_rate=1.0,
             _llmobs_ml_app="<ml-app-name>",
             _llmobs_instrumented_proxy_urls="http://localhost:4000",
         ),

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -4,8 +4,8 @@ import mock
 from mock import patch as mock_patch
 import pytest
 
-from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.contrib.botocore.bedrock_utils import _MODELS
 from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
 from tests.contrib.botocore.bedrock_utils import BOTO_VERSION
@@ -14,51 +14,47 @@ from tests.contrib.botocore.bedrock_utils import bedrock_converse_args_with_syst
 from tests.contrib.botocore.bedrock_utils import create_bedrock_converse_request
 from tests.contrib.botocore.bedrock_utils import get_mock_response_data
 from tests.contrib.botocore.bedrock_utils import get_request_vcr
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
 from tests.utils import override_global_config
+
+
+BEDROCK_TAGS = {"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"}
 
 
 @pytest.mark.parametrize(
     "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
 )
 class TestLLMObsBedrock:
-    @staticmethod
-    def expected_llmobs_span_event(
-        span, n_output, model_id=None, input_message=False, output_message=False, metadata=None, token_metrics=None
+    @classmethod
+    def _assert_llm_span(
+        cls,
+        span,
+        n_output,
+        model_id=None,
+        input_message=False,
+        output_message=False,
+        metadata=None,
+        metrics=None,
     ):
-        expected_input = [{"content": mock.ANY}]
-        if input_message:
-            expected_input = [{"content": mock.ANY, "role": "user"}]
-        expected_output = []
-        if output_message:
-            expected_output = [{"content": mock.ANY} for _ in range(n_output)]
+        expected_input = [{"content": mock.ANY, "role": "user"}] if input_message else [{"content": mock.ANY}]
+        expected_output = [{"content": mock.ANY} for _ in range(n_output)] if output_message else []
 
-        # Use empty dicts as defaults for _expected_llmobs_llm_span_event to avoid None issues
-        expected_parameters = metadata if metadata is not None else {}
-        expected_token_metrics = token_metrics if token_metrics is not None else None
-
-        expected_event = _expected_llmobs_llm_span_event(
-            span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(span),
+            span_kind="llm",
             model_name=model_id or "",
             model_provider="amazon_bedrock",
             input_messages=expected_input,
             output_messages=expected_output,
-            metadata=expected_parameters,
-            token_metrics=expected_token_metrics,
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+            # Pass metadata only when explicitly provided so the matcher skips the
+            # subset check (mirrors the prior ``mock.ANY`` whole-value escape hatch).
+            metadata=metadata if metadata is not None else None,
+            metrics=metrics if metrics is not None else None,
+            tags=BEDROCK_TAGS,
         )
 
-        # If parameters were not explicitly provided, use mock.ANY to match anything
-        if metadata is None:
-            expected_event["meta"]["metadata"] = mock.ANY
-        if token_metrics is None:
-            expected_event["metrics"] = mock.ANY
-
-        return expected_event
-
     @classmethod
-    def _test_llmobs_invoke(cls, provider, bedrock_client, test_spans, llmobs_events, cassette_name=None, n_output=1):
+    def _test_llmobs_invoke(cls, provider, bedrock_client, test_spans, cassette_name=None, n_output=1):
         if cassette_name is None:
             cassette_name = "%s_invoke.yaml" % provider
         body = _REQUEST_BODIES[provider]
@@ -85,23 +81,19 @@ class TestLLMObsBedrock:
                 model = "us." + model
             response = bedrock_client.invoke_model(body=body, modelId=model)
             json.loads(response.get("body").read())
-        span = test_spans.pop_traces()[0][0]
-
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == cls.expected_llmobs_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        cls._assert_llm_span(
+            spans[0],
             n_output,
             model_id=model,
             input_message="message" in provider,
             output_message=True,
             metadata=expected_metadata,
         )
-        LLMObs.disable()
 
     @classmethod
-    def _test_llmobs_invoke_stream(
-        cls, provider, bedrock_client, test_spans, llmobs_events, cassette_name=None, n_output=1
-    ):
+    def _test_llmobs_invoke_stream(cls, provider, bedrock_client, test_spans, cassette_name=None, n_output=1):
         if cassette_name is None:
             cassette_name = "%s_invoke_stream.yaml" % provider
         body = _REQUEST_BODIES[provider]
@@ -125,11 +117,10 @@ class TestLLMObsBedrock:
             response = bedrock_client.invoke_model_with_response_stream(body=body, modelId=model)
             for _ in response.get("body"):
                 pass
-        span = test_spans.pop_traces()[0][0]
-
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == cls.expected_llmobs_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        cls._assert_llm_span(
+            spans[0],
             n_output,
             model_id=model,
             input_message="message" in provider,
@@ -137,37 +128,36 @@ class TestLLMObsBedrock:
             metadata=expected_metadata,
         )
 
-    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke("ai21", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke("ai21", bedrock_client, test_spans)
 
-    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke("amazon", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke("amazon", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke("anthropic", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke("anthropic", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke("anthropic_message", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke("anthropic_message", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_single_output_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
+    def test_llmobs_cohere_single_output_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
         self._test_llmobs_invoke(
-            "cohere", bedrock_client, test_spans, llmobs_events, cassette_name="cohere_invoke_single_output.yaml"
+            "cohere", bedrock_client, test_spans, cassette_name="cohere_invoke_single_output.yaml"
         )
 
-    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
+    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
         self._test_llmobs_invoke(
             "cohere",
             bedrock_client,
             test_spans,
-            llmobs_events,
             cassette_name="cohere_invoke_multi_output.yaml",
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke("meta", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke("meta", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_rerank_invoke(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
+    def test_llmobs_cohere_rerank_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
         cassette_name = "cohere_rerank_invoke.yaml"
         model = "cohere.rerank-v3-5:0"
         prompt_data = "What is the capital of the United States?"
@@ -179,50 +169,40 @@ class TestLLMObsBedrock:
         with get_request_vcr().use_cassette(cassette_name):
             response = bedrock_client.invoke_model(body=body, modelId=model)
             json.loads(response.get("body").read())
-        span = test_spans.pop_traces()[0][0]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        self._assert_llm_span(spans[0], 1, model_id=model)
 
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == self.expected_llmobs_span_event(span, 1, model_id=model)
-        LLMObs.disable()
+    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke_stream("amazon", bedrock_client, test_spans)
 
-    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke_stream("amazon", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke_stream("anthropic", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke_stream("anthropic", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_anthropic_message_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_message_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events
-    ):
-        self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, test_spans, llmobs_events)
-
-    def test_llmobs_cohere_single_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events
-    ):
+    def test_llmobs_cohere_single_output_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
             test_spans,
-            llmobs_events,
             cassette_name="cohere_invoke_stream_single_output.yaml",
         )
 
-    def test_llmobs_cohere_multi_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events
-    ):
+    def test_llmobs_cohere_multi_output_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
             test_spans,
-            llmobs_events,
             cassette_name="cohere_invoke_stream_multi_output.yaml",
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events):
-        self._test_llmobs_invoke_stream("meta", bedrock_client, test_spans, llmobs_events)
+    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+        self._test_llmobs_invoke_stream("meta", bedrock_client, test_spans)
 
-    def test_llmobs_only_patches_bedrock(self, ddtrace_global_config, llmobs_span_writer, tracer, test_spans):
+    def test_llmobs_only_patches_bedrock(self, ddtrace_global_config, tracer, test_spans):
         llmobs_service.disable()
 
         with override_global_config(
@@ -247,7 +227,7 @@ class TestLLMObsBedrock:
 
         llmobs_service.disable()
 
-    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, test_spans, llmobs_events, request_vcr):
+    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, test_spans, request_vcr):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -255,35 +235,34 @@ class TestLLMObsBedrock:
                 body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]
                 response = bedrock_client.invoke_model(body=body, modelId=model)
                 json.loads(response.get("body").read())
-        span = test_spans.pop_traces()[0][0]
-
-        metadata = mock.ANY
-
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name=model,
             model_provider="amazon_bedrock",
             input_messages=[{"content": mock.ANY}],
-            metadata=metadata,
             output_messages=[{"content": ""}],
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+            error={
+                "type": spans[0].get_tag("error.type"),
+                "message": spans[0].get_tag("error.message"),
+                "stack": spans[0].get_tag("error.stack"),
+            },
+            tags=BEDROCK_TAGS,
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse(cls, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse(self, bedrock_client, request_vcr, test_spans):
         request_params = create_bedrock_converse_request(**bedrock_converse_args_with_system_and_tool)
         with request_vcr.use_cassette("bedrock_converse.yaml"):
             response = bedrock_client.converse(**request_params)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="anthropic.claude-3-sonnet-20240229-v1:0",
             model_provider="amazon_bedrock",
             input_messages=[
@@ -309,17 +288,17 @@ class TestLLMObsBedrock:
                 "temperature": request_params.get("inferenceConfig", {}).get("temperature"),
                 "max_tokens": request_params.get("inferenceConfig", {}).get("maxTokens"),
             },
-            token_metrics={
+            metrics={
                 "input_tokens": response["usage"]["inputTokens"],
                 "output_tokens": response["usage"]["outputTokens"],
                 "total_tokens": response["usage"]["totalTokens"],
             },
             tool_definitions=[FETCH_CONCEPT_TOOL_DEFINITION],
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+            tags=BEDROCK_TAGS,
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_error(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_error(self, bedrock_client, request_vcr, test_spans):
         """Test error handling for the Bedrock Converse API."""
         import botocore
 
@@ -330,10 +309,11 @@ class TestLLMObsBedrock:
             with request_vcr.use_cassette("bedrock_converse_error.yaml"):
                 bedrock_client.converse(**request_params)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="anthropic.claude-3-sonnet-20240229-v1:0",
             model_provider="amazon_bedrock",
             input_messages=[{"role": "user", "content": "Explain the concept of distributed tracing in a simple way"}],
@@ -342,14 +322,16 @@ class TestLLMObsBedrock:
                 "temperature": request_params.get("inferenceConfig", {}).get("temperature", 0.0),
                 "max_tokens": request_params.get("inferenceConfig", {}).get("maxTokens", 0),
             },
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+            error={
+                "type": spans[0].get_tag("error.type"),
+                "message": spans[0].get_tag("error.message"),
+                "stack": spans[0].get_tag("error.stack"),
+            },
+            tags=BEDROCK_TAGS,
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_stream(cls, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_stream(self, bedrock_client, request_vcr, test_spans):
         output_msg = ""
         request_params = create_bedrock_converse_request(**bedrock_converse_args_with_system_and_tool)
         with request_vcr.use_cassette("bedrock_converse_stream.yaml"):
@@ -359,11 +341,11 @@ class TestLLMObsBedrock:
                     if "text" in chunk["contentBlockDelta"]["delta"]:
                         output_msg += chunk["contentBlockDelta"]["delta"]["text"]
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="anthropic.claude-3-sonnet-20240229-v1:0",
             model_provider="amazon_bedrock",
             input_messages=[
@@ -388,17 +370,17 @@ class TestLLMObsBedrock:
                 "temperature": request_params.get("inferenceConfig", {}).get("temperature"),
                 "max_tokens": request_params.get("inferenceConfig", {}).get("maxTokens"),
             },
-            token_metrics={
+            metrics={
                 "input_tokens": 259,
                 "output_tokens": 64,
                 "total_tokens": 323,
             },
             tool_definitions=[FETCH_CONCEPT_TOOL_DEFINITION],
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+            tags=BEDROCK_TAGS,
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_modified_stream(cls, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_modified_stream(self, bedrock_client, request_vcr, test_spans):
         """
         Verify that LLM Obs tracing works even if stream chunks are modified mid-stream.
         """
@@ -413,11 +395,11 @@ class TestLLMObsBedrock:
                 # delete keys from streamed chunk
                 [chunk.pop(key) for key in list(chunk.keys())]
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="anthropic.claude-3-sonnet-20240229-v1:0",
             model_provider="amazon_bedrock",
             input_messages=[
@@ -442,17 +424,17 @@ class TestLLMObsBedrock:
                 "temperature": request_params.get("inferenceConfig", {}).get("temperature"),
                 "max_tokens": request_params.get("inferenceConfig", {}).get("maxTokens"),
             },
-            token_metrics={
+            metrics={
                 "input_tokens": 259,
                 "output_tokens": 64,
                 "total_tokens": 323,
             },
             tool_definitions=[FETCH_CONCEPT_TOOL_DEFINITION],
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+            tags=BEDROCK_TAGS,
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_prompt_caching(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_prompt_caching(self, bedrock_client, request_vcr, test_spans):
         """Test that prompt caching metrics are properly captured for both cache creation and cache read."""
         large_system_prompt = "Software architecture guidelines: " + "bye " * 1024
         large_system_content = [
@@ -476,11 +458,11 @@ class TestLLMObsBedrock:
                     )
                 ),
             )
-            assert len(llmobs_events) == 2
-            spans = test_spans.pop_traces()
-            span1, span2 = spans[0][0], spans[1][0]
-            assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-                span1,
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 2
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="llm",
                 model_name="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
                 model_provider="amazon_bedrock",
                 input_messages=[
@@ -494,17 +476,18 @@ class TestLLMObsBedrock:
                     "stop_reason": "end_turn",
                     "temperature": 0.7,
                 },
-                token_metrics={
+                metrics={
                     "input_tokens": 1039,
                     "output_tokens": 264,
                     "total_tokens": 1303,
                     "cache_write_input_tokens": 1028,
                     "cache_read_input_tokens": 0,
                 },
-                tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+                tags=BEDROCK_TAGS,
             )
-            assert llmobs_events[1] == _expected_llmobs_llm_span_event(
-                span2,
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[1]),
+                span_kind="llm",
                 model_name="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
                 model_provider="amazon_bedrock",
                 input_messages=[
@@ -518,18 +501,18 @@ class TestLLMObsBedrock:
                     "stop_reason": "end_turn",
                     "temperature": 0.7,
                 },
-                token_metrics={
+                metrics={
                     "input_tokens": 1040,
                     "output_tokens": 185,
                     "total_tokens": 1225,
                     "cache_write_input_tokens": 0,
                     "cache_read_input_tokens": 1028,
                 },
-                tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+                tags=BEDROCK_TAGS,
             )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_stream_prompt_caching(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_stream_prompt_caching(self, bedrock_client, request_vcr, test_spans):
         """Test that prompt caching metrics are properly captured for streamed converse responses."""
         large_system_prompt = "Software architecture guidelines: " + "hello " * 1024
         large_system_content = [
@@ -556,12 +539,12 @@ class TestLLMObsBedrock:
             for _ in stream_2["stream"]:
                 pass
 
-            assert len(llmobs_events) == 2
-            spans = test_spans.pop_traces()
-            span1, span2 = spans[0][0], spans[1][0]
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 2
 
-            assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-                span1,
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="llm",
                 model_name="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
                 model_provider="amazon_bedrock",
                 input_messages=[
@@ -574,17 +557,18 @@ class TestLLMObsBedrock:
                     "max_tokens": 1000,
                     "temperature": 0.7,
                 },
-                token_metrics={
+                metrics={
                     "input_tokens": 1039,
                     "output_tokens": 236,
                     "total_tokens": 1275,
                     "cache_write_input_tokens": 1028,
                     "cache_read_input_tokens": 0,
                 },
-                tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+                tags=BEDROCK_TAGS,
             )
-            assert llmobs_events[1] == _expected_llmobs_llm_span_event(
-                span2,
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[1]),
+                span_kind="llm",
                 model_name="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
                 model_provider="amazon_bedrock",
                 input_messages=[
@@ -597,18 +581,18 @@ class TestLLMObsBedrock:
                     "max_tokens": 1000,
                     "temperature": 0.7,
                 },
-                token_metrics={
+                metrics={
                     "input_tokens": 1040,
                     "output_tokens": 250,
                     "total_tokens": 1290,
                     "cache_write_input_tokens": 0,
                     "cache_read_input_tokens": 1028,
                 },
-                tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+                tags=BEDROCK_TAGS,
             )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_tool_result_text(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_tool_result_text(self, bedrock_client, request_vcr, test_spans):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -620,13 +604,14 @@ class TestLLMObsBedrock:
                 ],
             )
 
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0]["meta"]["input"]["messages"] == [
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["messages"] == [
             {"tool_results": [{"result": "bar", "tool_id": "foo", "type": "toolResult"}], "role": "user"}
         ]
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_tool_result_json(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_tool_result_json(self, bedrock_client, request_vcr, test_spans):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -641,15 +626,14 @@ class TestLLMObsBedrock:
                 ],
             )
 
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0]["meta"]["input"]["messages"] == [
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["messages"] == [
             {"tool_results": [{"result": '{"result": "bar"}', "tool_id": "foo", "type": "toolResult"}], "role": "user"}
         ]
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_tool_result_json_non_text_or_json(
-        self, bedrock_client, request_vcr, test_spans, llmobs_events
-    ):
+    def test_llmobs_converse_tool_result_json_non_text_or_json(self, bedrock_client, request_vcr, test_spans):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -678,8 +662,9 @@ class TestLLMObsBedrock:
                 ],
             )
 
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0]["meta"]["input"]["messages"] == [
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["messages"] == [
             {
                 "tool_results": [
                     {"result": "[Unsupported content type(s): image]", "tool_id": "foo", "type": "toolResult"}
@@ -702,18 +687,6 @@ class TestLLMObsBedrock:
     ],
 )
 class TestLLMObsBedrockProxy:
-    @staticmethod
-    def expected_llmobs_span_event_proxy(span, n_output, message=False, metadata=None):
-        expected_parameters = metadata if metadata is not None else mock.ANY
-        return _expected_llmobs_non_llm_span_event(
-            span,
-            span_kind="workflow",
-            input_value=mock.ANY,
-            output_value=mock.ANY,
-            metadata=expected_parameters,
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
-        )
-
     @classmethod
     def _test_llmobs_invoke_proxy(
         cls,
@@ -721,7 +694,6 @@ class TestLLMObsBedrockProxy:
         provider,
         bedrock_client,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
         n_output=1,
     ):
@@ -745,18 +717,18 @@ class TestLLMObsBedrockProxy:
             response = bedrock_client.invoke_model(body=body, modelId=model)
             json.loads(response.get("body").read())
 
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
         if "_llmobs_instrumented_proxy_urls" in ddtrace_global_config:
-            span = test_spans.pop_traces()[0][0]
-            assert len(llmobs_events) == 1
-            assert llmobs_events[0] == cls.expected_llmobs_span_event_proxy(
-                span, n_output, message="message" in provider
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="workflow",
+                input_value=mock.ANY,
+                output_value=mock.ANY,
+                tags=BEDROCK_TAGS,
             )
         else:
-            span = test_spans.pop_traces()[0][0]
-            assert len(llmobs_events) == 1
-            assert llmobs_events[0]["meta"]["span"]["kind"] == "llm"
-
-        LLMObs.disable()
+            assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
 
     @classmethod
     def _test_llmobs_invoke_stream_proxy(
@@ -765,7 +737,6 @@ class TestLLMObsBedrockProxy:
         provider,
         bedrock_client,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
         n_output=1,
     ):
@@ -790,28 +761,27 @@ class TestLLMObsBedrockProxy:
             for _ in response.get("body"):
                 pass
 
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
         if (
             "_llmobs_instrumented_proxy_urls" in ddtrace_global_config
             and ddtrace_global_config["_llmobs_instrumented_proxy_urls"]
         ):
-            span = test_spans.pop_traces()[0][0]
-            assert len(llmobs_events) == 1
-            assert llmobs_events[0] == cls.expected_llmobs_span_event_proxy(
-                span, n_output, message="message" in provider
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="workflow",
+                input_value=mock.ANY,
+                output_value=mock.ANY,
+                tags=BEDROCK_TAGS,
             )
         else:
-            span = test_spans.pop_traces()[0][0]
-            assert len(llmobs_events) == 1
-            assert llmobs_events[0]["meta"]["span"]["kind"] == "llm"
-
-        LLMObs.disable()
+            assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
 
     def test_llmobs_ai21_invoke_proxy(
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -819,7 +789,6 @@ class TestLLMObsBedrockProxy:
             "ai21",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -828,7 +797,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -836,7 +804,6 @@ class TestLLMObsBedrockProxy:
             "amazon",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -845,7 +812,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -853,7 +819,6 @@ class TestLLMObsBedrockProxy:
             "anthropic",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -862,7 +827,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -870,7 +834,6 @@ class TestLLMObsBedrockProxy:
             "anthropic_message",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -879,7 +842,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -887,7 +849,6 @@ class TestLLMObsBedrockProxy:
             "cohere",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -896,7 +857,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -904,7 +864,6 @@ class TestLLMObsBedrockProxy:
             "cohere",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
             n_output=2,
         )
@@ -914,7 +873,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_proxy(
@@ -922,9 +880,7 @@ class TestLLMObsBedrockProxy:
             "meta",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
-            get_mock_response_data("meta"),
         )
 
     def test_llmobs_amazon_invoke_stream_proxy(
@@ -932,7 +888,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_stream_proxy(
@@ -940,7 +895,6 @@ class TestLLMObsBedrockProxy:
             "amazon",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -949,7 +903,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_stream_proxy(
@@ -957,7 +910,6 @@ class TestLLMObsBedrockProxy:
             "anthropic",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -966,7 +918,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_stream_proxy(
@@ -974,7 +925,6 @@ class TestLLMObsBedrockProxy:
             "anthropic_message",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -983,7 +933,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_stream_proxy(
@@ -991,7 +940,6 @@ class TestLLMObsBedrockProxy:
             "cohere",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -1000,7 +948,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_stream_proxy(
@@ -1008,7 +955,6 @@ class TestLLMObsBedrockProxy:
             "cohere",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
             n_output=2,
         )
@@ -1018,7 +964,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http,
     ):
         self._test_llmobs_invoke_stream_proxy(
@@ -1026,7 +971,6 @@ class TestLLMObsBedrockProxy:
             "meta",
             bedrock_client_proxy,
             test_spans,
-            llmobs_events,
             mock_invoke_model_http,
         )
 
@@ -1035,7 +979,6 @@ class TestLLMObsBedrockProxy:
         ddtrace_global_config,
         bedrock_client_proxy,
         test_spans,
-        llmobs_events,
         mock_invoke_model_http_error,
         mock_invoke_model_response_error,
     ):
@@ -1053,20 +996,21 @@ class TestLLMObsBedrockProxy:
             "_llmobs_instrumented_proxy_urls" in ddtrace_global_config
             and ddtrace_global_config["_llmobs_instrumented_proxy_urls"]
         ):
-            span = test_spans.pop_traces()[0][0]
-            assert len(llmobs_events) == 1
-            assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-                span,
-                "workflow",
+            spans = [s for trace in test_spans.pop_traces() for s in trace]
+            assert len(spans) == 1
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(spans[0]),
+                span_kind="workflow",
                 input_value=mock.ANY,
                 output_value=mock.ANY,
                 metadata={"temperature": 0.9, "max_tokens": 60},
-                tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
-                error="botocore.exceptions.ClientError",
-                error_message=mock.ANY,
-                error_stack=mock.ANY,
+                tags=BEDROCK_TAGS,
+                error={
+                    "type": "botocore.exceptions.ClientError",
+                    "message": mock.ANY,
+                    "stack": mock.ANY,
+                },
             )
-        LLMObs.disable()
 
 
 def test_shadow_tags_invoke_when_llmobs_disabled(tracer):

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -23,9 +23,6 @@ from tests.utils import override_global_config
 BEDROCK_TAGS = {"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"}
 
 
-@pytest.mark.parametrize(
-    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
-)
 class TestLLMObsBedrock:
     @classmethod
     def _assert_llm_span(
@@ -130,24 +127,28 @@ class TestLLMObsBedrock:
             metadata=expected_metadata,
         )
 
-    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("ai21", bedrock_client, test_spans)
 
-    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("amazon", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("anthropic", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("anthropic_message", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_single_output_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_cohere_single_output_invoke(
+        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+    ):
         self._test_llmobs_invoke(
             "cohere", bedrock_client, test_spans, cassette_name="cohere_invoke_single_output.yaml"
         )
 
-    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_cohere_multi_output_invoke(
+        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+    ):
         self._test_llmobs_invoke(
             "cohere",
             bedrock_client,
@@ -156,10 +157,10 @@ class TestLLMObsBedrock:
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("meta", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_rerank_invoke(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_cohere_rerank_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         cassette_name = "cohere_rerank_invoke.yaml"
         model = "cohere.rerank-v3-5:0"
         prompt_data = "What is the capital of the United States?"
@@ -175,16 +176,20 @@ class TestLLMObsBedrock:
         assert len(spans) == 1
         self._assert_llm_span(spans[0], 1, model_id=model)
 
-    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("amazon", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("anthropic", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_message_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_anthropic_message_invoke_stream(
+        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+    ):
         self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_single_output_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_cohere_single_output_invoke_stream(
+        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+    ):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
@@ -192,7 +197,9 @@ class TestLLMObsBedrock:
             cassette_name="cohere_invoke_stream_single_output.yaml",
         )
 
-    def test_llmobs_cohere_multi_output_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_cohere_multi_output_invoke_stream(
+        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+    ):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
@@ -201,10 +208,10 @@ class TestLLMObsBedrock:
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, test_spans):
+    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("meta", bedrock_client, test_spans)
 
-    def test_llmobs_only_patches_bedrock(self, ddtrace_global_config, tracer, test_spans):
+    def test_llmobs_only_patches_bedrock(self, ddtrace_global_config, tracer, bedrock_llmobs, test_spans):
         llmobs_service.disable()
 
         with override_global_config(
@@ -229,7 +236,7 @@ class TestLLMObsBedrock:
 
         llmobs_service.disable()
 
-    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, test_spans, request_vcr):
+    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans, request_vcr):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -255,7 +262,7 @@ class TestLLMObsBedrock:
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         request_params = create_bedrock_converse_request(**bedrock_converse_args_with_system_and_tool)
         with request_vcr.use_cassette("bedrock_converse.yaml"):
             response = bedrock_client.converse(**request_params)
@@ -300,7 +307,7 @@ class TestLLMObsBedrock:
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_error(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_error(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         """Test error handling for the Bedrock Converse API."""
         import botocore
 
@@ -333,7 +340,7 @@ class TestLLMObsBedrock:
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_stream(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_stream(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         output_msg = ""
         request_params = create_bedrock_converse_request(**bedrock_converse_args_with_system_and_tool)
         with request_vcr.use_cassette("bedrock_converse_stream.yaml"):
@@ -382,7 +389,7 @@ class TestLLMObsBedrock:
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_modified_stream(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_modified_stream(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         """
         Verify that LLM Obs tracing works even if stream chunks are modified mid-stream.
         """
@@ -436,7 +443,7 @@ class TestLLMObsBedrock:
         )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_prompt_caching(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_prompt_caching(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         """Test that prompt caching metrics are properly captured for both cache creation and cache read."""
         large_system_prompt = "Software architecture guidelines: " + "bye " * 1024
         large_system_content = [
@@ -514,7 +521,7 @@ class TestLLMObsBedrock:
             )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_stream_prompt_caching(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_stream_prompt_caching(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         """Test that prompt caching metrics are properly captured for streamed converse responses."""
         large_system_prompt = "Software architecture guidelines: " + "hello " * 1024
         large_system_content = [
@@ -594,7 +601,7 @@ class TestLLMObsBedrock:
             )
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_tool_result_text(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_tool_result_text(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -613,7 +620,7 @@ class TestLLMObsBedrock:
         ]
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_tool_result_json(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_tool_result_json(self, bedrock_client, request_vcr, bedrock_llmobs, test_spans):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -635,7 +642,9 @@ class TestLLMObsBedrock:
         ]
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_tool_result_json_non_text_or_json(self, bedrock_client, request_vcr, test_spans):
+    def test_llmobs_converse_tool_result_json_non_text_or_json(
+        self, bedrock_client, request_vcr, bedrock_llmobs, test_spans
+    ):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -783,6 +792,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -798,6 +808,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -813,6 +824,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -828,6 +840,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -843,6 +856,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -858,6 +872,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -874,6 +889,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -889,6 +905,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -904,6 +921,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -919,6 +937,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -934,6 +953,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -949,6 +969,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -965,6 +986,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http,
     ):
@@ -980,6 +1002,7 @@ class TestLLMObsBedrockProxy:
         self,
         ddtrace_global_config,
         bedrock_client_proxy,
+        bedrock_llmobs,
         test_spans,
         mock_invoke_model_http_error,
         mock_invoke_model_response_error,

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -127,24 +127,24 @@ class TestLLMObsBedrock:
             metadata=expected_metadata,
         )
 
-    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_ai21_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("ai21", bedrock_client, test_spans)
 
-    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_amazon_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("amazon", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_anthropic_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("anthropic", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_anthropic_message(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("anthropic_message", bedrock_client, test_spans)
 
     def test_llmobs_cohere_single_output_invoke(
-        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+        self, bedrock_client, bedrock_llmobs, test_spans
     ):
         self._test_llmobs_invoke("cohere", bedrock_client, test_spans, cassette_name="cohere_invoke_single_output.yaml")
 
-    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_cohere_multi_output_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke(
             "cohere",
             bedrock_client,
@@ -153,10 +153,10 @@ class TestLLMObsBedrock:
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_meta_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke("meta", bedrock_client, test_spans)
 
-    def test_llmobs_cohere_rerank_invoke(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_cohere_rerank_invoke(self, bedrock_client, bedrock_llmobs, test_spans):
         cassette_name = "cohere_rerank_invoke.yaml"
         model = "cohere.rerank-v3-5:0"
         prompt_data = "What is the capital of the United States?"
@@ -172,19 +172,19 @@ class TestLLMObsBedrock:
         assert len(spans) == 1
         self._assert_llm_span(spans[0], 1, model_id=model)
 
-    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_amazon_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("amazon", bedrock_client, test_spans)
 
-    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_anthropic_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("anthropic", bedrock_client, test_spans)
 
     def test_llmobs_anthropic_message_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+        self, bedrock_client, bedrock_llmobs, test_spans
     ):
         self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, test_spans)
 
     def test_llmobs_cohere_single_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+        self, bedrock_client, bedrock_llmobs, test_spans
     ):
         self._test_llmobs_invoke_stream(
             "cohere",
@@ -194,7 +194,7 @@ class TestLLMObsBedrock:
         )
 
     def test_llmobs_cohere_multi_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans
+        self, bedrock_client, bedrock_llmobs, test_spans
     ):
         self._test_llmobs_invoke_stream(
             "cohere",
@@ -204,10 +204,10 @@ class TestLLMObsBedrock:
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans):
+    def test_llmobs_meta_invoke_stream(self, bedrock_client, bedrock_llmobs, test_spans):
         self._test_llmobs_invoke_stream("meta", bedrock_client, test_spans)
 
-    def test_llmobs_only_patches_bedrock(self, ddtrace_global_config, tracer, bedrock_llmobs, test_spans):
+    def test_llmobs_only_patches_bedrock(self, tracer, bedrock_llmobs, test_spans):
         llmobs_service.disable()
 
         with override_global_config(
@@ -232,7 +232,7 @@ class TestLLMObsBedrock:
 
         llmobs_service.disable()
 
-    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, bedrock_llmobs, test_spans, request_vcr):
+    def test_llmobs_error(self, bedrock_client, bedrock_llmobs, test_spans, request_vcr):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -684,12 +684,8 @@ class TestLLMObsBedrock:
 @pytest.mark.parametrize(
     "ddtrace_global_config",
     [
-        dict(_llmobs_enabled=True, _llmobs_ml_app="<ml-app-name>"),
-        dict(
-            _llmobs_enabled=True,
-            _llmobs_ml_app="<ml-app-name>",
-            _llmobs_instrumented_proxy_urls="http://localhost:4000",
-        ),
+        {},
+        {"_llmobs_instrumented_proxy_urls": "http://localhost:4000"},
     ],
 )
 class TestLLMObsBedrockProxy:


### PR DESCRIPTION
Migrates botocore (bedrock + bedrock_agents) LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `bedrock_llmobs(tracer, monkeypatch, llmobs_span_writer)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs (`agentless_enabled=False`) against the test tracer, and swaps in a real `TestLLMObsSpanWriter` (not a mock) so bedrock_agents' synthetic span events — which have no backing APM span — are still observable.

Stacked on #17789.
