### PR TITLE
test(llmobs): migrate langchain tests to assert on LLMObsSpanData

### DIFF
--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -26,31 +26,27 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    """Override of the shared ``test_spans`` fixture that, when LLMObs is enabled
-    via ``ddtrace_global_config``, sets ``_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`` so
-    ``meta_struct["_llmobs"]`` is preserved on spans for assertion via
-    ``_get_llmobs_data_metastruct``. The langchain integration also needs the
-    instrumented-proxy-URL config in place at ``LLMObs.enable()`` time, so the
-    override is applied via ``override_global_config`` here.
+def langchain_llmobs(tracer, monkeypatch):
+    """Enable LLMObs with langchain-specific config (instrumented proxy URLs).
+
+    The langchain integration reads ``_llmobs_instrumented_proxy_urls`` to
+    decide whether a request goes through an instrumented proxy
+    (-> workflow span) or directly to the model (-> llm span).
     """
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                LLMObs.disable()
-                LLMObs.enable(
-                    _tracer=test_spans.tracer,
-                    ml_app="langchain_test",
-                    integrations_enabled=False,
-                )
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_dd_api_key": "<not-a-real-key>",
+            "_llmobs_sample_rate": 1.0,
+            "_llmobs_instrumented_proxy_urls": "http://localhost:4000",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, ml_app="langchain_test", integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 # scoping this fixture to "module" overcomes issues with patching ABC embeddings/vectorstore classes

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -38,7 +38,6 @@ def langchain_llmobs(tracer, monkeypatch):
     with override_global_config(
         {
             "_dd_api_key": "<not-a-real-key>",
-            "_llmobs_sample_rate": 1.0,
             "_llmobs_instrumented_proxy_urls": "http://localhost:4000",
         }
     ):

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -1,13 +1,13 @@
 import importlib
 import os
+from unittest import mock
 
 import pytest
 
 from ddtrace.contrib.internal.langchain.patch import patch as langchain_core_patch
 from ddtrace.contrib.internal.langchain.patch import unpatch as langchain_core_unpatch
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.llmobs import LLMObs as llmobs_service
-from tests.llmobs._utils import TestLLMObsSpanWriter
+from ddtrace.llmobs import LLMObs
 from tests.utils import override_env
 from tests.utils import override_global_config
 
@@ -21,27 +21,36 @@ def llmobs_env():
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs(
-    tracer,
-    llmobs_span_writer,
-):
-    with override_global_config(
-        dict(_dd_api_key="<not-a-real-key>", _llmobs_instrumented_proxy_urls="http://localhost:4000")
-    ):
-        llmobs_service.enable(_tracer=tracer, ml_app="langchain_test", integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-        llmobs_service.disable()
-
-
-@pytest.fixture
-def llmobs_events(llmobs, llmobs_span_writer):
-    yield llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    """Override of the shared ``test_spans`` fixture that, when LLMObs is enabled
+    via ``ddtrace_global_config``, sets ``_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`` so
+    ``meta_struct["_llmobs"]`` is preserved on spans for assertion via
+    ``_get_llmobs_data_metastruct``. The langchain integration also needs the
+    instrumented-proxy-URL config in place at ``LLMObs.enable()`` time, so the
+    override is applied via ``override_global_config`` here.
+    """
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                LLMObs.disable()
+                LLMObs.enable(
+                    _tracer=test_spans.tracer,
+                    ml_app="langchain_test",
+                    integrations_enabled=False,
+                )
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 # scoping this fixture to "module" overcomes issues with patching ABC embeddings/vectorstore classes

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -13,19 +13,6 @@ from tests.utils import override_global_config
 
 
 @pytest.fixture
-def llmobs_env():
-    return {
-        "DD_API_KEY": "<default-not-a-real-key>",
-        "DD_LLMOBS_ML_APP": "unnamed-ml-app",
-    }
-
-
-@pytest.fixture
-def ddtrace_global_config():
-    return {}
-
-
-@pytest.fixture
 def langchain_llmobs(tracer, monkeypatch):
     """Enable LLMObs with langchain-specific config (instrumented proxy URLs).
 

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -80,7 +80,7 @@ def _create_multi_message_prompt_template(langchain_core, metadata=None):
     return template
 
 
