### PR TITLE
test(llmobs): migrate crewai tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -1,5 +1,6 @@
 import os
 import time
+from unittest import mock
 
 from crewai import Agent
 from crewai import Crew
@@ -17,12 +18,11 @@ import vcr
 
 from ddtrace.contrib.internal.crewai.patch import patch
 from ddtrace.contrib.internal.crewai.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs import LLMObs
 from tests.contrib.crewai.utils import budget_text
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.contrib.crewai.utils import itinerary_text
 from tests.contrib.crewai.utils import welcome_email_text
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
 
 
@@ -343,22 +343,28 @@ def crewai(monkeypatch):
 
 
 @pytest.fixture
-def crewai_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "tests.contrib.crewai"}
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs_events(crewai_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use the mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()

--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -343,28 +343,19 @@ def crewai(monkeypatch):
 
 
 @pytest.fixture
-def ddtrace_global_config():
-    return {}
-
-
-@pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use the mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def crewai_llmobs(tracer, monkeypatch):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-api_key>",
+            "_llmobs_sample_rate": 1.0,
+            "service": "tests.contrib.crewai",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()

--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -350,7 +350,6 @@ def crewai_llmobs(tracer, monkeypatch):
         {
             "_llmobs_ml_app": "<ml-app-name>",
             "_dd_api_key": "<not-a-real-api_key>",
-            "_llmobs_sample_rate": 1.0,
             "service": "tests.contrib.crewai",
         }
     ):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -6,6 +6,7 @@ import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_span_name
@@ -274,21 +275,18 @@ def _assert_simple_flow_events(spans):
     assert get_llmobs_output_value(spans[1]) == "New York City"
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
-        meta_0 = _get_llmobs_data_metastruct(spans[0])
-        meta_1 = _get_llmobs_data_metastruct(spans[1])
-        meta_2 = _get_llmobs_data_metastruct(spans[2])
-        input_val = json.loads(meta_0["meta"]["input"]["value"])
+        input_val = json.loads(get_llmobs_input_value(spans[0]))
         assert input_val == {"continent": "North America"}
-        assert meta_0["meta"]["output"]["value"] == fun_fact_text
-        input_val = json.loads(meta_1["meta"]["input"]["value"])
+        assert get_llmobs_output_value(spans[0]) == fun_fact_text
+        input_val = json.loads(get_llmobs_input_value(spans[1]))
         assert input_val["args"] == []
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        input_val = json.loads(meta_2["meta"]["input"]["value"])
+        input_val = json.loads(get_llmobs_input_value(spans[2]))
         assert input_val["args"] == ["New York City"]
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        assert meta_2["meta"]["output"]["value"] == fun_fact_text
+        assert get_llmobs_output_value(spans[2]) == fun_fact_text
 
 
 def _assert_simple_flow_links(spans):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -6,6 +6,9 @@ import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_output_value
+from ddtrace.llmobs._utils import get_llmobs_parent_id
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
@@ -116,7 +119,7 @@ def _expected_tool_kwargs():
 
 def _llmobs_name(span):
     """Return the LLMObs span name as projected to the wire (matches event['name'])."""
-    return _get_llmobs_data_metastruct(span).get("name") or span.name
+    return get_llmobs_span_name(span) or span.name
 
 
 def _link_event(span):
@@ -142,10 +145,10 @@ def _assert_basic_crew_events(spans):
         kwargs = _expected_agent_kwargs(_llmobs_name(span)) if kind == "agent" else EXPECTED_SPAN_KWARGS
         assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **kwargs)
     # assert parent_id chain: workflow -> task -> agent
-    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
-    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[3].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[3]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[4]) == str(spans[3].span_id)  # agent -> task
 
 
 def _assert_basic_crew_links(spans):
@@ -171,9 +174,9 @@ def _assert_tool_crew_events(spans):
     )
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
     # assert parent_id chain: workflow -> task -> agent -> tool
-    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
-    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[2].span_id)  # tool -> agent
+    assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[3]) == str(spans[2].span_id)  # tool -> agent
 
 
 def _assert_tool_crew_links(spans):
