### PR TITLE
ci(benchmarks): set recursive computation max_rss SLO to 46MB

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -836,7 +836,7 @@ experiments:
           - name: recursivecomputation-deep
             thresholds:
               - execution_time < 320.95 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 46.00 MB
           - name: recursivecomputation-deep-profiled
             thresholds:
               - execution_time < 359.15 ms
@@ -844,11 +844,11 @@ experiments:
           - name: recursivecomputation-medium
             thresholds:
               - execution_time < 7.45 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 46.00 MB
           - name: recursivecomputation-shallow
             thresholds:
               - execution_time < 1.05 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 46.00 MB
 
           # samplingrules
           - name: samplingrules-average_match


### PR DESCRIPTION
## Description

Makes the max_rss SLO for recursive computation benchmark all to 46 MB.

We are seeing some inconsistent values from the benchmark runs, some ~36MB, but a few jump to ~44MB. The jump isn't consistent, and we don't have a clear cause yet.

46MB was chosen to match the max rss used for the profiled variant of this benchmark.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
