### PR TITLE
feat(llmobs): add Experiment.rerun_evaluators() with replay spans

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1,5 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
+import asyncio
+from copy import copy
 from copy import deepcopy
 from dataclasses import dataclass
 from dataclasses import field
@@ -1118,7 +1120,7 @@ class DatasetRecordUpdateWithId(DatasetRecordUpdate):
     record_id: str
 
 
-class TaskResult(TypedDict):
+class _TaskResultRequired(TypedDict):
     idx: int
     span_id: str
     trace_id: str
@@ -1126,6 +1128,11 @@ class TaskResult(TypedDict):
     output: JSONType
     metadata: dict[str, JSONType]
     error: dict[str, Optional[str]]
+
+
+class TaskResult(_TaskResultRequired, total=False):
+    duration: int
+    span_name: str
 
 
 class EvaluationResult(TypedDict):
@@ -1252,6 +1259,93 @@ class ExperimentResult(TypedDict):
     summary_evaluations: dict[str, dict[str, JSONType]]
     rows: list[ExperimentRowResult]
     runs: list[ExperimentRun]
+
+
+def _build_span_copies(
+    prior_rows: "list[ExperimentRowResult]",
+    new_experiment_id: str,
+    base_tags: list[str],
+) -> "tuple[list[dict], dict[str, str], str]":
+    """Build semantically identical span dicts with fresh UUIDs and an offset timestamp.
+
+    For each row with a span_id, a new span dict is produced with:
+    - A fresh UUID for span_id (old → new mapping stored in id_map)
+    - A single shared new trace_id for the entire batch
+    - start_ns offset uniformly to the current wall clock while preserving relative ordering
+    - duration preserved from the original span (stored on the row from run() or pull())
+    - name preserved from the original span (stored on the row from run() or pull())
+    - All meta content (input, output, expected_output, metadata) copied verbatim
+    - Tags updated to reference new_experiment_id instead of the original
+
+    Returns ``(span_dicts, id_map, new_trace_id)`` where ``id_map`` maps each original
+    span_id to its new UUID so eval metrics can reference the correct new span IDs.
+    """
+    rows_with_span = [r for r in prior_rows if r.get("span_id")]
+    if not rows_with_span:
+        return [], {}, ""
+
+    timestamps = [r["timestamp"] for r in rows_with_span if r.get("timestamp")]
+    min_start_ns = min(timestamps) if timestamps else 0
+    offset_ns = time.time_ns() - min_start_ns
+    new_trace_id = str(uuid.uuid4())
+    id_map: dict[str, str] = {r["span_id"]: str(uuid.uuid4()) for r in rows_with_span}
+
+    spans = []
+    for row in rows_with_span:
+        # Replace experiment_id tag; preserve every other tag from base_tags.
+        tags = [t for t in base_tags if not t.startswith("experiment_id:")]
+        record_id = row.get("record_id")
+        if record_id:
+            tags.append(f"dataset_record_id:{record_id}")
+        tags.append(f"experiment_id:{new_experiment_id}")
+        tags.append(f"parent_experiment_span_id:{row['span_id']}")
+
+        span: dict = {
+            "span_id": id_map[row["span_id"]],
+            "trace_id": new_trace_id,
+            "name": row.get("span_name") or "experiment_record",
+            "start_ns": (row["timestamp"] or 0) + offset_ns,
+            "duration": row.get("duration") or 1,  # backend requires non-zero (Go `required` tag)
+            "meta": {
+                "input": row.get("input"),
+                "output": row.get("output"),
+                "expected_output": row.get("expected_output"),
+                "metadata": row.get("metadata"),
+                "parent_experiment_span_id": row["span_id"],
+            },
+            "status": row.get("status", "ok"),
+            "tags": tags,
+        }
+        spans.append(span)
+
+    return spans, id_map, new_trace_id
+
+
+def _task_results_from_previous(
+    rows: "list[ExperimentRowResult]",
+    id_map: "dict[str, str]",
+    new_trace_id: str,
+) -> "list[TaskResult]":
+    """Reconstruct TaskResult objects from a previous ExperimentRun's rows.
+
+    Used by eval-only re-runs to reuse prior task outputs without re-executing the task.
+    span_id and trace_id are replaced with new values from id_map / new_trace_id so that
+    eval metrics emitted for the re-run reference the newly created span copies.
+    """
+    return [
+        {
+            "idx": row["idx"],
+            "span_id": id_map.get(row["span_id"], row["span_id"]),
+            "trace_id": new_trace_id or row["trace_id"],
+            "timestamp": row["timestamp"],
+            "duration": row["duration"],
+            "span_name": row["span_name"],
+            "output": row["output"],
+            "metadata": row["metadata"],
+            "error": row["error"],
+        }
+        for row in rows
+    ]
 
 
 def _parse_experiment_result(response: dict) -> "ExperimentResult":
@@ -1887,8 +1981,8 @@ class Experiment:
                 "span_id": task_result.get("span_id", ""),
                 "trace_id": task_result.get("trace_id", ""),
                 "timestamp": task_result.get("timestamp", 0),
-                "duration": cast(int, task_result.get("duration") or 0),
-                "span_name": cast(str, task_result.get("span_name") or "experiment_record"),
+                "duration": task_result.get("duration", 0),
+                "span_name": task_result.get("span_name", "experiment_record"),
                 "record_id": record.get("record_id", ""),
                 "input": record["input_data"],
                 "expected_output": record["expected_output"],
@@ -2170,6 +2264,54 @@ class Experiment:
         self._tags["experiment_id"] = str(experiment_id)
         self._run_name = experiment_run_name
 
+    def _create_rerun_experiment(
+        self,
+        evaluators: "Sequence[Union[EvaluatorType, AsyncEvaluatorType]]",
+    ) -> "tuple[str, str]":
+        """Create a new experiment entity for this re-run.
+
+        The new experiment has ``parent_experiment_id`` set to the current experiment's ID,
+        making the lineage traversable. Returns ``(experiment_id, experiment_name)``.
+
+        :raises ValueError: if LLMObs is not enabled, if the current experiment has no ID,
+                            or if dataset information cannot be resolved from the loaded
+                            dataset or span tags from a prior pull().
+        """
+        assert self._llmobs_instance is not None and self._llmobs_instance.enabled  # nosec B101
+
+        # Resolve project_id lazily — not set if the experiment was never run() in this session
+        if not self._project_id:
+            project = self._llmobs_instance._dne_client.project_create_or_get(self._project_name)
+            self._project_id = project.get("_id", "")
+            self._tags["project_id"] = self._project_id
+
+        # Resolve dataset_id — prefer the loaded dataset, fall back to what was extracted
+        # from span tags during pull() and stored on self._dataset_id.
+        dataset_id = (self._dataset._id if self._dataset is not None else None) or self._dataset_id
+        if not dataset_id:
+            raise ValueError(
+                "Cannot create re-run experiment: dataset_id is not available. "
+                "Either provide a dataset when creating the experiment or ensure "
+                "the original spans include a 'dataset_id:<uuid>' tag (populated "
+                "automatically when the original run was performed with a dataset)."
+            )
+
+        dataset_version = (self._dataset._version if self._dataset is not None else None) or self._dataset_version or 0
+
+        evaluator_names = [e.name if hasattr(e, "name") else getattr(e, "__name__", str(e)) for e in evaluators]
+        new_name = f"{self.name}-rerun-{int(time.time() * 1000)}"
+
+        experiment_id, _ = self._llmobs_instance._dne_client.experiment_create(
+            name=new_name,
+            dataset_id=dataset_id,
+            project_id=self._project_id,
+            dataset_version=dataset_version,
+            exp_config={"evaluators": evaluator_names},
+            tags=convert_tags_dict_to_list(self._tags),
+            parent_experiment_id=str(self._id),
+        )
+        return experiment_id, new_name
+
     async def run(
         self,
         jobs: int = 10,
@@ -2405,11 +2547,15 @@ class Experiment:
                     metadata=record.get("metadata"),
                     config=self._config or None,
                 )
