### PR TITLE
test(llmobs): migrate crewai, openai_agents, langgraph to assert LLMObsSpanData

### DIFF
--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -1,5 +1,6 @@
 import os
 import time
+from unittest import mock
 
 from crewai import Agent
 from crewai import Crew
@@ -17,12 +18,11 @@ import vcr
 
 from ddtrace.contrib.internal.crewai.patch import patch
 from ddtrace.contrib.internal.crewai.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs import LLMObs
 from tests.contrib.crewai.utils import budget_text
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.contrib.crewai.utils import itinerary_text
 from tests.contrib.crewai.utils import welcome_email_text
-from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import override_global_config
 
 
@@ -343,22 +343,28 @@ def crewai(monkeypatch):
 
 
 @pytest.fixture
-def crewai_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "tests.contrib.crewai"}
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs_events(crewai_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use the mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()

--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -343,28 +343,19 @@ def crewai(monkeypatch):
 
 
 @pytest.fixture
-def ddtrace_global_config():
-    return {}
-
-
-@pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use the mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def crewai_llmobs(tracer, monkeypatch):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-api_key>",
+            "_llmobs_sample_rate": 1.0,
+            "service": "tests.contrib.crewai",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()

--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -350,7 +350,6 @@ def crewai_llmobs(tracer, monkeypatch):
         {
             "_llmobs_ml_app": "<ml-app-name>",
             "_dd_api_key": "<not-a-real-api_key>",
-            "_llmobs_sample_rate": 1.0,
             "service": "tests.contrib.crewai",
         }
     ):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -6,6 +6,7 @@ import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_span_name
@@ -274,21 +275,18 @@ def _assert_simple_flow_events(spans):
     assert get_llmobs_output_value(spans[1]) == "New York City"
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
-        meta_0 = _get_llmobs_data_metastruct(spans[0])
-        meta_1 = _get_llmobs_data_metastruct(spans[1])
-        meta_2 = _get_llmobs_data_metastruct(spans[2])
-        input_val = json.loads(meta_0["meta"]["input"]["value"])
+        input_val = json.loads(get_llmobs_input_value(spans[0]))
         assert input_val == {"continent": "North America"}
-        assert meta_0["meta"]["output"]["value"] == fun_fact_text
-        input_val = json.loads(meta_1["meta"]["input"]["value"])
+        assert get_llmobs_output_value(spans[0]) == fun_fact_text
+        input_val = json.loads(get_llmobs_input_value(spans[1]))
         assert input_val["args"] == []
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        input_val = json.loads(meta_2["meta"]["input"]["value"])
+        input_val = json.loads(get_llmobs_input_value(spans[2]))
         assert input_val["args"] == ["New York City"]
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        assert meta_2["meta"]["output"]["value"] == fun_fact_text
+        assert get_llmobs_output_value(spans[2]) == fun_fact_text
 
 
 def _assert_simple_flow_links(spans):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -6,6 +6,9 @@ import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_output_value
+from ddtrace.llmobs._utils import get_llmobs_parent_id
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
@@ -116,7 +119,7 @@ def _expected_tool_kwargs():
 
 def _llmobs_name(span):
     """Return the LLMObs span name as projected to the wire (matches event['name'])."""
-    return _get_llmobs_data_metastruct(span).get("name") or span.name
+    return get_llmobs_span_name(span) or span.name
 
 
 def _link_event(span):
@@ -142,10 +145,10 @@ def _assert_basic_crew_events(spans):
         kwargs = _expected_agent_kwargs(_llmobs_name(span)) if kind == "agent" else EXPECTED_SPAN_KWARGS
         assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **kwargs)
     # assert parent_id chain: workflow -> task -> agent
-    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
-    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[3].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[3]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[4]) == str(spans[3].span_id)  # agent -> task
 
 
 def _assert_basic_crew_links(spans):
@@ -171,9 +174,9 @@ def _assert_tool_crew_events(spans):
     )
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
     # assert parent_id chain: workflow -> task -> agent -> tool
-    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
-    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[2].span_id)  # tool -> agent
+    assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[3]) == str(spans[2].span_id)  # tool -> agent
 
 
 def _assert_tool_crew_links(spans):
@@ -200,10 +203,10 @@ def _assert_async_crew_events(spans):
         _get_llmobs_data_metastruct(spans[5]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[5]))
     )
     # assert parent_id chain: workflow -> task -> agent, workflow -> task -> agent
