### PR TITLE
chore: ignore commit-headless when updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       gh-actions-packages:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "commit-headless:*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,5 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "commit-headless:*"
+      - dependency-name: "DataDog/commit-headless:*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This change has dependabot ignore new versions of commit-headless. See https://github.com/DataDog/dd-trace-py/pull/17440 for more details on how 3.x doesn't work with our current code.