@@ -200,10 +203,10 @@ def _assert_async_crew_events(spans):
         _get_llmobs_data_metastruct(spans[5]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[5]))
     )
     # assert parent_id chain: workflow -> task -> agent, workflow -> task -> agent
-    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
-    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[5])["parent_id"] == str(spans[4].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[4]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[5]) == str(spans[4].span_id)  # agent -> task
 
 
 def _assert_async_crew_links(spans):
@@ -268,7 +271,7 @@ def _assert_simple_flow_events(spans):
     assert len(spans) == 3
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
-    assert _get_llmobs_data_metastruct(spans[1])["meta"]["output"]["value"] == "New York City"
+    assert get_llmobs_output_value(spans[1]) == "New York City"
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
         meta_0 = _get_llmobs_data_metastruct(spans[0])

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -9,6 +9,7 @@ from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
+from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
@@ -129,8 +130,7 @@ def _link_event(span):
     ``_assert_span_link`` only reads ``span_id`` and ``span_links`` from the dicts it's
     given, so we splice them out of the metastruct payload and the underlying span.
     """
-    metastruct = _get_llmobs_data_metastruct(span)
-    return {"span_id": str(span.span_id), "span_links": metastruct.get("span_links") or []}
+    return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
 
 
 def _ordered_spans(test_spans):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -19,15 +19,6 @@ from tests.llmobs._utils import assert_llmobs_span_data
 CREWAI_VERSION = parse_version(getattr(crewai, "__version__", "0.0.0"))
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.contrib.crewai",
-)
-
-
 AGENT_TO_EXPECTED_AGENT_MANIFEST = {
     "Senior Research Scientist": {
         "framework": "CrewAI",
@@ -333,8 +324,7 @@ def _assert_router_flow_links(spans):
     _assert_span_link(events[3], events[0], "output", "output")
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_basic_crew(crewai, basic_crew, request_vcr, test_spans):
+def test_basic_crew(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff(inputs={"topic": "AI"})
     spans = _ordered_spans(test_spans)
@@ -342,8 +332,7 @@ def test_basic_crew(crewai, basic_crew, request_vcr, test_spans):
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans):
+def test_basic_crew_for_each(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff_for_each(inputs=[{"topic": "AI"}])
     spans = _ordered_spans(test_spans)
@@ -351,8 +340,7 @@ def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans):
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans):
+async def test_basic_crew_async(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_async(inputs={"topic": "AI"})
     spans = _ordered_spans(test_spans)
@@ -360,8 +348,7 @@ async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans):
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_spans):
+async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_for_each_async(inputs=[{"topic": "AI"}])
     spans = _ordered_spans(test_spans)
@@ -369,8 +356,7 @@ async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_s
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans):
+def test_crew_with_tool(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -378,8 +364,7 @@ def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans):
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans):
+def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -387,8 +372,7 @@ def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans):
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans):
+async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -396,8 +380,7 @@ async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans):
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, test_spans):
+async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -405,8 +388,7 @@ async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, tes
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans):
+def test_async_crew(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -414,8 +396,7 @@ def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans):
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans):
+def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -423,8 +404,7 @@ def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans):
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans):
+async def test_async_crew_async(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -432,8 +412,7 @@ async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, test_spans):
+async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -441,8 +420,7 @@ async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, t
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans):
+def test_conditional_crew(crewai, conditional_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         conditional_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -450,8 +428,7 @@ def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans):
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, test_spans):
+async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await conditional_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -459,8 +436,7 @@ async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, tes
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans):
+def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -468,8 +444,7 @@ def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans):
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
+def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -477,8 +452,7 @@ def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, test_spans):
+async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -486,8 +460,7 @@ async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, t
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
+async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -495,48 +468,42 @@ async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, reque
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_simple_flow(crewai, simple_flow, test_spans):
+def test_simple_flow(crewai, simple_flow, crewai_llmobs, test_spans):
     simple_flow.kickoff(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_simple_flow_events(spans)
     _assert_simple_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_simple_flow_async(crewai, simple_flow_async, test_spans):
+async def test_simple_flow_async(crewai, simple_flow_async, crewai_llmobs, test_spans):
     await simple_flow_async.kickoff_async(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_simple_flow_events(spans)
     _assert_simple_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_complex_flow(crewai, complex_flow, test_spans):
+def test_complex_flow(crewai, complex_flow, crewai_llmobs, test_spans):
     complex_flow.kickoff(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_complex_flow_events(spans)
     _assert_complex_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_complex_flow_async(crewai, complex_flow_async, test_spans):
+async def test_complex_flow_async(crewai, complex_flow_async, crewai_llmobs, test_spans):
     await complex_flow_async.kickoff_async(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_complex_flow_events(spans)
     _assert_complex_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_router_flow(crewai, router_flow, test_spans):
+def test_router_flow(crewai, router_flow, crewai_llmobs, test_spans):
     router_flow.kickoff()
     spans = _ordered_spans(test_spans)
     _assert_router_flow_events(spans)
     _assert_router_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_router_flow_async(crewai, router_flow_async, test_spans):
+async def test_router_flow_async(crewai, router_flow_async, crewai_llmobs, test_spans):
     await router_flow_async.kickoff_async()
     spans = _ordered_spans(test_spans)
     _assert_router_flow_events(spans)

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -2,14 +2,25 @@ import json
 
 import crewai
 import mock
+import pytest
 
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
 
 
 CREWAI_VERSION = parse_version(getattr(crewai, "__version__", "0.0.0"))
+
+
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.contrib.crewai",
+)
 
 
 AGENT_TO_EXPECTED_AGENT_MANIFEST = {
@@ -73,132 +84,146 @@ AGENT_TO_EXPECTED_AGENT_MANIFEST = {
     },
 }
 
-EXPECTED_SPAN_ARGS = {
+
+# Common kwargs for non-agent crew/task spans. ``span_links`` is asserted separately
+# via the link helpers below so it doesn't appear here. ``parent_id=mock.ANY`` mirrors
+# the previous behaviour: async-task spans don't have a deterministic in-process parent.
+EXPECTED_SPAN_KWARGS = {
     "input_value": mock.ANY,
     "output_value": mock.ANY,
     "metadata": mock.ANY,
     "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-    "span_links": True,
-    "parent_id": mock.ANY,  # async task spans don't have in-process parent links
+    "parent_id": mock.ANY,
 }
 
 
-def expected_agent_span_args(role):
+def _expected_agent_kwargs(role):
     return {
         "input_value": mock.ANY,
         "output_value": mock.ANY,
         "metadata": {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[role]}},
         "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-        "span_links": True,
-        "parent_id": mock.ANY,  # async task spans don't have in-process parent links
+        "parent_id": mock.ANY,
     }
 
 
-def _assert_basic_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 5
-    for llmobs_span, span, kind in zip(llmobs_events, spans, ("workflow", "task", "agent", "task", "agent")):
-        extra_args = expected_agent_span_args(llmobs_span["name"]) if kind == "agent" else EXPECTED_SPAN_ARGS
-        assert llmobs_span == _expected_llmobs_non_llm_span_event(span, span_kind=kind, **extra_args)
+def _expected_tool_kwargs():
+    return {
+        "input_value": mock.ANY,
+        "output_value": mock.ANY,
+        "metadata": mock.ANY,
+        "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
+    }
+
+
+def _llmobs_name(span):
+    """Return the LLMObs span name as projected to the wire (matches event['name'])."""
+    return _get_llmobs_data_metastruct(span).get("name") or span.name
+
+
+def _link_event(span):
+    """Build a minimal dict that ``_assert_span_link`` can consume.
+
+    ``_assert_span_link`` only reads ``span_id`` and ``span_links`` from the dicts it's
+    given, so we splice them out of the metastruct payload and the underlying span.
+    """
+    metastruct = _get_llmobs_data_metastruct(span)
+    return {"span_id": str(span.span_id), "span_links": metastruct.get("span_links") or []}
+
+
+def _ordered_spans(test_spans):
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    spans.sort(key=lambda s: s.start_ns)
+    return spans
+
+
+def _assert_basic_crew_events(spans):
+    assert len(spans) == 5
+    expected_kinds = ("workflow", "task", "agent", "task", "agent")
+    for span, kind in zip(spans, expected_kinds):
+        kwargs = _expected_agent_kwargs(_llmobs_name(span)) if kind == "agent" else EXPECTED_SPAN_KWARGS
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **kwargs)
     # assert parent_id chain: workflow -> task -> agent
-    assert llmobs_events[1]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[2]["parent_id"] == llmobs_events[1]["span_id"]  # agent -> task
-    assert llmobs_events[3]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[4]["parent_id"] == llmobs_events[3]["span_id"]  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[3].span_id)  # agent -> task
 
 
-def _assert_basic_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_basic_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[3], "output", "input")
+    _assert_span_link(events[3], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
-    _assert_span_link(llmobs_events[3], llmobs_events[4], "input", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[3], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(events[3], events[4], "input", "input")
+    _assert_span_link(events[4], events[3], "output", "output")
 
 
-def _assert_tool_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 4
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-        spans[2], span_kind="agent", **expected_agent_span_args(llmobs_events[2]["name"])
+def _assert_tool_crew_events(spans):
+    assert len(spans) == 4
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[2]))
     )
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-        spans[3],
-        span_kind="tool",
-        input_value=mock.ANY,
-        output_value=mock.ANY,
-        metadata=mock.ANY,
-        tags={"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-    )
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
     # assert parent_id chain: workflow -> task -> agent -> tool
-    assert llmobs_events[1]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[2]["parent_id"] == llmobs_events[1]["span_id"]  # agent -> task
-    assert llmobs_events[3]["parent_id"] == llmobs_events[2]["span_id"]  # tool -> agent
+    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[2].span_id)  # tool -> agent
 
 
-def _assert_tool_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_tool_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
 
 
-def _assert_async_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 6
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-        spans[2], span_kind="agent", **expected_agent_span_args(llmobs_events[2]["name"])
+def _assert_async_crew_events(spans):
+    assert len(spans) == 6
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[2]))
     )
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-        spans[3],
-        span_kind="tool",
-        input_value=mock.ANY,
-        output_value=mock.ANY,
-        metadata=mock.ANY,
-        tags={"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-    )
-    assert llmobs_events[4] == _expected_llmobs_non_llm_span_event(spans[4], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[5] == _expected_llmobs_non_llm_span_event(
-        spans[5], span_kind="agent", **expected_agent_span_args(llmobs_events[5]["name"])
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[4]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[5]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[5]))
     )
     # assert parent_id chain: workflow -> task -> agent, workflow -> task -> agent
-    assert llmobs_events[1]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[2]["parent_id"] == llmobs_events[1]["span_id"]  # agent -> task
-    assert llmobs_events[4]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[5]["parent_id"] == llmobs_events[4]["span_id"]  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[5])["parent_id"] == str(spans[4].span_id)  # agent -> task
 
 
-def _assert_async_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_async_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[4], "output", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[4], "output", "input")
+    _assert_span_link(events[4], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
-    _assert_span_link(llmobs_events[4], llmobs_events[5], "input", "input")
-    _assert_span_link(llmobs_events[5], llmobs_events[4], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(events[4], events[5], "input", "input")
+    _assert_span_link(events[5], events[4], "output", "output")
 
 
-def _assert_hierarchical_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 12
+def _assert_hierarchical_crew_events(spans):
+    assert len(spans) == 12
     expected_span_kinds = (
         "workflow",
         "task",
@@ -213,294 +238,307 @@ def _assert_hierarchical_crew_events(llmobs_events, spans):
         "tool",
         "agent",
     )
-    for llmobs_span, span, kind in zip(llmobs_events, spans, expected_span_kinds):
+    for span, kind in zip(spans, expected_span_kinds):
         if kind is None:  # Not expecting any span links for this tool span
-            assert llmobs_span == _expected_llmobs_non_llm_span_event(
-                span,
-                span_kind="tool",
-                input_value=mock.ANY,
-                output_value=mock.ANY,
-                metadata=mock.ANY,
-                tags={"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-            )
+            assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind="tool", **_expected_tool_kwargs())
             continue
-        assert llmobs_span == _expected_llmobs_non_llm_span_event(span, span_kind=kind, **EXPECTED_SPAN_ARGS)
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **EXPECTED_SPAN_KWARGS)
 
 
-def _assert_hierarchical_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_hierarchical_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[8], "output", "input")
-    _assert_span_link(llmobs_events[8], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[3], "output", "input")
+    _assert_span_link(events[3], events[8], "output", "input")
+    _assert_span_link(events[8], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
-    _assert_span_link(llmobs_events[3], llmobs_events[4], "input", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[3], "output", "output")
-    _assert_span_link(llmobs_events[5], llmobs_events[6], "input", "input")
-    _assert_span_link(llmobs_events[6], llmobs_events[5], "output", "output")
-    _assert_span_link(llmobs_events[8], llmobs_events[9], "input", "input")
-    _assert_span_link(llmobs_events[9], llmobs_events[8], "output", "output")
-    _assert_span_link(llmobs_events[10], llmobs_events[11], "input", "input")
-    _assert_span_link(llmobs_events[11], llmobs_events[10], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(events[3], events[4], "input", "input")
+    _assert_span_link(events[4], events[3], "output", "output")
+    _assert_span_link(events[5], events[6], "input", "input")
+    _assert_span_link(events[6], events[5], "output", "output")
+    _assert_span_link(events[8], events[9], "input", "input")
+    _assert_span_link(events[9], events[8], "output", "output")
+    _assert_span_link(events[10], events[11], "input", "input")
+    _assert_span_link(events[11], events[10], "output", "output")
 
 
-def _assert_simple_flow_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 3
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1]["meta"]["output"]["value"] == "New York City"
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(spans[2], span_kind="task", **EXPECTED_SPAN_ARGS)
+def _assert_simple_flow_events(spans):
+    assert len(spans) == 3
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert _get_llmobs_data_metastruct(spans[1])["meta"]["output"]["value"] == "New York City"
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
-        input_val = json.loads(llmobs_events[0]["meta"]["input"]["value"])
+        meta_0 = _get_llmobs_data_metastruct(spans[0])
+        meta_1 = _get_llmobs_data_metastruct(spans[1])
+        meta_2 = _get_llmobs_data_metastruct(spans[2])
+        input_val = json.loads(meta_0["meta"]["input"]["value"])
         assert input_val == {"continent": "North America"}
-        assert llmobs_events[0]["meta"]["output"]["value"] == fun_fact_text
-        input_val = json.loads(llmobs_events[1]["meta"]["input"]["value"])
+        assert meta_0["meta"]["output"]["value"] == fun_fact_text
+        input_val = json.loads(meta_1["meta"]["input"]["value"])
         assert input_val["args"] == []
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        input_val = json.loads(llmobs_events[2]["meta"]["input"]["value"])
+        input_val = json.loads(meta_2["meta"]["input"]["value"])
         assert input_val["args"] == ["New York City"]
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        assert llmobs_events[2]["meta"]["output"]["value"] == fun_fact_text
+        assert meta_2["meta"]["output"]["value"] == fun_fact_text
 
 
-def _assert_simple_flow_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "output", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[0], "output", "output")
+def _assert_simple_flow_links(spans):
+    events = [_link_event(s) for s in spans]
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[2], "output", "input")
+    _assert_span_link(events[2], events[0], "output", "output")
 
 
-def _assert_complex_flow_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 6
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(spans[2], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(spans[3], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[4] == _expected_llmobs_non_llm_span_event(spans[4], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[5] == _expected_llmobs_non_llm_span_event(spans[5], span_kind="task", **EXPECTED_SPAN_ARGS)
+def _assert_complex_flow_events(spans):
+    assert len(spans) == 6
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    for i in range(1, 6):
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_SPAN_KWARGS)
 
 
-def _assert_complex_flow_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[0], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[5], llmobs_events[0], "output", "output")
+def _assert_complex_flow_links(spans):
+    events = [_link_event(s) for s in spans]
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[0], events[2], "input", "input")
+    _assert_span_link(events[5], events[0], "output", "output")
 
-    _assert_span_link(llmobs_events[1], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[4], "output", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[5], "output", "input")
+    _assert_span_link(events[1], events[3], "output", "input")
+    _assert_span_link(events[1], events[4], "output", "input")
+    _assert_span_link(events[1], events[5], "output", "input")
 
-    _assert_span_link(llmobs_events[2], llmobs_events[5], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[5], "output", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[5], "output", "input")
-
-
-def _assert_router_flow_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 4
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(spans[2], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(spans[3], span_kind="task", **EXPECTED_SPAN_ARGS)
+    _assert_span_link(events[2], events[5], "output", "input")
+    _assert_span_link(events[3], events[5], "output", "input")
+    _assert_span_link(events[4], events[5], "output", "input")
 
 
-def _assert_router_flow_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "output", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[0], "output", "output")
+def _assert_router_flow_events(spans):
+    assert len(spans) == 4
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    for i in range(1, 4):
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_SPAN_KWARGS)
 
 
-def test_basic_crew(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+def _assert_router_flow_links(spans):
+    events = [_link_event(s) for s in spans]
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[2], "output", "input")
+    _assert_span_link(events[2], events[3], "output", "input")
+    _assert_span_link(events[3], events[0], "output", "output")
+
+
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_basic_crew(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff(inputs={"topic": "AI"})
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff_for_each(inputs=[{"topic": "AI"}])
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_async(inputs={"topic": "AI"})
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_for_each_async(inputs=[{"topic": "AI"}])
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         conditional_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await conditional_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-def test_simple_flow(crewai, simple_flow, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_simple_flow(crewai, simple_flow, test_spans):
     simple_flow.kickoff(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_simple_flow_events(llmobs_events, spans)
-    _assert_simple_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_simple_flow_events(spans)
+    _assert_simple_flow_links(spans)
 
 
-async def test_simple_flow_async(crewai, simple_flow_async, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_simple_flow_async(crewai, simple_flow_async, test_spans):
     await simple_flow_async.kickoff_async(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_simple_flow_events(llmobs_events, spans)
-    _assert_simple_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_simple_flow_events(spans)
+    _assert_simple_flow_links(spans)
 
 
-def test_complex_flow(crewai, complex_flow, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_complex_flow(crewai, complex_flow, test_spans):
     complex_flow.kickoff(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_complex_flow_events(llmobs_events, spans)
-    _assert_complex_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_complex_flow_events(spans)
+    _assert_complex_flow_links(spans)
 
 
-async def test_complex_flow_async(crewai, complex_flow_async, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_complex_flow_async(crewai, complex_flow_async, test_spans):
     await complex_flow_async.kickoff_async(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_complex_flow_events(llmobs_events, spans)
-    _assert_complex_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_complex_flow_events(spans)
+    _assert_complex_flow_links(spans)
 
 
-def test_router_flow(crewai, router_flow, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_router_flow(crewai, router_flow, test_spans):
     router_flow.kickoff()
-    spans = test_spans.pop_traces()[0]
-    _assert_router_flow_events(llmobs_events, spans)
-    _assert_router_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_router_flow_events(spans)
+    _assert_router_flow_links(spans)
 
 
-async def test_router_flow_async(crewai, router_flow_async, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_router_flow_async(crewai, router_flow_async, test_spans):
     await router_flow_async.kickoff_async()
-    spans = test_spans.pop_traces()[0]
-    _assert_router_flow_events(llmobs_events, spans)
-    _assert_router_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_router_flow_events(spans)
+    _assert_router_flow_links(spans)

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -91,7 +91,6 @@ AGENT_TO_EXPECTED_AGENT_MANIFEST = {
 EXPECTED_SPAN_KWARGS = {
     "input_value": mock.ANY,
     "output_value": mock.ANY,
-    "metadata": mock.ANY,
     "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
     "parent_id": mock.ANY,
 }
@@ -111,7 +110,6 @@ def _expected_tool_kwargs():
     return {
         "input_value": mock.ANY,
         "output_value": mock.ANY,
-        "metadata": mock.ANY,
         "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
     }
 


### PR DESCRIPTION
## Summary

Migrates contrib crewai LLMObs tests from `llmobs_events`-based wire-event assertions to `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`, asserting against the canonical `LLMObsSpanData` payload on the span's `meta_struct["_llmobs"]`.

Stacked on #17789 (openai PR — adds the matcher's role normalization and `mock.ANY` whole-value support; this PR uses both via `metadata=mock.ANY` for crew/task spans and explicit `_dd.agent_manifest` pinning for agent spans).

## What changes

- `conftest.py`: new `test_spans` override sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1` via `monkeypatch` so the meta_struct scrub is skipped while LLMObs is enabled. Mocks out `_llmobs_span_writer` so no background flush thread is left running. Mirrors the mcp pattern (override wraps `override_global_config(ddtrace_global_config)`) since the `crewai` library fixture is plain (no provider-config plumbing).
- Drops the `crewai_llmobs`, `llmobs_span_writer`, and `llmobs_events` fixtures from conftest, and the `TestLLMObsSpanWriter` import.
- Drops the `_expected_llmobs_non_llm_span_event` import; replaces with `assert_llmobs_span_data` + `_get_llmobs_data_metastruct`.
- Module-level `LLMOBS_GLOBAL_CONFIG` constant (with `_llmobs_enabled=True`, `_llmobs_sample_rate=1.0`); each of the 24 LLMObs tests is decorated with `@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])` to trigger the override path.
- All 14 bespoke `_assert_*_crew_*` / `_assert_*_flow_*` helpers (7 `_events` + 7 `_links`) rewritten:
  - `_events` helpers now take `spans` only (no `llmobs_events` arg) and call `assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=..., **kwargs)` per span. `parent_id` chain assertions read from the metastruct payload (`_get_llmobs_data_metastruct(s)["parent_id"]`) and compare against `str(spans[i].span_id)`.
  - **Span-link strategy:** `_assert_span_link` only reads `span_id` and `span_links` from the dicts it's given, so a tiny `_link_event(span)` helper splices `{"span_id": str(span.span_id), "span_links": metastruct.get("span_links") or []}` and the existing assertion logic is reused unchanged. The 7 `_links` helpers now take `spans` and build the link-event list inline.
  - Hoisted shared kwargs into `EXPECTED_SPAN_KWARGS` / `_expected_agent_kwargs(role)` / `_expected_tool_kwargs()`. Dropped `span_links=True` (not a matcher kwarg — span links are asserted separately).
- New `_ordered_spans(test_spans)` helper flattens `pop_traces()` and sorts by `start_ns` (the matcher needs spans in start-time order to align with the previous `llmobs_events.sort(key=lambda e: e["start_ns"])` ordering).
- Per-flow inline assertions on `meta.input.value` / `meta.output.value` now read from the metastruct (`_get_llmobs_data_metastruct(s)["meta"]["input"]["value"]`) instead of the wire event.

## Fixtures left for review

none — fully migrated. The two `_llmobs_span_writer` references that remain in `conftest.py` are the standard mock-and-stop pattern from the `test_spans` override (mirrored from anthropic/openai/google_adk/mcp), not surviving fixtures.

## Test status

Local execution blocked by Rust native-extension build failure (`could not compile `ring` (build script)`) which reproduces against the `yunkim/llmobs-test-meta-struct-openai` base on the same checkout — environmental, not introduced by this PR. CI on this branch will exercise the migrated tests against `crewai~=0.102.0` and the latest `crewai` venvs across Python 3.10 / 3.11 / 3.12.

Claude session: `5a0031b3-5dfd-4ed2-a3f8-ef98ee7c8c24`
Resume: `claude --resume 5a0031b3-5dfd-4ed2-a3f8-ef98ee7c8c24`