-    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
-    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[0].span_id)  # task -> workflow
-    assert _get_llmobs_data_metastruct(spans[5])["parent_id"] == str(spans[4].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
+    assert get_llmobs_parent_id(spans[4]) == str(spans[0].span_id)  # task -> workflow
+    assert get_llmobs_parent_id(spans[5]) == str(spans[4].span_id)  # agent -> task
 
 
 def _assert_async_crew_links(spans):
@@ -268,7 +271,7 @@ def _assert_simple_flow_events(spans):
     assert len(spans) == 3
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
-    assert _get_llmobs_data_metastruct(spans[1])["meta"]["output"]["value"] == "New York City"
+    assert get_llmobs_output_value(spans[1]) == "New York City"
     assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
         meta_0 = _get_llmobs_data_metastruct(spans[0])

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -9,6 +9,7 @@ from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
+from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
@@ -129,8 +130,7 @@ def _link_event(span):
     ``_assert_span_link`` only reads ``span_id`` and ``span_links`` from the dicts it's
     given, so we splice them out of the metastruct payload and the underlying span.
     """
-    metastruct = _get_llmobs_data_metastruct(span)
-    return {"span_id": str(span.span_id), "span_links": metastruct.get("span_links") or []}
+    return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
 
 
 def _ordered_spans(test_spans):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -2,14 +2,12 @@ import json
 
 import crewai
 import mock
-import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_value
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
-from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
@@ -115,15 +113,6 @@ def _llmobs_name(span):
     return get_llmobs_span_name(span) or span.name
 
 
-def _link_event(span):
-    """Build a minimal dict that ``_assert_span_link`` can consume.
-
-    ``_assert_span_link`` only reads ``span_id`` and ``span_links`` from the dicts it's
-    given, so we splice them out of the metastruct payload and the underlying span.
-    """
-    return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
-
-
 def _ordered_spans(test_spans):
     spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda s: s.start_ns)
@@ -144,17 +133,16 @@ def _assert_basic_crew_events(spans):
 
 
 def _assert_basic_crew_links(spans):
-    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[1], events[3], "output", "input")
-    _assert_span_link(events[3], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[1], spans[3], "output", "input")
+    _assert_span_link(spans[3], spans[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(events[1], events[2], "input", "input")
-    _assert_span_link(events[2], events[1], "output", "output")
-    _assert_span_link(events[3], events[4], "input", "input")
-    _assert_span_link(events[4], events[3], "output", "output")
+    _assert_span_link(spans[1], spans[2], "input", "input")
+    _assert_span_link(spans[2], spans[1], "output", "output")
+    _assert_span_link(spans[3], spans[4], "input", "input")
+    _assert_span_link(spans[4], spans[3], "output", "output")
 
 
 def _assert_tool_crew_events(spans):
@@ -172,14 +160,13 @@ def _assert_tool_crew_events(spans):
 
 
 def _assert_tool_crew_links(spans):
-    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[1], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[1], spans[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(events[1], events[2], "input", "input")
-    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(spans[1], spans[2], "input", "input")
+    _assert_span_link(spans[2], spans[1], "output", "output")
 
 
 def _assert_async_crew_events(spans):
@@ -202,17 +189,16 @@ def _assert_async_crew_events(spans):
 
 
 def _assert_async_crew_links(spans):
-    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[1], events[4], "output", "input")
-    _assert_span_link(events[4], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[1], spans[4], "output", "input")
+    _assert_span_link(spans[4], spans[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(events[1], events[2], "input", "input")
-    _assert_span_link(events[2], events[1], "output", "output")
-    _assert_span_link(events[4], events[5], "input", "input")
-    _assert_span_link(events[5], events[4], "output", "output")
+    _assert_span_link(spans[1], spans[2], "input", "input")
+    _assert_span_link(spans[2], spans[1], "output", "output")
+    _assert_span_link(spans[4], spans[5], "input", "input")
+    _assert_span_link(spans[5], spans[4], "output", "output")
 
 
 def _assert_hierarchical_crew_events(spans):
@@ -239,24 +225,23 @@ def _assert_hierarchical_crew_events(spans):
 
 
 def _assert_hierarchical_crew_links(spans):
-    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[1], events[3], "output", "input")
-    _assert_span_link(events[3], events[8], "output", "input")
-    _assert_span_link(events[8], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[1], spans[3], "output", "input")
+    _assert_span_link(spans[3], spans[8], "output", "input")
+    _assert_span_link(spans[8], spans[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(events[1], events[2], "input", "input")
-    _assert_span_link(events[2], events[1], "output", "output")
-    _assert_span_link(events[3], events[4], "input", "input")
-    _assert_span_link(events[4], events[3], "output", "output")
-    _assert_span_link(events[5], events[6], "input", "input")
-    _assert_span_link(events[6], events[5], "output", "output")
-    _assert_span_link(events[8], events[9], "input", "input")
-    _assert_span_link(events[9], events[8], "output", "output")
-    _assert_span_link(events[10], events[11], "input", "input")
-    _assert_span_link(events[11], events[10], "output", "output")
+    _assert_span_link(spans[1], spans[2], "input", "input")
+    _assert_span_link(spans[2], spans[1], "output", "output")
+    _assert_span_link(spans[3], spans[4], "input", "input")
+    _assert_span_link(spans[4], spans[3], "output", "output")
+    _assert_span_link(spans[5], spans[6], "input", "input")
+    _assert_span_link(spans[6], spans[5], "output", "output")
+    _assert_span_link(spans[8], spans[9], "input", "input")
+    _assert_span_link(spans[9], spans[8], "output", "output")
+    _assert_span_link(spans[10], spans[11], "input", "input")
+    _assert_span_link(spans[11], spans[10], "output", "output")
 
 
 def _assert_simple_flow_events(spans):
@@ -281,10 +266,9 @@ def _assert_simple_flow_events(spans):
 
 
 def _assert_simple_flow_links(spans):
-    events = [_link_event(s) for s in spans]
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[1], events[2], "output", "input")
-    _assert_span_link(events[2], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[1], spans[2], "output", "input")
+    _assert_span_link(spans[2], spans[0], "output", "output")
 
 
 def _assert_complex_flow_events(spans):
@@ -295,18 +279,17 @@ def _assert_complex_flow_events(spans):
 
 
 def _assert_complex_flow_links(spans):
-    events = [_link_event(s) for s in spans]
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[0], events[2], "input", "input")
-    _assert_span_link(events[5], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[0], spans[2], "input", "input")
+    _assert_span_link(spans[5], spans[0], "output", "output")
 
-    _assert_span_link(events[1], events[3], "output", "input")
-    _assert_span_link(events[1], events[4], "output", "input")
-    _assert_span_link(events[1], events[5], "output", "input")
+    _assert_span_link(spans[1], spans[3], "output", "input")
+    _assert_span_link(spans[1], spans[4], "output", "input")
+    _assert_span_link(spans[1], spans[5], "output", "input")
 
-    _assert_span_link(events[2], events[5], "output", "input")
-    _assert_span_link(events[3], events[5], "output", "input")
-    _assert_span_link(events[4], events[5], "output", "input")
+    _assert_span_link(spans[2], spans[5], "output", "input")
+    _assert_span_link(spans[3], spans[5], "output", "input")
+    _assert_span_link(spans[4], spans[5], "output", "input")
 
 
 def _assert_router_flow_events(spans):
@@ -317,11 +300,10 @@ def _assert_router_flow_events(spans):
 
 
 def _assert_router_flow_links(spans):
-    events = [_link_event(s) for s in spans]
-    _assert_span_link(events[0], events[1], "input", "input")
-    _assert_span_link(events[1], events[2], "output", "input")
-    _assert_span_link(events[2], events[3], "output", "input")
-    _assert_span_link(events[3], events[0], "output", "output")
+    _assert_span_link(spans[0], spans[1], "input", "input")
+    _assert_span_link(spans[1], spans[2], "output", "input")
+    _assert_span_link(spans[2], spans[3], "output", "input")
+    _assert_span_link(spans[3], spans[0], "output", "output")
 
 
 def test_basic_crew(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -19,15 +19,6 @@ from tests.llmobs._utils import assert_llmobs_span_data
 CREWAI_VERSION = parse_version(getattr(crewai, "__version__", "0.0.0"))
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.contrib.crewai",
-)
-
-
 AGENT_TO_EXPECTED_AGENT_MANIFEST = {
     "Senior Research Scientist": {
         "framework": "CrewAI",
@@ -333,8 +324,7 @@ def _assert_router_flow_links(spans):
     _assert_span_link(events[3], events[0], "output", "output")
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_basic_crew(crewai, basic_crew, request_vcr, test_spans):
+def test_basic_crew(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff(inputs={"topic": "AI"})
     spans = _ordered_spans(test_spans)
@@ -342,8 +332,7 @@ def test_basic_crew(crewai, basic_crew, request_vcr, test_spans):
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans):
+def test_basic_crew_for_each(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff_for_each(inputs=[{"topic": "AI"}])
     spans = _ordered_spans(test_spans)
@@ -351,8 +340,7 @@ def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans):
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans):
+async def test_basic_crew_async(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_async(inputs={"topic": "AI"})
     spans = _ordered_spans(test_spans)
@@ -360,8 +348,7 @@ async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans):
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_spans):
+async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_for_each_async(inputs=[{"topic": "AI"}])
     spans = _ordered_spans(test_spans)
@@ -369,8 +356,7 @@ async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_s
     _assert_basic_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans):
+def test_crew_with_tool(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -378,8 +364,7 @@ def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans):
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans):
+def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -387,8 +372,7 @@ def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans):
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans):
+async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -396,8 +380,7 @@ async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans):
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, test_spans):
+async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -405,8 +388,7 @@ async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, tes
     _assert_tool_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans):
+def test_async_crew(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -414,8 +396,7 @@ def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans):
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans):
+def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -423,8 +404,7 @@ def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans):
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans):
+async def test_async_crew_async(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -432,8 +412,7 @@ async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, test_spans):
+async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -441,8 +420,7 @@ async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, t
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans):
+def test_conditional_crew(crewai, conditional_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         conditional_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -450,8 +428,7 @@ def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans):
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, test_spans):
+async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await conditional_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -459,8 +436,7 @@ async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, tes
     _assert_async_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans):
+def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -468,8 +444,7 @@ def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans):
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
+def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -477,8 +452,7 @@ def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, test_spans):
+async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
     spans = _ordered_spans(test_spans)
@@ -486,8 +460,7 @@ async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, t
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
+async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, crewai_llmobs, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
     spans = _ordered_spans(test_spans)
@@ -495,48 +468,42 @@ async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, reque
     _assert_hierarchical_crew_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_simple_flow(crewai, simple_flow, test_spans):
+def test_simple_flow(crewai, simple_flow, crewai_llmobs, test_spans):
     simple_flow.kickoff(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_simple_flow_events(spans)
     _assert_simple_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_simple_flow_async(crewai, simple_flow_async, test_spans):
+async def test_simple_flow_async(crewai, simple_flow_async, crewai_llmobs, test_spans):
     await simple_flow_async.kickoff_async(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_simple_flow_events(spans)
     _assert_simple_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_complex_flow(crewai, complex_flow, test_spans):
+def test_complex_flow(crewai, complex_flow, crewai_llmobs, test_spans):
     complex_flow.kickoff(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_complex_flow_events(spans)
     _assert_complex_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_complex_flow_async(crewai, complex_flow_async, test_spans):
+async def test_complex_flow_async(crewai, complex_flow_async, crewai_llmobs, test_spans):
     await complex_flow_async.kickoff_async(inputs={"continent": "North America"})
     spans = _ordered_spans(test_spans)
     _assert_complex_flow_events(spans)
     _assert_complex_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_router_flow(crewai, router_flow, test_spans):
+def test_router_flow(crewai, router_flow, crewai_llmobs, test_spans):
     router_flow.kickoff()
     spans = _ordered_spans(test_spans)
     _assert_router_flow_events(spans)
     _assert_router_flow_links(spans)
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-async def test_router_flow_async(crewai, router_flow_async, test_spans):
+async def test_router_flow_async(crewai, router_flow_async, crewai_llmobs, test_spans):
     await router_flow_async.kickoff_async()
     spans = _ordered_spans(test_spans)
     _assert_router_flow_events(spans)

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -2,14 +2,25 @@ import json
 
 import crewai
 import mock
+import pytest
 
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.llmobs._utils import _assert_span_link
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
 
 
 CREWAI_VERSION = parse_version(getattr(crewai, "__version__", "0.0.0"))
+
+
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.contrib.crewai",
+)
 
 
 AGENT_TO_EXPECTED_AGENT_MANIFEST = {
@@ -73,132 +84,146 @@ AGENT_TO_EXPECTED_AGENT_MANIFEST = {
     },
 }
 
-EXPECTED_SPAN_ARGS = {
+
+# Common kwargs for non-agent crew/task spans. ``span_links`` is asserted separately
+# via the link helpers below so it doesn't appear here. ``parent_id=mock.ANY`` mirrors
+# the previous behaviour: async-task spans don't have a deterministic in-process parent.
+EXPECTED_SPAN_KWARGS = {
     "input_value": mock.ANY,
     "output_value": mock.ANY,
     "metadata": mock.ANY,
     "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-    "span_links": True,
-    "parent_id": mock.ANY,  # async task spans don't have in-process parent links
+    "parent_id": mock.ANY,
 }
 
 
-def expected_agent_span_args(role):
+def _expected_agent_kwargs(role):
     return {
         "input_value": mock.ANY,
         "output_value": mock.ANY,
         "metadata": {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[role]}},
         "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-        "span_links": True,
-        "parent_id": mock.ANY,  # async task spans don't have in-process parent links
+        "parent_id": mock.ANY,
     }
 
 
-def _assert_basic_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 5
-    for llmobs_span, span, kind in zip(llmobs_events, spans, ("workflow", "task", "agent", "task", "agent")):
-        extra_args = expected_agent_span_args(llmobs_span["name"]) if kind == "agent" else EXPECTED_SPAN_ARGS
-        assert llmobs_span == _expected_llmobs_non_llm_span_event(span, span_kind=kind, **extra_args)
+def _expected_tool_kwargs():
+    return {
+        "input_value": mock.ANY,
+        "output_value": mock.ANY,
+        "metadata": mock.ANY,
+        "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
+    }
+
+
+def _llmobs_name(span):
+    """Return the LLMObs span name as projected to the wire (matches event['name'])."""
+    return _get_llmobs_data_metastruct(span).get("name") or span.name
+
+
+def _link_event(span):
+    """Build a minimal dict that ``_assert_span_link`` can consume.
+
+    ``_assert_span_link`` only reads ``span_id`` and ``span_links`` from the dicts it's
+    given, so we splice them out of the metastruct payload and the underlying span.
+    """
+    metastruct = _get_llmobs_data_metastruct(span)
+    return {"span_id": str(span.span_id), "span_links": metastruct.get("span_links") or []}
+
+
+def _ordered_spans(test_spans):
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    spans.sort(key=lambda s: s.start_ns)
+    return spans
+
+
+def _assert_basic_crew_events(spans):
+    assert len(spans) == 5
+    expected_kinds = ("workflow", "task", "agent", "task", "agent")
+    for span, kind in zip(spans, expected_kinds):
+        kwargs = _expected_agent_kwargs(_llmobs_name(span)) if kind == "agent" else EXPECTED_SPAN_KWARGS
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **kwargs)
     # assert parent_id chain: workflow -> task -> agent
-    assert llmobs_events[1]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[2]["parent_id"] == llmobs_events[1]["span_id"]  # agent -> task
-    assert llmobs_events[3]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[4]["parent_id"] == llmobs_events[3]["span_id"]  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[3].span_id)  # agent -> task
 
 
-def _assert_basic_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_basic_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[3], "output", "input")
+    _assert_span_link(events[3], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
-    _assert_span_link(llmobs_events[3], llmobs_events[4], "input", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[3], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(events[3], events[4], "input", "input")
+    _assert_span_link(events[4], events[3], "output", "output")
 
 
-def _assert_tool_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 4
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-        spans[2], span_kind="agent", **expected_agent_span_args(llmobs_events[2]["name"])
+def _assert_tool_crew_events(spans):
+    assert len(spans) == 4
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[2]))
     )
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-        spans[3],
-        span_kind="tool",
-        input_value=mock.ANY,
-        output_value=mock.ANY,
-        metadata=mock.ANY,
-        tags={"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-    )
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
     # assert parent_id chain: workflow -> task -> agent -> tool
-    assert llmobs_events[1]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[2]["parent_id"] == llmobs_events[1]["span_id"]  # agent -> task
-    assert llmobs_events[3]["parent_id"] == llmobs_events[2]["span_id"]  # tool -> agent
+    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[3])["parent_id"] == str(spans[2].span_id)  # tool -> agent
 
 
-def _assert_tool_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_tool_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
 
 
-def _assert_async_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 6
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(
-        spans[2], span_kind="agent", **expected_agent_span_args(llmobs_events[2]["name"])
+def _assert_async_crew_events(spans):
+    assert len(spans) == 6
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[2]))
     )
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(
-        spans[3],
-        span_kind="tool",
-        input_value=mock.ANY,
-        output_value=mock.ANY,
-        metadata=mock.ANY,
-        tags={"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-    )
-    assert llmobs_events[4] == _expected_llmobs_non_llm_span_event(spans[4], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[5] == _expected_llmobs_non_llm_span_event(
-        spans[5], span_kind="agent", **expected_agent_span_args(llmobs_events[5]["name"])
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[4]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[5]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[5]))
     )
     # assert parent_id chain: workflow -> task -> agent, workflow -> task -> agent
-    assert llmobs_events[1]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[2]["parent_id"] == llmobs_events[1]["span_id"]  # agent -> task
-    assert llmobs_events[4]["parent_id"] == llmobs_events[0]["span_id"]  # task -> workflow
-    assert llmobs_events[5]["parent_id"] == llmobs_events[4]["span_id"]  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[1])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[2])["parent_id"] == str(spans[1].span_id)  # agent -> task
+    assert _get_llmobs_data_metastruct(spans[4])["parent_id"] == str(spans[0].span_id)  # task -> workflow
+    assert _get_llmobs_data_metastruct(spans[5])["parent_id"] == str(spans[4].span_id)  # agent -> task
 
 
-def _assert_async_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_async_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[4], "output", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[4], "output", "input")
+    _assert_span_link(events[4], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
-    _assert_span_link(llmobs_events[4], llmobs_events[5], "input", "input")
-    _assert_span_link(llmobs_events[5], llmobs_events[4], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(events[4], events[5], "input", "input")
+    _assert_span_link(events[5], events[4], "output", "output")
 
 
-def _assert_hierarchical_crew_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 12
+def _assert_hierarchical_crew_events(spans):
+    assert len(spans) == 12
     expected_span_kinds = (
         "workflow",
         "task",
@@ -213,294 +238,307 @@ def _assert_hierarchical_crew_events(llmobs_events, spans):
         "tool",
         "agent",
     )
-    for llmobs_span, span, kind in zip(llmobs_events, spans, expected_span_kinds):
+    for span, kind in zip(spans, expected_span_kinds):
         if kind is None:  # Not expecting any span links for this tool span
-            assert llmobs_span == _expected_llmobs_non_llm_span_event(
-                span,
-                span_kind="tool",
-                input_value=mock.ANY,
-                output_value=mock.ANY,
-                metadata=mock.ANY,
-                tags={"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
-            )
+            assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind="tool", **_expected_tool_kwargs())
             continue
-        assert llmobs_span == _expected_llmobs_non_llm_span_event(span, span_kind=kind, **EXPECTED_SPAN_ARGS)
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **EXPECTED_SPAN_KWARGS)
 
 
-def _assert_hierarchical_crew_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
+def _assert_hierarchical_crew_links(spans):
+    events = [_link_event(s) for s in spans]
     # span links for crew -> task
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[8], "output", "input")
-    _assert_span_link(llmobs_events[8], llmobs_events[0], "output", "output")
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[3], "output", "input")
+    _assert_span_link(events[3], events[8], "output", "input")
+    _assert_span_link(events[8], events[0], "output", "output")
 
     # span links for task -> agent
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[1], "output", "output")
-    _assert_span_link(llmobs_events[3], llmobs_events[4], "input", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[3], "output", "output")
-    _assert_span_link(llmobs_events[5], llmobs_events[6], "input", "input")
-    _assert_span_link(llmobs_events[6], llmobs_events[5], "output", "output")
-    _assert_span_link(llmobs_events[8], llmobs_events[9], "input", "input")
-    _assert_span_link(llmobs_events[9], llmobs_events[8], "output", "output")
-    _assert_span_link(llmobs_events[10], llmobs_events[11], "input", "input")
-    _assert_span_link(llmobs_events[11], llmobs_events[10], "output", "output")
+    _assert_span_link(events[1], events[2], "input", "input")
+    _assert_span_link(events[2], events[1], "output", "output")
+    _assert_span_link(events[3], events[4], "input", "input")
+    _assert_span_link(events[4], events[3], "output", "output")
+    _assert_span_link(events[5], events[6], "input", "input")
+    _assert_span_link(events[6], events[5], "output", "output")
+    _assert_span_link(events[8], events[9], "input", "input")
+    _assert_span_link(events[9], events[8], "output", "output")
+    _assert_span_link(events[10], events[11], "input", "input")
+    _assert_span_link(events[11], events[10], "output", "output")
 
 
-def _assert_simple_flow_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 3
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1]["meta"]["output"]["value"] == "New York City"
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(spans[2], span_kind="task", **EXPECTED_SPAN_ARGS)
+def _assert_simple_flow_events(spans):
+    assert len(spans) == 3
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert _get_llmobs_data_metastruct(spans[1])["meta"]["output"]["value"] == "New York City"
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
-        input_val = json.loads(llmobs_events[0]["meta"]["input"]["value"])
+        meta_0 = _get_llmobs_data_metastruct(spans[0])
+        meta_1 = _get_llmobs_data_metastruct(spans[1])
+        meta_2 = _get_llmobs_data_metastruct(spans[2])
+        input_val = json.loads(meta_0["meta"]["input"]["value"])
         assert input_val == {"continent": "North America"}
-        assert llmobs_events[0]["meta"]["output"]["value"] == fun_fact_text
-        input_val = json.loads(llmobs_events[1]["meta"]["input"]["value"])
+        assert meta_0["meta"]["output"]["value"] == fun_fact_text
+        input_val = json.loads(meta_1["meta"]["input"]["value"])
         assert input_val["args"] == []
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        input_val = json.loads(llmobs_events[2]["meta"]["input"]["value"])
+        input_val = json.loads(meta_2["meta"]["input"]["value"])
         assert input_val["args"] == ["New York City"]
         assert input_val["kwargs"] == {}
         assert input_val["flow_state"] == {"id": mock.ANY, "continent": "North America"}
-        assert llmobs_events[2]["meta"]["output"]["value"] == fun_fact_text
+        assert meta_2["meta"]["output"]["value"] == fun_fact_text
 
 
-def _assert_simple_flow_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "output", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[0], "output", "output")
+def _assert_simple_flow_links(spans):
+    events = [_link_event(s) for s in spans]
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[2], "output", "input")
+    _assert_span_link(events[2], events[0], "output", "output")
 
 
-def _assert_complex_flow_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 6
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(spans[2], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(spans[3], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[4] == _expected_llmobs_non_llm_span_event(spans[4], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[5] == _expected_llmobs_non_llm_span_event(spans[5], span_kind="task", **EXPECTED_SPAN_ARGS)
+def _assert_complex_flow_events(spans):
+    assert len(spans) == 6
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    for i in range(1, 6):
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_SPAN_KWARGS)
 
 
-def _assert_complex_flow_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[0], llmobs_events[2], "input", "input")
-    _assert_span_link(llmobs_events[5], llmobs_events[0], "output", "output")
+def _assert_complex_flow_links(spans):
+    events = [_link_event(s) for s in spans]
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[0], events[2], "input", "input")
+    _assert_span_link(events[5], events[0], "output", "output")
 
-    _assert_span_link(llmobs_events[1], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[4], "output", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[5], "output", "input")
+    _assert_span_link(events[1], events[3], "output", "input")
+    _assert_span_link(events[1], events[4], "output", "input")
+    _assert_span_link(events[1], events[5], "output", "input")
 
-    _assert_span_link(llmobs_events[2], llmobs_events[5], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[5], "output", "input")
-    _assert_span_link(llmobs_events[4], llmobs_events[5], "output", "input")
-
-
-def _assert_router_flow_events(llmobs_events, spans):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    assert len(spans) == len(llmobs_events) == 4
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(spans[0], span_kind="workflow", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(spans[1], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[2] == _expected_llmobs_non_llm_span_event(spans[2], span_kind="task", **EXPECTED_SPAN_ARGS)
-    assert llmobs_events[3] == _expected_llmobs_non_llm_span_event(spans[3], span_kind="task", **EXPECTED_SPAN_ARGS)
+    _assert_span_link(events[2], events[5], "output", "input")
+    _assert_span_link(events[3], events[5], "output", "input")
+    _assert_span_link(events[4], events[5], "output", "input")
 
 
-def _assert_router_flow_links(llmobs_events):
-    llmobs_events.sort(key=lambda span: span["start_ns"])
-    _assert_span_link(llmobs_events[0], llmobs_events[1], "input", "input")
-    _assert_span_link(llmobs_events[1], llmobs_events[2], "output", "input")
-    _assert_span_link(llmobs_events[2], llmobs_events[3], "output", "input")
-    _assert_span_link(llmobs_events[3], llmobs_events[0], "output", "output")
+def _assert_router_flow_events(spans):
+    assert len(spans) == 4
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    for i in range(1, 4):
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_SPAN_KWARGS)
 
 
-def test_basic_crew(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+def _assert_router_flow_links(spans):
+    events = [_link_event(s) for s in spans]
+    _assert_span_link(events[0], events[1], "input", "input")
+    _assert_span_link(events[1], events[2], "output", "input")
+    _assert_span_link(events[2], events[3], "output", "input")
+    _assert_span_link(events[3], events[0], "output", "output")
+
+
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_basic_crew(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff(inputs={"topic": "AI"})
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_basic_crew_for_each(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         basic_crew.kickoff_for_each(inputs=[{"topic": "AI"}])
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_basic_crew_async(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_async(inputs={"topic": "AI"})
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_basic_crew_async_for_each(crewai, basic_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_basic_crew.yaml"):
         await basic_crew.kickoff_for_each_async(inputs=[{"topic": "AI"}])
-    spans = test_spans.pop_traces()[0]
-    _assert_basic_crew_events(llmobs_events, spans)
-    _assert_basic_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_basic_crew_events(spans)
+    _assert_basic_crew_links(spans)
 
 
-def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_crew_with_tool(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_crew_with_tool_for_each(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         tool_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_crew_with_tool_async(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_crew_with_tool_async_for_each(crewai, tool_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_tool.yaml"):
         await tool_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_tool_crew_events(llmobs_events, spans)
-    _assert_tool_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_tool_crew_events(spans)
+    _assert_tool_crew_links(spans)
 
 
-def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_async_crew(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_async_crew_for_each(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         async_exec_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_async_crew_async(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_async_crew_async_for_each(crewai, async_exec_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await async_exec_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_conditional_crew(crewai, conditional_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         conditional_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_conditional_crew_async(crewai, conditional_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_crew_with_async_tasks.yaml"):
         await conditional_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_async_crew_events(llmobs_events, spans)
-    _assert_async_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_async_crew_events(spans)
+    _assert_async_crew_links(spans)
 
 
-def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_hierarchical_crew(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_hierarchical_crew_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         hierarchical_crew.kickoff_for_each(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_hierarchical_crew_async(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_async(inputs={"ages": [10, 12, 14, 16, 18]})
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_hierarchical_crew_async_for_each(crewai, hierarchical_crew, request_vcr, test_spans):
     with request_vcr.use_cassette("test_hierarchical_crew.yaml"):
         await hierarchical_crew.kickoff_for_each_async(inputs=[{"ages": [10, 12, 14, 16, 18]}])
-    spans = test_spans.pop_traces()[0]
-    _assert_hierarchical_crew_events(llmobs_events, spans)
-    _assert_hierarchical_crew_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_hierarchical_crew_events(spans)
+    _assert_hierarchical_crew_links(spans)
 
 
-def test_simple_flow(crewai, simple_flow, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_simple_flow(crewai, simple_flow, test_spans):
     simple_flow.kickoff(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_simple_flow_events(llmobs_events, spans)
-    _assert_simple_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_simple_flow_events(spans)
+    _assert_simple_flow_links(spans)
 
 
-async def test_simple_flow_async(crewai, simple_flow_async, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_simple_flow_async(crewai, simple_flow_async, test_spans):
     await simple_flow_async.kickoff_async(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_simple_flow_events(llmobs_events, spans)
-    _assert_simple_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_simple_flow_events(spans)
+    _assert_simple_flow_links(spans)
 
 
-def test_complex_flow(crewai, complex_flow, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_complex_flow(crewai, complex_flow, test_spans):
     complex_flow.kickoff(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_complex_flow_events(llmobs_events, spans)
-    _assert_complex_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_complex_flow_events(spans)
+    _assert_complex_flow_links(spans)
 
 
-async def test_complex_flow_async(crewai, complex_flow_async, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_complex_flow_async(crewai, complex_flow_async, test_spans):
     await complex_flow_async.kickoff_async(inputs={"continent": "North America"})
-    spans = test_spans.pop_traces()[0]
-    _assert_complex_flow_events(llmobs_events, spans)
-    _assert_complex_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_complex_flow_events(spans)
+    _assert_complex_flow_links(spans)
 
 
-def test_router_flow(crewai, router_flow, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_router_flow(crewai, router_flow, test_spans):
     router_flow.kickoff()
-    spans = test_spans.pop_traces()[0]
-    _assert_router_flow_events(llmobs_events, spans)
-    _assert_router_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_router_flow_events(spans)
+    _assert_router_flow_links(spans)
 
 
-async def test_router_flow_async(crewai, router_flow_async, test_spans, llmobs_events):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+async def test_router_flow_async(crewai, router_flow_async, test_spans):
     await router_flow_async.kickoff_async()
-    spans = test_spans.pop_traces()[0]
-    _assert_router_flow_events(llmobs_events, spans)
-    _assert_router_flow_links(llmobs_events)
+    spans = _ordered_spans(test_spans)
+    _assert_router_flow_events(spans)
+    _assert_router_flow_links(spans)

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -82,7 +82,7 @@ AGENT_TO_EXPECTED_AGENT_MANIFEST = {
 # Common kwargs for non-agent crew/task spans. ``span_links`` is asserted separately
 # via the link helpers below so it doesn't appear here. ``parent_id=mock.ANY`` mirrors
 # the previous behaviour: async-task spans don't have a deterministic in-process parent.
-EXPECTED_SPAN_KWARGS = {
+EXPECTED_BASE_SPAN_DATA = {
     "input_value": mock.ANY,
     "output_value": mock.ANY,
     "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
@@ -90,7 +90,7 @@ EXPECTED_SPAN_KWARGS = {
 }
 
 
-def _expected_agent_kwargs(role):
+def _expected_agent_span_data(role):
     return {
         "input_value": mock.ANY,
         "output_value": mock.ANY,
@@ -100,7 +100,7 @@ def _expected_agent_kwargs(role):
     }
 
 
-def _expected_tool_kwargs():
+def _expected_tool_span_data():
     return {
         "input_value": mock.ANY,
         "output_value": mock.ANY,
@@ -123,7 +123,7 @@ def _assert_basic_crew_events(spans):
     assert len(spans) == 5
     expected_kinds = ("workflow", "task", "agent", "task", "agent")
     for span, kind in zip(spans, expected_kinds):
-        kwargs = _expected_agent_kwargs(_llmobs_name(span)) if kind == "agent" else EXPECTED_SPAN_KWARGS
+        kwargs = _expected_agent_span_data(_llmobs_name(span)) if kind == "agent" else EXPECTED_BASE_SPAN_DATA
         assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **kwargs)
     # assert parent_id chain: workflow -> task -> agent
     assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
@@ -147,12 +147,12 @@ def _assert_basic_crew_links(spans):
 
 def _assert_tool_crew_events(spans):
     assert len(spans) == 4
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_BASE_SPAN_DATA)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
     assert_llmobs_span_data(
-        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[2]))
+        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_span_data(_llmobs_name(spans[2]))
     )
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_span_data())
     # assert parent_id chain: workflow -> task -> agent -> tool
     assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
     assert get_llmobs_parent_id(spans[2]) == str(spans[1].span_id)  # agent -> task
@@ -171,15 +171,15 @@ def _assert_tool_crew_links(spans):
 
 def _assert_async_crew_events(spans):
     assert len(spans) == 6
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_BASE_SPAN_DATA)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
     assert_llmobs_span_data(
-        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[2]))
+        _get_llmobs_data_metastruct(spans[2]), span_kind="agent", **_expected_agent_span_data(_llmobs_name(spans[2]))
     )
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_kwargs())
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[4]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[3]), span_kind="tool", **_expected_tool_span_data())
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[4]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
     assert_llmobs_span_data(
-        _get_llmobs_data_metastruct(spans[5]), span_kind="agent", **_expected_agent_kwargs(_llmobs_name(spans[5]))
+        _get_llmobs_data_metastruct(spans[5]), span_kind="agent", **_expected_agent_span_data(_llmobs_name(spans[5]))
     )
     # assert parent_id chain: workflow -> task -> agent, workflow -> task -> agent
     assert get_llmobs_parent_id(spans[1]) == str(spans[0].span_id)  # task -> workflow
@@ -219,9 +219,9 @@ def _assert_hierarchical_crew_events(spans):
     )
     for span, kind in zip(spans, expected_span_kinds):
         if kind is None:  # Not expecting any span links for this tool span
-            assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind="tool", **_expected_tool_kwargs())
+            assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind="tool", **_expected_tool_span_data())
             continue
-        assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **EXPECTED_SPAN_KWARGS)
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(span), span_kind=kind, **EXPECTED_BASE_SPAN_DATA)
 
 
 def _assert_hierarchical_crew_links(spans):
@@ -246,10 +246,10 @@ def _assert_hierarchical_crew_links(spans):
 
 def _assert_simple_flow_events(spans):
     assert len(spans) == 3
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_BASE_SPAN_DATA)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[1]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
     assert get_llmobs_output_value(spans[1]) == "New York City"
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[2]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
     if CREWAI_VERSION >= (0, 119, 0):  # Tracking I/O and state management only available CrewAI >=0.119.0
         input_val = json.loads(get_llmobs_input_value(spans[0]))
         assert input_val == {"continent": "North America"}
@@ -273,9 +273,9 @@ def _assert_simple_flow_links(spans):
 
 def _assert_complex_flow_events(spans):
     assert len(spans) == 6
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_BASE_SPAN_DATA)
     for i in range(1, 6):
-        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
 
 
 def _assert_complex_flow_links(spans):
@@ -294,9 +294,9 @@ def _assert_complex_flow_links(spans):
 
 def _assert_router_flow_events(spans):
     assert len(spans) == 4
-    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_SPAN_KWARGS)
+    assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[0]), span_kind="workflow", **EXPECTED_BASE_SPAN_DATA)
     for i in range(1, 4):
-        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_SPAN_KWARGS)
+        assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), span_kind="task", **EXPECTED_BASE_SPAN_DATA)
 
 
 def _assert_router_flow_links(spans):

--- a/tests/contrib/crewai/test_crewai_llmobs.py
+++ b/tests/contrib/crewai/test_crewai_llmobs.py
@@ -91,7 +91,6 @@ AGENT_TO_EXPECTED_AGENT_MANIFEST = {
 EXPECTED_SPAN_KWARGS = {
     "input_value": mock.ANY,
     "output_value": mock.ANY,
-    "metadata": mock.ANY,
     "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
     "parent_id": mock.ANY,
 }
@@ -111,7 +110,6 @@ def _expected_tool_kwargs():
     return {
         "input_value": mock.ANY,
         "output_value": mock.ANY,
-        "metadata": mock.ANY,
         "tags": {"service": "tests.contrib.crewai", "ml_app": "<ml-app-name>", "integration": "crewai"},
     }
 

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -51,11 +51,6 @@ def langchain():
 
 
 @pytest.fixture
-def ddtrace_global_config():
-    return {}
-
-
-@pytest.fixture
 def langgraph_llmobs(tracer, monkeypatch):
     monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
     LLMObs.disable()

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -56,26 +56,22 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def langgraph_llmobs(tracer, monkeypatch):
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "unnamed-ml-app",
+            "_dd_api_key": "<not-a-real-api_key>",
+            "_llmobs_sample_rate": 1.0,
+            "service": "tests.llmobs",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()
 
 
 class State(TypedDict):

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -63,7 +63,6 @@ def langgraph_llmobs(tracer, monkeypatch):
         {
             "_llmobs_ml_app": "unnamed-ml-app",
             "_dd_api_key": "<not-a-real-api_key>",
-            "_llmobs_sample_rate": 1.0,
             "service": "tests.llmobs",
         }
     ):

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -2,6 +2,7 @@ import operator
 import os
 from typing import Annotated
 from typing import TypedDict
+from unittest import mock
 
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
@@ -17,8 +18,7 @@ from ddtrace.contrib.internal.langgraph.patch import patch
 from ddtrace.contrib.internal.langgraph.patch import unpatch
 from ddtrace.contrib.internal.openai.patch import patch as patch_openai
 from ddtrace.contrib.internal.openai.patch import unpatch as unpatch_openai
-from ddtrace.llmobs import LLMObs as llmobs_service
-from tests.llmobs._utils import TestLLMObsSpanWriter
+from ddtrace.llmobs import LLMObs
 from tests.utils import override_global_config
 
 
@@ -50,27 +50,32 @@ def langchain():
     unpatch_langchain()
 
 
-def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "unnamed-ml-app", "service": "tests.llmobs"}
+@pytest.fixture
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
-
-
-@pytest.fixture
-def llmobs(tracer, llmobs_span_writer):
-    with override_global_config(default_global_config()):
-        llmobs_service.enable(_tracer=tracer)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
-
-
-@pytest.fixture
-def llmobs_events(llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()
 
 
 class State(TypedDict):

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -331,7 +331,9 @@ class TestLangGraphLLMObs:
         assert b_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_simple_graph(self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges):
+    def test_agent_manifest_simple_graph(
+        self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges
+    ):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}
         )
@@ -421,7 +423,9 @@ class TestLangGraphLLMObs:
         assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_populates_tools_from_tool_node(self, langgraph_llmobs, test_spans, custom_agent_with_tool_node):
+    def test_agent_manifest_populates_tools_from_tool_node(
+        self, langgraph_llmobs, test_spans, custom_agent_with_tool_node
+    ):
         custom_agent_with_tool_node.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
 

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -4,308 +4,353 @@ import random
 import pytest
 
 from ddtrace.contrib.internal.langgraph.patch import LANGGRAPH_VERSION
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.llmobs._utils import _assert_span_link
 
 
-def _find_span_by_name(llmobs_events, name):
-    """Find a single span by name."""
-    for event in llmobs_events:
-        if event["name"] == name:
-            return event
-    assert False, f"Span '{name}' not found in llmobs span events"
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="unnamed-ml-app",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.llmobs",
+)
 
 
-def _find_spans_by_name(llmobs_events, names):
-    """Find multiple spans by name, sorting by start_ns."""
-    spans = []
-    for event in llmobs_events:
-        if event["name"] in names:
-            spans.append(event)
-    if len(spans) != len(names):
-        assert False, f"Spans {names} not found in llmobs span events"
-    return sorted(spans, key=lambda x: x["start_ns"])
+def _link_view(span):
+    """Adapt an APM span into the dict shape ``_assert_span_link`` expects.
+
+    ``_assert_span_link`` was written against the wire-event shape; in the
+    meta_struct world span_links live on ``span._meta_struct["_llmobs"]``
+    rather than at the top level of an event.
+    """
+    return {
+        "span_id": str(span.span_id),
+        "span_links": _get_llmobs_data_metastruct(span).get("span_links", []),
+    }
 
 
+def _find_span_by_name(spans, name):
+    """Find a single span by its LLMObs meta_struct name."""
+    for span in spans:
+        if _get_llmobs_data_metastruct(span).get("name") == name:
+            return span
+    assert False, f"Span '{name}' not found in spans"
+
+
+def _find_spans_by_name(spans, names):
+    """Find multiple spans by name, sorted by start_ns."""
+    matched = [span for span in spans if _get_llmobs_data_metastruct(span).get("name") in names]
+    if len(matched) != len(names):
+        assert False, f"Spans {names} not found in spans"
+    return sorted(matched, key=lambda s: s.start_ns)
+
+
+def _collect_spans(test_spans):
+    return [s for trace in test_spans.pop_traces() for s in trace]
+
+
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLangGraphLLMObs:
-    def test_simple_graph(self, llmobs_events, simple_graph):
+    def test_simple_graph(self, test_spans, simple_graph):
         simple_graph.invoke({"a_list": [], "which": "a"}, stream_mode=["values"])
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
         # Check that the graph span has the appropriate output
         # stream_mode=["values"] should result in the last yield being a tuple
-        assert graph_span["meta"]["output"]["value"] == json.dumps({"a_list": ["a", "b"], "which": "a"})
+        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    async def test_simple_graph_async(self, llmobs_events, simple_graph):
+    async def test_simple_graph_async(self, test_spans, simple_graph):
         await simple_graph.ainvoke({"a_list": [], "which": "a"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
         # Check that the graph span has the appropriate output
         # default stream_mode of "values" should result in the last yield being an object
-        assert graph_span["meta"]["output"]["value"] == json.dumps({"a_list": ["a", "b"], "which": "a"})
+        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    def test_conditional_graph(self, llmobs_events, conditional_graph):
+    def test_conditional_graph(self, test_spans, conditional_graph):
         conditional_graph.invoke({"a_list": [], "which": "c"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        c_span = _find_span_by_name(llmobs_events, "c")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        c_span = _find_span_by_name(spans, "c")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(c_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(c_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
 
-    async def test_conditional_graph_async(self, llmobs_events, conditional_graph):
+    async def test_conditional_graph_async(self, test_spans, conditional_graph):
         await conditional_graph.ainvoke({"a_list": [], "which": "b"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-    def test_subgraph(self, llmobs_events, complex_graph):
+    def test_subgraph(self, test_spans, complex_graph):
         complex_graph.invoke({"a_list": [], "which": "b"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        b1_span = _find_span_by_name(llmobs_events, "b1")
-        b2_span = _find_span_by_name(llmobs_events, "b2")
-        b3_span = _find_span_by_name(llmobs_events, "b3")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        b1_span = _find_span_by_name(spans, "b1")
+        b2_span = _find_span_by_name(spans, "b2")
+        b3_span = _find_span_by_name(spans, "b3")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(b_span, b1_span, "input", "input")
-        _assert_span_link(b1_span, b2_span, "output", "input")
-        _assert_span_link(b2_span, b3_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(b_span), _link_view(b1_span), "input", "input")
+        _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
+        _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    async def test_subgraph_async(self, llmobs_events, complex_graph):
+    async def test_subgraph_async(self, test_spans, complex_graph):
         await complex_graph.ainvoke({"a_list": [], "which": "b"})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        b1_span = _find_span_by_name(llmobs_events, "b1")
-        b2_span = _find_span_by_name(llmobs_events, "b2")
-        b3_span = _find_span_by_name(llmobs_events, "b3")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        b1_span = _find_span_by_name(spans, "b1")
+        b2_span = _find_span_by_name(spans, "b2")
+        b3_span = _find_span_by_name(spans, "b3")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b3_span, b_span, "output", "output")
-        _assert_span_link(b_span, b1_span, "input", "input")
-        _assert_span_link(b1_span, b2_span, "output", "input")
-        _assert_span_link(b2_span, b3_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
+        _assert_span_link(_link_view(b_span), _link_view(b1_span), "input", "input")
+        _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
+        _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    def test_fanning_graph(self, llmobs_events, fanning_graph):
+    def test_fanning_graph(self, test_spans, fanning_graph):
         fanning_graph.invoke({"a_list": [], "which": ""})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(d_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    async def test_fanning_graph_async(self, llmobs_events, fanning_graph):
+    async def test_fanning_graph_async(self, test_spans, fanning_graph):
         await fanning_graph.ainvoke({"a_list": [], "which": ""})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
 
-        assert graph_span["name"] == "LangGraph"
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(d_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
+        assert _get_llmobs_data_metastruct(graph_span).get("name") == "LangGraph"
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    def test_graph_with_send(self, llmobs_events, graph_with_send):
+    def test_graph_with_send(self, test_spans, graph_with_send):
         graph_with_send.invoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(llmobs_events, ["b", "b", "b"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(spans, ["b", "b", "b"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span_1, graph_span, "output", "output")
-        _assert_span_link(b_span_2, graph_span, "output", "output")
-        _assert_span_link(b_span_3, graph_span, "output", "output")
-        _assert_span_link(a_span, b_span_1, "output", "input")
-        _assert_span_link(a_span, b_span_2, "output", "input")
-        _assert_span_link(a_span, b_span_3, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span_1), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_2), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_3), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_1), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    async def test_graph_with_send_async(self, llmobs_events, graph_with_send):
+    async def test_graph_with_send_async(self, test_spans, graph_with_send):
         await graph_with_send.ainvoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(llmobs_events, ["b", "b", "b"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span_1, b_span_2, b_span_3 = _find_spans_by_name(spans, ["b", "b", "b"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span_1, graph_span, "output", "output")
-        _assert_span_link(b_span_2, graph_span, "output", "output")
-        _assert_span_link(b_span_3, graph_span, "output", "output")
-        _assert_span_link(a_span, b_span_1, "output", "input")
-        _assert_span_link(a_span, b_span_2, "output", "input")
-        _assert_span_link(a_span, b_span_3, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span_1), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_2), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(b_span_3), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_1), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    def test_graph_with_send_complex(self, llmobs_events, graph_with_send_complex):
+    def test_graph_with_send_complex(self, test_spans, graph_with_send_complex):
         graph_with_send_complex.invoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_span_from_send, e_span = _find_spans_by_name(llmobs_events, ["e", "e"])
-        f_span = _find_span_by_name(llmobs_events, "f")
-        g_span = _find_span_by_name(llmobs_events, "g")
-        h_span = _find_span_by_name(llmobs_events, "h")
-        i_span = _find_span_by_name(llmobs_events, "i")
-        j_span = _find_span_by_name(llmobs_events, "j")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_span_from_send, e_span = _find_spans_by_name(spans, ["e", "e"])
+        f_span = _find_span_by_name(spans, "f")
+        g_span = _find_span_by_name(spans, "g")
+        h_span = _find_span_by_name(spans, "h")
+        i_span = _find_span_by_name(spans, "i")
+        j_span = _find_span_by_name(spans, "j")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(b_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span_from_send, "output", "input")
-        _assert_span_link(c_span, f_span, "output", "input")
-        _assert_span_link(c_span, g_span, "output", "input")
-        _assert_span_link(d_span, h_span, "output", "input")
-        _assert_span_link(e_span, h_span, "output", "input")
-        _assert_span_link(e_span_from_send, h_span, "output", "input")
-        _assert_span_link(f_span, i_span, "output", "input")
-        _assert_span_link(g_span, i_span, "output", "input")
-        _assert_span_link(h_span, j_span, "output", "input")
-        _assert_span_link(i_span, j_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span_from_send), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(f_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(g_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span_from_send), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(f_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(g_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
+        _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    async def test_graph_with_send_complex_async(self, llmobs_events, graph_with_send_complex):
+    async def test_graph_with_send_complex_async(self, test_spans, graph_with_send_complex):
         await graph_with_send_complex.ainvoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_span_from_send, e_span = _find_spans_by_name(llmobs_events, ["e", "e"])
-        f_span = _find_span_by_name(llmobs_events, "f")
-        g_span = _find_span_by_name(llmobs_events, "g")
-        h_span = _find_span_by_name(llmobs_events, "h")
-        i_span = _find_span_by_name(llmobs_events, "i")
-        j_span = _find_span_by_name(llmobs_events, "j")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_span_from_send, e_span = _find_spans_by_name(spans, ["e", "e"])
+        f_span = _find_span_by_name(spans, "f")
+        g_span = _find_span_by_name(spans, "g")
+        h_span = _find_span_by_name(spans, "h")
+        i_span = _find_span_by_name(spans, "i")
+        j_span = _find_span_by_name(spans, "j")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(b_span, d_span, "output", "input")
-        _assert_span_link(b_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span, "output", "input")
-        _assert_span_link(c_span, e_span_from_send, "output", "input")
-        _assert_span_link(c_span, f_span, "output", "input")
-        _assert_span_link(c_span, g_span, "output", "input")
-        _assert_span_link(d_span, h_span, "output", "input")
-        _assert_span_link(e_span, h_span, "output", "input")
-        _assert_span_link(e_span_from_send, h_span, "output", "input")
-        _assert_span_link(f_span, i_span, "output", "input")
-        _assert_span_link(g_span, i_span, "output", "input")
-        _assert_span_link(h_span, j_span, "output", "input")
-        _assert_span_link(i_span, j_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(e_span_from_send), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(f_span), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(g_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(e_span_from_send), _link_view(h_span), "output", "input")
+        _assert_span_link(_link_view(f_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(g_span), _link_view(i_span), "output", "input")
+        _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
+        _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    def test_graph_with_uneven_sides(self, llmobs_events, graph_with_uneven_sides):
+    def test_graph_with_uneven_sides(self, test_spans, graph_with_uneven_sides):
         graph_with_uneven_sides.invoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_first_finish, e_second_finish = _find_spans_by_name(llmobs_events, ["e", "e"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_first_finish, e_second_finish = _find_spans_by_name(spans, ["e", "e"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, e_first_finish, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
-        _assert_span_link(d_span, e_second_finish, "output", "input")
-        _assert_span_link(e_first_finish, graph_span, "output", "output")
-        _assert_span_link(e_second_finish, graph_span, "output", "output")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_first_finish), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(e_second_finish), "output", "input")
+        _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_graph_with_uneven_sides_async(self, llmobs_events, graph_with_uneven_sides):
+    async def test_graph_with_uneven_sides_async(self, test_spans, graph_with_uneven_sides):
         await graph_with_uneven_sides.ainvoke({"a_list": []})
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
-        c_span = _find_span_by_name(llmobs_events, "c")
-        d_span = _find_span_by_name(llmobs_events, "d")
-        e_first_finish, e_second_finish = _find_spans_by_name(llmobs_events, ["e", "e"])
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
+        c_span = _find_span_by_name(spans, "c")
+        d_span = _find_span_by_name(spans, "d")
+        e_first_finish, e_second_finish = _find_spans_by_name(spans, ["e", "e"])
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
-        _assert_span_link(a_span, c_span, "output", "input")
-        _assert_span_link(b_span, e_first_finish, "output", "input")
-        _assert_span_link(c_span, d_span, "output", "input")
-        _assert_span_link(d_span, e_second_finish, "output", "input")
-        _assert_span_link(e_first_finish, graph_span, "output", "output")
-        _assert_span_link(e_second_finish, graph_span, "output", "output")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(_link_view(b_span), _link_view(e_first_finish), "output", "input")
+        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
+        _assert_span_link(_link_view(d_span), _link_view(e_second_finish), "output", "input")
+        _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_astream_events(self, simple_graph, llmobs_events):
+    async def test_astream_events(self, test_spans, simple_graph):
         async for _ in simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2"):
             pass
-        graph_span = _find_span_by_name(llmobs_events, "LangGraph")
-        a_span = _find_span_by_name(llmobs_events, "a")
-        b_span = _find_span_by_name(llmobs_events, "b")
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        a_span = _find_span_by_name(spans, "a")
+        b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, graph_span, "input", "input")
-        _assert_span_link(b_span, graph_span, "output", "output")
-        _assert_span_link(graph_span, a_span, "input", "input")
-        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(None, _link_view(graph_span), "input", "input")
+        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
+        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
+        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-        assert a_span["meta"]["output"]["value"] is not None
-        assert b_span["meta"]["output"]["value"] is not None
+        a_output = _get_llmobs_data_metastruct(a_span).get("meta", {}).get("output", {})
+        b_output = _get_llmobs_data_metastruct(b_span).get("meta", {}).get("output", {})
+        assert a_output.get("value") is not None
+        assert b_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_simple_graph(self, llmobs_events, agentic_graph_with_conditional_and_definitive_edges):
+    def test_agent_manifest_simple_graph(self, test_spans, agentic_graph_with_conditional_and_definitive_edges):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}
         )
+        spans = _collect_spans(test_spans)
 
-        agent_a_span = _find_span_by_name(llmobs_events, "agent_a")
+        agent_a_span = _find_span_by_name(spans, "agent_a")
         try:
-            conditional_agent_span = _find_span_by_name(llmobs_events, "agent_b")
+            conditional_agent_span = _find_span_by_name(spans, "agent_b")
             conditional_agent_name = "agent_b"
         except AssertionError:
-            conditional_agent_span = _find_span_by_name(llmobs_events, "agent_c")
+            conditional_agent_span = _find_span_by_name(spans, "agent_c")
             conditional_agent_name = "agent_c"
 
-        agent_d_span = _find_span_by_name(llmobs_events, "agent_d")
+        agent_d_span = _find_span_by_name(spans, "agent_d")
 
         expected_agent_a_manifest = {
             "framework": "LangGraph",
@@ -331,19 +376,22 @@ class TestLangGraphLLMObs:
             "tools": [],
         }
 
-        assert agent_a_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_a_manifest
-        assert (
-            conditional_agent_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_conditional_agent_manifest
-        )
-        assert agent_d_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_d_manifest
+        agent_a_metadata = _get_llmobs_data_metastruct(agent_a_span).get("meta", {}).get("metadata", {})
+        conditional_metadata = _get_llmobs_data_metastruct(conditional_agent_span).get("meta", {}).get("metadata", {})
+        agent_d_metadata = _get_llmobs_data_metastruct(agent_d_span).get("meta", {}).get("metadata", {})
+
+        assert agent_a_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_a_manifest
+        assert conditional_metadata.get("_dd", {}).get("agent_manifest") == expected_conditional_agent_manifest
+        assert agent_d_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_d_manifest
 
     @pytest.mark.skipif(
         LANGGRAPH_VERSION < (0, 3, 21), reason="create_react_agent has full support after LangGraph 0.3.21"
     )
-    def test_agent_manifest_from_create_react_agent(self, llmobs_events, agent_from_create_react_agent):
+    def test_agent_manifest_from_create_react_agent(self, test_spans, agent_from_create_react_agent):
         agent_from_create_react_agent.invoke({"messages": [{"role": "user", "content": "What is 2 + 2?"}]})
+        spans = _collect_spans(test_spans)
 
-        react_agent_span = _find_span_by_name(llmobs_events, "not_your_average_bostonian")
+        react_agent_span = _find_span_by_name(spans, "not_your_average_bostonian")
 
         expected_agent_manifest = {
             "framework": "LangGraph",
@@ -374,13 +422,15 @@ class TestLangGraphLLMObs:
             "instructions": "You are a helpful assistant who talks with a Boston accent but is also very nice. You speak in full sentences with at least 15 words.",  # noqa: E501
         }
 
-        assert react_agent_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_manifest
+        react_agent_metadata = _get_llmobs_data_metastruct(react_agent_span).get("meta", {}).get("metadata", {})
+        assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_populates_tools_from_tool_node(self, llmobs_events, custom_agent_with_tool_node):
+    def test_agent_manifest_populates_tools_from_tool_node(self, test_spans, custom_agent_with_tool_node):
         custom_agent_with_tool_node.invoke({"a_list": []})
+        spans = _collect_spans(test_spans)
 
-        agent_span = _find_span_by_name(llmobs_events, "custom_agent_with_tool_node")
+        agent_span = _find_span_by_name(spans, "custom_agent_with_tool_node")
 
         expected_agent_manifest = {
             "framework": "LangGraph",
@@ -405,23 +455,26 @@ class TestLangGraphLLMObs:
             ],
         }
 
-        assert agent_span["meta"]["metadata"]["_dd"]["agent_manifest"] == expected_agent_manifest
+        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        assert agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_manifest_different_recursion_limit(
-        self, llmobs_events, agentic_graph_with_conditional_and_definitive_edges
+        self, test_spans, agentic_graph_with_conditional_and_definitive_edges
     ):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}, {"recursion_limit": 100}
         )
+        spans = _collect_spans(test_spans)
 
-        agent_span = _find_span_by_name(llmobs_events, "agent")
+        agent_span = _find_span_by_name(spans, "agent")
 
-        assert agent_span["meta"]["metadata"]["_dd"]["agent_manifest"]["max_iterations"] == 100
+        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        assert agent_metadata.get("_dd", {}).get("agent_manifest", {}).get("max_iterations") == 100
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_with_tool_calls_integrations_enabled(
-        self, llmobs_events, agent_from_create_react_agent_integrations_enabled
+        self, test_spans, agent_from_create_react_agent_integrations_enabled
     ):
         """
         Test that invoking an agent with tool calls while other integrations are enabled results in
@@ -430,23 +483,35 @@ class TestLangGraphLLMObs:
         agent_from_create_react_agent_integrations_enabled.invoke(
             {"messages": [{"role": "user", "content": "What is 2 + 2?"}]}
         )
+        spans = _collect_spans(test_spans)
 
-        assert len(llmobs_events) == 11
+        # Filter to LLMObs-bearing spans (some APM-only spans may be present from langchain/openai patching)
+        llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
+        llmobs_spans.sort(key=lambda s: s.start_ns)
 
-        first_llm_span = llmobs_events[0]
-        tool_span = llmobs_events[4]
-        second_llm_span = llmobs_events[6]
+        assert len(llmobs_spans) == 11
 
-        assert first_llm_span["meta"]["span"]["kind"] == "llm"
-        assert tool_span["meta"]["span"]["kind"] == "tool"
-        assert second_llm_span["meta"]["span"]["kind"] == "llm"
+        first_llm_span = llmobs_spans[0]
+        tool_span = llmobs_spans[4]
+        second_llm_span = llmobs_spans[6]
+
+        first_llm_meta = _get_llmobs_data_metastruct(first_llm_span).get("meta", {})
+        tool_meta = _get_llmobs_data_metastruct(tool_span).get("meta", {})
+        second_llm_meta = _get_llmobs_data_metastruct(second_llm_span).get("meta", {})
+
+        assert first_llm_meta.get("span", {}).get("kind") == "llm"
+        assert tool_meta.get("span", {}).get("kind") == "tool"
+        assert second_llm_meta.get("span", {}).get("kind") == "llm"
+
+        tool_links = _get_llmobs_data_metastruct(tool_span).get("span_links", [])
+        second_llm_links = _get_llmobs_data_metastruct(second_llm_span).get("span_links", [])
 
         # assert llm -> tool span link
-        assert tool_span["span_links"][1]["span_id"] == first_llm_span["span_id"]
-        assert tool_span["span_links"][1]["attributes"]["from"] == "output"
-        assert tool_span["span_links"][1]["attributes"]["to"] == "input"
+        assert tool_links[1]["span_id"] == str(first_llm_span.span_id)
+        assert tool_links[1]["attributes"]["from"] == "output"
+        assert tool_links[1]["attributes"]["to"] == "input"
 
         # assert tool -> llm span link
-        assert second_llm_span["span_links"][0]["span_id"] == tool_span["span_id"]
-        assert second_llm_span["span_links"][0]["attributes"]["from"] == "output"
-        assert second_llm_span["span_links"][0]["attributes"]["to"] == "input"
+        assert second_llm_links[0]["span_id"] == str(tool_span.span_id)
+        assert second_llm_links[0]["attributes"]["from"] == "output"
+        assert second_llm_links[0]["attributes"]["to"] == "input"

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -13,19 +13,6 @@ from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 
 
-def _link_view(span):
-    """Adapt an APM span into the dict shape ``_assert_span_link`` expects.
-
-    ``_assert_span_link`` was written against the wire-event shape; in the
-    meta_struct world span_links live on ``span._meta_struct["_llmobs"]``
-    rather than at the top level of an event.
-    """
-    return {
-        "span_id": str(span.span_id),
-        "span_links": get_llmobs_span_links(span) or [],
-    }
-
-
 def _find_span_by_name(spans, name):
     """Find a single span by its LLMObs meta_struct name."""
     for span in spans:
@@ -54,10 +41,10 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
 
         # Check that the graph span has the appropriate output
         # stream_mode=["values"] should result in the last yield being a tuple
@@ -71,10 +58,10 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
 
         # Check that the graph span has the appropriate output
         # default stream_mode of "values" should result in the last yield being an object
@@ -88,10 +75,10 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         c_span = _find_span_by_name(spans, "c")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(c_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(c_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, c_span, "output", "input")
 
     async def test_conditional_graph_async(self, langgraph_llmobs, test_spans, conditional_graph):
         await conditional_graph.ainvoke({"a_list": [], "which": "b"})
@@ -100,10 +87,10 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
 
     def test_subgraph(self, langgraph_llmobs, test_spans, complex_graph):
         complex_graph.invoke({"a_list": [], "which": "b"})
@@ -115,14 +102,14 @@ class TestLangGraphLLMObs:
         b2_span = _find_span_by_name(spans, "b2")
         b3_span = _find_span_by_name(spans, "b3")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
-        _assert_span_link(_link_view(b_span), _link_view(b1_span), "input", "input")
-        _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
-        _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b3_span, b_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(b3_span, b_span, "output", "output")
+        _assert_span_link(b_span, b1_span, "input", "input")
+        _assert_span_link(b1_span, b2_span, "output", "input")
+        _assert_span_link(b2_span, b3_span, "output", "input")
 
     async def test_subgraph_async(self, langgraph_llmobs, test_spans, complex_graph):
         await complex_graph.ainvoke({"a_list": [], "which": "b"})
@@ -134,14 +121,14 @@ class TestLangGraphLLMObs:
         b2_span = _find_span_by_name(spans, "b2")
         b3_span = _find_span_by_name(spans, "b3")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(b3_span), _link_view(b_span), "output", "output")
-        _assert_span_link(_link_view(b_span), _link_view(b1_span), "input", "input")
-        _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
-        _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b3_span, b_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(b3_span, b_span, "output", "output")
+        _assert_span_link(b_span, b1_span, "input", "input")
+        _assert_span_link(b1_span, b2_span, "output", "input")
+        _assert_span_link(b2_span, b3_span, "output", "input")
 
     def test_fanning_graph(self, langgraph_llmobs, test_spans, fanning_graph):
         fanning_graph.invoke({"a_list": [], "which": ""})
@@ -152,13 +139,13 @@ class TestLangGraphLLMObs:
         c_span = _find_span_by_name(spans, "c")
         d_span = _find_span_by_name(spans, "d")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(d_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(a_span, c_span, "output", "input")
+        _assert_span_link(b_span, d_span, "output", "input")
+        _assert_span_link(c_span, d_span, "output", "input")
 
     async def test_fanning_graph_async(self, langgraph_llmobs, test_spans, fanning_graph):
         await fanning_graph.ainvoke({"a_list": [], "which": ""})
@@ -170,13 +157,13 @@ class TestLangGraphLLMObs:
         d_span = _find_span_by_name(spans, "d")
 
         assert get_llmobs_span_name(graph_span) == "LangGraph"
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(d_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(a_span, c_span, "output", "input")
+        _assert_span_link(b_span, d_span, "output", "input")
+        _assert_span_link(c_span, d_span, "output", "input")
 
     def test_graph_with_send(self, langgraph_llmobs, test_spans, graph_with_send):
         graph_with_send.invoke({"a_list": []})
@@ -185,13 +172,13 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         b_span_1, b_span_2, b_span_3 = _find_spans_by_name(spans, ["b", "b", "b"])
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b_span_1), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(b_span_2), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(b_span_3), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(a_span), _link_view(b_span_1), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b_span_1, graph_span, "output", "output")
+        _assert_span_link(b_span_2, graph_span, "output", "output")
+        _assert_span_link(b_span_3, graph_span, "output", "output")
+        _assert_span_link(a_span, b_span_1, "output", "input")
+        _assert_span_link(a_span, b_span_2, "output", "input")
+        _assert_span_link(a_span, b_span_3, "output", "input")
 
     async def test_graph_with_send_async(self, langgraph_llmobs, test_spans, graph_with_send):
         await graph_with_send.ainvoke({"a_list": []})
@@ -200,13 +187,13 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         b_span_1, b_span_2, b_span_3 = _find_spans_by_name(spans, ["b", "b", "b"])
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b_span_1), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(b_span_2), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(b_span_3), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(a_span), _link_view(b_span_1), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b_span_1, graph_span, "output", "output")
+        _assert_span_link(b_span_2, graph_span, "output", "output")
+        _assert_span_link(b_span_3, graph_span, "output", "output")
+        _assert_span_link(a_span, b_span_1, "output", "input")
+        _assert_span_link(a_span, b_span_2, "output", "input")
+        _assert_span_link(a_span, b_span_3, "output", "input")
 
     def test_graph_with_send_complex(self, langgraph_llmobs, test_spans, graph_with_send_complex):
         graph_with_send_complex.invoke({"a_list": []})