-def _llm_span_kwargs(span, input_role=None, mock_io=False, mock_token_metrics=False, metadata=None):
+def _expected_llm_span_data(span, input_role=None, mock_io=False, mock_token_metrics=False, metadata=None):
     """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain LLM span.
 
     Mirrors the structural shape produced by the legacy
@@ -112,7 +112,7 @@ def _llm_span_kwargs(span, input_role=None, mock_io=False, mock_token_metrics=Fa
     )
 
 
-def _chain_span_kwargs(input_value=None, output_value=None, metadata=None):
+def _expected_chain_span_data(input_value=None, output_value=None, metadata=None):
     """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain chain (workflow) span."""
     metadata = metadata if metadata else mock.ANY
     return dict(
@@ -149,7 +149,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_llm_span_kwargs(spans[0], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+            **_expected_llm_span_data(spans[0], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
         )
 
     @mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
@@ -162,7 +162,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)
             ),
         )
@@ -182,7 +182,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_llm_span_kwargs(
+            **_expected_llm_span_data(
                 spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0, "max_tokens": 256}
             ),
         )
@@ -219,7 +219,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
                 metadata={"temperature": 0.0, "max_tokens": 256},
             ),
@@ -435,13 +435,13 @@ class TestLangChainLLMObs:
         assert len(spans) == 2
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
             ),
         )
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[1]),
-            **_llm_span_kwargs(spans[1], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+            **_expected_llm_span_data(spans[1], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
         )
         expected_prompt = {
             "id": "test_langchain_llmobs.prompt",
@@ -476,14 +476,14 @@ class TestLangChainLLMObs:
 
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
                 output_value=mock.ANY,
             ),
         )
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[1]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
                 output_value=mock.ANY,
             ),
@@ -496,7 +496,7 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
         assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[3]), **_llm_span_kwargs(spans[3], mock_token_metrics=True)
+            _get_llmobs_data_metastruct(spans[3]), **_expected_llm_span_data(spans[3], mock_token_metrics=True)
         )
         expected_prompt_3 = {
             "id": "langchain.unknown_prompt_template",
@@ -509,7 +509,7 @@ class TestLangChainLLMObs:
         assert get_llmobs_input_prompt(spans[3]) == expected_prompt_3
 
         assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[4]), **_llm_span_kwargs(spans[4], mock_token_metrics=True)
+            _get_llmobs_data_metastruct(spans[4]), **_expected_llm_span_data(spans[4], mock_token_metrics=True)
         )
         expected_prompt_4 = {
             "id": "test_langchain_llmobs.prompt2",
@@ -534,7 +534,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 3
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY),
+            **_expected_chain_span_data(input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY),
         )
 
         # The two LLM spans (one per batch item) can come back in either order; check by
@@ -542,7 +542,7 @@ class TestLangChainLLMObs:
         for child in spans[1:3]:
             assert_llmobs_span_data(
                 _get_llmobs_data_metastruct(child),
-                **_llm_span_kwargs(child, input_role="user", mock_token_metrics=True),
+                **_expected_llm_span_data(child, input_role="user", mock_token_metrics=True),
             )
             prompt_block = get_llmobs_input_prompt(child)
             assert prompt_block["id"] == "langchain.unknown_prompt_template"
@@ -575,7 +575,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 2
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps(
                     [
                         {
@@ -591,7 +591,7 @@ class TestLangChainLLMObs:
         )
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[1]),
-            **_llm_span_kwargs(spans[1], mock_io=True, mock_token_metrics=True),
+            **_expected_llm_span_data(spans[1], mock_io=True, mock_token_metrics=True),
         )
 
     def test_llmobs_anthropic_chat_model(self, langchain_anthropic, langchain_llmobs, test_spans, anthropic_url):
@@ -613,7 +613,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_llm_span_kwargs(
+            **_expected_llm_span_data(
                 spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0, "max_tokens": 15}
             ),
         )
@@ -658,7 +658,7 @@ class TestLangChainLLMObs:
         assert span.get_tag("langchain.request.model") == "gemini-2.5-flash"
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(span),
-            **_llm_span_kwargs(span, input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0}),
+            **_expected_llm_span_data(span, input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0}),
         )
 
     def test_llmobs_embedding_documents(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
@@ -803,7 +803,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 2
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
+            **_expected_chain_span_data(
                 input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
                 output_value=mock.ANY,
             ),

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -19,6 +19,7 @@ from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.llmobs._utils import get_llmobs_span_name
+from ddtrace.llmobs._utils import get_llmobs_tags
 from ddtrace.trace import Span
 from tests.contrib.langchain.utils import mock_langchain_chat_generate_response
 from tests.contrib.langchain.utils import mock_langchain_llm_generate_response
@@ -122,14 +123,6 @@ def _expected_chain_span_data(input_value=None, output_value=None, metadata=None
         metadata=metadata,
         tags=COMMON_TAGS,
     )
-
-
-def _has_prompt_tracking_tag(metastruct):
-    """Return True if the prompt-tracking tag is present (handles dict-shape and list-shape tags)."""
-    tags = metastruct.get("tags") or {}
-    if isinstance(tags, dict):
-        return tags.get("prompt_tracking_instrumentation_method") == "auto"
-    return any(t == "prompt_tracking_instrumentation_method:auto" for t in tags)
 
 
 def _llmobs_spans(test_spans):
@@ -254,7 +247,7 @@ class TestLangChainLLMObs:
         assert actual_prompt["variables"] == variable_dict
         assert "tags" in actual_prompt
         assert actual_prompt["tags"] == {"test_type": "basic_invoke", "author": "test_suite"}
-        assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[1]))
+        assert get_llmobs_tags(spans[1]).get("prompt_tracking_instrumentation_method") == "auto"
 
     def test_llmobs_string_prompt_template_direct_invoke(
         self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
@@ -287,7 +280,7 @@ class TestLangChainLLMObs:
         assert actual_prompt["variables"] == variable_dict
         assert "tags" in actual_prompt
         assert actual_prompt["tags"] == {"test_type": "direct_invoke", "interaction": "greeting"}
-        assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[0]))
+        assert get_llmobs_tags(spans[0]).get("prompt_tracking_instrumentation_method") == "auto"
 
     def test_llmobs_string_prompt_template_invoke_chat_model(
         self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -422,10 +422,12 @@ def test_llmobs_chain(langchain_core, langchain_openai, openai_url, langchain_ll
         input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[0]).get("span_links")
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
         **_expected_llm_span_data(spans[1], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
     )
+    assert _get_llmobs_data_metastruct(spans[1]).get("span_links")
     expected_prompt = {
         "id": "test_langchain_llmobs.prompt",
         "ml_app": "langchain_test",
@@ -464,12 +466,14 @@ def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, langc
         input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[0]).get("span_links")
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
         span_kind="workflow",
         input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[1]).get("span_links")
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[2]),
         span_kind="task",
@@ -477,9 +481,11 @@ def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, langc
         output_value="Spanish",
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[2]).get("span_links")
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[3]), **_expected_llm_span_data(spans[3], mock_token_metrics=True)
     )
+    assert _get_llmobs_data_metastruct(spans[3]).get("span_links")
     expected_prompt_3 = {
         "id": "langchain.unknown_prompt_template",
         "ml_app": "langchain_test",
@@ -493,6 +499,7 @@ def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, langc
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[4]), **_expected_llm_span_data(spans[4], mock_token_metrics=True)
     )
+    assert _get_llmobs_data_metastruct(spans[4]).get("span_links")
     expected_prompt_4 = {
         "id": "test_langchain_llmobs.prompt2",
         "ml_app": "langchain_test",
@@ -521,6 +528,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, langchain_llmobs, 
         input_value=json.dumps(["chickens", "pigs"], sort_keys=True),
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[0]).get("span_links")
 
     # The two LLM spans (one per batch item) can come back in either order; check by
     # matching the variables.topic in each span's prompt block.
@@ -529,6 +537,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, langchain_llmobs, 
             _get_llmobs_data_metastruct(child),
             **_expected_llm_span_data(child, input_role="user", mock_token_metrics=True),
         )
+        assert _get_llmobs_data_metastruct(child).get("span_links")
         prompt_block = get_llmobs_input_prompt(child)
         assert prompt_block["id"] == "langchain.unknown_prompt_template"
         assert prompt_block["ml_app"] == "langchain_test"
@@ -576,10 +585,12 @@ def test_llmobs_chain_schema_io(langchain_core, langchain_openai, openai_url, la
         output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[0]).get("span_links")
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
         **_expected_llm_span_data(spans[1], mock_io=True, mock_token_metrics=True),
     )
+    assert _get_llmobs_data_metastruct(spans[1]).get("span_links")
 
 
 def test_llmobs_anthropic_chat_model(langchain_anthropic, langchain_llmobs, test_spans, anthropic_url):
@@ -701,6 +712,7 @@ def test_llmobs_vectorstore_similarity_search(langchain_in_memory_vectorstore, l
         output_value="[1 document(s) retrieved]",
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[0]).get("span_links")
 
 
 def test_llmobs_chat_model_tool_calls(langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
@@ -802,6 +814,7 @@ def test_llmobs_streamed_chain(
         input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[0]).get("span_links")
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
         span_kind="llm",
@@ -816,6 +829,7 @@ def test_llmobs_streamed_chain(
         metrics={},
         tags=COMMON_TAGS,
     )
+    assert _get_llmobs_data_metastruct(spans[1]).get("span_links")
 
 
 @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -11,6 +11,9 @@ from ddtrace import patch
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_prompt
+from ddtrace.llmobs._utils import get_llmobs_metrics
+from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.trace import Span
 from tests.contrib.langchain.utils import mock_langchain_chat_generate_response
 from tests.contrib.langchain.utils import mock_langchain_llm_generate_response
@@ -176,7 +179,7 @@ class TestLangChainLLMObs:
         llm.invoke("What is the capital of France?")
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
+        assert get_llmobs_span_kind(spans[0]) == "llm"
 
 
     def test_llmobs_openai_chat_model(self, langchain_core, langchain_openai, test_spans, openai_url):
@@ -206,7 +209,7 @@ class TestLangChainLLMObs:
 
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1
-        metrics = _get_llmobs_data_metastruct(spans[0]).get("metrics") or {}
+        metrics = get_llmobs_metrics(spans[0]) or {}
         assert metrics.get("input_tokens") is None
         assert metrics.get("output_tokens") is None
         assert metrics.get("total_tokens") is None
@@ -233,7 +236,7 @@ class TestLangChainLLMObs:
         chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1
-        assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
+        assert get_llmobs_span_kind(spans[0]) == "llm"
 
 
     def test_llmobs_string_prompt_template_invoke(self, langchain_core, langchain_openai, openai_url, test_spans):
@@ -250,7 +253,7 @@ class TestLangChainLLMObs:
 
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 2
-        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[1])
         assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
         assert actual_prompt["template"] == template_string
         assert actual_prompt["variables"] == variable_dict
@@ -277,7 +280,7 @@ class TestLangChainLLMObs:
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1  # Only LLM span, prompt template invoke doesn't create LLMObs event by itself
 
-        actual_prompt = _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[0])
         assert actual_prompt["id"] == "test_langchain_llmobs.greeting_template"
         assert actual_prompt["template"] == template_string
         assert actual_prompt["variables"] == variable_dict
@@ -298,7 +301,7 @@ class TestLangChainLLMObs:
 
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 2
-        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[1])
         assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
         assert actual_prompt["template"] == template_string
         assert actual_prompt["variables"] == variable_dict
@@ -320,7 +323,7 @@ class TestLangChainLLMObs:
 
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 2
-        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[1])
         assert actual_prompt["id"] == "test_langchain_llmobs.single_variable_template"
         assert actual_prompt["template"] == template_string
         # Should convert string input to dict format with single variable
@@ -349,7 +352,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 2
 
         # Verify the prompt structure in the LLM span
-        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[1])
         assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
         assert actual_prompt["variables"] == variable_dict
         assert actual_prompt.get("template") is None
@@ -383,7 +386,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1  # Only LLM span for direct invoke
 
         # Verify the prompt structure
-        actual_prompt = _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[0])
         assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
         assert actual_prompt["variables"] == variable_dict
         assert actual_prompt.get("template") is None
@@ -415,7 +418,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 1  # Only LLM span for direct invoke
 
         # Verify the prompt structure
-        actual_prompt = _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["prompt"]
+        actual_prompt = get_llmobs_input_prompt(spans[0])
         assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
         assert actual_prompt["variables"] == variable_dict
         assert actual_prompt.get("template") is None
@@ -452,7 +455,7 @@ class TestLangChainLLMObs:
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
         }
-        assert _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"] == expected_prompt
+        assert get_llmobs_input_prompt(spans[1]) == expected_prompt
 
 
     def test_llmobs_chain_nested(self, langchain_core, langchain_openai, openai_url, test_spans):
@@ -505,7 +508,7 @@ class TestLangChainLLMObs:
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
         }
-        assert _get_llmobs_data_metastruct(spans[3])["meta"]["input"]["prompt"] == expected_prompt_3
+        assert get_llmobs_input_prompt(spans[3]) == expected_prompt_3
 
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[4]), **_llm_span_kwargs(spans[4], mock_token_metrics=True)
@@ -518,7 +521,7 @@ class TestLangChainLLMObs:
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
         }
-        assert _get_llmobs_data_metastruct(spans[4])["meta"]["input"]["prompt"] == expected_prompt_4
+        assert get_llmobs_input_prompt(spans[4]) == expected_prompt_4
 
 
     @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
@@ -546,7 +549,7 @@ class TestLangChainLLMObs:
                 _get_llmobs_data_metastruct(child),
                 **_llm_span_kwargs(child, input_role="user", mock_token_metrics=True),
             )
-            prompt_block = _get_llmobs_data_metastruct(child)["meta"]["input"]["prompt"]
+            prompt_block = get_llmobs_input_prompt(child)
             assert prompt_block["id"] == "langchain.unknown_prompt_template"
             assert prompt_block["ml_app"] == "langchain_test"
             assert prompt_block["chat_template"] == [{"content": "Tell me a short joke about {topic}", "role": "user"}]

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -133,884 +133,909 @@ def _llmobs_spans(test_spans):
     return spans
 
 
-class TestLangChainLLMObs:
-    def test_llmobs_openai_llm(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
-        llm = langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
-        llm.invoke("Can you explain what Descartes meant by 'I think, therefore I am'?")
+def test_llmobs_openai_llm(langchain_openai, langchain_llmobs, test_spans, openai_url):
+    llm = langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
+    llm.invoke("Can you explain what Descartes meant by 'I think, therefore I am'?")
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_llm_span_data(spans[0], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+    )
+
+
+@mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
+def test_llmobs_openai_llm_proxy(mock_generate, langchain_openai, langchain_llmobs, test_spans):
+    mock_generate.return_value = mock_langchain_llm_generate_response
+    llm = langchain_openai.OpenAI(base_url="http://localhost:4000", model="gpt-3.5-turbo")
+    llm.invoke("What is the capital of France?")
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)
+        ),
+    )
+
+    # span created from request with non-proxy URL should result in an LLM span
+    llm = langchain_openai.OpenAI(base_url="http://localhost:8000", model="gpt-3.5-turbo")
+    llm.invoke("What is the capital of France?")
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert get_llmobs_span_kind(spans[0]) == "llm"
+
+
+def test_llmobs_openai_chat_model(langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
+    chat_model.invoke([langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")])
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_llm_span_data(
+            spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0, "max_tokens": 256}
+        ),
+    )
+
+
+def test_llmobs_openai_chat_model_no_usage(langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
+    if parse_version(importlib.metadata.version("langchain_openai")) < (0, 2, 0):
+        pytest.skip("langchain-openai <0.2.0 does not support stream_usage=False")
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url, stream_usage=False)
+
+    response = chat_model.stream(
+        [langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")]
+    )
+    for _ in response:
+        pass
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    metrics = get_llmobs_metrics(spans[0]) or {}
+    assert metrics.get("input_tokens") is None
+    assert metrics.get("output_tokens") is None
+    assert metrics.get("total_tokens") is None
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_openai_chat_model_proxy(mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans):
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
+    chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
+            metadata={"temperature": 0.0, "max_tokens": 256},
+        ),
+    )
+
+    # span created from request with non-proxy URL should result in an LLM span
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:8000")
+    chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert get_llmobs_span_kind(spans[0]) == "llm"
+
+
+def test_llmobs_string_prompt_template_invoke(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    template_string = "You are a helpful assistant. Please answer this question: {question}"
+    variable_dict = {"question": "What is machine learning?"}
+    prompt_template = langchain_core.prompts.PromptTemplate(
+        input_variables=list(variable_dict.keys()),
+        template=template_string,
+        metadata={"test_type": "basic_invoke", "author": "test_suite"},
+    )
+    llm = langchain_openai.OpenAI(base_url=openai_url)
+    chain = prompt_template | llm
+    chain.invoke(variable_dict)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    actual_prompt = get_llmobs_input_prompt(spans[1])
+    assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
+    assert actual_prompt["template"] == template_string
+    assert actual_prompt["variables"] == variable_dict
+    assert "tags" in actual_prompt
+    assert actual_prompt["tags"] == {"test_type": "basic_invoke", "author": "test_suite"}
+    assert get_llmobs_tags(spans[1]).get("prompt_tracking_instrumentation_method") == "auto"
+
+
+def test_llmobs_string_prompt_template_direct_invoke(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    """Test StringPromptTemplate (PromptTemplate) with variable name detection using direct invoke (no chains)."""
+    template_string = "Good {time_of_day}, {name}! How are you doing today?"
+    variable_dict = {"name": "Alice", "time_of_day": "morning"}
+    greeting_template = langchain_core.prompts.PromptTemplate(
+        input_variables=list(variable_dict.keys()),
+        template=template_string,
+        metadata={
+            "test_type": "direct_invoke",
+            "interaction": "greeting",
+            "not_string_1": True,
+            "not_string_2": 10,
+        },
+    )
+    llm = langchain_openai.OpenAI(base_url=openai_url)
+
+    # Direct invoke on template first, then pass to LLM (no chain)
+    prompt_value = greeting_template.invoke(variable_dict)
+    llm.invoke(prompt_value)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1  # Only LLM span, prompt template invoke doesn't create LLMObs event by itself
+
+    actual_prompt = get_llmobs_input_prompt(spans[0])
+    assert actual_prompt["id"] == "test_langchain_llmobs.greeting_template"
+    assert actual_prompt["template"] == template_string
+    assert actual_prompt["variables"] == variable_dict
+    assert "tags" in actual_prompt
+    assert actual_prompt["tags"] == {"test_type": "direct_invoke", "interaction": "greeting"}
+    assert get_llmobs_tags(spans[0]).get("prompt_tracking_instrumentation_method") == "auto"
+
+
+def test_llmobs_string_prompt_template_invoke_chat_model(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    template_string = "You are a helpful assistant. Please answer this question: {question}"
+    variable_dict = {"question": "What is machine learning?"}
+    prompt_template = langchain_core.prompts.PromptTemplate(
+        input_variables=list(variable_dict.keys()), template=template_string
+    )
+    chat_model = langchain_openai.ChatOpenAI(base_url=openai_url)
+    chain = prompt_template | chat_model
+    chain.invoke(variable_dict)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    actual_prompt = get_llmobs_input_prompt(spans[1])
+    assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
+    assert actual_prompt["template"] == template_string
+    assert actual_prompt["variables"] == variable_dict
+
+
+def test_llmobs_string_prompt_template_single_variable_string_input(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    template_string = "Write a creative story about {topic}."
+    single_variable_template = langchain_core.prompts.PromptTemplate(
+        input_variables=["topic"], template=template_string
+    )
+    llm = langchain_openai.OpenAI(base_url=openai_url)
+    chain = single_variable_template | llm
+
+    # Pass string input directly instead of dict for single variable template
+    string_input = "time travel"
+    chain.invoke(string_input)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    actual_prompt = get_llmobs_input_prompt(spans[1])
+    assert actual_prompt["id"] == "test_langchain_llmobs.single_variable_template"
+    assert actual_prompt["template"] == template_string
+    # Should convert string input to dict format with single variable
+    assert actual_prompt["variables"] == {"topic": "time travel"}
+
+
+def test_llmobs_multi_message_prompt_template_sync_chain(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    test_metadata = {"template_type": "multi_message", "test_scenario": "sync_chain", "message_count": 10}
+    multi_message_template = _create_multi_message_prompt_template(langchain_core, metadata=test_metadata)
+    llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+    chain = multi_message_template | llm
+
+    variable_dict = {
+        "domain": "creative writing",
+        "context": "focus on storytelling",
+        "task": "writing a short story",
+        "specific_help": "character development",
+        "output_type": "guidance",
+        "style": "engaging",
+        "limit": "100",
+    }
+
+    chain.invoke(variable_dict)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+
+    # Verify the prompt structure in the LLM span
+    actual_prompt = get_llmobs_input_prompt(spans[1])
+    assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
+    assert actual_prompt["variables"] == variable_dict
+    assert actual_prompt.get("template") is None
+    assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+    # Check that metadata from the multi-message prompt template is preserved
+    assert "tags" in actual_prompt
+    assert actual_prompt["tags"] == {k: v for k, v in test_metadata.items() if isinstance(v, str)}
+
+
+def test_llmobs_multi_message_prompt_template_sync_direct_invoke(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    multi_message_template = _create_multi_message_prompt_template(langchain_core)
+    llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+
+    variable_dict = {
+        "domain": "data analysis",
+        "context": "focus on accuracy",
+        "task": "analyzing datasets",
+        "specific_help": "statistical methods",
+        "output_type": "insights",
+        "style": "detailed",
+        "limit": "150",
+    }
+
+    # Test direct invoke on template then LLM (no chain)
+    prompt_value = multi_message_template.invoke(variable_dict)
+    llm.invoke(prompt_value)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1  # Only LLM span for direct invoke
+
+    # Verify the prompt structure
+    actual_prompt = get_llmobs_input_prompt(spans[0])
+    assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
+    assert actual_prompt["variables"] == variable_dict
+    assert actual_prompt.get("template") is None
+    assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+
+
+@pytest.mark.asyncio
+async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
+    langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+):
+    multi_message_template = _create_multi_message_prompt_template(langchain_core)
+    llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+
+    variable_dict = {
+        "domain": "software engineering",
+        "context": "focus on best practices",
+        "task": "code review",
+        "specific_help": "performance optimization",
+        "output_type": "recommendations",
+        "style": "thorough",
+        "limit": "200",
+    }
+
+    # Test direct async invoke on template then LLM
+    prompt_value = await multi_message_template.ainvoke(variable_dict)
+    await llm.ainvoke(prompt_value)
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1  # Only LLM span for direct invoke
+
+    # Verify the prompt structure
+    actual_prompt = get_llmobs_input_prompt(spans[0])
+    assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
+    assert actual_prompt["variables"] == variable_dict
+    assert actual_prompt.get("template") is None
+    assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+
+
+def test_llmobs_chain(langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+        [("system", "You are world class technical documentation writer."), ("user", "{input}")]
+    )
+    chain = prompt | langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
+    chain.invoke({"input": "Can you explain what an LLM chain is?"})
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
+        ),
+    )
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[1]),
+        **_expected_llm_span_data(spans[1], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+    )
+    expected_prompt = {
+        "id": "test_langchain_llmobs.prompt",
+        "ml_app": "langchain_test",
+        "chat_template": [
+            {"content": "You are world class technical documentation writer.", "role": "system"},
+            {"content": "{input}", "role": "user"},
+        ],
+        "variables": {"input": "Can you explain what an LLM chain is?"},
+        "_dd_context_variable_keys": ["context"],
+        "_dd_query_variable_keys": ["question"],
+    }
+    assert get_llmobs_input_prompt(spans[1]) == expected_prompt
+
+
+def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    prompt1 = langchain_core.prompts.ChatPromptTemplate.from_template("what is the city {person} is from?")
+    prompt2 = langchain_core.prompts.ChatPromptTemplate.from_template(
+        "what country is the city {city} in? respond in {language}"
+    )
+    model = langchain_openai.OpenAI(base_url=openai_url)
+    chain1 = prompt1 | model | langchain_core.output_parsers.StrOutputParser()
+    chain2 = prompt2 | model | langchain_core.output_parsers.StrOutputParser()
+    complete_chain = {"city": chain1, "language": itemgetter("language")} | chain2
+
+    complete_chain.invoke({"person": "Spongebob Squarepants", "language": "Spanish"})
+
+    # Use the APM trace (parent-first ordering) directly; the legacy test indexed by
+    # ``trace[i]`` here, and that maps 1:1 to the LLMObs spans on the same Spans.
+    trace = test_spans.pop_traces()[0]
+    spans = [s for s in trace if _get_llmobs_data_metastruct(s)]
+    assert len(spans) == 5
+
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
+            output_value=mock.ANY,
+        ),
+    )
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[1]),
+        **_expected_chain_span_data(
+            input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
+            output_value=mock.ANY,
+        ),
+    )
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[2]),
+        span_kind="task",
+        input_value=json.dumps({"person": "Spongebob Squarepants", "language": "Spanish"}, sort_keys=True),
+        output_value="Spanish",
+        tags=COMMON_TAGS,
+    )
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[3]), **_expected_llm_span_data(spans[3], mock_token_metrics=True)
+    )
+    expected_prompt_3 = {
+        "id": "langchain.unknown_prompt_template",
+        "ml_app": "langchain_test",
+        "chat_template": [{"content": "what is the city {person} is from?", "role": "user"}],
+        "variables": {"person": "Spongebob Squarepants", "language": "Spanish"},
+        "_dd_context_variable_keys": ["context"],
+        "_dd_query_variable_keys": ["question"],
+    }
+    assert get_llmobs_input_prompt(spans[3]) == expected_prompt_3
+
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[4]), **_expected_llm_span_data(spans[4], mock_token_metrics=True)
+    )
+    expected_prompt_4 = {
+        "id": "test_langchain_llmobs.prompt2",
+        "ml_app": "langchain_test",
+        "chat_template": [{"content": "what country is the city {city} in? respond in {language}", "role": "user"}],
+        "variables": {"city": mock.ANY, "language": "Spanish"},
+        "_dd_context_variable_keys": ["context"],
+        "_dd_query_variable_keys": ["question"],
+    }
+    assert get_llmobs_input_prompt(spans[4]) == expected_prompt_4
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
+def test_llmobs_chain_batch(langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
+    prompt = langchain_core.prompts.ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
+    output_parser = langchain_core.output_parsers.StrOutputParser()
+    model = langchain_openai.ChatOpenAI(base_url=openai_url)
+    chain = {"topic": langchain_core.runnables.RunnablePassthrough()} | prompt | model | output_parser
+
+    chain.batch(inputs=["chickens", "pigs"])
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 3
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY
+        ),
+    )
+
+    # The two LLM spans (one per batch item) can come back in either order; check by
+    # matching the variables.topic in each span's prompt block.
+    for child in spans[1:3]:
         assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_llm_span_data(spans[0], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+            _get_llmobs_data_metastruct(child),
+            **_expected_llm_span_data(child, input_role="user", mock_token_metrics=True),
         )
+        prompt_block = get_llmobs_input_prompt(child)
+        assert prompt_block["id"] == "langchain.unknown_prompt_template"
+        assert prompt_block["ml_app"] == "langchain_test"
+        assert prompt_block["chat_template"] == [{"content": "Tell me a short joke about {topic}", "role": "user"}]
+        assert prompt_block["variables"]["topic"] in ("chickens", "pigs")
 
-    @mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
-    def test_llmobs_openai_llm_proxy(self, mock_generate, langchain_openai, langchain_llmobs, test_spans):
-        mock_generate.return_value = mock_langchain_llm_generate_response
-        llm = langchain_openai.OpenAI(base_url="http://localhost:4000", model="gpt-3.5-turbo")
-        llm.invoke("What is the capital of France?")
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(
-                input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)
-            ),
-        )
+def test_llmobs_chain_schema_io(langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+        [
+            ("system", "You're an assistant who's good at {ability}. Respond in 20 words or fewer"),
+            langchain_core.prompts.MessagesPlaceholder(variable_name="history"),
+            ("human", "{input}"),
+        ]
+    )
+    chain = prompt | langchain_openai.ChatOpenAI(base_url=openai_url)
 
-        # span created from request with non-proxy URL should result in an LLM span
-        llm = langchain_openai.OpenAI(base_url="http://localhost:8000", model="gpt-3.5-turbo")
-        llm.invoke("What is the capital of France?")
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert get_llmobs_span_kind(spans[0]) == "llm"
-
-    def test_llmobs_openai_chat_model(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
-        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
-        chat_model.invoke([langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")])
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_llm_span_data(
-                spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0, "max_tokens": 256}
-            ),
-        )
-
-    def test_llmobs_openai_chat_model_no_usage(
-        self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url
-    ):
-        if parse_version(importlib.metadata.version("langchain_openai")) < (0, 2, 0):
-            pytest.skip("langchain-openai <0.2.0 does not support stream_usage=False")
-        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url, stream_usage=False)
-
-        response = chat_model.stream(
-            [langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")]
-        )
-        for _ in response:
-            pass
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        metrics = get_llmobs_metrics(spans[0]) or {}
-        assert metrics.get("input_tokens") is None
-        assert metrics.get("output_tokens") is None
-        assert metrics.get("total_tokens") is None
-
-    @mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
-    def test_llmobs_openai_chat_model_proxy(
-        self, mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
-    ):
-        mock_generate.return_value = mock_langchain_chat_generate_response
-        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
-        chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(
-                input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
-                metadata={"temperature": 0.0, "max_tokens": 256},
-            ),
-        )
-
-        # span created from request with non-proxy URL should result in an LLM span
-        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:8000")
-        chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert get_llmobs_span_kind(spans[0]) == "llm"
-
-    def test_llmobs_string_prompt_template_invoke(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        template_string = "You are a helpful assistant. Please answer this question: {question}"
-        variable_dict = {"question": "What is machine learning?"}
-        prompt_template = langchain_core.prompts.PromptTemplate(
-            input_variables=list(variable_dict.keys()),
-            template=template_string,
-            metadata={"test_type": "basic_invoke", "author": "test_suite"},
-        )
-        llm = langchain_openai.OpenAI(base_url=openai_url)
-        chain = prompt_template | llm
-        chain.invoke(variable_dict)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        actual_prompt = get_llmobs_input_prompt(spans[1])
-        assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
-        assert actual_prompt["template"] == template_string
-        assert actual_prompt["variables"] == variable_dict
-        assert "tags" in actual_prompt
-        assert actual_prompt["tags"] == {"test_type": "basic_invoke", "author": "test_suite"}
-        assert get_llmobs_tags(spans[1]).get("prompt_tracking_instrumentation_method") == "auto"
-
-    def test_llmobs_string_prompt_template_direct_invoke(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        """Test StringPromptTemplate (PromptTemplate) with variable name detection using direct invoke (no chains)."""
-        template_string = "Good {time_of_day}, {name}! How are you doing today?"
-        variable_dict = {"name": "Alice", "time_of_day": "morning"}
-        greeting_template = langchain_core.prompts.PromptTemplate(
-            input_variables=list(variable_dict.keys()),
-            template=template_string,
-            metadata={
-                "test_type": "direct_invoke",
-                "interaction": "greeting",
-                "not_string_1": True,
-                "not_string_2": 10,
-            },
-        )
-        llm = langchain_openai.OpenAI(base_url=openai_url)
-
-        # Direct invoke on template first, then pass to LLM (no chain)
-        prompt_value = greeting_template.invoke(variable_dict)
-        llm.invoke(prompt_value)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1  # Only LLM span, prompt template invoke doesn't create LLMObs event by itself
-
-        actual_prompt = get_llmobs_input_prompt(spans[0])
-        assert actual_prompt["id"] == "test_langchain_llmobs.greeting_template"
-        assert actual_prompt["template"] == template_string
-        assert actual_prompt["variables"] == variable_dict
-        assert "tags" in actual_prompt
-        assert actual_prompt["tags"] == {"test_type": "direct_invoke", "interaction": "greeting"}
-        assert get_llmobs_tags(spans[0]).get("prompt_tracking_instrumentation_method") == "auto"
-
-    def test_llmobs_string_prompt_template_invoke_chat_model(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        template_string = "You are a helpful assistant. Please answer this question: {question}"
-        variable_dict = {"question": "What is machine learning?"}
-        prompt_template = langchain_core.prompts.PromptTemplate(
-            input_variables=list(variable_dict.keys()), template=template_string
-        )
-        chat_model = langchain_openai.ChatOpenAI(base_url=openai_url)
-        chain = prompt_template | chat_model
-        chain.invoke(variable_dict)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        actual_prompt = get_llmobs_input_prompt(spans[1])
-        assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
-        assert actual_prompt["template"] == template_string
-        assert actual_prompt["variables"] == variable_dict
-
-    def test_llmobs_string_prompt_template_single_variable_string_input(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        template_string = "Write a creative story about {topic}."
-        single_variable_template = langchain_core.prompts.PromptTemplate(
-            input_variables=["topic"], template=template_string
-        )
-        llm = langchain_openai.OpenAI(base_url=openai_url)
-        chain = single_variable_template | llm
-
-        # Pass string input directly instead of dict for single variable template
-        string_input = "time travel"
-        chain.invoke(string_input)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        actual_prompt = get_llmobs_input_prompt(spans[1])
-        assert actual_prompt["id"] == "test_langchain_llmobs.single_variable_template"
-        assert actual_prompt["template"] == template_string
-        # Should convert string input to dict format with single variable
-        assert actual_prompt["variables"] == {"topic": "time travel"}
-
-    def test_llmobs_multi_message_prompt_template_sync_chain(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        test_metadata = {"template_type": "multi_message", "test_scenario": "sync_chain", "message_count": 10}
-        multi_message_template = _create_multi_message_prompt_template(langchain_core, metadata=test_metadata)
-        llm = langchain_openai.ChatOpenAI(base_url=openai_url)
-        chain = multi_message_template | llm
-
-        variable_dict = {
-            "domain": "creative writing",
-            "context": "focus on storytelling",
-            "task": "writing a short story",
-            "specific_help": "character development",
-            "output_type": "guidance",
-            "style": "engaging",
-            "limit": "100",
-        }
-
-        chain.invoke(variable_dict)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-
-        # Verify the prompt structure in the LLM span
-        actual_prompt = get_llmobs_input_prompt(spans[1])
-        assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
-        assert actual_prompt["variables"] == variable_dict
-        assert actual_prompt.get("template") is None
-        assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
-        # Check that metadata from the multi-message prompt template is preserved
-        assert "tags" in actual_prompt
-        assert actual_prompt["tags"] == {k: v for k, v in test_metadata.items() if isinstance(v, str)}
-
-    def test_llmobs_multi_message_prompt_template_sync_direct_invoke(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        multi_message_template = _create_multi_message_prompt_template(langchain_core)
-        llm = langchain_openai.ChatOpenAI(base_url=openai_url)
-
-        variable_dict = {
-            "domain": "data analysis",
-            "context": "focus on accuracy",
-            "task": "analyzing datasets",
-            "specific_help": "statistical methods",
-            "output_type": "insights",
-            "style": "detailed",
-            "limit": "150",
-        }
-
-        # Test direct invoke on template then LLM (no chain)
-        prompt_value = multi_message_template.invoke(variable_dict)
-        llm.invoke(prompt_value)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1  # Only LLM span for direct invoke
-
-        # Verify the prompt structure
-        actual_prompt = get_llmobs_input_prompt(spans[0])
-        assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
-        assert actual_prompt["variables"] == variable_dict
-        assert actual_prompt.get("template") is None
-        assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
-
-    @pytest.mark.asyncio
-    async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
-        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
-    ):
-        multi_message_template = _create_multi_message_prompt_template(langchain_core)
-        llm = langchain_openai.ChatOpenAI(base_url=openai_url)
-
-        variable_dict = {
-            "domain": "software engineering",
-            "context": "focus on best practices",
-            "task": "code review",
-            "specific_help": "performance optimization",
-            "output_type": "recommendations",
-            "style": "thorough",
-            "limit": "200",
-        }
-
-        # Test direct async invoke on template then LLM
-        prompt_value = await multi_message_template.ainvoke(variable_dict)
-        await llm.ainvoke(prompt_value)
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1  # Only LLM span for direct invoke
-
-        # Verify the prompt structure
-        actual_prompt = get_llmobs_input_prompt(spans[0])
-        assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
-        assert actual_prompt["variables"] == variable_dict
-        assert actual_prompt.get("template") is None
-        assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
-
-    def test_llmobs_chain(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
-        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
-            [("system", "You are world class technical documentation writer."), ("user", "{input}")]
-        )
-        chain = prompt | langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
-        chain.invoke({"input": "Can you explain what an LLM chain is?"})
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(
-                input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
-            ),
-        )
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[1]),
-            **_expected_llm_span_data(spans[1], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
-        )
-        expected_prompt = {
-            "id": "test_langchain_llmobs.prompt",
-            "ml_app": "langchain_test",
-            "chat_template": [
-                {"content": "You are world class technical documentation writer.", "role": "system"},
-                {"content": "{input}", "role": "user"},
+    chain.invoke(
+        {
+            "ability": "world capitals",
+            "history": [
+                langchain_core.messages.HumanMessage(content="Can you be my science teacher instead?"),
+                langchain_core.messages.AIMessage(content="Yes"),
             ],
-            "variables": {"input": "Can you explain what an LLM chain is?"},
-            "_dd_context_variable_keys": ["context"],
-            "_dd_query_variable_keys": ["question"],
+            "input": "What's the powerhouse of the cell?",
         }
-        assert get_llmobs_input_prompt(spans[1]) == expected_prompt
+    )
 
-    def test_llmobs_chain_nested(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
-        prompt1 = langchain_core.prompts.ChatPromptTemplate.from_template("what is the city {person} is from?")
-        prompt2 = langchain_core.prompts.ChatPromptTemplate.from_template(
-            "what country is the city {city} in? respond in {language}"
-        )
-        model = langchain_openai.OpenAI(base_url=openai_url)
-        chain1 = prompt1 | model | langchain_core.output_parsers.StrOutputParser()
-        chain2 = prompt2 | model | langchain_core.output_parsers.StrOutputParser()
-        complete_chain = {"city": chain1, "language": itemgetter("language")} | chain2
-
-        complete_chain.invoke({"person": "Spongebob Squarepants", "language": "Spanish"})
-
-        # Use the APM trace (parent-first ordering) directly; the legacy test indexed by
-        # ``trace[i]`` here, and that maps 1:1 to the LLMObs spans on the same Spans.
-        trace = test_spans.pop_traces()[0]
-        spans = [s for s in trace if _get_llmobs_data_metastruct(s)]
-        assert len(spans) == 5
-
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(
-                input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
-                output_value=mock.ANY,
-            ),
-        )
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[1]),
-            **_expected_chain_span_data(
-                input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
-                output_value=mock.ANY,
-            ),
-        )
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[2]),
-            span_kind="task",
-            input_value=json.dumps({"person": "Spongebob Squarepants", "language": "Spanish"}, sort_keys=True),
-            output_value="Spanish",
-            tags=COMMON_TAGS,
-        )
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[3]), **_expected_llm_span_data(spans[3], mock_token_metrics=True)
-        )
-        expected_prompt_3 = {
-            "id": "langchain.unknown_prompt_template",
-            "ml_app": "langchain_test",
-            "chat_template": [{"content": "what is the city {person} is from?", "role": "user"}],
-            "variables": {"person": "Spongebob Squarepants", "language": "Spanish"},
-            "_dd_context_variable_keys": ["context"],
-            "_dd_query_variable_keys": ["question"],
-        }
-        assert get_llmobs_input_prompt(spans[3]) == expected_prompt_3
-
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[4]), **_expected_llm_span_data(spans[4], mock_token_metrics=True)
-        )
-        expected_prompt_4 = {
-            "id": "test_langchain_llmobs.prompt2",
-            "ml_app": "langchain_test",
-            "chat_template": [{"content": "what country is the city {city} in? respond in {language}", "role": "user"}],
-            "variables": {"city": mock.ANY, "language": "Spanish"},
-            "_dd_context_variable_keys": ["context"],
-            "_dd_query_variable_keys": ["question"],
-        }
-        assert get_llmobs_input_prompt(spans[4]) == expected_prompt_4
-
-    @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
-    def test_llmobs_chain_batch(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
-        prompt = langchain_core.prompts.ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
-        output_parser = langchain_core.output_parsers.StrOutputParser()
-        model = langchain_openai.ChatOpenAI(base_url=openai_url)
-        chain = {"topic": langchain_core.runnables.RunnablePassthrough()} | prompt | model | output_parser
-
-        chain.batch(inputs=["chickens", "pigs"])
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 3
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY),
-        )
-
-        # The two LLM spans (one per batch item) can come back in either order; check by
-        # matching the variables.topic in each span's prompt block.
-        for child in spans[1:3]:
-            assert_llmobs_span_data(
-                _get_llmobs_data_metastruct(child),
-                **_expected_llm_span_data(child, input_role="user", mock_token_metrics=True),
-            )
-            prompt_block = get_llmobs_input_prompt(child)
-            assert prompt_block["id"] == "langchain.unknown_prompt_template"
-            assert prompt_block["ml_app"] == "langchain_test"
-            assert prompt_block["chat_template"] == [{"content": "Tell me a short joke about {topic}", "role": "user"}]
-            assert prompt_block["variables"]["topic"] in ("chickens", "pigs")
-
-    def test_llmobs_chain_schema_io(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
-        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
-            [
-                ("system", "You're an assistant who's good at {ability}. Respond in 20 words or fewer"),
-                langchain_core.prompts.MessagesPlaceholder(variable_name="history"),
-                ("human", "{input}"),
-            ]
-        )
-        chain = prompt | langchain_openai.ChatOpenAI(base_url=openai_url)
-
-        chain.invoke(
-            {
-                "ability": "world capitals",
-                "history": [
-                    langchain_core.messages.HumanMessage(content="Can you be my science teacher instead?"),
-                    langchain_core.messages.AIMessage(content="Yes"),
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps(
+                [
+                    {
+                        "ability": "world capitals",
+                        "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
+                        "input": "What's the powerhouse of the cell?",
+                    }
                 ],
-                "input": "What's the powerhouse of the cell?",
-            }
-        )
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(
-                input_value=json.dumps(
-                    [
-                        {
-                            "ability": "world capitals",
-                            "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
-                            "input": "What's the powerhouse of the cell?",
-                        }
-                    ],
-                    sort_keys=True,
-                ),
-                output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
+                sort_keys=True,
             ),
-        )
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[1]),
-            **_expected_llm_span_data(spans[1], mock_io=True, mock_token_metrics=True),
-        )
+            output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
+        ),
+    )
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[1]),
+        **_expected_llm_span_data(spans[1], mock_io=True, mock_token_metrics=True),
+    )
 
-    def test_llmobs_anthropic_chat_model(self, langchain_anthropic, langchain_llmobs, test_spans, anthropic_url):
-        kwargs = dict(
+
+def test_llmobs_anthropic_chat_model(langchain_anthropic, langchain_llmobs, test_spans, anthropic_url):
+    kwargs = dict(
+        temperature=0,
+        max_tokens=15,
+        model_name="claude-sonnet-4-5-20250929",
+    )
+
+    if "anthropic_api_url" in langchain_anthropic.ChatAnthropic.__fields__:
+        kwargs["anthropic_api_url"] = anthropic_url
+    else:
+        kwargs["base_url"] = anthropic_url
+
+    chat = langchain_anthropic.ChatAnthropic(**kwargs)
+    chat.invoke("When do you use 'whom' instead of 'who'?")
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_llm_span_data(
+            spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0, "max_tokens": 15}
+        ),
+    )
+
+
+def test_llmobs_google_genai_chat_model(langchain_google_genai, langchain_llmobs, test_spans):
+    if langchain_google_genai is None:
+        pytest.skip("langchain-google-genai not installed")
+
+    try:
+        from google.genai import types
+    except ImportError:
+        pytest.skip("google-genai SDK not installed (langchain-google-genai 2.x uses legacy SDK)")
+
+    mock_response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part.from_text(text="You use 'whom' as the object of a verb or preposition.")],
+                )
+            )
+        ],
+        usage_metadata=types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=10, candidates_token_count=12, total_token_count=22
+        ),
+    )
+
+    with mock.patch("google.genai.models.Models._generate_content", return_value=mock_response):
+        chat = langchain_google_genai.ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
             temperature=0,
-            max_tokens=15,
-            model_name="claude-sonnet-4-5-20250929",
+            max_output_tokens=15,
         )
-
-        if "anthropic_api_url" in langchain_anthropic.ChatAnthropic.__fields__:
-            kwargs["anthropic_api_url"] = anthropic_url
-        else:
-            kwargs["base_url"] = anthropic_url
-
-        chat = langchain_anthropic.ChatAnthropic(**kwargs)
         chat.invoke("When do you use 'whom' instead of 'who'?")
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_llm_span_data(
-                spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0, "max_tokens": 15}
-            ),
-        )
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    span = spans[0]
+    # Verify the fix: provider should be "google-generativeai" (not "chat"),
+    # and model name should be "gemini-2.5-flash" (not "models/gemini-2.5-flash").
+    assert span.get_tag("langchain.request.provider") == "google-generative-ai"
+    assert span.get_tag("langchain.request.model") == "gemini-2.5-flash"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(span),
+        **_expected_llm_span_data(span, input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0}),
+    )
 
-    def test_llmobs_google_genai_chat_model(self, langchain_google_genai, langchain_llmobs, test_spans):
-        if langchain_google_genai is None:
-            pytest.skip("langchain-google-genai not installed")
 
-        try:
-            from google.genai import types
-        except ImportError:
-            pytest.skip("google-genai SDK not installed (langchain-google-genai 2.x uses legacy SDK)")
+def test_llmobs_embedding_documents(langchain_openai, langchain_llmobs, test_spans, openai_url):
+    embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
+    embedding_model.embed_documents(["hello world", "goodbye world"])
 
-        mock_response = types.GenerateContentResponse(
-            candidates=[
-                types.Candidate(
-                    content=types.Content(
-                        role="model",
-                        parts=[types.Part.from_text(text="You use 'whom' as the object of a verb or preposition.")],
-                    )
-                )
-            ],
-            usage_metadata=types.GenerateContentResponseUsageMetadata(
-                prompt_token_count=10, candidates_token_count=12, total_token_count=22
-            ),
-        )
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="embedding",
+        model_name="text-embedding-ada-002",
+        model_provider="openai",
+        input_documents=[{"text": "hello world"}, {"text": "goodbye world"}],
+        output_value="[2 embedding(s) returned with size 1536]",
+        tags=COMMON_TAGS,
+    )
 
-        with mock.patch("google.genai.models.Models._generate_content", return_value=mock_response):
-            chat = langchain_google_genai.ChatGoogleGenerativeAI(
-                model="gemini-2.5-flash",
-                temperature=0,
-                max_output_tokens=15,
-            )
-            chat.invoke("When do you use 'whom' instead of 'who'?")
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        span = spans[0]
-        # Verify the fix: provider should be "google-generativeai" (not "chat"),
-        # and model name should be "gemini-2.5-flash" (not "models/gemini-2.5-flash").
-        assert span.get_tag("langchain.request.provider") == "google-generative-ai"
-        assert span.get_tag("langchain.request.model") == "gemini-2.5-flash"
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(span),
-            **_expected_llm_span_data(span, input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0}),
-        )
+def test_llmobs_embedding_query(langchain_openai, langchain_llmobs, test_spans, openai_url):
+    embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
+    embedding_model.embed_query("hello world")
 
-    def test_llmobs_embedding_documents(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
-        embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
-        embedding_model.embed_documents(["hello world", "goodbye world"])
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="embedding",
+        model_name=embedding_model.model,
+        model_provider="openai",
+        input_documents=[{"text": "hello world"}],
+        output_value="[1 embedding(s) returned with size 1536]",
+        tags=COMMON_TAGS,
+    )
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            span_kind="embedding",
-            model_name="text-embedding-ada-002",
-            model_provider="openai",
-            input_documents=[{"text": "hello world"}, {"text": "goodbye world"}],
-            output_value="[2 embedding(s) returned with size 1536]",
-            tags=COMMON_TAGS,
-        )
 
-    def test_llmobs_embedding_query(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
-        embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
-        embedding_model.embed_query("hello world")
+def test_llmobs_vectorstore_similarity_search(langchain_in_memory_vectorstore, langchain_llmobs, test_spans):
+    vectorstore = langchain_in_memory_vectorstore
+    vectorstore.similarity_search("France", k=1)
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            span_kind="embedding",
-            model_name=embedding_model.model,
-            model_provider="openai",
-            input_documents=[{"text": "hello world"}],
-            output_value="[1 embedding(s) returned with size 1536]",
-            tags=COMMON_TAGS,
-        )
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    # spans[0] is the retrieval span (outer); spans[1] is the embedding sub-call.
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="retrieval",
+        input_value="France",
+        output_documents=[{"text": mock.ANY, "id": mock.ANY, "name": mock.ANY}],
+        output_value="[1 document(s) retrieved]",
+        tags=COMMON_TAGS,
+    )
 
-    def test_llmobs_vectorstore_similarity_search(self, langchain_in_memory_vectorstore, langchain_llmobs, test_spans):
-        vectorstore = langchain_in_memory_vectorstore
-        vectorstore.similarity_search("France", k=1)
 
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        # spans[0] is the retrieval span (outer); spans[1] is the embedding sub-call.
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            span_kind="retrieval",
-            input_value="France",
-            output_documents=[{"text": mock.ANY, "id": mock.ANY, "name": mock.ANY}],
-            output_value="[1 document(s) retrieved]",
-            tags=COMMON_TAGS,
-        )
+def test_llmobs_chat_model_tool_calls(langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
+    @langchain_core.tools.tool
+    def add(a: int, b: int) -> int:
+        """Adds a and b.
+        Args:
+            a: first int
+            b: second int
+        """
+        return a + b
 
-    def test_llmobs_chat_model_tool_calls(
-        self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url
-    ):
-        @langchain_core.tools.tool
-        def add(a: int, b: int) -> int:
-            """Adds a and b.
-            Args:
-                a: first int
-                b: second int
-            """
-            return a + b
+    llm = langchain_openai.ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0.7, base_url=openai_url)
+    llm_with_tools = llm.bind_tools([add])
+    llm_with_tools.invoke([langchain_core.messages.HumanMessage(content="What is the sum of 1 and 2?")])
 
-        llm = langchain_openai.ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0.7, base_url=openai_url)
-        llm_with_tools = llm.bind_tools([add])
-        llm_with_tools.invoke([langchain_core.messages.HumanMessage(content="What is the sum of 1 and 2?")])
-
-        spans = _llmobs_spans(langchain_llmobs, test_spans)
-        assert len(spans) == 1
-        span = spans[0]
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(span),
-            span_kind="llm",
-            model_name=span.get_tag("langchain.request.model"),
-            model_provider=span.get_tag("langchain.request.provider"),
-            input_messages=[{"role": "user", "content": "What is the sum of 1 and 2?"}],
-            output_messages=[
-                {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "name": "add",
-                            "arguments": {"a": 1, "b": 2},
-                            "tool_id": mock.ANY,
-                        }
-                    ],
-                }
-            ],
-            metadata={"temperature": 0.7},
-            metrics={"input_tokens": mock.ANY, "output_tokens": mock.ANY, "total_tokens": mock.ANY},
-            tags=COMMON_TAGS,
-        )
-
-    def test_llmobs_base_tool_invoke(self, langchain_core, langchain_llmobs, test_spans):
-        from math import pi
-
-        def circumference_tool(radius: float) -> float:
-            return float(radius) * 2.0 * pi
-
-        calculator = langchain_core.tools.StructuredTool.from_function(
-            func=circumference_tool,
-            name="Circumference calculator",
-            description="Use this tool when you need to calculate a circumference using the radius of a circle",
-            return_direct=True,
-            response_format="content",
-        )
-
-        calculator.invoke("2", config={"test": "this is to test config"})
-
-        spans = _llmobs_spans(langchain_llmobs, test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            span_kind="tool",
-            input_value="2",
-            output_value="12.566370614359172",
-            metadata={
-                "tool_config": {"test": "this is to test config"},
-                "tool_info": {
-                    "name": "Circumference calculator",
-                    "description": mock.ANY,
-                },
-            },
-            tags=COMMON_TAGS,
-        )
-
-    @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_llmobs_streamed_chain(
-        self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream
-    ):
-        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
-            [("system", "You are a world class technical documentation writer."), ("user", "{input}")]
-        )
-        llm = langchain_openai.ChatOpenAI(model="gpt-4o", base_url=openai_url, temperature=0.7, max_tokens=256)
-        parser = langchain_core.output_parsers.StrOutputParser()
-
-        chain = prompt | llm | parser
-
-        consume_stream(chain.stream({"input": "how can langsmith help with testing?"}))
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 2
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            **_expected_chain_span_data(
-                input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
-                output_value=mock.ANY,
-            ),
-        )
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[1]),
-            span_kind="llm",
-            model_name=spans[1].get_tag("langchain.request.model"),
-            model_provider=spans[1].get_tag("langchain.request.provider"),
-            input_messages=[
-                {"content": "You are a world class technical documentation writer.", "role": "SystemMessage"},
-                {"content": "how can langsmith help with testing?", "role": "HumanMessage"},
-            ],
-            output_messages=[{"content": mock.ANY, "role": "assistant"}],
-            metadata={"temperature": 0.7, "max_tokens": 256},
-            metrics={},
-            tags=COMMON_TAGS,
-        )
-
-    @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_llmobs_streamed_llm(self, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream):
-        llm = langchain_openai.OpenAI(base_url=openai_url, n=1, seed=1, logprobs=None, logit_bias=None)
-
-        consume_stream(llm.stream("What is 2+2?\n\n"))
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        span = spans[0]
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(span),
-            span_kind="llm",
-            model_name=span.get_tag("langchain.request.model"),
-            model_provider=span.get_tag("langchain.request.provider"),
-            input_messages=[
-                {"content": "What is 2+2?\n\n"},
-            ],
-            output_messages=[{"content": "The answer is 4."}],
-            metadata={"temperature": 0.7, "max_tokens": 256},
-            metrics={},
-            tags=COMMON_TAGS,
-        )
-
-    def test_llmobs_non_ascii_completion(self, langchain_openai, openai_url, langchain_llmobs, test_spans):
-        llm = langchain_openai.OpenAI(base_url=openai_url)
-        llm.invoke("안녕,\n 지금 몇 시야?")
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 1
-        assert get_llmobs_input_messages(spans[0])[0]["content"] == "안녕,\n 지금 몇 시야?"
-
-    def test_llmobs_runnable_lambda_invoke(self, langchain_core, langchain_llmobs, test_spans):
-        def add(inputs: dict) -> int:
-            return inputs["a"] + inputs["b"]
-
-        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-        result = runnable_lambda.invoke(dict(a=1, b=2))
-        assert result == 3
-
-        spans = _llmobs_spans(langchain_llmobs, test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            span_kind="task",
-            input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
-            output_value="3",
-            tags=COMMON_TAGS,
-        )
-
-    async def test_llmobs_runnable_lambda_ainvoke(self, langchain_core, langchain_llmobs, test_spans):
-        async def add(inputs: dict) -> int:
-            return inputs["a"] + inputs["b"]
-
-        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-        result = await runnable_lambda.ainvoke(dict(a=1, b=2))
-        assert result == 3
-
-        spans = _llmobs_spans(langchain_llmobs, test_spans)
-        assert len(spans) == 1
-        assert_llmobs_span_data(
-            _get_llmobs_data_metastruct(spans[0]),
-            span_kind="task",
-            input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
-            output_value="3",
-            tags=COMMON_TAGS,
-        )
-
-    def test_llmobs_runnable_lambda_batch(self, langchain_core, langchain_llmobs, test_spans):
-        def add(inputs: dict) -> int:
-            return inputs["a"] + inputs["b"]
-
-        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-        result = runnable_lambda.batch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
-        assert result == [3, 7, 11]
-
-        spans = _llmobs_spans(langchain_llmobs, test_spans)
-        assert len(spans) == 4
-
-        # parent should be batch span
-        assert get_llmobs_parent_id(spans[0]) == "undefined"
-        assert get_llmobs_span_name(spans[0]) == "add_batch"
-        assert get_llmobs_span_kind(spans[0]) == "task"
-        assert get_llmobs_input_value(spans[0]) == json.dumps(
-            [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
-        )
-        assert get_llmobs_output_value(spans[0]) == json.dumps([3, 7, 11], sort_keys=True)
-
-        # assert all children have batch as the parent
-        # however, order of children is not guaranteed
-        # loosely check that the children have the correct input and output values
-        parent_span_id = str(spans[0].span_id)
-        for i in range(1, 4):
-            assert get_llmobs_parent_id(spans[i]) == parent_span_id
-            assert get_llmobs_span_name(spans[i]) == "add"
-            assert get_llmobs_span_kind(spans[i]) == "task"
-
-            input_value = json.loads(get_llmobs_input_value(spans[i]))
-            output_value = json.loads(get_llmobs_output_value(spans[i]))
-            assert "a" in input_value
-            assert "b" in input_value
-            assert isinstance(output_value, int)
-
-    async def test_llmobs_runnable_lambda_abatch(self, langchain_core, langchain_llmobs, test_spans):
-        async def add(inputs: dict) -> int:
-            return inputs["a"] + inputs["b"]
-
-        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-        result = await runnable_lambda.abatch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
-        assert result == [3, 7, 11]
-
-        spans = _llmobs_spans(langchain_llmobs, test_spans)
-        assert len(spans) == 4
-
-        # parent should be batch span
-        assert get_llmobs_parent_id(spans[0]) == "undefined"
-        assert get_llmobs_span_name(spans[0]) == "add_batch"
-        assert get_llmobs_span_kind(spans[0]) == "task"
-        assert get_llmobs_input_value(spans[0]) == json.dumps(
-            [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
-        )
-        assert get_llmobs_output_value(spans[0]) == json.dumps([3, 7, 11], sort_keys=True)
-
-        # assert all children have batch as the parent
-        # however, order of children is not guaranteed
-        # loosely check that the children have the correct input and output values
-        parent_span_id = str(spans[0].span_id)
-        for i in range(1, 4):
-            assert get_llmobs_parent_id(spans[i]) == parent_span_id
-            assert get_llmobs_span_name(spans[i]) == "add"
-            assert get_llmobs_span_kind(spans[i]) == "task"
-
-            input_value = json.loads(get_llmobs_input_value(spans[i]))
-            output_value = json.loads(get_llmobs_output_value(spans[i]))
-            assert "a" in input_value
-            assert "b" in input_value
-            assert isinstance(output_value, int)
-
-    def test_llmobs_runnable_with_span_links(self, langchain_core, langchain_llmobs, test_spans):
-        sequence = langchain_core.runnables.RunnableLambda(lambda x: x + 1, name="add_1") | {
-            "mul_2": langchain_core.runnables.RunnableLambda(lambda x: x * 2, name="mul_2"),
-            "mul_5": langchain_core.runnables.RunnableLambda(lambda x: x * 5, name="mul_5"),
-        }
-
-        result = sequence.invoke(1)
-
-        assert result == {"mul_2": 4, "mul_5": 10}
-
-        spans = _llmobs_spans(test_spans)
-        assert len(spans) == 4
-
-        metas = [_get_llmobs_data_metastruct(s) for s in spans]
-        span_ids = [str(s.span_id) for s in spans]
-
-        # assert output -> output links for runnable sequence span from last two runnable lambdas
-        # the order of the links is not guaranteed
-        expected_links = [
+    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    assert len(spans) == 1
+    span = spans[0]
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(span),
+        span_kind="llm",
+        model_name=span.get_tag("langchain.request.model"),
+        model_provider=span.get_tag("langchain.request.provider"),
+        input_messages=[{"role": "user", "content": "What is the sum of 1 and 2?"}],
+        output_messages=[
             {
-                "trace_id": mock.ANY,
-                "span_id": span_ids[2],
-                "attributes": {"from": "output", "to": "output"},
-            },
-            {
-                "trace_id": mock.ANY,
-                "span_id": span_ids[3],
-                "attributes": {"from": "output", "to": "output"},
-            },
-        ]
-        assert len(metas[0]["span_links"]) == len(expected_links)
-        for expected_link in expected_links:
-            assert expected_link in metas[0]["span_links"]
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "name": "add",
+                        "arguments": {"a": 1, "b": 2},
+                        "tool_id": mock.ANY,
+                    }
+                ],
+            }
+        ],
+        metadata={"temperature": 0.7},
+        metrics={"input_tokens": mock.ANY, "output_tokens": mock.ANY, "total_tokens": mock.ANY},
+        tags=COMMON_TAGS,
+    )
 
-        # assert input -> input links for add_1 span
-        assert metas[1]["span_links"] == [
-            {
-                "trace_id": mock.ANY,
-                "span_id": span_ids[0],
-                "attributes": {"from": "input", "to": "input"},
-            },
-        ]
 
-        # assert output -> input links for mul_2 and mul_5 spans
-        assert metas[2]["span_links"] == [
-            {
-                "trace_id": mock.ANY,
-                "span_id": span_ids[1],
-                "attributes": {"from": "output", "to": "input"},
+def test_llmobs_base_tool_invoke(langchain_core, langchain_llmobs, test_spans):
+    from math import pi
+
+    def circumference_tool(radius: float) -> float:
+        return float(radius) * 2.0 * pi
+
+    calculator = langchain_core.tools.StructuredTool.from_function(
+        func=circumference_tool,
+        name="Circumference calculator",
+        description="Use this tool when you need to calculate a circumference using the radius of a circle",
+        return_direct=True,
+        response_format="content",
+    )
+
+    calculator.invoke("2", config={"test": "this is to test config"})
+
+    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="tool",
+        input_value="2",
+        output_value="12.566370614359172",
+        metadata={
+            "tool_config": {"test": "this is to test config"},
+            "tool_info": {
+                "name": "Circumference calculator",
+                "description": mock.ANY,
             },
-        ]
-        assert metas[3]["span_links"] == [
-            {
-                "trace_id": mock.ANY,
-                "span_id": span_ids[1],
-                "attributes": {"from": "output", "to": "input"},
-            },
-        ]
+        },
+        tags=COMMON_TAGS,
+    )
+
+
+@pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
+def test_llmobs_streamed_chain(
+    langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream
+):
+    prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+        [("system", "You are a world class technical documentation writer."), ("user", "{input}")]
+    )
+    llm = langchain_openai.ChatOpenAI(model="gpt-4o", base_url=openai_url, temperature=0.7, max_tokens=256)
+    parser = langchain_core.output_parsers.StrOutputParser()
+
+    chain = prompt | llm | parser
+
+    consume_stream(chain.stream({"input": "how can langsmith help with testing?"}))
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 2
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_chain_span_data(
+            input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
+            output_value=mock.ANY,
+        ),
+    )
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[1]),
+        span_kind="llm",
+        model_name=spans[1].get_tag("langchain.request.model"),
+        model_provider=spans[1].get_tag("langchain.request.provider"),
+        input_messages=[
+            {"content": "You are a world class technical documentation writer.", "role": "SystemMessage"},
+            {"content": "how can langsmith help with testing?", "role": "HumanMessage"},
+        ],
+        output_messages=[{"content": mock.ANY, "role": "assistant"}],
+        metadata={"temperature": 0.7, "max_tokens": 256},
+        metrics={},
+        tags=COMMON_TAGS,
+    )
+
+
+@pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
+def test_llmobs_streamed_llm(langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream):
+    llm = langchain_openai.OpenAI(base_url=openai_url, n=1, seed=1, logprobs=None, logit_bias=None)
+
+    consume_stream(llm.stream("What is 2+2?\n\n"))
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    span = spans[0]
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(span),
+        span_kind="llm",
+        model_name=span.get_tag("langchain.request.model"),
+        model_provider=span.get_tag("langchain.request.provider"),
+        input_messages=[
+            {"content": "What is 2+2?\n\n"},
+        ],
+        output_messages=[{"content": "The answer is 4."}],
+        metadata={"temperature": 0.7, "max_tokens": 256},
+        metrics={},
+        tags=COMMON_TAGS,
+    )
+
+
+def test_llmobs_non_ascii_completion(langchain_openai, openai_url, langchain_llmobs, test_spans):
+    llm = langchain_openai.OpenAI(base_url=openai_url)
+    llm.invoke("안녕,\n 지금 몇 시야?")
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 1
+    assert get_llmobs_input_messages(spans[0])[0]["content"] == "안녕,\n 지금 몇 시야?"
+
+
+def test_llmobs_runnable_lambda_invoke(langchain_core, langchain_llmobs, test_spans):
+    def add(inputs: dict) -> int:
+        return inputs["a"] + inputs["b"]
+
+    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+    result = runnable_lambda.invoke(dict(a=1, b=2))
+    assert result == 3
+
+    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="task",
+        input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
+        output_value="3",
+        tags=COMMON_TAGS,
+    )
+
+
+async def test_llmobs_runnable_lambda_ainvoke(langchain_core, langchain_llmobs, test_spans):
+    async def add(inputs: dict) -> int:
+        return inputs["a"] + inputs["b"]
+
+    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+    result = await runnable_lambda.ainvoke(dict(a=1, b=2))
+    assert result == 3
+
+    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="task",
+        input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
+        output_value="3",
+        tags=COMMON_TAGS,
+    )
+
+
+def test_llmobs_runnable_lambda_batch(langchain_core, langchain_llmobs, test_spans):
+    def add(inputs: dict) -> int:
+        return inputs["a"] + inputs["b"]
+
+    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+    result = runnable_lambda.batch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
+    assert result == [3, 7, 11]
+
+    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    assert len(spans) == 4
+
+    # parent should be batch span
+    assert get_llmobs_parent_id(spans[0]) == "undefined"
+    assert get_llmobs_span_name(spans[0]) == "add_batch"
+    assert get_llmobs_span_kind(spans[0]) == "task"
+    assert get_llmobs_input_value(spans[0]) == json.dumps(
+        [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
+    )
+    assert get_llmobs_output_value(spans[0]) == json.dumps([3, 7, 11], sort_keys=True)
+
+    # assert all children have batch as the parent
+    # however, order of children is not guaranteed
+    # loosely check that the children have the correct input and output values
+    parent_span_id = str(spans[0].span_id)
+    for i in range(1, 4):
+        assert get_llmobs_parent_id(spans[i]) == parent_span_id
+        assert get_llmobs_span_name(spans[i]) == "add"
+        assert get_llmobs_span_kind(spans[i]) == "task"
+
+        input_value = json.loads(get_llmobs_input_value(spans[i]))
+        output_value = json.loads(get_llmobs_output_value(spans[i]))
+        assert "a" in input_value
+        assert "b" in input_value
+        assert isinstance(output_value, int)
+
+
+async def test_llmobs_runnable_lambda_abatch(langchain_core, langchain_llmobs, test_spans):
+    async def add(inputs: dict) -> int:
+        return inputs["a"] + inputs["b"]
+
+    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+    result = await runnable_lambda.abatch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
+    assert result == [3, 7, 11]
+
+    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    assert len(spans) == 4
+
+    # parent should be batch span
+    assert get_llmobs_parent_id(spans[0]) == "undefined"
+    assert get_llmobs_span_name(spans[0]) == "add_batch"
+    assert get_llmobs_span_kind(spans[0]) == "task"
+    assert get_llmobs_input_value(spans[0]) == json.dumps(
+        [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
+    )
+    assert get_llmobs_output_value(spans[0]) == json.dumps([3, 7, 11], sort_keys=True)
+
+    # assert all children have batch as the parent
+    # however, order of children is not guaranteed
+    # loosely check that the children have the correct input and output values
+    parent_span_id = str(spans[0].span_id)
+    for i in range(1, 4):
+        assert get_llmobs_parent_id(spans[i]) == parent_span_id
+        assert get_llmobs_span_name(spans[i]) == "add"
+        assert get_llmobs_span_kind(spans[i]) == "task"
+
+        input_value = json.loads(get_llmobs_input_value(spans[i]))
+        output_value = json.loads(get_llmobs_output_value(spans[i]))
+        assert "a" in input_value
+        assert "b" in input_value
+        assert isinstance(output_value, int)
+
+
+def test_llmobs_runnable_with_span_links(langchain_core, langchain_llmobs, test_spans):
+    sequence = langchain_core.runnables.RunnableLambda(lambda x: x + 1, name="add_1") | {
+        "mul_2": langchain_core.runnables.RunnableLambda(lambda x: x * 2, name="mul_2"),
+        "mul_5": langchain_core.runnables.RunnableLambda(lambda x: x * 5, name="mul_5"),
+    }
+
+    result = sequence.invoke(1)
+
+    assert result == {"mul_2": 4, "mul_5": 10}
+
+    spans = _llmobs_spans(test_spans)
+    assert len(spans) == 4
+
+    metas = [_get_llmobs_data_metastruct(s) for s in spans]
+    span_ids = [str(s.span_id) for s in spans]
+
+    # assert output -> output links for runnable sequence span from last two runnable lambdas
+    # the order of the links is not guaranteed
+    expected_links = [
+        {
+            "trace_id": mock.ANY,
+            "span_id": span_ids[2],
+            "attributes": {"from": "output", "to": "output"},
+        },
+        {
+            "trace_id": mock.ANY,
+            "span_id": span_ids[3],
+            "attributes": {"from": "output", "to": "output"},
+        },
+    ]
+    assert len(metas[0]["span_links"]) == len(expected_links)
+    for expected_link in expected_links:
+        assert expected_link in metas[0]["span_links"]
+
+    # assert input -> input links for add_1 span
+    assert metas[1]["span_links"] == [
+        {
+            "trace_id": mock.ANY,
+            "span_id": span_ids[0],
+            "attributes": {"from": "input", "to": "input"},
+        },
+    ]
+
+    # assert output -> input links for mul_2 and mul_5 spans
+    assert metas[2]["span_links"] == [
+        {
+            "trace_id": mock.ANY,
+            "span_id": span_ids[1],
+            "attributes": {"from": "output", "to": "input"},
+        },
+    ]
+    assert metas[3]["span_links"] == [
+        {
+            "trace_id": mock.ANY,
+            "span_id": span_ids[1],
+            "attributes": {"from": "output", "to": "input"},
+        },
+    ]
 
 
 def test_llmobs_set_tags_with_none_response(langchain_core):

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -107,19 +107,11 @@ def _expected_llm_span_data(span, input_role=None, mock_io=False, mock_token_met
     )
 
 
-def _llmobs_spans(test_spans):
-    """Collect all spans from ``pop_traces()`` that have an LLMObsSpanData metastruct, sorted by start_ns."""
-    spans = [s for trace in test_spans.pop_traces() for s in trace]
-    spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
-    spans.sort(key=lambda s: s.start_ns)
-    return spans
-
-
 def test_llmobs_openai_llm(langchain_openai, langchain_llmobs, test_spans, openai_url):
     llm = langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
     llm.invoke("Can you explain what Descartes meant by 'I think, therefore I am'?")
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -133,7 +125,7 @@ def test_llmobs_openai_llm_proxy(mock_generate, langchain_openai, langchain_llmo
     llm = langchain_openai.OpenAI(base_url="http://localhost:4000", model="gpt-3.5-turbo")
     llm.invoke("What is the capital of France?")
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -145,7 +137,7 @@ def test_llmobs_openai_llm_proxy(mock_generate, langchain_openai, langchain_llmo
     # span created from request with non-proxy URL should result in an LLM span
     llm = langchain_openai.OpenAI(base_url="http://localhost:8000", model="gpt-3.5-turbo")
     llm.invoke("What is the capital of France?")
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert get_llmobs_span_kind(spans[0]) == "llm"
 
@@ -154,7 +146,7 @@ def test_llmobs_openai_chat_model(langchain_core, langchain_openai, langchain_ll
     chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
     chat_model.invoke([langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")])
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -175,7 +167,7 @@ def test_llmobs_openai_chat_model_no_usage(langchain_core, langchain_openai, lan
     for _ in response:
         pass
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     metrics = get_llmobs_metrics(spans[0]) or {}
     assert metrics.get("input_tokens") is None
@@ -189,7 +181,7 @@ def test_llmobs_openai_chat_model_proxy(mock_generate, langchain_core, langchain
     chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
     chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -202,7 +194,7 @@ def test_llmobs_openai_chat_model_proxy(mock_generate, langchain_core, langchain
     # span created from request with non-proxy URL should result in an LLM span
     chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:8000")
     chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert get_llmobs_span_kind(spans[0]) == "llm"
 
@@ -221,7 +213,8 @@ def test_llmobs_string_prompt_template_invoke(
     chain = prompt_template | llm
     chain.invoke(variable_dict)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     actual_prompt = get_llmobs_input_prompt(spans[1])
     assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
@@ -254,7 +247,7 @@ def test_llmobs_string_prompt_template_direct_invoke(
     prompt_value = greeting_template.invoke(variable_dict)
     llm.invoke(prompt_value)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1  # Only LLM span, prompt template invoke doesn't create LLMObs event by itself
 
     actual_prompt = get_llmobs_input_prompt(spans[0])
@@ -278,7 +271,8 @@ def test_llmobs_string_prompt_template_invoke_chat_model(
     chain = prompt_template | chat_model
     chain.invoke(variable_dict)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     actual_prompt = get_llmobs_input_prompt(spans[1])
     assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
@@ -300,7 +294,8 @@ def test_llmobs_string_prompt_template_single_variable_string_input(
     string_input = "time travel"
     chain.invoke(string_input)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     actual_prompt = get_llmobs_input_prompt(spans[1])
     assert actual_prompt["id"] == "test_langchain_llmobs.single_variable_template"
@@ -329,7 +324,8 @@ def test_llmobs_multi_message_prompt_template_sync_chain(
 
     chain.invoke(variable_dict)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
 
     # Verify the prompt structure in the LLM span
@@ -363,7 +359,7 @@ def test_llmobs_multi_message_prompt_template_sync_direct_invoke(
     prompt_value = multi_message_template.invoke(variable_dict)
     llm.invoke(prompt_value)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1  # Only LLM span for direct invoke
 
     # Verify the prompt structure
@@ -395,7 +391,7 @@ async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
     prompt_value = await multi_message_template.ainvoke(variable_dict)
     await llm.ainvoke(prompt_value)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1  # Only LLM span for direct invoke
 
     # Verify the prompt structure
@@ -413,7 +409,8 @@ def test_llmobs_chain(langchain_core, langchain_openai, openai_url, langchain_ll
     chain = prompt | langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
     chain.invoke({"input": "Can you explain what an LLM chain is?"})
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -512,7 +509,7 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, langchain_llmobs, 
 
     chain.batch(inputs=["chickens", "pigs"])
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 3
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -556,7 +553,8 @@ def test_llmobs_chain_schema_io(langchain_core, langchain_openai, openai_url, la
         }
     )
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -595,7 +593,7 @@ def test_llmobs_anthropic_chat_model(langchain_anthropic, langchain_llmobs, test
     chat = langchain_anthropic.ChatAnthropic(**kwargs)
     chat.invoke("When do you use 'whom' instead of 'who'?")
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -636,7 +634,7 @@ def test_llmobs_google_genai_chat_model(langchain_google_genai, langchain_llmobs
         )
         chat.invoke("When do you use 'whom' instead of 'who'?")
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     span = spans[0]
     # Verify the fix: provider should be "google-generativeai" (not "chat"),
@@ -653,7 +651,7 @@ def test_llmobs_embedding_documents(langchain_openai, langchain_llmobs, test_spa
     embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
     embedding_model.embed_documents(["hello world", "goodbye world"])
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -670,7 +668,7 @@ def test_llmobs_embedding_query(langchain_openai, langchain_llmobs, test_spans, 
     embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
     embedding_model.embed_query("hello world")
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -687,7 +685,8 @@ def test_llmobs_vectorstore_similarity_search(langchain_in_memory_vectorstore, l
     vectorstore = langchain_in_memory_vectorstore
     vectorstore.similarity_search("France", k=1)
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     # spans[0] is the retrieval span (outer); spans[1] is the embedding sub-call.
     assert_llmobs_span_data(
@@ -714,7 +713,7 @@ def test_llmobs_chat_model_tool_calls(langchain_core, langchain_openai, langchai
     llm_with_tools = llm.bind_tools([add])
     llm_with_tools.invoke([langchain_core.messages.HumanMessage(content="What is the sum of 1 and 2?")])
 
-    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     span = spans[0]
     assert_llmobs_span_data(
@@ -758,7 +757,7 @@ def test_llmobs_base_tool_invoke(langchain_core, langchain_llmobs, test_spans):
 
     calculator.invoke("2", config={"test": "this is to test config"})
 
-    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -790,7 +789,8 @@ def test_llmobs_streamed_chain(
 
     consume_stream(chain.stream({"input": "how can langsmith help with testing?"}))
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
     assert len(spans) == 2
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -820,7 +820,7 @@ def test_llmobs_streamed_llm(langchain_openai, langchain_llmobs, test_spans, ope
 
     consume_stream(llm.stream("What is 2+2?\n\n"))
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     span = spans[0]
     assert_llmobs_span_data(
@@ -842,7 +842,7 @@ def test_llmobs_non_ascii_completion(langchain_openai, openai_url, langchain_llm
     llm = langchain_openai.OpenAI(base_url=openai_url)
     llm.invoke("안녕,\n 지금 몇 시야?")
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert get_llmobs_input_messages(spans[0])[0]["content"] == "안녕,\n 지금 몇 시야?"
 
@@ -855,7 +855,7 @@ def test_llmobs_runnable_lambda_invoke(langchain_core, langchain_llmobs, test_sp
     result = runnable_lambda.invoke(dict(a=1, b=2))
     assert result == 3
 
-    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -874,7 +874,7 @@ async def test_llmobs_runnable_lambda_ainvoke(langchain_core, langchain_llmobs, 
     result = await runnable_lambda.ainvoke(dict(a=1, b=2))
     assert result == 3
 
-    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
@@ -893,7 +893,7 @@ def test_llmobs_runnable_lambda_batch(langchain_core, langchain_llmobs, test_spa
     result = runnable_lambda.batch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
     assert result == [3, 7, 11]
 
-    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 4
 
     # parent should be batch span
@@ -929,7 +929,7 @@ async def test_llmobs_runnable_lambda_abatch(langchain_core, langchain_llmobs, t
     result = await runnable_lambda.abatch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
     assert result == [3, 7, 11]
 
-    spans = _llmobs_spans(langchain_llmobs, test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 4
 
     # parent should be batch span
@@ -967,7 +967,7 @@ def test_llmobs_runnable_with_span_links(langchain_core, langchain_llmobs, test_
 
     assert result == {"mul_2": 4, "mul_5": 10}
 
-    spans = _llmobs_spans(test_spans)
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 4
 
     metas = [_get_llmobs_data_metastruct(s) for s in spans]

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -113,18 +113,6 @@ def _expected_llm_span_data(span, input_role=None, mock_io=False, mock_token_met
     )
 
 
-def _expected_chain_span_data(input_value=None, output_value=None, metadata=None):
-    """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain chain (workflow) span."""
-    metadata = metadata if metadata else mock.ANY
-    return dict(
-        span_kind="workflow",
-        input_value=input_value if input_value is not None else mock.ANY,
-        output_value=output_value if output_value is not None else mock.ANY,
-        metadata=metadata,
-        tags=COMMON_TAGS,
-    )
-
-
 def _llmobs_spans(test_spans):
     """Collect all spans from ``pop_traces()`` that have an LLMObsSpanData metastruct, sorted by start_ns."""
     spans = [s for trace in test_spans.pop_traces() for s in trace]
@@ -155,9 +143,9 @@ def test_llmobs_openai_llm_proxy(mock_generate, langchain_openai, langchain_llmo
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)
-        ),
+        span_kind="workflow",
+        input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True),
+        tags=COMMON_TAGS,
     )
 
     # span created from request with non-proxy URL should result in an LLM span
@@ -211,10 +199,10 @@ def test_llmobs_openai_chat_model_proxy(mock_generate, langchain_core, langchain
     assert len(spans) == 1
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
-            metadata={"temperature": 0.0, "max_tokens": 256},
-        ),
+        span_kind="workflow",
+        input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
+        metadata={"temperature": 0.0, "max_tokens": 256},
+        tags=COMMON_TAGS,
     )
 
     # span created from request with non-proxy URL should result in an LLM span
@@ -435,9 +423,9 @@ def test_llmobs_chain(langchain_core, langchain_openai, openai_url, langchain_ll
     assert len(spans) == 2
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
-        ),
+        span_kind="workflow",
+        input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
+        tags=COMMON_TAGS,
     )
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
@@ -477,17 +465,15 @@ def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, langc
 
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
-            output_value=mock.ANY,
-        ),
+        span_kind="workflow",
+        input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
+        tags=COMMON_TAGS,
     )
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
-        **_expected_chain_span_data(
-            input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
-            output_value=mock.ANY,
-        ),
+        span_kind="workflow",
+        input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
+        tags=COMMON_TAGS,
     )
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[2]),
@@ -536,9 +522,9 @@ def test_llmobs_chain_batch(langchain_core, langchain_openai, langchain_llmobs, 
     assert len(spans) == 3
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY
-        ),
+        span_kind="workflow",
+        input_value=json.dumps(["chickens", "pigs"], sort_keys=True),
+        tags=COMMON_TAGS,
     )
 
     # The two LLM spans (one per batch item) can come back in either order; check by
@@ -580,19 +566,19 @@ def test_llmobs_chain_schema_io(langchain_core, langchain_openai, openai_url, la
     assert len(spans) == 2
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps(
-                [
-                    {
-                        "ability": "world capitals",
-                        "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
-                        "input": "What's the powerhouse of the cell?",
-                    }
-                ],
-                sort_keys=True,
-            ),
-            output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
+        span_kind="workflow",
+        input_value=json.dumps(
+            [
+                {
+                    "ability": "world capitals",
+                    "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
+                    "input": "What's the powerhouse of the cell?",
+                }
+            ],
+            sort_keys=True,
         ),
+        output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
+        tags=COMMON_TAGS,
     )
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),
@@ -814,10 +800,9 @@ def test_llmobs_streamed_chain(
     assert len(spans) == 2
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_chain_span_data(
-            input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
-            output_value=mock.ANY,
-        ),
+        span_kind="workflow",
+        input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
+        tags=COMMON_TAGS,
     )
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[1]),

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -45,18 +45,6 @@ PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE = [
 ]
 
 
-# Default global config for LLMObs-enabled tests. Mirrors the previous ``llmobs``
-# fixture: agentless-style API key + the proxy URL config that the langchain
-# integration uses to decide whether a request goes through an instrumented proxy
-# (-> workflow span) or directly to the model (-> llm span).
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-key>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    _llmobs_instrumented_proxy_urls="http://localhost:4000",
-)
-
-
 COMMON_TAGS = {
     "ml_app": "langchain_test",
     "service": "tests.contrib.langchain",
@@ -152,9 +140,8 @@ def _llmobs_spans(test_spans):
     return spans
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLangChainLLMObs:
-    def test_llmobs_openai_llm(self, langchain_openai, test_spans, openai_url):
+    def test_llmobs_openai_llm(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
         llm = langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
         llm.invoke("Can you explain what Descartes meant by 'I think, therefore I am'?")
 
@@ -167,7 +154,7 @@ class TestLangChainLLMObs:
 
 
     @mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
-    def test_llmobs_openai_llm_proxy(self, mock_generate, langchain_openai, test_spans):
+    def test_llmobs_openai_llm_proxy(self, mock_generate, langchain_openai, langchain_llmobs, test_spans):
         mock_generate.return_value = mock_langchain_llm_generate_response
         llm = langchain_openai.OpenAI(base_url="http://localhost:4000", model="gpt-3.5-turbo")
         llm.invoke("What is the capital of France?")
@@ -187,7 +174,7 @@ class TestLangChainLLMObs:
         assert get_llmobs_span_kind(spans[0]) == "llm"
 
 
-    def test_llmobs_openai_chat_model(self, langchain_core, langchain_openai, test_spans, openai_url):
+    def test_llmobs_openai_chat_model(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
         chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
         chat_model.invoke([langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")])
 
@@ -201,7 +188,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_openai_chat_model_no_usage(self, langchain_core, langchain_openai, test_spans, openai_url):
+    def test_llmobs_openai_chat_model_no_usage(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
         if parse_version(importlib.metadata.version("langchain_openai")) < (0, 2, 0):
             pytest.skip("langchain-openai <0.2.0 does not support stream_usage=False")
         chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url, stream_usage=False)
@@ -221,7 +208,7 @@ class TestLangChainLLMObs:
 
 
     @mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
-    def test_llmobs_openai_chat_model_proxy(self, mock_generate, langchain_core, langchain_openai, test_spans):
+    def test_llmobs_openai_chat_model_proxy(self, mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans):
         mock_generate.return_value = mock_langchain_chat_generate_response
         chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
         chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
@@ -244,7 +231,7 @@ class TestLangChainLLMObs:
         assert get_llmobs_span_kind(spans[0]) == "llm"
 
 
-    def test_llmobs_string_prompt_template_invoke(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_string_prompt_template_invoke(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         template_string = "You are a helpful assistant. Please answer this question: {question}"
         variable_dict = {"question": "What is machine learning?"}
         prompt_template = langchain_core.prompts.PromptTemplate(
@@ -267,7 +254,7 @@ class TestLangChainLLMObs:
         assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[1]))
 
 
-    def test_llmobs_string_prompt_template_direct_invoke(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_string_prompt_template_direct_invoke(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         """Test StringPromptTemplate (PromptTemplate) with variable name detection using direct invoke (no chains)."""
         template_string = "Good {time_of_day}, {name}! How are you doing today?"
         variable_dict = {"name": "Alice", "time_of_day": "morning"}
@@ -294,7 +281,7 @@ class TestLangChainLLMObs:
         assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[0]))
 
 
-    def test_llmobs_string_prompt_template_invoke_chat_model(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_string_prompt_template_invoke_chat_model(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         template_string = "You are a helpful assistant. Please answer this question: {question}"
         variable_dict = {"question": "What is machine learning?"}
         prompt_template = langchain_core.prompts.PromptTemplate(
@@ -313,7 +300,7 @@ class TestLangChainLLMObs:
 
 
     def test_llmobs_string_prompt_template_single_variable_string_input(self, 
-        langchain_core, langchain_openai, openai_url, test_spans
+        langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
     ):
         template_string = "Write a creative story about {topic}."
         single_variable_template = langchain_core.prompts.PromptTemplate(
@@ -335,7 +322,7 @@ class TestLangChainLLMObs:
         assert actual_prompt["variables"] == {"topic": "time travel"}
 
 
-    def test_llmobs_multi_message_prompt_template_sync_chain(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_multi_message_prompt_template_sync_chain(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         test_metadata = {"template_type": "multi_message", "test_scenario": "sync_chain", "message_count": 10}
         multi_message_template = _create_multi_message_prompt_template(langchain_core, metadata=test_metadata)
         llm = langchain_openai.ChatOpenAI(base_url=openai_url)
@@ -368,7 +355,7 @@ class TestLangChainLLMObs:
 
 
     def test_llmobs_multi_message_prompt_template_sync_direct_invoke(self, 
-        langchain_core, langchain_openai, openai_url, test_spans
+        langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
     ):
         multi_message_template = _create_multi_message_prompt_template(langchain_core)
         llm = langchain_openai.ChatOpenAI(base_url=openai_url)
@@ -400,7 +387,7 @@ class TestLangChainLLMObs:
 
     @pytest.mark.asyncio
     async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
-        self, langchain_core, langchain_openai, openai_url, test_spans
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
     ):
         multi_message_template = _create_multi_message_prompt_template(langchain_core)
         llm = langchain_openai.ChatOpenAI(base_url=openai_url)
@@ -430,7 +417,7 @@ class TestLangChainLLMObs:
         assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
 
 
-    def test_llmobs_chain(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_chain(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
             [("system", "You are world class technical documentation writer."), ("user", "{input}")]
         )
@@ -463,7 +450,7 @@ class TestLangChainLLMObs:
         assert get_llmobs_input_prompt(spans[1]) == expected_prompt
 
 
-    def test_llmobs_chain_nested(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_chain_nested(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         prompt1 = langchain_core.prompts.ChatPromptTemplate.from_template("what is the city {person} is from?")
         prompt2 = langchain_core.prompts.ChatPromptTemplate.from_template(
             "what country is the city {city} in? respond in {language}"
@@ -530,7 +517,7 @@ class TestLangChainLLMObs:
 
 
     @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
-    def test_llmobs_chain_batch(self, langchain_core, langchain_openai, test_spans, openai_url):
+    def test_llmobs_chain_batch(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
         output_parser = langchain_core.output_parsers.StrOutputParser()
         model = langchain_openai.ChatOpenAI(base_url=openai_url)
@@ -561,7 +548,7 @@ class TestLangChainLLMObs:
             assert prompt_block["variables"]["topic"] in ("chickens", "pigs")
 
 
-    def test_llmobs_chain_schema_io(self, langchain_core, langchain_openai, openai_url, test_spans):
+    def test_llmobs_chain_schema_io(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
             [
                 ("system", "You're an assistant who's good at {ability}. Respond in 20 words or fewer"),
@@ -606,7 +593,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_anthropic_chat_model(self, langchain_anthropic, test_spans, anthropic_url):
+    def test_llmobs_anthropic_chat_model(self, langchain_anthropic, langchain_llmobs, test_spans, anthropic_url):
         kwargs = dict(
             temperature=0,
             max_tokens=15,
@@ -631,7 +618,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_google_genai_chat_model(self, langchain_google_genai, test_spans):
+    def test_llmobs_google_genai_chat_model(self, langchain_google_genai, langchain_llmobs, test_spans):
         if langchain_google_genai is None:
             pytest.skip("langchain-google-genai not installed")
 
@@ -675,7 +662,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_embedding_documents(self, langchain_openai, test_spans, openai_url):
+    def test_llmobs_embedding_documents(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
         embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
         embedding_model.embed_documents(["hello world", "goodbye world"])
 
@@ -692,7 +679,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_embedding_query(self, langchain_openai, test_spans, openai_url):
+    def test_llmobs_embedding_query(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
         embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
         embedding_model.embed_query("hello world")
 
@@ -709,7 +696,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_vectorstore_similarity_search(self, langchain_in_memory_vectorstore, test_spans):
+    def test_llmobs_vectorstore_similarity_search(self, langchain_in_memory_vectorstore, langchain_llmobs, test_spans):
         vectorstore = langchain_in_memory_vectorstore
         vectorstore.similarity_search("France", k=1)
 
@@ -726,7 +713,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_chat_model_tool_calls(self, langchain_core, langchain_openai, test_spans, openai_url):
+    def test_llmobs_chat_model_tool_calls(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
         @langchain_core.tools.tool
         def add(a: int, b: int) -> int:
             """Adds a and b.
