### PR TITLE
ci(native): add ast-grep lint for #[pyclass] missing __traverse__

### DIFF
--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -34,10 +34,18 @@ rule:
             field: type
             stopBy: end
             regex: "Py<|PyObject|PyBackedString"
-    # No __traverse__ method exists in an `impl <THIS_STRUCT>` block in the
-    # same file. We bind the impl target to $NAME so a sibling pyclass with
-    # its own __traverse__ does not silently mask this one (which was the
-    # cross-pyclass false negative caught in code review).
+    # No __traverse__ method exists in a `#[pymethods] impl <THIS_STRUCT>`
+    # block in the same file.
+    #
+    # Three constraints on the impl block:
+    #   1. The impl target type must be $NAME (so a sibling pyclass's
+    #      __traverse__ does not satisfy this struct's check).
+    #   2. The impl must be annotated with #[pymethods]. PyO3 only wires
+    #      __traverse__ into tp_traverse from impls inside a #[pymethods]
+    #      block; a plain `impl Foo { fn __traverse__ ... }` is a regular
+    #      Rust method and the type's GC slot stays empty.
+    #   3. The impl must contain a function named __traverse__.
+    #
     # We check both directions because impl blocks may appear before or
     # after the struct definition.
     - not:
@@ -48,6 +56,12 @@ rule:
             - has:
                 field: type
                 pattern: $NAME
+            - follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                kind: attribute_item
+                regex: "pymethods"
             - has:
                 stopBy: end
                 kind: function_item
@@ -62,6 +76,12 @@ rule:
             - has:
                 field: type
                 pattern: $NAME
+            - follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                kind: attribute_item
+                regex: "pymethods"
             - has:
                 stopBy: end
                 kind: function_item

--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -1,0 +1,88 @@
+id: pyclass-missing-traverse
+message: "PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak"
+severity: warning
+language: rust
+files:
+  - "src/native/**/*.rs"
+rule:
+  all:
+    - kind: struct_item
+    - follows:
+        stopBy: end
+        kind: attribute_item
+        regex: "pyclass"
+    # Has at least one field whose type mentions a Python-owning reference.
+    # PyBackedString is included because it opaquely holds Option<Py<PyAny>>;
+    # without traversal, a str subclass with __dict__ stored in such a field
+    # can close an uncollectable cycle (see test_span_event_string_attribute_*
+    # cases in tests/tracer/test_span_data.py).
+    - has:
+        kind: field_declaration_list
+        has:
+          kind: field_declaration
+          has:
+            field: type
+            stopBy: end
+            regex: "Py<|PyObject|PyBackedString"
+    # No __traverse__ method exists in any sibling impl block in the same file.
+    # We check both directions (precedes / follows) because impl blocks may
+    # appear before or after the struct.
+    - not:
+        precedes:
+          stopBy: end
+          kind: impl_item
+          has:
+            stopBy: end
+            kind: function_item
+            has:
+              field: name
+              regex: "^__traverse__$"
+    - not:
+        follows:
+          stopBy: end
+          kind: impl_item
+          has:
+            stopBy: end
+            kind: function_item
+            has:
+              field: name
+              regex: "^__traverse__$"
+note: |
+  PyO3 does not auto-derive Python's cyclic-GC protocol. A #[pyclass] that
+  holds a Py<...>, PyObject, or PyBackedString field without implementing
+  __traverse__ is born without Py_TPFLAGS_HAVE_GC, so CPython's cyclic
+  collector never inspects its instances. Any reference cycle that passes
+  through such a field leaks for the lifetime of the process.
+
+  This was the root cause of the SpanData/SpanLink/SpanEvent leak fixed by
+  the PR that introduced this lint. See:
+  - releasenotes/notes/fix-span-cyclic-gc-leak-*.yaml
+  - tests/tracer/test_span_data.py (cyclic GC support tests)
+  - PyO3 RFC #5663 ("automatic garbage collector derives", open)
+
+  How to fix:
+
+    #[pymethods]
+    impl MyClass {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            // Visit every owned Py<...> / PyObject / wrapper that holds one.
+            visit.call(&self.some_py_dict)?;
+            self.some_pybacked_string.traverse(&visit)?;
+            Ok(())
+        }
+
+        // Only if the class is not `frozen`. If frozen, traversal alone is
+        // usually sufficient because the cycle can be broken on the mutable
+        // (Python-side) participant.
+        fn __clear__(&mut self) {
+            // Drop owned Python references that may participate in cycles.
+        }
+    }
+
+  If the field is known to hold only atomic Python objects (e.g. PyString,
+  PyLong, PyNone) AND will never be exposed to user-supplied subclasses with
+  a __dict__, traversal is technically optional for cycle-breaking — but it
+  is still required for correct refcount accounting from CPython's
+  perspective (`gc.get_referents`, debugger tooling). Implement it.