@@ -223,22 +210,22 @@ class TestLangGraphLLMObs:
         i_span = _find_span_by_name(spans, "i")
         j_span = _find_span_by_name(spans, "j")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(e_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(e_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(e_span_from_send), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(f_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(g_span), "output", "input")
-        _assert_span_link(_link_view(d_span), _link_view(h_span), "output", "input")
-        _assert_span_link(_link_view(e_span), _link_view(h_span), "output", "input")
-        _assert_span_link(_link_view(e_span_from_send), _link_view(h_span), "output", "input")
-        _assert_span_link(_link_view(f_span), _link_view(i_span), "output", "input")
-        _assert_span_link(_link_view(g_span), _link_view(i_span), "output", "input")
-        _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
-        _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(b_span, d_span, "output", "input")
+        _assert_span_link(b_span, e_span, "output", "input")
+        _assert_span_link(c_span, e_span, "output", "input")
+        _assert_span_link(c_span, e_span_from_send, "output", "input")
+        _assert_span_link(c_span, f_span, "output", "input")
+        _assert_span_link(c_span, g_span, "output", "input")
+        _assert_span_link(d_span, h_span, "output", "input")
+        _assert_span_link(e_span, h_span, "output", "input")
+        _assert_span_link(e_span_from_send, h_span, "output", "input")
+        _assert_span_link(f_span, i_span, "output", "input")
+        _assert_span_link(g_span, i_span, "output", "input")
+        _assert_span_link(h_span, j_span, "output", "input")
+        _assert_span_link(i_span, j_span, "output", "input")
 
     async def test_graph_with_send_complex_async(self, langgraph_llmobs, test_spans, graph_with_send_complex):
         await graph_with_send_complex.ainvoke({"a_list": []})
@@ -255,22 +242,22 @@ class TestLangGraphLLMObs:
         i_span = _find_span_by_name(spans, "i")
         j_span = _find_span_by_name(spans, "j")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(e_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(e_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(e_span_from_send), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(f_span), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(g_span), "output", "input")
-        _assert_span_link(_link_view(d_span), _link_view(h_span), "output", "input")
-        _assert_span_link(_link_view(e_span), _link_view(h_span), "output", "input")
-        _assert_span_link(_link_view(e_span_from_send), _link_view(h_span), "output", "input")
-        _assert_span_link(_link_view(f_span), _link_view(i_span), "output", "input")
-        _assert_span_link(_link_view(g_span), _link_view(i_span), "output", "input")
-        _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
-        _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(b_span, d_span, "output", "input")
+        _assert_span_link(b_span, e_span, "output", "input")
+        _assert_span_link(c_span, e_span, "output", "input")
+        _assert_span_link(c_span, e_span_from_send, "output", "input")
+        _assert_span_link(c_span, f_span, "output", "input")
+        _assert_span_link(c_span, g_span, "output", "input")
+        _assert_span_link(d_span, h_span, "output", "input")
+        _assert_span_link(e_span, h_span, "output", "input")
+        _assert_span_link(e_span_from_send, h_span, "output", "input")
+        _assert_span_link(f_span, i_span, "output", "input")
+        _assert_span_link(g_span, i_span, "output", "input")
+        _assert_span_link(h_span, j_span, "output", "input")
+        _assert_span_link(i_span, j_span, "output", "input")
 
     def test_graph_with_uneven_sides(self, langgraph_llmobs, test_spans, graph_with_uneven_sides):
         graph_with_uneven_sides.invoke({"a_list": []})
@@ -282,15 +269,15 @@ class TestLangGraphLLMObs:
         d_span = _find_span_by_name(spans, "d")
         e_first_finish, e_second_finish = _find_spans_by_name(spans, ["e", "e"])
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(e_first_finish), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
-        _assert_span_link(_link_view(d_span), _link_view(e_second_finish), "output", "input")
-        _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(a_span, c_span, "output", "input")
+        _assert_span_link(b_span, e_first_finish, "output", "input")
+        _assert_span_link(c_span, d_span, "output", "input")
+        _assert_span_link(d_span, e_second_finish, "output", "input")
+        _assert_span_link(e_first_finish, graph_span, "output", "output")
+        _assert_span_link(e_second_finish, graph_span, "output", "output")
 
     async def test_graph_with_uneven_sides_async(self, langgraph_llmobs, test_spans, graph_with_uneven_sides):
         await graph_with_uneven_sides.ainvoke({"a_list": []})
@@ -302,15 +289,15 @@ class TestLangGraphLLMObs:
         d_span = _find_span_by_name(spans, "d")
         e_first_finish, e_second_finish = _find_spans_by_name(spans, ["e", "e"])
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
-        _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
-        _assert_span_link(_link_view(b_span), _link_view(e_first_finish), "output", "input")
-        _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
-        _assert_span_link(_link_view(d_span), _link_view(e_second_finish), "output", "input")
-        _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
+        _assert_span_link(a_span, c_span, "output", "input")
+        _assert_span_link(b_span, e_first_finish, "output", "input")
+        _assert_span_link(c_span, d_span, "output", "input")
+        _assert_span_link(d_span, e_second_finish, "output", "input")
+        _assert_span_link(e_first_finish, graph_span, "output", "output")
+        _assert_span_link(e_second_finish, graph_span, "output", "output")
 
     async def test_astream_events(self, langgraph_llmobs, test_spans, simple_graph):
         async for _ in simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2"):
@@ -320,10 +307,10 @@ class TestLangGraphLLMObs:
         a_span = _find_span_by_name(spans, "a")
         b_span = _find_span_by_name(spans, "b")
 
-        _assert_span_link(None, _link_view(graph_span), "input", "input")
-        _assert_span_link(_link_view(b_span), _link_view(graph_span), "output", "output")
-        _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
-        _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
+        _assert_span_link(None, graph_span, "input", "input")
+        _assert_span_link(b_span, graph_span, "output", "output")
+        _assert_span_link(graph_span, a_span, "input", "input")
+        _assert_span_link(a_span, b_span, "output", "input")
 
         a_output = get_llmobs_output(a_span) or {}
         b_output = get_llmobs_output(b_span) or {}

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -475,15 +475,13 @@ class TestLangGraphLLMObs:
         llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
         llmobs_spans.sort(key=lambda s: s.start_ns)
 
-        assert len(llmobs_spans) == 11
-
-        first_llm_span = llmobs_spans[0]
-        tool_span = llmobs_spans[4]
-        second_llm_span = llmobs_spans[6]
-
-        assert get_llmobs_span_kind(first_llm_span) == "llm"
-        assert get_llmobs_span_kind(tool_span) == "tool"
-        assert get_llmobs_span_kind(second_llm_span) == "llm"
+        # Pick by kind rather than positional index: langgraph >=0.3.22 emits an enclosing agent span
+        # whose start_ns precedes the inner llm span, which would shift fixed offsets.
+        llm_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "llm"]
+        tool_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "tool"]
+        first_llm_span = llm_spans[0]
+        second_llm_span = llm_spans[1]
+        tool_span = tool_spans[0]
 
         tool_links = get_llmobs_span_links(tool_span) or []
         second_llm_links = get_llmobs_span_links(second_llm_span) or []

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -13,15 +13,6 @@ from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="unnamed-ml-app",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.llmobs",
-)
-
-
 def _link_view(span):
     """Adapt an APM span into the dict shape ``_assert_span_link`` expects.
 
@@ -55,9 +46,8 @@ def _collect_spans(test_spans):
     return [s for trace in test_spans.pop_traces() for s in trace]
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 class TestLangGraphLLMObs:
-    def test_simple_graph(self, test_spans, simple_graph):
+    def test_simple_graph(self, langgraph_llmobs, test_spans, simple_graph):
         simple_graph.invoke({"a_list": [], "which": "a"}, stream_mode=["values"])
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -74,7 +64,7 @@ class TestLangGraphLLMObs:
         graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    async def test_simple_graph_async(self, test_spans, simple_graph):
+    async def test_simple_graph_async(self, langgraph_llmobs, test_spans, simple_graph):
         await simple_graph.ainvoke({"a_list": [], "which": "a"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -91,7 +81,7 @@ class TestLangGraphLLMObs:
         graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
-    def test_conditional_graph(self, test_spans, conditional_graph):
+    def test_conditional_graph(self, langgraph_llmobs, test_spans, conditional_graph):
         conditional_graph.invoke({"a_list": [], "which": "c"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -103,7 +93,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
         _assert_span_link(_link_view(a_span), _link_view(c_span), "output", "input")
 
-    async def test_conditional_graph_async(self, test_spans, conditional_graph):
+    async def test_conditional_graph_async(self, langgraph_llmobs, test_spans, conditional_graph):
         await conditional_graph.ainvoke({"a_list": [], "which": "b"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -115,7 +105,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-    def test_subgraph(self, test_spans, complex_graph):
+    def test_subgraph(self, langgraph_llmobs, test_spans, complex_graph):
         complex_graph.invoke({"a_list": [], "which": "b"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -134,7 +124,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
         _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    async def test_subgraph_async(self, test_spans, complex_graph):
+    async def test_subgraph_async(self, langgraph_llmobs, test_spans, complex_graph):
         await complex_graph.ainvoke({"a_list": [], "which": "b"})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -153,7 +143,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b1_span), _link_view(b2_span), "output", "input")
         _assert_span_link(_link_view(b2_span), _link_view(b3_span), "output", "input")
 
-    def test_fanning_graph(self, test_spans, fanning_graph):
+    def test_fanning_graph(self, langgraph_llmobs, test_spans, fanning_graph):
         fanning_graph.invoke({"a_list": [], "which": ""})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -170,7 +160,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
         _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    async def test_fanning_graph_async(self, test_spans, fanning_graph):
+    async def test_fanning_graph_async(self, langgraph_llmobs, test_spans, fanning_graph):
         await fanning_graph.ainvoke({"a_list": [], "which": ""})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -188,7 +178,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(b_span), _link_view(d_span), "output", "input")
         _assert_span_link(_link_view(c_span), _link_view(d_span), "output", "input")
 
-    def test_graph_with_send(self, test_spans, graph_with_send):
+    def test_graph_with_send(self, langgraph_llmobs, test_spans, graph_with_send):
         graph_with_send.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -203,7 +193,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    async def test_graph_with_send_async(self, test_spans, graph_with_send):
+    async def test_graph_with_send_async(self, langgraph_llmobs, test_spans, graph_with_send):
         await graph_with_send.ainvoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -218,7 +208,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(a_span), _link_view(b_span_2), "output", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span_3), "output", "input")
 
-    def test_graph_with_send_complex(self, test_spans, graph_with_send_complex):
+    def test_graph_with_send_complex(self, langgraph_llmobs, test_spans, graph_with_send_complex):
         graph_with_send_complex.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -250,7 +240,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
         _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    async def test_graph_with_send_complex_async(self, test_spans, graph_with_send_complex):
+    async def test_graph_with_send_complex_async(self, langgraph_llmobs, test_spans, graph_with_send_complex):
         await graph_with_send_complex.ainvoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -282,7 +272,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(h_span), _link_view(j_span), "output", "input")
         _assert_span_link(_link_view(i_span), _link_view(j_span), "output", "input")
 
-    def test_graph_with_uneven_sides(self, test_spans, graph_with_uneven_sides):
+    def test_graph_with_uneven_sides(self, langgraph_llmobs, test_spans, graph_with_uneven_sides):
         graph_with_uneven_sides.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -302,7 +292,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
         _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_graph_with_uneven_sides_async(self, test_spans, graph_with_uneven_sides):
+    async def test_graph_with_uneven_sides_async(self, langgraph_llmobs, test_spans, graph_with_uneven_sides):
         await graph_with_uneven_sides.ainvoke({"a_list": []})
         spans = _collect_spans(test_spans)
         graph_span = _find_span_by_name(spans, "LangGraph")
@@ -322,7 +312,7 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(e_first_finish), _link_view(graph_span), "output", "output")
         _assert_span_link(_link_view(e_second_finish), _link_view(graph_span), "output", "output")
 
-    async def test_astream_events(self, test_spans, simple_graph):
+    async def test_astream_events(self, langgraph_llmobs, test_spans, simple_graph):
         async for _ in simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2"):
             pass
         spans = _collect_spans(test_spans)
@@ -341,7 +331,7 @@ class TestLangGraphLLMObs:
         assert b_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_simple_graph(self, test_spans, agentic_graph_with_conditional_and_definitive_edges):
+    def test_agent_manifest_simple_graph(self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}
         )
@@ -392,7 +382,7 @@ class TestLangGraphLLMObs:
     @pytest.mark.skipif(
         LANGGRAPH_VERSION < (0, 3, 21), reason="create_react_agent has full support after LangGraph 0.3.21"
     )
-    def test_agent_manifest_from_create_react_agent(self, test_spans, agent_from_create_react_agent):
+    def test_agent_manifest_from_create_react_agent(self, langgraph_llmobs, test_spans, agent_from_create_react_agent):
         agent_from_create_react_agent.invoke({"messages": [{"role": "user", "content": "What is 2 + 2?"}]})
         spans = _collect_spans(test_spans)
 
@@ -431,7 +421,7 @@ class TestLangGraphLLMObs:
         assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
-    def test_agent_manifest_populates_tools_from_tool_node(self, test_spans, custom_agent_with_tool_node):
+    def test_agent_manifest_populates_tools_from_tool_node(self, langgraph_llmobs, test_spans, custom_agent_with_tool_node):
         custom_agent_with_tool_node.invoke({"a_list": []})
         spans = _collect_spans(test_spans)
 
@@ -465,7 +455,7 @@ class TestLangGraphLLMObs:
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_manifest_different_recursion_limit(
-        self, test_spans, agentic_graph_with_conditional_and_definitive_edges
+        self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges
     ):
         agentic_graph_with_conditional_and_definitive_edges.invoke(
             {"a_list": [], "which": random.choice(["agent_b", "agent_c"])}, {"recursion_limit": 100}
@@ -479,7 +469,7 @@ class TestLangGraphLLMObs:
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_with_tool_calls_integrations_enabled(
-        self, test_spans, agent_from_create_react_agent_integrations_enabled
+        self, langgraph_llmobs, test_spans, agent_from_create_react_agent_integrations_enabled
     ):
         """
         Test that invoking an agent with tool calls while other integrations are enabled results in

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -5,6 +5,11 @@ import pytest
 
 from ddtrace.contrib.internal.langgraph.patch import LANGGRAPH_VERSION
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_metadata
+from ddtrace.llmobs._utils import get_llmobs_output
+from ddtrace.llmobs._utils import get_llmobs_span_kind
+from ddtrace.llmobs._utils import get_llmobs_span_links
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 
 
