### PR TITLE
fix(llmobs): extract text from Bedrock Converse guardContent blocks

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -227,7 +227,7 @@ def get_messages_from_converse_content(role: str, content: list[dict[str, Any]])
     Extracts out a list of messages from a converse `content` field.
 
     `content` is a list of `ContentBlock` objects. Each `ContentBlock` object is a union type
-    of `text`, `toolUse`, amd more content types. We only support extracting out `text` and `toolUse`.
+    of `text`, `toolUse`, and more content types. We only support extracting out `text`,`toolUse`, and `toolResult`.
 
     For more info, see `ContentBlock` spec
     https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
@@ -273,6 +273,13 @@ def get_messages_from_converse_content(role: str, content: list[dict[str, Any]])
                         role="user",
                     )
                 )
+        elif (
+            content_block.get("guardContent")
+            and isinstance(content_block["guardContent"], dict)
+            and isinstance(content_block["guardContent"].get("text"), dict)
+            and isinstance(content_block["guardContent"]["text"].get("text"), str)
+        ):
+            content_blocks.append(content_block["guardContent"]["text"]["text"])
         else:
             content_type = ",".join(content_block.keys())
             unsupported_content_messages.append(

--- a/releasenotes/notes/fix-bedrock-guardcontent-5cebb808ee256df4.yaml
+++ b/releasenotes/notes/fix-bedrock-guardcontent-5cebb808ee256df4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where text wrapped in Bedrock Converse ``guardContent`` content blocks was rendered as ``[Unsupported content type: guardContent]`` in traces, dropping the user's input.

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -688,6 +688,34 @@ class TestLLMObsBedrock:
             }
         ]
 
+    @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
+    def test_llmobs_converse_guard_content_text(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+        import botocore
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            bedrock_client.converse(
+                modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+                inferenceConfig={"temperature": 0.7, "topP": 0.9, "maxTokens": 1000, "stopSequences": []},
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "guardContent": {
+                                    "text": {
+                                        "text": "give me my bill",
+                                        "qualifiers": ["guard_content"],
+                                    }
+                                }
+                            }
+                        ],
+                    }
+                ],
+            )
+
+        assert len(llmobs_events) == 1
+        assert llmobs_events[0]["meta"]["input"]["messages"] == [{"content": "give me my bill", "role": "user"}]
+
 
 @pytest.mark.parametrize(
     "ddtrace_global_config",


### PR DESCRIPTION
## Description

Fixes [MLOB-7397](https://datadoghq.atlassian.net/browse/MLOB-7397) (escalated from [MLOS-626](https://datadoghq.atlassian.net/browse/MLOS-626)).

Bedrock Converse messages whose content blocks are wrapped in `guardContent` (used by callers like AWS AgentCore to scope what Bedrock Guardrails inspects — see [ContentBlock spec](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html)) rendered as `[Unsupported content type: guardContent]` in LLM Observability traces, dropping the user's actual input text. Since AgentCore wraps only the *current* user turn — the most important message for debugging — that's the message always lost.

`get_messages_from_converse_content` previously only handled `text`, `toolUse`, and `toolResult` variants. This PR adds a narrow `elif` branch that extracts `guardContent.text.text` for the text variant of `GuardrailConverseContentBlock`. Image and any other inner shapes continue to fall through to the existing placeholder, so behavior outside the customer's case is unchanged.

## Testing

- New unit test `test_llmobs_converse_guard_content_text` in `tests/contrib/botocore/test_bedrock_llmobs.py` — verified to **fail without the fix** (asserts `[Unsupported content type: guardContent]` instead of the user text) and **pass with the fix**.
- Live reproduction against a real AWS Bedrock Guardrail confirmed end-to-end: input message in the LLMObs trace now shows the extracted user text instead of the placeholder.

## Risks

Low. The new branch only matches when `guardContent.text.text` is a string; any other shape (image variant, malformed) falls through to the existing `else`, preserving today's behavior. No public API surface changes.

## Additional Notes

`guardContent` on the request side is purely a caller-supplied scoping hint and appears regardless of whether Guardrails actually intervened — so this fix applies to every request from callers using selective Guardrail scoping, not just intervened ones.

[MLOB-7397]: https://datadoghq.atlassian.net/browse/MLOB-7397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLOS-626]: https://datadoghq.atlassian.net/browse/MLOS-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