### PR TITLE
fix(llmobs): propagate dataset_id via baggage when running experiments

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -110,6 +110,7 @@ EXPERIMENT_RUN_ITERATION_KEY = "_ml_obs.experiment_run_iteration"
 EXPERIMENT_PROJECT_NAME_KEY = "_ml_obs.experiment_project_name"
 EXPERIMENT_PROJECT_ID_KEY = "_ml_obs.experiment_project_id"
 EXPERIMENT_DATASET_NAME_KEY = "_ml_obs.experiment_dataset_name"
+EXPERIMENT_DATASET_ID_KEY = "_ml_obs.experiment_dataset_id"
 EXPERIMENT_NAME_KEY = "_ml_obs.experiment_name"
 
 # experiment context keys

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -2206,6 +2206,7 @@ class Experiment:
                 run_id=str(run._id),
                 run_iteration=run._run_iteration,
                 dataset_name=self._dataset.name,
+                dataset_id=str(self._dataset._id),
                 project_name=self._project_name,
                 project_id=self._project_id,
                 experiment_name=self.name,

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -58,6 +58,7 @@ from ddtrace.llmobs._constants import DISPATCH_ON_OPENAI_AGENT_SPAN_FINISH
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
 from ddtrace.llmobs._constants import EXPERIMENT_CSV_FIELD_MAX_SIZE
+from ddtrace.llmobs._constants import EXPERIMENT_DATASET_ID_KEY
 from ddtrace.llmobs._constants import EXPERIMENT_DATASET_NAME_KEY
 from ddtrace.llmobs._constants import EXPERIMENT_ID_KEY
 from ddtrace.llmobs._constants import EXPERIMENT_NAME_KEY
@@ -1934,6 +1935,7 @@ class LLMObs(Service):
             (EXPERIMENT_RUN_ID_KEY, "run_id"),
             (EXPERIMENT_RUN_ITERATION_KEY, "run_iteration"),
             (EXPERIMENT_DATASET_NAME_KEY, "dataset_name"),
+            (EXPERIMENT_DATASET_ID_KEY, "dataset_id"),
             (EXPERIMENT_PROJECT_ID_KEY, "project_id"),
             (EXPERIMENT_PROJECT_NAME_KEY, "project_name"),
             (EXPERIMENT_NAME_KEY, "experiment_name"),
@@ -2226,6 +2228,7 @@ class LLMObs(Service):
         run_id: Optional[str] = None,
         run_iteration: Optional[int] = None,
         dataset_name: Optional[str] = None,
+        dataset_id: Optional[str] = None,
         project_name: Optional[str] = None,
         project_id: Optional[str] = None,
         experiment_name: Optional[str] = None,
@@ -2257,6 +2260,9 @@ class LLMObs(Service):
         if dataset_name:
             span.context.set_baggage_item(EXPERIMENT_DATASET_NAME_KEY, dataset_name)
             _annotate_llmobs_span_data(span, tags={"dataset_name": dataset_name})
+        if dataset_id:
+            span.context.set_baggage_item(EXPERIMENT_DATASET_ID_KEY, dataset_id)
+            _annotate_llmobs_span_data(span, tags={"dataset_id": dataset_id})
         if project_id:
             span.context.set_baggage_item(EXPERIMENT_PROJECT_ID_KEY, project_id)
             _annotate_llmobs_span_data(span, tags={"project_id": project_id})

--- a/releasenotes/notes/llmobs-experiment-child-span-dataset-id-propagation-98a020ae4c524ba1.yaml
+++ b/releasenotes/notes/llmobs-experiment-child-span-dataset-id-propagation-98a020ae4c524ba1.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    llmobs: fixes child spans created within an experiment task not inheriting the ``dataset_id``
+    tag. Previously only ``dataset_name`` was propagated via baggage to child spans; ``dataset_id``
+    is now propagated as well, making dataset, project, and experiment context (name and ID) consistent
+    across all spans in an experiment trace.


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

propagate dataset_id via baggage when running experiments. we should propagate ID/name for experiments/datasets/projects and we're only missing this case


