### PR TITLE
chore(llmobs): strip large I/O from unsampled span meta_struct

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -297,6 +297,7 @@ class SpanAggregator(SpanProcessor):
         partial_flush_min_spans: int,
         dd_processors: Optional[list[TraceProcessor]] = None,
         user_processors: Optional[list[TraceProcessor]] = None,
+        post_sampling_processors: Optional[list[TraceProcessor]] = None,
     ):
         # Set partial flushing
         self.partial_flush_enabled = partial_flush_enabled
@@ -308,6 +309,7 @@ class SpanAggregator(SpanProcessor):
         self.tags_processor = TraceTagsProcessor()
         self.dd_processors = dd_processors or []
         self.user_processors = user_processors or []
+        self.post_sampling_processors = post_sampling_processors or []
         self.service_name_processor = ServiceNameProcessor()
         self.writer = create_trace_writer(response_callback=self._agent_response_callback)
         # Initialize the trace buffer and lock
@@ -385,7 +387,9 @@ class SpanAggregator(SpanProcessor):
         for tp in chain(
             self.dd_processors,
             self.user_processors,
-            [self.sampling_processor, self.tags_processor, self.service_name_processor],
+            [self.sampling_processor],
+            self.post_sampling_processors,
+            [self.tags_processor, self.service_name_processor],
         ):
             try:
                 spans = tp.process_trace(spans) or []

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -72,6 +72,11 @@ EXPERIMENT_CSV_FIELD_MAX_SIZE = 10 * 1024 * 1024
 DROPPED_IO_COLLECTION_ERROR = "dropped_io"
 DROPPED_VALUE_TEXT = "[This value has been dropped because this span's size exceeds the 5MB size limit.]"
 DROPPED_IO_COLLECTION_ERROR_UNSAMPLED = "dropped_io_unsampled"
+# Tag surfaced into meta_struct["_llmobs"]["tags"] for spans the SDK shipped because the trace was APM-unsampled.
+# Read by the dd-go LLMObs trace-indexer to route the span through the metrics-only fast path. Per-span signal,
+# necessary because APM places _sampling_priority_v1 only on the local trace root and TSP fan-outs trace chunks
+# into individual span messages downstream.
+DD_LLMOBS_UNSAMPLED_TAG_KEY = "_dd.llmobs.unsampled"
 
 ROOT_PARENT_ID = "undefined"
 

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -71,6 +71,7 @@ EXPERIMENT_CSV_FIELD_MAX_SIZE = 10 * 1024 * 1024
 
 DROPPED_IO_COLLECTION_ERROR = "dropped_io"
 DROPPED_VALUE_TEXT = "[This value has been dropped because this span's size exceeds the 5MB size limit.]"
+DROPPED_IO_COLLECTION_ERROR_UNSAMPLED = "dropped_io_unsampled"
 
 ROOT_PARENT_ID = "undefined"
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -118,6 +118,7 @@ from ddtrace.llmobs._prompt_optimization import validate_test_dataset
 from ddtrace.llmobs._prompts import ManagedPrompt
 from ddtrace.llmobs._prompts.cache import WarmCache
 from ddtrace.llmobs._prompts.manager import PromptManager
+from ddtrace.llmobs._unsampled import LLMObsUnsampledStripProcessor
 from ddtrace.llmobs._utils import AnnotationContext
 from ddtrace.llmobs._utils import LinkTracker
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
@@ -829,6 +830,10 @@ class LLMObs(Service):
             # Add APM trace filter to drop all APM traces when DD_APM_TRACING_ENABLED is falsy
             apm_filter = APMTracingEnabledFilter()
             cls._instance.tracer._span_aggregator.dd_processors.append(apm_filter)
+
+            # Strip large LLMObs I/O from APM-attached meta_struct on traces APM sampling rejected,
+            # so the unsampled-LLMObs metrics path doesn't ship full prompts for spans that won't be indexed.
+            cls._instance.tracer._span_aggregator.post_sampling_processors.append(LLMObsUnsampledStripProcessor())
 
             cls.enabled = True
             # Align config._llmobs_enabled with effective state for user-initiated calls.

