### PR TITLE
feat(llmobs): add Experiment.pull() with optional task and dataset

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1301,7 +1301,7 @@ def _parse_experiment_result(response: dict) -> "ExperimentResult":
                 continue
             latest_ts[label] = ts
             metric_type = em.get("metric_type", "score")
-            value = em.get("score_value") if metric_type == "score" else em.get("boolean_value")
+            value = em.get(f"{metric_type}_value")
             evaluations[label] = {
                 "value": value,
                 "type": metric_type,
@@ -1344,8 +1344,21 @@ def _parse_experiment_result(response: dict) -> "ExperimentResult":
 
     rows.sort(key=lambda r: r["idx"])
 
+    summary_evaluations: dict[str, dict[str, JSONType]] = {}
+    for sm in attributes.get("summary_metrics") or []:
+        label = sm.get("label", "")
+        if not label:
+            continue
+        metric_type = sm.get("metric_type", "score")
+        summary_evaluations[label] = {
+            "value": sm.get(f"{metric_type}_value"),
+            "type": metric_type,
+            "reasoning": sm.get("reasoning"),
+            "assessment": sm.get("assessment"),
+        }
+
     run_info = _ExperimentRunInfo(run_interation=0)
-    experiment_run = ExperimentRun(run_info, summary_evaluations={}, rows=rows)
+    experiment_run = ExperimentRun(run_info, summary_evaluations=summary_evaluations, rows=rows)
     return Experiment._build_result([experiment_run])
 
 

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1140,18 +1140,24 @@ class _ExperimentRunInfo:
         self._run_iteration = run_interation + 1
 
 
-class ExperimentRowResult(TypedDict):
+class _ExperimentRowResultRequired(TypedDict):
     idx: int
     record_id: Optional[str]
     span_id: str
     trace_id: str
     timestamp: int
+    duration: int
+    span_name: str
     input: JSONType
     output: JSONType
     expected_output: JSONType
     evaluations: dict[str, dict[str, JSONType]]
     metadata: dict[str, JSONType]
     error: dict[str, Optional[str]]
+
+
+class ExperimentRowResult(_ExperimentRowResultRequired, total=False):
+    pass
 
 
 class ExperimentRun:
@@ -1246,6 +1252,101 @@ class ExperimentResult(TypedDict):
     summary_evaluations: dict[str, dict[str, JSONType]]
     rows: list[ExperimentRowResult]
     runs: list[ExperimentRun]
+
+
+def _parse_experiment_result(response: dict) -> "ExperimentResult":
+    """Deserialise a backend ``/events`` response into an ``ExperimentResult``.
+
+    Response shape (single JSON:API object):
+    ``{"data": {"id": "<experiment_id>", "type": "experiment_events",
+    "attributes": {"spans": [...], "summary_metrics": [...]}}}``
+
+    Each item in ``attributes.spans`` is one experiment span with flat fields
+    (``span_id``, ``trace_id``, ``name``, ``start_ns``, ``duration``, ``tags``,
+    ``meta`` containing ``input``/``output``/``expected_output``/``metadata``/``error``,
+    and ``eval_metrics``).  ``eval_metrics`` on each span (when present) are converted
+    to the ``evaluations`` dict format used by ``ExperimentRowResult``.  When multiple
+    eval events share the same label (e.g. original run + re-run), the one with the
+    latest ``timestamp_ms`` wins.
+    """
+    data = response.get("data") or {}
+    attributes = data.get("attributes") or {}
+    spans = attributes.get("spans") or []
+
+    rows: list[ExperimentRowResult] = []
+    for i, span in enumerate(spans):
+        meta = span.get("meta") or {}
+        metadata: dict = meta.get("metadata") or {}
+
+        # idx: use array position (no dataset_record_index in the new response shape)
+        idx: int = i
+
+        # record_id is stored as a "dataset_record_id:<uuid>" tag
+        record_id: Optional[str] = None
+        for tag in span.get("tags") or []:
+            if isinstance(tag, str) and tag.startswith("dataset_record_id:"):
+                record_id = tag.split(":", 1)[1]
+                break
+
+        # Convert eval_metrics list → evaluations dict keyed by label.
+        # Multiple events per label are possible (original run + re-run); keep latest by timestamp_ms.
+        evaluations: dict = {}
+        latest_ts: dict[str, int] = {}
+        for em in span.get("eval_metrics") or []:
+            label = em.get("label", "")
+            if not label:
+                continue
+            ts = em.get("timestamp_ms", 0) or 0
+            if label in latest_ts and ts < latest_ts[label]:
+                continue
+            latest_ts[label] = ts
+            metric_type = em.get("metric_type", "score")
+            value = em.get("score_value") if metric_type == "score" else em.get("boolean_value")
+            evaluations[label] = {
+                "value": value,
+                "type": metric_type,
+                "reasoning": em.get("reasoning"),
+                "assessment": em.get("assessment"),
+            }
+
+        # Normalise error: the API returns an empty dict {} when there is no error.
+        raw_error = meta.get("error") or {}
+        normalised_error: dict[str, Optional[str]] = {
+            "type": raw_error.get("type") or None,
+            "message": raw_error.get("message") or None,
+            "stack": raw_error.get("stack") or None,
+        }
+
+        duration = span.get("duration") or 0
+        if not duration:
+            logger.warning(
+                "Span %s from experiment pull response is missing a duration field; "
+                "rerun_evaluators() will use a fallback of 1 ns.",
+                span.get("span_id", "<unknown>"),
+            )
+
+        row: ExperimentRowResult = {
+            "idx": idx,
+            "record_id": record_id,
+            "span_id": span.get("span_id", ""),
+            "trace_id": span.get("trace_id", ""),
+            "timestamp": span.get("start_ns", 0),
+            "duration": duration,
+            "span_name": span.get("name", "experiment_record"),
+            "input": meta.get("input") or {},
+            "output": meta.get("output"),
+            "expected_output": meta.get("expected_output"),
+            "evaluations": evaluations,
+            "metadata": metadata,
+            "error": normalised_error,
+        }
+        rows.append(row)
+
+    rows.sort(key=lambda r: r["idx"])
+
+    run_info = _ExperimentRunInfo(run_interation=0)
+    experiment_run = ExperimentRun(run_info, summary_evaluations={}, rows=rows)
+    return Experiment._build_result([experiment_run])
 
 
 class Dataset:
@@ -1681,7 +1782,7 @@ class Experiment:
     or ``LLMObs.experiment()`` to get a ``SyncExperiment`` wrapper (for sync callers).
     """
 
-    _task: Union[TaskType, AsyncTaskType]
+    _task: Optional[Union[TaskType, AsyncTaskType]]
     _evaluators: Sequence[Union[EvaluatorType, AsyncEvaluatorType]]
     _summary_evaluators: Sequence[Union[SummaryEvaluatorType, AsyncSummaryEvaluatorType]]
 
@@ -1693,10 +1794,10 @@ class Experiment:
     def __init__(
         self,
         name: str,
-        task: Union[TaskType, AsyncTaskType],
-        dataset: Dataset,
-        evaluators: Sequence[Union[EvaluatorType, AsyncEvaluatorType]],
-        project_name: str,
+        task: Optional[Union[TaskType, AsyncTaskType]] = None,
+        dataset: Optional[Dataset] = None,
+        evaluators: Sequence[Union[EvaluatorType, AsyncEvaluatorType]] = (),
+        project_name: str = "",
         description: str = "",
         tags: Optional[dict[str, str]] = None,
         config: Optional[ConfigType] = None,
@@ -1707,7 +1808,7 @@ class Experiment:
     ) -> None:
         self.name = name
         self._task = task
-        self._task_accepts_metadata = "metadata" in inspect.signature(task).parameters
+        self._task_accepts_metadata = "metadata" in inspect.signature(task).parameters if task is not None else False
         self._dataset = dataset
         self._evaluators = list(evaluators)
         self._remote_evaluator_names: set[str] = {
@@ -1720,11 +1821,11 @@ class Experiment:
         self._tags: dict[str, str] = tags or {}
         self._tags["ddtrace.version"] = str(__version__)
         self._tags["project_name"] = project_name
-        self._tags["dataset_name"] = dataset.name
+        self._tags["dataset_name"] = dataset.name if dataset is not None else ""
         self._tags["experiment_name"] = name
         self._config: dict[str, JSONType] = config or {}
         # Write dataset tags to experiment config
-        if dataset.filter_tags:
+        if dataset is not None and dataset.filter_tags:
             self._config["filtered_record_tags"] = dataset.filter_tags
         self._runs: int = runs or 1
         self._llmobs_instance = _llmobs_instance
@@ -1740,8 +1841,13 @@ class Experiment:
         self._project_name = project_name
         self._project_id: Optional[str] = None
         self._id: Optional[str] = None
+        # Populated from dataset if provided, or extracted from span tags during pull()
+        # so that _create_rerun_experiment() can reference them without a dataset.
+        self._dataset_id: Optional[str] = dataset._id if dataset is not None else None
+        self._dataset_version: Optional[int] = dataset._version if dataset is not None else None
         self._run_name: Optional[str] = None
         self.experiment_span: Optional["ExportedLLMObsSpan"] = None
+        self._interrupted: bool = False
 
     @property
     def url(self) -> str:
@@ -1755,6 +1861,7 @@ class Experiment:
         evaluations: list[EvaluationResult],
         summary_evaluations: Optional[list[EvaluationResult]],
     ) -> ExperimentRun:
+        assert self._dataset is not None  # nosec B101
         experiment_results = []
         for idx, task_result in enumerate(task_results):
             output_data = task_result["output"]
@@ -1767,6 +1874,8 @@ class Experiment:
                 "span_id": task_result.get("span_id", ""),
                 "trace_id": task_result.get("trace_id", ""),
                 "timestamp": task_result.get("timestamp", 0),
+                "duration": cast(int, task_result.get("duration") or 0),
+                "span_name": cast(str, task_result.get("span_name") or "experiment_record"),
                 "record_id": record.get("record_id", ""),
                 "input": record["input_data"],
                 "expected_output": record["expected_output"],
@@ -1930,6 +2039,7 @@ class Experiment:
 
     def _get_subset_dataset(self, sample_size: Optional[int]) -> Dataset:
         """Get dataset containing the first sample_size records of the original dataset."""
+        assert self._dataset is not None  # nosec B101
         if sample_size is not None and sample_size < len(self._dataset):
             subset_records = [deepcopy(record) for record in self._dataset._records[:sample_size]]
             subset_name = "[Test subset of {} records] {}".format(sample_size, self._dataset.name)
@@ -1989,6 +2099,7 @@ class Experiment:
         list[dict[str, Any]],
         dict[str, list[JSONType]],
     ]:
+        assert self._dataset is not None  # nosec B101
         inputs: list[JSONType] = []
         outputs: list[JSONType] = []
         expected_outputs: list[JSONType] = []
@@ -2027,6 +2138,7 @@ class Experiment:
         self._project_id = project.get("_id", "")
         self._tags["project_id"] = self._project_id
 
+        assert self._dataset is not None  # nosec B101
         (
             experiment_id,
             experiment_run_name,
@@ -2076,6 +2188,12 @@ class Experiment:
             raise ValueError("jobs must be at least 1")
         if max_retries < 0:
             raise ValueError("max_retries must be >= 0")
+        if self._task is None or self._dataset is None:
+            raise ValueError(
+                "task and dataset are required to run an experiment from scratch. "
+                "Either provide them when creating the experiment, or call `pull()` first "
+                "and use `rerun_evaluators()` to re-score the stored results."
+            )
 
         self._setup_experiment(
             "LLMObs is not enabled. Ensure LLM Observability is enabled via `LLMObs.enable(...)` "
@@ -2195,6 +2313,8 @@ class Experiment:
         retry_delay: Callable[[int], float] = lambda attempt: 0.1 * (attempt + 1),
     ) -> Optional[TaskResult]:
         """Process single record asynchronously."""
+        assert self._task is not None  # nosec B101
+        assert self._dataset is not None  # nosec B101
         asyncio = get_asyncio()
         if not self._llmobs_instance or not self._llmobs_instance.enabled:
             return None
@@ -2272,24 +2392,23 @@ class Experiment:
                     metadata=record.get("metadata"),
                     config=self._config or None,
                 )
-
-                return {
-                    "idx": idx,
-                    "span_id": span_id,
-                    "trace_id": trace_id,
-                    "timestamp": span.start_ns,
-                    "output": output_data,
-                    "metadata": {
-                        "dataset_record_index": idx,
-                        "experiment_name": self.name,
-                        "dataset_name": self._dataset.name,
-                    },
-                    "error": {
-                        "message": span.get_tag(ERROR_MSG),
-                        "stack": span.get_tag(ERROR_STACK),
-                        "type": span.get_tag(ERROR_TYPE),
-                    },
-                }
+            return {
+                "idx": idx,
+                "span_id": span_id,
+                "trace_id": trace_id,
+                "timestamp": span.start_ns,
+                "output": output_data,
+                "metadata": {
+                    "dataset_record_index": idx,
+                    "experiment_name": self.name,
+                    "dataset_name": self._dataset.name,
+                },
+                "error": {
+                    "message": span.get_tag(ERROR_MSG),
+                    "stack": span.get_tag(ERROR_STACK),
+                    "type": span.get_tag(ERROR_TYPE),
+                },
+            }
 
     def _check_task_result_error(self, task_result: TaskResult, raise_errors: bool) -> None:
         err_dict = task_result.get("error") or {}
@@ -2352,6 +2471,7 @@ class Experiment:
         raise_errors: bool = False,
         max_retries: int = 0,
         retry_delay: Callable[[int], float] = lambda attempt: 0.1 * (attempt + 1),
+        _override_evaluators: Optional[Sequence[Union[EvaluatorType, AsyncEvaluatorType]]] = None,
     ) -> EvaluationResult:
         asyncio = get_asyncio()
         idx = task_result["idx"]
@@ -2454,8 +2574,9 @@ class Experiment:
                     **extra_return_values,
                 }
 
+        evaluators_to_use = _override_evaluators if _override_evaluators is not None else self._evaluators
         results = await asyncio.gather(
-            *[_run_single_evaluator(ev) for ev in self._evaluators],
+            *[_run_single_evaluator(ev) for ev in evaluators_to_use],
             return_exceptions=True,
         )
         row_results: dict[str, dict[str, JSONType]] = {}
@@ -2476,6 +2597,7 @@ class Experiment:
         max_retries: int = 0,
         retry_delay: Callable[[int], float] = lambda attempt: 0.1 * (attempt + 1),
     ) -> list[EvaluationResult]:
+        assert self._dataset is not None  # nosec B101
         asyncio = get_asyncio()
         semaphore = asyncio.Semaphore(jobs)
         coros = [
@@ -2575,6 +2697,8 @@ class Experiment:
         raise_errors: bool = False,
         jobs: int = 10,
     ) -> list[EvaluationResult]:
+        if not self._summary_evaluators:
+            return []
         (
             inputs,
             outputs,
@@ -2803,10 +2927,10 @@ class SyncExperiment:
     def __init__(
         self,
         name: str,
-        task: Union[TaskType, AsyncTaskType],
-        dataset: Dataset,
-        evaluators: Sequence[Union[EvaluatorType, AsyncEvaluatorType]],
-        project_name: str,
+        task: Optional[Union[TaskType, AsyncTaskType]] = None,
+        dataset: Optional[Dataset] = None,
+        evaluators: Sequence[Union[EvaluatorType, AsyncEvaluatorType]] = (),
+        project_name: str = "",
         description: str = "",
         tags: Optional[dict[str, str]] = None,
         config: Optional[ConfigType] = None,
@@ -2846,7 +2970,8 @@ class SyncExperiment:
         :param max_retries: Maximum number of retries for failed tasks and evaluators (default: 0)
         :param retry_delay: Callable that takes the attempt number (0-based) and returns the delay
                             in seconds before the next retry. Default: ``0.1 * (attempt + 1)``
-        :return: ExperimentResult containing evaluation results and metadata
+        :return: ExperimentResult containing evaluation results and metadata. Also stored on
+                 ``self.result``.
         """
         asyncio = get_asyncio()
         coro = self._experiment.run(
@@ -2883,9 +3008,9 @@ class SyncExperiment:
 
             df = experiment.as_dataframe()
             run1 = df[df[("run_iteration", "")] == 1]
-            df.groupby(("run_iteration", ""))[(\"evaluations\", \"exact_match\")].apply(...)
+            df.groupby(("run_iteration", ""))[("evaluations", "exact_match")].apply(...)
 
-        :raises ValueError: if ``self.result`` is ``None`` (experiment not yet run).
+        :raises ValueError: if ``self.result`` is ``None`` (experiment not yet run or pulled).
         :raises ImportError: if ``pandas`` is not installed.
         :return: ``pd.DataFrame`` with ``pd.MultiIndex`` columns and a reset integer index.
         """
@@ -2898,7 +3023,7 @@ class SyncExperiment:
             ) from e
 
         if self.result is None:
-            raise ValueError("No result found. Call run() before as_dataframe().")
+            raise ValueError("No result found. Call run() or pull() before as_dataframe().")
 
         frames = []
         for run in self.result.get("runs", []):
@@ -2912,6 +3037,70 @@ class SyncExperiment:
             return pd.DataFrame()
 
         return pd.concat(frames, ignore_index=True)
+
+    def pull(self, include_eval_metrics: bool = True) -> None:
+        """Fetch prior experiment results from the backend and store them on ``self.result``.
+
+        Uses the experiment's own name and project to find the latest run (or uses the
+        known ``_id`` directly if the experiment has already been run in this session).
+        Returns ``None`` — results are accessible via ``self.result``.
+
+        After a successful ``pull()``, ``rerun_evaluators()`` can be called immediately
+        to re-score the fetched outputs with updated evaluators.
+
+        :param include_eval_metrics: Whether to include evaluator scores from the original
+                                     run. Default: ``True``.
+        :raises ValueError: If LLMObs is not enabled.
+        :raises ValueError: If neither an experiment ID nor name+project are available.
+        :raises ValueError: If the backend call fails.
+        """
+        if not self._experiment._llmobs_instance or not self._experiment._llmobs_instance.enabled:
+            raise ValueError("LLMObs is not enabled. Enable LLMObs before calling pull().")
+
+        client = self._experiment._llmobs_instance._dne_client
+        experiment_id = self._experiment._id
+
+        if experiment_id:
+            raw = client.experiment_events_get(
+                experiment_id=str(experiment_id),
+                include_eval_metrics=include_eval_metrics,
+            )
+        else:
+            experiment_name = self._experiment.name
+            project_name = self._experiment._project_name
+            if not experiment_name or not project_name:
+                raise ValueError(
+                    "experiment name and project_name are required to pull results when "
+                    "the experiment has not been run in the current session."
+                )
+            raw = client.experiment_events_get(
+                project_name=project_name,
+                experiment_name=experiment_name,
+                include_eval_metrics=include_eval_metrics,
+            )
+
+        self.result = _parse_experiment_result(raw)
+
+        # Populate _id from data.id and dataset_id / project_id from the first span's tags.
+        # The /events API returns a single JSON:API object whose primary id is the experiment UUID;
+        # span-level tags carry the dataset_id / project_id.
+        data = raw.get("data") or {}
+        attributes = data.get("attributes") or {}
+        if not self._experiment._id:
+            experiment_id_from_response = data.get("id")
+            if experiment_id_from_response:
+                self._experiment._id = experiment_id_from_response
+        spans = attributes.get("spans") or []
+        first_span = spans[0] if spans else {}
+        for tag in first_span.get("tags") or []:
+            if not isinstance(tag, str):
+                continue
+            if not self._experiment._id and tag.startswith("experiment_id:"):
+                self._experiment._id = tag.split(":", 1)[1]
+            elif tag.startswith("dataset_id:") and self._experiment._dataset_id is None:
+                self._experiment._dataset_id = tag.split(":", 1)[1]
+            elif tag.startswith("project_id:") and not self._experiment._project_id:
+                self._experiment._project_id = tag.split(":", 1)[1]
 
     @property
     def url(self) -> str:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1279,9 +1279,9 @@ class LLMObs(Service):
     def experiment(
         cls,
         name: str,
-        task: TaskType,
-        dataset: Dataset,
-        evaluators: Sequence[EvaluatorType],
+        task: Optional[TaskType] = None,
+        dataset: Optional[Dataset] = None,
+        evaluators: Sequence[EvaluatorType] = (),
         description: str = "",
         project_name: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
@@ -1311,8 +1311,9 @@ class LLMObs(Service):
         :param runs: The number of times to run the experiment, or, run the task for every dataset record the defined
                      number of times.
         """
-        _validate_task_signature(task, is_async=False)
-        if not isinstance(dataset, Dataset):
+        if task is not None:
+            _validate_task_signature(task, is_async=False)
+        if dataset is not None and not isinstance(dataset, Dataset):
             raise TypeError("Dataset must be an LLMObs Dataset object.")
         if not evaluators:
             raise TypeError("Evaluators must be a list of callable functions or BaseEvaluator instances.")
@@ -1511,6 +1512,7 @@ class LLMObs(Service):
             raise ValueError("LLMObs is not enabled. Ensure LLM Observability is enabled via `LLMObs.enable(...)`")
         experiment = cls._instance._dne_client.experiment_get(experiment_id)
         experiment._llmobs_instance = cls._instance
+        assert experiment._dataset is not None  # nosec B101
         experiment._dataset._records = dataset_records
         experiment._task = task
         experiment._evaluators = evaluators

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -882,7 +882,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         if spans:
             attributes["spans"] = cast(list[JSONType], spans)
         body: dict[str, JSONType] = {"data": {"type": "experiments", "attributes": attributes}}
-        logger.debug("experiment_eval_post payload: %s", json.dumps(body))
+        logger.debug("experiment_eval_post payload: %s", body)
         resp = self.request(
             "POST",
             path,

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -882,7 +882,6 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         if spans:
             attributes["spans"] = cast(list[JSONType], spans)
         body: dict[str, JSONType] = {"data": {"type": "experiments", "attributes": attributes}}
-        logger.debug("experiment_eval_post payload: %s", body)
         resp = self.request(
             "POST",
             path,

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -811,23 +811,24 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         ensure_unique: bool = True,
     ) -> tuple[str, str]:
         path = "/api/unstable/llm-obs/v1/experiments"
+        attributes: dict[str, JSONType] = {
+            "name": name,
+            "description": description or "",
+            "dataset_id": dataset_id,
+            "project_id": project_id,
+            "dataset_version": dataset_version,
+            "config": exp_config or {},
+            "metadata": {"tags": tags or []},
+            "ensure_unique": ensure_unique,
+            "run_count": runs,
+        }
         resp = self.request(
             "POST",
             path,
             body={
                 "data": {
                     "type": "experiments",
-                    "attributes": {
-                        "name": name,
-                        "description": description or "",
-                        "dataset_id": dataset_id,
-                        "project_id": project_id,
-                        "dataset_version": dataset_version,
-                        "config": exp_config or {},
-                        "metadata": {"tags": tags or []},
-                        "ensure_unique": ensure_unique,
-                        "run_count": runs,
-                    },
+                    "attributes": attributes,
                 }
             },
         )
@@ -866,22 +867,26 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             logger.warning("Failed to update experiment %s status: %s", experiment_id, resp.status)
 
     def experiment_eval_post(
-        self, experiment_id: str, events: list[LLMObsExperimentEvalMetricEvent], tags: list[str]
+        self,
+        experiment_id: str,
+        events: list[LLMObsExperimentEvalMetricEvent],
+        tags: list[str],
+        spans: Optional[list[dict]] = None,
     ) -> None:
         path = f"/api/unstable/llm-obs/v1/experiments/{experiment_id}/events"
+        attributes: dict[str, JSONType] = {
+            "scope": "experiments",
+            "metrics": cast(list[JSONType], events),
+            "tags": cast(list[JSONType], tags),
+        }
+        if spans:
+            attributes["spans"] = cast(list[JSONType], spans)
+        body: dict[str, JSONType] = {"data": {"type": "experiments", "attributes": attributes}}
+        logger.debug("experiment_eval_post payload: %s", json.dumps(body))
         resp = self.request(
             "POST",
             path,
-            body={
-                "data": {
-                    "type": "experiments",
-                    "attributes": {
-                        "scope": "experiments",
-                        "metrics": cast(list[JSONType], events),
-                        "tags": tags,
-                    },
-                }
-            },
+            body=body,
         )
         if resp.status not in (200, 202):
             raise ValueError(
@@ -889,6 +894,48 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             )
         logger.debug("Sent %d experiment evaluation metrics for %s", len(events), experiment_id)
         return None
+
+    def experiment_events_get(
+        self,
+        experiment_id: Optional[str] = None,
+        project_name: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        include_eval_metrics: bool = True,
+    ) -> dict:
+        """Fetch span events for a prior experiment run.
+
+        Pass ``experiment_id`` for direct UUID lookup, or ``project_name`` +
+        ``experiment_name`` for name-based resolution (returns latest run).
+
+        Response shape (JSON:API):
+        ``{"data": {"id": "<uuid>", "type": "experiment_events",``
+        ``"attributes": {"spans": [...], "summary_metrics": []}}}``
+
+        Each span has ``span_id``, ``trace_id``, ``name``, ``start_ns`` (nanoseconds),
+        ``duration`` (nanoseconds), ``tags``, ``meta`` (with ``input``, ``output``,
+        ``expected_output``, ``metadata``, ``error`` sub-keys), and ``eval_metrics``
+        (populated when ``include_eval_metrics=True``).
+        """
+        if experiment_id:
+            path = f"/api/unstable/llm-obs/v1/experiments/{experiment_id}/events"
+            if include_eval_metrics:
+                path += "?include[eval_metrics]=true"
+        elif project_name and experiment_name:
+            encoded_project = urllib.parse.quote(project_name, safe="")
+            encoded_name = urllib.parse.quote(experiment_name, safe="")
+            path = (
+                f"/api/unstable/llm-obs/v1/experiments/events"
+                f"?filter[project_name]={encoded_project}"
+                f"&filter[experiment_name]={encoded_name}"
+            )
+            if include_eval_metrics:
+                path += "&include[eval_metrics]=true"
+        else:
+            raise ValueError("Either experiment_id or (project_name and experiment_name) must be provided.")
+        resp = self.request("GET", path)
+        if resp.status != 200:
+            raise ValueError(f"Failed to get experiment events: {resp.status} {resp.get_json()}")
+        return resp.get_json()
 
     def evaluator_infer(
         self,

--- a/releasenotes/notes/llmobs-experiment-pull-c7d8e9f0a1b2c3d4.yaml
+++ b/releasenotes/notes/llmobs-experiment-pull-c7d8e9f0a1b2c3d4.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    LLM Observability: Add ``SyncExperiment.pull()`` to fetch prior experiment results from the
+    Datadog backend and store them on ``experiment.result``, enabling cross-session workflows
+    without re-executing the task or providing a dataset.
+    Pass ``include_eval_metrics=False`` to fetch task outputs only (without the original
+    evaluator scores). If the experiment has been run in the current session its UUID is used
+    for a direct lookup; otherwise the latest run is resolved by experiment name and project.
+    ``task`` and ``dataset`` are now optional when creating an experiment via
+    ``LLMObs.experiment()``, supporting pull-based workflows. Calling ``run()`` without
+    providing ``task`` and ``dataset`` raises a ``ValueError``.

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -5101,6 +5101,77 @@ def test_parse_experiment_result_new_format():
     assert row1["evaluations"] == {}
 
 
+def test_parse_experiment_result_all_metric_types():
+    """_parse_experiment_result correctly reads score, boolean, categorical, and json metric values."""
+    from ddtrace.llmobs._experiment import _parse_experiment_result
+
+    def _span(span_id, eval_metrics):
+        return {
+            "span_id": span_id,
+            "trace_id": "trace-x",
+            "name": "task",
+            "start_ns": 0,
+            "duration": 1,
+            "meta": {"input": {}, "output": "out", "expected_output": None, "metadata": {}, "error": {}},
+            "tags": [],
+            "eval_metrics": eval_metrics,
+        }
+
+    response = {
+        "data": {
+            "id": "exp-1",
+            "type": "experiment_events",
+            "attributes": {
+                "spans": [
+                    _span(
+                        "s1",
+                        [
+                            {"label": "score_metric", "metric_type": "score", "score_value": 0.95},
+                            {"label": "bool_metric", "metric_type": "boolean", "boolean_value": False},
+                            {"label": "cat_metric", "metric_type": "categorical", "categorical_value": "good"},
+                            {"label": "json_metric", "metric_type": "json", "json_value": {"k": "v"}},
+                        ],
+                    )
+                ],
+                "summary_metrics": [],
+            },
+        }
+    }
+
+    result = _parse_experiment_result(response)
+    evals = result["runs"][0].rows[0]["evaluations"]
+    assert evals["score_metric"] == {"value": 0.95, "type": "score", "reasoning": None, "assessment": None}
+    assert evals["bool_metric"] == {"value": False, "type": "boolean", "reasoning": None, "assessment": None}
+    assert evals["cat_metric"] == {"value": "good", "type": "categorical", "reasoning": None, "assessment": None}
+    assert evals["json_metric"] == {"value": {"k": "v"}, "type": "json", "reasoning": None, "assessment": None}
+
+
+def test_parse_experiment_result_summary_metrics():
+    """_parse_experiment_result populates summary_evaluations from attributes.summary_metrics."""
+    from ddtrace.llmobs._experiment import _parse_experiment_result
+
+    response = {
+        "data": {
+            "id": "exp-1",
+            "type": "experiment_events",
+            "attributes": {
+                "spans": [],
+                "summary_metrics": [
+                    {"label": "overall_score", "metric_type": "score", "score_value": 0.88},
+                    {"label": "overall_pass", "metric_type": "boolean", "boolean_value": True},
+                    {"label": "quality", "metric_type": "categorical", "categorical_value": "high"},
+                ],
+            },
+        }
+    }
+
+    result = _parse_experiment_result(response)
+    summary_evals = result["runs"][0].summary_evaluations
+    assert summary_evals["overall_score"] == {"value": 0.88, "type": "score", "reasoning": None, "assessment": None}
+    assert summary_evals["overall_pass"] == {"value": True, "type": "boolean", "reasoning": None, "assessment": None}
+    assert summary_evals["quality"] == {"value": "high", "type": "categorical", "reasoning": None, "assessment": None}
+
+
 def test_prepare_summary_evaluator_data_handles_none_metadata():
     """Records with metadata=None (e.g. from API returning null) must not crash data prep."""
     dataset = _make_dataset_with_records(

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -2128,6 +2128,214 @@ def test_experiment_run_w_summary(llmobs, test_dataset_one_record):
     assert exp.url == f"https://app.datadoghq.com/llm/experiments/{exp._experiment._id}"
 
 
+# ---------------------------------------------------------------------------
+# pull() / Optional task+dataset tests
+# ---------------------------------------------------------------------------
+
+
+def test_experiment_run_stores_result(llmobs, test_dataset_one_record):
+    """run() stores the result on self.result."""
+    with (
+        mock.patch("ddtrace.llmobs._experiment.Experiment._process_record") as mock_process_record,
+        mock.patch.object(
+            llmobs._instance._dne_client,
+            "experiment_create",
+            return_value=("mock-exp-id", "test_experiment"),
+        ),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post"),
+    ):
+        mock_process_record.return_value = {
+            "idx": 0,
+            "span_id": "123",
+            "trace_id": "456",
+            "timestamp": MOCK_TIMESTAMP_NS,
+            "output": {"prompt": "What is the capital of France?"},
+            "metadata": {},
+            "error": {"message": None, "type": None, "stack": None},
+        }
+        exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+        result = exp.run()
+
+    assert exp.result is result
+
+
+def test_experiment_init_without_task_and_dataset(llmobs):
+    """Creating an experiment without task or dataset must not raise — supports pull() workflow."""
+    exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
+    assert exp._experiment._task is None
+    assert exp._experiment._dataset is None
+
+
+def test_experiment_run_without_task_raises(llmobs):
+    """Calling run() on an experiment without task/dataset must raise ValueError."""
+    exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
+    with pytest.raises(ValueError, match="task and dataset are required to run an experiment from scratch"):
+        exp.run()
+
+
+MOCK_PULL_RESPONSE = {
+    "data": {
+        "id": "mock-experiment-id",
+        "type": "experiment_events",
+        "attributes": {
+            "spans": [
+                {
+                    "duration": 500_000_000,
+                    "eval_metrics": [
+                        {
+                            "label": "correctness",
+                            "metric_type": "score",
+                            "score_value": 0.9,
+                            "timestamp_ms": MOCK_TIMESTAMP_NS // 1_000_000,
+                            "assessment": "pass",
+                            "reasoning": "Correct",
+                        }
+                    ],
+                    "meta": {
+                        "input": {"question": "What is the capital of France?"},
+                        "output": {"answer": "Paris"},
+                        "expected_output": {"answer": "Paris"},
+                        "metadata": {"experiment_name": "test-exp"},
+                        "error": {},
+                    },
+                    "name": "my_task",
+                    "span_id": "abc123",
+                    "start_ns": MOCK_TIMESTAMP_NS,
+                    "status": "ok",
+                    "tags": [
+                        "dataset_record_id:rec-uuid-1",
+                        "experiment_id:mock-experiment-id",
+                        "dataset_id:mock-dataset-id",
+                        "project_id:mock-project-id",
+                    ],
+                    "trace_id": "def456",
+                }
+            ],
+            "summary_metrics": [],
+        },
+    }
+}
+
+
+def test_experiment_pull_by_id(llmobs):
+    """pull() with known _id calls by-UUID endpoint and populates self.result."""
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+    exp._experiment._id = "mock-experiment-id"
+
+    with mock.patch.object(
+        llmobs._instance._dne_client, "experiment_events_get", return_value=MOCK_PULL_RESPONSE
+    ) as mock_get:
+        exp.pull()
+
+    mock_get.assert_called_once_with(experiment_id="mock-experiment-id", include_eval_metrics=True)
+    assert exp.result is not None
+    rows = exp.result["runs"][0].rows
+    assert len(rows) == 1
+    assert rows[0]["span_id"] == "abc123"
+    assert rows[0]["trace_id"] == "def456"
+    assert rows[0]["input"] == {"question": "What is the capital of France?"}
+    assert rows[0]["output"] == {"answer": "Paris"}
+
+
+def test_experiment_pull_by_name(llmobs):
+    """pull() without _id calls by-name endpoint using experiment name + project_name."""
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+    assert exp._experiment._id is None
+
+    with mock.patch.object(
+        llmobs._instance._dne_client, "experiment_events_get", return_value=MOCK_PULL_RESPONSE
+    ) as mock_get:
+        exp.pull()
+
+    mock_get.assert_called_once_with(
+        project_name="my-project",
+        experiment_name="test-exp",
+        include_eval_metrics=True,
+    )
+    assert exp.result is not None
+
+
+def test_experiment_pull_sets_id_from_response(llmobs):
+    """pull() sets _experiment._id from the response so rerun_evaluators() can post metrics."""
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+    assert exp._experiment._id is None
+
+    with mock.patch.object(llmobs._instance._dne_client, "experiment_events_get", return_value=MOCK_PULL_RESPONSE):
+        exp.pull()
+
+    assert exp._experiment._id == "mock-experiment-id"
+
+
+def test_experiment_pull_parses_eval_metrics(llmobs):
+    """pull() with eval metrics populates evaluations dict on rows."""
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+    exp._experiment._id = "mock-experiment-id"
+
+    with mock.patch.object(llmobs._instance._dne_client, "experiment_events_get", return_value=MOCK_PULL_RESPONSE):
+        exp.pull()
+
+    evals = exp.result["runs"][0].rows[0]["evaluations"]
+    assert "correctness" in evals
+    assert evals["correctness"]["value"] == 0.9
+    assert evals["correctness"]["type"] == "score"
+    assert evals["correctness"]["assessment"] == "pass"
+
+
+def test_experiment_pull_no_eval_metrics(llmobs):
+    """pull(include_eval_metrics=False) omits evaluations but still parses spans."""
+    response_no_evals = {
+        "data": {
+            "id": "mock-experiment-id",
+            "type": "experiment_events",
+            "attributes": {
+                "spans": [
+                    {
+                        "duration": 500_000_000,
+                        "eval_metrics": [],
+                        "meta": {
+                            "input": {"question": "Q"},
+                            "output": {"answer": "A"},
+                            "expected_output": None,
+                            "metadata": {},
+                            "error": {},
+                        },
+                        "name": "my_task",
+                        "span_id": "abc123",
+                        "start_ns": MOCK_TIMESTAMP_NS,
+                        "status": "ok",
+                        "tags": [],
+                        "trace_id": "def456",
+                    }
+                ],
+                "summary_metrics": [],
+            },
+        }
+    }
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+    exp._experiment._id = "mock-experiment-id"
+
+    with mock.patch.object(
+        llmobs._instance._dne_client, "experiment_events_get", return_value=response_no_evals
+    ) as mock_get:
+        exp.pull(include_eval_metrics=False)
+
+    mock_get.assert_called_once_with(experiment_id="mock-experiment-id", include_eval_metrics=False)
+    assert exp.result["runs"][0].rows[0]["evaluations"] == {}
+
+
+def test_experiment_pull_populates_duration_and_span_name(llmobs):
+    """pull() correctly populates duration and span_name on each result row."""
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+    exp._experiment._id = "mock-experiment-id"
+
+    with mock.patch.object(llmobs._instance._dne_client, "experiment_events_get", return_value=MOCK_PULL_RESPONSE):
+        exp.pull()
+
+    row = exp.result["runs"][0].rows[0]
+    assert row["duration"] == 500_000_000
+    assert row["span_name"] == "my_task"
+
+
 @pytest.mark.parametrize(
     "dd_site,expected_base",
     [
@@ -4796,6 +5004,101 @@ def test_csv_dataset_as_dataframe(llmobs, tmp_csv_file_for_upload):
         finally:
             if dataset_id:
                 llmobs._delete_dataset(dataset_id=dataset_id)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _parse_experiment_result and the rerun-from-pull data flow
+# ---------------------------------------------------------------------------
+
+
+def test_parse_experiment_result_new_format():
+    """_parse_experiment_result correctly extracts all fields from the new JSON:API single-object format."""
+    from ddtrace.llmobs._experiment import _parse_experiment_result
+
+    response = {
+        "data": {
+            "id": "328ee888-f8b4-4338-966e-1ec58d4f2f00",
+            "type": "experiment_events",
+            "attributes": {
+                "spans": [
+                    {
+                        "duration": 798_832_000,
+                        "eval_metrics": [
+                            {
+                                "timestamp_ms": 1776188906109,
+                                "metric_type": "boolean",
+                                "label": "exact_match",
+                                "boolean_value": True,
+                            }
+                        ],
+                        "meta": {
+                            "error": {},
+                            "input": {"question": "What is the capital of China?"},
+                            "output": "Beijing",
+                            "expected_output": "Beijing",
+                            "metadata": {"difficulty": "easy"},
+                        },
+                        "name": "generate_capital",
+                        "span_id": "18038324847088772928",
+                        "start_ns": 1776188906109254000,
+                        "status": "ok",
+                        "tags": [
+                            "dataset_record_id:5dc422e6efd7435daef344390aaab33d",
+                            "experiment_id:328ee888-f8b4-4338-966e-1ec58d4f2f00",
+                        ],
+                        "trace_id": "trace-abc",
+                    },
+                    {
+                        "duration": 836_075_000,
+                        "eval_metrics": [],
+                        "meta": {
+                            "error": {},
+                            "input": {"question": "Which city is the capital of Canada?"},
+                            "output": "Ottawa",
+                            "expected_output": "Ottawa",
+                            "metadata": {},
+                        },
+                        "name": "generate_capital",
+                        "span_id": "14723195948267668179",
+                        "start_ns": 1776188906107593000,
+                        "status": "ok",
+                        "tags": [
+                            "dataset_record_id:0087dc9f23c94d82b3afc08a3db8268b",
+                        ],
+                        "trace_id": "trace-def",
+                    },
+                ],
+                "summary_metrics": [],
+            },
+        }
+    }
+
+    result = _parse_experiment_result(response)
+    rows = result["runs"][0].rows
+    assert len(rows) == 2
+
+    row0 = rows[0]
+    assert row0["span_id"] == "18038324847088772928"
+    assert row0["trace_id"] == "trace-abc"
+    assert row0["timestamp"] == 1776188906109254000
+    assert row0["duration"] == 798_832_000
+    assert row0["span_name"] == "generate_capital"
+    assert row0["input"] == {"question": "What is the capital of China?"}
+    assert row0["output"] == "Beijing"
+    assert row0["expected_output"] == "Beijing"
+    assert row0["metadata"] == {"difficulty": "easy"}
+    assert row0["record_id"] == "5dc422e6efd7435daef344390aaab33d"
+    assert row0["error"] == {"type": None, "message": None, "stack": None}
+    assert "exact_match" in row0["evaluations"]
+    assert row0["evaluations"]["exact_match"]["value"] is True
+    assert row0["evaluations"]["exact_match"]["type"] == "boolean"
+
+    row1 = rows[1]
+    assert row1["span_id"] == "14723195948267668179"
+    assert row1["duration"] == 836_075_000
+    assert row1["span_name"] == "generate_capital"
+    assert row1["record_id"] == "0087dc9f23c94d82b3afc08a3db8268b"
+    assert row1["evaluations"] == {}
 
 
 def test_prepare_summary_evaluator_data_handles_none_metadata():


### PR DESCRIPTION
## Summary

- Make `task` and `dataset` optional in `Experiment.__init__`, `SyncExperiment.__init__`, and `LLMObs.experiment()` to support cross-session workflows where no task is needed at construction time
- Add `run()` guard that raises `ValueError` when task/dataset are absent
- Add `SyncExperiment.pull()` to fetch prior experiment results from the backend (`GET /api/unstable/llm-obs/v1/experiments/{id}/events`) and store them on `experiment.result`
- Add `LLMObsExperimentsClient.experiment_events_get()` writer method
- Add `_parse_experiment_result()` to deserialise the JSON:API single-object response
- `ExperimentRowResult` TypedDict gains required `duration` and `span_name` fields

## Context

This is the first PR in a two-PR stack splitting the original #17292 (`re-run-evals`).

Stack:
1. **This PR** — `pull()` + optional task/dataset (base: `main`)
2. [rerunning](https://github.com/DataDog/dd-trace-py/pull/17808) — `rerun_evaluators()` + replay spans (base: this PR)

## Test plan

- [ ] `scripts/run-tests tests/llmobs/test_experiments.py -k "pull or optional or without_task"` green
- [ ] `hatch run lint:ruff check --no-cache ddtrace/llmobs/` clean
- [ ] `hatch run lint:mypy ddtrace/llmobs/_experiment.py ddtrace/llmobs/_writer.py ddtrace/llmobs/_llmobs.py` clean
- [ ] `hatch run lint:security` clean (no B101 issues)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)