### PR TITLE
test(llmobs): migrate litellm tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/litellm/conftest.py
+++ b/tests/contrib/litellm/conftest.py
@@ -1,11 +1,12 @@
+from unittest import mock
+
 import pytest
 
 from ddtrace.contrib.internal.litellm.patch import patch
 from ddtrace.contrib.internal.litellm.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs import LLMObs
 from tests.contrib.litellm.utils import get_request_vcr
 from tests.contrib.litellm.utils import model_list
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
 
 
@@ -19,13 +20,26 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(is_agentless=True, interval=1.0, timeout=1.0)
-
-
-@pytest.fixture
-def llmobs_events(litellm_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use the mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 @pytest.fixture
@@ -41,21 +55,6 @@ def litellm(ddtrace_global_config, monkeypatch):
 
         yield litellm
         unpatch()
-
-
-@pytest.fixture
-def litellm_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {
-            "_llmobs_ml_app": "<ml-app-name>",
-            "_dd_api_key": "<not-a-real-key>",
-        }
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/litellm/conftest.py
+++ b/tests/contrib/litellm/conftest.py
@@ -10,28 +10,16 @@ from tests.contrib.litellm.utils import model_list
 from tests.utils import override_global_config
 
 
-def default_global_config():
-    return {}
-
-
 @pytest.fixture
-def ddtrace_global_config():
-    return {}
+def litellm(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "<not-a-real-key>")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "<not-a-real-key>")
+    monkeypatch.setenv("COHERE_API_KEY", "<not-a-real-key>")
+    patch()
+    import litellm
 
-
-@pytest.fixture
-def litellm(ddtrace_global_config, monkeypatch):
-    global_config = default_global_config()
-    global_config.update(ddtrace_global_config)
-    with override_global_config(global_config):
-        monkeypatch.setenv("OPENAI_API_KEY", "<not-a-real-key>")
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "<not-a-real-key>")
-        monkeypatch.setenv("COHERE_API_KEY", "<not-a-real-key>")
-        patch()
-        import litellm
-
-        yield litellm
-        unpatch()
+    yield litellm
+    unpatch()
 
 
 @pytest.fixture

--- a/tests/contrib/litellm/conftest.py
+++ b/tests/contrib/litellm/conftest.py
@@ -20,29 +20,6 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use the mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
-
-
-@pytest.fixture
 def litellm(ddtrace_global_config, monkeypatch):
     global_config = default_global_config()
     global_config.update(ddtrace_global_config)
@@ -55,6 +32,23 @@ def litellm(ddtrace_global_config, monkeypatch):
 
         yield litellm
         unpatch()
+
+
+@pytest.fixture
+def litellm_llmobs(tracer, monkeypatch):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 @pytest.fixture

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -5,6 +5,7 @@ from ddtrace._monkey import patch
 from ddtrace.contrib.internal.litellm.patch import get_version
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_metrics
 from ddtrace.llmobs._utils import get_llmobs_output_messages
 from ddtrace.llmobs._utils import get_llmobs_span_kind
@@ -662,9 +663,8 @@ def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
             )
     spans = [s for trace in test_spans.pop_traces() for s in trace]
     assert len(spans) == 1
-    data = _get_llmobs_data_metastruct(spans[0])
-    assert data["meta"]["input"]["messages"] == messages
-    assert data["meta"]["output"]["messages"]
+    assert get_llmobs_input_messages(spans[0]) == messages
+    assert get_llmobs_output_messages(spans[0])
 
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
@@ -684,9 +684,8 @@ def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
             )
     spans = [s for trace in test_spans.pop_traces() for s in trace]
     assert len(spans) == 1
-    data = _get_llmobs_data_metastruct(spans[0])
-    assert data["meta"]["input"]["messages"] == messages
-    assert data["meta"]["output"]["messages"]
+    assert get_llmobs_input_messages(spans[0]) == messages
+    assert get_llmobs_output_messages(spans[0])
 
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
@@ -706,9 +705,8 @@ def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_ena
                 )
     spans = [s for trace in test_spans.pop_traces() for s in trace]
     assert len(spans) == 1
-    data = _get_llmobs_data_metastruct(spans[0])
-    assert data["meta"]["input"]["messages"] == messages
-    assert data["meta"]["output"]["messages"]
+    assert get_llmobs_input_messages(spans[0]) == messages
+    assert get_llmobs_output_messages(spans[0])
 
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
@@ -728,9 +726,8 @@ def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled
             )
     spans = [s for trace in test_spans.pop_traces() for s in trace]
     assert len(spans) == 1