+            # span.__exit__ has now been called and span.finish() has run;
+            # span.duration_ns is the real wall-clock duration in nanoseconds, not 0.
             return {
                 "idx": idx,
                 "span_id": span_id,
                 "trace_id": trace_id,
                 "timestamp": span.start_ns,
+                "duration": span.duration_ns or 0,
+                "span_name": self._task.__name__,
                 "output": output_data,
                 "metadata": {
                     "dataset_record_index": idx,
@@ -2966,6 +3112,43 @@ class SyncExperiment:
             runs=runs,
         )
 
+    @classmethod
+    def _for_rerun(
+        cls,
+        parent: "SyncExperiment",
+        new_id: str,
+        new_name: str,
+        evaluators: "Sequence[Union[EvaluatorType, AsyncEvaluatorType]]",
+        result: ExperimentResult,
+        summary_evaluators: "Optional[list[Union[SummaryEvaluatorType, AsyncSummaryEvaluatorType]]]" = None,
+    ) -> "SyncExperiment":
+        """Build a SyncExperiment clone representing a completed rerun.
+
+        Shallow-copies the parent's Experiment, overriding only the fields that differ
+        for the rerun (id, name, tags, evaluators). All other state — dataset, task,
+        llmobs_instance, config, project info — is shared by reference.
+        """
+        rerun = cls.__new__(cls)
+        exp = copy(parent._experiment)
+        exp._id = new_id
+        exp.name = new_name
+        exp._tags = {**parent._experiment._tags, "experiment_id": new_id}
+        exp._evaluators = list(evaluators)
+        if summary_evaluators is not None:
+            exp._summary_evaluators = list(summary_evaluators)
+        exp._remote_evaluator_names = {
+            e.name  # type: ignore[union-attr]
+            for e in evaluators
+            if hasattr(e, "_is_remote_evaluator") and e._is_remote_evaluator
+        }
+        exp._run_results = []
+        exp._retries = []
+        exp._has_errors = False
+        exp._interrupted = False
+        rerun._experiment = exp
+        rerun.result = result
+        return rerun
+
     def run(
         self,
         jobs: int = 1,
@@ -3051,6 +3234,75 @@ class SyncExperiment:
 
         return pd.concat(frames, ignore_index=True)
 
+    def rerun_evaluators(
+        self,
+        evaluators: "Optional[Sequence[Union[EvaluatorType, AsyncEvaluatorType]]]" = None,
+        missing_task_strategy: str = "raise",
+        jobs: int = 1,
+        raise_errors: bool = False,
+        max_retries: int = 0,
+        retry_delay: Optional[Callable[[int], float]] = None,
+        summary_evaluators: Optional["Sequence[Union[SummaryEvaluatorType, AsyncSummaryEvaluatorType]]"] = None,
+    ) -> "SyncExperiment":
+        """Re-run evaluators on the stored task outputs from the previous run.
+
+        Creates a new experiment entity on the backend (linked via ``parent_experiment_id``)
+        and returns it as a new ``SyncExperiment`` object, leaving the original experiment
+        unchanged.  This means multiple independent reruns can be created from the same
+        original without losing track of any of them:
+
+        .. code-block:: python
+
+            rerun1 = exp.rerun_evaluators([evaluator_v2])
+            rerun2 = exp.rerun_evaluators([evaluator_v3])
+            # exp, rerun1, rerun2 all have their own IDs and results
+
+        Reads task outputs from ``self.result`` — call ``run()`` or ``pull()`` first.
+
+        :param evaluators: Evaluators to run against the stored outputs. When omitted (or ``None``),
+                           the experiment's own evaluators (set at construction time) are reused.
+                           Pass an explicit list to override — for example to fix a bug in an
+                           evaluator or add a new one — without modifying the original experiment.
+        :param missing_task_strategy: How to handle rows with task errors.
+                                      ``"raise"`` (default) raises immediately, ``"skip"``
+                                      drops failed rows, ``"retry"`` re-executes failed tasks.
+        :param jobs: Maximum number of concurrent evaluator executions (default: 1)
+        :param raise_errors: Whether to raise exceptions on evaluator errors (default: False)
+        :param max_retries: Maximum number of retries for failed evaluators (default: 0)
+        :param retry_delay: Callable that takes the attempt number (0-based) and returns the delay
+                            in seconds before the next retry. Default: ``0.1 * (attempt + 1)``
+        :param summary_evaluators: Optional summary evaluators to run after all rows are evaluated.
+                                   When omitted, the experiment's own summary evaluators are used.
+        :return: New ``SyncExperiment`` representing the rerun, with its own ID and result.
+        :raises ValueError: if no evaluators are available (neither provided nor set on the experiment),
+                            or ``self.result`` is ``None``.
+        """
+        # Resolve evaluators: use provided list or fall back to the experiment's own evaluators.
+        resolved_evaluators: "Sequence[Union[EvaluatorType, AsyncEvaluatorType]]"
+        if evaluators is not None:
+            resolved_evaluators = evaluators
+        else:
+            resolved_evaluators = self._experiment._evaluators
+        if not resolved_evaluators:
+            raise ValueError(
+                "No evaluators available for rerun_evaluators(). "
+                "Either pass an evaluators list or set evaluators when creating the experiment."
+            )
+        if self.result is None:
+            raise ValueError(
+                "No previous result found. Run the experiment first via `run()` or load a prior run via `pull()`."
+            )
+        return self._rerun_evaluators(
+            self.result,
+            list(resolved_evaluators),
+            missing_task_strategy,
+            jobs,
+            raise_errors,
+            max_retries,
+            retry_delay,
+            list(summary_evaluators) if summary_evaluators else None,
+        )
+
     def pull(self, include_eval_metrics: bool = True) -> None:
         """Fetch prior experiment results from the backend and store them on ``self.result``.
 
@@ -3114,6 +3366,280 @@ class SyncExperiment:
                 self._experiment._dataset_id = tag.split(":", 1)[1]
             elif tag.startswith("project_id:") and not self._experiment._project_id:
                 self._experiment._project_id = tag.split(":", 1)[1]
+
+    def _rerun_evaluators(
+        self,
+        previous_result: ExperimentResult,
+        evaluators: "list[Union[EvaluatorType, AsyncEvaluatorType]]",
+        missing_task_strategy: str,
+        jobs: int,
+        raise_errors: bool,
+        max_retries: int,
+        retry_delay: Optional[Callable[[int], float]],
+        summary_evaluators: "Optional[list[Union[SummaryEvaluatorType, AsyncSummaryEvaluatorType]]]",
+    ) -> "SyncExperiment":
+        """Re-run evaluators on task outputs from a previous experiment run.
+
+        Creates a new experiment entity on the backend linked to the original via
+        ``parent_experiment_id``.  Span copies with fresh UUIDs are emitted so the
+        re-run is fully independent.  The original experiment's state is never mutated —
+        all rerun-specific state (ID, tags, evaluators) is carried locally and only written
+        to the returned ``SyncExperiment`` clone.
+
+        :param previous_result: ExperimentResult whose task outputs to reuse.
+        :param evaluators: Row-level evaluators to run (already resolved by ``rerun_evaluators``).
+        :param missing_task_strategy: ``"raise"`` (default), ``"skip"``, or ``"retry"``.
+        :param summary_evaluators: Optional summary evaluators; if None uses the experiment's own.
+        :raises ValueError: if ``missing_task_strategy`` is invalid, ``"raise"`` is used
+                            with rows that have task errors, LLMObs is not enabled, or the
+                            experiment has not been run yet (``self._experiment._id`` is None).
+        """
+        if missing_task_strategy not in ("raise", "skip", "retry"):
+            raise ValueError(
+                "missing_task_strategy must be 'raise', 'skip', or 'retry', got '{}'.".format(missing_task_strategy)
+            )
+
+        rows = previous_result["runs"][0].rows if previous_result.get("runs") else previous_result["rows"]
+
+        if missing_task_strategy == "raise":
+            for row in rows:
+                if (row.get("error") or {}).get("message"):
+                    raise ValueError(
+                        "Cannot re-run evaluators: row {} has a task error. "
+                        "Use missing_task_strategy='skip' or 'retry' to handle failed rows.".format(row["idx"])
+                    )
+            rows_to_eval = rows
+            rows_to_retry: list[ExperimentRowResult] = []
+        elif missing_task_strategy == "skip":
+            rows_to_eval = [r for r in rows if not (r.get("error") or {}).get("message")]
+            rows_to_retry = []
+        else:  # "retry"
+            rows_to_eval = [r for r in rows if not (r.get("error") or {}).get("message")]
+            rows_to_retry = [r for r in rows if (r.get("error") or {}).get("message")]
+
+        def _default_retry_delay(attempt: int) -> float:
+            return 0.1 * (attempt + 1)
+
+        resolved_retry_delay: Callable[[int], float] = retry_delay if retry_delay is not None else _default_retry_delay
+
+        if not self._experiment._llmobs_instance or not self._experiment._llmobs_instance.enabled:
+            raise ValueError(
+                "LLMObs is not enabled. Ensure LLM Observability is enabled via `LLMObs.enable(...)` "
+                "and create the experiment via `LLMObs.experiment(...)` before re-running evaluators."
+            )
+        if not self._experiment._id:
+            raise ValueError(
+                "Experiment has no ID. Run the experiment via `run()` or call `pull()` first "
+                "before calling `rerun_evaluators()`."
+            )
+
+        # Build a fallback record lookup from prior rows when no dataset is loaded
+        # (e.g. after pull() without a dataset). Keys are row idx values.
+        fallback_records: dict[int, DatasetRecord] = {}
+        if self._experiment._dataset is None:
+            all_rows = (rows_to_eval or []) + (rows_to_retry or [])
+            for row in all_rows:
+                fallback_records[row["idx"]] = {
+                    "record_id": row.get("record_id") or "",
+                    "canonical_id": None,
+                    "input_data": cast(dict, row.get("input") or {}),
+                    "expected_output": row.get("expected_output"),
+                    "metadata": cast(dict, row.get("metadata") or {}),
+                    "tags": [],
+                }
+
+        def _get_record(idx: int) -> DatasetRecord:
+            if self._experiment._dataset is not None:
+                return self._experiment._dataset[idx]
+            return fallback_records[idx]
+
+        # Compute remote evaluator names from the provided evaluators so that
+        # _generate_metrics_for_record() correctly marks managed (LLM-as-judge) evals.
+        rerun_remote_names: set[str] = {
+            e.name  # type: ignore[union-attr]
+            for e in evaluators
+            if hasattr(e, "_is_remote_evaluator") and e._is_remote_evaluator
+        }
+
+        async def _run() -> "SyncExperiment":
+            run = _ExperimentRunInfo(0)
+
+            # Step 1 — create a new experiment entity with parent_experiment_id so the
+            # lineage is traversable and the re-run accumulates into a clean aggregate.
+            new_experiment_id, new_name = self._experiment._create_rerun_experiment(evaluators)
+
+            # Temporarily update _id and _tags on the shared Experiment so that
+            # _process_record (for retried rows), _generate_metric_from_evaluation,
+            # and _run_summary_evaluators all stamp the new experiment ID.
+            # Both are restored unconditionally in the finally block below so the
+            # original experiment is left untouched regardless of success or failure.
+            original_id = self._experiment._id
+            original_tags = dict(self._experiment._tags)
+            self._experiment._id = new_experiment_id
+            self._experiment._tags["experiment_id"] = new_experiment_id
+            self._experiment._tags["run_id"] = str(run._id)
+            self._experiment._tags["run_iteration"] = str(run._run_iteration)
+
+            try:
+                # Step 2 — build span copies: new UUIDs, shared trace_id, offset timestamps.
+                # span_name and duration are read from each row (stored during run() or pull()).
+                span_copies, id_map, new_trace_id = _build_span_copies(
+                    rows_to_eval,
+                    new_experiment_id,
+                    convert_tags_dict_to_list(self._experiment._tags),
+                )
+
+                # Step 3 — reconstruct task results pointing at the new span IDs so that
+                # eval metrics emitted later reference the freshly created span copies.
+                task_results = _task_results_from_previous(rows_to_eval, id_map, new_trace_id)
+
+                # Step 4 — re-execute failed rows (creates new spans via the normal task path).
+                if rows_to_retry:
+                    if self._experiment._dataset is None:
+                        raise ValueError(
+                            "Cannot retry failed rows without a dataset. "
+                            "Provide a dataset when creating the experiment or use "
+                            "missing_task_strategy='skip'."
+                        )
+                    semaphore = asyncio.Semaphore(jobs)
+                    retry_coros = [
+                        self._experiment._process_record(
+                            (row["idx"], self._experiment._dataset[row["idx"]]),
+                            run,
+                            semaphore,
+                            max_retries=max_retries,
+                            retry_delay=resolved_retry_delay,
+                        )
+                        for row in rows_to_retry
+                    ]
+                    retried = list(await asyncio.gather(*retry_coros, return_exceptions=True))
+                    for r in retried:
+                        if isinstance(r, BaseException):
+                            if raise_errors:
+                                raise r
+                            continue
+                        if r is not None:
+                            task_results.append(r)
+                            self._experiment._check_task_result_error(r, raise_errors)
+                    task_results.sort(key=lambda t: t["idx"])
+
+                # Step 5 — run only the provided evaluators, not the experiment's own list.
+                semaphore = asyncio.Semaphore(jobs)
+                eval_coros = [
+                    self._experiment._evaluate_record(
+                        _get_record(task_result["idx"]),
+                        task_result,
+                        semaphore,
+                        raise_errors,
+                        max_retries,
+                        resolved_retry_delay,
+                        _override_evaluators=evaluators,
+                    )
+                    for task_result in task_results
+                ]
+                evaluations = list(await asyncio.gather(*eval_coros))
+
+                # Step 6 — post span copies and eval metrics to the NEW experiment.
+                eval_post_failed = False
+                if self._experiment._llmobs_instance:
+                    pending_metrics: list["LLMObsExperimentEvalMetricEvent"] = []
+                    original_remote_names = self._experiment._remote_evaluator_names
+                    self._experiment._remote_evaluator_names = rerun_remote_names
+                    try:
+                        for task_result, evaluation in zip(task_results, evaluations):
+                            if evaluation:
+                                pending_metrics.extend(
+                                    self._experiment._generate_metrics_for_record(task_result, evaluation)
+                                )
+                    finally:
+                        self._experiment._remote_evaluator_names = original_remote_names
+
+                    if pending_metrics:
+                        try:
+                            self._experiment._llmobs_instance._dne_client.experiment_eval_post(
+                                new_experiment_id,
+                                pending_metrics,
+                                convert_tags_dict_to_list(self._experiment._tags),
+                                spans=span_copies if span_copies else None,
+                            )
+                        except Exception:
+                            eval_post_failed = True
+                            logger.debug("Failed to post eval metrics for re-run", exc_info=True)
+                            self._experiment._update_status("failed")
+                        else:
+                            self._experiment._llmobs_instance.flush()
+
+                # Step 7 — run summary evaluators (provided ones or experiment's own set).
+                original_summary_evs = self._experiment._summary_evaluators
+                if summary_evaluators is not None:
+                    self._experiment._summary_evaluators = summary_evaluators
+                try:
+                    summary_evals = await self._experiment._run_summary_evaluators(
+                        task_results, evaluations, raise_errors, jobs=jobs
+                    )
+                finally:
+                    self._experiment._summary_evaluators = original_summary_evs
+
+                # Step 8 — build the ExperimentRun result rows.
+                experiment_rows: list[ExperimentRowResult] = []
+                for task_result, evaluation in zip(task_results, evaluations):
+                    idx = task_result["idx"]
+                    record = _get_record(idx)
+                    metadata: dict[str, JSONType] = {
+                        "tags": cast(list[JSONType], convert_tags_dict_to_list(self._experiment._tags))
+                    }
+                    metadata.update(task_result.get("metadata") or {})
+                    exp_row: ExperimentRowResult = {
+                        "idx": idx,
+                        "span_id": task_result.get("span_id", ""),
+                        "trace_id": task_result.get("trace_id", ""),
+                        "timestamp": task_result.get("timestamp", 0),
+                        "duration": task_result.get("duration", 0),
+                        "span_name": task_result.get("span_name", "experiment_record"),
+                        "record_id": record.get("record_id", ""),
+                        "input": record["input_data"],
+                        "expected_output": record["expected_output"],
+                        "output": task_result["output"],
+                        "evaluations": evaluation["evaluations"] if evaluation else {},
+                        "metadata": metadata,
+                        "error": task_result["error"],
+                    }
+                    experiment_rows.append(exp_row)
+
+                summary_eval_dict: dict[str, dict[str, JSONType]] = {}
+                if summary_evals:
+                    for se in summary_evals:
+                        for name, data in se["evaluations"].items():
+                            summary_eval_dict[name] = data
+
+                run_obj = ExperimentRun(run, summary_eval_dict, experiment_rows)
+                result = Experiment._build_result([run_obj])
+                self._experiment._log_experiment_summary(result)
+                logger.info("Rerun experiment URL: %s", self._experiment.url, extra={"product": "llmobs"})
+                if not eval_post_failed:
+                    self._experiment._update_status("completed")
+                return SyncExperiment._for_rerun(
+                    self,
+                    new_experiment_id,
+                    new_name,
+                    evaluators,
+                    result,
+                    summary_evaluators=summary_evaluators,
+                )
+            finally:
+                # Restore original identity so this experiment object is unchanged.
+                self._experiment._id = original_id
+                self._experiment._tags = original_tags
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(_run())
+        else:
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(asyncio.run, _run()).result()
 
     @property
     def url(self) -> str:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -809,6 +809,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         description: Optional[str] = None,
         runs: Optional[int] = 1,
         ensure_unique: bool = True,
+        parent_experiment_id: Optional[str] = None,
     ) -> tuple[str, str]:
         path = "/api/unstable/llm-obs/v1/experiments"
         attributes: dict[str, JSONType] = {
@@ -822,6 +823,8 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             "ensure_unique": ensure_unique,
             "run_count": runs,
         }
+        if parent_experiment_id is not None:
+            attributes["parent_experiment_id"] = parent_experiment_id
         resp = self.request(
             "POST",
             path,

--- a/releasenotes/notes/llmobs-experiment-rerun-evaluators-b3c4d5e6f7a8b9c0.yaml
+++ b/releasenotes/notes/llmobs-experiment-rerun-evaluators-b3c4d5e6f7a8b9c0.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    LLM Observability: Add ``SyncExperiment.rerun_evaluators()`` to re-run evaluators on the
+    stored task outputs from a previous experiment run without re-executing the task function.
+    Reads from ``experiment.result`` (set by ``run()`` or ``pull()``) and returns a
+    new ``SyncExperiment`` with fresh evaluations while preserving original span IDs,
+    trace IDs, inputs, and outputs via replay span copies linked back to the originals via
+    ``parent_experiment_span_id``.
+    The ``missing_task_strategy`` parameter controls behavior when prior rows contain errors:
+    ``"raise"`` (default) raises immediately, ``"skip"`` omits the row, and ``"retry"``
+    re-executes the task for that row.

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -1631,6 +1631,8 @@ def test_experiment_run_task(llmobs, test_dataset, test_dataset_records):
         "span_id": mock.ANY,
         "trace_id": mock.ANY,
         "timestamp": mock.ANY,
+        "duration": mock.ANY,
+        "span_name": "dummy_task",
         "output": {"prompt": "What is the capital of France?"},
         "metadata": {
             "dataset_record_index": 0,
@@ -1644,6 +1646,8 @@ def test_experiment_run_task(llmobs, test_dataset, test_dataset_records):
         "span_id": mock.ANY,
         "trace_id": mock.ANY,
         "timestamp": mock.ANY,
+        "duration": mock.ANY,
+        "span_name": "dummy_task",
         "output": {"prompt": "What is the capital of Canada?"},
         "metadata": {
             "dataset_record_index": 1,
@@ -1664,6 +1668,8 @@ def test_experiment_run_task_error(llmobs, test_dataset_one_record):
             "span_id": mock.ANY,
             "trace_id": mock.ANY,
             "timestamp": mock.ANY,
+            "duration": mock.ANY,
+            "span_name": "faulty_task",
             "output": None,
             "metadata": {
                 "dataset_record_index": 0,
@@ -2129,7 +2135,7 @@ def test_experiment_run_w_summary(llmobs, test_dataset_one_record):
 
 
 # ---------------------------------------------------------------------------
-# pull() / Optional task+dataset tests
+# Eval-only re-run tests
 # ---------------------------------------------------------------------------
 
 
@@ -2159,6 +2165,288 @@ def test_experiment_run_stores_result(llmobs, test_dataset_one_record):
     assert exp.result is result
 
 
+def test_experiment_rerun_evaluators_skips_task(llmobs, test_dataset_one_record):
+    """rerun_evaluators() must not call _process_record again for successful rows."""
+    from ddtrace.llmobs._experiment import ExperimentResult
+    from ddtrace.llmobs._experiment import ExperimentRun
+
+    run_info = run_info_with_stable_id(0)
+    prior_row = {
+        "idx": 0,
+        "record_id": "record-id-1",
+        "span_id": "abc",
+        "trace_id": "def",
+        "timestamp": MOCK_TIMESTAMP_NS,
+        "duration": 500_000_000,
+        "span_name": "my_task",
+        "input": {"prompt": "What is the capital of France?"},
+        "output": {"prompt": "What is the capital of France?"},
+        "expected_output": {"answer": "Paris"},
+        "evaluations": {},
+        "metadata": {},
+        "error": {"message": None, "type": None, "stack": None},
+    }
+    prior_run = ExperimentRun(run_info, {}, [prior_row])
+    first_result: ExperimentResult = {"summary_evaluations": {}, "rows": [prior_row], "runs": [prior_run]}
+
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+    exp.result = first_result
+    exp._experiment._id = "mock-original-exp-id"
+    exp._experiment._project_id = "mock-project-id"
+
+    with (
+        mock.patch("ddtrace.llmobs._experiment.Experiment._process_record") as mock_process_record,
+        mock.patch.object(
+            llmobs._instance._dne_client,
+            "experiment_create",
+            return_value=("new-rerun-exp-id", "test_experiment-rerun"),
+        ),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post"),
+    ):
+        new_result = exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+    # _process_record must not be called at all on re-run
+    assert mock_process_record.call_count == 0
+    # Output is preserved from the prior result
+    assert new_result.result["runs"][0].rows[0]["output"] == prior_row["output"]
+    # New span IDs are generated — they must differ from the originals
+    assert new_result.result["runs"][0].rows[0]["span_id"] != "abc"
+    assert new_result.result["runs"][0].rows[0]["trace_id"] != "def"
+    # Both new IDs must be valid UUIDs
+    assert UUID(new_result.result["runs"][0].rows[0]["span_id"])
+    assert UUID(new_result.result["runs"][0].rows[0]["trace_id"])
+    # rerun returns a new SyncExperiment; the original experiment is unchanged
+    assert new_result is not exp
+    assert new_result.result is not first_result
+    assert exp.result is first_result
+
+
+def test_experiment_rerun_raises_on_task_errors(llmobs, test_dataset_one_record):
+    """missing_task_strategy='raise' (default) should raise if a prior row has an error."""
+    from ddtrace.llmobs._experiment import ExperimentResult
+    from ddtrace.llmobs._experiment import ExperimentRun
+
+    run_info = run_info_with_stable_id(0)
+    error_run = ExperimentRun(
+        run_info,
+        {},
+        [
+            {
+                "idx": 0,
+                "record_id": "r0",
+                "span_id": "s1",
+                "trace_id": "t1",
+                "timestamp": 1000,
+                "duration": 500_000_000,
+                "span_name": "my_task",
+                "input": {"prompt": "What is the capital of France?"},
+                "output": None,
+                "expected_output": {"answer": "Paris"},
+                "evaluations": {},
+                "metadata": {},
+                "error": {"message": "task failed", "type": "ValueError", "stack": None},
+            }
+        ],
+    )
+    previous: ExperimentResult = {"summary_evaluations": {}, "rows": error_run.rows, "runs": [error_run]}
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+    exp.result = previous
+
+    with pytest.raises(ValueError, match="task error"):
+        exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+
+def test_experiment_rerun_skip_strategy(llmobs):
+    """missing_task_strategy='skip' drops failed rows and evaluates only successful ones."""
+    from ddtrace.llmobs._experiment import ExperimentResult
+    from ddtrace.llmobs._experiment import ExperimentRun
+
+    run_info = run_info_with_stable_id(0)
+    mixed_run = ExperimentRun(
+        run_info,
+        {},
+        [
+            {
+                "idx": 0,
+                "record_id": "r0",
+                "span_id": "s1",
+                "trace_id": "t1",
+                "timestamp": 1000,
+                "duration": 500_000_000,
+                "span_name": "my_task",
+                "input": {"prompt": "What is the capital of France?"},
+                "output": {"prompt": "What is the capital of France?"},
+                "expected_output": {"answer": "Paris"},
+                "evaluations": {},
+                "metadata": {},
+                "error": {"message": None, "type": None, "stack": None},
+            },
+            {
+                "idx": 1,
+                "record_id": "r1",
+                "span_id": "s2",
+                "trace_id": "t2",
+                "timestamp": 1001,
+                "duration": 500_000_000,
+                "span_name": "my_task",
+                "input": {"prompt": "What is the capital of Germany?"},
+                "output": None,
+                "expected_output": {"answer": "Berlin"},
+                "evaluations": {},
+                "metadata": {},
+                "error": {"message": "task failed", "type": "ValueError", "stack": None},
+            },
+        ],
+    )
+    previous: ExperimentResult = {"summary_evaluations": {}, "rows": mixed_run.rows, "runs": [mixed_run]}
+
+    # Use no-dataset experiment to avoid backend calls; fallback_records are built from prior rows.
+    exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
+    exp.result = previous
+    # Set fake IDs normally populated by run() or pull()
+    exp._experiment._id = "mock-original-exp-id"
+    exp._experiment._project_id = "mock-project-id"
+    exp._experiment._dataset_id = "mock-dataset-id"
+    with (
+        mock.patch.object(
+            llmobs._instance._dne_client,
+            "experiment_create",
+            return_value=("new-rerun-exp-id", "test_experiment-rerun"),
+        ),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post"),
+    ):
+        new_result = exp.rerun_evaluators(evaluators=[dummy_evaluator], missing_task_strategy="skip")
+
+    assert len(new_result.result["runs"][0].rows) == 1
+    assert new_result.result["runs"][0].rows[0]["idx"] == 0
+
+
+def test_experiment_rerun_invalid_strategy(llmobs, test_dataset_one_record):
+    """An unrecognised missing_task_strategy should raise immediately."""
+    from ddtrace.llmobs._experiment import ExperimentResult
+    from ddtrace.llmobs._experiment import ExperimentRun
+
+    run_info = run_info_with_stable_id(0)
+    good_run = ExperimentRun(
+        run_info,
+        {},
+        [
+            {
+                "idx": 0,
+                "record_id": "r0",
+                "span_id": "s1",
+                "trace_id": "t1",
+                "timestamp": 1000,
+                "duration": 500_000_000,
+                "span_name": "my_task",
+                "input": {"prompt": "What is the capital of France?"},
+                "output": {"prompt": "What is the capital of France?"},
+                "expected_output": {"answer": "Paris"},
+                "evaluations": {},
+                "metadata": {},
+                "error": {"message": None, "type": None, "stack": None},
+            }
+        ],
+    )
+    previous: ExperimentResult = {"summary_evaluations": {}, "rows": good_run.rows, "runs": [good_run]}
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+    exp.result = previous
+
+    with pytest.raises(ValueError, match="missing_task_strategy"):
+        exp.rerun_evaluators(evaluators=[dummy_evaluator], missing_task_strategy="unknown")
+
+
+def test_experiment_rerun_no_prior_result(llmobs, test_dataset_one_record):
+    """rerun_evaluators() raises ValueError when called before run() or pull()."""
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+    with pytest.raises(ValueError, match="No previous result"):
+        exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+
+def test_experiment_rerun_requires_evaluators(llmobs, test_dataset_one_record):
+    """rerun_evaluators() raises ValueError when no evaluators are available."""
+    from ddtrace.llmobs._experiment import ExperimentResult
+    from ddtrace.llmobs._experiment import ExperimentRun
+
+    run_info = run_info_with_stable_id(0)
+    good_run = ExperimentRun(
+        run_info,
+        {},
+        [
+            {
+                "idx": 0,
+                "record_id": "r0",
+                "span_id": "s1",
+                "trace_id": "t1",
+                "timestamp": 1000,
+                "duration": 500_000_000,
+                "span_name": "my_task",
+                "input": {"prompt": "Q"},
+                "output": {"answer": "A"},
+                "expected_output": {"answer": "A"},
+                "evaluations": {},
+                "metadata": {},
+                "error": {"message": None, "type": None, "stack": None},
+            }
+        ],
+    )
+    previous: ExperimentResult = {"summary_evaluations": {}, "rows": good_run.rows, "runs": [good_run]}
+    # Explicit empty list → no evaluators available → should raise
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+    exp.result = previous
+
+    with pytest.raises(ValueError, match="No evaluators available"):
+        exp.rerun_evaluators(evaluators=[])
+
+
+def test_experiment_rerun_creates_new_experiment_with_parent_id(llmobs, test_dataset_one_record):
+    """rerun_evaluators() creates a new child experiment with parent_experiment_id set."""
+    from ddtrace.llmobs._experiment import ExperimentResult
+    from ddtrace.llmobs._experiment import ExperimentRun
+
+    run_info = run_info_with_stable_id(0)
+    prior_row = {
+        "idx": 0,
+        "record_id": "record-id-1",
+        "span_id": "abc",
+        "trace_id": "def",
+        "timestamp": MOCK_TIMESTAMP_NS,
+        "duration": 500_000_000,
+        "span_name": "my_task",
+        "input": {"prompt": "What is the capital of France?"},
+        "output": {"prompt": "What is the capital of France?"},
+        "expected_output": {"answer": "Paris"},
+        "evaluations": {},
+        "metadata": {},
+        "error": {"message": None, "type": None, "stack": None},
+    }
+    prior_run = ExperimentRun(run_info, {}, [prior_row])
+    prior_result: ExperimentResult = {"summary_evaluations": {}, "rows": [prior_row], "runs": [prior_run]}
+
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
+    exp.result = prior_result
+    original_id = "mock-original-exp-id"
+    exp._experiment._id = original_id
+    exp._experiment._project_id = "mock-project-id"
+
+    create_calls = []
+
+    def capture_create(*args, **kwargs):
+        create_calls.append(kwargs if kwargs else args)
+        return ("new-rerun-exp-id", "test_experiment-rerun")
+
+    with (
+        mock.patch.object(llmobs._instance._dne_client, "experiment_create", side_effect=capture_create),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post"),
+    ):
+        exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+    # experiment_create IS called once for the re-run experiment
+    assert len(create_calls) == 1
+    # The original experiment ID is unchanged
+    assert exp._experiment._id == original_id
+
+
 def test_experiment_init_without_task_and_dataset(llmobs):
     """Creating an experiment without task or dataset must not raise — supports pull() workflow."""
     exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
@@ -2171,6 +2459,87 @@ def test_experiment_run_without_task_raises(llmobs):
     exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
     with pytest.raises(ValueError, match="task and dataset are required to run an experiment from scratch"):
         exp.run()
+
+
+def test_experiment_rerun_without_task_succeeds(llmobs):
+    """rerun_evaluators() after pull() emits new span copies and references new IDs in eval metrics."""
+    row = {
+        "record_id": "r1",
+        "idx": 0,
+        "span_id": "abc",
+        "trace_id": "def",
+        "timestamp": MOCK_TIMESTAMP_NS,
+        "duration": 500_000_000,
+        "span_name": "my_task",
+        "input": {"question": "What is the capital of France?"},
+        "expected_output": {"answer": "Paris"},
+        "output": {"answer": "Paris"},
+        "metadata": {},
+        "evaluations": {},
+        "error": {"message": None, "type": None, "stack": None},
+    }
+    run_info = _ExperimentRunInfo(run_interation=0)
+    prior_run = ExperimentRun(run_info, summary_evaluations={}, rows=[row])
+    prior_result = {"runs": [prior_run], "rows": [row], "summary_evaluations": {}}
+
+    exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
+    # Simulate result from pull() — no run() needed
+    exp.result = prior_result
+    # Manually set fields that are normally populated by run()/_setup_experiment or pull()
+    exp._experiment._id = "mock-experiment-id"
+    exp._experiment._project_id = "mock-project-id"
+    exp._experiment._dataset_id = "mock-dataset-id"
+
+    call_kwargs = {}
+    new_experiment_ids: list[str] = []
+
+    def capture_create(*args, **kwargs):
+        # Return a fake new experiment id
+        new_id = "new-rerun-experiment-id"
+        new_experiment_ids.append(new_id)
+        return new_id, "test_experiment-rerun-12345"
+
+    def capture_eval_post(experiment_id, events, tags, spans=None):
+        call_kwargs["experiment_id"] = experiment_id
+        call_kwargs["events"] = events
+        call_kwargs["spans"] = spans
+
+    with (
+        mock.patch.object(llmobs._instance._dne_client, "experiment_create", side_effect=capture_create),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post", side_effect=capture_eval_post),
+    ):
+        new_result = exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+    assert new_result is not exp
+    assert new_result.result is not prior_result
+    result_row = new_result.result["runs"][0].rows[0]
+    # Output is preserved from the pulled data
+    assert result_row["output"] == {"answer": "Paris"}
+    # New span IDs are generated — they must differ from the originals
+    assert result_row["span_id"] != "abc"
+    assert result_row["trace_id"] != "def"
+    # Both new IDs must be valid UUIDs
+    assert UUID(result_row["span_id"])
+    assert UUID(result_row["trace_id"])
+    # A new child experiment was created
+    assert len(new_experiment_ids) == 1
+    # Eval metrics and span copies are posted to the new experiment
+    assert call_kwargs.get("experiment_id") == "new-rerun-experiment-id"
+    assert len(call_kwargs.get("events", [])) > 0
+    # Eval metrics reference the new span/trace IDs (not original "abc"/"def")
+    for metric in call_kwargs["events"]:
+        assert metric["span_id"] == result_row["span_id"]
+        assert metric["trace_id"] == result_row["trace_id"]
+    # Span copies are sent with new IDs and an offset timestamp
+    assert call_kwargs["spans"] is not None
+    assert len(call_kwargs["spans"]) == 1
+    span_copy = call_kwargs["spans"][0]
+    assert span_copy["span_id"] == result_row["span_id"]
+    assert span_copy["trace_id"] == result_row["trace_id"]
+    assert span_copy["start_ns"] != MOCK_TIMESTAMP_NS
+    # parent_experiment_span_id links span copy back to the original span
+    assert "parent_experiment_span_id:abc" in span_copy["tags"]
+    assert span_copy["meta"]["parent_experiment_span_id"] == "abc"
 
 
 MOCK_PULL_RESPONSE = {
@@ -2334,6 +2703,60 @@ def test_experiment_pull_populates_duration_and_span_name(llmobs):
     row = exp.result["runs"][0].rows[0]
     assert row["duration"] == 500_000_000
     assert row["span_name"] == "my_task"
+
+
+def test_experiment_pull_then_rerun(llmobs):
+    """pull() + rerun_evaluators(): fresh span copies with new UUIDs emitted to a new child experiment."""
+    exp = llmobs.experiment("test-exp", evaluators=[dummy_evaluator], project_name="my-project")
+
+    with mock.patch.object(llmobs._instance._dne_client, "experiment_events_get", return_value=MOCK_PULL_RESPONSE):
+        exp.pull()
+
+    assert exp.result is not None
+    assert exp._experiment._id == "mock-experiment-id"
+
+    call_kwargs: dict = {}
+    new_experiment_ids: list[str] = []
+
+    def capture_create(*args, **kwargs):
+        new_id = "new-rerun-experiment-id"
+        new_experiment_ids.append(new_id)
+        return new_id, "test-exp-rerun-12345"
+
+    def capture_eval_post(experiment_id, events, tags, spans=None):
+        call_kwargs["experiment_id"] = experiment_id
+        call_kwargs["events"] = events
+        call_kwargs["spans"] = spans
+
+    with (
+        mock.patch.object(llmobs._instance._dne_client, "experiment_create", side_effect=capture_create),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post", side_effect=capture_eval_post),
+    ):
+        # No evaluators argument — uses the experiment's own evaluators (cross-session notebook pattern)
+        new_result = exp.rerun_evaluators()
+
+    result_row = new_result.result["runs"][0].rows[0]
+    # Output is preserved from pulled data
+    assert result_row["output"] == {"answer": "Paris"}
+    # New span IDs are generated — they must differ from the originals
+    assert result_row["span_id"] != "abc123"
+    assert result_row["trace_id"] != "def456"
+    assert UUID(result_row["span_id"])
+    assert UUID(result_row["trace_id"])
+    # A new child experiment was created
+    assert len(new_experiment_ids) == 1
+    # Eval metrics and span copies posted to the new experiment
+    assert call_kwargs.get("experiment_id") == "new-rerun-experiment-id"
+    assert len(call_kwargs.get("events", [])) > 0
+    for metric in call_kwargs["events"]:
+        assert metric["span_id"] == result_row["span_id"]
+        assert metric["trace_id"] == result_row["trace_id"]
+    # Span copies sent with new IDs and an offset timestamp
+    assert call_kwargs["spans"] is not None
+    assert len(call_kwargs["spans"]) == 1
+    assert call_kwargs["spans"][0]["span_id"] == result_row["span_id"]
+    assert call_kwargs["spans"][0]["trace_id"] == result_row["trace_id"]
+    assert call_kwargs["spans"][0]["start_ns"] != MOCK_TIMESTAMP_NS
 
 
 @pytest.mark.parametrize(
@@ -5170,6 +5593,181 @@ def test_parse_experiment_result_summary_metrics():
     assert summary_evals["overall_score"] == {"value": 0.88, "type": "score", "reasoning": None, "assessment": None}
     assert summary_evals["overall_pass"] == {"value": True, "type": "boolean", "reasoning": None, "assessment": None}
     assert summary_evals["quality"] == {"value": "high", "type": "categorical", "reasoning": None, "assessment": None}
+
+
+def test_rerun_preserves_all_span_fields(llmobs):
+    """rerun_evaluators() preserves duration, span_name, input, output, expected_output, and
+    record_id from the prior result (e.g. populated via pull()) into the new result rows.
+    """
+    run_info = _ExperimentRunInfo(run_interation=0)
+    prior_row = {
+        "idx": 0,
+        "record_id": "rec-uuid-1",
+        "span_id": "original-span",
+        "trace_id": "original-trace",
+        "timestamp": MOCK_TIMESTAMP_NS,
+        "duration": 798_832_000,
+        "span_name": "generate_capital",
+        "input": {"question": "What is the capital of China?"},
+        "output": "Beijing",
+        "expected_output": "Beijing",
+        "evaluations": {},
+        "metadata": {"difficulty": "easy"},
+        "error": {"message": None, "type": None, "stack": None},
+    }
+    prior_run = ExperimentRun(run_info, {}, [prior_row])
+    prior_result = {"summary_evaluations": {}, "rows": [prior_row], "runs": [prior_run]}
+
+    exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
+    exp.result = prior_result
+    exp._experiment._id = "mock-original-exp-id"
+    exp._experiment._project_id = "mock-project-id"
+    exp._experiment._dataset_id = "mock-dataset-id"
+
+    posted_spans = []
+
+    def capture_eval_post(experiment_id, events, tags, spans=None):
+        if spans:
+            posted_spans.extend(spans)
+
+    with (
+        mock.patch.object(
+            llmobs._instance._dne_client, "experiment_create", return_value=("new-rerun-exp-id", "test-exp-rerun")
+        ),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post", side_effect=capture_eval_post),
+    ):
+        new_result = exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+    result_row = new_result.result["runs"][0].rows[0]
+
+    # Span identity is regenerated — new UUIDs, different from the originals
+    assert result_row["span_id"] != "original-span"
+    assert result_row["trace_id"] != "original-trace"
+    assert UUID(result_row["span_id"])
+    assert UUID(result_row["trace_id"])
+
+    # All span metadata from the pulled result is preserved in the new rows
+    assert result_row["duration"] == 798_832_000
+    assert result_row["span_name"] == "generate_capital"
+    assert result_row["input"] == {"question": "What is the capital of China?"}
+    assert result_row["output"] == "Beijing"
+    assert result_row["expected_output"] == "Beijing"
+    assert result_row["record_id"] == "rec-uuid-1"
+
+    # parent_experiment_span_id is set on the posted span copy — links back to original span
+    assert len(posted_spans) == 1
+    span_copy = posted_spans[0]
+    assert "parent_experiment_span_id:original-span" in span_copy["tags"]
+    assert span_copy["meta"]["parent_experiment_span_id"] == "original-span"
+
+
+def test_experiment_rerun_span_copies_carry_new_run_id_and_iteration(llmobs):
+    """Span copies emitted during rerun_evaluators() must carry the new run_id and run_iteration,
+    not the stale values from the original run().
+    """
+    run_info = _ExperimentRunInfo(run_interation=0)
+    prior_row = {
+        "idx": 0,
+        "record_id": "rec-1",
+        "span_id": "orig-span",
+        "trace_id": "orig-trace",
+        "timestamp": MOCK_TIMESTAMP_NS,
+        "duration": 500_000_000,
+        "span_name": "task",
+        "input": {"q": "hi"},
+        "output": "hello",
+        "expected_output": "hello",
+        "evaluations": {},
+        "metadata": {},
+        "error": {"message": None, "type": None, "stack": None},
+    }
+    prior_run = ExperimentRun(run_info, {}, [prior_row])
+    prior_result = {"summary_evaluations": {}, "rows": [prior_row], "runs": [prior_run]}
+
+    exp = llmobs.experiment("test_experiment", evaluators=[dummy_evaluator], project_name="my-project")
+    exp.result = prior_result
+    exp._experiment._id = "original-exp-id"
+    exp._experiment._project_id = "mock-project-id"
+    exp._experiment._dataset_id = "mock-dataset-id"
+    # Stamp stale run_id / run_iteration as if a prior run() happened
+    exp._experiment._tags["run_id"] = "stale-run-uuid"
+    exp._experiment._tags["run_iteration"] = "999"
+
+    posted_tags: list[list[str]] = []
+
+    def capture_eval_post(experiment_id, events, tags, spans=None):
+        posted_tags.append(list(tags))
+
+    with (
+        mock.patch.object(
+            llmobs._instance._dne_client, "experiment_create", return_value=("new-rerun-id", "test-exp-rerun")
+        ),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post", side_effect=capture_eval_post),
+    ):
+        exp.rerun_evaluators(evaluators=[dummy_evaluator])
+
+    assert len(posted_tags) == 1
+    tag_list = posted_tags[0]
+    # run_id and run_iteration must be the NEW rerun values, not "stale-run-uuid" / "999"
+    run_id_tags = [t for t in tag_list if t.startswith("run_id:")]
+    run_iter_tags = [t for t in tag_list if t.startswith("run_iteration:")]
+    assert len(run_id_tags) == 1
+    assert run_id_tags[0] != "run_id:stale-run-uuid"
+    assert len(run_iter_tags) == 1
+    assert run_iter_tags[0] == "run_iteration:1"
+    # Original tags are restored — stale values survive after the call returns
+    assert exp._experiment._tags.get("run_id") == "stale-run-uuid"
+    assert exp._experiment._tags.get("run_iteration") == "999"
+
+
+def test_experiment_rerun_for_rerun_persists_summary_evaluators(llmobs):
+    """_for_rerun() must carry the override summary_evaluators onto the returned clone."""
+    run_info = _ExperimentRunInfo(run_interation=0)
+    prior_row = {
+        "idx": 0,
+        "record_id": "rec-1",
+        "span_id": "orig-span",
+        "trace_id": "orig-trace",
+        "timestamp": MOCK_TIMESTAMP_NS,
+        "duration": 500_000_000,
+        "span_name": "task",
+        "input": {"q": "hi"},
+        "output": "hello",
+        "expected_output": "hello",
+        "evaluations": {},
+        "metadata": {},
+        "error": {"message": None, "type": None, "stack": None},
+    }
+    prior_run = ExperimentRun(run_info, {}, [prior_row])
+    prior_result = {"summary_evaluations": {}, "rows": [prior_row], "runs": [prior_run]}
+
+    exp = llmobs.experiment(
+        "test_experiment",
+        evaluators=[dummy_evaluator],
+        project_name="my-project",
+        summary_evaluators=[dummy_summary_evaluator],
+    )
+    exp.result = prior_result
+    exp._experiment._id = "original-exp-id"
+    exp._experiment._project_id = "mock-project-id"
+    exp._experiment._dataset_id = "mock-dataset-id"
+
+    with (
+        mock.patch.object(
+            llmobs._instance._dne_client, "experiment_create", return_value=("new-rerun-id", "test-exp-rerun")
+        ),
+        mock.patch.object(llmobs._instance._dne_client, "experiment_eval_post"),
+    ):
+        # Pass a different summary_evaluator as an override
+        new_exp = exp.rerun_evaluators(
+            evaluators=[dummy_evaluator],
+            summary_evaluators=[async_dummy_summary_evaluator],
+        )
+
+    # Clone carries the override, not the parent's original
+    assert list(new_exp._experiment._summary_evaluators) == [async_dummy_summary_evaluator]
+    # Parent is unchanged
+    assert list(exp._experiment._summary_evaluators) == [dummy_summary_evaluator]
 
 
 def test_prepare_summary_evaluator_data_handles_none_metadata():


### PR DESCRIPTION
## Summary

- Add `SyncExperiment.rerun_evaluators()` to re-score stored task outputs from a previous run without re-executing the task
- Emits replay span copies with fresh UUIDs and offset timestamps; each copy carries `parent_experiment_span_id` in both `meta` and `tags` to link it back to the original span
- Creates a new experiment entity on the backend with `parent_experiment_id` set to the original experiment's UUID (lineage traversable)
- `missing_task_strategy` parameter: `"raise"` (default), `"skip"`, or `"retry"` for errored rows
- `_process_record` now returns `duration` and `span_name` used by replay span construction

## Context

This is the second PR in the stack splitting #17292 (`re-run-evals`).

Stack:
1. #17807 — `pull()` + optional task/dataset (base: `main`) ← **merge first**
2. **This PR** — `rerun_evaluators()` + replay spans (base: #17807)

## Test plan

- [ ] `scripts/run-tests tests/llmobs/test_experiments.py -k "rerun"` green
- [ ] `hatch run lint:ruff check --no-cache ddtrace/llmobs/` clean
- [ ] `hatch run lint:mypy ddtrace/llmobs/_experiment.py ddtrace/llmobs/_writer.py` clean
- [ ] `hatch run lint:security` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)