### PR TITLE
ci(serverless): [DO NOT MERGE] validate lambda-python linkage fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,11 @@ serverless lambda tests:
   trigger:
     project: DataDog/datadog-lambda-python
     strategy: depend
-    branch: main
+    # AIDEV-TODO: TEMPORARY — REVERT to `branch: main` before merging this PR.
+    # Pointed at the lambda-python PR (DataDog/datadog-lambda-python#813) so
+    # we can validate that its setup_python_env.sh actually fetches this
+    # PR's ddtrace wheel via UPSTREAM_PIPELINE_ID.
+    branch: rey.abolofia/fix-ddtrace-pr
   needs:
     - job: "upload serverless"
   variables:


### PR DESCRIPTION
> ## :warning: DO NOT MERGE
>
> Temporary PR. Will be **closed without merging** once we've confirmed the linkage fix in DataDog/datadog-lambda-python#813 actually pulls this PR's ddtrace wheel into lambda-python's `unit-test` job.

## Summary

Points the `serverless lambda tests` trigger at the lambda-python PR branch (`rey.abolofia/fix-ddtrace-pr`) instead of `main`. With that change, this PR's CI:

1. Builds + uploads serverless wheels (`upload serverless` job, unchanged).
2. Triggers lambda-python's PR pipeline with `UPSTREAM_PIPELINE_ID = $CI_PIPELINE_ID`.
3. Lambda-python's PR has the new `scripts/setup_python_env.sh` which rewrites `pyproject.toml`'s ddtrace dep to point at the wheel uploaded in step 1, then runs `pip install .[dev]` and `pytest -vv` against it.

If the linkage is wired correctly, the unit-test job's logs should print `ddtrace version: <dev-shape string>` from the diagnostic line in `setup_python_env.sh`.

## Background

dd-trace-py's `serverless lambda tests` job triggers lambda-python on every dd-trace-py PR with `UPSTREAM_PIPELINE_ID` set, but lambda-python's `unit-test` job was running `pip install .[dev]` against the released ddtrace — so dd-trace-py PRs that broke lambda-python imports went undetected. That's how v4.8.0 shipped and required emergency hotfix lambda-python#811 (`fix: pin ddtrace to <4.8.0 to avoid import errors`). DataDog/datadog-lambda-python#813 fixes the unit-test side; this PR validates the round-trip.

## Test plan

- [ ] Push triggers dd-trace-py CI; `serverless lambda tests` job dispatches lambda-python's `rey.abolofia/fix-ddtrace-pr` pipeline.
- [ ] In the dispatched lambda-python pipeline, inspect a `unit-test (pythonXY-amd64)` job log and confirm:
  - [ ] `Replacing ddtrace dep with: ddtrace_serverless = { file = "..." }` line is present.
  - [ ] `ddtrace version: <dev-shape>` line is present (suffixed with `.dev`/`.post`/`+sha`, not a clean release tag).
  - [ ] `pytest -vv` runs against the swapped ddtrace and passes.
- [ ] Close this PR without merging once the above is confirmed; lambda-python#813 is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)