--- a/ddtrace/llmobs/_unsampled.py
+++ b/ddtrace/llmobs/_unsampled.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from ddtrace._trace.processor import TraceProcessor
 from ddtrace._trace.span import Span
+from ddtrace.llmobs._constants import DD_LLMOBS_UNSAMPLED_TAG_KEY
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR_UNSAMPLED
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 
@@ -41,14 +42,16 @@ class LLMObsUnsampledStripProcessor(TraceProcessor):
 
 def _strip_llmobs_io(llmobs_data: dict[str, Any]) -> None:
     meta = llmobs_data.get(LLMOBS_STRUCT.META)
-    if not isinstance(meta, dict):
-        return
-    meta.pop(LLMOBS_STRUCT.INPUT, None)
-    meta.pop(LLMOBS_STRUCT.OUTPUT, None)
-    meta.pop(LLMOBS_STRUCT.EXPECTED_OUTPUT, None)
-    meta.pop(LLMOBS_STRUCT.TOOL_DEFINITIONS, None)
-    metadata = meta.setdefault(LLMOBS_STRUCT.METADATA, {})
-    metadata_dd = metadata.setdefault(LLMOBS_STRUCT.METADATA_DD, {})
-    errs = metadata_dd.setdefault("collection_errors", [])
-    if DROPPED_IO_COLLECTION_ERROR_UNSAMPLED not in errs:
-        errs.append(DROPPED_IO_COLLECTION_ERROR_UNSAMPLED)
+    if isinstance(meta, dict):
+        meta.pop(LLMOBS_STRUCT.INPUT, None)
+        meta.pop(LLMOBS_STRUCT.OUTPUT, None)
+        meta.pop(LLMOBS_STRUCT.EXPECTED_OUTPUT, None)
+        meta.pop(LLMOBS_STRUCT.TOOL_DEFINITIONS, None)
+        metadata = meta.setdefault(LLMOBS_STRUCT.METADATA, {})
+        metadata_dd = metadata.setdefault(LLMOBS_STRUCT.METADATA_DD, {})
+        errs = metadata_dd.setdefault("collection_errors", [])
+        if DROPPED_IO_COLLECTION_ERROR_UNSAMPLED not in errs:
+            errs.append(DROPPED_IO_COLLECTION_ERROR_UNSAMPLED)
+    # Per-span marker so the backend can detect unsampled-for-metrics after trace-chunk fan-out.
+    tags = llmobs_data.setdefault(LLMOBS_STRUCT.TAGS, {})
+    tags[DD_LLMOBS_UNSAMPLED_TAG_KEY] = "1"

--- a/ddtrace/llmobs/_unsampled.py
+++ b/ddtrace/llmobs/_unsampled.py
@@ -1,0 +1,54 @@
+from typing import Any
+from typing import Optional
+
+from ddtrace._trace.processor import TraceProcessor
+from ddtrace._trace.span import Span
+from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR_UNSAMPLED
+from ddtrace.llmobs._constants import LLMOBS_STRUCT
+
+
+class LLMObsUnsampledStripProcessor(TraceProcessor):
+    """Strip large input/output payloads from LLMObs span data when the trace
+    has been sampled out by APM head-based sampling.
+
+    The unsampled-LLMObs path forwards APM spans to intake even when sampling
+    rejected the trace, so the backend can still emit token/cost metrics. The
+    full input/output payloads are useless on that path (the spans are not
+    indexed) and stripping them keeps the bandwidth cost down.
+
+    Must run after ``TraceSamplingProcessor.process_trace``, since the
+    sampling priority on the local-root span is finalized there.
+    """
+
+    def process_trace(self, trace: list[Span]) -> Optional[list[Span]]:
+        if not trace:
+            return trace
+        root = trace[0]._local_root or trace[0]
+        # Priority is on the context here; the copy onto span._metrics happens later in the chain.
+        priority = root.context.sampling_priority
+        if priority is None or priority >= 1:
+            return trace
+        for span in trace:
+            if not span._has_meta_structs():
+                continue
+            llmobs_data = span._get_struct_tag(LLMOBS_STRUCT.KEY)
+            if not llmobs_data:
+                continue
+            _strip_llmobs_io(llmobs_data)
+            span._set_struct_tag(LLMOBS_STRUCT.KEY, llmobs_data)
+        return trace
+
+
+def _strip_llmobs_io(llmobs_data: dict[str, Any]) -> None:
+    meta = llmobs_data.get(LLMOBS_STRUCT.META)
+    if not isinstance(meta, dict):
+        return
+    meta.pop(LLMOBS_STRUCT.INPUT, None)
+    meta.pop(LLMOBS_STRUCT.OUTPUT, None)
+    meta.pop(LLMOBS_STRUCT.EXPECTED_OUTPUT, None)
+    meta.pop(LLMOBS_STRUCT.TOOL_DEFINITIONS, None)
+    metadata = meta.setdefault(LLMOBS_STRUCT.METADATA, {})
+    metadata_dd = metadata.setdefault(LLMOBS_STRUCT.METADATA_DD, {})
+    errs = metadata_dd.setdefault("collection_errors", [])
+    if DROPPED_IO_COLLECTION_ERROR_UNSAMPLED not in errs:
+        errs.append(DROPPED_IO_COLLECTION_ERROR_UNSAMPLED)

