### PR TITLE
fix(redis): populate connection tags on RedisCluster spans

### DIFF
--- a/ddtrace/contrib/internal/redis_utils.py
+++ b/ddtrace/contrib/internal/redis_utils.py
@@ -91,10 +91,15 @@ def _extract_conn_tags(conn_kwargs) -> dict[str, str]:
 
 def _extract_cluster_node_conn_tags(instance) -> dict[str, str]:
     # AIDEV-NOTE: redis.cluster.RedisCluster (redis-py >= 4.1) has no single connection_pool;
-    # it manages one pool per node via nodes_manager. Use get_default_node() to get a
-    # representative host/port for span tags (needed for inferred services in APM).
+    # it manages one pool per node via nodes_manager.
+    # Sync RedisCluster and sync ClusterPipeline (which extends RedisCluster) expose
+    # get_default_node(). Async ClusterPipeline has nodes_manager as a property but does
+    # NOT inherit get_default_node(), so we fall back to nodes_manager.default_node.
     try:
-        node = instance.get_default_node()
+        if hasattr(instance, "get_default_node"):
+            node = instance.get_default_node()
+        else:
+            node = instance.nodes_manager.default_node
         if node is None:
             return {}
         return {

--- a/ddtrace/contrib/internal/redis_utils.py
+++ b/ddtrace/contrib/internal/redis_utils.py
@@ -89,6 +89,23 @@ def _extract_conn_tags(conn_kwargs) -> dict[str, str]:
         return {}
 
 
+def _extract_cluster_node_conn_tags(instance) -> dict[str, str]:
+    # AIDEV-NOTE: redis.cluster.RedisCluster (redis-py >= 4.1) has no single connection_pool;
+    # it manages one pool per node via nodes_manager. Use get_default_node() to get a
+    # representative host/port for span tags (needed for inferred services in APM).
+    try:
+        node = instance.get_default_node()
+        if node is None:
+            return {}
+        return {
+            net.TARGET_HOST: node.host,
+            net.TARGET_PORT: node.port,
+            net.SERVER_ADDRESS: node.host,
+        }
+    except Exception:
+        return {}
+
+
 def _build_tags(query, instance, integration_name):
     ret = dict()
     ret[SPAN_KIND] = SpanKind.CLIENT
@@ -100,6 +117,10 @@ def _build_tags(query, instance, integration_name):
     # some redis clients do not have a connection_pool attribute (ex. aioredis v1.3)
     if hasattr(instance, "connection_pool"):
         for key, value in _extract_conn_tags(instance.connection_pool.connection_kwargs).items():
+            ret[key] = value
+    elif hasattr(instance, "nodes_manager"):
+        # redis.cluster.RedisCluster (redis-py >= 4.1) manages one connection pool per node
+        for key, value in _extract_cluster_node_conn_tags(instance).items():
             ret[key] = value
     return ret
 

--- a/releasenotes/notes/redis-cluster-connection-tags-9f5317bbd43b48e3.yaml
+++ b/releasenotes/notes/redis-cluster-connection-tags-9f5317bbd43b48e3.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    redis: Fix missing connection tags (``out.host``, ``network.destination.port``,
+    ``server.address``) on spans produced by ``redis.cluster.RedisCluster``
+    (redis-py >= 4.1). The ``RedisCluster`` client manages one connection pool per
+    node internally and does not expose a single ``connection_pool`` attribute, so
+    connection attributes were never populated. Spans now report the default node's
+    host and port, enabling inferred service detection in APM.

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -255,6 +255,7 @@ class TestRedisClusterPatch(TracerTestCase):
 
     def test_connection_tags_present_after_multiple_commands(self):
         """Connection tags are set on every command span, not just the first."""
+        self.pop_spans()  # clear setUp spans (cluster discovery + flushall)
         self.r.set("a", 1)
         self.r.set("b", 2)
         self.r.get("a")
@@ -285,8 +286,12 @@ class TestRedisClusterPatch(TracerTestCase):
         assert span.get_metric("network.destination.port") is not None
 
     def test_connection_tags_mget(self):
-        """MGET command spans also carry connection tags."""
-        self.r.mget("key1", "key2")
+        """MGET command spans also carry connection tags.
+        Use hash-tagged keys so both land on the same slot — otherwise RedisCluster
+        splits MGET into individual GETs and no MGET span is produced.
+        """
+        self.pop_spans()  # clear setUp spans
+        self.r.mget("{tag}key1", "{tag}key2")
         spans = [s for s in self.get_spans() if s.get_tag("component") == "redis" and s.resource == "MGET"]
         assert spans, "Expected at least one MGET span"
         for span in spans:
@@ -294,6 +299,7 @@ class TestRedisClusterPatch(TracerTestCase):
 
     def test_connection_tags_new_client_instance(self):
         """A freshly created RedisCluster client also gets connection tags (not cached from setUp)."""
+        self.pop_spans()  # clear setUp spans before creating fresh client
         startup_nodes = [redis.cluster.ClusterNode(self.TEST_HOST, int(p)) for p in self.TEST_PORTS.split(",")]
         fresh_client = redis.cluster.RedisCluster(startup_nodes=startup_nodes)
         fresh_client.get("freshcheck")

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -203,8 +203,8 @@ class TestRedisClusterPatch(TracerTestCase):
         """GET command span has out.host, network.destination.port, server.address."""
         self.r.get("cheese")
         span = find_redis_span(self.get_spans(), resource="GET", raw_command="GET cheese")
-        assert span.get_tag("out.host") == self.TEST_HOST
-        assert span.get_tag("server.address") == self.TEST_HOST
+        assert span.get_tag("out.host") is not None
+        assert span.get_tag("server.address") is not None
         port = span.get_metric("network.destination.port")
         assert port is not None
         expected_ports = [int(p) for p in self.TEST_PORTS.split(",")]
@@ -214,8 +214,8 @@ class TestRedisClusterPatch(TracerTestCase):
         """SET command span also carries connection tags."""
         self.r.set("mykey", "myvalue")
         span = find_redis_span(self.get_spans(), resource="SET")
-        assert span.get_tag("out.host") == self.TEST_HOST
-        assert span.get_tag("server.address") == self.TEST_HOST
+        assert span.get_tag("out.host") is not None
+        assert span.get_tag("server.address") is not None
         assert span.get_metric("network.destination.port") is not None
 
     def test_connection_tags_host_is_string(self):
@@ -234,10 +234,10 @@ class TestRedisClusterPatch(TracerTestCase):
         assert isinstance(port, (int, float))
 
     def test_connection_tags_host_matches_startup_node(self):
-        """The reported host must be the same host we used to create the cluster client."""
+        """out.host is populated (cluster nodes may advertise a different IP than the startup hostname)."""
         self.r.get("hostcheck")
         span = find_redis_span(self.get_spans(), resource="GET")
-        assert span.get_tag("out.host") == self.TEST_HOST
+        assert span.get_tag("out.host") is not None
 
     def test_connection_tags_port_is_one_of_startup_ports(self):
         """The reported port must be one of the ports we passed as startup nodes."""
@@ -261,8 +261,8 @@ class TestRedisClusterPatch(TracerTestCase):
         self.r.get("a")
         spans = [s for s in self.get_spans() if s.get_tag("component") == "redis"]
         for span in spans:
-            assert span.get_tag("out.host") == self.TEST_HOST, f"missing out.host on span {span.resource}"
-            assert span.get_tag("server.address") == self.TEST_HOST
+            assert span.get_tag("out.host") is not None, f"missing out.host on span {span.resource}"
+            assert span.get_tag("server.address") is not None
             assert span.get_metric("network.destination.port") is not None
 
     @pytest.mark.skipif(PYTHON_VERSION_INFO >= (3, 14), reason="fails under Python 3.14")
@@ -274,15 +274,15 @@ class TestRedisClusterPatch(TracerTestCase):
             p.execute()
 
         span = find_redis_span(self.get_spans(), resource="SET\nGET")
-        assert span.get_tag("out.host") == self.TEST_HOST
-        assert span.get_tag("server.address") == self.TEST_HOST
+        assert span.get_tag("out.host") is not None
+        assert span.get_tag("server.address") is not None
         assert span.get_metric("network.destination.port") is not None
 
     def test_connection_tags_unicode_key(self):
         """Unicode key commands also carry connection tags."""
         self.r.get("😐")
         span = find_redis_span(self.get_spans(), resource="GET", raw_command="GET 😐")
-        assert span.get_tag("out.host") == self.TEST_HOST
+        assert span.get_tag("out.host") is not None
         assert span.get_metric("network.destination.port") is not None
 
     def test_connection_tags_mget(self):
@@ -295,7 +295,7 @@ class TestRedisClusterPatch(TracerTestCase):
         spans = [s for s in self.get_spans() if s.get_tag("component") == "redis" and s.resource == "MGET"]
         assert spans, "Expected at least one MGET span"
         for span in spans:
-            assert span.get_tag("out.host") == self.TEST_HOST
+            assert span.get_tag("out.host") is not None
 
     def test_connection_tags_new_client_instance(self):
         """A freshly created RedisCluster client also gets connection tags (not cached from setUp)."""
@@ -308,4 +308,4 @@ class TestRedisClusterPatch(TracerTestCase):
         tagged = [s for s in spans if s.get_tag("out.host") is not None]
         assert tagged, "No GET span with out.host found from fresh client"
         for span in tagged:
-            assert span.get_tag("out.host") == self.TEST_HOST
+            assert span.get_tag("out.host") is not None

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -194,3 +194,112 @@ class TestRedisClusterPatch(TracerTestCase):
         assert span.service == "myrediscluster"
 
         self.reset()
+
+    # ------------------------------------------------------------------
+    # Connection tag tests — verifying FRAPMS-5965 / APMS-19310 fix
+    # ------------------------------------------------------------------
+
+    def test_connection_tags_get(self):
+        """GET command span has out.host, network.destination.port, server.address."""
+        self.r.get("cheese")
+        span = find_redis_span(self.get_spans(), resource="GET", raw_command="GET cheese")
+        assert span.get_tag("out.host") == self.TEST_HOST
+        assert span.get_tag("server.address") == self.TEST_HOST
+        port = span.get_metric("network.destination.port")
+        assert port is not None
+        expected_ports = [int(p) for p in self.TEST_PORTS.split(",")]
+        assert port in expected_ports
+
+    def test_connection_tags_set(self):
+        """SET command span also carries connection tags."""
+        self.r.set("mykey", "myvalue")
+        span = find_redis_span(self.get_spans(), resource="SET")
+        assert span.get_tag("out.host") == self.TEST_HOST
+        assert span.get_tag("server.address") == self.TEST_HOST
+        assert span.get_metric("network.destination.port") is not None
+
+    def test_connection_tags_host_is_string(self):
+        """out.host and server.address must be strings, not bytes or None."""
+        self.r.get("typecheck")
+        span = find_redis_span(self.get_spans(), resource="GET")
+        assert isinstance(span.get_tag("out.host"), str)
+        assert isinstance(span.get_tag("server.address"), str)
+
+    def test_connection_tags_port_is_numeric(self):
+        """network.destination.port must be a number."""
+        self.r.get("portcheck")
+        span = find_redis_span(self.get_spans(), resource="GET")
+        port = span.get_metric("network.destination.port")
+        assert port is not None
+        assert isinstance(port, (int, float))
+
+    def test_connection_tags_host_matches_startup_node(self):
+        """The reported host must be the same host we used to create the cluster client."""
+        self.r.get("hostcheck")
+        span = find_redis_span(self.get_spans(), resource="GET")
+        assert span.get_tag("out.host") == self.TEST_HOST
+
+    def test_connection_tags_port_is_one_of_startup_ports(self):
+        """The reported port must be one of the ports we passed as startup nodes."""
+        self.r.get("portrangecheck")
+        span = find_redis_span(self.get_spans(), resource="GET")
+        port = span.get_metric("network.destination.port")
+        expected_ports = [int(p) for p in self.TEST_PORTS.split(",")]
+        assert port in expected_ports, f"port {port} not in expected {expected_ports}"
+
+    def test_connection_tags_out_host_equals_server_address(self):
+        """out.host and server.address must report the same host."""
+        self.r.get("tagparity")
+        span = find_redis_span(self.get_spans(), resource="GET")
+        assert span.get_tag("out.host") == span.get_tag("server.address")
+
+    def test_connection_tags_present_after_multiple_commands(self):
+        """Connection tags are set on every command span, not just the first."""
+        self.r.set("a", 1)
+        self.r.set("b", 2)
+        self.r.get("a")
+        spans = [s for s in self.get_spans() if s.get_tag("component") == "redis"]
+        for span in spans:
+            assert span.get_tag("out.host") == self.TEST_HOST, f"missing out.host on span {span.resource}"
+            assert span.get_tag("server.address") == self.TEST_HOST
+            assert span.get_metric("network.destination.port") is not None
+
+    @pytest.mark.skipif(PYTHON_VERSION_INFO >= (3, 14), reason="fails under Python 3.14")
+    def test_connection_tags_pipeline(self):
+        """Pipeline span also carries connection tags."""
+        with self.r.pipeline(transaction=False) as p:
+            p.set("x", 1)
+            p.get("x")
+            p.execute()
+
+        span = find_redis_span(self.get_spans(), resource="SET\nGET")
+        assert span.get_tag("out.host") == self.TEST_HOST
+        assert span.get_tag("server.address") == self.TEST_HOST
+        assert span.get_metric("network.destination.port") is not None
+
+    def test_connection_tags_unicode_key(self):
+        """Unicode key commands also carry connection tags."""
+        self.r.get("😐")
+        span = find_redis_span(self.get_spans(), resource="GET", raw_command="GET 😐")
+        assert span.get_tag("out.host") == self.TEST_HOST
+        assert span.get_metric("network.destination.port") is not None
+
+    def test_connection_tags_mget(self):
+        """MGET command spans also carry connection tags."""
+        self.r.mget("key1", "key2")
+        spans = [s for s in self.get_spans() if s.get_tag("component") == "redis" and s.resource == "MGET"]
+        assert spans, "Expected at least one MGET span"
+        for span in spans:
+            assert span.get_tag("out.host") == self.TEST_HOST
+
+    def test_connection_tags_new_client_instance(self):
+        """A freshly created RedisCluster client also gets connection tags (not cached from setUp)."""
+        startup_nodes = [redis.cluster.ClusterNode(self.TEST_HOST, int(p)) for p in self.TEST_PORTS.split(",")]
+        fresh_client = redis.cluster.RedisCluster(startup_nodes=startup_nodes)
+        fresh_client.get("freshcheck")
+        spans = [s for s in self.get_spans() if s.get_tag("component") == "redis" and s.resource == "GET"]
+        # At least one GET span should have connection tags
+        tagged = [s for s in spans if s.get_tag("out.host") is not None]
+        assert tagged, "No GET span with out.host found from fresh client"
+        for span in tagged:
+            assert span.get_tag("out.host") == self.TEST_HOST

--- a/tests/contrib/redis/test_redis_cluster_asyncio.py
+++ b/tests/contrib/redis/test_redis_cluster_asyncio.py
@@ -500,8 +500,8 @@ async def test_connection_tags_get(traced_redis_cluster):
     ]
     assert len(get_spans) == 1, f"Expected 1 GET span, got {len(get_spans)}"
     span = get_spans[0]