@@ -740,7 +727,7 @@ class TestLangChainLLMObs:
         llm_with_tools = llm.bind_tools([add])
         llm_with_tools.invoke([langchain_core.messages.HumanMessage(content="What is the sum of 1 and 2?")])
 
-        spans = _llmobs_spans(test_spans)
+        spans = _llmobs_spans(langchain_llmobs, test_spans)
         assert len(spans) == 1
         span = spans[0]
         assert_llmobs_span_data(
@@ -768,7 +755,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_base_tool_invoke(self, langchain_core, test_spans):
+    def test_llmobs_base_tool_invoke(self, langchain_core, langchain_llmobs, test_spans):
         from math import pi
 
         def circumference_tool(radius: float) -> float:
@@ -784,7 +771,7 @@ class TestLangChainLLMObs:
 
         calculator.invoke("2", config={"test": "this is to test config"})
 
-        spans = _llmobs_spans(test_spans)
+        spans = _llmobs_spans(langchain_llmobs, test_spans)
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
@@ -803,7 +790,7 @@ class TestLangChainLLMObs:
 
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_llmobs_streamed_chain(self, langchain_core, langchain_openai, test_spans, openai_url, consume_stream):
+    def test_llmobs_streamed_chain(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
             [("system", "You are a world class technical documentation writer."), ("user", "{input}")]
         )
@@ -840,7 +827,7 @@ class TestLangChainLLMObs:
 
 
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_llmobs_streamed_llm(self, langchain_openai, test_spans, openai_url, consume_stream):
+    def test_llmobs_streamed_llm(self, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream):
         llm = langchain_openai.OpenAI(base_url=openai_url, n=1, seed=1, logprobs=None, logit_bias=None)
 
         consume_stream(llm.stream("What is 2+2?\n\n"))
@@ -863,7 +850,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_non_ascii_completion(self, langchain_openai, openai_url, test_spans):
+    def test_llmobs_non_ascii_completion(self, langchain_openai, openai_url, langchain_llmobs, test_spans):
         llm = langchain_openai.OpenAI(base_url=openai_url)
         llm.invoke("안녕,\n 지금 몇 시야?")
 
@@ -872,7 +859,7 @@ class TestLangChainLLMObs:
         assert get_llmobs_input_messages(spans[0])[0]["content"] == "안녕,\n 지금 몇 시야?"
 
 
-    def test_llmobs_runnable_lambda_invoke(self, langchain_core, test_spans):
+    def test_llmobs_runnable_lambda_invoke(self, langchain_core, langchain_llmobs, test_spans):
         def add(inputs: dict) -> int:
             return inputs["a"] + inputs["b"]
 
@@ -880,7 +867,7 @@ class TestLangChainLLMObs:
         result = runnable_lambda.invoke(dict(a=1, b=2))
         assert result == 3
 
-        spans = _llmobs_spans(test_spans)
+        spans = _llmobs_spans(langchain_llmobs, test_spans)
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
@@ -891,7 +878,7 @@ class TestLangChainLLMObs:
         )
 
 