-    data = _get_llmobs_data_metastruct(spans[0])
-    assert data["meta"]["input"]["messages"] == messages
-    assert data["meta"]["output"]["messages"]
+    assert get_llmobs_input_messages(spans[0]) == messages
+    assert get_llmobs_output_messages(spans[0])
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -20,6 +20,7 @@ from tests.contrib.litellm.utils import get_cassette_name
 from tests.contrib.litellm.utils import parse_response
 from tests.contrib.litellm.utils import tools
 from tests.llmobs._utils import assert_llmobs_span_data
+from tests.utils import override_global_config
 
 
 LITELLM_TAGS = {"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"}
@@ -235,28 +236,25 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize(
-        "ddtrace_global_config",
-        [{"_llmobs_instrumented_proxy_urls": "http://localhost:4000"}],
-    )
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_proxy(
         self, litellm, request_vcr_include_localhost, litellm_llmobs, test_spans, stream, n, consume_stream
     ):
-        with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):
-            messages = [{"content": "Hey, what is up?", "role": "user"}]
-            resp = litellm.completion(
-                model="gpt-3.5-turbo",
-                messages=messages,
-                stream=stream,
-                n=n,
-                stream_options={"include_usage": True},
-                api_base="http://localhost:4000",
-            )
-            if stream:
-                output_messages, _ = consume_stream(resp, n)
-            else:
-                output_messages, _ = parse_response(resp)
+        with override_global_config({"_llmobs_instrumented_proxy_urls": "http://localhost:4000"}):
+            with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):
+                messages = [{"content": "Hey, what is up?", "role": "user"}]
+                resp = litellm.completion(
+                    model="gpt-3.5-turbo",
+                    messages=messages,
+                    stream=stream,
+                    n=n,
+                    stream_options={"include_usage": True},
+                    api_base="http://localhost:4000",
+                )
+                if stream:
+                    output_messages, _ = consume_stream(resp, n)
+                else:
+                    output_messages, _ = parse_response(resp)
 
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -43,7 +43,7 @@ LITELLM_TAGS = {"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "
 class TestLLMObsLiteLLM:
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    def test_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = litellm.completion(
@@ -74,7 +74,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_exclude_usage(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    def test_completion_exclude_usage(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n, False)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = litellm.completion(
@@ -105,7 +105,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_with_tools(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    def test_completion_with_tools(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         if stream and n > 1:
             pytest.skip(
                 "Streamed responses with multiple completions and tool calls are not supported: see open issue https://github.com/BerriAI/litellm/issues/8977"
@@ -154,7 +154,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
-    async def test_acompletion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    async def test_acompletion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = await litellm.acompletion(
@@ -185,7 +185,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_text_completion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    def test_text_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
             resp = litellm.text_completion(
@@ -216,7 +216,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
-    async def test_atext_completion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    async def test_atext_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
             resp = await litellm.atext_completion(
@@ -251,7 +251,7 @@ class TestLLMObsLiteLLM:
     )
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_proxy(
-        self, litellm, request_vcr_include_localhost, test_spans, stream, n, consume_stream
+        self, litellm, request_vcr_include_localhost, litellm_llmobs, test_spans, stream, n, consume_stream
     ):
         with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -288,7 +288,7 @@ class TestLLMObsLiteLLM:
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_base_url_set(
-        self, litellm, request_vcr_include_localhost, test_spans, stream, n, consume_stream
+        self, litellm, request_vcr_include_localhost, litellm_llmobs, test_spans, stream, n, consume_stream
     ):
         with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -327,7 +327,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_router_completion(self, litellm, request_vcr, test_spans, router, stream, n, consume_stream):
+    def test_router_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = router.completion(
@@ -368,7 +368,7 @@ class TestLLMObsLiteLLM:
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_router_acompletion(
-        self, litellm, request_vcr, test_spans, router, stream, n, consume_stream
+        self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
     ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -409,7 +409,7 @@ class TestLLMObsLiteLLM:
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_router_text_completion(
-        self, litellm, request_vcr, test_spans, router, stream, n, consume_stream
+        self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
     ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
@@ -450,7 +450,7 @@ class TestLLMObsLiteLLM:
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_router_atext_completion(
-        self, litellm, request_vcr, test_spans, router, stream, n, consume_stream
+        self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
     ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
@@ -491,7 +491,7 @@ class TestLLMObsLiteLLM:
     @pytest.mark.skip(reason="Patching Open AI to be used within the LiteLLM library appears to be flaky")
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_openai_enabled(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
+    def test_completion_openai_enabled(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             patch(openai=True)
 
@@ -513,7 +513,7 @@ class TestLLMObsLiteLLM:
         assert get_llmobs_span_name(spans[0]) == expected_name
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-    def test_completion_anthropic_token_metrics(self, litellm, request_vcr, test_spans, stream, n):
+    def test_completion_anthropic_token_metrics(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n):
         """Test that cache token metrics (cache_read, cache_write) are captured for Anthropic models via litellm."""
         if stream or n > 1:
             pytest.skip("Anthropic cassette is non-streamed, single-choice only")
@@ -552,7 +552,7 @@ class TestLLMObsLiteLLM:
         assert "cache_write_input_tokens" in event_metrics
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-    def test_completion_anthropic_cache_1h_ttl(self, litellm, request_vcr, test_spans, stream, n):
+    def test_completion_anthropic_cache_1h_ttl(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n):
         """Test that 1h cache TTL breakdown metrics are captured for Anthropic models via litellm."""
         if stream or n > 1:
             pytest.skip("Anthropic cassette is non-streamed, single-choice only")
@@ -607,7 +607,7 @@ class TestLLMObsLiteLLM:
         )
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-    def test_completion_with_reasoning(self, litellm, request_vcr, test_spans, stream, n):
+    def test_completion_with_reasoning(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n):
         """Test that reasoning_content and reasoning_output_tokens are captured for models with reasoning."""
         if stream or n > 1:
             pytest.skip("Reasoning cassette is non-streamed, single-choice only")
@@ -649,7 +649,7 @@ _OPENAI_ENABLED = "ddtrace.llmobs._integrations.litellm.LLMObs._integration_is_e
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, test_spans
+    litellm, request_vcr_include_localhost, litellm_llmobs, test_spans
 ):
     """Regression: model='litellm_proxy/<gpt-model>' with OpenAI integration enabled must still produce LLMObs spans."""
     messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -669,7 +669,7 @@ def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, test_spans
+    litellm, request_vcr_include_localhost, litellm_llmobs, test_spans
 ):
     """Regression: use_litellm_proxy=True with an OpenAI model name must still produce LLMObs spans."""
     messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -690,7 +690,7 @@ def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, test_spans
+    litellm, request_vcr_include_localhost, litellm_llmobs, test_spans
 ):
     """Regression: litellm.use_litellm_proxy = True with an OpenAI model name must still produce LLMObs spans."""
     messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -711,7 +711,7 @@ def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_ena
 
 @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, test_spans, monkeypatch
+    litellm, request_vcr_include_localhost, litellm_llmobs, test_spans, monkeypatch
 ):
     """Regression: USE_LITELLM_PROXY=true env var with an OpenAI model name must still produce LLMObs spans."""
     monkeypatch.setenv("USE_LITELLM_PROXY", "true")

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -4,6 +4,7 @@ import pytest
 from ddtrace._monkey import patch
 from ddtrace.contrib.internal.litellm.patch import get_version
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.litellm.utils import async_consume_stream_aiter
 from tests.contrib.litellm.utils import async_consume_stream_anext
@@ -13,8 +14,16 @@ from tests.contrib.litellm.utils import expected_router_settings
 from tests.contrib.litellm.utils import get_cassette_name
 from tests.contrib.litellm.utils import parse_response
 from tests.contrib.litellm.utils import tools
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
+
+
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+)
+LITELLM_TAGS = {"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"}
 
 
 @pytest.mark.parametrize(
@@ -27,8 +36,9 @@ from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
     ],
 )
 class TestLLMObsLiteLLM:
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion(self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream):
+    def test_completion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = litellm.completion(
@@ -43,21 +53,23 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=messages,
             output_messages=output_messages,
             metadata={"stream": stream, "n": n, "stream_options": {"include_usage": True}},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_exclude_usage(self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream):
+    def test_completion_exclude_usage(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n, False)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = litellm.completion(
@@ -72,21 +84,23 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=messages,
             output_messages=output_messages,
             metadata={"stream": stream, "n": n, "stream_options": {"include_usage": False}},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_with_tools(self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream):
+    def test_completion_with_tools(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         if stream and n > 1:
             pytest.skip(
                 "Streamed responses with multiple completions and tool calls are not supported: see open issue https://github.com/BerriAI/litellm/issues/8977"
@@ -107,10 +121,11 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=messages,
@@ -128,12 +143,13 @@ class TestLLMObsLiteLLM:
                     "schema": tools[0]["function"]["parameters"],
                 }
             ],
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
-    async def test_acompletion(self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream):
+    async def test_acompletion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = await litellm.acompletion(
@@ -148,21 +164,23 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=messages,
             output_messages=output_messages,
             metadata={"stream": stream, "n": n, "stream_options": {"include_usage": True}},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_text_completion(self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream):
+    def test_text_completion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
             resp = litellm.text_completion(
@@ -177,21 +195,23 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp, is_completion=True)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=[{"content": prompt}],
             output_messages=output_messages,
             metadata={"stream": stream, "n": n, "stream_options": {"include_usage": True}},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
-    async def test_atext_completion(self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream):
+    async def test_atext_completion(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
             resp = await litellm.atext_completion(
@@ -206,23 +226,27 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp, is_completion=True)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=[{"content": prompt}],
             output_messages=output_messages,
             metadata={"stream": stream, "n": n, "stream_options": {"include_usage": True}},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_instrumented_proxy_urls="http://localhost:4000")])
+    @pytest.mark.parametrize(
+        "ddtrace_global_config",
+        [dict(LLMOBS_GLOBAL_CONFIG, _llmobs_instrumented_proxy_urls="http://localhost:4000")],
+    )
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_proxy(
-        self, litellm, request_vcr_include_localhost, llmobs_events, test_spans, stream, n, consume_stream
+        self, litellm, request_vcr_include_localhost, test_spans, stream, n, consume_stream
     ):
         with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -239,10 +263,10 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, _ = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
             span_kind="workflow",
             input_value=safe_json(messages, ensure_ascii=False),
             output_value=safe_json(output_messages, ensure_ascii=False),
@@ -253,12 +277,13 @@ class TestLLMObsLiteLLM:
                 "api_base": "http://localhost:4000",
                 "model": "gpt-3.5-turbo",
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_base_url_set(
-        self, litellm, request_vcr_include_localhost, llmobs_events, test_spans, stream, n, consume_stream
+        self, litellm, request_vcr_include_localhost, test_spans, stream, n, consume_stream
     ):
         with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -275,10 +300,11 @@ class TestLLMObsLiteLLM:
             else:
                 output_messages, token_metrics = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="gpt-3.5-turbo",
             model_provider="openai",
             input_messages=messages,
@@ -290,14 +316,13 @@ class TestLLMObsLiteLLM:
                 "base_url": "http://localhost:4000",
                 "model": "gpt-3.5-turbo",
             },
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_router_completion(
-        self, litellm, request_vcr, llmobs_events, test_spans, router, stream, n, consume_stream
-    ):
+    def test_router_completion(self, litellm, request_vcr, test_spans, router, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = router.completion(
@@ -315,15 +340,15 @@ class TestLLMObsLiteLLM:
         trace = test_spans.pop_traces()[0]
         assert len(trace) == 2
         router_span = trace[0]
+        llm_span = trace[1]
 
-        assert len(llmobs_events) == 2
-        router_event = llmobs_events[1]
-        llm_event = llmobs_events[0]
+        # The downstream LLM span is an "llm" kind named "completion"
+        llm_data = _get_llmobs_data_metastruct(llm_span)
+        assert llm_data["meta"]["span"]["kind"] == "llm"
+        assert llm_data["name"] == "completion"
 
-        assert llm_event["meta"]["span"]["kind"] == "llm"
-        assert llm_event["name"] == "completion"
-        assert router_event == _expected_llmobs_non_llm_span_event(
-            router_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(router_span),
             span_kind="workflow",
             input_value=safe_json(messages, ensure_ascii=False),
             output_value=safe_json(output_messages, ensure_ascii=False),
@@ -333,12 +358,13 @@ class TestLLMObsLiteLLM:
                 "stream_options": {"include_usage": True},
                 "router_settings": expected_router_settings,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_router_acompletion(
-        self, litellm, request_vcr, llmobs_events, test_spans, router, stream, n, consume_stream
+        self, litellm, request_vcr, test_spans, router, stream, n, consume_stream
     ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -357,15 +383,14 @@ class TestLLMObsLiteLLM:
         trace = test_spans.pop_traces()[0]
         assert len(trace) == 2
         router_span = trace[0]
+        llm_span = trace[1]
 
-        assert len(llmobs_events) == 2
-        router_event = llmobs_events[1]
-        llm_event = llmobs_events[0]
+        llm_data = _get_llmobs_data_metastruct(llm_span)
+        assert llm_data["meta"]["span"]["kind"] == "llm"
+        assert llm_data["name"] == "acompletion"
 
-        assert llm_event["meta"]["span"]["kind"] == "llm"
-        assert llm_event["name"] == "acompletion"
-        assert router_event == _expected_llmobs_non_llm_span_event(
-            router_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(router_span),
             span_kind="workflow",
             input_value=safe_json(messages, ensure_ascii=False),
             output_value=safe_json(output_messages, ensure_ascii=False),
@@ -375,12 +400,13 @@ class TestLLMObsLiteLLM:
                 "stream_options": {"include_usage": True},
                 "router_settings": expected_router_settings,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_router_text_completion(
-        self, litellm, request_vcr, llmobs_events, test_spans, router, stream, n, consume_stream
+        self, litellm, request_vcr, test_spans, router, stream, n, consume_stream
     ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
@@ -399,15 +425,14 @@ class TestLLMObsLiteLLM:
         trace = test_spans.pop_traces()[0]
         assert len(trace) == 2
         router_span = trace[0]
+        llm_span = trace[1]
 
-        assert len(llmobs_events) == 2
-        router_event = llmobs_events[1]
-        llm_event = llmobs_events[0]
+        llm_data = _get_llmobs_data_metastruct(llm_span)
+        assert llm_data["meta"]["span"]["kind"] == "llm"
+        assert llm_data["name"] == "text_completion"
 
-        assert llm_event["meta"]["span"]["kind"] == "llm"
-        assert llm_event["name"] == "text_completion"
-        assert router_event == _expected_llmobs_non_llm_span_event(
-            router_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(router_span),
             span_kind="workflow",
             input_value=safe_json([{"content": prompt}], ensure_ascii=False),
             output_value=safe_json(output_messages, ensure_ascii=False),
@@ -417,12 +442,13 @@ class TestLLMObsLiteLLM:
                 "stream_options": {"include_usage": True},
                 "router_settings": expected_router_settings,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            tags=LITELLM_TAGS,
         )
 
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_router_atext_completion(
-        self, litellm, request_vcr, llmobs_events, test_spans, router, stream, n, consume_stream
+        self, litellm, request_vcr, test_spans, router, stream, n, consume_stream
     ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             prompt = "Hey, what is up?"
@@ -441,15 +467,14 @@ class TestLLMObsLiteLLM:
         trace = test_spans.pop_traces()[0]
         assert len(trace) == 2
         router_span = trace[0]
+        llm_span = trace[1]
 
-        assert len(llmobs_events) == 2
-        router_event = llmobs_events[1]
-        llm_event = llmobs_events[0]
+        llm_data = _get_llmobs_data_metastruct(llm_span)
+        assert llm_data["meta"]["span"]["kind"] == "llm"
+        assert llm_data["name"] == "atext_completion"
 
-        assert llm_event["meta"]["span"]["kind"] == "llm"
-        assert llm_event["name"] == "atext_completion"
-        assert router_event == _expected_llmobs_non_llm_span_event(
-            router_span,
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(router_span),
             span_kind="workflow",
             input_value=safe_json([{"content": prompt}], ensure_ascii=False),
             output_value=safe_json(output_messages, ensure_ascii=False),
@@ -459,14 +484,13 @@ class TestLLMObsLiteLLM:
                 "stream_options": {"include_usage": True},
                 "router_settings": expected_router_settings,
             },
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            tags=LITELLM_TAGS,
         )
 
     @pytest.mark.skip(reason="Patching Open AI to be used within the LiteLLM library appears to be flaky")
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_openai_enabled(
-        self, litellm, request_vcr, llmobs_events, test_spans, stream, n, consume_stream
-    ):
+    def test_completion_openai_enabled(self, litellm, request_vcr, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             patch(openai=True)
 
@@ -482,10 +506,13 @@ class TestLLMObsLiteLLM:
                 for _ in resp:
                     pass
 
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0]["name"] == "OpenAI.createChatCompletion" if not stream else "litellm.request"
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        expected_name = "OpenAI.createChatCompletion" if not stream else "litellm.request"
+        assert _get_llmobs_data_metastruct(spans[0])["name"] == expected_name
 
-    def test_completion_anthropic_token_metrics(self, litellm, request_vcr, llmobs_events, test_spans, stream, n):
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+    def test_completion_anthropic_token_metrics(self, litellm, request_vcr, test_spans, stream, n):
         """Test that cache token metrics (cache_read, cache_write) are captured for Anthropic models via litellm."""
         if stream or n > 1:
             pytest.skip("Anthropic cassette is non-streamed, single-choice only")
@@ -504,25 +531,27 @@ class TestLLMObsLiteLLM:
         token_metrics["ephemeral_1h_input_tokens"] = 0
         token_metrics["ephemeral_5m_input_tokens"] = 2
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="claude-sonnet-4-5-20250929",
             model_provider="anthropic",
             input_messages=messages,
             output_messages=output_messages,
             metadata={},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
         # Verify cache token metrics are present
-        event_metrics = llmobs_events[0]["metrics"]
+        event_metrics = _get_llmobs_data_metastruct(spans[0])["metrics"]
         assert "cache_read_input_tokens" in event_metrics
         assert "cache_write_input_tokens" in event_metrics
 
-    def test_completion_anthropic_cache_1h_ttl(self, litellm, request_vcr, llmobs_events, test_spans, stream, n):
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+    def test_completion_anthropic_cache_1h_ttl(self, litellm, request_vcr, test_spans, stream, n):
         """Test that 1h cache TTL breakdown metrics are captured for Anthropic models via litellm."""
         if stream or n > 1:
             pytest.skip("Anthropic cassette is non-streamed, single-choice only")
@@ -562,20 +591,22 @@ class TestLLMObsLiteLLM:
         token_metrics["ephemeral_1h_input_tokens"] = 2056
         token_metrics["ephemeral_5m_input_tokens"] = 14
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="claude-sonnet-4-20250514",
             model_provider="anthropic",
             input_messages=mock.ANY,
             output_messages=output_messages,
             metadata={},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
-    def test_completion_with_reasoning(self, litellm, request_vcr, llmobs_events, test_spans, stream, n):
+    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+    def test_completion_with_reasoning(self, litellm, request_vcr, test_spans, stream, n):
         """Test that reasoning_content and reasoning_output_tokens are captured for models with reasoning."""
         if stream or n > 1:
             pytest.skip("Reasoning cassette is non-streamed, single-choice only")
@@ -588,25 +619,26 @@ class TestLLMObsLiteLLM:
             )
             output_messages, token_metrics = parse_response(resp)
 
-        span = test_spans.pop_traces()[0][0]
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-            span,
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="llm",
             model_name="o3-mini",
             model_provider="openai",
             input_messages=messages,
             output_messages=output_messages,
             metadata={},
-            token_metrics=token_metrics,
-            tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"},
+            metrics=token_metrics,
+            tags=LITELLM_TAGS,
         )
 
         # Verify reasoning output message is present
-        event_output = llmobs_events[0]["meta"]["output"]["messages"]
+        event_output = _get_llmobs_data_metastruct(spans[0])["meta"]["output"]["messages"]
         assert any(msg.get("role") == "reasoning" for msg in event_output)
 
         # Verify reasoning_output_tokens metric is present
-        event_metrics = llmobs_events[0]["metrics"]
+        event_metrics = _get_llmobs_data_metastruct(spans[0])["metrics"]
         assert "reasoning_output_tokens" in event_metrics
         assert event_metrics["reasoning_output_tokens"] == 15
 
@@ -614,8 +646,9 @@ class TestLLMObsLiteLLM:
 _OPENAI_ENABLED = "ddtrace.llmobs._integrations.litellm.LLMObs._integration_is_enabled"
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, llmobs_events, test_spans
+    litellm, request_vcr_include_localhost, test_spans
 ):
     """Regression: model='litellm_proxy/<gpt-model>' with OpenAI integration enabled must still produce LLMObs spans."""
     messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -627,14 +660,16 @@ def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
                 api_base="http://localhost:4000",
                 api_key="<not-a-real-key>",
             )
-    assert len(llmobs_events) == 1
-    event = llmobs_events[0]
-    assert event["meta"]["input"]["messages"] == messages
-    assert event["meta"]["output"]["messages"]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    data = _get_llmobs_data_metastruct(spans[0])
+    assert data["meta"]["input"]["messages"] == messages
+    assert data["meta"]["output"]["messages"]
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, llmobs_events, test_spans
+    litellm, request_vcr_include_localhost, test_spans
 ):
     """Regression: use_litellm_proxy=True with an OpenAI model name must still produce LLMObs spans."""
     messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -647,14 +682,16 @@ def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
                 api_key="<not-a-real-key>",
                 use_litellm_proxy=True,
             )
-    assert len(llmobs_events) == 1
-    event = llmobs_events[0]
-    assert event["meta"]["input"]["messages"] == messages
-    assert event["meta"]["output"]["messages"]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    data = _get_llmobs_data_metastruct(spans[0])
+    assert data["meta"]["input"]["messages"] == messages
+    assert data["meta"]["output"]["messages"]
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, llmobs_events, test_spans
+    litellm, request_vcr_include_localhost, test_spans
 ):
     """Regression: litellm.use_litellm_proxy = True with an OpenAI model name must still produce LLMObs spans."""
     messages = [{"content": "Hey, what is up?", "role": "user"}]
@@ -667,14 +704,16 @@ def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_ena
                     api_base="http://localhost:4000",
                     api_key="<not-a-real-key>",
                 )
-    assert len(llmobs_events) == 1
-    event = llmobs_events[0]
-    assert event["meta"]["input"]["messages"] == messages
-    assert event["meta"]["output"]["messages"]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    data = _get_llmobs_data_metastruct(spans[0])
+    assert data["meta"]["input"]["messages"] == messages
+    assert data["meta"]["output"]["messages"]
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled(
-    litellm, request_vcr_include_localhost, llmobs_events, test_spans, monkeypatch
+    litellm, request_vcr_include_localhost, test_spans, monkeypatch
 ):
     """Regression: USE_LITELLM_PROXY=true env var with an OpenAI model name must still produce LLMObs spans."""
     monkeypatch.setenv("USE_LITELLM_PROXY", "true")
@@ -687,10 +726,11 @@ def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled
                 api_base="http://localhost:4000",
                 api_key="<not-a-real-key>",
             )
-    assert len(llmobs_events) == 1
-    event = llmobs_events[0]
-    assert event["meta"]["input"]["messages"] == messages
-    assert event["meta"]["output"]["messages"]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    data = _get_llmobs_data_metastruct(spans[0])
+    assert data["meta"]["input"]["messages"] == messages
+    assert data["meta"]["output"]["messages"]
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -5,6 +5,10 @@ from ddtrace._monkey import patch
 from ddtrace.contrib.internal.litellm.patch import get_version
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_metrics
+from ddtrace.llmobs._utils import get_llmobs_output_messages
+from ddtrace.llmobs._utils import get_llmobs_span_kind
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.litellm.utils import async_consume_stream_aiter
 from tests.contrib.litellm.utils import async_consume_stream_anext
@@ -343,9 +347,8 @@ class TestLLMObsLiteLLM:
         llm_span = trace[1]
 
         # The downstream LLM span is an "llm" kind named "completion"
-        llm_data = _get_llmobs_data_metastruct(llm_span)
-        assert llm_data["meta"]["span"]["kind"] == "llm"
-        assert llm_data["name"] == "completion"
+        assert get_llmobs_span_kind(llm_span) == "llm"
+        assert get_llmobs_span_name(llm_span) == "completion"
 
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(router_span),
@@ -385,9 +388,8 @@ class TestLLMObsLiteLLM:
         router_span = trace[0]
         llm_span = trace[1]
 
-        llm_data = _get_llmobs_data_metastruct(llm_span)
-        assert llm_data["meta"]["span"]["kind"] == "llm"
-        assert llm_data["name"] == "acompletion"
+        assert get_llmobs_span_kind(llm_span) == "llm"
+        assert get_llmobs_span_name(llm_span) == "acompletion"
 
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(router_span),
@@ -427,9 +429,8 @@ class TestLLMObsLiteLLM:
         router_span = trace[0]
         llm_span = trace[1]
 
-        llm_data = _get_llmobs_data_metastruct(llm_span)
-        assert llm_data["meta"]["span"]["kind"] == "llm"
-        assert llm_data["name"] == "text_completion"
+        assert get_llmobs_span_kind(llm_span) == "llm"
+        assert get_llmobs_span_name(llm_span) == "text_completion"
 
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(router_span),
@@ -469,9 +470,8 @@ class TestLLMObsLiteLLM:
         router_span = trace[0]
         llm_span = trace[1]
 
-        llm_data = _get_llmobs_data_metastruct(llm_span)
-        assert llm_data["meta"]["span"]["kind"] == "llm"
-        assert llm_data["name"] == "atext_completion"
+        assert get_llmobs_span_kind(llm_span) == "llm"
+        assert get_llmobs_span_name(llm_span) == "atext_completion"
 
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(router_span),
@@ -509,7 +509,7 @@ class TestLLMObsLiteLLM:
         spans = [s for trace in test_spans.pop_traces() for s in trace]
         assert len(spans) == 1
         expected_name = "OpenAI.createChatCompletion" if not stream else "litellm.request"
-        assert _get_llmobs_data_metastruct(spans[0])["name"] == expected_name
+        assert get_llmobs_span_name(spans[0]) == expected_name
 
     @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     def test_completion_anthropic_token_metrics(self, litellm, request_vcr, test_spans, stream, n):
@@ -546,7 +546,7 @@ class TestLLMObsLiteLLM:
         )
 
         # Verify cache token metrics are present
-        event_metrics = _get_llmobs_data_metastruct(spans[0])["metrics"]
+        event_metrics = get_llmobs_metrics(spans[0])
         assert "cache_read_input_tokens" in event_metrics
         assert "cache_write_input_tokens" in event_metrics
 
@@ -634,11 +634,11 @@ class TestLLMObsLiteLLM:
         )
 
         # Verify reasoning output message is present
-        event_output = _get_llmobs_data_metastruct(spans[0])["meta"]["output"]["messages"]
+        event_output = get_llmobs_output_messages(spans[0])
         assert any(msg.get("role") == "reasoning" for msg in event_output)
 
         # Verify reasoning_output_tokens metric is present
-        event_metrics = _get_llmobs_data_metastruct(spans[0])["metrics"]
+        event_metrics = get_llmobs_metrics(spans[0])
         assert "reasoning_output_tokens" in event_metrics
         assert event_metrics["reasoning_output_tokens"] == 15
 

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -22,12 +22,6 @@ from tests.contrib.litellm.utils import tools
 from tests.llmobs._utils import assert_llmobs_span_data
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-)
 LITELLM_TAGS = {"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "integration": "litellm"}
 
 
@@ -41,7 +35,6 @@ LITELLM_TAGS = {"ml_app": "<ml-app-name>", "service": "tests.contrib.litellm", "
     ],
 )
 class TestLLMObsLiteLLM:
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
@@ -72,7 +65,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_exclude_usage(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n, False)):
@@ -103,7 +95,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_with_tools(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         if stream and n > 1:
@@ -152,7 +143,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_acompletion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
@@ -183,7 +173,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_text_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
@@ -214,7 +203,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_atext_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
@@ -247,7 +235,7 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.parametrize(
         "ddtrace_global_config",
-        [dict(LLMOBS_GLOBAL_CONFIG, _llmobs_instrumented_proxy_urls="http://localhost:4000")],
+        [{"_llmobs_instrumented_proxy_urls": "http://localhost:4000"}],
     )
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_proxy(
@@ -285,7 +273,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_base_url_set(
         self, litellm, request_vcr_include_localhost, litellm_llmobs, test_spans, stream, n, consume_stream
@@ -325,7 +312,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_router_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
@@ -365,7 +351,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_router_acompletion(
         self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
@@ -406,7 +391,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_router_text_completion(
         self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
@@ -447,7 +431,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [async_consume_stream_aiter, async_consume_stream_anext])
     async def test_router_atext_completion(
         self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
@@ -489,7 +472,6 @@ class TestLLMObsLiteLLM:
         )
 
     @pytest.mark.skip(reason="Patching Open AI to be used within the LiteLLM library appears to be flaky")
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
     def test_completion_openai_enabled(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
@@ -512,7 +494,6 @@ class TestLLMObsLiteLLM:
         expected_name = "OpenAI.createChatCompletion" if not stream else "litellm.request"
         assert get_llmobs_span_name(spans[0]) == expected_name
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     def test_completion_anthropic_token_metrics(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n):
         """Test that cache token metrics (cache_read, cache_write) are captured for Anthropic models via litellm."""
         if stream or n > 1:
@@ -551,7 +532,6 @@ class TestLLMObsLiteLLM:
         assert "cache_read_input_tokens" in event_metrics
         assert "cache_write_input_tokens" in event_metrics
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     def test_completion_anthropic_cache_1h_ttl(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n):
         """Test that 1h cache TTL breakdown metrics are captured for Anthropic models via litellm."""
         if stream or n > 1:
@@ -606,7 +586,6 @@ class TestLLMObsLiteLLM:
             tags=LITELLM_TAGS,
         )
 
-    @pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
     def test_completion_with_reasoning(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n):
         """Test that reasoning_content and reasoning_output_tokens are captured for models with reasoning."""
         if stream or n > 1:
@@ -647,7 +626,6 @@ class TestLLMObsLiteLLM:
 _OPENAI_ENABLED = "ddtrace.llmobs._integrations.litellm.LLMObs._integration_is_enabled"
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
     litellm, request_vcr_include_localhost, litellm_llmobs, test_spans
 ):
@@ -667,7 +645,6 @@ def test_completion_litellm_proxy_model_not_suppressed_when_openai_enabled(
     assert get_llmobs_output_messages(spans[0])
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
     litellm, request_vcr_include_localhost, litellm_llmobs, test_spans
 ):
@@ -688,7 +665,6 @@ def test_completion_use_litellm_proxy_kwarg_not_suppressed_when_openai_enabled(
     assert get_llmobs_output_messages(spans[0])
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_enabled(
     litellm, request_vcr_include_localhost, litellm_llmobs, test_spans
 ):
@@ -709,7 +685,6 @@ def test_completion_use_litellm_proxy_module_flag_not_suppressed_when_openai_ena
     assert get_llmobs_output_messages(spans[0])
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled(
     litellm, request_vcr_include_localhost, litellm_llmobs, test_spans, monkeypatch
 ):

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -66,7 +66,9 @@ class TestLLMObsLiteLLM:
         )
 
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_exclude_usage(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
+    def test_completion_exclude_usage(
+        self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream
+    ):
         with request_vcr.use_cassette(get_cassette_name(stream, n, False)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = litellm.completion(
@@ -313,7 +315,9 @@ class TestLLMObsLiteLLM:
         )
 
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_router_completion(self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream):
+    def test_router_completion(
+        self, litellm, request_vcr, litellm_llmobs, test_spans, router, stream, n, consume_stream
+    ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             messages = [{"content": "Hey, what is up?", "role": "user"}]
             resp = router.completion(
@@ -473,7 +477,9 @@ class TestLLMObsLiteLLM:
 
     @pytest.mark.skip(reason="Patching Open AI to be used within the LiteLLM library appears to be flaky")
     @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-    def test_completion_openai_enabled(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
+    def test_completion_openai_enabled(
+        self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream
+    ):
         with request_vcr.use_cassette(get_cassette_name(stream, n)):
             patch(openai=True)
 


### PR DESCRIPTION
Migrates litellm LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `litellm_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
