### PR TITLE
fix(llmobs): per-invocation state for Bedrock Agent integration

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -31,8 +31,6 @@ log = get_logger(__name__)
 
 class BedrockIntegration(BaseLLMIntegration):
     _integration_name = "bedrock"
-    _spans: dict[str, LLMObsSpanEvent] = {}  # Maps LLMObs span ID to LLMObs span events
-    _active_span_by_step_id: dict[str, LLMObsSpanEvent] = {}  # Maps trace step ID to currently active span
 
     def _llmobs_set_tags(
         self,
@@ -180,24 +178,23 @@ class BedrockIntegration(BaseLLMIntegration):
         """Translate bedrock agent traces to LLMObs span events."""
         if not traces or not self.llmobs_enabled:
             return
+        # Per-invocation state. Held on the class previously, which raced across concurrent invoke_agent calls.
+        spans: dict[str, LLMObsSpanEvent] = {}
+        active_span_by_step_id: dict[str, LLMObsSpanEvent] = {}
         for trace in traces:
             trace_step_id = _extract_trace_step_id(trace)
-            current_active_span_event = self._active_span_by_step_id.pop(trace_step_id, None)
+            current_active_span_event = active_span_by_step_id.pop(trace_step_id, None)
             translated_span_event, finished = translate_bedrock_trace(
                 trace, root_span, current_active_span_event, trace_step_id
             )
             if translated_span_event:
-                self._spans[translated_span_event["span_id"]] = translated_span_event
+                spans[translated_span_event["span_id"]] = translated_span_event
                 if not finished:
-                    self._active_span_by_step_id[trace_step_id] = translated_span_event
-            _create_or_update_bedrock_trace_step_span(
-                trace, trace_step_id, translated_span_event, root_span, self._spans
-            )
-        for _, span_event in self._spans.items():
+                    active_span_by_step_id[trace_step_id] = translated_span_event
+            _create_or_update_bedrock_trace_step_span(trace, trace_step_id, translated_span_event, root_span, spans)
+        for _, span_event in spans.items():
             LLMObs._instance._llmobs_span_writer.enqueue(span_event)
             record_bedrock_agent_span_event_created(span_event)
-        self._spans.clear()
-        self._active_span_by_step_id.clear()
 
     @staticmethod
     def _extract_input_message_for_converse(prompt: list[dict[str, Any]]) -> list[Message]:

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -178,7 +178,6 @@ class BedrockIntegration(BaseLLMIntegration):
         """Translate bedrock agent traces to LLMObs span events."""
         if not traces or not self.llmobs_enabled:
             return
-        # Per-invocation state. Held on the class previously, which raced across concurrent invoke_agent calls.
         spans: dict[str, LLMObsSpanEvent] = {}
         active_span_by_step_id: dict[str, LLMObsSpanEvent] = {}
         for trace in traces:

--- a/releasenotes/notes/fix-bedrock-agent-concurrent-invoke-state-826a3d5a247b7664.yaml
+++ b/releasenotes/notes/fix-bedrock-agent-concurrent-invoke-state-826a3d5a247b7664.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes a concurrency hazard in the Bedrock Agent integration where
+    overlapping ``invoke_agent`` calls in the same process shared class-level state, which
+    could orphan pending step or inner spans and cross-attribute spans between concurrent
+    invocations. Per-invocation state is now used.

--- a/releasenotes/notes/fix-bedrock-agent-concurrent-invoke-state-826a3d5a247b7664.yaml
+++ b/releasenotes/notes/fix-bedrock-agent-concurrent-invoke-state-826a3d5a247b7664.yaml
@@ -1,7 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes a concurrency hazard in the Bedrock Agent integration where
-    overlapping ``invoke_agent`` calls in the same process shared class-level state, which
-    could orphan pending step or inner spans and cross-attribute spans between concurrent
-    invocations. Per-invocation state is now used.
+    LLM Observability: Fixes a concurrency bug in the Bedrock Agent integration where concurrent ``invoke_agent`` calls could orphan or cross-attribute spans due to shared class-level state. Per-invocation state is now used.

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -177,28 +177,3 @@ def test_agent_invoke_stream_trace_disabled(
             pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["name"] == "Bedrock Agent {}".format(AGENT_ID)
-
-
-def test_translate_bedrock_traces_does_not_share_state_across_invocations(
-    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, llmobs_events
-):
-    """Two ``invoke_agent`` calls in the same process must each produce the same number of LLMObs
-    events. With the previous class-level state dicts the second invocation could leak entries
-    from the first (or skip entries that were marked as already-active). Regression test for the
-    per-invocation state migration.
-    """
-    counts = []
-    for _ in range(2):
-        with request_vcr.use_cassette("agent_invoke.yaml"):
-            response = bedrock_agent_client.invoke_agent(
-                agentAliasId=AGENT_ALIAS_ID,
-                agentId=AGENT_ID,
-                sessionId="test_session",
-                enableTrace=True,
-                inputText=AGENT_INPUT,
-            )
-            for _ in response["completion"]:
-                pass
-        counts.append(len(llmobs_events))
-    assert counts[0] > 0, "expected the cassette to produce LLMObs events"
-    assert counts[1] == 2 * counts[0], "second invocation produced a different event count than the first"

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -177,3 +177,28 @@ def test_agent_invoke_stream_trace_disabled(
             pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["name"] == "Bedrock Agent {}".format(AGENT_ID)
+
+
+def test_translate_bedrock_traces_does_not_share_state_across_invocations(
+    bedrock_agent_client, request_vcr, bedrock_agents_llmobs, llmobs_events
+):
+    """Two ``invoke_agent`` calls in the same process must each produce the same number of LLMObs
+    events. With the previous class-level state dicts the second invocation could leak entries
+    from the first (or skip entries that were marked as already-active). Regression test for the
+    per-invocation state migration.
+    """
+    counts = []
+    for _ in range(2):
+        with request_vcr.use_cassette("agent_invoke.yaml"):
+            response = bedrock_agent_client.invoke_agent(
+                agentAliasId=AGENT_ALIAS_ID,
+                agentId=AGENT_ID,
+                sessionId="test_session",
+                enableTrace=True,
+                inputText=AGENT_INPUT,
+            )
+            for _ in response["completion"]:
+                pass
+        counts.append(len(llmobs_events))
+    assert counts[0] > 0, "expected the cassette to produce LLMObs events"
+    assert counts[1] == 2 * counts[0], "second invocation produced a different event count than the first"


### PR DESCRIPTION
## Description

The Bedrock Agent integration kept its in-flight ``_spans`` and ``_active_span_by_step_id`` dicts on the ``BedrockIntegration`` class, so they were shared across every ``invoke_agent`` call in the same process. Two concurrent invocations could:

- orphan a pending ``modelInvocationInput`` (the next call would consume it as if it were its own); or
- attribute a step span from one invocation to another.

This PR moves both dicts into ``translate_bedrock_traces`` as locals so each invocation owns its own state. The legacy ``LLMObsSpanEvent`` flow is otherwise unchanged — no contract change to LLMObs payloads.

## Testing

- New regression test ``test_translate_bedrock_traces_does_not_share_state_across_invocations`` runs the cassette twice in the same process and asserts the second invocation produces the same number of LLMObs events as the first.
- Existing ``test_agent_invoke`` / ``test_agent_invoke_stream`` / ``test_agent_invoke_trace_disabled`` / ``test_agent_invoke_stream_trace_disabled`` continue to pass.

## Risks

Low — purely scoping change. The dicts were only ever populated and drained inside ``translate_bedrock_traces``; nothing else on the class read from them.

## Additional Notes

This is the first of three small, independently reviewable PRs split out of a larger Bedrock Agent refactor:

1. **(this PR)** Concurrency fix — per-invocation state.
2. Migration — emit Bedrock Agent step events as APM child spans + add snapshot tests.
3. Duration fix — stretch the ``Bedrock Agent`` root span to encompass its back-dated children.

Made with [Cursor](https://cursor.com)