-    async def test_llmobs_runnable_lambda_ainvoke(self, langchain_core, test_spans):
+    async def test_llmobs_runnable_lambda_ainvoke(self, langchain_core, langchain_llmobs, test_spans):
         async def add(inputs: dict) -> int:
             return inputs["a"] + inputs["b"]
 
@@ -899,7 +886,7 @@ class TestLangChainLLMObs:
         result = await runnable_lambda.ainvoke(dict(a=1, b=2))
         assert result == 3
 
-        spans = _llmobs_spans(test_spans)
+        spans = _llmobs_spans(langchain_llmobs, test_spans)
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
@@ -910,7 +897,7 @@ class TestLangChainLLMObs:
         )
 
 
-    def test_llmobs_runnable_lambda_batch(self, langchain_core, test_spans):
+    def test_llmobs_runnable_lambda_batch(self, langchain_core, langchain_llmobs, test_spans):
         def add(inputs: dict) -> int:
             return inputs["a"] + inputs["b"]
 
@@ -918,7 +905,7 @@ class TestLangChainLLMObs:
         result = runnable_lambda.batch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
         assert result == [3, 7, 11]
 
-        spans = _llmobs_spans(test_spans)
+        spans = _llmobs_spans(langchain_llmobs, test_spans)
         assert len(spans) == 4
 
         # parent should be batch span