--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -6,9 +6,19 @@ files:
   - "src/native/**/*.rs"
 rule:
   all:
+    # Capture the struct name so we can match impl blocks that target it.
     - kind: struct_item
+      has:
+        field: name
+        pattern: $NAME
+    # The #[pyclass] attribute must be attached to THIS struct: walk only
+    # through other attribute_items (e.g. #[derive(Default)]) and stop at
+    # anything else. Without the stopBy constraint, an unrelated helper
+    # struct after a pyclass would falsely match the earlier #[pyclass].
     - follows:
-        stopBy: end
+        stopBy:
+          not:
+            kind: attribute_item
         kind: attribute_item
         regex: "pyclass"
     # Has at least one field whose type mentions a Python-owning reference.
@@ -24,29 +34,40 @@ rule:
             field: type
             stopBy: end
             regex: "Py<|PyObject|PyBackedString"
-    # No __traverse__ method exists in any sibling impl block in the same file.
-    # We check both directions (precedes / follows) because impl blocks may
-    # appear before or after the struct.
+    # No __traverse__ method exists in an `impl <THIS_STRUCT>` block in the
+    # same file. We bind the impl target to $NAME so a sibling pyclass with
+    # its own __traverse__ does not silently mask this one (which was the
+    # cross-pyclass false negative caught in code review).
+    # We check both directions because impl blocks may appear before or
+    # after the struct definition.
     - not:
         precedes:
           stopBy: end
           kind: impl_item
-          has:
-            stopBy: end
-            kind: function_item
-            has:
-              field: name
-              regex: "^__traverse__$"
+          all:
+            - has:
+                field: type
+                pattern: $NAME
+            - has:
+                stopBy: end
+                kind: function_item
+                has:
+                  field: name
+                  regex: "^__traverse__$"
     - not:
         follows:
           stopBy: end
           kind: impl_item
-          has:
-            stopBy: end
-            kind: function_item
-            has:
-              field: name
-              regex: "^__traverse__$"
+          all:
+            - has:
+                field: type
+                pattern: $NAME
+            - has:
+                stopBy: end
+                kind: function_item
+                has:
+                  field: name
+                  regex: "^__traverse__$"
 note: |
   PyO3 does not auto-derive Python's cyclic-GC protocol. A #[pyclass] that
   holds a Py<...>, PyObject, or PyBackedString field without implementing

--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -1,6 +1,6 @@
 id: pyclass-missing-traverse
 message: "PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak"
-severity: warning
+severity: error
 language: rust
 files:
   - "src/native/**/*.rs"