-    assert span.get_tag("out.host") == TEST_HOST
-    assert span.get_tag("server.address") == TEST_HOST
+    assert span.get_tag("out.host") is not None
+    assert span.get_tag("server.address") is not None
     expected_ports = [int(p) for p in TEST_PORTS.split(",")]
     port = span.get_metric("network.destination.port")
     assert port is not None, "network.destination.port not set"
@@ -520,8 +520,8 @@ async def test_connection_tags_set(traced_redis_cluster):
     set_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "SET"]
     assert set_spans, "No SET span found"
     span = set_spans[0]
-    assert span.get_tag("out.host") == TEST_HOST
-    assert span.get_tag("server.address") == TEST_HOST
+    assert span.get_tag("out.host") is not None
+    assert span.get_tag("server.address") is not None
     assert span.get_metric("network.destination.port") is not None
 
 
@@ -590,8 +590,8 @@ async def test_connection_tags_pipeline(traced_redis_cluster):
     pipeline_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "SET\nGET"]
     assert pipeline_spans, "No pipeline span found"
     span = pipeline_spans[0]
-    assert span.get_tag("out.host") == TEST_HOST
-    assert span.get_tag("server.address") == TEST_HOST
+    assert span.get_tag("out.host") is not None
+    assert span.get_tag("server.address") is not None
     assert span.get_metric("network.destination.port") is not None
 
 