@@ -946,7 +933,7 @@ class TestLangChainLLMObs:
             assert isinstance(output_value, int)
 
 
-    async def test_llmobs_runnable_lambda_abatch(self, langchain_core, test_spans):
+    async def test_llmobs_runnable_lambda_abatch(self, langchain_core, langchain_llmobs, test_spans):
         async def add(inputs: dict) -> int:
             return inputs["a"] + inputs["b"]
 
@@ -954,7 +941,7 @@ class TestLangChainLLMObs:
         result = await runnable_lambda.abatch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
         assert result == [3, 7, 11]
 
-        spans = _llmobs_spans(test_spans)
+        spans = _llmobs_spans(langchain_llmobs, test_spans)
         assert len(spans) == 4
 
         # parent should be batch span
@@ -982,7 +969,7 @@ class TestLangChainLLMObs:
             assert isinstance(output_value, int)
 
 
-    def test_llmobs_runnable_with_span_links(self, langchain_core, test_spans):
+    def test_llmobs_runnable_with_span_links(self, langchain_core, langchain_llmobs, test_spans):
         sequence = langchain_core.runnables.RunnableLambda(lambda x: x + 1, name="add_1") | {
             "mul_2": langchain_core.runnables.RunnableLambda(lambda x: x * 2, name="mul_2"),
             "mul_5": langchain_core.runnables.RunnableLambda(lambda x: x * 5, name="mul_5"),

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -82,14 +82,8 @@ def _create_multi_message_prompt_template(langchain_core, metadata=None):
 
 
 def _expected_llm_span_data(span, input_role=None, mock_io=False, mock_token_metrics=False, metadata=None):
-    """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain LLM span.
-
-    Mirrors the structural shape produced by the legacy
-    ``_expected_langchain_llmobs_llm_span`` helper. The prompt block (when present) is
-    asserted separately by callers against ``meta.input.prompt`` on the metastruct.
-    """
+    """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain LLM span."""
     provider = span.get_tag("langchain.request.provider")
-    metadata = metadata if metadata else mock.ANY
 
     input_messages = [{"content": mock.ANY}]
     output_messages = [{"content": mock.ANY}]

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -10,11 +10,11 @@ import pytest
 from ddtrace import patch
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.trace import Span
 from tests.contrib.langchain.utils import mock_langchain_chat_generate_response
 from tests.contrib.langchain.utils import mock_langchain_llm_generate_response
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
 from tests.llmobs._utils import iterate_stream
 from tests.llmobs._utils import next_stream
 from tests.subprocesstest import SubprocessTestCase
@@ -35,6 +35,25 @@ PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE = [
     {"role": "assistant", "content": "Let me provide {output_type}"},
     {"role": "developer", "content": "Make it {style} and under {limit} words"},
 ]
+
+
+# Default global config for LLMObs-enabled tests. Mirrors the previous ``llmobs``
+# fixture: agentless-style API key + the proxy URL config that the langchain
+# integration uses to decide whether a request goes through an instrumented proxy
+# (-> workflow span) or directly to the model (-> llm span).
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-key>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    _llmobs_instrumented_proxy_urls="http://localhost:4000",
+)
+
+
+COMMON_TAGS = {
+    "ml_app": "langchain_test",
+    "service": "tests.contrib.langchain",
+    "integration": "langchain",
+}
 
 
 def _create_multi_message_prompt_template(langchain_core, metadata=None):
@@ -65,11 +84,14 @@ def _create_multi_message_prompt_template(langchain_core, metadata=None):
     return template
 
 
-def _expected_langchain_llmobs_llm_span(
-    span, input_role=None, mock_io=False, mock_token_metrics=False, span_links=False, metadata=None, prompt=None
-):
-    provider = span.get_tag("langchain.request.provider")
+def _llm_span_kwargs(span, input_role=None, mock_io=False, mock_token_metrics=False, metadata=None):
+    """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain LLM span.
 
+    Mirrors the structural shape produced by the legacy
+    ``_expected_langchain_llmobs_llm_span`` helper. The prompt block (when present) is
+    asserted separately by callers against ``meta.input.prompt`` on the metastruct.
+    """
+    provider = span.get_tag("langchain.request.provider")
     metadata = metadata if metadata else mock.ANY
 
     input_messages = [{"content": mock.ANY}]
@@ -82,336 +104,344 @@ def _expected_langchain_llmobs_llm_span(
         {"input_tokens": mock.ANY, "output_tokens": mock.ANY, "total_tokens": mock.ANY} if mock_token_metrics else {}
     )
 
-    return _expected_llmobs_llm_span_event(
-        span,
+    return dict(
+        span_kind="llm",
         model_name=span.get_tag("langchain.request.model"),
         model_provider=provider,
         input_messages=input_messages if not mock_io else mock.ANY,
         output_messages=output_messages if not mock_io else mock.ANY,
         metadata=metadata,
-        token_metrics=metrics,
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-        span_links=span_links,
-        prompt=prompt,
-        prompt_tracking_instrumentation_method="auto" if prompt else None,
+        metrics=metrics,
+        tags=COMMON_TAGS,
     )
 
 
-def _expected_langchain_llmobs_chain_span(span, input_value=None, output_value=None, span_links=False, metadata=None):
+def _chain_span_kwargs(input_value=None, output_value=None, metadata=None):
+    """Build kwargs to splat into ``assert_llmobs_span_data`` for a langchain chain (workflow) span."""
     metadata = metadata if metadata else mock.ANY
-    return _expected_llmobs_non_llm_span_event(
-        span,
-        "workflow",
+    return dict(
+        span_kind="workflow",
         input_value=input_value if input_value is not None else mock.ANY,
         output_value=output_value if output_value is not None else mock.ANY,
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-        span_links=span_links,
         metadata=metadata,
+        tags=COMMON_TAGS,
     )
 
 
-def test_llmobs_openai_llm(langchain_openai, llmobs_events, tracer, test_spans, openai_url):
-    llm = langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
-    llm.invoke("Can you explain what Descartes meant by 'I think, therefore I am'?")
-
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_langchain_llmobs_llm_span(
-        span, mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}
-    )
+def _has_prompt_tracking_tag(metastruct):
+    """Return True if the prompt-tracking tag is present (handles dict-shape and list-shape tags)."""
+    tags = metastruct.get("tags") or {}
+    if isinstance(tags, dict):
+        return tags.get("prompt_tracking_instrumentation_method") == "auto"
+    return any(t == "prompt_tracking_instrumentation_method:auto" for t in tags)
 
 
-@mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
-def test_llmobs_openai_llm_proxy(mock_generate, langchain_openai, llmobs_events, tracer, test_spans):
-    mock_generate.return_value = mock_langchain_llm_generate_response
-    llm = langchain_openai.OpenAI(base_url="http://localhost:4000", model="gpt-3.5-turbo")
-    llm.invoke("What is the capital of France?")
-
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_langchain_llmobs_chain_span(
-        span,
-        input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True),
-    )
-
-    # span created from request with non-proxy URL should result in an LLM span
-    llm = langchain_openai.OpenAI(base_url="http://localhost:8000", model="gpt-3.5-turbo")
-    llm.invoke("What is the capital of France?")
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 2
-    assert llmobs_events[1]["meta"]["span"]["kind"] == "llm"
+def _llmobs_spans(test_spans):
+    """Collect all spans from ``pop_traces()`` that have an LLMObsSpanData metastruct, sorted by start_ns."""
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
+    spans.sort(key=lambda s: s.start_ns)
+    return spans
 
 
-def test_llmobs_openai_chat_model(langchain_core, langchain_openai, llmobs_events, tracer, test_spans, openai_url):
-    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
-    chat_model.invoke([langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")])
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+class TestLangChainLLMObs:
+    def test_llmobs_openai_llm(self, langchain_openai, test_spans, openai_url):
+        llm = langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
+        llm.invoke("Can you explain what Descartes meant by 'I think, therefore I am'?")
 
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_langchain_llmobs_llm_span(
-        span,
-        input_role="user",
-        mock_token_metrics=True,
-        metadata={"temperature": 0.0, "max_tokens": 256},
-    )
-
-
-def test_llmobs_openai_chat_model_no_usage(langchain_core, langchain_openai, llmobs_events, openai_url):
-    if parse_version(importlib.metadata.version("langchain_openai")) < (0, 2, 0):
-        pytest.skip("langchain-openai <0.2.0 does not support stream_usage=False")
-    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url, stream_usage=False)
-
-    response = chat_model.stream(
-        [langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")]
-    )
-    for _ in response:
-        pass
-
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0]["metrics"].get("input_tokens") is None
-    assert llmobs_events[0]["metrics"].get("output_tokens") is None
-    assert llmobs_events[0]["metrics"].get("total_tokens") is None
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_llm_span_kwargs(spans[0], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+        )
 
 
-@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
-def test_llmobs_openai_chat_model_proxy(
-    mock_generate, langchain_core, langchain_openai, llmobs_events, tracer, test_spans
-):
-    mock_generate.return_value = mock_langchain_chat_generate_response
-    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
-    chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
+    @mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
+    def test_llmobs_openai_llm_proxy(self, mock_generate, langchain_openai, test_spans):
+        mock_generate.return_value = mock_langchain_llm_generate_response
+        llm = langchain_openai.OpenAI(base_url="http://localhost:4000", model="gpt-3.5-turbo")
+        llm.invoke("What is the capital of France?")
 
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_langchain_llmobs_chain_span(
-        span,
-        input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
-        metadata={"temperature": 0.0, "max_tokens": 256},
-    )
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)),
+        )
 
-    # span created from request with non-proxy URL should result in an LLM span
-    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:8000")
-    chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 2
-    assert llmobs_events[1]["meta"]["span"]["kind"] == "llm"
+        # span created from request with non-proxy URL should result in an LLM span
+        llm = langchain_openai.OpenAI(base_url="http://localhost:8000", model="gpt-3.5-turbo")
+        llm.invoke("What is the capital of France?")
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
 
 
-def test_llmobs_string_prompt_template_invoke(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer, test_spans
-):
-    template_string = "You are a helpful assistant. Please answer this question: {question}"
-    variable_dict = {"question": "What is machine learning?"}
-    prompt_template = langchain_core.prompts.PromptTemplate(
-        input_variables=list(variable_dict.keys()),
-        template=template_string,
-        metadata={"test_type": "basic_invoke", "author": "test_suite"},
-    )
-    llm = langchain_openai.OpenAI(base_url=openai_url)
-    chain = prompt_template | llm
-    chain.invoke(variable_dict)
+    def test_llmobs_openai_chat_model(self, langchain_core, langchain_openai, test_spans, openai_url):
+        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
+        chat_model.invoke([langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")])
 
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 2
-    actual_prompt = llmobs_events[1]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
-    assert actual_prompt["template"] == template_string
-    assert actual_prompt["variables"] == variable_dict
-    assert "tags" in actual_prompt
-    assert actual_prompt["tags"] == {"test_type": "basic_invoke", "author": "test_suite"}
-    assert "prompt_tracking_instrumentation_method:auto" in llmobs_events[1]["tags"]
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_llm_span_kwargs(
+                spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0, "max_tokens": 256}
+            ),
+        )
 
 
-def test_llmobs_string_prompt_template_direct_invoke(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer
-):
-    """Test StringPromptTemplate (PromptTemplate) with variable name detection using direct invoke (no chains)."""
-    template_string = "Good {time_of_day}, {name}! How are you doing today?"
-    variable_dict = {"name": "Alice", "time_of_day": "morning"}
-    greeting_template = langchain_core.prompts.PromptTemplate(
-        input_variables=list(variable_dict.keys()),
-        template=template_string,
-        metadata={"test_type": "direct_invoke", "interaction": "greeting", "not_string_1": True, "not_string_2": 10},
-    )
-    llm = langchain_openai.OpenAI(base_url=openai_url)
+    def test_llmobs_openai_chat_model_no_usage(self, langchain_core, langchain_openai, test_spans, openai_url):
+        if parse_version(importlib.metadata.version("langchain_openai")) < (0, 2, 0):
+            pytest.skip("langchain-openai <0.2.0 does not support stream_usage=False")
+        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url, stream_usage=False)
 
-    # Direct invoke on template first, then pass to LLM (no chain)
-    prompt_value = greeting_template.invoke(variable_dict)
-    llm.invoke(prompt_value)
+        response = chat_model.stream(
+            [langchain_core.messages.HumanMessage(content="When do you use 'who' instead of 'whom'?")]
+        )
+        for _ in response:
+            pass
 
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 1  # Only LLM span, prompt template invoke doesn't create LLMObs event by itself
-
-    actual_prompt = llmobs_events[0]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.greeting_template"
-    assert actual_prompt["template"] == template_string
-    assert actual_prompt["variables"] == variable_dict
-    assert "tags" in actual_prompt
-    assert actual_prompt["tags"] == {"test_type": "direct_invoke", "interaction": "greeting"}
-    assert "prompt_tracking_instrumentation_method:auto" in llmobs_events[0]["tags"]
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        metrics = _get_llmobs_data_metastruct(spans[0]).get("metrics") or {}
+        assert metrics.get("input_tokens") is None
+        assert metrics.get("output_tokens") is None
+        assert metrics.get("total_tokens") is None
 
 
-def test_llmobs_string_prompt_template_invoke_chat_model(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer
-):
-    template_string = "You are a helpful assistant. Please answer this question: {question}"
-    variable_dict = {"question": "What is machine learning?"}
-    prompt_template = langchain_core.prompts.PromptTemplate(
-        input_variables=list(variable_dict.keys()), template=template_string
-    )
-    chat_model = langchain_openai.ChatOpenAI(base_url=openai_url)
-    chain = prompt_template | chat_model
-    chain.invoke(variable_dict)
+    @mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+    def test_llmobs_openai_chat_model_proxy(self, mock_generate, langchain_core, langchain_openai, test_spans):
+        mock_generate.return_value = mock_langchain_chat_generate_response
+        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
+        chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
 
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 2
-    actual_prompt = llmobs_events[1]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
-    assert actual_prompt["template"] == template_string
-    assert actual_prompt["variables"] == variable_dict
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(
+                input_value=json.dumps([{"content": "What is the capital of France?", "role": "user"}], sort_keys=True),
+                metadata={"temperature": 0.0, "max_tokens": 256},
+            ),
+        )
 
-
-def test_llmobs_string_prompt_template_single_variable_string_input(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer
-):
-    template_string = "Write a creative story about {topic}."
-    single_variable_template = langchain_core.prompts.PromptTemplate(
-        input_variables=["topic"], template=template_string
-    )
-    llm = langchain_openai.OpenAI(base_url=openai_url)
-    chain = single_variable_template | llm
-
-    # Pass string input directly instead of dict for single variable template
-    string_input = "time travel"
-    chain.invoke(string_input)
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 2
-    actual_prompt = llmobs_events[1]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.single_variable_template"
-    assert actual_prompt["template"] == template_string
-    # Should convert string input to dict format with single variable
-    assert actual_prompt["variables"] == {"topic": "time travel"}
+        # span created from request with non-proxy URL should result in an LLM span
+        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:8000")
+        chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert _get_llmobs_data_metastruct(spans[0])["meta"]["span"]["kind"] == "llm"
 
 
-def test_llmobs_multi_message_prompt_template_sync_chain(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer
-):
-    test_metadata = {"template_type": "multi_message", "test_scenario": "sync_chain", "message_count": 10}
-    multi_message_template = _create_multi_message_prompt_template(langchain_core, metadata=test_metadata)
-    llm = langchain_openai.ChatOpenAI(base_url=openai_url)
-    chain = multi_message_template | llm
+    def test_llmobs_string_prompt_template_invoke(self, langchain_core, langchain_openai, openai_url, test_spans):
+        template_string = "You are a helpful assistant. Please answer this question: {question}"
+        variable_dict = {"question": "What is machine learning?"}
+        prompt_template = langchain_core.prompts.PromptTemplate(
+            input_variables=list(variable_dict.keys()),
+            template=template_string,
+            metadata={"test_type": "basic_invoke", "author": "test_suite"},
+        )
+        llm = langchain_openai.OpenAI(base_url=openai_url)
+        chain = prompt_template | llm
+        chain.invoke(variable_dict)
 
-    variable_dict = {
-        "domain": "creative writing",
-        "context": "focus on storytelling",
-        "task": "writing a short story",
-        "specific_help": "character development",
-        "output_type": "guidance",
-        "style": "engaging",
-        "limit": "100",
-    }
-
-    chain.invoke(variable_dict)
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 2
-
-    # Verify the prompt structure in the LLM span
-    actual_prompt = llmobs_events[1]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
-    assert actual_prompt["variables"] == variable_dict
-    assert actual_prompt.get("template") is None
-    assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
-    # Check that metadata from the multi-message prompt template is preserved
-    assert "tags" in actual_prompt
-    assert actual_prompt["tags"] == {k: v for k, v in test_metadata.items() if isinstance(v, str)}
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
+        assert actual_prompt["template"] == template_string
+        assert actual_prompt["variables"] == variable_dict
+        assert "tags" in actual_prompt
+        assert actual_prompt["tags"] == {"test_type": "basic_invoke", "author": "test_suite"}
+        assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[1]))
 
 
-def test_llmobs_multi_message_prompt_template_sync_direct_invoke(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer
-):
-    multi_message_template = _create_multi_message_prompt_template(langchain_core)
-    llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+    def test_llmobs_string_prompt_template_direct_invoke(self, langchain_core, langchain_openai, openai_url, test_spans):
+        """Test StringPromptTemplate (PromptTemplate) with variable name detection using direct invoke (no chains)."""
+        template_string = "Good {time_of_day}, {name}! How are you doing today?"
+        variable_dict = {"name": "Alice", "time_of_day": "morning"}
+        greeting_template = langchain_core.prompts.PromptTemplate(
+            input_variables=list(variable_dict.keys()),
+            template=template_string,
+            metadata={"test_type": "direct_invoke", "interaction": "greeting", "not_string_1": True, "not_string_2": 10},
+        )
+        llm = langchain_openai.OpenAI(base_url=openai_url)
 
-    variable_dict = {
-        "domain": "data analysis",
-        "context": "focus on accuracy",
-        "task": "analyzing datasets",
-        "specific_help": "statistical methods",
-        "output_type": "insights",
-        "style": "detailed",
-        "limit": "150",
-    }
+        # Direct invoke on template first, then pass to LLM (no chain)
+        prompt_value = greeting_template.invoke(variable_dict)
+        llm.invoke(prompt_value)
 
-    # Test direct invoke on template then LLM (no chain)
-    prompt_value = multi_message_template.invoke(variable_dict)
-    llm.invoke(prompt_value)
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1  # Only LLM span, prompt template invoke doesn't create LLMObs event by itself
 
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 1  # Only LLM span for direct invoke
-
-    # Verify the prompt structure
-    actual_prompt = llmobs_events[0]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
-    assert actual_prompt["variables"] == variable_dict
-    assert actual_prompt.get("template") is None
-    assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+        actual_prompt = _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.greeting_template"
+        assert actual_prompt["template"] == template_string
+        assert actual_prompt["variables"] == variable_dict
+        assert "tags" in actual_prompt
+        assert actual_prompt["tags"] == {"test_type": "direct_invoke", "interaction": "greeting"}
+        assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[0]))
 
 
-@pytest.mark.asyncio
-async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
-    langchain_core, langchain_openai, openai_url, llmobs_events, tracer
-):
-    multi_message_template = _create_multi_message_prompt_template(langchain_core)
-    llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+    def test_llmobs_string_prompt_template_invoke_chat_model(self, langchain_core, langchain_openai, openai_url, test_spans):
+        template_string = "You are a helpful assistant. Please answer this question: {question}"
+        variable_dict = {"question": "What is machine learning?"}
+        prompt_template = langchain_core.prompts.PromptTemplate(
+            input_variables=list(variable_dict.keys()), template=template_string
+        )
+        chat_model = langchain_openai.ChatOpenAI(base_url=openai_url)
+        chain = prompt_template | chat_model
+        chain.invoke(variable_dict)
 
