### PR TITLE
fix: limit tracestate header extraction

### DIFF
--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -106,6 +106,8 @@ BAGGAGE_TAG_PREFIX = "baggage."
 # max 32 list-members; vendors SHOULD propagate at least 512 characters (we cap parsing to that size).
 DD_TRACE_TRACESTATE_MAX_ITEMS = 32
 DD_TRACE_TRACESTATE_MAX_BYTES = 512
+# Per W3C Trace Context, oversized list-members are preferred targets when truncating by size.
+DD_TRACE_TRACESTATE_ITEM_MAX_CHARS = 128
 
 SPAN_EVENTS_HAS_EXCEPTION = "_dd.span_events.has_exception"
 COLLECTOR_MAX_SIZE_PER_SPAN = 100

--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -102,6 +102,11 @@ DD_TRACE_BAGGAGE_MAX_ITEMS = 64
 DD_TRACE_BAGGAGE_MAX_BYTES = 8192
 BAGGAGE_TAG_PREFIX = "baggage."
 
+# W3C Trace Context tracestate (https://www.w3.org/TR/trace-context/):
+# max 32 list-members; vendors SHOULD propagate at least 512 characters (we cap parsing to that size).
+DD_TRACE_TRACESTATE_MAX_ITEMS = 32
+DD_TRACE_TRACESTATE_MAX_BYTES = 512
+
 SPAN_EVENTS_HAS_EXCEPTION = "_dd.span_events.has_exception"
 COLLECTOR_MAX_SIZE_PER_SPAN = 100
 

--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -103,7 +103,7 @@ DD_TRACE_BAGGAGE_MAX_BYTES = 8192
 BAGGAGE_TAG_PREFIX = "baggage."
 
 # W3C Trace Context tracestate (https://www.w3.org/TR/trace-context/):
-# max 32 list-members; vendors SHOULD propagate at least 512 characters (we cap parsing to that size).
+# max 32 list-members; vendors SHOULD propagate at most 512 characters (we cap parsing to that size).
 DD_TRACE_TRACESTATE_MAX_ITEMS = 32
 DD_TRACE_TRACESTATE_MAX_BYTES = 512
 # Per W3C Trace Context, oversized list-members are preferred targets when truncating by size.

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -33,6 +33,7 @@ from ..internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
 from ..internal.constants import BAGGAGE_TAG_PREFIX
 from ..internal.constants import DD_TRACE_BAGGAGE_MAX_BYTES
 from ..internal.constants import DD_TRACE_BAGGAGE_MAX_ITEMS
+from ..internal.constants import DD_TRACE_TRACESTATE_ITEM_MAX_CHARS
 from ..internal.constants import DD_TRACE_TRACESTATE_MAX_BYTES
 from ..internal.constants import DD_TRACE_TRACESTATE_MAX_ITEMS
 from ..internal.constants import HIGHER_ORDER_TRACE_ID_BITS as _HIGHER_ORDER_TRACE_ID_BITS
@@ -789,6 +790,108 @@ class _TraceContext:
         return sampling_priority
 
     @staticmethod