@@ -26,21 +31,21 @@ def _link_view(span):
     """
     return {
         "span_id": str(span.span_id),
-        "span_links": _get_llmobs_data_metastruct(span).get("span_links", []),
+        "span_links": get_llmobs_span_links(span) or [],
     }
 
 
 def _find_span_by_name(spans, name):
     """Find a single span by its LLMObs meta_struct name."""
     for span in spans:
-        if _get_llmobs_data_metastruct(span).get("name") == name:
+        if get_llmobs_span_name(span) == name:
             return span
     assert False, f"Span '{name}' not found in spans"
 
 
 def _find_spans_by_name(spans, names):
     """Find multiple spans by name, sorted by start_ns."""
-    matched = [span for span in spans if _get_llmobs_data_metastruct(span).get("name") in names]
+    matched = [span for span in spans if get_llmobs_span_name(span) in names]
     if len(matched) != len(names):
         assert False, f"Spans {names} not found in spans"
     return sorted(matched, key=lambda s: s.start_ns)
@@ -66,7 +71,7 @@ class TestLangGraphLLMObs:
 
         # Check that the graph span has the appropriate output
         # stream_mode=["values"] should result in the last yield being a tuple
-        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
     async def test_simple_graph_async(self, test_spans, simple_graph):
@@ -83,7 +88,7 @@ class TestLangGraphLLMObs:
 
         # Check that the graph span has the appropriate output
         # default stream_mode of "values" should result in the last yield being an object
-        graph_output = _get_llmobs_data_metastruct(graph_span).get("meta", {}).get("output", {})
+        graph_output = get_llmobs_output(graph_span) or {}
         assert graph_output.get("value") == json.dumps({"a_list": ["a", "b"], "which": "a"})
 
     def test_conditional_graph(self, test_spans, conditional_graph):
@@ -174,7 +179,7 @@ class TestLangGraphLLMObs:
         c_span = _find_span_by_name(spans, "c")
         d_span = _find_span_by_name(spans, "d")
 
-        assert _get_llmobs_data_metastruct(graph_span).get("name") == "LangGraph"
+        assert get_llmobs_span_name(graph_span) == "LangGraph"
         _assert_span_link(None, _link_view(graph_span), "input", "input")
         _assert_span_link(_link_view(d_span), _link_view(graph_span), "output", "output")
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
@@ -330,8 +335,8 @@ class TestLangGraphLLMObs:
         _assert_span_link(_link_view(graph_span), _link_view(a_span), "input", "input")
         _assert_span_link(_link_view(a_span), _link_view(b_span), "output", "input")
 
-        a_output = _get_llmobs_data_metastruct(a_span).get("meta", {}).get("output", {})
-        b_output = _get_llmobs_data_metastruct(b_span).get("meta", {}).get("output", {})
+        a_output = get_llmobs_output(a_span) or {}
+        b_output = get_llmobs_output(b_span) or {}
         assert a_output.get("value") is not None
         assert b_output.get("value") is not None
 
@@ -376,9 +381,9 @@ class TestLangGraphLLMObs:
             "tools": [],
         }
 
-        agent_a_metadata = _get_llmobs_data_metastruct(agent_a_span).get("meta", {}).get("metadata", {})
-        conditional_metadata = _get_llmobs_data_metastruct(conditional_agent_span).get("meta", {}).get("metadata", {})
-        agent_d_metadata = _get_llmobs_data_metastruct(agent_d_span).get("meta", {}).get("metadata", {})
+        agent_a_metadata = get_llmobs_metadata(agent_a_span) or {}
+        conditional_metadata = get_llmobs_metadata(conditional_agent_span) or {}
+        agent_d_metadata = get_llmobs_metadata(agent_d_span) or {}
 
         assert agent_a_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_a_manifest
         assert conditional_metadata.get("_dd", {}).get("agent_manifest") == expected_conditional_agent_manifest
@@ -422,7 +427,7 @@ class TestLangGraphLLMObs:
             "instructions": "You are a helpful assistant who talks with a Boston accent but is also very nice. You speak in full sentences with at least 15 words.",  # noqa: E501
         }
 
-        react_agent_metadata = _get_llmobs_data_metastruct(react_agent_span).get("meta", {}).get("metadata", {})
+        react_agent_metadata = get_llmobs_metadata(react_agent_span) or {}
         assert react_agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
@@ -455,7 +460,7 @@ class TestLangGraphLLMObs:
             ],
         }
 
-        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        agent_metadata = get_llmobs_metadata(agent_span) or {}
         assert agent_metadata.get("_dd", {}).get("agent_manifest") == expected_agent_manifest
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
@@ -469,7 +474,7 @@ class TestLangGraphLLMObs:
 
         agent_span = _find_span_by_name(spans, "agent")
 
-        agent_metadata = _get_llmobs_data_metastruct(agent_span).get("meta", {}).get("metadata", {})
+        agent_metadata = get_llmobs_metadata(agent_span) or {}
         assert agent_metadata.get("_dd", {}).get("agent_manifest", {}).get("max_iterations") == 100
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
@@ -495,16 +500,12 @@ class TestLangGraphLLMObs:
         tool_span = llmobs_spans[4]
         second_llm_span = llmobs_spans[6]
 
-        first_llm_meta = _get_llmobs_data_metastruct(first_llm_span).get("meta", {})
-        tool_meta = _get_llmobs_data_metastruct(tool_span).get("meta", {})
-        second_llm_meta = _get_llmobs_data_metastruct(second_llm_span).get("meta", {})
+        assert get_llmobs_span_kind(first_llm_span) == "llm"
+        assert get_llmobs_span_kind(tool_span) == "tool"
+        assert get_llmobs_span_kind(second_llm_span) == "llm"
 
-        assert first_llm_meta.get("span", {}).get("kind") == "llm"
-        assert tool_meta.get("span", {}).get("kind") == "tool"
-        assert second_llm_meta.get("span", {}).get("kind") == "llm"
-
-        tool_links = _get_llmobs_data_metastruct(tool_span).get("span_links", [])
-        second_llm_links = _get_llmobs_data_metastruct(second_llm_span).get("span_links", [])
+        tool_links = get_llmobs_span_links(tool_span) or []
+        second_llm_links = get_llmobs_span_links(second_llm_span) or []
 
         # assert llm -> tool span link
         assert tool_links[1]["span_id"] == str(first_llm_span.span_id)

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -473,10 +473,10 @@ class TestLangGraphLLMObs:
 
         # Filter to LLMObs-bearing spans (some APM-only spans may be present from langchain/openai patching)
         llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
-        llmobs_spans.sort(key=lambda s: s.start_ns)
+        # Sort by finish time: the innermost llm span (openai, nested under langchain) finishes — and
+        # dispatches DISPATCH_ON_LLM_TOOL_CHOICE — first, so tool_links[1] resolves to llm_spans[0].
+        llmobs_spans.sort(key=lambda s: (s.start_ns or 0) + (s.duration_ns or 0))
 
-        # Pick by kind rather than positional index: langgraph >=0.3.22 emits an enclosing agent span
-        # whose start_ns precedes the inner llm span, which would shift fixed offsets.
         llm_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "llm"]
         tool_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "tool"]
         first_llm_span = llm_spans[0]

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -473,11 +473,15 @@ class TestLangGraphLLMObs:
 
         # Filter to LLMObs-bearing spans (some APM-only spans may be present from langchain/openai patching)
         llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
-        # Sort by finish time: the innermost llm span (openai, nested under langchain) finishes — and
-        # dispatches DISPATCH_ON_LLM_TOOL_CHOICE — first, so tool_links[1] resolves to llm_spans[0].
-        llmobs_spans.sort(key=lambda s: (s.start_ns or 0) + (s.duration_ns or 0))
+        llmobs_spans.sort(key=lambda s: s.start_ns)
 
+        # Both langchain (ChatOpenAI) and openai chat spans are kind="llm" here (langchain stays
+        # is_workflow=False since the conftest patches openai via low-level patch(), which doesn't
+        # update _PATCHED_MODULES). Filter to innermost llm spans — openai dispatches LLM_TOOL_CHOICE
+        # / TOOL_CALL_OUTPUT_USED first, so the LinkTracker links land on the openai spans.
         llm_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "llm"]
+        llm_parent_ids = {s.parent_id for s in llm_spans}
+        llm_spans = [s for s in llm_spans if s.span_id not in llm_parent_ids]
         tool_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "tool"]
         first_llm_span = llm_spans[0]
         second_llm_span = llm_spans[1]

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -471,20 +471,17 @@ class TestLangGraphLLMObs:
         )
         spans = _collect_spans(test_spans)
 
-        # Filter to LLMObs-bearing spans (some APM-only spans may be present from langchain/openai patching)
+        # APM-only spans may be present from langchain/openai patching
         llmobs_spans = [s for s in spans if _get_llmobs_data_metastruct(s)]
         llmobs_spans.sort(key=lambda s: s.start_ns)
 
-        # Both langchain (ChatOpenAI) and openai chat spans are kind="llm" here (langchain stays
-        # is_workflow=False since the conftest patches openai via low-level patch(), which doesn't
-        # update _PATCHED_MODULES). Filter to innermost llm spans — openai dispatches LLM_TOOL_CHOICE
-        # / TOOL_CALL_OUTPUT_USED first, so the LinkTracker links land on the openai spans.
+        # LinkTracker (first-dispatcher-wins) attaches links to the innermost llm span
         llm_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "llm"]
         llm_parent_ids = {s.parent_id for s in llm_spans}
-        llm_spans = [s for s in llm_spans if s.span_id not in llm_parent_ids]
+        nested_llm_spans = [s for s in llm_spans if s.span_id not in llm_parent_ids]
         tool_spans = [s for s in llmobs_spans if get_llmobs_span_kind(s) == "tool"]
-        first_llm_span = llm_spans[0]
-        second_llm_span = llm_spans[1]
+        first_llm_span = nested_llm_spans[0]
+        second_llm_span = nested_llm_spans[1]
         tool_span = tool_spans[0]
 
         tool_links = get_llmobs_span_links(tool_span) or []

--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -207,23 +207,23 @@ def ddtrace_global_config():
 
 
 @pytest.fixture
-def test_spans(ddtrace_global_config, test_spans, monkeypatch):
-    try:
-        if ddtrace_global_config.get("_llmobs_enabled", False):
-            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
-            # after enqueueing to LLMObsSpanWriter.
-            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
-            with override_global_config(ddtrace_global_config):
-                # Have to disable and re-enable LLMObs to use to mock tracer.
-                LLMObs.disable()
-                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
-                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-                # background flush thread alive trying to ship spans during the test.
-                LLMObs._instance._llmobs_span_writer.stop()
-                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
-                yield test_spans
-        else:
-            yield test_spans
-    finally:
-        LLMObs.disable()
+def openai_agents_llmobs(tracer, monkeypatch):
+    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
+    # enqueueing to LLMObsSpanWriter.
+    monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+            "service": "tests.contrib.agents",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False)
+        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+        # background flush thread alive trying to ship spans during the test.
+        LLMObs._instance._llmobs_span_writer.stop()
+        LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+        yield LLMObs
+    LLMObs.disable()

--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 from agents import Agent
 from agents import GuardrailFunctionOutput
@@ -12,8 +13,7 @@ import vcr
 
 from ddtrace.contrib.internal.openai_agents.patch import patch
 from ddtrace.contrib.internal.openai_agents.patch import unpatch
-from ddtrace.llmobs import LLMObs as llmobs_service
-from tests.llmobs._utils import TestLLMObsSpanWriter
+from ddtrace.llmobs import LLMObs
 from tests.utils import override_global_config
 
 
@@ -202,22 +202,28 @@ def openai(agents):
 
 
 @pytest.fixture
-def llmobs_span_writer():
-    yield TestLLMObsSpanWriter(1.0, 5.0, is_agentless=True, _site="datad0g.com", _api_key="<not-a-real-key>")
+def ddtrace_global_config():
+    return {}
 
 
 @pytest.fixture
-def agents_llmobs(tracer, llmobs_span_writer):
-    llmobs_service.disable()
-    with override_global_config(
-        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "tests.contrib.agents"}
-    ):
-        llmobs_service.enable(_tracer=tracer, integrations_enabled=False)
-        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
-        yield llmobs_service
-    llmobs_service.disable()
-
-
-@pytest.fixture
-def llmobs_events(agents_llmobs, llmobs_span_writer):
-    return llmobs_span_writer.events
+def test_spans(ddtrace_global_config, test_spans, monkeypatch):
+    try:
+        if ddtrace_global_config.get("_llmobs_enabled", False):
+            # Preserve meta_struct["_llmobs"] on spans so tests can assert against
+            # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it
+            # after enqueueing to LLMObsSpanWriter.
+            monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
+            with override_global_config(ddtrace_global_config):
+                # Have to disable and re-enable LLMObs to use to mock tracer.
+                LLMObs.disable()
+                LLMObs.enable(_tracer=test_spans.tracer, integrations_enabled=False)
+                # Replace the real LLMObsSpanWriter with a mock so we don't keep a
+                # background flush thread alive trying to ship spans during the test.
+                LLMObs._instance._llmobs_span_writer.stop()
+                LLMObs._instance._llmobs_span_writer = mock.MagicMock()
+                yield test_spans
+        else:
+            yield test_spans
+    finally:
+        LLMObs.disable()

--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -202,11 +202,6 @@ def openai(agents):
 
 
 @pytest.fixture
-def ddtrace_global_config():
-    return {}
-
-
-@pytest.fixture
 def openai_agents_llmobs(tracer, monkeypatch):
     # Preserve meta_struct["_llmobs"] on spans so tests can assert against
     # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after

--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -203,9 +203,6 @@ def openai(agents):
 
 @pytest.fixture
 def openai_agents_llmobs(tracer, monkeypatch):
-    # Preserve meta_struct["_llmobs"] on spans so tests can assert against
-    # LLMObsSpanData via _get_llmobs_data_metastruct; production scrubs it after
-    # enqueueing to LLMObsSpanWriter.
     monkeypatch.setenv("_DD_LLMOBS_TEST_KEEP_META_STRUCT", "1")
     LLMObs.disable()
     with override_global_config(
@@ -216,8 +213,6 @@ def openai_agents_llmobs(tracer, monkeypatch):
         }
     ):
         LLMObs.enable(_tracer=tracer, integrations_enabled=False)
-        # Replace the real LLMObsSpanWriter with a mock so we don't keep a
-        # background flush thread alive trying to ship spans during the test.
         LLMObs._instance._llmobs_span_writer.stop()
         LLMObs._instance._llmobs_span_writer = mock.MagicMock()
         yield LLMObs

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -4,7 +4,6 @@ import mock
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
-from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
@@ -120,11 +119,6 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
-def _link_view(span):
-    """Build a dict the shape `_assert_span_link` expects (span_id + span_links)."""
-    return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
-
-
 def _assert_expected_agent_run(
     expected_span_names: list[str],
     spans,
@@ -184,7 +178,7 @@ def _assert_expected_agent_run(
                     name=expected_span_names[i + 1],
                 )
             for tool_span in previous_tool_spans:
-                _assert_span_link(_link_view(tool_span), _link_view(span), "output", "input")
+                _assert_span_link(tool_span, span, "output", "input")
         else:
             tool_call = tool_calls[i // 2]
             error = None
@@ -207,7 +201,7 @@ def _assert_expected_agent_run(
                 **io_args,
             )
             # assert tool is linked to the previous LLM call
-            _assert_span_link(_link_view(spans[i]), _link_view(span), "output", "input")
+            _assert_span_link(spans[i], span, "output", "input")
             previous_tool_spans.append(span)
     return previous_tool_spans
 
@@ -758,9 +752,9 @@ async def test_llmobs_oai_agents_with_guardrail_spans(
     assert len(spans) == 7
 
     # assert input guardrail span links to LLM span
-    _assert_span_link(_link_view(spans[2]), _link_view(spans[3]), "output", "input")
+    _assert_span_link(spans[2], spans[3], "output", "input")
     # assert LLM span links to output guardrail span
-    _assert_span_link(_link_view(spans[5]), _link_view(spans[6]), "output", "input")
+    _assert_span_link(spans[5], spans[6], "output", "input")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
 
@@ -118,11 +119,6 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
-def _llmobs_name(span):
-    """Get the LLMObs name from a span's meta_struct['_llmobs']."""
-    return _get_llmobs_data_metastruct(span).get("name")
-
-
 class _SpanLinkView:
     """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
     ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict.
@@ -215,13 +211,13 @@ def _assert_expected_agent_run(
         previous_tool_spans = []
     # Names match the LLMObs name on each span in order.
     for i, span in enumerate(spans):
-        assert _llmobs_name(span) == expected_span_names[i], (
-            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, actual={_llmobs_name(span)!r}"
+        assert get_llmobs_span_name(span) == expected_span_names[i], (
+            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, actual={get_llmobs_span_name(span)!r}"
         )
     # First span: agent span.
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_agent_kwargs(spans[0], _llmobs_name(spans[0])),
+        **_expected_agent_kwargs(spans[0], get_llmobs_span_name(spans[0])),
     )
 
     for i, span in enumerate(spans[1:]):
@@ -261,7 +257,7 @@ async def test_llmobs_single_agent(agents, openai_agents_llmobs, test_spans, req
 
     assert len(spans) == 3
 
-    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert get_llmobs_span_name(spans[0]) == "Agent workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
@@ -306,7 +302,7 @@ async def test_llmobs_streamed_single_agent(agents, openai_agents_llmobs, test_s
 
     assert len(spans) == 3
 
-    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert get_llmobs_span_name(spans[0]) == "Agent workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
@@ -344,7 +340,7 @@ def test_llmobs_single_agent_sync(agents, openai_agents_llmobs, test_spans, requ
 
     assert len(spans) == 3
 
-    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert get_llmobs_span_name(spans[0]) == "Agent workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
@@ -389,7 +385,7 @@ async def test_llmobs_manual_tracing_llmobs(agents, openai_agents_llmobs, test_s
 
     assert len(spans) == 4
 
-    assert _llmobs_name(spans[0]) == "Simple Workflow"
+    assert get_llmobs_span_name(spans[0]) == "Simple Workflow"
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_llmobs_span_name
 from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
@@ -119,55 +120,9 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
-class _SpanLinkView:
-    """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
-    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict.
-    """
-
-    def __init__(self, span):
-        self._span = span
-        self._metastruct = _get_llmobs_data_metastruct(span)
-
-    def __getitem__(self, key):
-        if key == "span_id":
-            return str(self._span.span_id)
-        if key == "span_links":
-            return self._metastruct.get("span_links", [])
-        raise KeyError(key)
-
-
-def _expected_agent_kwargs(span, agent_name: str) -> dict:
-    """Build the kwargs for ``assert_llmobs_span_data`` for an agent span."""
-    return dict(
-        span_kind="agent",
-        metadata=_expected_agent_metadata(agent_name),
-        tags=COMMON_TAGS,
-        name=agent_name,
-    )
-
-
-def _expected_llm_kwargs(
-    input_messages,
-    output_messages,
-    name: Optional[str] = None,
-) -> dict:
-    """Build the kwargs for ``assert_llmobs_span_data`` for an LLM (response) span."""
-    return dict(
-        span_kind="llm",
-        input_messages=input_messages,
-        output_messages=output_messages,
-        metrics={
-            "input_tokens": mock.ANY,
-            "output_tokens": mock.ANY,
-            "total_tokens": mock.ANY,
-            "reasoning_output_tokens": mock.ANY,
-        },
-        metadata=COMMON_RESPONSE_LLM_METADATA,
-        model_name="gpt-4o-2024-08-06",
-        model_provider="openai",
-        tags=COMMON_TAGS,
-        name=name,
-    )
+def _link_view(span):
+    """Build a dict the shape `_assert_span_link` expects (span_id + span_links)."""
+    return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
 
 
 def _expected_tool_kwargs(tool_call: dict) -> dict:
@@ -217,7 +172,10 @@ def _assert_expected_agent_run(
     # First span: agent span.
     assert_llmobs_span_data(
         _get_llmobs_data_metastruct(spans[0]),
-        **_expected_agent_kwargs(spans[0], get_llmobs_span_name(spans[0])),
+        span_kind="agent",
+        metadata=_expected_agent_metadata(get_llmobs_span_name(spans[0])),
+        tags=COMMON_TAGS,
+        name=get_llmobs_span_name(spans[0]),
     )
 
     for i, span in enumerate(spans[1:]):
@@ -226,14 +184,23 @@ def _assert_expected_agent_run(
             if not is_chat:
                 assert_llmobs_span_data(
                     _get_llmobs_data_metastruct(span),
-                    **_expected_llm_kwargs(
-                        input_messages=llm_calls[i // 2][0],
-                        output_messages=llm_calls[i // 2][1],
-                        name=expected_span_names[i + 1],
-                    ),
+                    span_kind="llm",
+                    input_messages=llm_calls[i // 2][0],
+                    output_messages=llm_calls[i // 2][1],
+                    metrics={
+                        "input_tokens": mock.ANY,
+                        "output_tokens": mock.ANY,
+                        "total_tokens": mock.ANY,
+                        "reasoning_output_tokens": mock.ANY,
+                    },
+                    metadata=COMMON_RESPONSE_LLM_METADATA,
+                    model_name="gpt-4o-2024-08-06",
+                    model_provider="openai",
+                    tags=COMMON_TAGS,
+                    name=expected_span_names[i + 1],
                 )
             for tool_span in previous_tool_spans:
-                _assert_span_link(_SpanLinkView(tool_span), _SpanLinkView(span), "output", "input")
+                _assert_span_link(_link_view(tool_span), _link_view(span), "output", "input")
         else:
             tool_call = tool_calls[i // 2]
             assert_llmobs_span_data(
@@ -241,7 +208,7 @@ def _assert_expected_agent_run(
                 **_expected_tool_kwargs(tool_call),
             )
             # assert tool is linked to the previous LLM call
-            _assert_span_link(_SpanLinkView(spans[i]), _SpanLinkView(span), "output", "input")
+            _assert_span_link(_link_view(spans[i]), _link_view(span), "output", "input")
             previous_tool_spans.append(span)
     return previous_tool_spans
 
@@ -792,9 +759,9 @@ async def test_llmobs_oai_agents_with_guardrail_spans(
     assert len(spans) == 7
 
     # assert input guardrail span links to LLM span
-    _assert_span_link(_SpanLinkView(spans[2]), _SpanLinkView(spans[3]), "output", "input")
+    _assert_span_link(_link_view(spans[2]), _link_view(spans[3]), "output", "input")
     # assert LLM span links to output guardrail span
-    _assert_span_link(_SpanLinkView(spans[5]), _SpanLinkView(spans[6]), "output", "input")
+    _assert_span_link(_link_view(spans[5]), _link_view(spans[6]), "output", "input")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -134,7 +134,8 @@ def _llmobs_name(span):
 
 class _SpanLinkView:
     """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