-    variable_dict = {
-        "domain": "software engineering",
-        "context": "focus on best practices",
-        "task": "code review",
-        "specific_help": "performance optimization",
-        "output_type": "recommendations",
-        "style": "thorough",
-        "limit": "200",
-    }
-
-    # Test direct async invoke on template then LLM
-    prompt_value = await multi_message_template.ainvoke(variable_dict)
-    await llm.ainvoke(prompt_value)
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(llmobs_events) == 1  # Only LLM span for direct invoke
-
-    # Verify the prompt structure
-    actual_prompt = llmobs_events[0]["meta"]["input"]["prompt"]
-    assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
-    assert actual_prompt["variables"] == variable_dict
-    assert actual_prompt.get("template") is None
-    assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.prompt_template"
+        assert actual_prompt["template"] == template_string
+        assert actual_prompt["variables"] == variable_dict
 
 
-def test_llmobs_chain(langchain_core, langchain_openai, openai_url, llmobs_events, tracer, test_spans):
-    prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
-        [("system", "You are world class technical documentation writer."), ("user", "{input}")]
-    )
-    chain = prompt | langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
-    chain.invoke({"input": "Can you explain what an LLM chain is?"})
+    def test_llmobs_string_prompt_template_single_variable_string_input(self, 
+        langchain_core, langchain_openai, openai_url, test_spans
+    ):
+        template_string = "Write a creative story about {topic}."
+        single_variable_template = langchain_core.prompts.PromptTemplate(
+            input_variables=["topic"], template=template_string
+        )
+        llm = langchain_openai.OpenAI(base_url=openai_url)
+        chain = single_variable_template | llm
 
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 2
-    assert llmobs_events[0] == _expected_langchain_llmobs_chain_span(
-        trace[0],
-        input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
-        span_links=True,
-    )
-    assert llmobs_events[1] == _expected_langchain_llmobs_llm_span(
-        trace[1],
-        mock_token_metrics=True,
-        span_links=True,
-        metadata={"max_tokens": 256, "temperature": 0.7},
-        prompt={
+        # Pass string input directly instead of dict for single variable template
+        string_input = "time travel"
+        chain.invoke(string_input)
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.single_variable_template"
+        assert actual_prompt["template"] == template_string
+        # Should convert string input to dict format with single variable
+        assert actual_prompt["variables"] == {"topic": "time travel"}
+
+
+    def test_llmobs_multi_message_prompt_template_sync_chain(self, langchain_core, langchain_openai, openai_url, test_spans):
+        test_metadata = {"template_type": "multi_message", "test_scenario": "sync_chain", "message_count": 10}
+        multi_message_template = _create_multi_message_prompt_template(langchain_core, metadata=test_metadata)
+        llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+        chain = multi_message_template | llm
+
+        variable_dict = {
+            "domain": "creative writing",
+            "context": "focus on storytelling",
+            "task": "writing a short story",
+            "specific_help": "character development",
+            "output_type": "guidance",
+            "style": "engaging",
+            "limit": "100",
+        }
+
+        chain.invoke(variable_dict)
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+
+        # Verify the prompt structure in the LLM span
+        actual_prompt = _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
+        assert actual_prompt["variables"] == variable_dict
+        assert actual_prompt.get("template") is None
+        assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+        # Check that metadata from the multi-message prompt template is preserved
+        assert "tags" in actual_prompt
+        assert actual_prompt["tags"] == {k: v for k, v in test_metadata.items() if isinstance(v, str)}
+
+
+    def test_llmobs_multi_message_prompt_template_sync_direct_invoke(self, 
+        langchain_core, langchain_openai, openai_url, test_spans
+    ):
+        multi_message_template = _create_multi_message_prompt_template(langchain_core)
+        llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+
+        variable_dict = {
+            "domain": "data analysis",
+            "context": "focus on accuracy",
+            "task": "analyzing datasets",
+            "specific_help": "statistical methods",
+            "output_type": "insights",
+            "style": "detailed",
+            "limit": "150",
+        }
+
+        # Test direct invoke on template then LLM (no chain)
+        prompt_value = multi_message_template.invoke(variable_dict)
+        llm.invoke(prompt_value)
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1  # Only LLM span for direct invoke
+
+        # Verify the prompt structure
+        actual_prompt = _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
+        assert actual_prompt["variables"] == variable_dict
+        assert actual_prompt.get("template") is None
+        assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+
+
+    @pytest.mark.asyncio
+    async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
+        self, langchain_core, langchain_openai, openai_url, test_spans
+    ):
+        multi_message_template = _create_multi_message_prompt_template(langchain_core)
+        llm = langchain_openai.ChatOpenAI(base_url=openai_url)
+
+        variable_dict = {
+            "domain": "software engineering",
+            "context": "focus on best practices",
+            "task": "code review",
+            "specific_help": "performance optimization",
+            "output_type": "recommendations",
+            "style": "thorough",
+            "limit": "200",
+        }
+
+        # Test direct async invoke on template then LLM
+        prompt_value = await multi_message_template.ainvoke(variable_dict)
+        await llm.ainvoke(prompt_value)
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1  # Only LLM span for direct invoke
+
+        # Verify the prompt structure
+        actual_prompt = _get_llmobs_data_metastruct(spans[0])["meta"]["input"]["prompt"]
+        assert actual_prompt["id"] == "test_langchain_llmobs.multi_message_template"
+        assert actual_prompt["variables"] == variable_dict
+        assert actual_prompt.get("template") is None
+        assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
+
+
+    def test_llmobs_chain(self, langchain_core, langchain_openai, openai_url, test_spans):
+        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+            [("system", "You are world class technical documentation writer."), ("user", "{input}")]
+        )
+        chain = prompt | langchain_openai.OpenAI(base_url=openai_url, max_tokens=256)
+        chain.invoke({"input": "Can you explain what an LLM chain is?"})
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(
+                input_value=json.dumps([{"input": "Can you explain what an LLM chain is?"}], sort_keys=True),
+            ),
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[1]),
+            **_llm_span_kwargs(spans[1], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
+        )
+        expected_prompt = {
             "id": "test_langchain_llmobs.prompt",
             "ml_app": "langchain_test",
             "chat_template": [
@@ -421,466 +451,593 @@ def test_llmobs_chain(langchain_core, langchain_openai, openai_url, llmobs_event
             "variables": {"input": "Can you explain what an LLM chain is?"},
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
-        },
-    )
+        }
+        assert _get_llmobs_data_metastruct(spans[1])["meta"]["input"]["prompt"] == expected_prompt
 
 
-def test_llmobs_chain_nested(langchain_core, langchain_openai, openai_url, llmobs_events, tracer, test_spans):
-    prompt1 = langchain_core.prompts.ChatPromptTemplate.from_template("what is the city {person} is from?")
-    prompt2 = langchain_core.prompts.ChatPromptTemplate.from_template(
-        "what country is the city {city} in? respond in {language}"
-    )
-    model = langchain_openai.OpenAI(base_url=openai_url)
-    chain1 = prompt1 | model | langchain_core.output_parsers.StrOutputParser()
-    chain2 = prompt2 | model | langchain_core.output_parsers.StrOutputParser()
-    complete_chain = {"city": chain1, "language": itemgetter("language")} | chain2
+    def test_llmobs_chain_nested(self, langchain_core, langchain_openai, openai_url, test_spans):
+        prompt1 = langchain_core.prompts.ChatPromptTemplate.from_template("what is the city {person} is from?")
+        prompt2 = langchain_core.prompts.ChatPromptTemplate.from_template(
+            "what country is the city {city} in? respond in {language}"
+        )
+        model = langchain_openai.OpenAI(base_url=openai_url)
+        chain1 = prompt1 | model | langchain_core.output_parsers.StrOutputParser()
+        chain2 = prompt2 | model | langchain_core.output_parsers.StrOutputParser()
+        complete_chain = {"city": chain1, "language": itemgetter("language")} | chain2
 
-    complete_chain.invoke({"person": "Spongebob Squarepants", "language": "Spanish"})
+        complete_chain.invoke({"person": "Spongebob Squarepants", "language": "Spanish"})
 
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 5
-    # Match LLMObs events to APM spans by span_id to avoid assuming a fixed ordering
-    # for the two parallel branches (chain1 LLM call vs itemgetter), whose start_ns
-    # ordering is non-deterministic due to thread scheduling in RunnableParallel.
-    events_by_span_id = {e["span_id"]: e for e in llmobs_events}
-    assert events_by_span_id[str(trace[0].span_id)] == _expected_langchain_llmobs_chain_span(
-        trace[0],
-        input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
-        output_value=mock.ANY,
-        span_links=True,
-    )
-    assert events_by_span_id[str(trace[1].span_id)] == _expected_langchain_llmobs_chain_span(
-        trace[1],
-        input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
-        output_value=mock.ANY,
-        span_links=True,
-    )
-    assert events_by_span_id[str(trace[2].span_id)] == _expected_llmobs_non_llm_span_event(
-        trace[2],
-        span_kind="task",
-        input_value=json.dumps({"person": "Spongebob Squarepants", "language": "Spanish"}, sort_keys=True),
-        output_value="Spanish",
-        span_links=True,
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
-    assert events_by_span_id[str(trace[3].span_id)] == _expected_langchain_llmobs_llm_span(
-        trace[3],
-        mock_token_metrics=True,
-        span_links=True,
-        prompt={
+        # Use the APM trace (parent-first ordering) directly; the legacy test indexed by
+        # ``trace[i]`` here, and that maps 1:1 to the LLMObs spans on the same Spans.
+        trace = test_spans.pop_traces()[0]
+        spans = [s for s in trace if _get_llmobs_data_metastruct(s)]
+        assert len(spans) == 5
+
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(
+                input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
+                output_value=mock.ANY,
+            ),
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[1]),
+            **_chain_span_kwargs(
+                input_value=json.dumps([{"person": "Spongebob Squarepants", "language": "Spanish"}], sort_keys=True),
+                output_value=mock.ANY,
+            ),
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[2]),
+            span_kind="task",
+            input_value=json.dumps({"person": "Spongebob Squarepants", "language": "Spanish"}, sort_keys=True),
+            output_value="Spanish",
+            tags=COMMON_TAGS,
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[3]), **_llm_span_kwargs(spans[3], mock_token_metrics=True)
+        )
+        expected_prompt_3 = {
             "id": "langchain.unknown_prompt_template",
             "ml_app": "langchain_test",
             "chat_template": [{"content": "what is the city {person} is from?", "role": "user"}],
             "variables": {"person": "Spongebob Squarepants", "language": "Spanish"},
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
-        },
-    )
-    assert events_by_span_id[str(trace[4].span_id)] == _expected_langchain_llmobs_llm_span(
-        trace[4],
-        mock_token_metrics=True,
-        span_links=True,
-        prompt={
+        }
+        assert _get_llmobs_data_metastruct(spans[3])["meta"]["input"]["prompt"] == expected_prompt_3
+
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[4]), **_llm_span_kwargs(spans[4], mock_token_metrics=True)
+        )
+        expected_prompt_4 = {
             "id": "test_langchain_llmobs.prompt2",
             "ml_app": "langchain_test",
             "chat_template": [{"content": "what country is the city {city} in? respond in {language}", "role": "user"}],
             "variables": {"city": mock.ANY, "language": "Spanish"},
             "_dd_context_variable_keys": ["context"],
             "_dd_query_variable_keys": ["question"],
-        },
-    )
-
-
-@pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
-def test_llmobs_chain_batch(langchain_core, langchain_openai, llmobs_events, tracer, test_spans, openai_url):
-    prompt = langchain_core.prompts.ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
-    output_parser = langchain_core.output_parsers.StrOutputParser()
-    model = langchain_openai.ChatOpenAI(base_url=openai_url)
-    chain = {"topic": langchain_core.runnables.RunnablePassthrough()} | prompt | model | output_parser
-
-    chain.batch(inputs=["chickens", "pigs"])
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 3
-    assert llmobs_events[0] == _expected_langchain_llmobs_chain_span(
-        trace[0],
-        input_value=json.dumps(["chickens", "pigs"], sort_keys=True),
-        output_value=mock.ANY,
-        span_links=True,
-    )
-
-    try:
-        assert llmobs_events[1] == _expected_langchain_llmobs_llm_span(
-            trace[1],
-            input_role="user",
-            mock_token_metrics=True,
-            span_links=True,
-            prompt={
-                "id": "langchain.unknown_prompt_template",
-                "ml_app": "langchain_test",
-                "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
-                "variables": {"topic": "chickens"},
-                "_dd_context_variable_keys": ["context"],
-                "_dd_query_variable_keys": ["question"],
-            },
-        )
-        assert llmobs_events[2] == _expected_langchain_llmobs_llm_span(
-            trace[2],
-            input_role="user",
-            mock_token_metrics=True,
-            span_links=True,
-            prompt={
-                "id": "langchain.unknown_prompt_template",
-                "ml_app": "langchain_test",
-                "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
-                "variables": {"topic": "pigs"},
-                "_dd_context_variable_keys": ["context"],
-                "_dd_query_variable_keys": ["question"],
-            },
-        )
-    except AssertionError:
-        assert llmobs_events[1] == _expected_langchain_llmobs_llm_span(
-            trace[2],
-            input_role="user",
-            mock_token_metrics=True,
-            span_links=True,
-            prompt={
-                "id": "langchain.unknown_prompt_template",
-                "ml_app": "langchain_test",
-                "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
-                "variables": {"topic": "chickens"},
-                "_dd_context_variable_keys": ["context"],
-                "_dd_query_variable_keys": ["question"],
-            },
-        )
-        assert llmobs_events[2] == _expected_langchain_llmobs_llm_span(
-            trace[1],
-            input_role="user",
-            mock_token_metrics=True,
-            span_links=True,
-            prompt={
-                "id": "langchain.unknown_prompt_template",
-                "ml_app": "langchain_test",
-                "chat_template": [{"content": "Tell me a short joke about {topic}", "role": "user"}],
-                "variables": {"topic": "pigs"},
-                "_dd_context_variable_keys": ["context"],
-                "_dd_query_variable_keys": ["question"],
-            },
-        )
-
-
-def test_llmobs_chain_schema_io(langchain_core, langchain_openai, openai_url, llmobs_events, tracer, test_spans):
-    prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
-        [
-            ("system", "You're an assistant who's good at {ability}. Respond in 20 words or fewer"),
-            langchain_core.prompts.MessagesPlaceholder(variable_name="history"),
-            ("human", "{input}"),
-        ]
-    )
-    chain = prompt | langchain_openai.ChatOpenAI(base_url=openai_url)
-
-    chain.invoke(
-        {
-            "ability": "world capitals",
-            "history": [
-                langchain_core.messages.HumanMessage(content="Can you be my science teacher instead?"),
-                langchain_core.messages.AIMessage(content="Yes"),
-            ],
-            "input": "What's the powerhouse of the cell?",
         }
-    )
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 2
-    assert llmobs_events[0] == _expected_langchain_llmobs_chain_span(
-        trace[0],
-        input_value=json.dumps(
-            [
-                {
-                    "ability": "world capitals",
-                    "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
-                    "input": "What's the powerhouse of the cell?",
-                }
-            ],
-            sort_keys=True,
-        ),
-        output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
-        span_links=True,
-    )
-    assert llmobs_events[1] == _expected_langchain_llmobs_llm_span(
-        trace[1],
-        mock_io=True,
-        mock_token_metrics=True,
-        span_links=True,
-    )
+        assert _get_llmobs_data_metastruct(spans[4])["meta"]["input"]["prompt"] == expected_prompt_4
 
 
-def test_llmobs_anthropic_chat_model(langchain_anthropic, llmobs_events, tracer, test_spans, anthropic_url):
-    kwargs = dict(
-        temperature=0,
-        max_tokens=15,
-        model_name="claude-sonnet-4-5-20250929",
-    )
+    @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
+    def test_llmobs_chain_batch(self, langchain_core, langchain_openai, test_spans, openai_url):
+        prompt = langchain_core.prompts.ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
+        output_parser = langchain_core.output_parsers.StrOutputParser()
+        model = langchain_openai.ChatOpenAI(base_url=openai_url)
+        chain = {"topic": langchain_core.runnables.RunnablePassthrough()} | prompt | model | output_parser
 
-    if "anthropic_api_url" in langchain_anthropic.ChatAnthropic.__fields__:
-        kwargs["anthropic_api_url"] = anthropic_url
-    else:
-        kwargs["base_url"] = anthropic_url
+        chain.batch(inputs=["chickens", "pigs"])
 
-    chat = langchain_anthropic.ChatAnthropic(**kwargs)
-    chat.invoke("When do you use 'whom' instead of 'who'?")
-
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_langchain_llmobs_llm_span(
-        span,
-        input_role="user",
-        mock_token_metrics=True,
-        metadata={"temperature": 0, "max_tokens": 15},
-    )
-
-
-def test_llmobs_google_genai_chat_model(langchain_google_genai, llmobs_events, tracer, test_spans):
-    if langchain_google_genai is None:
-        pytest.skip("langchain-google-genai not installed")
-
-    try:
-        from google.genai import types
-    except ImportError:
-        pytest.skip("google-genai SDK not installed (langchain-google-genai 2.x uses legacy SDK)")
-
-    mock_response = types.GenerateContentResponse(
-        candidates=[
-            types.Candidate(
-                content=types.Content(
-                    role="model",
-                    parts=[types.Part.from_text(text="You use 'whom' as the object of a verb or preposition.")],
-                )
-            )
-        ],
-        usage_metadata=types.GenerateContentResponseUsageMetadata(
-            prompt_token_count=10, candidates_token_count=12, total_token_count=22
-        ),
-    )
-
-    with mock.patch("google.genai.models.Models._generate_content", return_value=mock_response):
-        chat = langchain_google_genai.ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
-            temperature=0,
-            max_output_tokens=15,
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 3
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(
+                input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY
+            ),
         )
+
+        # The two LLM spans (one per batch item) can come back in either order; check by
+        # matching the variables.topic in each span's prompt block.
+        for child in spans[1:3]:
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(child),
+                **_llm_span_kwargs(child, input_role="user", mock_token_metrics=True),
+            )
+            prompt_block = _get_llmobs_data_metastruct(child)["meta"]["input"]["prompt"]
+            assert prompt_block["id"] == "langchain.unknown_prompt_template"
+            assert prompt_block["ml_app"] == "langchain_test"
+            assert prompt_block["chat_template"] == [{"content": "Tell me a short joke about {topic}", "role": "user"}]
+            assert prompt_block["variables"]["topic"] in ("chickens", "pigs")
+
+
+    def test_llmobs_chain_schema_io(self, langchain_core, langchain_openai, openai_url, test_spans):
+        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+            [
+                ("system", "You're an assistant who's good at {ability}. Respond in 20 words or fewer"),
+                langchain_core.prompts.MessagesPlaceholder(variable_name="history"),
+                ("human", "{input}"),
+            ]
+        )
+        chain = prompt | langchain_openai.ChatOpenAI(base_url=openai_url)
+
+        chain.invoke(
+            {
+                "ability": "world capitals",
+                "history": [
+                    langchain_core.messages.HumanMessage(content="Can you be my science teacher instead?"),
+                    langchain_core.messages.AIMessage(content="Yes"),
+                ],
+                "input": "What's the powerhouse of the cell?",
+            }
+        )
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(
+                input_value=json.dumps(
+                    [
+                        {
+                            "ability": "world capitals",
+                            "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
+                            "input": "What's the powerhouse of the cell?",
+                        }
+                    ],
+                    sort_keys=True,
+                ),
+                output_value=json.dumps(["assistant", "Mitochondria"], sort_keys=True),
+            ),
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[1]),
+            **_llm_span_kwargs(spans[1], mock_io=True, mock_token_metrics=True),
+        )
+
+
+    def test_llmobs_anthropic_chat_model(self, langchain_anthropic, test_spans, anthropic_url):
+        kwargs = dict(
+            temperature=0,
+            max_tokens=15,
+            model_name="claude-sonnet-4-5-20250929",
+        )
+
+        if "anthropic_api_url" in langchain_anthropic.ChatAnthropic.__fields__:
+            kwargs["anthropic_api_url"] = anthropic_url
+        else:
+            kwargs["base_url"] = anthropic_url
+
+        chat = langchain_anthropic.ChatAnthropic(**kwargs)
         chat.invoke("When do you use 'whom' instead of 'who'?")
 
-    span = test_spans.pop_traces()[0][0]
-    # Verify the fix: provider should be "google-generativeai" (not "chat"),
-    # and model name should be "gemini-2.5-flash" (not "models/gemini-2.5-flash").
-    assert span.get_tag("langchain.request.provider") == "google-generative-ai"
-    assert span.get_tag("langchain.request.model") == "gemini-2.5-flash"
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_langchain_llmobs_llm_span(
-        span,
-        input_role="user",
-        mock_token_metrics=True,
-        metadata={"temperature": 0.0},
-    )
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_llm_span_kwargs(
+                spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0, "max_tokens": 15}
+            ),
+        )
 
 
-def test_llmobs_embedding_documents(langchain_openai, llmobs_events, tracer, test_spans, openai_url):
-    embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
-    embedding_model.embed_documents(["hello world", "goodbye world"])
+    def test_llmobs_google_genai_chat_model(self, langchain_google_genai, test_spans):
+        if langchain_google_genai is None:
+            pytest.skip("langchain-google-genai not installed")
 
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        trace[0],
-        span_kind="embedding",
-        model_name="text-embedding-ada-002",
-        model_provider="openai",
-        input_documents=[{"text": "hello world"}, {"text": "goodbye world"}],
-        output_value="[2 embedding(s) returned with size 1536]",
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
+        try:
+            from google.genai import types
+        except ImportError:
+            pytest.skip("google-genai SDK not installed (langchain-google-genai 2.x uses legacy SDK)")
 
+        mock_response = types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(
+                        role="model",
+                        parts=[types.Part.from_text(text="You use 'whom' as the object of a verb or preposition.")],
+                    )
+                )
+            ],
+            usage_metadata=types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=10, candidates_token_count=12, total_token_count=22
+            ),
+        )
 
-def test_llmobs_embedding_query(langchain_openai, llmobs_events, tracer, test_spans, openai_url):
-    embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
-    embedding_model.embed_query("hello world")
+        with mock.patch("google.genai.models.Models._generate_content", return_value=mock_response):
+            chat = langchain_google_genai.ChatGoogleGenerativeAI(
+                model="gemini-2.5-flash",
+                temperature=0,
+                max_output_tokens=15,
+            )
+            chat.invoke("When do you use 'whom' instead of 'who'?")
 
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        trace[0],
-        span_kind="embedding",
-        model_name=embedding_model.model,
-        model_provider="openai",
-        input_documents=[{"text": "hello world"}],
-        output_value="[1 embedding(s) returned with size 1536]",
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
-
-
-def test_llmobs_vectorstore_similarity_search(langchain_in_memory_vectorstore, llmobs_events, tracer, test_spans):
-    vectorstore = langchain_in_memory_vectorstore
-    vectorstore.similarity_search("France", k=1)
-
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 2
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    expected_span = _expected_llmobs_non_llm_span_event(
-        trace[0],
-        "retrieval",
-        input_value="France",
-        output_documents=[{"text": mock.ANY, "id": mock.ANY, "name": mock.ANY}],
-        output_value="[1 document(s) retrieved]",
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-        span_links=True,
-    )
-    assert llmobs_events[0] == expected_span
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        span = spans[0]
+        # Verify the fix: provider should be "google-generativeai" (not "chat"),
+        # and model name should be "gemini-2.5-flash" (not "models/gemini-2.5-flash").
+        assert span.get_tag("langchain.request.provider") == "google-generative-ai"
+        assert span.get_tag("langchain.request.model") == "gemini-2.5-flash"
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(span),
+            **_llm_span_kwargs(span, input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0}),
+        )
 
 
-def test_llmobs_chat_model_tool_calls(langchain_core, langchain_openai, llmobs_events, tracer, test_spans, openai_url):
-    @langchain_core.tools.tool
-    def add(a: int, b: int) -> int:
-        """Adds a and b.
-        Args:
-            a: first int
-            b: second int
-        """
-        return a + b
+    def test_llmobs_embedding_documents(self, langchain_openai, test_spans, openai_url):
+        embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
+        embedding_model.embed_documents(["hello world", "goodbye world"])
 