--- a/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
+++ b/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
@@ -1,0 +1,200 @@
+id: pyclass-missing-traverse
+snapshots:
+  ? |
+    #[pyclass(frozen)]
+    pub struct LeakBacked {
+        name: PyBackedString,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakBacked {
+            name: PyBackedString,
+        }
+      style: primary
+      start: 19
+      end: 70
+    - source: '#[pyclass(frozen)]'
+      style: secondary
+      start: 0
+      end: 18
+    - source: PyBackedString
+      style: secondary
+      start: 53
+      end: 67
+    - source: 'name: PyBackedString'
+      style: secondary
+      start: 47
+      end: 67
+    - source: |-
+        {
+            name: PyBackedString,
+        }
+      style: secondary
+      start: 41
+      end: 70
+  ? |
+    #[pyclass]
+    #[derive(Default)]
+    pub struct LeakDerive {
+        attrs: Option<Py<PyDict>>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakDerive {
+            attrs: Option<Py<PyDict>>,
+        }
+      style: primary
+      start: 30
+      end: 86
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Option<Py<PyDict>>
+      style: secondary
+      start: 65
+      end: 83
+    - source: 'attrs: Option<Py<PyDict>>'
+      style: secondary
+      start: 58
+      end: 83
+    - source: |-
+        {
+            attrs: Option<Py<PyDict>>,
+        }
+      style: secondary
+      start: 52
+      end: 86
+  ? |
+    #[pyclass]
+    pub struct LeakAny {
+        cached: Option<Py<PyAny>>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakAny {
+            cached: Option<Py<PyAny>>,
+        }
+      style: primary
+      start: 11
+      end: 64
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Option<Py<PyAny>>
+      style: secondary
+      start: 44
+      end: 61
+    - source: 'cached: Option<Py<PyAny>>'
+      style: secondary
+      start: 36
+      end: 61
+    - source: |-
+        {
+            cached: Option<Py<PyAny>>,
+        }
+      style: secondary
+      start: 30
+      end: 64
+  ? |
+    #[pyclass]
+    pub struct LeakDict {
+        attrs: Py<PyDict>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakDict {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 11
+      end: 57
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Py<PyDict>
+      style: secondary
+      start: 44
+      end: 54
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 37
+      end: 54
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 31
+      end: 57
+  ? |
+    #[pyclass]
+    pub struct LeakWrongImpl {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakWrongImpl {
+        fn other(&self) {}
+    }
+  : labels:
+    - source: |-
+        pub struct LeakWrongImpl {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 11
+      end: 62
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Py<PyDict>
+      style: secondary
+      start: 49
+      end: 59
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 42
+      end: 59
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 36
+      end: 62
+  ? |
+    #[pyo3::pyclass(name = "Leaky", module = "x")]
+    pub struct LeakQualified {
+        attrs: Py<PyDict>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakQualified {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 47
+      end: 98
+    - source: '#[pyo3::pyclass(name = "Leaky", module = "x")]'
+      style: secondary
+      start: 0
+      end: 46
+    - source: Py<PyDict>
+      style: secondary
+      start: 85
+      end: 95
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 78
+      end: 95
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 72
+      end: 98

--- a/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
+++ b/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
@@ -13,6 +13,10 @@ snapshots:
       style: primary
       start: 19
       end: 70
+    - source: LeakBacked
+      style: secondary
+      start: 30
+      end: 40
     - source: '#[pyclass(frozen)]'
       style: secondary
       start: 0
@@ -46,6 +50,10 @@ snapshots:
       style: primary
       start: 30
       end: 86
+    - source: LeakDerive
+      style: secondary
+      start: 41
+      end: 51
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -67,6 +75,62 @@ snapshots:
       end: 86
   ? |
     #[pyclass]
+    pub struct GoodOne {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl GoodOne {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+
+    #[pyclass]
+    pub struct LeakySibling {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakySibling {
+        fn other(&self) {}
+    }
+  : labels:
+    - source: |-
+        pub struct LeakySibling {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 259
+      end: 309
+    - source: LeakySibling
+      style: secondary
+      start: 270
+      end: 282
+    - source: '#[pyclass]'
+      style: secondary
+      start: 248
+      end: 258
+    - source: Py<PyDict>
+      style: secondary
+      start: 296
+      end: 306
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 289
+      end: 306
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 283
+      end: 309
+  ? |
+    #[pyclass]
     pub struct LeakAny {
         cached: Option<Py<PyAny>>,
     }
@@ -78,6 +142,10 @@ snapshots:
       style: primary
       start: 11
       end: 64
+    - source: LeakAny
+      style: secondary
+      start: 22
+      end: 29
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -110,6 +178,10 @@ snapshots:
       style: primary
       start: 11
       end: 57
+    - source: LeakDict
+      style: secondary
+      start: 22
+      end: 30
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -147,6 +219,10 @@ snapshots:
       style: primary
       start: 11
       end: 62
+    - source: LeakWrongImpl
+      style: secondary
+      start: 22
+      end: 35
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -179,6 +255,10 @@ snapshots:
       style: primary
       start: 47
       end: 98
+    - source: LeakQualified
+      style: secondary
+      start: 58
+      end: 71
     - source: '#[pyo3::pyclass(name = "Leaky", module = "x")]'
       style: secondary
       start: 0

--- a/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
+++ b/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
@@ -243,6 +243,51 @@ snapshots:
       start: 36
       end: 62
   ? |
+    #[pyclass]
+    pub struct LeakyPlainImpl {
+        attrs: Py<PyDict>,
+    }
+
+    impl LeakyPlainImpl {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+  : labels:
+    - source: |-
+        pub struct LeakyPlainImpl {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 11
+      end: 63
+    - source: LeakyPlainImpl
+      style: secondary
+      start: 22
+      end: 36
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Py<PyDict>
+      style: secondary
+      start: 50
+      end: 60
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 43
+      end: 60
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 37
+      end: 63
+  ? |
     #[pyo3::pyclass(name = "Leaky", module = "x")]
     pub struct LeakQualified {
         attrs: Py<PyDict>,

--- a/.sg/tests/pyclass-missing-traverse-test.yml
+++ b/.sg/tests/pyclass-missing-traverse-test.yml
@@ -1,0 +1,112 @@
+id: pyclass-missing-traverse
+valid:
+  # pyclass with no Python-owning fields — OK
+  - |
+    #[pyclass]
+    pub struct PureRust {
+        value: String,
+        count: u64,
+    }
+  # pyclass with Py<PyDict> AND a __traverse__ impl in the same file — OK
+  - |
+    #[pyclass]
+    pub struct WithTraverse {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl WithTraverse {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+  # pyclass with PyBackedString field plus __traverse__ — OK
+  - |
+    #[pyclass(frozen)]
+    pub struct FrozenWithTraverse {
+        name: PyBackedString,
+    }
+
+    #[pymethods]
+    impl FrozenWithTraverse {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            self.name.traverse(&visit)?;
+            Ok(())
+        }
+    }
+  # __traverse__ defined in a separately attributed impl block — OK
+  - |
+    #[pyclass]
+    pub struct SplitImpl {
+        attrs: Py<PyDict>,
+    }
+
+    impl SplitImpl {
+        fn helper(&self) {}
+    }
+
+    #[pymethods]
+    impl SplitImpl {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+  # Plain (non-pyclass) struct that happens to hold Py<...> — OK,
+  # not exposed to Python so no GC protocol concern.
+  - |
+    pub struct NotAPyclass {
+        attrs: Py<PyDict>,
+    }
+invalid:
+  # Owned Py<PyDict> field, no __traverse__
+  - |
+    #[pyclass]
+    pub struct LeakDict {
+        attrs: Py<PyDict>,
+    }
+  # Owned Py<PyAny> wrapped in Option, no __traverse__
+  - |
+    #[pyclass]
+    pub struct LeakAny {
+        cached: Option<Py<PyAny>>,
+    }
+  # PyBackedString field, no __traverse__ (the str-subclass-with-__dict__
+  # cycle is real — see test_span_event_string_attribute_value_cycle_*)
+  - |
+    #[pyclass(frozen)]
+    pub struct LeakBacked {
+        name: PyBackedString,
+    }
+  # Fully-qualified pyo3::pyclass attribute — also covered
+  - |
+    #[pyo3::pyclass(name = "Leaky", module = "x")]
+    pub struct LeakQualified {
+        attrs: Py<PyDict>,
+    }
+  # Multiple attributes between #[pyclass] and the struct (e.g. derive)
+  # — `follows: stopBy: end` must walk past them.
+  - |
+    #[pyclass]
+    #[derive(Default)]
+    pub struct LeakDerive {
+        attrs: Option<Py<PyDict>>,
+    }
+  # Sibling impl exists but does NOT define __traverse__
+  - |
+    #[pyclass]
+    pub struct LeakWrongImpl {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakWrongImpl {
+        fn other(&self) {}
+    }

--- a/.sg/tests/pyclass-missing-traverse-test.yml
+++ b/.sg/tests/pyclass-missing-traverse-test.yml
@@ -65,6 +65,29 @@ valid:
     pub struct NotAPyclass {
         attrs: Py<PyDict>,
     }
+  # Plain Rust helper struct following a correctly-traversed pyclass —
+  # OK. Regression test: an earlier version of this rule used
+  # `follows: stopBy: end` for the pyclass attribute, which made this
+  # helper match the earlier struct's #[pyclass] attribute.
+  - |
+    #[pyclass]
+    pub struct PyExposed {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl PyExposed {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+
+    pub struct InternalHelper {
+        cached: Py<PyAny>,
+    }
 invalid:
   # Owned Py<PyDict> field, no __traverse__
   - |
@@ -108,5 +131,36 @@ invalid:
 
     #[pymethods]
     impl LeakWrongImpl {
+        fn other(&self) {}
+    }
+  # Two pyclasses in the same file: one correctly traverses, the other
+  # does not. Regression test: an earlier version of this rule treated
+  # any sibling __traverse__ in the file as satisfying every pyclass,
+  # so adding a leaky pyclass next to an already-fixed one went
+  # undetected. The rule must now match __traverse__ to the specific
+  # impl target.
+  - |
+    #[pyclass]
+    pub struct GoodOne {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl GoodOne {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+
+    #[pyclass]
+    pub struct LeakySibling {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakySibling {
         fn other(&self) {}
     }

--- a/.sg/tests/pyclass-missing-traverse-test.yml
+++ b/.sg/tests/pyclass-missing-traverse-test.yml
@@ -164,3 +164,21 @@ invalid:
     impl LeakySibling {
         fn other(&self) {}
     }
+  # __traverse__ defined in a plain `impl` block (no #[pymethods]).
+  # PyO3 only wires __traverse__ into tp_traverse when it lives inside a
+  # #[pymethods] block; a regular impl method is invisible to the GC
+  # slot, so the type still leaks. Regression test for Codex P2 #3.
+  - |
+    #[pyclass]
+    pub struct LeakyPlainImpl {
+        attrs: Py<PyDict>,
+    }
+
+    impl LeakyPlainImpl {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }


### PR DESCRIPTION
## Description

Adds an ast-grep lint that flags PyO3 `#[pyclass]` structs holding Python
references (`Py<...>`, `PyObject`, or `PyBackedString` fields) without a
matching `__traverse__` implementation.

### Why

PyO3 does not auto-derive Python's cyclic-GC protocol. A `#[pyclass]` with
`Py<...>` / `PyObject` / `PyBackedString` fields and no `__traverse__` method
is born without `Py_TPFLAGS_HAVE_GC`, which means CPython's cyclic collector
never inspects its instances. **Any reference cycle that passes through such
a field leaks for the lifetime of the process** — refcounting alone cannot
break it.

This is exactly what regressed in 4.x and was fixed by #17867 (the
`SpanData` / `SpanLink` / `SpanEvent` leak through `meta_struct`,
`SpanLink.attributes`, and `SpanEvent.attributes`).

### Prior art (none reusable)

- **PyO3 [RFC #5663](https://github.com/PyO3/pyo3/issues/5663)** — "automatic
  garbage collector derives". Open, not implemented. Filed by maintainer
  David Hewitt with explicit motivation: *"if users don't do this properly,
  it leads to memory leaks. My experience working on pydantic-core … it's
  easy to get a `__traverse__` or clear implementation wrong."*
- **clippy** — no PyO3-aware lints.
- **Major PyO3 consumers** (pydantic-core, qiskit, opsml, crabwalk,
  pyreqwest) all hand-write `__traverse__` and rely on code review.

So we built one. The repo already had ast-grep wired into
`hatch run lint:sg` (19 existing rules across `.sg/rules/`), so this is a
single rule + test file using existing infrastructure — no new tooling.

### What the rule catches

A `struct_item` is flagged when **all** of:
1. It follows a `#[pyclass(...)]` (or `#[pyo3::pyclass(...)]`) attribute
   (with `stopBy: end` to walk past intermediate `#[derive(...)]` etc.).
2. It has a field whose type matches the regex `Py<|PyObject|PyBackedString`.
3. Neither a preceding nor a following `impl` block in the same file
   contains a `fn __traverse__`.

`PyBackedString` is included because it opaquely wraps `Option<Py<PyAny>>`;
a `str` subclass with `__dict__` stored in such a field can close an
uncollectable cycle (this is exactly the case
`test_span_event_string_attribute_value_cycle_is_collectable` in #17867
exercises).

## Testing

- `hatch run lint:sg-test` — 20 rules pass (19 existing + the new one).
  6 invalid and 5 valid test cases cover: bare `Py<PyDict>`,
  `Option<Py<PyAny>>`, `PyBackedString` on `frozen` classes,
  fully-qualified `#[pyo3::pyclass]`, multiple attrs between `#[pyclass]`
  and the struct (the `SpanData` `#[derive(Default)]` shape), sibling impl
  with a different method, plus the corresponding clean variants.
- **End-to-end verification against the real codebase:**

| Tree state | Expected | Actual |
|---|---|---|
| `main` (pre-#17867) | flag `SpanData`, `SpanLink`, `SpanEvent` | ✅ exactly those 3 |
| `main` + #17867 applied to `src/native/` | no warnings | ✅ 0 |
| Other pyclasses in `src/native/` (Crashtracker, DDSketch, FFE, library_config, tracer_flare, data_pipeline, shared_runtime) | no warnings | ✅ 0 (none store Python references) |

## Risks

Low.

- The rule is `severity: warning`, so it won't gate CI by default. It runs
  under `hatch run lint:sg` which is part of `lint:checks`.
- Scope is restricted to `src/native/**/*.rs` via the rule's `files:` glob.
- If a future legitimate `#[pyclass]` stores only atomic Python types
  (e.g. `Py<PyLong>`) and somehow doesn't need traversal, the rule can be
  silenced inline with the standard ast-grep ignore comment, or the field
  can be wrapped in a Rust newtype. In practice, traversal should always
  be implemented for correct refcount accounting (`gc.get_referents`,
  debugger tooling) even when cycles are impossible.

## Additional Notes

- This adds 0 runtime cost; ast-grep is already part of `lint:checks`.
- Snapshot file (`.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml`)
  is auto-generated by `ast-grep test --update-all`, matching the convention
  of all 19 existing rules.
- No release note required (`changelog/no-changelog`): CI/lint-only change.

### Follow-up ideas (not in this PR)

- Add a paragraph to `.cursor/rules/native-code.mdc` pointing migrators of
  `__slots__` Python classes to native pyclasses at this rule.
- When PyO3 RFC #5663 ships, this rule becomes obsolete and can be removed.
