### PR TITLE
test(llmobs): fix unmigrated botocore test

### DIFF
--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -673,7 +673,7 @@ class TestLLMObsBedrock:
         ]
 
     @pytest.mark.skipif(BOTO_VERSION < (1, 34, 131), reason="Converse API not available until botocore 1.34.131")
-    def test_llmobs_converse_guard_content_text(self, bedrock_client, request_vcr, test_spans, llmobs_events):
+    def test_llmobs_converse_guard_content_text(self, bedrock_client, bedrock_llmobs, test_spans):
         import botocore
 
         with pytest.raises(botocore.exceptions.ClientError):
@@ -697,8 +697,9 @@ class TestLLMObsBedrock:
                 ],
             )
 
-        assert len(llmobs_events) == 1
-        assert llmobs_events[0]["meta"]["input"]["messages"] == [{"content": "give me my bill", "role": "user"}]
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert get_llmobs_input_messages(spans[0]) == [{"content": "give me my bill", "role": "user"}]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- `test_llmobs_converse_guard_content_text` has been failing on `main` since #17801 merged. It was overlooked by that PR's migration: the test still uses the old `llmobs_events` fixture but never pulls in `bedrock_llmobs`, so LLMObs is never enabled and `len(llmobs_events) == 1` fails with `0 == 1`.
- Pre-#17801, `llmobs_events` transitively depended on `bedrock_llmobs` (the fixture wired LLMObs + the test span writer). The new conftest dropped that link, and every other test in `TestLLMObsBedrock` was rewritten to take `bedrock_llmobs` explicitly — except this one.
- Migrate this test to the same pattern as the three nearby `test_llmobs_converse_tool_result_*` tests: `bedrock_llmobs` + `test_spans` + `get_llmobs_input_messages(spans[0])`.

## Test plan

- [x] Ran the test locally on Python 3.10 / botocore 1.38.26 (the lowest pinned venv where `BOTO_VERSION >= (1, 34, 131)` so the `skipif` doesn't fire): passes.
- [ ] CI green on the botocore suite.

Claude session: `6d4c7e26-fb57-405b-9cd3-586ac14a911a`
Resume: `claude --resume 6d4c7e26-fb57-405b-9cd3-586ac14a911a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)