-    llm = langchain_openai.ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0.7, base_url=openai_url)
-    llm_with_tools = llm.bind_tools([add])
-    llm_with_tools.invoke([langchain_core.messages.HumanMessage(content="What is the sum of 1 and 2?")])
-
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        span,
-        model_name=span.get_tag("langchain.request.model"),
-        model_provider=span.get_tag("langchain.request.provider"),
-        input_messages=[{"role": "user", "content": "What is the sum of 1 and 2?"}],
-        output_messages=[
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {
-                        "name": "add",
-                        "arguments": {"a": 1, "b": 2},
-                        "tool_id": mock.ANY,
-                    }
-                ],
-            }
-        ],
-        metadata={"temperature": 0.7},
-        token_metrics={"input_tokens": mock.ANY, "output_tokens": mock.ANY, "total_tokens": mock.ANY},
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="embedding",
+            model_name="text-embedding-ada-002",
+            model_provider="openai",
+            input_documents=[{"text": "hello world"}, {"text": "goodbye world"}],
+            output_value="[2 embedding(s) returned with size 1536]",
+            tags=COMMON_TAGS,
+        )
 
 
-def test_llmobs_base_tool_invoke(langchain_core, llmobs_events, tracer, test_spans):
-    from math import pi
+    def test_llmobs_embedding_query(self, langchain_openai, test_spans, openai_url):
+        embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
+        embedding_model.embed_query("hello world")
 
-    def circumference_tool(radius: float) -> float:
-        return float(radius) * 2.0 * pi
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="embedding",
+            model_name=embedding_model.model,
+            model_provider="openai",
+            input_documents=[{"text": "hello world"}],
+            output_value="[1 embedding(s) returned with size 1536]",
+            tags=COMMON_TAGS,
+        )
 
-    calculator = langchain_core.tools.StructuredTool.from_function(
-        func=circumference_tool,
-        name="Circumference calculator",
-        description="Use this tool when you need to calculate a circumference using the radius of a circle",
-        return_direct=True,
-        response_format="content",
-    )
 
-    calculator.invoke("2", config={"test": "this is to test config"})
+    def test_llmobs_vectorstore_similarity_search(self, langchain_in_memory_vectorstore, test_spans):
+        vectorstore = langchain_in_memory_vectorstore
+        vectorstore.similarity_search("France", k=1)
 
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        span,
-        span_kind="tool",
-        input_value="2",
-        output_value="12.566370614359172",
-        metadata={
-            "tool_config": {"test": "this is to test config"},
-            "tool_info": {
-                "name": "Circumference calculator",
-                "description": mock.ANY,
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        # spans[0] is the retrieval span (outer); spans[1] is the embedding sub-call.
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="retrieval",
+            input_value="France",
+            output_documents=[{"text": mock.ANY, "id": mock.ANY, "name": mock.ANY}],
+            output_value="[1 document(s) retrieved]",
+            tags=COMMON_TAGS,
+        )
+
+
+    def test_llmobs_chat_model_tool_calls(self, langchain_core, langchain_openai, test_spans, openai_url):
+        @langchain_core.tools.tool
+        def add(a: int, b: int) -> int:
+            """Adds a and b.
+            Args:
+                a: first int
+                b: second int
+            """
+            return a + b
+
+        llm = langchain_openai.ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0.7, base_url=openai_url)
+        llm_with_tools = llm.bind_tools([add])
+        llm_with_tools.invoke([langchain_core.messages.HumanMessage(content="What is the sum of 1 and 2?")])
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        span = spans[0]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(span),
+            span_kind="llm",
+            model_name=span.get_tag("langchain.request.model"),
+            model_provider=span.get_tag("langchain.request.provider"),
+            input_messages=[{"role": "user", "content": "What is the sum of 1 and 2?"}],
+            output_messages=[
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "name": "add",
+                            "arguments": {"a": 1, "b": 2},
+                            "tool_id": mock.ANY,
+                        }
+                    ],
+                }
+            ],
+            metadata={"temperature": 0.7},
+            metrics={"input_tokens": mock.ANY, "output_tokens": mock.ANY, "total_tokens": mock.ANY},
+            tags=COMMON_TAGS,
+        )
+
+
+    def test_llmobs_base_tool_invoke(self, langchain_core, test_spans):
+        from math import pi
+
+        def circumference_tool(radius: float) -> float:
+            return float(radius) * 2.0 * pi
+
+        calculator = langchain_core.tools.StructuredTool.from_function(
+            func=circumference_tool,
+            name="Circumference calculator",
+            description="Use this tool when you need to calculate a circumference using the radius of a circle",
+            return_direct=True,
+            response_format="content",
+        )
+
+        calculator.invoke("2", config={"test": "this is to test config"})
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="tool",
+            input_value="2",
+            output_value="12.566370614359172",
+            metadata={
+                "tool_config": {"test": "this is to test config"},
+                "tool_info": {
+                    "name": "Circumference calculator",
+                    "description": mock.ANY,
+                },
             },
-        },
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
+            tags=COMMON_TAGS,
+        )
 
 
-@pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-def test_llmobs_streamed_chain(
-    langchain_core, langchain_openai, llmobs_events, tracer, test_spans, openai_url, consume_stream
-):
-    prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
-        [("system", "You are a world class technical documentation writer."), ("user", "{input}")]
-    )
-    llm = langchain_openai.ChatOpenAI(model="gpt-4o", base_url=openai_url, temperature=0.7, max_tokens=256)
-    parser = langchain_core.output_parsers.StrOutputParser()
+    @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
+    def test_llmobs_streamed_chain(self, langchain_core, langchain_openai, test_spans, openai_url, consume_stream):
+        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+            [("system", "You are a world class technical documentation writer."), ("user", "{input}")]
+        )
+        llm = langchain_openai.ChatOpenAI(model="gpt-4o", base_url=openai_url, temperature=0.7, max_tokens=256)
+        parser = langchain_core.output_parsers.StrOutputParser()
 
-    chain = prompt | llm | parser
+        chain = prompt | llm | parser
 
-    consume_stream(chain.stream({"input": "how can langsmith help with testing?"}))
+        consume_stream(chain.stream({"input": "how can langsmith help with testing?"}))
 
-    trace = test_spans.pop_traces()[0]
-    assert len(llmobs_events) == 2
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert llmobs_events[0] == _expected_langchain_llmobs_chain_span(
-        trace[0],
-        input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
-        output_value=mock.ANY,
-        span_links=True,
-    )
-    assert llmobs_events[1] == _expected_llmobs_llm_span_event(
-        trace[1],
-        model_name=trace[1].get_tag("langchain.request.model"),
-        model_provider=trace[1].get_tag("langchain.request.provider"),
-        input_messages=[
-            {"content": "You are a world class technical documentation writer.", "role": "SystemMessage"},
-            {"content": "how can langsmith help with testing?", "role": "HumanMessage"},
-        ],
-        output_messages=[{"content": mock.ANY, "role": "assistant"}],
-        metadata={"temperature": 0.7, "max_tokens": 256},
-        token_metrics={},
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-        span_links=True,
-    )
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 2
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            **_chain_span_kwargs(
+                input_value=json.dumps({"input": "how can langsmith help with testing?"}, sort_keys=True),
+                output_value=mock.ANY,
+            ),
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[1]),
+            span_kind="llm",
+            model_name=spans[1].get_tag("langchain.request.model"),
+            model_provider=spans[1].get_tag("langchain.request.provider"),
+            input_messages=[
+                {"content": "You are a world class technical documentation writer.", "role": "SystemMessage"},
+                {"content": "how can langsmith help with testing?", "role": "HumanMessage"},
+            ],
+            output_messages=[{"content": mock.ANY, "role": "assistant"}],
+            metadata={"temperature": 0.7, "max_tokens": 256},
+            metrics={},
+            tags=COMMON_TAGS,
+        )
 
 
-@pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-def test_llmobs_streamed_llm(langchain_openai, llmobs_events, tracer, test_spans, openai_url, consume_stream):
-    llm = langchain_openai.OpenAI(base_url=openai_url, n=1, seed=1, logprobs=None, logit_bias=None)
+    @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
+    def test_llmobs_streamed_llm(self, langchain_openai, test_spans, openai_url, consume_stream):
+        llm = langchain_openai.OpenAI(base_url=openai_url, n=1, seed=1, logprobs=None, logit_bias=None)
 
-    consume_stream(llm.stream("What is 2+2?\n\n"))
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
-        span,
-        model_name=span.get_tag("langchain.request.model"),
-        model_provider=span.get_tag("langchain.request.provider"),
-        input_messages=[
-            {"content": "What is 2+2?\n\n"},
-        ],
-        output_messages=[{"content": "The answer is 4."}],
-        metadata={"temperature": 0.7, "max_tokens": 256},
-        token_metrics={},
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
+        consume_stream(llm.stream("What is 2+2?\n\n"))
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        span = spans[0]
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(span),
+            span_kind="llm",
+            model_name=span.get_tag("langchain.request.model"),
+            model_provider=span.get_tag("langchain.request.provider"),
+            input_messages=[
+                {"content": "What is 2+2?\n\n"},
+            ],
+            output_messages=[{"content": "The answer is 4."}],
+            metadata={"temperature": 0.7, "max_tokens": 256},
+            metrics={},
+            tags=COMMON_TAGS,
+        )
 
 
-def test_llmobs_non_ascii_completion(langchain_openai, openai_url, llmobs_events):
-    llm = langchain_openai.OpenAI(base_url=openai_url)
-    llm.invoke("안녕,\n 지금 몇 시야?")
+    def test_llmobs_non_ascii_completion(self, langchain_openai, openai_url, test_spans):
+        llm = langchain_openai.OpenAI(base_url=openai_url)
+        llm.invoke("안녕,\n 지금 몇 시야?")
 
-    assert len(llmobs_events) == 1
-    actual_llmobs_span_event = llmobs_events[0]
-    assert actual_llmobs_span_event["meta"]["input"]["messages"][0]["content"] == "안녕,\n 지금 몇 시야?"
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        metastruct = _get_llmobs_data_metastruct(spans[0])
+        assert metastruct["meta"]["input"]["messages"][0]["content"] == "안녕,\n 지금 몇 시야?"
+
+
+    def test_llmobs_runnable_lambda_invoke(self, langchain_core, test_spans):
+        def add(inputs: dict) -> int:
+            return inputs["a"] + inputs["b"]
+
+        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+        result = runnable_lambda.invoke(dict(a=1, b=2))
+        assert result == 3
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="task",
+            input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
+            output_value="3",
+            tags=COMMON_TAGS,
+        )
+
+
+    async def test_llmobs_runnable_lambda_ainvoke(self, langchain_core, test_spans):
+        async def add(inputs: dict) -> int:
+            return inputs["a"] + inputs["b"]
+
+        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+        result = await runnable_lambda.ainvoke(dict(a=1, b=2))
+        assert result == 3
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="task",
+            input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
+            output_value="3",
+            tags=COMMON_TAGS,
+        )
+
+
+    def test_llmobs_runnable_lambda_batch(self, langchain_core, test_spans):
+        def add(inputs: dict) -> int:
+            return inputs["a"] + inputs["b"]
+
+        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+        result = runnable_lambda.batch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
+        assert result == [3, 7, 11]
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 4
+
+        parent_meta = _get_llmobs_data_metastruct(spans[0])
+        # parent should be batch span
+        assert parent_meta["parent_id"] == "undefined"
+        assert parent_meta["name"] == "add_batch"
+        assert parent_meta["meta"]["span"]["kind"] == "task"
+        assert parent_meta["meta"]["input"]["value"] == json.dumps(
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
+        )
+        assert parent_meta["meta"]["output"]["value"] == json.dumps([3, 7, 11], sort_keys=True)
+
+        # assert all children have batch as the parent
+        # however, order of children is not guaranteed
+        # loosely check that the children have the correct input and output values
+        parent_span_id = str(spans[0].span_id)
+        for i in range(1, 4):
+            child_meta = _get_llmobs_data_metastruct(spans[i])
+            assert child_meta["parent_id"] == parent_span_id
+            assert child_meta["name"] == "add"
+            assert child_meta["meta"]["span"]["kind"] == "task"
+
+            input_value = json.loads(child_meta["meta"]["input"]["value"])
+            output_value = json.loads(child_meta["meta"]["output"]["value"])
+            assert "a" in input_value
+            assert "b" in input_value
+            assert isinstance(output_value, int)
+
+
+    async def test_llmobs_runnable_lambda_abatch(self, langchain_core, test_spans):
+        async def add(inputs: dict) -> int:
+            return inputs["a"] + inputs["b"]
+
+        runnable_lambda = langchain_core.runnables.RunnableLambda(add)
+        result = await runnable_lambda.abatch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
+        assert result == [3, 7, 11]
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 4
+
+        parent_meta = _get_llmobs_data_metastruct(spans[0])
+        # parent should be batch span
+        assert parent_meta["parent_id"] == "undefined"
+        assert parent_meta["name"] == "add_batch"
+        assert parent_meta["meta"]["span"]["kind"] == "task"
+        assert parent_meta["meta"]["input"]["value"] == json.dumps(
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
+        )
+        assert parent_meta["meta"]["output"]["value"] == json.dumps([3, 7, 11], sort_keys=True)
+
+        # assert all children have batch as the parent
+        # however, order of children is not guaranteed
+        # loosely check that the children have the correct input and output values
+        parent_span_id = str(spans[0].span_id)
+        for i in range(1, 4):
+            child_meta = _get_llmobs_data_metastruct(spans[i])
+            assert child_meta["parent_id"] == parent_span_id
+            assert child_meta["name"] == "add"
+            assert child_meta["meta"]["span"]["kind"] == "task"
+
+            input_value = json.loads(child_meta["meta"]["input"]["value"])
+            output_value = json.loads(child_meta["meta"]["output"]["value"])
+            assert "a" in input_value
+            assert "b" in input_value
+            assert isinstance(output_value, int)
+
+
+    def test_llmobs_runnable_with_span_links(self, langchain_core, test_spans):
+        sequence = langchain_core.runnables.RunnableLambda(lambda x: x + 1, name="add_1") | {
+            "mul_2": langchain_core.runnables.RunnableLambda(lambda x: x * 2, name="mul_2"),
+            "mul_5": langchain_core.runnables.RunnableLambda(lambda x: x * 5, name="mul_5"),
+        }
+
+        result = sequence.invoke(1)
+
+        assert result == {"mul_2": 4, "mul_5": 10}
+
+        spans = _llmobs_spans(test_spans)
+        assert len(spans) == 4
+
+        metas = [_get_llmobs_data_metastruct(s) for s in spans]
+        span_ids = [str(s.span_id) for s in spans]
+
+        # assert output -> output links for runnable sequence span from last two runnable lambdas
+        # the order of the links is not guaranteed
+        expected_links = [
+            {
+                "trace_id": mock.ANY,
+                "span_id": span_ids[2],
+                "attributes": {"from": "output", "to": "output"},
+            },
+            {
+                "trace_id": mock.ANY,
+                "span_id": span_ids[3],
+                "attributes": {"from": "output", "to": "output"},
+            },
+        ]
+        assert len(metas[0]["span_links"]) == len(expected_links)
+        for expected_link in expected_links:
+            assert expected_link in metas[0]["span_links"]
+
+        # assert input -> input links for add_1 span
+        assert metas[1]["span_links"] == [
+            {
+                "trace_id": mock.ANY,
+                "span_id": span_ids[0],
+                "attributes": {"from": "input", "to": "input"},
+            },
+        ]
+
+        # assert output -> input links for mul_2 and mul_5 spans
+        assert metas[2]["span_links"] == [
+            {
+                "trace_id": mock.ANY,
+                "span_id": span_ids[1],
+                "attributes": {"from": "output", "to": "input"},
+            },
+        ]
+        assert metas[3]["span_links"] == [
+            {
+                "trace_id": mock.ANY,
+                "span_id": span_ids[1],
+                "attributes": {"from": "output", "to": "input"},
+            },
+        ]
+
 
 
 def test_llmobs_set_tags_with_none_response(langchain_core):
@@ -894,173 +1051,14 @@ def test_llmobs_set_tags_with_none_response(langchain_core):
     )
 
 
