### PR TITLE
fix(asm): tag usr.session_id on authenticated Django request spans

### DIFF
--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -159,7 +159,7 @@ def _on_django_process(
                 hash_login = _hash_user_id(user_login)
                 span._set_attribute(APPSEC.USER_LOGIN_USERNAME, hash_login)
             span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, mode)
-            set_user(None, hash_id, propagate=True, may_block=False, span=span)
+            set_user(None, hash_id, propagate=True, session_id=session_key, may_block=False, span=span)
         elif mode == LOGIN_EVENTS_MODE.IDENT:
             if user_id:
                 span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
@@ -172,6 +172,7 @@ def _on_django_process(
                 propagate=True,
                 email=user_extra.get("email"),
                 name=user_extra.get("name"),
+                session_id=session_key,
                 may_block=False,
                 span=span,
             )

--- a/releasenotes/notes/asm-django-session-id-on-request-span-853d812e1ac34cd3.yaml
+++ b/releasenotes/notes/asm-django-session-id-on-request-span-853d812e1ac34cd3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    AAP: This fix resolves an issue where the ``usr.session_id`` tag was missing from
+    the entry span of authenticated follow-up Django requests when automatic user
+    instrumentation was enabled. They now also carry ``usr.session_id``, matching other
+    authenticated user-tagging paths.

--- a/tests/appsec/integrations/django_tests/test_appsec_django.py
+++ b/tests/appsec/integrations/django_tests/test_appsec_django.py
@@ -222,6 +222,43 @@ def test_django_login_sucess_identification(client, test_spans, tracer, use_logi
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("mode", (LOGIN_EVENTS_MODE.IDENT, LOGIN_EVENTS_MODE.ANON))
+def test_django_authenticated_request_tags_session_id(client, test_spans, tracer, mode):
+    """
+    Per-request auto-user path must tag both `usr.id` and `usr.session_id` on the entry span
+    of authenticated follow-up requests, not only on the `django.contrib.auth.login` event span.
+    """
+    from django.contrib.auth import get_user
+    from django.contrib.auth.models import User
+
+    with (
+        override_global_config(
+            dict(
+                _asm_enabled=True,
+                _auto_user_instrumentation_local_mode=mode,
+            )
+        ),
+        update_django_config(),
+    ):
+        test_user = User.objects.create(username="fred", first_name="Fred", email="fred@test.com")
+        test_user.set_password("secret")
+        test_user.save()
+        assert client.login(username="fred", password="secret")
+        assert get_user(client).is_authenticated
+        session_key = client.session.session_key
+        assert session_key
+
+        test_spans.reset()
+        response = client.get("/")
+        assert response.status_code == 200
+
+        request_span = test_spans.find_span(name="django.request")
+        assert request_span.get_tag(user.SESSION_ID) == session_key
+        if mode == LOGIN_EVENTS_MODE.IDENT:
+            assert request_span.get_tag(user.ID)
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("use_login", (False, True))
 @pytest.mark.parametrize("use_email", (False, True))
 @pytest.mark.parametrize("use_realname", (False, True))


### PR DESCRIPTION
APPSEC-62657

## Description

The Django AppSec auto-instrumentation already extracts `request.session.session_key` on every authenticated request and forwards it to the WAF as `REQUEST_SESSION_ID`. However, the two `set_user(...)` calls in `_on_django_process` did not pass `session_id` through, so request entry spans carried `usr.id` but were missing `usr.session_id`.

This change passes `session_id=session_key` to both `set_user(...)` calls, matching the login-event path (`_on_django_login`) and the SDK behavior (`track_user_sdk.track_user`). Customers querying spans by `usr.session_id` now see it on every authenticated request, not only the login span.

## Testing

- New parametrized test `test_django_authenticated_request_tags_session_id` (IDENT and ANON) logs in, makes a follow-up `client.get("/")`, and asserts the `django.request` entry span carries `usr.session_id == client.session.session_key`.
- All 28 related tests in `tests/appsec/integrations/django_tests/test_appsec_django.py` pass on Python 3.13 + Django 4.2 (`appsec_integrations_django` venv `492b83f`).

## Risks

None. The change only adds an existing per-request value to `set_user`, which already guards `if session_id:` before tagging. The anonymous-session branch is unchanged.
