### PR TITLE
fix(llmobs): bedrock agent root span encompasses back-dated children

### DIFF
--- a/ddtrace/contrib/internal/botocore/services/bedrock_agents.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock_agents.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 import wrapt
 
@@ -35,14 +36,18 @@ class TracedBotocoreEventStream(wrapt.ObjectProxy):
             if not self._dd_span.finished:
                 traces, chunks = _extract_traces_response_from_chunks(self._stream_chunks)
                 response = _process_streamed_response_chunks(chunks)
+                latest_child_ns = 0
                 try:
-                    self._dd_integration.translate_bedrock_traces(traces, self._dd_span)
+                    latest_child_ns = self._dd_integration.translate_bedrock_traces(traces, self._dd_span)
                 except Exception:
                     log.error("Error translating Bedrock traces", exc_info=True)
                 self._dd_integration.llmobs_set_tags(
                     self._dd_span, self._args, self._kwargs, response, operation="agent"
                 )
-                self._dd_span.finish()
+                # Push finish past wall-clock now if any back-dated child ended later (AWS clock
+                # skew or fast-replay).
+                finish_ns = max(time.time_ns(), int(latest_child_ns or 0))
+                self._dd_span.finish(finish_time=finish_ns / 1e9)
 
 
 def _extract_traces_response_from_chunks(chunks):

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -175,10 +175,14 @@ class BedrockIntegration(BaseLLMIntegration):
             return
         _annotate_llmobs_span_data(span, output_value=str(response))
 
-    def translate_bedrock_traces(self, traces, root_span) -> None:
-        """Translate bedrock agent traces to back-dated APM child spans of ``root_span``."""
+    def translate_bedrock_traces(self, traces, root_span) -> int:
+        """Translate bedrock agent traces to back-dated APM child spans of ``root_span``.
+
+        Returns the latest child end time (ns), or 0 if no children were created. Caller uses it
+        to push ``root_span``'s finish forward so the root covers its back-dated children.
+        """
         if not traces or not self.llmobs_enabled:
-            return
+            return 0
         # Per-invocation state. Held on the class previously, which raced across concurrent invoke_agent calls.
         step_spans_by_step_id: dict[str, Span] = {}
         active_span_by_step_id: dict[str, Span] = {}
@@ -199,15 +203,31 @@ class BedrockIntegration(BaseLLMIntegration):
                 if not finished:
                     active_span_by_step_id[trace_step_id] = inner_span
                 _propagate_inner_io_to_step_span(step_span, inner_span)
-        # Default finish_time = start_ns + 1ms (not wall-clock now) so back-dated orphans get a sane duration.
+        # Default finish_time = start_ns + 1ms (not wall-clock now) so back-dated orphans get a
+        # sane duration. Track earliest across both step and inner spans: guardrail inners can
+        # start before their step when AWS metadata predates the trace event's eventTime.
+        earliest_start_ns = int(root_span.start_ns or 0)
+        latest_end_ns = 0
         for step_id, step_span in step_spans_by_step_id.items():
             inners = inner_spans_by_step_id.get(step_id, [])
             for inner in inners:
                 inner.finish(finish_time=(int(inner.start_ns or 0) + DEFAULT_SPAN_DURATION_NS) / 1e9)
+                inner_start = int(inner.start_ns or 0)
+                if inner_start:
+                    earliest_start_ns = min(earliest_start_ns, inner_start)
             latest_inner_end_ns = max((_max_finish_ns(s) for s in inners), default=0)
             step_span.finish(
                 finish_time=(latest_inner_end_ns or int(step_span.start_ns or 0) + DEFAULT_SPAN_DURATION_NS) / 1e9
             )
+            step_start = int(step_span.start_ns or 0)
+            if step_start:
+                earliest_start_ns = min(earliest_start_ns, step_start)
+            latest_end_ns = max(latest_end_ns, _max_finish_ns(step_span))
+        # Stretch root over back-dated children (clock skew or fast-replay can push events outside
+        # the wall-clock window). Caller extends finish forward via the returned latest_end_ns.
+        if earliest_start_ns < int(root_span.start_ns or 0):
+            root_span.start_ns = earliest_start_ns
+        return latest_end_ns
 
     @staticmethod
     def _extract_input_message_for_converse(prompt: list[dict[str, Any]]) -> list[Message]:

--- a/releasenotes/notes/fix-bedrock-agent-root-span-duration-3e8b41ad0a90c5c2.yaml
+++ b/releasenotes/notes/fix-bedrock-agent-root-span-duration-3e8b41ad0a90c5c2.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes the duration of the ``Bedrock Agent <agent_id>`` span so it
+    encompasses its back-dated step / inner child spans. Previously the root span's window
+    only spanned the local ``invoke_agent`` round-trip, leaving children (which use AWS-side
+    ``eventTime`` for their ``start_ns``) appearing before and after the parent on the trace
+    timeline. The root span is now stretched to cover the earliest child start and latest
+    child end.

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -117,10 +117,10 @@ def test_agent_invoke(bedrock_agent_client, request_vcr, bedrock_agents_llmobs, 
             pass
     llmobs_events.sort(key=lambda span: span["start_ns"])
     assert len(llmobs_events) == 20
-    # The agent span starts at wall-clock time when ``invoke_agent`` is called, while the
-    # back-dated child spans use AWS-side ``eventTime``s, so the agent ends up with the latest
-    # ``start_ns`` after sorting.
-    _assert_agent_span(llmobs_events[-1], EXPECTED_OUTPUT)
+    # The agent span is stretched to cover its back-dated children (so it no longer has the latest
+    # start_ns); look it up by name instead of relying on sort order.
+    agent_span = next(e for e in llmobs_events if e["name"].startswith("Bedrock Agent"))
+    _assert_agent_span(agent_span, EXPECTED_OUTPUT)
     trace_step_spans = _extract_trace_step_spans(llmobs_events)
     _assert_trace_step_spans(trace_step_spans)
     inner_spans = _extract_inner_spans(llmobs_events)
@@ -141,10 +141,10 @@ def test_agent_invoke_stream(bedrock_agent_client, request_vcr, bedrock_agents_l
             pass
     llmobs_events.sort(key=lambda span: span["start_ns"])
     assert len(llmobs_events) == 20
-    # The agent span starts at wall-clock time when ``invoke_agent`` is called, while the
-    # back-dated child spans use AWS-side ``eventTime``s, so the agent ends up with the latest
-    # ``start_ns`` after sorting.
-    _assert_agent_span(llmobs_events[-1], EXPECTED_OUTPUT)
+    # The agent span is stretched to cover its back-dated children (so it no longer has the latest
+    # start_ns); look it up by name instead of relying on sort order.
+    agent_span = next(e for e in llmobs_events if e["name"].startswith("Bedrock Agent"))
+    _assert_agent_span(agent_span, EXPECTED_OUTPUT)
     trace_step_spans = _extract_trace_step_spans(llmobs_events)
     _assert_trace_step_spans(trace_step_spans)
     inner_spans = _extract_inner_spans(llmobs_events)
@@ -186,6 +186,36 @@ def test_agent_invoke_stream_trace_disabled(
             pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["name"] == "Bedrock Agent {}".format(AGENT_ID)
+
+
+def test_agent_span_covers_back_dated_children(
+    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, test_spans, llmobs_events
+):
+    """The root agent span's start/end must encompass every back-dated child span. The cassette's
+    AWS event times are far in the past, while the root span starts at test runtime; without the
+    stretch in ``translate_bedrock_traces`` + ``TracedBotocoreEventStream``, children would
+    appear to start before and end after their parent.
+    """
+    with request_vcr.use_cassette("agent_invoke.yaml"):
+        response = bedrock_agent_client.invoke_agent(
+            agentAliasId=AGENT_ALIAS_ID,
+            agentId=AGENT_ID,
+            sessionId="test_session",
+            enableTrace=True,
+            inputText=AGENT_INPUT,
+        )
+        for _ in response["completion"]:
+            pass
+    assert len(llmobs_events) == 20
+    root_event = next(e for e in llmobs_events if e["name"].startswith("Bedrock Agent"))
+    children = [e for e in llmobs_events if e is not root_event]
+    root_start = root_event["start_ns"]
+    root_end = root_start + root_event["duration"]
+    for child in children:
+        child_start = child["start_ns"]
+        child_end = child_start + child["duration"]
+        assert child_start >= root_start, f"{child['name']} starts before root"
+        assert child_end <= root_end, f"{child['name']} ends after root"
 
 
 def test_translated_step_events_share_apm_trace_id_with_root(

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock_agents.test_agent_invoke_with_step_spans.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock_agents.test_agent_invoke_with_step_spans.json
@@ -14,13 +14,13 @@
       "_dd.llmobs.span_kind": "agent",
       "_dd.llmobs.submitted": "1",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69fa05c900000000",
+      "_dd.p.tid": "69fa072a00000000",
       "_dd.svc_src": "botocore",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:dd-trace-py,svc.auto:tests.contrib.botocore",
       "language": "python",
-      "llmobs_parent_id": "10962284287018574249",
-      "llmobs_trace_id": "69fa05c9000000004893ddbfe74ce8da",
-      "runtime-id": "15c0a173560d4946b58c6752975f5873"
+      "llmobs_parent_id": "1252656382048455110",
+      "llmobs_trace_id": "69fa072a00000000d950a185895c1739",
+      "runtime-id": "708aa414986548358a22bfb72e013e00"
     },
     "metrics": {
       "_dd.llmobs.enabled": 1.0,
@@ -28,10 +28,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 26242.0
+      "process_id": 37297.0
     },
-    "duration": 11314000,
-    "start": 1777993161204838000
+    "duration": 29367425746636032,
+    "start": 1748626088886678016
   },
      {
        "name": "guardrailTrace Step",


### PR DESCRIPTION
## Description

> Stacks on #17887. Merge that one first.

The Bedrock Agent ``invoke_agent`` root span (``aws.bedrock-agent-runtime``) previously reported a duration covering only the local ``invoke_agent`` round-trip (often a few milliseconds), even though the translated step / inner APM child spans introduced in #17887 use AWS-side ``eventTime`` for their ``start_ns`` and so represent the much longer server-side execution window.

The result was a malformed trace where children appeared **before** and **after** their parent on the timeline. Example from the snapshot before the fix: root span = 11 ms, children = ~22 seconds spread across May 2025.

This PR:
- Updates ``BedrockIntegration.translate_bedrock_traces`` to track the earliest child ``start_ns`` across all step / inner spans, back-date ``root_span.start_ns`` when needed, and return the latest child end (``latest_end_ns``).
- Updates ``TracedBotocoreEventStream.__iter__`` to use that return value, finishing the root span with ``finish_time = max(time.time_ns(), latest_end_ns)`` so the root extends past wall-clock now if any back-dated child ended later (AWS clock skew or fast cassette replay).

## Testing

- New test ``test_agent_span_covers_back_dated_children`` asserts every child event's ``[start, end]`` window falls within the root agent span's window. This test fails on #17887 alone and passes once this PR is applied — it is the regression test for the duration bug.
- Existing ``test_agent_invoke`` and ``test_agent_invoke_stream`` updated to look up the agent span by name (``startswith(\"Bedrock Agent\")``) instead of relying on it being the latest by ``start_ns`` after sorting, since the root is now back-dated.
- Snapshot ``test_agent_invoke_with_step_spans`` regenerated; the testagent ignores ``start`` / ``duration`` so this is a structural change only.

Run with: ``DD_TRACE_AGENT_PORT=9126 riot -v run --pass-env -p3.13 -s botocore -k 'bedrock_agent'``. All 14 tests pass.

## Risks

- The root span's ``start_ns`` is mutated after creation. This is unusual but safe because the span has not been finished yet and no sub-spans of the root depend on its ``start_ns`` once they hold their own back-dated values.
- The root span's ``finish_time`` is now ``max(wall-clock, latest_child_ns)``. In normal operation (no clock skew) this is identical to wall-clock; only fast cassette replay or large AWS-side clock skew causes deviation.
- Trace ingestion downstream (Datadog Agent) accepts back-dated spans up to its own freshness window; users replaying very old recordings may still see drops, but this is unchanged from #17887.

## Additional Notes

- Hard-stacked on #17887. Both PRs together produce traces where the root span fully encompasses its children on the timeline.

Made with [Cursor](https://cursor.com)