-def test_llmobs_runnable_lambda_invoke(langchain_core, llmobs_events, tracer, test_spans):
-    def add(inputs: dict) -> int:
-        return inputs["a"] + inputs["b"]
-
-    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-    result = runnable_lambda.invoke(dict(a=1, b=2))
-    assert result == 3
-
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        span,
-        span_kind="task",
-        input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
-        output_value="3",
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
-
-
-async def test_llmobs_runnable_lambda_ainvoke(langchain_core, llmobs_events, tracer, test_spans):
-    async def add(inputs: dict) -> int:
-        return inputs["a"] + inputs["b"]
-
-    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-    result = await runnable_lambda.ainvoke(dict(a=1, b=2))
-    assert result == 3
-
-    span = test_spans.pop_traces()[0][0]
-    assert len(llmobs_events) == 1
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        span,
-        span_kind="task",
-        input_value=json.dumps({"a": 1, "b": 2}, sort_keys=True),
-        output_value="3",
-        tags={"ml_app": "langchain_test", "service": "tests.contrib.langchain", "integration": "langchain"},
-    )
-
-
-def test_llmobs_runnable_lambda_batch(langchain_core, llmobs_events):
-    def add(inputs: dict) -> int:
-        return inputs["a"] + inputs["b"]
-
-    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-    result = runnable_lambda.batch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
-    assert result == [3, 7, 11]
-
-    assert len(llmobs_events) == 4
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-
-    # parent should be batch span
-    assert llmobs_events[0]["parent_id"] == "undefined"
-    assert llmobs_events[0]["name"] == "add_batch"
-    assert llmobs_events[0]["meta"]["span"]["kind"] == "task"
-    assert llmobs_events[0]["meta"]["input"]["value"] == json.dumps(
-        [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
-    )
-    assert llmobs_events[0]["meta"]["output"]["value"] == json.dumps([3, 7, 11], sort_keys=True)
-
-    # assert all children have batch as the parent
-    # however, order of children is not guaranteed
-    # loosely check that the children have the correct input and output values
-    for i in range(1, 4):
-        assert llmobs_events[i]["parent_id"] == llmobs_events[0]["span_id"]
-        assert llmobs_events[i]["name"] == "add"
-        assert llmobs_events[i]["meta"]["span"]["kind"] == "task"
-
-        input_value = json.loads(llmobs_events[i]["meta"]["input"]["value"])
-        output_value = json.loads(llmobs_events[i]["meta"]["output"]["value"])
-        assert "a" in input_value
-        assert "b" in input_value
-        assert isinstance(output_value, int)
-
-
-async def test_llmobs_runnable_lambda_abatch(langchain_core, llmobs_events):
-    async def add(inputs: dict) -> int:
-        return inputs["a"] + inputs["b"]
-
-    runnable_lambda = langchain_core.runnables.RunnableLambda(add)
-    result = await runnable_lambda.abatch([dict(a=1, b=2), dict(a=3, b=4), dict(a=5, b=6)])
-    assert result == [3, 7, 11]
-
-    assert len(llmobs_events) == 4
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-
-    # parent should be batch span
-    assert llmobs_events[0]["parent_id"] == "undefined"
-    assert llmobs_events[0]["name"] == "add_batch"
-    assert llmobs_events[0]["meta"]["span"]["kind"] == "task"
-    assert llmobs_events[0]["meta"]["input"]["value"] == json.dumps(
-        [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
-    )
-    assert llmobs_events[0]["meta"]["output"]["value"] == json.dumps([3, 7, 11], sort_keys=True)
-
-    # assert all children have batch as the parent
-    # however, order of children is not guaranteed
-    # loosely check that the children have the correct input and output values
-    for i in range(1, 4):
-        assert llmobs_events[i]["parent_id"] == llmobs_events[0]["span_id"]
-        assert llmobs_events[i]["name"] == "add"
-        assert llmobs_events[i]["meta"]["span"]["kind"] == "task"
-
-        input_value = json.loads(llmobs_events[i]["meta"]["input"]["value"])
-        output_value = json.loads(llmobs_events[i]["meta"]["output"]["value"])
-        assert "a" in input_value
-        assert "b" in input_value
-        assert isinstance(output_value, int)
-
-
-def test_llmobs_runnable_with_span_links(langchain_core, llmobs_events):
-    sequence = langchain_core.runnables.RunnableLambda(lambda x: x + 1, name="add_1") | {
-        "mul_2": langchain_core.runnables.RunnableLambda(lambda x: x * 2, name="mul_2"),
-        "mul_5": langchain_core.runnables.RunnableLambda(lambda x: x * 5, name="mul_5"),
-    }
-
-    result = sequence.invoke(1)
-
-    assert result == {"mul_2": 4, "mul_5": 10}
-    assert len(llmobs_events) == 4
-
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-
-    # assert output -> output links for runnable sequence span from last two runnable lambdas
-    # the order of the links is not guaranteed
-    expected_links = [
-        {
-            "trace_id": mock.ANY,
-            "span_id": llmobs_events[2]["span_id"],
-            "attributes": {"from": "output", "to": "output"},
-        },
-        {
-            "trace_id": mock.ANY,
-            "span_id": llmobs_events[3]["span_id"],
-            "attributes": {"from": "output", "to": "output"},
-        },
-    ]
-    assert len(llmobs_events[0]["span_links"]) == len(expected_links)
-    for expected_link in expected_links:
-        assert expected_link in llmobs_events[0]["span_links"]
-
-    # assert input -> input links for add_1 span
-    assert llmobs_events[1]["span_links"] == [
-        {
-            "trace_id": mock.ANY,
-            "span_id": llmobs_events[0]["span_id"],
-            "attributes": {"from": "input", "to": "input"},
-        },
-    ]
-
-    # assert output -> input links for mul_2 and mul_5 spans
-    assert llmobs_events[2]["span_links"] == [
-        {
-            "trace_id": mock.ANY,
-            "span_id": llmobs_events[1]["span_id"],
-            "attributes": {"from": "output", "to": "input"},
-        },
-    ]
-    assert llmobs_events[3]["span_links"] == [
-        {
-            "trace_id": mock.ANY,
-            "span_id": llmobs_events[1]["span_id"],
-            "attributes": {"from": "output", "to": "input"},
-        },
-    ]
-
-
+# TODO(meta-struct migration): The TestTraceStructureWithLLMIntegrations class
+# below verifies cross-integration trace structure (langchain + openai/anthropic
+# patched together) by patching ``ddtrace.llmobs._llmobs.LLMObsSpanWriter`` and
+# inspecting ``enqueue.call_args_list`` directly inside subprocesses spawned by
+# ``run_in_subprocess``. The subprocesses don't share fixture state with the
+# parent pytest process, so the meta_struct env-var/test_spans-override approach
+# can't be used here without re-architecting how each subprocess test is set up.
+# Leaving on the wire-event pattern for the cleanup PR to address.
 class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
     bedrock_env_config = dict(
         AWS_ACCESS_KEY_ID="testing",

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -11,9 +11,14 @@ from ddtrace import patch
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_input_prompt
+from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_metrics
+from ddtrace.llmobs._utils import get_llmobs_output_value
+from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_span_kind
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from ddtrace.trace import Span
 from tests.contrib.langchain.utils import mock_langchain_chat_generate_response
 from tests.contrib.langchain.utils import mock_langchain_llm_generate_response
@@ -864,8 +869,7 @@ class TestLangChainLLMObs:
 
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1
-        metastruct = _get_llmobs_data_metastruct(spans[0])
-        assert metastruct["meta"]["input"]["messages"][0]["content"] == "안녕,\n 지금 몇 시야?"
+        assert get_llmobs_input_messages(spans[0])[0]["content"] == "안녕,\n 지금 몇 시야?"
 
 
     def test_llmobs_runnable_lambda_invoke(self, langchain_core, test_spans):
@@ -917,28 +921,26 @@ class TestLangChainLLMObs:
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 4
 
-        parent_meta = _get_llmobs_data_metastruct(spans[0])
         # parent should be batch span
-        assert parent_meta["parent_id"] == "undefined"
-        assert parent_meta["name"] == "add_batch"
-        assert parent_meta["meta"]["span"]["kind"] == "task"
-        assert parent_meta["meta"]["input"]["value"] == json.dumps(
+        assert get_llmobs_parent_id(spans[0]) == "undefined"
+        assert get_llmobs_span_name(spans[0]) == "add_batch"
+        assert get_llmobs_span_kind(spans[0]) == "task"
+        assert get_llmobs_input_value(spans[0]) == json.dumps(
             [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
         )
-        assert parent_meta["meta"]["output"]["value"] == json.dumps([3, 7, 11], sort_keys=True)
+        assert get_llmobs_output_value(spans[0]) == json.dumps([3, 7, 11], sort_keys=True)
 
         # assert all children have batch as the parent
         # however, order of children is not guaranteed
         # loosely check that the children have the correct input and output values
         parent_span_id = str(spans[0].span_id)
         for i in range(1, 4):
-            child_meta = _get_llmobs_data_metastruct(spans[i])
-            assert child_meta["parent_id"] == parent_span_id
-            assert child_meta["name"] == "add"
-            assert child_meta["meta"]["span"]["kind"] == "task"
+            assert get_llmobs_parent_id(spans[i]) == parent_span_id
+            assert get_llmobs_span_name(spans[i]) == "add"
+            assert get_llmobs_span_kind(spans[i]) == "task"
 
-            input_value = json.loads(child_meta["meta"]["input"]["value"])
-            output_value = json.loads(child_meta["meta"]["output"]["value"])
+            input_value = json.loads(get_llmobs_input_value(spans[i]))
+            output_value = json.loads(get_llmobs_output_value(spans[i]))
             assert "a" in input_value
             assert "b" in input_value
             assert isinstance(output_value, int)
@@ -955,28 +957,26 @@ class TestLangChainLLMObs:
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 4
 
-        parent_meta = _get_llmobs_data_metastruct(spans[0])
         # parent should be batch span
-        assert parent_meta["parent_id"] == "undefined"
-        assert parent_meta["name"] == "add_batch"
-        assert parent_meta["meta"]["span"]["kind"] == "task"
-        assert parent_meta["meta"]["input"]["value"] == json.dumps(
+        assert get_llmobs_parent_id(spans[0]) == "undefined"
+        assert get_llmobs_span_name(spans[0]) == "add_batch"
+        assert get_llmobs_span_kind(spans[0]) == "task"
+        assert get_llmobs_input_value(spans[0]) == json.dumps(
             [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], sort_keys=True
         )
-        assert parent_meta["meta"]["output"]["value"] == json.dumps([3, 7, 11], sort_keys=True)
+        assert get_llmobs_output_value(spans[0]) == json.dumps([3, 7, 11], sort_keys=True)
 
         # assert all children have batch as the parent
         # however, order of children is not guaranteed
         # loosely check that the children have the correct input and output values
         parent_span_id = str(spans[0].span_id)
         for i in range(1, 4):
-            child_meta = _get_llmobs_data_metastruct(spans[i])
-            assert child_meta["parent_id"] == parent_span_id
-            assert child_meta["name"] == "add"
-            assert child_meta["meta"]["span"]["kind"] == "task"
+            assert get_llmobs_parent_id(spans[i]) == parent_span_id
+            assert get_llmobs_span_name(spans[i]) == "add"
+            assert get_llmobs_span_kind(spans[i]) == "task"
 
-            input_value = json.loads(child_meta["meta"]["input"]["value"])
-            output_value = json.loads(child_meta["meta"]["output"]["value"])
+            input_value = json.loads(get_llmobs_input_value(spans[i]))
+            output_value = json.loads(get_llmobs_output_value(spans[i]))
             assert "a" in input_value
             assert "b" in input_value
             assert isinstance(output_value, int)

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -7,14 +7,17 @@ import sys
 import mock
 import pytest
 
+import ddtrace
 from ddtrace import patch
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_documents
 from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_input_prompt
 from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_metrics
+from ddtrace.llmobs._utils import get_llmobs_output_messages
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_span_kind
@@ -28,6 +31,7 @@ from tests.llmobs._utils import iterate_stream
 from tests.llmobs._utils import next_stream
 from tests.subprocesstest import SubprocessTestCase
 from tests.subprocesstest import run_in_subprocess
+from tests.utils import DummyWriter
 
 
 # Multi-message prompt template test constants
@@ -1028,14 +1032,6 @@ def test_llmobs_set_tags_with_none_response(langchain_core):
     )
 
 
-# TODO(meta-struct migration): The TestTraceStructureWithLLMIntegrations class
-# below verifies cross-integration trace structure (langchain + openai/anthropic
-# patched together) by patching ``ddtrace.llmobs._llmobs.LLMObsSpanWriter`` and
-# inspecting ``enqueue.call_args_list`` directly inside subprocesses spawned by
-# ``run_in_subprocess``. The subprocesses don't share fixture state with the
-# parent pytest process, so the meta_struct env-var/test_spans-override approach
-# can't be used here without re-architecting how each subprocess test is set up.
-# Leaving on the wire-event pattern for the cleanup PR to address.
 class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
     bedrock_env_config = dict(
         AWS_ACCESS_KEY_ID="testing",
@@ -1063,38 +1059,44 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
     )
 
     def setUp(self):
+        # Keep meta_struct["_llmobs"] on spans after enqueue so we can assert against it.
+        os.environ["_DD_LLMOBS_TEST_KEEP_META_STRUCT"] = "1"
+        # Install a DummyWriter so we can pop spans off the global tracer in-process.
+        ddtrace.tracer._span_aggregator.writer = DummyWriter()
+        # Mock LLMObsSpanWriter to avoid real network calls; we no longer assert against it.
         patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
         LLMObsSpanWriterMock = patcher.start()
-        mock_llmobs_span_writer = mock.MagicMock()
-        LLMObsSpanWriterMock.return_value = mock_llmobs_span_writer
-
-        self.mock_llmobs_span_writer = mock_llmobs_span_writer
-
+        LLMObsSpanWriterMock.return_value = mock.MagicMock()
         super(TestTraceStructureWithLLMIntegrations, self).setUp()
 
     def tearDown(self):
         LLMObs.disable()
 
-    def _assert_trace_structure_from_writer_call_args(self, span_kinds):
-        assert self.mock_llmobs_span_writer.enqueue.call_count == len(span_kinds)
+    def _llmobs_spans(self):
+        spans = [
+            s
+            for trace in ddtrace.tracer._span_aggregator.writer.pop_traces()
+            for s in trace
+            if _get_llmobs_data_metastruct(s)
+        ]
+        spans.sort(key=lambda s: s.start_ns)
+        return spans
 
-        calls = self.mock_llmobs_span_writer.enqueue.call_args_list[::-1]
-
-        for span_kind, call in zip(span_kinds, calls):
-            call_args = call.args[0]
-
-            assert call_args["meta"]["span"]["kind"] == span_kind, (
-                f"Span kind is {call_args['meta']['span']['kind']} but expected {span_kind}"
-            )
-            if span_kind == "workflow":
-                assert len(call_args["meta"]["input"]["value"]) > 0
-                assert len(call_args["meta"]["output"]["value"]) > 0
-            elif span_kind == "llm":
-                assert len(call_args["meta"]["input"]["messages"]) > 0
-                assert len(call_args["meta"]["output"]["messages"]) > 0
-            elif span_kind == "embedding":
-                assert len(call_args["meta"]["input"]["documents"]) > 0
-                assert len(call_args["meta"]["output"]["value"]) > 0
+    def _assert_span_kinds(self, span_kinds):
+        spans = self._llmobs_spans()
+        assert len(spans) == len(span_kinds)
+        for span, expected_kind in zip(spans, span_kinds):
+            actual_kind = get_llmobs_span_kind(span)
+            assert actual_kind == expected_kind, f"Span kind is {actual_kind} but expected {expected_kind}"
+            if expected_kind == "workflow":
+                assert get_llmobs_input_value(span)
+                assert get_llmobs_output_value(span)
+            elif expected_kind == "llm":
+                assert get_llmobs_input_messages(span)
+                assert get_llmobs_output_messages(span)
+            elif expected_kind == "embedding":
+                assert get_llmobs_input_documents(span)
+                assert get_llmobs_output_value(span)
 
     @staticmethod
     def _call_openai_llm(OpenAI):
@@ -1137,7 +1139,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         patch(langchain=True, openai=True)
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_openai_llm(OpenAI)
-        self._assert_trace_structure_from_writer_call_args(["workflow", "llm"])
+        self._assert_span_kinds(["workflow", "llm"])
 
     @run_in_subprocess(env_overrides=azure_openai_env_config)
     def test_llmobs_with_openai_enabled_azure(self):
@@ -1146,7 +1148,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         patch(langchain=True, openai=True)
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_azure_openai_chat(AzureChatOpenAI)
-        self._assert_trace_structure_from_writer_call_args(["workflow", "llm"])
+        self._assert_span_kinds(["workflow", "llm"])
 
     @run_in_subprocess(env_overrides=openai_env_config)
     def test_llmobs_with_openai_enabled_non_ascii_value(self):
@@ -1157,8 +1159,9 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         llm = OpenAI(base_url="http://localhost:9126/vcr/openai")
         llm.invoke("안녕,\n 지금 몇 시야?")
-        langchain_span = self.mock_llmobs_span_writer.enqueue.call_args_list[1][0][0]
-        assert langchain_span["meta"]["input"]["value"] == '[{"content": "안녕,\\n 지금 몇 시야?"}]'
+        spans = self._llmobs_spans()
+        assert get_llmobs_span_kind(spans[0]) == "workflow"
+        assert get_llmobs_input_value(spans[0]) == '[{"content": "안녕,\\n 지금 몇 시야?"}]'
 
     @run_in_subprocess(env_overrides=openai_env_config)
     def test_llmobs_langchain_with_embedding_model_openai_enabled(self):
@@ -1168,7 +1171,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_openai_embedding(OpenAIEmbeddings)
-        self._assert_trace_structure_from_writer_call_args(["workflow", "embedding"])
+        self._assert_span_kinds(["workflow", "embedding"])
 
     @run_in_subprocess(env_overrides=openai_env_config)
     def test_llmobs_langchain_with_embedding_model_openai_disabled(self):
@@ -1178,7 +1181,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_openai_embedding(OpenAIEmbeddings)
-        self._assert_trace_structure_from_writer_call_args(["embedding"])
+        self._assert_span_kinds(["embedding"])
 
     @run_in_subprocess(env_overrides=openai_env_config)
     def test_llmobs_with_openai_disabled(self):
@@ -1188,7 +1191,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_openai_llm(OpenAI)
-        self._assert_trace_structure_from_writer_call_args(["llm"])
+        self._assert_span_kinds(["llm"])
 
     @run_in_subprocess(env_overrides=azure_openai_env_config)
     def test_llmobs_with_openai_disabled_azure(self):
@@ -1198,7 +1201,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_azure_openai_chat(AzureChatOpenAI)
-        self._assert_trace_structure_from_writer_call_args(["llm"])
+        self._assert_span_kinds(["llm"])
 
     @run_in_subprocess(env_overrides=anthropic_env_config)
     def test_llmobs_with_anthropic_enabled(self):
@@ -1208,7 +1211,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_anthropic_chat(ChatAnthropic)
-        self._assert_trace_structure_from_writer_call_args(["workflow", "llm"])
+        self._assert_span_kinds(["workflow", "llm"])
 
     @run_in_subprocess(env_overrides=anthropic_env_config)
     def test_llmobs_with_anthropic_disabled(self):
@@ -1219,7 +1222,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
 
         self._call_anthropic_chat(ChatAnthropic)
-        self._assert_trace_structure_from_writer_call_args(["llm"])
+        self._assert_span_kinds(["llm"])
 
 
 def test_shadow_tags_chat_when_llmobs_disabled(tracer):

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -152,7 +152,6 @@ class TestLangChainLLMObs:
             **_llm_span_kwargs(spans[0], mock_token_metrics=True, metadata={"max_tokens": 256, "temperature": 0.7}),
         )
 
-
     @mock.patch("langchain_core.language_models.llms.BaseLLM._generate_helper")
     def test_llmobs_openai_llm_proxy(self, mock_generate, langchain_openai, langchain_llmobs, test_spans):
         mock_generate.return_value = mock_langchain_llm_generate_response
@@ -163,7 +162,9 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)),
+            **_chain_span_kwargs(
+                input_value=json.dumps([{"content": "What is the capital of France?"}], sort_keys=True)
+            ),
         )
 
         # span created from request with non-proxy URL should result in an LLM span
@@ -172,7 +173,6 @@ class TestLangChainLLMObs:
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1
         assert get_llmobs_span_kind(spans[0]) == "llm"
-
 
     def test_llmobs_openai_chat_model(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
         chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url)
@@ -187,8 +187,9 @@ class TestLangChainLLMObs:
             ),
         )
 
-
-    def test_llmobs_openai_chat_model_no_usage(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
+    def test_llmobs_openai_chat_model_no_usage(
+        self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url
+    ):
         if parse_version(importlib.metadata.version("langchain_openai")) < (0, 2, 0):
             pytest.skip("langchain-openai <0.2.0 does not support stream_usage=False")
         chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=openai_url, stream_usage=False)
@@ -206,9 +207,10 @@ class TestLangChainLLMObs:
         assert metrics.get("output_tokens") is None
         assert metrics.get("total_tokens") is None
 
-
     @mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
-    def test_llmobs_openai_chat_model_proxy(self, mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans):
+    def test_llmobs_openai_chat_model_proxy(
+        self, mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+    ):
         mock_generate.return_value = mock_langchain_chat_generate_response
         chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url="http://localhost:4000")
         chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
@@ -230,8 +232,9 @@ class TestLangChainLLMObs:
         assert len(spans) == 1
         assert get_llmobs_span_kind(spans[0]) == "llm"
 
-
-    def test_llmobs_string_prompt_template_invoke(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    def test_llmobs_string_prompt_template_invoke(
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+    ):
         template_string = "You are a helpful assistant. Please answer this question: {question}"
         variable_dict = {"question": "What is machine learning?"}
         prompt_template = langchain_core.prompts.PromptTemplate(
@@ -253,15 +256,21 @@ class TestLangChainLLMObs:
         assert actual_prompt["tags"] == {"test_type": "basic_invoke", "author": "test_suite"}
         assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[1]))
 
-
-    def test_llmobs_string_prompt_template_direct_invoke(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    def test_llmobs_string_prompt_template_direct_invoke(
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+    ):
         """Test StringPromptTemplate (PromptTemplate) with variable name detection using direct invoke (no chains)."""
         template_string = "Good {time_of_day}, {name}! How are you doing today?"
         variable_dict = {"name": "Alice", "time_of_day": "morning"}
         greeting_template = langchain_core.prompts.PromptTemplate(
             input_variables=list(variable_dict.keys()),
             template=template_string,
-            metadata={"test_type": "direct_invoke", "interaction": "greeting", "not_string_1": True, "not_string_2": 10},
+            metadata={
+                "test_type": "direct_invoke",
+                "interaction": "greeting",
+                "not_string_1": True,
+                "not_string_2": 10,
+            },
         )
         llm = langchain_openai.OpenAI(base_url=openai_url)
 
@@ -280,8 +289,9 @@ class TestLangChainLLMObs:
         assert actual_prompt["tags"] == {"test_type": "direct_invoke", "interaction": "greeting"}
         assert _has_prompt_tracking_tag(_get_llmobs_data_metastruct(spans[0]))
 
-
-    def test_llmobs_string_prompt_template_invoke_chat_model(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    def test_llmobs_string_prompt_template_invoke_chat_model(
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+    ):
         template_string = "You are a helpful assistant. Please answer this question: {question}"
         variable_dict = {"question": "What is machine learning?"}
         prompt_template = langchain_core.prompts.PromptTemplate(
@@ -298,9 +308,8 @@ class TestLangChainLLMObs:
         assert actual_prompt["template"] == template_string
         assert actual_prompt["variables"] == variable_dict
 
-
-    def test_llmobs_string_prompt_template_single_variable_string_input(self, 
-        langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+    def test_llmobs_string_prompt_template_single_variable_string_input(
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
     ):
         template_string = "Write a creative story about {topic}."
         single_variable_template = langchain_core.prompts.PromptTemplate(
@@ -321,8 +330,9 @@ class TestLangChainLLMObs:
         # Should convert string input to dict format with single variable
         assert actual_prompt["variables"] == {"topic": "time travel"}
 
-
-    def test_llmobs_multi_message_prompt_template_sync_chain(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
+    def test_llmobs_multi_message_prompt_template_sync_chain(
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+    ):
         test_metadata = {"template_type": "multi_message", "test_scenario": "sync_chain", "message_count": 10}
         multi_message_template = _create_multi_message_prompt_template(langchain_core, metadata=test_metadata)
         llm = langchain_openai.ChatOpenAI(base_url=openai_url)
@@ -353,9 +363,8 @@ class TestLangChainLLMObs:
         assert "tags" in actual_prompt
         assert actual_prompt["tags"] == {k: v for k, v in test_metadata.items() if isinstance(v, str)}
 
-
-    def test_llmobs_multi_message_prompt_template_sync_direct_invoke(self, 
-        langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
+    def test_llmobs_multi_message_prompt_template_sync_direct_invoke(
+        self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans
     ):
         multi_message_template = _create_multi_message_prompt_template(langchain_core)
         llm = langchain_openai.ChatOpenAI(base_url=openai_url)
@@ -383,7 +392,6 @@ class TestLangChainLLMObs:
         assert actual_prompt["variables"] == variable_dict
         assert actual_prompt.get("template") is None
         assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
-
 
     @pytest.mark.asyncio
     async def test_llmobs_multi_message_prompt_template_async_direct_invoke(
@@ -416,7 +424,6 @@ class TestLangChainLLMObs:
         assert actual_prompt.get("template") is None
         assert actual_prompt["chat_template"] == PROMPT_TEMPLATE_EXPECTED_CHAT_TEMPLATE
 
-
     def test_llmobs_chain(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
             [("system", "You are world class technical documentation writer."), ("user", "{input}")]
@@ -448,7 +455,6 @@ class TestLangChainLLMObs:
             "_dd_query_variable_keys": ["question"],
         }
         assert get_llmobs_input_prompt(spans[1]) == expected_prompt
-
 
     def test_llmobs_chain_nested(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         prompt1 = langchain_core.prompts.ChatPromptTemplate.from_template("what is the city {person} is from?")
@@ -515,7 +521,6 @@ class TestLangChainLLMObs:
         }
         assert get_llmobs_input_prompt(spans[4]) == expected_prompt_4
 
-
     @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python <3.11 required")
     def test_llmobs_chain_batch(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
@@ -529,9 +534,7 @@ class TestLangChainLLMObs:
         assert len(spans) == 3
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            **_chain_span_kwargs(
-                input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY
-            ),
+            **_chain_span_kwargs(input_value=json.dumps(["chickens", "pigs"], sort_keys=True), output_value=mock.ANY),
         )
 
         # The two LLM spans (one per batch item) can come back in either order; check by
@@ -546,7 +549,6 @@ class TestLangChainLLMObs:
             assert prompt_block["ml_app"] == "langchain_test"
             assert prompt_block["chat_template"] == [{"content": "Tell me a short joke about {topic}", "role": "user"}]
             assert prompt_block["variables"]["topic"] in ("chickens", "pigs")
-
 
     def test_llmobs_chain_schema_io(self, langchain_core, langchain_openai, openai_url, langchain_llmobs, test_spans):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
@@ -592,7 +594,6 @@ class TestLangChainLLMObs:
             **_llm_span_kwargs(spans[1], mock_io=True, mock_token_metrics=True),
         )
 
-
     def test_llmobs_anthropic_chat_model(self, langchain_anthropic, langchain_llmobs, test_spans, anthropic_url):
         kwargs = dict(
             temperature=0,
@@ -616,7 +617,6 @@ class TestLangChainLLMObs:
                 spans[0], input_role="user", mock_token_metrics=True, metadata={"temperature": 0, "max_tokens": 15}
             ),
         )
-
 
     def test_llmobs_google_genai_chat_model(self, langchain_google_genai, langchain_llmobs, test_spans):
         if langchain_google_genai is None:
@@ -661,7 +661,6 @@ class TestLangChainLLMObs:
             **_llm_span_kwargs(span, input_role="user", mock_token_metrics=True, metadata={"temperature": 0.0}),
         )
 
-
     def test_llmobs_embedding_documents(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
         embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
         embedding_model.embed_documents(["hello world", "goodbye world"])
@@ -677,7 +676,6 @@ class TestLangChainLLMObs:
             output_value="[2 embedding(s) returned with size 1536]",
             tags=COMMON_TAGS,
         )
-
 
     def test_llmobs_embedding_query(self, langchain_openai, langchain_llmobs, test_spans, openai_url):
         embedding_model = langchain_openai.embeddings.OpenAIEmbeddings(base_url=openai_url)
@@ -695,7 +693,6 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
     def test_llmobs_vectorstore_similarity_search(self, langchain_in_memory_vectorstore, langchain_llmobs, test_spans):
         vectorstore = langchain_in_memory_vectorstore
         vectorstore.similarity_search("France", k=1)
@@ -712,8 +709,9 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
-    def test_llmobs_chat_model_tool_calls(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url):
+    def test_llmobs_chat_model_tool_calls(
+        self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url
+    ):
         @langchain_core.tools.tool
         def add(a: int, b: int) -> int:
             """Adds a and b.
@@ -754,7 +752,6 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
     def test_llmobs_base_tool_invoke(self, langchain_core, langchain_llmobs, test_spans):
         from math import pi
 
@@ -788,9 +785,10 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
-    def test_llmobs_streamed_chain(self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream):
+    def test_llmobs_streamed_chain(
+        self, langchain_core, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream
+    ):
         prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
             [("system", "You are a world class technical documentation writer."), ("user", "{input}")]
         )
@@ -825,7 +823,6 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
     @pytest.mark.parametrize("consume_stream", [iterate_stream, next_stream])
     def test_llmobs_streamed_llm(self, langchain_openai, langchain_llmobs, test_spans, openai_url, consume_stream):
         llm = langchain_openai.OpenAI(base_url=openai_url, n=1, seed=1, logprobs=None, logit_bias=None)
@@ -849,7 +846,6 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
     def test_llmobs_non_ascii_completion(self, langchain_openai, openai_url, langchain_llmobs, test_spans):
         llm = langchain_openai.OpenAI(base_url=openai_url)
         llm.invoke("안녕,\n 지금 몇 시야?")
@@ -857,7 +853,6 @@ class TestLangChainLLMObs:
         spans = _llmobs_spans(test_spans)
         assert len(spans) == 1
         assert get_llmobs_input_messages(spans[0])[0]["content"] == "안녕,\n 지금 몇 시야?"
-
 
     def test_llmobs_runnable_lambda_invoke(self, langchain_core, langchain_llmobs, test_spans):
         def add(inputs: dict) -> int:
@@ -877,7 +872,6 @@ class TestLangChainLLMObs:
             tags=COMMON_TAGS,
         )
 
-
     async def test_llmobs_runnable_lambda_ainvoke(self, langchain_core, langchain_llmobs, test_spans):
         async def add(inputs: dict) -> int:
             return inputs["a"] + inputs["b"]
@@ -895,7 +889,6 @@ class TestLangChainLLMObs:
             output_value="3",
             tags=COMMON_TAGS,
         )
-
 
     def test_llmobs_runnable_lambda_batch(self, langchain_core, langchain_llmobs, test_spans):
         def add(inputs: dict) -> int:
@@ -932,7 +925,6 @@ class TestLangChainLLMObs:
             assert "b" in input_value
             assert isinstance(output_value, int)
 
-
     async def test_llmobs_runnable_lambda_abatch(self, langchain_core, langchain_llmobs, test_spans):
         async def add(inputs: dict) -> int:
             return inputs["a"] + inputs["b"]
@@ -967,7 +959,6 @@ class TestLangChainLLMObs:
             assert "a" in input_value
             assert "b" in input_value
             assert isinstance(output_value, int)
-
 
     def test_llmobs_runnable_with_span_links(self, langchain_core, langchain_llmobs, test_spans):
         sequence = langchain_core.runnables.RunnableLambda(lambda x: x + 1, name="add_1") | {
@@ -1027,7 +1018,6 @@ class TestLangChainLLMObs:
                 "attributes": {"from": "output", "to": "input"},
             },
         ]
-
 
 
 def test_llmobs_set_tags_with_none_response(langchain_core):


### PR DESCRIPTION
Migrates langchain LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`.

Conftest: replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `langchain_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs (with `ml_app="langchain_test"` and `_llmobs_instrumented_proxy_urls="http://localhost:4000"` so proxied requests route to workflow spans), and mocks the span writer.

Stacked on #17789.