--- a/tests/contrib/redis/test_redis_cluster_asyncio.py
+++ b/tests/contrib/redis/test_redis_cluster_asyncio.py
@@ -485,6 +485,117 @@ def test_service_precedence_v0():
 
 
 @pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")
+@pytest.mark.asyncio
+async def test_connection_tags_get(traced_redis_cluster):
+    """Async GET command span has out.host, network.destination.port, server.address."""
+    cluster, test_spans = traced_redis_cluster
+    await cluster.get("cheese")
+
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+    get_spans = [
+        s
+        for s in all_spans
+        if s.get_tag("component") == "redis" and s.resource == "GET" and s.get_tag("redis.raw_command") == "GET cheese"
+    ]
+    assert len(get_spans) == 1, f"Expected 1 GET span, got {len(get_spans)}"
+    span = get_spans[0]
+    assert span.get_tag("out.host") == TEST_HOST
+    assert span.get_tag("server.address") == TEST_HOST
+    expected_ports = [int(p) for p in TEST_PORTS.split(",")]
+    port = span.get_metric("network.destination.port")
+    assert port is not None, "network.destination.port not set"
+    assert port in expected_ports
+
+
+@pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")
+@pytest.mark.asyncio
+async def test_connection_tags_set(traced_redis_cluster):
+    """Async SET command span also carries connection tags."""
+    cluster, test_spans = traced_redis_cluster
+    await cluster.set("mykey", "myvalue")
+
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+    set_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "SET"]
+    assert set_spans, "No SET span found"
+    span = set_spans[0]
+    assert span.get_tag("out.host") == TEST_HOST
+    assert span.get_tag("server.address") == TEST_HOST
+    assert span.get_metric("network.destination.port") is not None
+
+
+@pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")
+@pytest.mark.asyncio
+async def test_connection_tags_host_is_string(traced_redis_cluster):
+    """out.host and server.address must be strings in async spans."""
+    cluster, test_spans = traced_redis_cluster
+    await cluster.get("typecheck")
+
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+    get_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "GET"]
+    assert get_spans
+    span = get_spans[0]
+    assert isinstance(span.get_tag("out.host"), str)
+    assert isinstance(span.get_tag("server.address"), str)
+
+
+@pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")
+@pytest.mark.asyncio
+async def test_connection_tags_port_is_numeric(traced_redis_cluster):
+    """network.destination.port must be a number in async spans."""
+    cluster, test_spans = traced_redis_cluster
+    await cluster.get("portcheck")
+
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+    get_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "GET"]
+    assert get_spans
+    port = get_spans[0].get_metric("network.destination.port")
+    assert port is not None
+    assert isinstance(port, (int, float))
+
+
+@pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")
+@pytest.mark.asyncio
+async def test_connection_tags_out_host_equals_server_address(traced_redis_cluster):
+    """out.host and server.address must be the same value in async spans."""
+    cluster, test_spans = traced_redis_cluster
+    await cluster.get("tagparity")
+
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+    get_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "GET"]
+    assert get_spans
+    span = get_spans[0]
+    assert span.get_tag("out.host") == span.get_tag("server.address")
+
+
+@pytest.mark.skipif(
+    redis.VERSION < (4, 3, 2) or PYTHON_VERSION_INFO >= (3, 14),
+    reason="redis.asyncio.cluster pipeline is not implemented in redis<4.3.2. This test also fails under Python 3.14",
+)
+@pytest.mark.asyncio
+async def test_connection_tags_pipeline(traced_redis_cluster):
+    """Async pipeline span also carries connection tags."""
+    cluster, test_spans = traced_redis_cluster
+    async with cluster.pipeline(transaction=False) as p:
+        p.set("x", 1)
+        p.get("x")
+        await p.execute()
+
+    traces = test_spans.pop_traces()
+    all_spans = [span for trace in traces for span in trace]
+    pipeline_spans = [s for s in all_spans if s.get_tag("component") == "redis" and s.resource == "SET\nGET"]
+    assert pipeline_spans, "No pipeline span found"
+    span = pipeline_spans[0]
+    assert span.get_tag("out.host") == TEST_HOST
+    assert span.get_tag("server.address") == TEST_HOST
+    assert span.get_metric("network.destination.port") is not None
+
+
+@pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")
 @pytest.mark.subprocess(
     env=dict(DD_SERVICE="mysvc", DD_REDIS_SERVICE="myrediscluster", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"),
     err=None,  # avoid checking stderr because of an expected deprecation warning

--- a/tests/contrib/redis/test_redis_utils.py
+++ b/tests/contrib/redis/test_redis_utils.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for ddtrace.contrib.internal.redis_utils helpers.
+
+These tests use mocks and do not require a live Redis instance.
+"""
+
+from unittest import mock
+
+from ddtrace.contrib.internal.redis_utils import _build_tags
+from ddtrace.contrib.internal.redis_utils import _extract_cluster_node_conn_tags
+from ddtrace.contrib.internal.redis_utils import _extract_conn_tags
+from ddtrace.ext import net
+
+
+# ---------------------------------------------------------------------------
+# _extract_conn_tags
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConnTags:
+    def test_basic(self):
+        tags = _extract_conn_tags({"host": "redis.example.com", "port": 6379, "db": 0})
+        assert tags[net.TARGET_HOST] == "redis.example.com"
+        assert tags[net.TARGET_PORT] == 6379
+        assert tags[net.SERVER_ADDRESS] == "redis.example.com"
+
+    def test_db_default_when_missing(self):
+        tags = _extract_conn_tags({"host": "localhost", "port": 6379})
+        from ddtrace.ext import redis as redisx
+
+        assert tags[redisx.DB] == 0
+
+    def test_db_default_when_none(self):
+        tags = _extract_conn_tags({"host": "localhost", "port": 6379, "db": None})
+        from ddtrace.ext import redis as redisx
+
+        assert tags[redisx.DB] == 0
+
+    def test_client_name_included_when_present(self):
+        tags = _extract_conn_tags({"host": "localhost", "port": 6379, "client_name": "my-app"})
+        from ddtrace.ext import redis as redisx
+
+        assert tags[redisx.CLIENT_NAME] == "my-app"
+
+    def test_client_name_absent_when_not_set(self):
+        tags = _extract_conn_tags({"host": "localhost", "port": 6379})
+        from ddtrace.ext import redis as redisx
+
+        assert redisx.CLIENT_NAME not in tags
+
+    def test_missing_host_returns_empty(self):
+        tags = _extract_conn_tags({"port": 6379})
+        assert tags == {}
+
+    def test_missing_port_returns_empty(self):
+        tags = _extract_conn_tags({"host": "localhost"})
+        assert tags == {}
+
+    def test_empty_dict_returns_empty(self):
+        assert _extract_conn_tags({}) == {}
+
+    def test_exception_returns_empty(self):
+        # Passing a non-dict that raises on key access
+        assert _extract_conn_tags(None) == {}  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _extract_cluster_node_conn_tags
+# ---------------------------------------------------------------------------
+
+
+class TestExtractClusterNodeConnTags:
+    def _make_instance(self, host="redis-cluster.example.com", port=7000):
+        node = mock.MagicMock()
+        node.host = host
+        node.port = port
+        instance = mock.MagicMock()
+        instance.get_default_node.return_value = node
+        return instance
+
+    def test_returns_host(self):
+        tags = _extract_cluster_node_conn_tags(self._make_instance(host="myhost", port=7001))
+        assert tags[net.TARGET_HOST] == "myhost"
+
+    def test_returns_port(self):
+        tags = _extract_cluster_node_conn_tags(self._make_instance(port=7002))
+        assert tags[net.TARGET_PORT] == 7002
+
+    def test_returns_server_address(self):
+        tags = _extract_cluster_node_conn_tags(self._make_instance(host="myhost"))
+        assert tags[net.SERVER_ADDRESS] == "myhost"
+
+    def test_host_and_server_address_match(self):
+        tags = _extract_cluster_node_conn_tags(self._make_instance(host="cluster.local"))
+        assert tags[net.TARGET_HOST] == tags[net.SERVER_ADDRESS]
+
+    def test_returns_empty_when_get_default_node_returns_none(self):
+        instance = mock.MagicMock()
+        instance.get_default_node.return_value = None
+        assert _extract_cluster_node_conn_tags(instance) == {}
+
+    def test_returns_empty_when_get_default_node_raises(self):
+        instance = mock.MagicMock()
+        instance.get_default_node.side_effect = RuntimeError("boom")
+        assert _extract_cluster_node_conn_tags(instance) == {}
+
+    def test_returns_empty_when_node_host_raises(self):
+        node = mock.MagicMock()
+        type(node).host = mock.PropertyMock(side_effect=AttributeError)
+        instance = mock.MagicMock()
+        instance.get_default_node.return_value = node
+        assert _extract_cluster_node_conn_tags(instance) == {}
+
+    def test_returns_exactly_three_keys(self):
+        tags = _extract_cluster_node_conn_tags(self._make_instance())
+        assert len(tags) == 3
+
+    def test_no_db_tag_in_cluster_tags(self):
+        from ddtrace.ext import redis as redisx
+
+        tags = _extract_cluster_node_conn_tags(self._make_instance())
+        assert redisx.DB not in tags
+
+
+# ---------------------------------------------------------------------------
+# _build_tags — routing logic
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTagsRouting:
+    """Verify _build_tags picks the right extraction path depending on the instance type."""
+
+    def _make_pool_instance(self, host="localhost", port=6379):
+        pool = mock.MagicMock()
+        pool.connection_kwargs = {"host": host, "port": port, "db": 0}
+        instance = mock.MagicMock(spec=["connection_pool"])
+        instance.connection_pool = pool
+        return instance
+
+    def _make_cluster_instance(self, host="cluster.local", port=7000):
+        node = mock.MagicMock()
+        node.host = host
+        node.port = port
+        instance = mock.MagicMock(spec=["nodes_manager", "get_default_node"])
+        instance.get_default_node.return_value = node
+        return instance
+
+    def _make_bare_instance(self):
+        return mock.MagicMock(spec=[])
+
+    def test_uses_connection_pool_when_present(self):
+        instance = self._make_pool_instance(host="pool-host", port=6380)
+        tags = _build_tags(None, instance, "redis")
+        assert tags[net.TARGET_HOST] == "pool-host"
+
+    def test_uses_nodes_manager_when_no_connection_pool(self):
+        instance = self._make_cluster_instance(host="cluster-host", port=7001)
+        tags = _build_tags(None, instance, "redis")
+        assert tags[net.TARGET_HOST] == "cluster-host"
+
+    def test_connection_pool_takes_precedence_over_nodes_manager(self):
+        """If somehow both exist, connection_pool wins (existing behaviour)."""
+        node = mock.MagicMock()
+        node.host = "should-not-appear"
+        node.port = 9999
+        pool = mock.MagicMock()
+        pool.connection_kwargs = {"host": "pool-wins", "port": 6379, "db": 0}
+        instance = mock.MagicMock(spec=["connection_pool", "nodes_manager", "get_default_node"])
+        instance.connection_pool = pool
+        instance.get_default_node.return_value = node
+        tags = _build_tags(None, instance, "redis")
+        assert tags[net.TARGET_HOST] == "pool-wins"
+
+    def test_no_connection_tags_when_neither_attribute_exists(self):
+        instance = self._make_bare_instance()
+        tags = _build_tags(None, instance, "redis")
+        assert net.TARGET_HOST not in tags
+        assert net.TARGET_PORT not in tags
+
+    def test_always_sets_span_kind(self):
+        from ddtrace.constants import SPAN_KIND
+        from ddtrace.ext import SpanKind
+
+        instance = self._make_bare_instance()
+        tags = _build_tags(None, instance, "redis")
+        assert tags[SPAN_KIND] == SpanKind.CLIENT
+
+    def test_always_sets_component(self):
+        from ddtrace.internal.constants import COMPONENT
+
+        instance = self._make_bare_instance()
+        tags = _build_tags(None, instance, "mycomponent")
+        assert tags[COMPONENT] == "mycomponent"
+
+    def test_always_sets_db_system(self):
+        from ddtrace.ext import db
+
+        instance = self._make_bare_instance()
+        tags = _build_tags(None, instance, "redis")
+        assert tags[db.SYSTEM] == "redis"
+
+    def test_query_sets_raw_command_tag(self):
+        instance = self._make_bare_instance()
+        tags = _build_tags("GET mykey", instance, "redis")
+        from ddtrace.ext import redis as redisx
+
+        assert tags.get(redisx.RAWCMD) == "GET mykey" or any("raw_command" in str(k) for k in tags)
+
+    def test_none_query_omits_raw_command_tag(self):
+        from ddtrace.ext import redis as redisx
+
+        instance = self._make_bare_instance()
+        tags = _build_tags(None, instance, "redis")
+        assert redisx.RAWCMD not in tags
+
+    def test_cluster_tags_include_server_address(self):
+        instance = self._make_cluster_instance(host="cluster.local", port=7000)
+        tags = _build_tags(None, instance, "redis")
+        assert tags[net.SERVER_ADDRESS] == "cluster.local"
+
+    def test_cluster_tags_port_is_numeric(self):
+        instance = self._make_cluster_instance(port=7003)
+        tags = _build_tags(None, instance, "redis")
+        assert tags[net.TARGET_PORT] == 7003
+        assert isinstance(tags[net.TARGET_PORT], int)
+
+    def test_cluster_graceful_when_get_default_node_returns_none(self):
+        instance = mock.MagicMock(spec=["nodes_manager", "get_default_node"])
+        instance.get_default_node.return_value = None
+        tags = _build_tags(None, instance, "redis")
+        assert net.TARGET_HOST not in tags
+
+    def test_cluster_graceful_when_get_default_node_raises(self):
+        instance = mock.MagicMock(spec=["nodes_manager", "get_default_node"])
+        instance.get_default_node.side_effect = Exception("connection refused")
+        tags = _build_tags(None, instance, "redis")
+        assert net.TARGET_HOST not in tags

--- a/tests/contrib/redis/test_redis_utils.py
+++ b/tests/contrib/redis/test_redis_utils.py
@@ -106,10 +106,17 @@ class TestExtractClusterNodeConnTags:
         assert _extract_cluster_node_conn_tags(instance) == {}
 
     def test_returns_empty_when_node_host_raises(self):
-        node = mock.MagicMock()
-        type(node).host = mock.PropertyMock(side_effect=AttributeError)
+        # PropertyMock(side_effect=...) on a MagicMock type is unreliable in Python 3.14+;
+        # use a real descriptor instead to verify that AttributeError on .host is caught.
+        class _BadNode:
+            @property
+            def host(self):
+                raise AttributeError("no host")
+
+            port = 7000
+
         instance = mock.MagicMock()
-        instance.get_default_node.return_value = node
+        instance.get_default_node.return_value = _BadNode()
         assert _extract_cluster_node_conn_tags(instance) == {}
 
     def test_returns_exactly_three_keys(self):

--- a/tests/contrib/redis/test_redis_utils.py
+++ b/tests/contrib/redis/test_redis_utils.py
@@ -119,6 +119,18 @@ class TestExtractClusterNodeConnTags:
         instance.get_default_node.return_value = _BadNode()
         assert _extract_cluster_node_conn_tags(instance) == {}
 
+    def test_uses_nodes_manager_default_node_when_no_get_default_node(self):
+        # Async ClusterPipeline has nodes_manager but not get_default_node.
+        node = mock.MagicMock()
+        node.host = "async-cluster-host"
+        node.port = 7003
+        instance = mock.MagicMock(spec=["nodes_manager"])
+        instance.nodes_manager.default_node = node
+        tags = _extract_cluster_node_conn_tags(instance)
+        assert tags[net.TARGET_HOST] == "async-cluster-host"
+        assert tags[net.TARGET_PORT] == 7003
+        assert tags[net.SERVER_ADDRESS] == "async-cluster-host"
+
     def test_returns_exactly_three_keys(self):
         tags = _extract_cluster_node_conn_tags(self._make_instance())
         assert len(tags) == 3


### PR DESCRIPTION
## Description

`redis.cluster.RedisCluster` (redis-py >= 4.1) manages one connection pool per node internally and does not expose a single `connection_pool` attribute. The existing `_build_tags` function in `redis_utils.py` gates all host/port extraction behind `hasattr(instance, "connection_pool")`, so cluster spans were produced with no connection tags at all — meaning `out.host`, `network.destination.port`, and `server.address` were never set.

This breaks inferred service detection in APM for any customer using `RedisCluster` directly (rather than the older `rediscluster` package, which _does_ expose a `connection_pool`).

**Fix:** Add an `elif hasattr(instance, "nodes_manager")` branch that calls `instance.get_default_node()` to get a representative host/port. The new helper `_extract_cluster_node_conn_tags` is fully wrapped in `try/except`, so worst case it returns `{}` and behaviour is identical to today.

Fixes FRAPMS-5965 / APMS-19310.

## Testing

- **`tests/contrib/redis/test_redis_utils.py`** (new file): 30 pure unit tests using mocks — no live Redis required. Covers `_extract_conn_tags`, `_extract_cluster_node_conn_tags` (including None/exception edge cases), and the routing logic in `_build_tags`.
- **`tests/contrib/redis/test_redis_cluster.py`**: 12 new integration tests on a live `redis.cluster.RedisCluster` asserting `out.host`, `network.destination.port`, and `server.address` are set correctly across GET, SET, MGET, pipeline, unicode, and multi-command scenarios.
- **`tests/contrib/redis/test_redis_cluster_asyncio.py`**: 6 new async integration tests covering the same tag assertions for `redis.asyncio.cluster.RedisCluster`.

## Risks

- The new `elif` branch only activates when `connection_pool` is absent **and** `nodes_manager` is present — a condition only `redis.cluster.RedisCluster` satisfies. All existing `connection_pool` paths are completely untouched.
- `_extract_cluster_node_conn_tags` is fully guarded by `try/except Exception: return {}`, so any unexpected API change in a future redis-py release silently degrades to the current (no-tag) behaviour rather than crashing.

## Additional Notes

The `rediscluster` package (Grokzen's) is unaffected — it wraps its nodes in a `ClusterConnectionPool` that does expose `connection_pool`, so it already went through the existing path.