### PR TITLE
fix: limit baggage header extraction

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -953,16 +953,37 @@ class _BaggageHeader:
             return Context(baggage={})
 
         baggage = {}
+        total_size = 0
         baggages = header_value.split(",")
-        for key_value in baggages:
+        for pair_index, key_value in enumerate(baggages):
+            if pair_index >= DD_TRACE_BAGGAGE_MAX_ITEMS:
+                log.warning("Baggage item limit exceeded, dropping excess items")
+                telemetry_writer.add_count_metric(
+                    namespace=TELEMETRY_NAMESPACE.TRACERS,
+                    name="context_header.truncated",
+                    value=1,
+                    tags=(("truncation_reason", "baggage_item_count_exceeded"),),
+                )
+                break
             if "=" not in key_value:
                 return _BaggageHeader._record_malformed_and_return_empty()
+            segment_bytes = len(key_value.encode("utf-8")) + (1 if baggage else 0)
+            if total_size + segment_bytes > DD_TRACE_BAGGAGE_MAX_BYTES:
+                log.warning("Baggage header size exceeded, dropping excess items")
+                telemetry_writer.add_count_metric(
+                    namespace=TELEMETRY_NAMESPACE.TRACERS,
+                    name="context_header.truncated",
+                    value=1,
+                    tags=(("truncation_reason", "baggage_byte_count_exceeded"),),
+                )
+                break
             key, value = key_value.split("=", 1)
             key = urllib.parse.unquote(key.strip())
             value = urllib.parse.unquote(value.strip())
             if not key or not value:
                 return _BaggageHeader._record_malformed_and_return_empty()
             baggage[key] = value
+            total_size += segment_bytes
 
         return Context(baggage=baggage)
 

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,6 +1,5 @@
 import itertools
 import re
-from typing import Dict  # noqa:F401
 from typing import Literal  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Union
@@ -953,7 +952,7 @@ class _BaggageHeader:
         if not header_value:
             return Context(baggage={})
 
-        baggage: Dict[str, str] = {}
+        baggage: dict[str, str] = {}
         total_size = 0
         baggages = header_value.split(",")
         for pair_index, key_value in enumerate(baggages):

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,5 +1,6 @@
 import itertools
 import re
+from typing import Dict  # noqa:F401
 from typing import Literal  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Union
@@ -952,7 +953,7 @@ class _BaggageHeader:
         if not header_value:
             return Context(baggage={})
 
-        baggage = {}
+        baggage: Dict[str, str] = {}
         total_size = 0
         baggages = header_value.split(",")
         for pair_index, key_value in enumerate(baggages):

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -957,7 +957,7 @@ class _BaggageHeader:
         baggages = header_value.split(",")
         for pair_index, key_value in enumerate(baggages):
             if pair_index >= DD_TRACE_BAGGAGE_MAX_ITEMS:
-                log.warning("Baggage item limit exceeded, dropping excess items")
+                log.warning("Baggage item limit exceeded, dropping excess items, skipped: %d items", len(baggages) - DD_TRACE_BAGGAGE_MAX_ITEMS)
                 telemetry_writer.add_count_metric(
                     namespace=TELEMETRY_NAMESPACE.TRACERS,
                     name="context_header.truncated",

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -66,6 +66,7 @@ _HTTP_HEADER_TAGS: Literal["x-datadog-tags"] = "x-datadog-tags"
 _HTTP_HEADER_TRACEPARENT: Literal["traceparent"] = "traceparent"
 _HTTP_HEADER_TRACESTATE: Literal["tracestate"] = "tracestate"
 _HTTP_HEADER_BAGGAGE: Literal["baggage"] = "baggage"
+BAGGAGE_DELIMITER = ","
 
 
 def _possible_header(header: str) -> frozenset[str]:
@@ -952,12 +953,15 @@ class _BaggageHeader:
         if not header_value:
             return Context(baggage={})
 
-        baggage: dict[str, str] = {}
+        baggage_data: dict[str, str] = {}
         total_size = 0
-        baggages = header_value.split(",")
-        for pair_index, key_value in enumerate(baggages):
+        splitted_header = header_value.split(BAGGAGE_DELIMITER)
+        for pair_index, key_value in enumerate(splitted_header):
             if pair_index >= DD_TRACE_BAGGAGE_MAX_ITEMS:
-                log.warning("Baggage item limit exceeded, dropping excess items, skipped: %d items", len(baggages) - DD_TRACE_BAGGAGE_MAX_ITEMS)
+                log.warning(
+                    "Baggage item limit exceeded, dropping excess items, skipped: %d items",
+                    len(splitted_header) - DD_TRACE_BAGGAGE_MAX_ITEMS,
+                )
                 telemetry_writer.add_count_metric(
                     namespace=TELEMETRY_NAMESPACE.TRACERS,
                     name="context_header.truncated",
@@ -967,9 +971,13 @@ class _BaggageHeader:
                 break
             if "=" not in key_value:
                 return _BaggageHeader._record_malformed_and_return_empty()
-            segment_bytes = len(key_value.encode("utf-8")) + (1 if baggage else 0)
+            base_size_bytes = len(key_value) if key_value.isascii() else len(key_value.encode("utf-8"))
+            segment_bytes = base_size_bytes + (len(BAGGAGE_DELIMITER) if baggage_data else 0)
             if total_size + segment_bytes > DD_TRACE_BAGGAGE_MAX_BYTES:
-                log.warning("Baggage header size exceeded, dropping excess items")
+                log.warning(
+                    "Baggage header size exceeded, dropping excess items. size would be %d bytes",
+                    total_size + segment_bytes,
+                )
                 telemetry_writer.add_count_metric(
                     namespace=TELEMETRY_NAMESPACE.TRACERS,
                     name="context_header.truncated",
@@ -982,10 +990,10 @@ class _BaggageHeader:
             value = urllib.parse.unquote(value.strip())
             if not key or not value:
                 return _BaggageHeader._record_malformed_and_return_empty()
-            baggage[key] = value
+            baggage_data[key] = value
             total_size += segment_bytes
 
-        return Context(baggage=baggage)
+        return Context(baggage=baggage_data)
 
 
 _PROP_STYLES = {

--- a/releasenotes/notes/tracing-baggage-extract-respects-max-limits-0b2b2ba957799159.yaml
+++ b/releasenotes/notes/tracing-baggage-extract-respects-max-limits-0b2b2ba957799159.yaml
@@ -1,6 +1,6 @@
 fixes:
   - |
-    tracing: Parsing incoming ``baggage`` HTTP headers now respects ``DD_TRACE_BAGGAGE_MAX_ITEMS``
-    and ``DD_TRACE_BAGGAGE_MAX_BYTES``, consistent with baggage injection. Previously, extraction
+    tracing: Parsing incoming ``baggage`` HTTP headers now respects ``DD_TRACE_BAGGAGE_MAX_ITEMS`` [default 64]
+    and ``DD_TRACE_BAGGAGE_MAX_BYTES`` [default 8192], consistent with baggage injection. Previously, extraction
     could retain every comma-separated entry regardless of those limits. The tracer drops excess
     pairs and records truncation telemetry when limits apply.

--- a/releasenotes/notes/tracing-baggage-extract-respects-max-limits-0b2b2ba957799159.yaml
+++ b/releasenotes/notes/tracing-baggage-extract-respects-max-limits-0b2b2ba957799159.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    tracing: Parsing incoming ``baggage`` HTTP headers now respects ``DD_TRACE_BAGGAGE_MAX_ITEMS``
+    and ``DD_TRACE_BAGGAGE_MAX_BYTES``, consistent with baggage injection. Previously, extraction
+    could retain every comma-separated entry regardless of those limits. The tracer drops excess
+    pairs and records truncation telemetry when limits apply.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -3464,6 +3464,65 @@ def test_baggageheader_maxbytes_inject():
     assert "key2" in header_value
 
 
+def test_baggageheader_maxitems_extract():
+    from ddtrace.internal.constants import DD_TRACE_BAGGAGE_MAX_ITEMS
+
+    pairs = [f"k{i}=v{i}" for i in range(DD_TRACE_BAGGAGE_MAX_ITEMS + 3)]
+    header_value = ",".join(pairs)
+    context = _BaggageHeader._extract({"baggage": header_value})
+    assert len(context._baggage) == DD_TRACE_BAGGAGE_MAX_ITEMS
+    for i in range(DD_TRACE_BAGGAGE_MAX_ITEMS):
+        assert context._baggage[f"k{i}"] == f"v{i}"
+    assert f"k{DD_TRACE_BAGGAGE_MAX_ITEMS}" not in context._baggage
+
+
+def test_baggageheader_maxitems_maxbytes_extract():
+    from ddtrace.internal.constants import DD_TRACE_BAGGAGE_MAX_BYTES
+    from ddtrace.internal.constants import DD_TRACE_BAGGAGE_MAX_ITEMS
+
+    pairs = []
+    for i in range(DD_TRACE_BAGGAGE_MAX_ITEMS + 3):
+        prefix = f"k{i}="
+        pad_len = DD_TRACE_BAGGAGE_MAX_BYTES - len(prefix.encode("utf-8"))
+        val = "v" * pad_len
+        pair = f"k{i}={val}"
+        assert len(pair.encode("utf-8")) == DD_TRACE_BAGGAGE_MAX_BYTES
+        pairs.append(pair)
+
+    header_value = ",".join(pairs)
+    context = _BaggageHeader._extract({"baggage": header_value})
+    # First segment fills the byte budget; comma + next segment exceed DD_TRACE_BAGGAGE_MAX_BYTES.
+    assert len(context._baggage) == 1
+    assert context._baggage["k0"] == pairs[0].split("=", 1)[1]
+    assert f"k{DD_TRACE_BAGGAGE_MAX_ITEMS}" not in context._baggage
+
+
+def test_baggageheader_maxbytes_extract():
+    from ddtrace.internal.constants import DD_TRACE_BAGGAGE_MAX_BYTES
+
+    # Single pair whose raw segment exceeds the byte limit — nothing parsed into baggage.
+    huge = "x" * (DD_TRACE_BAGGAGE_MAX_BYTES + 1)
+    context = _BaggageHeader._extract({"baggage": f"k={huge}"})
+    assert context._baggage == {}
+
+    # Multiple pairs: keep a prefix whose comma-separated wire size stays within the limit.
+    chunk = "a" * (DD_TRACE_BAGGAGE_MAX_BYTES // 3)
+    header_value = ",".join([f"key{i}={chunk}" for i in range(4)])
+    context = _BaggageHeader._extract({"baggage": header_value})
+    total_size = 0
+    expected_baggage = {}
+    for seg in header_value.split(","):
+        segment_bytes = len(seg.encode("utf-8")) + (1 if expected_baggage else 0)
+        if total_size + segment_bytes > DD_TRACE_BAGGAGE_MAX_BYTES:
+            break
+        key, _, value = seg.partition("=")
+        expected_baggage[key] = value
+        total_size += segment_bytes
+    assert context._baggage == expected_baggage
+    assert total_size <= DD_TRACE_BAGGAGE_MAX_BYTES
+    assert "key3" not in context._baggage
+
+
 @pytest.mark.parametrize(
     "headers,expected_baggage",
     [


### PR DESCRIPTION
Parsing incoming ``baggage`` HTTP headers now respects ``DD_TRACE_BAGGAGE_MAX_ITEMS`` and ``DD_TRACE_BAGGAGE_MAX_BYTES``, consistent with baggage injection. Previously, extraction could retain every comma-separated entry regardless of those limits. The tracer drops excess pairs and records truncation telemetry when limits apply.