+    def _tracestate_member_exceeds_item_char_cap(member: str) -> bool:
+        return len(member) > DD_TRACE_TRACESTATE_ITEM_MAX_CHARS
+
+    @staticmethod
+    def _tracestate_drop_items_until_count_prefer_oversized(items: list[str], max_count: int) -> None:
+        """Shrink ``items`` in place until ``len(items) <= max_count``.
+
+        Removes list-members with more than ``DD_TRACE_TRACESTATE_ITEM_MAX_CHARS`` characters
+        first (left to right), then drops from the end if still over the cap.
+        """
+        while len(items) > max_count:
+            for i, m in enumerate(items):
+                if _TraceContext._tracestate_member_exceeds_item_char_cap(m):
+                    del items[i]
+                    break
+            else:
+                items.pop()
+
+    @staticmethod
+    def _tracestate_pack_members_to_byte_limit(
+        members: list[str], *, never_skip_first: bool = False
+    ) -> list[str]:
+        """Append members until the UTF-8 byte budget is exhausted.
+
+        When a member does not fit, it is skipped if it exceeds ``DD_TRACE_TRACESTATE_ITEM_MAX_CHARS``
+        (so smaller later entries can still be kept); otherwise packing stops.
+        If ``never_skip_first`` is true, the first member is always kept (even over budget).
+        """
+        ts_l: list[str] = []
+        total_bytes = 0
+        for idx, member in enumerate(members):
+            segment_len = len(member.encode("utf-8")) + (1 if ts_l else 0)
+            if never_skip_first and idx == 0:
+                ts_l.append(member)
+                total_bytes += segment_len
+                continue
+            if total_bytes + segment_len <= DD_TRACE_TRACESTATE_MAX_BYTES:
+                ts_l.append(member)
+                total_bytes += segment_len
+                continue
+            if _TraceContext._tracestate_member_exceeds_item_char_cap(member):
+                log.debug(
+                    "tracestate skipping list-member over item char limit while fitting byte budget",
+                )
+                continue
+            log.debug(
+                "tracestate byte length exceeds maximum (%d), truncating whole entries",
+                DD_TRACE_TRACESTATE_MAX_BYTES,
+            )
+            break
+        return ts_l
+
+    @staticmethod
+    def _tracestate_members_after_limits_no_dd(members_stripped: list[str]) -> list[str]:
+        items = list(members_stripped)
+        if len(items) > DD_TRACE_TRACESTATE_MAX_ITEMS:
+            log.debug(
+                "tracestate list-member count exceeds maximum (%d), truncating",
+                DD_TRACE_TRACESTATE_MAX_ITEMS,
+            )
+            _TraceContext._tracestate_drop_items_until_count_prefer_oversized(items, DD_TRACE_TRACESTATE_MAX_ITEMS)
+        return _TraceContext._tracestate_pack_members_to_byte_limit(items, never_skip_first=False)
+
+    @staticmethod
+    def _tracestate_members_after_limits(members_stripped: list[str]) -> list[str]:
+        """Apply list-member and UTF-8 byte limits to tracestate segments.
+
+        The Datadog ``dd=`` list-member is preferred: the last ``dd=`` entry is always kept
+        (even when it alone exceeds the byte cap), placed first for budgeting, and never
+        displaced by other vendors under the byte limit. List-members longer than
+        ``DD_TRACE_TRACESTATE_ITEM_MAX_CHARS`` are dropped first when trimming count or bytes.
+        """
+        dd_index = -1
+        for i in range(len(members_stripped) - 1, -1, -1):
+            if members_stripped[i].startswith("dd="):
+                dd_index = i
+                break
+
+        if dd_index < 0:
+            return _TraceContext._tracestate_members_after_limits_no_dd(members_stripped)
+
+        dd_mem = members_stripped[dd_index]
+        others: list[str] = []
+        for j, m in enumerate(members_stripped):
+            if j == dd_index:
+                continue
+            if m.startswith("dd="):
+                continue
+            others.append(m)
+
+        max_others = DD_TRACE_TRACESTATE_MAX_ITEMS - 1
+        if len(others) > max_others:
+            log.debug(
+                "tracestate list-member count exceeds maximum (%d), truncating",
+                DD_TRACE_TRACESTATE_MAX_ITEMS,
+            )
+            _TraceContext._tracestate_drop_items_until_count_prefer_oversized(others, max_others)
+
+        prioritized = [dd_mem] + others
+        return _TraceContext._tracestate_pack_members_to_byte_limit(prioritized, never_skip_first=True)
+
+    @staticmethod
     def _extract(headers: dict[str, str]) -> Optional[Context]:
         try:
             tp = _extract_header_value(_POSSIBLE_HTTP_HEADER_TRACEPARENT, headers)
@@ -821,24 +924,7 @@ class _TraceContext:
             # whitespace is allowed, but whitespace to start or end values should be trimmed
             # e.g. "foo=1 \t , \t bar=2, \t baz=3" -> "foo=1,bar=2,baz=3"
             members_stripped = [member.strip() for member in ts.split(",")]