--- a/releasenotes/notes/llmobs-strip-unsampled-io-2bcd5161e9cd903d.yaml
+++ b/releasenotes/notes/llmobs-strip-unsampled-io-2bcd5161e9cd903d.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    LLM Observability: When the APM head-based sampler has rejected a trace
+    (sampling priority < 1), large input/output payloads are now stripped from
+    the LLMObs data attached to the APM span before submission. This avoids
+    shipping full prompt history, messages, documents, tool definitions, and
+    expected outputs on the unsampled-spans metrics path, where those payloads
+    would otherwise add bandwidth without being indexed.

--- a/releasenotes/notes/llmobs-strip-unsampled-io-2bcd5161e9cd903d.yaml
+++ b/releasenotes/notes/llmobs-strip-unsampled-io-2bcd5161e9cd903d.yaml
@@ -1,9 +1,0 @@
----
-other:
-  - |
-    LLM Observability: When the APM head-based sampler has rejected a trace
-    (sampling priority < 1), large input/output payloads are now stripped from
-    the LLMObs data attached to the APM span before submission. This avoids
-    shipping full prompt history, messages, documents, tool definitions, and
-    expected outputs on the unsampled-spans metrics path, where those payloads
-    would otherwise add bandwidth without being indexed.

--- a/tests/llmobs/test_unsampled_stripping.py
+++ b/tests/llmobs/test_unsampled_stripping.py
@@ -1,0 +1,131 @@
+from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR_UNSAMPLED
+from ddtrace.llmobs._constants import LLMOBS_STRUCT
+from ddtrace.llmobs._unsampled import LLMObsUnsampledStripProcessor
+from ddtrace.trace import Span
+
+
+def _llmobs_payload():
+    return {
+        LLMOBS_STRUCT.NAME: "my_span",
+        LLMOBS_STRUCT.ML_APP: "test-app",
+        LLMOBS_STRUCT.METRICS: {"input_tokens": 10, "output_tokens": 5},
+        LLMOBS_STRUCT.TAGS: {"env": "prod"},
+        LLMOBS_STRUCT.META: {
+            LLMOBS_STRUCT.SPAN: {LLMOBS_STRUCT.KIND: "llm"},
+            LLMOBS_STRUCT.MODEL_NAME: "gpt-4",
+            LLMOBS_STRUCT.MODEL_PROVIDER: "openai",
+            LLMOBS_STRUCT.METADATA: {
+                "temperature": 0.5,
+                LLMOBS_STRUCT.METADATA_DD: {LLMOBS_STRUCT.COST_TAGS: ["team:llm-obs"]},
+            },
+            LLMOBS_STRUCT.INPUT: {
+                LLMOBS_STRUCT.MESSAGES: [{"role": "user", "content": "hello"}],
+                LLMOBS_STRUCT.PROMPT: {"template": "Say hi"},
+            },
+            LLMOBS_STRUCT.OUTPUT: {
+                LLMOBS_STRUCT.MESSAGES: [{"role": "assistant", "content": "hi"}],
+            },
+            LLMOBS_STRUCT.TOOL_DEFINITIONS: [{"name": "calc"}],
+            LLMOBS_STRUCT.EXPECTED_OUTPUT: "hi",
+        },
+    }
+
+
+def _make_span(priority=None, with_llmobs=True):
+    span = Span(name="root")
+    if priority is not None:
+        span.context.sampling_priority = priority
+    if with_llmobs:
+        span._set_struct_tag(LLMOBS_STRUCT.KEY, _llmobs_payload())
+    return span
+
+
+def _data(span):
+    return span._get_struct_tag(LLMOBS_STRUCT.KEY)
+
+
+def test_strips_io_when_priority_is_auto_reject():
+    span = _make_span(priority=0)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    data = _data(span)
+    meta = data[LLMOBS_STRUCT.META]
+    assert LLMOBS_STRUCT.INPUT not in meta
+    assert LLMOBS_STRUCT.OUTPUT not in meta
+    assert LLMOBS_STRUCT.EXPECTED_OUTPUT not in meta
+    assert LLMOBS_STRUCT.TOOL_DEFINITIONS not in meta
+    assert meta[LLMOBS_STRUCT.MODEL_NAME] == "gpt-4"
+    assert meta[LLMOBS_STRUCT.MODEL_PROVIDER] == "openai"
+    assert meta[LLMOBS_STRUCT.SPAN][LLMOBS_STRUCT.KIND] == "llm"
+    assert meta[LLMOBS_STRUCT.METADATA]["temperature"] == 0.5
+    assert meta[LLMOBS_STRUCT.METADATA][LLMOBS_STRUCT.METADATA_DD][LLMOBS_STRUCT.COST_TAGS] == ["team:llm-obs"]
+    assert data[LLMOBS_STRUCT.METRICS] == {"input_tokens": 10, "output_tokens": 5}
+    assert data[LLMOBS_STRUCT.TAGS] == {"env": "prod"}
+    assert data[LLMOBS_STRUCT.NAME] == "my_span"
+    assert data[LLMOBS_STRUCT.ML_APP] == "test-app"
+    errs = meta[LLMOBS_STRUCT.METADATA][LLMOBS_STRUCT.METADATA_DD]["collection_errors"]
+    assert DROPPED_IO_COLLECTION_ERROR_UNSAMPLED in errs
+
+
+def test_strips_io_when_priority_is_user_reject():
+    span = _make_span(priority=-1)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    meta = _data(span)[LLMOBS_STRUCT.META]
+    assert LLMOBS_STRUCT.INPUT not in meta
+    assert LLMOBS_STRUCT.OUTPUT not in meta
+
+
+def test_does_not_strip_when_priority_is_auto_keep():
+    span = _make_span(priority=1)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    meta = _data(span)[LLMOBS_STRUCT.META]
+    assert LLMOBS_STRUCT.INPUT in meta
+    assert LLMOBS_STRUCT.OUTPUT in meta
+    assert LLMOBS_STRUCT.TOOL_DEFINITIONS in meta
+    assert LLMOBS_STRUCT.EXPECTED_OUTPUT in meta
+
+
+def test_does_not_strip_when_priority_is_user_keep():
+    span = _make_span(priority=2)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    meta = _data(span)[LLMOBS_STRUCT.META]
+    assert LLMOBS_STRUCT.INPUT in meta
+    assert LLMOBS_STRUCT.OUTPUT in meta
+
+
+def test_does_not_strip_when_priority_is_unset():
+    span = _make_span(priority=None)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    meta = _data(span)[LLMOBS_STRUCT.META]
+    assert LLMOBS_STRUCT.INPUT in meta
+    assert LLMOBS_STRUCT.OUTPUT in meta
+
+
+def test_skips_spans_without_llmobs_struct():
+    span = _make_span(priority=0, with_llmobs=False)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    assert _data(span) is None
+
+
+def test_strips_all_llmobs_spans_in_trace():
+    root = _make_span(priority=0)
+    child = Span(name="child")
+    child._local_root_value = root
+    child._set_struct_tag(LLMOBS_STRUCT.KEY, _llmobs_payload())
+    LLMObsUnsampledStripProcessor().process_trace([root, child])
+    for span in (root, child):
+        meta = _data(span)[LLMOBS_STRUCT.META]
+        assert LLMOBS_STRUCT.INPUT not in meta
+        assert LLMOBS_STRUCT.OUTPUT not in meta
+
+
+def test_idempotent_collection_error_marker():
+    span = _make_span(priority=0)
+    proc = LLMObsUnsampledStripProcessor()
+    proc.process_trace([span])
+    proc.process_trace([span])
+    errs = _data(span)[LLMOBS_STRUCT.META][LLMOBS_STRUCT.METADATA][LLMOBS_STRUCT.METADATA_DD]["collection_errors"]
+    assert errs.count(DROPPED_IO_COLLECTION_ERROR_UNSAMPLED) == 1
+
+
+def test_empty_trace_is_passthrough():
+    assert LLMObsUnsampledStripProcessor().process_trace([]) == []

