### PR TITLE
chore(protobuf): regression test to catch (then fix later) possible attribute errors

### DIFF
--- a/tests/contrib/protobuf/test_protobuf.py
+++ b/tests/contrib/protobuf/test_protobuf.py
@@ -35,6 +35,9 @@ def test_unpatch_does_not_raise_after_message_class_wrapped():
     with override_global_config({"_data_streams_enabled": True}):
         patch()
         importlib.reload(other_message_pb2)  # _traced_build can trigger errors
+        OtherMessage = other_message_pb2.OtherMessage
+        other_message = OtherMessage()
+        other_message.SerializeToString()
         unpatch()  # should not raise AttributeErrors
 
 

--- a/tests/contrib/protobuf/test_protobuf.py
+++ b/tests/contrib/protobuf/test_protobuf.py
@@ -25,6 +25,19 @@ OTHER_MESSAGE_SCHEMA_DEF = (
 OTHER_MESSAGE_SCHEMA_ID = "2475724054364642627"
 
 
+def test_unpatch_does_not_raise_after_message_class_wrapped():
+    """
+    Regression test to confirm that unpatch() should not throw AttributeErrors
+    on SerializeToString since Protobuf 5.x+ had a change in the upb/C extension.
+    """
+    from tests.utils import override_global_config
+
+    with override_global_config({"_data_streams_enabled": True}):
+        patch()
+        importlib.reload(other_message_pb2)  # _traced_build can trigger errors
+        unpatch()  # should not raise AttributeErrors
+
+
 def test_patching(protobuf):
     """
     When patching protobuf library


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

Attempts to reproduce the protobuf error from https://gitlab.ddbuild.io/datadog/apm-reliability/dd-trace-py/builds/1655817006

```
og_getattr = <built-in function getattr>
    def _wrapped_getattr(obj, name, *default):
        og_getattr = self.original_getattr
    
        if name in ("_datadog_patch", "__datadog_patch"):
            is_processed = obj in self.processed_objects
            is_patched = obj in self.patched_objects
    
            if not is_processed and not is_patched:
                tb = traceback.extract_stack()[:-1]
                tb_string = "".join(traceback.format_list(tb))
                self.patched_objects[obj] = tb_string
    
        if default:
            return og_getattr(obj, name, default[0])
>       return og_getattr(obj, name)
E       AttributeError: SerializeToString. Did you mean: 'SerializePartialToString'?
scripts/integration_registry/registry_update_helpers/integration_registry_manager.py:162: AttributeError
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->

I'm waiting to see if CI correctly fails in this commit, then will fix in another commit.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