-            if len(members_stripped) > DD_TRACE_TRACESTATE_MAX_ITEMS:
-                log.debug(
-                    "tracestate list-member count exceeds maximum (%d), truncating",
-                    DD_TRACE_TRACESTATE_MAX_ITEMS,
-                )
-                members_stripped = members_stripped[:DD_TRACE_TRACESTATE_MAX_ITEMS]
-            ts_l = []
-            total_bytes = 0
-            for member in members_stripped:
-                segment_len = len(member.encode("utf-8")) + (1 if ts_l else 0)
-                if total_bytes + segment_len > DD_TRACE_TRACESTATE_MAX_BYTES:
-                    log.debug(
-                        "tracestate byte length exceeds maximum (%d), truncating whole entries",
-                        DD_TRACE_TRACESTATE_MAX_BYTES,
-                    )
-                    break
-                ts_l.append(member)
-                total_bytes += segment_len
+            ts_l = _TraceContext._tracestate_members_after_limits(members_stripped)
             ts = ",".join(ts_l)
             # the value MUST contain only ASCII characters in the
             # range of 0x20 to 0x7E

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -33,6 +33,8 @@ from ..internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
 from ..internal.constants import BAGGAGE_TAG_PREFIX
 from ..internal.constants import DD_TRACE_BAGGAGE_MAX_BYTES
 from ..internal.constants import DD_TRACE_BAGGAGE_MAX_ITEMS
+from ..internal.constants import DD_TRACE_TRACESTATE_MAX_BYTES
+from ..internal.constants import DD_TRACE_TRACESTATE_MAX_ITEMS
 from ..internal.constants import HIGHER_ORDER_TRACE_ID_BITS as _HIGHER_ORDER_TRACE_ID_BITS
 from ..internal.constants import LAST_DD_PARENT_ID_KEY
 from ..internal.constants import MAX_UINT_64BITS as _MAX_UINT_64BITS
@@ -818,7 +820,25 @@ class _TraceContext:
         if ts:
             # whitespace is allowed, but whitespace to start or end values should be trimmed
             # e.g. "foo=1 \t , \t bar=2, \t baz=3" -> "foo=1,bar=2,baz=3"
-            ts_l = [member.strip() for member in ts.split(",")]
+            members_stripped = [member.strip() for member in ts.split(",")]
+            if len(members_stripped) > DD_TRACE_TRACESTATE_MAX_ITEMS:
+                log.debug(
+                    "tracestate list-member count exceeds maximum (%d), truncating",
+                    DD_TRACE_TRACESTATE_MAX_ITEMS,
+                )
+                members_stripped = members_stripped[:DD_TRACE_TRACESTATE_MAX_ITEMS]
+            ts_l = []
+            total_bytes = 0
+            for member in members_stripped:
+                segment_len = len(member.encode("utf-8")) + (1 if ts_l else 0)
+                if total_bytes + segment_len > DD_TRACE_TRACESTATE_MAX_BYTES:
+                    log.debug(
+                        "tracestate byte length exceeds maximum (%d), truncating whole entries",
+                        DD_TRACE_TRACESTATE_MAX_BYTES,
+                    )
+                    break
+                ts_l.append(member)
+                total_bytes += segment_len
             ts = ",".join(ts_l)
             # the value MUST contain only ASCII characters in the
             # range of 0x20 to 0x7E

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -837,6 +837,11 @@ class _TraceContext:
                 ts_l.append(member)
                 total_bytes += segment_len
                 continue