--- a/tests/llmobs/test_unsampled_stripping.py
+++ b/tests/llmobs/test_unsampled_stripping.py
@@ -1,3 +1,4 @@
+from ddtrace.llmobs._constants import DD_LLMOBS_UNSAMPLED_TAG_KEY
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR_UNSAMPLED
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._unsampled import LLMObsUnsampledStripProcessor
@@ -59,7 +60,7 @@ def test_strips_io_when_priority_is_auto_reject():
     assert meta[LLMOBS_STRUCT.METADATA]["temperature"] == 0.5
     assert meta[LLMOBS_STRUCT.METADATA][LLMOBS_STRUCT.METADATA_DD][LLMOBS_STRUCT.COST_TAGS] == ["team:llm-obs"]
     assert data[LLMOBS_STRUCT.METRICS] == {"input_tokens": 10, "output_tokens": 5}
-    assert data[LLMOBS_STRUCT.TAGS] == {"env": "prod"}
+    assert data[LLMOBS_STRUCT.TAGS] == {"env": "prod", DD_LLMOBS_UNSAMPLED_TAG_KEY: "1"}
     assert data[LLMOBS_STRUCT.NAME] == "my_span"
     assert data[LLMOBS_STRUCT.ML_APP] == "test-app"
     errs = meta[LLMOBS_STRUCT.METADATA][LLMOBS_STRUCT.METADATA_DD]["collection_errors"]
