### PR TITLE
ci: wait for selenium

### DIFF
--- a/tests/contrib/config.py
+++ b/tests/contrib/config.py
@@ -154,3 +154,8 @@ VALKEY_CLUSTER_CONFIG = {
     "host": "127.0.0.1",
     "ports": os.getenv("TEST_VALKEYCLUSTER_PORTS", "7000,7001,7002,7003,7004,7005"),
 }
+
+SELENIUM_CONFIG = {
+    "host": os.getenv("TEST_SELENIUM_HOST", "127.0.0.1"),
+    "port": int(os.getenv("TEST_SELENIUM_PORT", 4444)),
+}

--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -24,6 +24,7 @@ from contrib.config import POSTGRES_CONFIG
 from contrib.config import PUBSUB_CONFIG
 from contrib.config import RABBITMQ_CONFIG
 from contrib.config import REDIS_CONFIG
+from contrib.config import SELENIUM_CONFIG
 from contrib.config import VERTICA_CONFIG
 import kombu
 import mysql.connector
@@ -134,6 +135,11 @@ def check_agent(url):
         raise Exception("Agent not ready")
 
 
+@try_until_timeout(Exception, args={"url": "http://{host}:{port}/status".format(**SELENIUM_CONFIG)})
+def check_selenium(url):
+    requests.get(url).raise_for_status()
+
+
 @try_until_timeout(Exception, args={"url": "http://{host}:{port}/".format(**ELASTICSEARCH_CONFIG)})
 def check_elasticsearch(url):
     requests.get(url).raise_for_status()
@@ -236,6 +242,7 @@ if __name__ == "__main__":
         "pubsub": check_pubsub,
         "rabbitmq": check_rabbitmq,
         "redis": check_redis,
+        "selenium-chrome": check_selenium,
         "testagent": check_agent,
         "vertica": check_vertica,
         "azurecosmosemulator": check_azurecosmosemulator,

--- a/tests/wait-for-services.py
+++ b/tests/wait-for-services.py
@@ -137,7 +137,10 @@ def check_agent(url):
 
 @try_until_timeout(Exception, args={"url": "http://{host}:{port}/status".format(**SELENIUM_CONFIG)})
 def check_selenium(url):
-    requests.get(url).raise_for_status()
+    resp = requests.get(url)
+    resp.raise_for_status()
+    if not resp.json().get("value", {}).get("ready"):
+        raise Exception("Selenium not ready")
 
 
 @try_until_timeout(Exception, args={"url": "http://{host}:{port}/".format(**ELASTICSEARCH_CONFIG)})


### PR DESCRIPTION
## Description

Sometimes Selenium docker would take some time to start, and some tests may fail the first try due to that:
```
$ riot -v run -s --pass-env wait -- testagent selenium-chrome
[14:30:01] INFO     Generating virtual environments for interpreters riot.py:986
                    Interpreter(_hint='3.9')
           INFO     Creating virtualenv                              riot.py:201
                    '/go/src/github.com/DataDog/apm-reliability/dd-t
                    race-py/.riot/venv_py3925' with interpreter
                    '/home/bits/.pyenv/versions/3.9.25/bin/python3.9
                    '.
[14:30:02] INFO     Skipping global deps install.                   riot.py:1003
           INFO     Running with Interpreter(_hint='3.9')            riot.py:775
           INFO     Creating virtualenv                              riot.py:201
                    '/go/src/github.com/DataDog/apm-reliability/dd-t
                    race-py/.riot/venv_py3925_39f016b78cad7d6' with
                    interpreter
                    '/home/bits/.pyenv/versions/3.9.25/bin/python3.9
                    '.
           INFO     Installing venv dependencies                     riot.py:625
                    .riot/requirements/39f016b.txt at
                    /go/src/github.com/DataDog/apm-reliability/dd-tr
                    ace-py/.riot/venv_py3925_39f016b78cad7d6.
[14:30:12] INFO     Running command 'python                          riot.py:838
                    tests/wait-for-services.py 'testagent'
                    'selenium-chrome'' in venv
                    '/go/src/github.com/DataDog/apm-reliability/dd-t
                    race-py/.riot/venv_py3925_39f016b78cad7d6'.
INFO:__main__:Attempt 0: check_agent({'url': 'http://testagent:9126/'})
INFO:__main__:Succeeded: check_agent
WARNING:__main__:Unknown service: selenium-chrome
[...]

>       raise exception_class(message, screen, stacktrace)
E       selenium.common.exceptions.WebDriverException: Message: unknown error: net::ERR_CONNECTION_REFUSED
```

`check_selenium` now validates both the HTTP status and the `value.ready` field in the `/status` response body. Selenium can return a 2xx before it is actually able to accept sessions; the `value.ready` boolean is the authoritative readiness signal defined in the [W3C WebDriver spec (§8.3 Status)](https://www.w3.org/TR/webdriver2/#status).

## Testing
Now we see:
```
INFO:__main__:Attempt 0: check_selenium({'url': 'http://127.0.0.1:4444/status'})
INFO:__main__:Succeeded: check_selenium
```
## Risks

None