### PR TITLE
feat(openfeature): add get_configuration() to DataDogProvider

### DIFF
--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -126,6 +126,10 @@ class DataDogProvider(AbstractProvider):
         """Returns provider metadata."""
         return self._metadata
 
+    def get_configuration(self) -> typing.Optional[ffe.Configuration]:
+        """Returns the currently loaded FFE configuration, or None if not yet received."""
+        return _get_ffe_config()
+
     def get_provider_hooks(self) -> list[typing.Any]:
         """
         Returns provider-level hooks.

--- a/releasenotes/notes/openfeature-provider-get-configuration-d16d0be4a0096198.yaml
+++ b/releasenotes/notes/openfeature-provider-get-configuration-d16d0be4a0096198.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    openfeature: ``DataDogProvider`` now exposes a ``get_configuration()`` method that returns the
+    currently loaded ``ffe.Configuration`` object, or ``None`` if no configuration has been received
+    yet from Remote Configuration.

--- a/tests/openfeature/test_provider.py
+++ b/tests/openfeature/test_provider.py
@@ -562,3 +562,17 @@ class TestInvalidFlagData:
         result = provider.resolve_boolean_details("invalid-type-flag", False)
         # Should return default since config is invalid
         assert result.value is False
+
+
+class TestGetConfiguration:
+    """Test get_configuration method on DataDogProvider."""
+
+    def test_get_configuration_returns_none_when_no_config_loaded(self, provider):
+        """Should return None when no configuration has been loaded."""
+        assert provider.get_configuration() is None
+
+    def test_get_configuration_returns_loaded_config(self, provider):
+        """Should return the configuration object after config is loaded."""
+        config = create_config(create_boolean_flag("test-flag", enabled=True, default_value=True))
+        process_ffe_configuration(config)
+        assert provider.get_configuration() is not None


### PR DESCRIPTION
## Summary
- Adds `get_configuration()` method to `DataDogProvider` that returns the currently loaded `ffe.Configuration` object
- Returns `None` when no configuration has been received yet from Remote Configuration
- Follows TDD: tests written first, confirmed failing, then minimal implementation added

## Test Plan
- [ ] `tests/openfeature/test_provider.py::TestGetConfiguration::test_get_configuration_returns_none_when_no_config_loaded` — verifies `None` returned before config load
- [ ] `tests/openfeature/test_provider.py::TestGetConfiguration::test_get_configuration_returns_loaded_config` — verifies non-`None` returned after `process_ffe_configuration` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)