@@ -72,6 +73,45 @@ def test_strips_io_when_priority_is_user_reject():
     meta = _data(span)[LLMOBS_STRUCT.META]
     assert LLMOBS_STRUCT.INPUT not in meta
     assert LLMOBS_STRUCT.OUTPUT not in meta
+
+
+def test_marks_unsampled_tag_at_auto_reject():
+    span = _make_span(priority=0)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    assert _data(span)[LLMOBS_STRUCT.TAGS][DD_LLMOBS_UNSAMPLED_TAG_KEY] == "1"
+
+
+def test_marks_unsampled_tag_at_user_reject():
+    span = _make_span(priority=-1)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    assert _data(span)[LLMOBS_STRUCT.TAGS][DD_LLMOBS_UNSAMPLED_TAG_KEY] == "1"
+
+
+def test_marks_unsampled_tag_on_every_span_in_trace():
+    root = _make_span(priority=0)
+    child1 = Span(name="child1")
+    child1._local_root_value = root
+    child1._set_struct_tag(LLMOBS_STRUCT.KEY, _llmobs_payload())
+    child2 = Span(name="child2")
+    child2._local_root_value = root
+    child2._set_struct_tag(LLMOBS_STRUCT.KEY, _llmobs_payload())
+    LLMObsUnsampledStripProcessor().process_trace([root, child1, child2])
+    for span in (root, child1, child2):
+        assert _data(span)[LLMOBS_STRUCT.TAGS][DD_LLMOBS_UNSAMPLED_TAG_KEY] == "1"
+
+
+def test_does_not_mark_unsampled_tag_at_auto_keep():
+    span = _make_span(priority=1)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    assert DD_LLMOBS_UNSAMPLED_TAG_KEY not in _data(span)[LLMOBS_STRUCT.TAGS]
+
+
+def test_unsampled_tag_does_not_clobber_existing_tags():
+    span = _make_span(priority=0)
+    LLMObsUnsampledStripProcessor().process_trace([span])
+    tags = _data(span)[LLMOBS_STRUCT.TAGS]
+    assert tags["env"] == "prod"
+    assert tags[DD_LLMOBS_UNSAMPLED_TAG_KEY] == "1"
 
 
 def test_does_not_strip_when_priority_is_auto_keep():