-    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict."""
+    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict.
+    """
 
     def __init__(self, span):
         self._span = span
@@ -224,8 +225,7 @@ def _assert_expected_agent_run(
     # Names match the LLMObs name on each span in order.
     for i, span in enumerate(spans):
         assert _llmobs_name(span) == expected_span_names[i], (
-            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, "
-            f"actual={_llmobs_name(span)!r}"
+            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, actual={_llmobs_name(span)!r}"
         )
     # First span: agent span.
     assert_llmobs_span_data(

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -8,15 +8,6 @@ from tests.llmobs._utils import _assert_span_link
 from tests.llmobs._utils import assert_llmobs_span_data
 
 
-LLMOBS_GLOBAL_CONFIG = dict(
-    _dd_api_key="<not-a-real-api_key>",
-    _llmobs_ml_app="<ml-app-name>",
-    _llmobs_enabled=True,
-    _llmobs_sample_rate=1.0,
-    service="tests.contrib.agents",
-)
-
-
 COMMON_TAGS = {"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"}
 
 
@@ -259,9 +250,8 @@ def _assert_expected_agent_run(
     return previous_tool_spans
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent(agents, test_spans, request_vcr, simple_agent):
+async def test_llmobs_single_agent(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = await agents.Runner.run(simple_agent, "What is the capital of France?")
@@ -299,9 +289,8 @@ async def test_llmobs_single_agent(agents, test_spans, request_vcr, simple_agent
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, simple_agent):
+async def test_llmobs_streamed_single_agent(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     from openai.types.responses import ResponseTextDeltaEvent
 
     final_output = ""
@@ -345,8 +334,7 @@ async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, sim
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
-def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, simple_agent):
+def test_llmobs_single_agent_sync(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = agents.Runner.run_sync(simple_agent, "What is the capital of France?")
@@ -384,9 +372,8 @@ def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, simple_agent)
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, simple_agent):
+async def test_llmobs_manual_tracing_llmobs(agents, openai_agents_llmobs, test_spans, request_vcr, simple_agent):
     from agents.tracing import custom_span
     from agents.tracing import trace
 
@@ -436,9 +423,10 @@ async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, sim
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_calls_llmobs(agents, test_spans, request_vcr, addition_agent):
+async def test_llmobs_single_agent_with_tool_calls_llmobs(
+    agents, openai_agents_llmobs, test_spans, request_vcr, addition_agent
+):
     with request_vcr.use_cassette("test_single_agent_with_tool_calls.yaml"):
         result = await agents.Runner.run(addition_agent, "What is the sum of 1 and 2?")
 
@@ -507,9 +495,10 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(agents, test_spans, re
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_vcr, weather_agent):
+async def test_llmobs_single_agent_with_ootb_tools(
+    agents, openai_agents_llmobs, test_spans, request_vcr, weather_agent
+):
     with request_vcr.use_cassette("test_single_agent_with_ootb_tools.yaml"):
         result = await agents.Runner.run(weather_agent, "What is the weather like in New York right now?")
 
@@ -549,9 +538,8 @@ async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_v
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, research_workflow):
+async def test_llmobs_multiple_agent_handoffs(agents, openai_agents_llmobs, test_spans, request_vcr, research_workflow):
     with request_vcr.use_cassette("test_multiple_agent_handoffs.yaml"):
         result = await agents.Runner.run(
             research_workflow, "What is a brief summary of what happened yesterday in the soccer world??"
@@ -666,9 +654,10 @@ async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, r
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_errors(agents, test_spans, request_vcr, addition_agent_with_tool_errors):
+async def test_llmobs_single_agent_with_tool_errors(
+    agents, openai_agents_llmobs, test_spans, request_vcr, addition_agent_with_tool_errors
+):
     with request_vcr.use_cassette("test_agent_with_tool_errors.yaml"):
         result = await agents.Runner.run(addition_agent_with_tool_errors, "What is the sum of 1 and 2?")
     spans = [s for trace in test_spans.pop_traces() for s in trace]
@@ -748,10 +737,9 @@ async def test_llmobs_single_agent_with_tool_errors(agents, test_spans, request_
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
 async def test_llmobs_oai_agents_with_chat_completions_span_linking(
-    agents, openai, test_spans, request_vcr, research_workflow
+    agents, openai, openai_agents_llmobs, test_spans, request_vcr, research_workflow
 ):
     with request_vcr.use_cassette("test_multiple_agent_handoffs_with_chat_completions.yaml"):
         result = await agents.Runner.run(
@@ -796,9 +784,8 @@ async def test_llmobs_oai_agents_with_chat_completions_span_linking(
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 async def test_llmobs_oai_agents_with_guardrail_spans(
-    agents, openai, test_spans, request_vcr, simple_agent_with_guardrail
+    agents, openai, openai_agents_llmobs, test_spans, request_vcr, simple_agent_with_guardrail
 ):
     with request_vcr.use_cassette("test_oai_agents_with_guardrail_spans.yaml"):
         await agents.Runner.run(simple_agent_with_guardrail, "What is the sum of 1 and 2?")

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -3,9 +3,21 @@ from typing import Optional
 import mock
 import pytest
 
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from tests.llmobs._utils import _assert_span_link
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
-from tests.llmobs._utils import _expected_llmobs_non_llm_span_event
+from tests.llmobs._utils import assert_llmobs_span_data
+
+
+LLMOBS_GLOBAL_CONFIG = dict(
+    _dd_api_key="<not-a-real-api_key>",
+    _llmobs_ml_app="<ml-app-name>",
+    _llmobs_enabled=True,
+    _llmobs_sample_rate=1.0,
+    service="tests.contrib.agents",
+)
+
+
+COMMON_TAGS = {"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"}
 
 
 COMMON_RESPONSE_LLM_METADATA = {
@@ -115,111 +127,162 @@ def _expected_agent_metadata(agent_name: str) -> dict:
     return {"_dd": {"agent_manifest": AGENT_TO_EXPECTED_AGENT_MANIFEST[agent_name]}}
 
 
+def _llmobs_name(span):
+    """Get the LLMObs name from a span's meta_struct['_llmobs']."""
+    return _get_llmobs_data_metastruct(span).get("name")
+
+
+class _SpanLinkView:
+    """Lightweight adapter so ``_assert_span_link`` can read ``span_id`` and
+    ``span_links`` from an APM span's ``meta_struct['_llmobs']`` dict."""
+
+    def __init__(self, span):
+        self._span = span
+        self._metastruct = _get_llmobs_data_metastruct(span)
+
+    def __getitem__(self, key):
+        if key == "span_id":
+            return str(self._span.span_id)
+        if key == "span_links":
+            return self._metastruct.get("span_links", [])
+        raise KeyError(key)
+
+
+def _expected_agent_kwargs(span, agent_name: str) -> dict:
+    """Build the kwargs for ``assert_llmobs_span_data`` for an agent span."""
+    return dict(
+        span_kind="agent",
+        metadata=_expected_agent_metadata(agent_name),
+        tags=COMMON_TAGS,
+        name=agent_name,
+    )
+
+
+def _expected_llm_kwargs(
+    input_messages,
+    output_messages,
+    name: Optional[str] = None,
+) -> dict:
+    """Build the kwargs for ``assert_llmobs_span_data`` for an LLM (response) span."""
+    return dict(
+        span_kind="llm",
+        input_messages=input_messages,
+        output_messages=output_messages,
+        metrics={
+            "input_tokens": mock.ANY,
+            "output_tokens": mock.ANY,
+            "total_tokens": mock.ANY,
+            "reasoning_output_tokens": mock.ANY,
+        },
+        metadata=COMMON_RESPONSE_LLM_METADATA,
+        model_name="gpt-4o-2024-08-06",
+        model_provider="openai",
+        tags=COMMON_TAGS,
+        name=name,
+    )
+
+
+def _expected_tool_kwargs(tool_call: dict) -> dict:
+    """Build the kwargs for ``assert_llmobs_span_data`` for a tool span."""
+    error = None
+    if tool_call["error"]:
+        error = {
+            "type": "Error running tool (non-fatal)",
+            "message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
+            "stack": mock.ANY,
+        }
+    kwargs = dict(span_kind="tool", tags=COMMON_TAGS, error=error)
+    if tool_call["type"] in ("function_call", "handoff"):
+        kwargs["input_value"] = mock.ANY
+        kwargs["output_value"] = mock.ANY
+    return kwargs
+
+
 def _assert_expected_agent_run(
     expected_span_names: list[str],
     spans,
-    llmobs_events,
     llm_calls: Optional[list[tuple[list[dict], list[dict]]]] = None,
     tool_calls: Optional[list[dict]] = None,
-    previous_tool_events: Optional[list[dict]] = None,
-    is_chat=False,
-) -> list[dict]:
-    """Assert expected LLMObs events matches actual events for an agent run
-    Return previous tool events for span linking assertions across agent runs
+    previous_tool_spans: Optional[list] = None,
+    is_chat: bool = False,
+) -> list:
+    """Assert expected LLMObs span data for an agent run.
+
+    Returns the list of tool spans seen so far (for cross-run span-link assertions).
+
     Args:
-        spans: list of spans from the mock tracer
-        llmobs_events: list of LLMObs events
-        agent_name: Name of the agent
-        llm_calls: list of (input_messages, output_messages) for each LLM call
-        tool_calls: list of information about tool calls
-        previous_tool_events: list of previous tool events for span linking assertions across agent runs
+        expected_span_names: ordered list of LLMObs span names expected for this run.
+        spans: list of APM spans, sorted by start_ns, beginning with the agent span.
+        llm_calls: list of ``(input_messages, output_messages)`` pairs for each LLM call.
+        tool_calls: list of dicts describing each tool call (``type``, ``error``, optional ``tool_name``).
+        previous_tool_spans: list of tool spans from prior agent runs to assert span-links against.
+        is_chat: when True, the LLM span is produced by the openai integration (chat completions);
+            skip its event-shape assertion (kept compatible with the original test).
     """
-    for i, event in enumerate(llmobs_events):
-        assert event["name"] == expected_span_names[i]
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
-        span_kind="agent",
-        metadata=_expected_agent_metadata(llmobs_events[0]["name"]),
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+    if previous_tool_spans is None:
+        previous_tool_spans = []
+    # Names match the LLMObs name on each span in order.
+    for i, span in enumerate(spans):
+        assert _llmobs_name(span) == expected_span_names[i], (
+            f"span[{i}] name mismatch: expected={expected_span_names[i]!r}, "
+            f"actual={_llmobs_name(span)!r}"
+        )
+    # First span: agent span.
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        **_expected_agent_kwargs(spans[0], _llmobs_name(spans[0])),
     )
-    if not previous_tool_events:
-        previous_tool_events = []
-    for i, event in enumerate(llmobs_events[1:]):
+
+    for i, span in enumerate(spans[1:]):
         if i % 2 == 0:
-            assert is_chat or event == _expected_llmobs_llm_span_event(
-                spans[i + 1],
-                span_kind="llm",
-                input_messages=llm_calls[i // 2][0],
-                output_messages=llm_calls[i // 2][1],
-                token_metrics={
-                    "input_tokens": mock.ANY,
-                    "output_tokens": mock.ANY,
-                    "total_tokens": mock.ANY,
-                    "reasoning_output_tokens": mock.ANY,
-                },
-                metadata=COMMON_RESPONSE_LLM_METADATA,
-                model_name="gpt-4o-2024-08-06",
-                model_provider="openai",
-                tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
-                span_links=i or previous_tool_events,
-                name=expected_span_names[i + 1],
-            )
-            for tool in previous_tool_events:
-                _assert_span_link(tool, event, "output", "input")
+            # LLM span — skip strict assertion in chat mode (handled by openai integration).
+            if not is_chat:
+                assert_llmobs_span_data(
+                    _get_llmobs_data_metastruct(span),
+                    **_expected_llm_kwargs(
+                        input_messages=llm_calls[i // 2][0],
+                        output_messages=llm_calls[i // 2][1],
+                        name=expected_span_names[i + 1],
+                    ),
+                )
+            for tool_span in previous_tool_spans:
+                _assert_span_link(_SpanLinkView(tool_span), _SpanLinkView(span), "output", "input")
         else:
             tool_call = tool_calls[i // 2]
-            error_args = (
-                {
-                    "error_message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
-                    "error": "Error running tool (non-fatal)",
-                }
-                if tool_call["error"]
-                else {}
-            )
-            io_args = (
-                {"input_value": mock.ANY, "output_value": mock.ANY}
-                if tool_call["type"] in ("function_call", "handoff")
-                else {}
-            )
-            assert event == _expected_llmobs_non_llm_span_event(
-                spans[i + 1],
-                span_kind="tool",
-                tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
-                span_links=True,
-                **io_args,
-                **error_args,
+            assert_llmobs_span_data(
+                _get_llmobs_data_metastruct(span),
+                **_expected_tool_kwargs(tool_call),
             )
             # assert tool is linked to the previous LLM call
-            _assert_span_link(llmobs_events[i], event, "output", "input")
-            previous_tool_events.append(event)
-    return previous_tool_events
+            _assert_span_link(_SpanLinkView(spans[i]), _SpanLinkView(span), "output", "input")
+            previous_tool_spans.append(span)
+    return previous_tool_spans
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+async def test_llmobs_single_agent(agents, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = await agents.Runner.run(simple_agent, "What is the capital of France?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert spans[0].name == "Agent workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -236,8 +299,9 @@ async def test_llmobs_single_agent(agents, test_spans, request_vcr, llmobs_event
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, simple_agent):
     from openai.types.responses import ResponseTextDeltaEvent
 
     final_output = ""
@@ -248,25 +312,23 @@ async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, llm
             if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
                 final_output += event.data.delta
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert llmobs_events[0]["name"] == "Agent workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -283,30 +345,29 @@ async def test_llmobs_streamed_single_agent(agents, test_spans, request_vcr, llm
     )
 
 
-def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
+def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, simple_agent):
     """Test tracing with a simple agent with no tools or handoffs"""
     with request_vcr.use_cassette("test_simple_agent.yaml"):
         result = agents.Runner.run_sync(simple_agent, "What is the capital of France?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert llmobs_events[0]["name"] == "Agent workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Agent workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -323,8 +384,9 @@ def test_llmobs_single_agent_sync(agents, test_spans, request_vcr, llmobs_events
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, llmobs_events, simple_agent):
+async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, simple_agent):
     from agents.tracing import custom_span
     from agents.tracing import trace
 
@@ -335,31 +397,29 @@ async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, llm
             cspan.finish()
             result = await agents.Runner.run(simple_agent, "What is the capital of France?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 4
+    assert len(spans) == 4
 
-    assert llmobs_events[0]["name"] == "Simple Workflow"
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert _llmobs_name(spans[0]) == "Simple Workflow"
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the capital of France?",
         output_value=result.final_output,
         metadata={"foo": "bar"},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
-    assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
-        spans[1],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[1]),
         span_kind="task",
         metadata={"foo": "bar"},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Simple Agent", "Simple Agent (LLM)"],
         spans[2:],
-        llmobs_events[2:],
         llm_calls=[
             (
                 [
@@ -376,31 +436,28 @@ async def test_llmobs_manual_tracing_llmobs(agents, test_spans, request_vcr, llm
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_calls_llmobs(
-    agents, test_spans, request_vcr, llmobs_events, addition_agent
-):
+async def test_llmobs_single_agent_with_tool_calls_llmobs(agents, test_spans, request_vcr, addition_agent):
     with request_vcr.use_cassette("test_single_agent_with_tool_calls.yaml"):
         result = await agents.Runner.run(addition_agent, "What is the sum of 1 and 2?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 5
+    assert len(spans) == 5
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the sum of 1 and 2?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Addition Agent", "Addition Agent (LLM)", "add", "Addition Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -450,29 +507,28 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_vcr, llmobs_events, weather_agent):
+async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_vcr, weather_agent):
     with request_vcr.use_cassette("test_single_agent_with_ootb_tools.yaml"):
         result = await agents.Runner.run(weather_agent, "What is the weather like in New York right now?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 3
+    assert len(spans) == 3
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the weather like in New York right now?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Weather Agent", "Weather Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -493,32 +549,31 @@ async def test_llmobs_single_agent_with_ootb_tools(agents, test_spans, request_v
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, llmobs_events, research_workflow):
+async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, research_workflow):
     with request_vcr.use_cassette("test_multiple_agent_handoffs.yaml"):
         result = await agents.Runner.run(
             research_workflow, "What is a brief summary of what happened yesterday in the soccer world??"
         )
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 8
+    assert len(spans) == 8
 
     # top level workflow
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is a brief summary of what happened yesterday in the soccer world??",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
-    previous_tool_events = _assert_expected_agent_run(
+    previous_tool_spans = _assert_expected_agent_run(
         ["Researcher", "Researcher (LLM)", "research", "Researcher (LLM)", "transfer_to_summarizer"],
         spans[1:6],
-        llmobs_events[1:6],
         llm_calls=[
             (
                 [
@@ -600,7 +655,6 @@ async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, l
     _assert_expected_agent_run(
         ["Summarizer", "Summarizer (LLM)"],
         spans[6:],
-        llmobs_events[6:],
         llm_calls=[
             (
                 mock.ANY,
@@ -608,34 +662,31 @@ async def test_llmobs_multiple_agent_handoffs(agents, test_spans, request_vcr, l
             )
         ],
         tool_calls=[],
-        previous_tool_events=previous_tool_events[-1:],
+        previous_tool_spans=previous_tool_spans[-1:],
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
-async def test_llmobs_single_agent_with_tool_errors(
-    agents, test_spans, request_vcr, llmobs_events, addition_agent_with_tool_errors
-):
+async def test_llmobs_single_agent_with_tool_errors(agents, test_spans, request_vcr, addition_agent_with_tool_errors):
     with request_vcr.use_cassette("test_agent_with_tool_errors.yaml"):
         result = await agents.Runner.run(addition_agent_with_tool_errors, "What is the sum of 1 and 2?")
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 5
+    assert len(spans) == 5
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         input_value="What is the sum of 1 and 2?",
         output_value=result.final_output,
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
     _assert_expected_agent_run(
         ["Addition Agent", "Addition Agent (LLM)", "add", "Addition Agent (LLM)"],
         spans[1:],
-        llmobs_events[1:],
         llm_calls=[
             (
                 [
@@ -697,28 +748,28 @@ async def test_llmobs_single_agent_with_tool_errors(
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 @pytest.mark.asyncio
 async def test_llmobs_oai_agents_with_chat_completions_span_linking(
-    agents, openai, test_spans, request_vcr, llmobs_events, research_workflow
+    agents, openai, test_spans, request_vcr, research_workflow
 ):
     with request_vcr.use_cassette("test_multiple_agent_handoffs_with_chat_completions.yaml"):
         result = await agents.Runner.run(
             research_workflow, "Research and then summarize what happened yesterday in the soccer world"
         )
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 8
+    assert len(spans) == 8
 
-    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        spans[0],
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
         span_kind="workflow",
         metadata={},
-        tags={"service": "tests.contrib.agents", "ml_app": "<ml-app-name>", "integration": "openai_agents"},
+        tags=COMMON_TAGS,
     )
-    previous_tool_events = _assert_expected_agent_run(
+    previous_tool_spans = _assert_expected_agent_run(
         [
             "Researcher",
             "OpenAI.createChatCompletion",
@@ -727,14 +778,12 @@ async def test_llmobs_oai_agents_with_chat_completions_span_linking(
             "transfer_to_summarizer",
         ],
         spans[1:6],
-        llmobs_events[1:6],
         tool_calls=[{"type": "function_call", "error": False}, {"type": "handoff", "error": False}],
         is_chat=True,
     )
     _assert_expected_agent_run(
         ["Summarizer", "OpenAI.createChatCompletion"],
         spans[6:],
-        llmobs_events[6:],
         llm_calls=[
             (
                 mock.ANY,
@@ -742,27 +791,27 @@ async def test_llmobs_oai_agents_with_chat_completions_span_linking(
             )
         ],
         tool_calls=[],
-        previous_tool_events=previous_tool_events[-1:],
+        previous_tool_spans=previous_tool_spans[-1:],
         is_chat=True,
     )
 
 
+@pytest.mark.parametrize("ddtrace_global_config", [LLMOBS_GLOBAL_CONFIG])
 async def test_llmobs_oai_agents_with_guardrail_spans(
-    agents, openai, test_spans, request_vcr, llmobs_events, simple_agent_with_guardrail
+    agents, openai, test_spans, request_vcr, simple_agent_with_guardrail
 ):
     with request_vcr.use_cassette("test_oai_agents_with_guardrail_spans.yaml"):
         await agents.Runner.run(simple_agent_with_guardrail, "What is the sum of 1 and 2?")
 
-    spans = test_spans.pop_traces()[0]
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
     spans.sort(key=lambda span: span.start_ns)
-    llmobs_events.sort(key=lambda event: event["start_ns"])
 
-    assert len(spans) == len(llmobs_events) == 7
+    assert len(spans) == 7
 
     # assert input guardrail span links to LLM span
-    _assert_span_link(llmobs_events[2], llmobs_events[3], "output", "input")
+    _assert_span_link(_SpanLinkView(spans[2]), _SpanLinkView(spans[3]), "output", "input")
     # assert LLM span links to output guardrail span
-    _assert_span_link(llmobs_events[5], llmobs_events[6], "output", "input")
+    _assert_span_link(_SpanLinkView(spans[5]), _SpanLinkView(spans[6]), "output", "input")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -125,22 +125,6 @@ def _link_view(span):
     return {"span_id": str(span.span_id), "span_links": get_llmobs_span_links(span) or []}
 
 
-def _expected_tool_kwargs(tool_call: dict) -> dict:
-    """Build the kwargs for ``assert_llmobs_span_data`` for a tool span."""
-    error = None
-    if tool_call["error"]:
-        error = {
-            "type": "Error running tool (non-fatal)",
-            "message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
-            "stack": mock.ANY,
-        }
-    kwargs = dict(span_kind="tool", tags=COMMON_TAGS, error=error)
-    if tool_call["type"] in ("function_call", "handoff"):
-        kwargs["input_value"] = mock.ANY
-        kwargs["output_value"] = mock.ANY
-    return kwargs
-
-
 def _assert_expected_agent_run(
     expected_span_names: list[str],
     spans,
@@ -203,9 +187,24 @@ def _assert_expected_agent_run(
                 _assert_span_link(_link_view(tool_span), _link_view(span), "output", "input")
         else:
             tool_call = tool_calls[i // 2]
+            error = None
+            if tool_call["error"]:
+                error = {
+                    "type": "Error running tool (non-fatal)",
+                    "message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
+                    "stack": mock.ANY,
+                }
+            io_args = (
+                {"input_value": mock.ANY, "output_value": mock.ANY}
+                if tool_call["type"] in ("function_call", "handoff")
+                else {}
+            )
             assert_llmobs_span_data(
                 _get_llmobs_data_metastruct(span),
-                **_expected_tool_kwargs(tool_call),
+                span_kind="tool",
+                tags=COMMON_TAGS,
+                error=error,
+                **io_args,
             )
             # assert tool is linked to the previous LLM call
             _assert_span_link(_link_view(spans[i]), _link_view(span), "output", "input")

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -20,6 +20,7 @@ from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
 from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._llmobs import _STANDARD_INTEGRATION_SPAN_NAMES
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
+from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
 from ddtrace.llmobs._writer import LLMObsSpanWriter
 from ddtrace.trace import Span
@@ -1006,18 +1007,19 @@ class TestLLMObsSpanWriter(LLMObsSpanWriter):
         super().enqueue(event)
 
 
-def _assert_span_link(from_span_event, to_span_event, from_io, to_io):
+def _assert_span_link(from_span, to_span, from_io, to_io):
+    """Assert a span link exists from ``from_span`` to ``to_span``.
+
+    Both arguments are APM ``Span`` objects whose ``meta_struct['_llmobs']``
+    payload is read via ``get_llmobs_span_links``. Pass ``from_span=None`` to
+    assert the destination span has no incoming link (``span_id="undefined"``).
     """
-    Assert that a span link exists between two span events, specifically the correct span ID and from/to specification.
-    """
-    found = False
-    expected_to_span_id = "undefined" if not from_span_event else from_span_event["span_id"]
-    for span_link in to_span_event["span_links"]:
+    expected_to_span_id = "undefined" if from_span is None else str(from_span.span_id)
+    for span_link in get_llmobs_span_links(to_span) or []:
         if span_link["span_id"] == expected_to_span_id:
             assert span_link["attributes"] == {"from": from_io, "to": to_io}
-            found = True
-            break
-    assert found
+            return
+    assert False, "expected span link not found"
 
 
 def iterate_stream(stream):

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -1008,12 +1008,7 @@ class TestLLMObsSpanWriter(LLMObsSpanWriter):
 
 
 def _assert_span_link(from_span, to_span, from_io, to_io):
-    """Assert a span link exists from ``from_span`` to ``to_span``.
-
-    Both arguments are APM ``Span`` objects whose ``meta_struct['_llmobs']``
-    payload is read via ``get_llmobs_span_links``. Pass ``from_span=None`` to
-    assert the destination span has no incoming link (``span_id="undefined"``).
-    """
+    """Assert a span link from ``from_span`` (or None for "undefined") to ``to_span``."""
     expected_to_span_id = "undefined" if from_span is None else str(from_span.span_id)
     for span_link in get_llmobs_span_links(to_span) or []:
         if span_link["span_id"] == expected_to_span_id:


### PR DESCRIPTION
Migrates crewai, langgraph, and openai_agents LLMObs tests from inspecting projected wire `LLMObsSpanEvent`s (via `mock_llmobs_writer.enqueue.*` / `llmobs_events`) to reading the canonical `LLMObsSpanData` directly off `span.meta_struct["_llmobs"]` and asserting via `assert_llmobs_span_data(_get_llmobs_data_metastruct(spans[i]), ...)`. Combined into one PR because all three use `_assert_span_link`, which is updated here to accept `Span` objects directly via `get_llmobs_span_links()` — that change folds the per-integration `_link_view`/`_link_event` adapters into the matcher itself.

Conftest (per integration): replaces the `test_spans` override / `mock_llmobs_writer` plumbing with a `crewai_llmobs` / `langgraph_llmobs` / `openai_agents_llmobs(tracer, monkeypatch)` fixture that sets `_DD_LLMOBS_TEST_KEEP_META_STRUCT=1`, enables LLMObs against the test tracer, and mocks the span writer.

Stacked on #17789.