+            if _TraceContext._tracestate_member_exceeds_item_char_cap(member):
+                log.debug(
+                    "tracestate skipping list-member over item char limit while fitting byte budget",
+                )
+                continue
             log.debug(
                 "tracestate byte length exceeds maximum (%d), truncating whole entries",
                 DD_TRACE_TRACESTATE_MAX_BYTES,

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -837,11 +837,6 @@ class _TraceContext:
                 ts_l.append(member)
                 total_bytes += segment_len
                 continue
-            if _TraceContext._tracestate_member_exceeds_item_char_cap(member):
-                log.debug(
-                    "tracestate skipping list-member over item char limit while fitting byte budget",
-                )
-                continue
             log.debug(
                 "tracestate byte length exceeds maximum (%d), truncating whole entries",
                 DD_TRACE_TRACESTATE_MAX_BYTES,

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -809,9 +809,7 @@ class _TraceContext:
                 items.pop()
 
     @staticmethod
-    def _tracestate_pack_members_to_byte_limit(
-        members: list[str], *, never_skip_first: bool = False
-    ) -> list[str]:
+    def _tracestate_pack_members_to_byte_limit(members: list[str], *, never_skip_first: bool = False) -> list[str]:
         """Append members until the UTF-8 byte budget is exhausted.
 
         When a member does not fit, it is skipped if it exceeds ``DD_TRACE_TRACESTATE_ITEM_MAX_CHARS``

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -799,14 +799,23 @@ class _TraceContext:
 
         Removes list-members with more than ``DD_TRACE_TRACESTATE_ITEM_MAX_CHARS`` characters
         first (left to right), then drops from the end if still over the cap.
+
+        Runs in O(len(items)) so attacker-controlled headers with many short list-members cannot
+        force quadratic work when trimming to ``max_count``.
         """
-        while len(items) > max_count:
-            for i, m in enumerate(items):
-                if _TraceContext._tracestate_member_exceeds_item_char_cap(m):
-                    del items[i]
-                    break
-            else:
-                items.pop()
+        if len(items) <= max_count:
+            return
+        excess = len(items) - max_count
+        removed = 0
+        kept: list[str] = []
+        for m in items:
+            if removed < excess and _TraceContext._tracestate_member_exceeds_item_char_cap(m):
+                removed += 1
+                continue
+            kept.append(m)
+        items[:] = kept
+        if len(items) > max_count:
+            del items[max_count:]
 
     @staticmethod
     def _tracestate_pack_members_to_byte_limit(members: list[str], *, never_skip_first: bool = False) -> list[str]:

--- a/releasenotes/notes/propagation-tracestate-parse-limits-8c4e91b2a3f5670d.yaml
+++ b/releasenotes/notes/propagation-tracestate-parse-limits-8c4e91b2a3f5670d.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    propagation: Limits parsing of the W3C ``tracestate`` header during ``tracecontext`` extraction to 32
+    list-members and 512 UTF-8 bytes, consistent with the W3C Trace Context specification
+    (https://www.w3.org/TR/trace-context/). Extra list-members and trailing whole entries that would
+    exceed the byte budget are ignored, so unusually large headers no longer expand unbounded work
+    during extraction.

--- a/releasenotes/notes/propagation-tracestate-parse-limits-8c4e91b2a3f5670d.yaml
+++ b/releasenotes/notes/propagation-tracestate-parse-limits-8c4e91b2a3f5670d.yaml
@@ -4,5 +4,4 @@ fixes:
     propagation: Limits parsing of the W3C ``tracestate`` header during ``tracecontext`` extraction to 32
     list-members and 512 UTF-8 bytes, consistent with the W3C Trace Context specification
     (https://www.w3.org/TR/trace-context/). Extra list-members and trailing whole entries that would
-    exceed the byte budget are ignored, so unusually large headers no longer expand unbounded work
-    during extraction.
+    exceed the byte budget are ignored.

--- a/releasenotes/notes/propagation-tracestate-parse-limits-8c4e91b2a3f5670d.yaml
+++ b/releasenotes/notes/propagation-tracestate-parse-limits-8c4e91b2a3f5670d.yaml
@@ -1,7 +1,10 @@
----
 fixes:
   - |
     propagation: Limits parsing of the W3C ``tracestate`` header during ``tracecontext`` extraction to 32
     list-members and 512 UTF-8 bytes, consistent with the W3C Trace Context specification
     (https://www.w3.org/TR/trace-context/). Extra list-members and trailing whole entries that would
-    exceed the byte budget are ignored.
+    exceed the byte budget are ignored, so unusually large headers no longer expand unbounded work
+    during extraction. The Datadog ``dd=`` list-member is preferred: it is kept when present (including
+    when it appears late in the header or alone exceeds the byte cap), and other vendors are dropped first.
+    List-members longer than ``DD_TRACE_TRACESTATE_ITEM_MAX_CHARS`` (128) characters are removed first
+    when trimming by list-member count or byte budget, so shorter vendor entries are kept when possible.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -19,6 +19,7 @@ from ddtrace.internal.constants import _PROPAGATION_BEHAVIOR_RESTART
 from ddtrace.internal.constants import _PROPAGATION_STYLE_BAGGAGE
 from ddtrace.internal.constants import _PROPAGATION_STYLE_NONE
 from ddtrace.internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
+from ddtrace.internal.constants import DD_TRACE_TRACESTATE_ITEM_MAX_CHARS
 from ddtrace.internal.constants import DD_TRACE_TRACESTATE_MAX_BYTES
 from ddtrace.internal.constants import DD_TRACE_TRACESTATE_MAX_ITEMS
 from ddtrace.internal.constants import LAST_DD_PARENT_ID_KEY
@@ -1159,6 +1160,74 @@ def test_tracecontext_get_context_max_items_plus_one_each_max_bytes_plus_one():
     assert ctx._meta[W3C_TRACESTATE_KEY] == ""
     assert ctx.sampling_priority == 1
     assert ctx.dd_origin is None
+
+
+def test_tracecontext_get_context_keeps_dd_when_oversized_vendor_members_fill_budget():
+    """``dd=`` is retained first; oversized non-dd members do not displace it."""
+    member_len = DD_TRACE_TRACESTATE_MAX_BYTES + 1
+
+    def one_member(i: int) -> str:
+        prefix = "k%02d=" % i
+        pad = member_len - len(prefix.encode("utf-8"))
+        return prefix + ("x" * pad)
+
+    members = [one_member(i) for i in range(DD_TRACE_TRACESTATE_MAX_ITEMS + 1)]
+    dd_mem = "dd=s:2;o:rum"
+    ts = ",".join(members + [dd_mem])
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    assert ctx._meta[W3C_TRACESTATE_KEY] == dd_mem
+    assert ctx.sampling_priority == 2
+    assert ctx.dd_origin == "rum"
+
+
+def test_tracecontext_get_context_dd_preferred_when_not_first_and_byte_capped():
+    long_first = "b=" + ("y" * (DD_TRACE_TRACESTATE_MAX_BYTES - 1))
+    short_dd = "dd=s:2;o:rum"
+    ts = long_first + "," + short_dd
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    assert ctx._meta[W3C_TRACESTATE_KEY] == short_dd
+    assert ctx.sampling_priority == 2
+    assert ctx.dd_origin == "rum"
+
+
+def test_tracecontext_get_context_dd_survives_list_member_count_when_last():
+    # 32 small vendors + dd = 33 list-members; trim non-dd to 31 so dd + 31 vendors remain.
+    prefix_members = ["z%d=%d" % (i, i) for i in range(DD_TRACE_TRACESTATE_MAX_ITEMS)]
+    ts = ",".join(prefix_members + ["dd=s:1"])
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    stored = ctx._meta[W3C_TRACESTATE_KEY]
+    assert stored.startswith("dd=")
+    assert "z0=0" in stored
+    assert "z30=30" in stored
+    assert "z31=31" not in stored
+    assert stored.count(",") == DD_TRACE_TRACESTATE_MAX_ITEMS - 1
+
+
+def test_tracecontext_get_context_drops_oversized_vendor_before_small_when_item_capped():
+    # 31 small keys + one oversized + ``dd`` => 32 non-dd slots would be exceeded by one extra
+    # small vendor; ``others`` length 32 must shrink to 31: drop ``h=`` (oversized) first, not z30.
+    small = ["z%d=%d" % (i, i) for i in range(DD_TRACE_TRACESTATE_MAX_ITEMS - 1)]  # z0..z30
+    huge = "h=" + ("x" * (DD_TRACE_TRACESTATE_ITEM_MAX_CHARS + 50))
+    assert len(huge) > DD_TRACE_TRACESTATE_ITEM_MAX_CHARS
+    ts = ",".join(small + [huge] + ["dd=s:1"])
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    stored = ctx._meta[W3C_TRACESTATE_KEY]
+    assert "h=" not in stored
+    assert "z30=30" in stored
+    assert stored.startswith("dd=")
+
+
+def test_tracecontext_get_context_skips_oversized_member_under_byte_budget_after_dd():
+    # ``dd`` first; next member alone would exceed byte cap and is over ITEM_MAX_CHARS, so it is
+    # skipped and a later small member is still included.
+    huge = "a=" + ("x" * (DD_TRACE_TRACESTATE_MAX_BYTES - 1))
+    assert len(huge) > DD_TRACE_TRACESTATE_ITEM_MAX_CHARS
+    ts = "dd=s:2;o:rum," + huge + ",z=9"
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    stored = ctx._meta[W3C_TRACESTATE_KEY]
+    assert stored.startswith("dd=")
+    assert "z=9" in stored
+    assert huge not in stored
 
 
 @pytest.mark.parametrize(

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -19,10 +19,13 @@ from ddtrace.internal.constants import _PROPAGATION_BEHAVIOR_RESTART
 from ddtrace.internal.constants import _PROPAGATION_STYLE_BAGGAGE
 from ddtrace.internal.constants import _PROPAGATION_STYLE_NONE
 from ddtrace.internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
+from ddtrace.internal.constants import DD_TRACE_TRACESTATE_MAX_BYTES
+from ddtrace.internal.constants import DD_TRACE_TRACESTATE_MAX_ITEMS
 from ddtrace.internal.constants import LAST_DD_PARENT_ID_KEY
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_MULTI
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_SINGLE
 from ddtrace.internal.constants import PROPAGATION_STYLE_DATADOG
+from ddtrace.internal.constants import W3C_TRACESTATE_KEY
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import _HTTP_BAGGAGE_PREFIX
 from ddtrace.propagation.http import _HTTP_HEADER_B3_FLAGS
@@ -1115,6 +1118,47 @@ TRACECONTEXT_HEADERS_VALID_64_bit = {
 def test_tracecontext_get_sampling_priority(sampling_priority_tp, sampling_priority_ts, expected_sampling_priority):
     traceparent_values = _TraceContext._get_sampling_priority(sampling_priority_tp, sampling_priority_ts)
     assert traceparent_values == expected_sampling_priority
+
+
+def test_tracecontext_get_context_truncates_tracestate_list_member_count():
+    many_members = ",".join("z%d=%d" % (i, i) for i in range(DD_TRACE_TRACESTATE_MAX_ITEMS + 3))
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, many_members, {})
+    stored = ctx._meta[W3C_TRACESTATE_KEY]
+    assert stored.count(",") == DD_TRACE_TRACESTATE_MAX_ITEMS - 1
+    assert ("z%d=" % (DD_TRACE_TRACESTATE_MAX_ITEMS - 1)) in stored
+    assert ("z%d=" % DD_TRACE_TRACESTATE_MAX_ITEMS) not in stored
+
+
+def test_tracecontext_get_context_truncates_tracestate_byte_length():
+    short_dd = "dd=s:2;o:rum"
+    # First member (12 B) + comma + second must exceed DD_TRACE_TRACESTATE_MAX_BYTES so the second is dropped.
+    ys = DD_TRACE_TRACESTATE_MAX_BYTES - len(short_dd.encode("utf-8")) - 2
+    long_second = "b=" + ("y" * ys)
+    ts = short_dd + "," + long_second
+    assert len(ts.encode("utf-8")) > DD_TRACE_TRACESTATE_MAX_BYTES
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    assert ctx._meta[W3C_TRACESTATE_KEY] == short_dd
+    assert ctx.sampling_priority == 2
+
+
+def test_tracecontext_get_context_max_items_plus_one_each_max_bytes_plus_one():
+    """MAX_ITEMS+1 members each longer than MAX_BYTES: item cap then byte cap leaves nothing stored."""
+    member_len = DD_TRACE_TRACESTATE_MAX_BYTES + 1
+
+    def one_member(i: int) -> str:
+        prefix = "k%02d=" % i
+        pad = member_len - len(prefix.encode("utf-8"))
+        assert pad >= 0
+        return prefix + ("x" * pad)
+
+    members = [one_member(i) for i in range(DD_TRACE_TRACESTATE_MAX_ITEMS + 1)]
+    for m in members:
+        assert len(m.encode("utf-8")) == member_len
+    ts = ",".join(members)
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, ts, {})
+    assert ctx._meta[W3C_TRACESTATE_KEY] == ""
+    assert ctx.sampling_priority == 1
+    assert ctx.dd_origin is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Limits parsing of the W3C ``tracestate`` header during ``tracecontext`` extraction to 32 list-members and 512 UTF-8 bytes, consistent with the W3C Trace Context specification (https://www.w3.org/TR/trace-context/). Extra list-members and trailing whole entries that would exceed the byte budget are ignored.