### PR DESCRIPTION
## Description

Adds an LLMObs trace processor (`LLMObsUnsampledStripProcessor`) that runs after APM sampling on every trace chunk. When the local-root sampling priority is `< 1` (`AUTO_REJECT` or `USER_REJECT`), the processor walks the trace and, for every span carrying LLMObs data in `meta_struct["_llmobs"]`:

1. **Strips large I/O fields** to avoid wasted bandwidth on the unsampled-spans metrics path:
   - `meta.input` (messages, documents, value, parameters, prompt)
   - `meta.output` (messages, documents, value, parameters, prompt)
   - `meta.expected_output`
   - `meta.tool_definitions`
2. **Marks the span** with `meta_struct["_llmobs"]["tags"]["_dd.llmobs.unsampled"] = "1"` so the dd-go LLMObs trace-indexer can route the span through the metrics-only fast path. Per-span signal — necessary because TSP fans out trace chunks into individual span messages and APM's `_sampling_priority_v1` lives on the local trace root only.
3. **Logs a marker** at `meta.metadata._dd.collection_errors = ["dropped_io_unsampled"]` for SDK-side observability.

Kept intact: `model_name`, `model_provider`, `span.kind`, `metadata` (incl. `_dd.cost_tags`), `metrics`, identification fields, and any non-marker tags.

The processor needs to run **after** sampling priority is finalized but before the encoder. To wire it in, this PR adds an optional `post_sampling_processors: list[TraceProcessor]` to `SpanAggregator`, slotted into the chain between `sampling_processor` and `tags_processor`. Default is empty, so non-LLMObs paths are unchanged. LLMObs appends its processor at enable time, alongside the existing `apm_filter`.

This is a no-op until (1) the separate SDK change lands that force-sends spans on APM reject, and (2) the dd-go unsampled-spans POC is enabled. Together those let the backend emit token/cost metrics for traces APM rejected, without indexing the spans or paying the bandwidth cost of full prompt history.

## Testing

`tests/llmobs/test_unsampled_stripping.py` — 14 unit tests, all passing on the llmobs suite (py3.13). Coverage:

- I/O stripping at `AUTO_REJECT (0)` and `USER_REJECT (-1)`; no-op at `AUTO_KEEP (1)`, `USER_KEEP (2)`, and unset priority
- `_dd.llmobs.unsampled:1` tag set at `0` and `-1`, not set at `1`, set on every span in a multi-span trace, and not clobbering existing tag entries
- Spans without `_llmobs` in `meta_struct` are untouched
- Idempotency of the `collection_errors` marker
- Empty trace passthrough

## Risks

Low. The `SpanAggregator` change is strictly additive: a default-empty `post_sampling_processors` list reproduces the previous chain exactly. The only registrant is the LLMObs path, behind LLMObs being enabled.

The processor itself only mutates `_meta_struct["_llmobs"]` on spans that already have it, and only when sampling priority is `< 1`. Today that condition is rare on LLMObs spans (they normally get dropped at the SDK before shipping). Once force-send-on-reject lands, this becomes the bandwidth-saver path.

## Additional Notes

- Agentless `LLMObsSpanWriter` event path is intentionally untouched.
- `changelog/no-changelog` per `docs/releasenotes.rst`: "Changes to internal API (Non-public facing, or not-yet released components/features)" do not need a release note.

Claude session: `b2df08e5-ddde-4046-ba5f-e4524825b292`
Resume: `claude --resume b2df08e5-ddde-4046-ba5f-e4524825b292`