### PR TITLE
chore(profiling): [4/n] remove 'is_internal' concept from Lock wrappers

### DIFF
--- a/ddtrace/profiling/collector/_lock.pyi
+++ b/ddtrace/profiling/collector/_lock.pyi
@@ -17,14 +17,12 @@ class _ProfiledLock:
     init_location: str
     acquired_time: typing.Optional[int]
     name: typing.Optional[str]
-    is_internal: bool
 
     def __init__(
         self,
         wrapped: typing.Any,
         tracer: typing.Optional[Tracer],
         capture_sampler: collector.CaptureSampler,
-        is_internal: bool = ...,
     ) -> None: ...
     def __eq__(self, other: object) -> bool: ...
     def __getattr__(self, name: str) -> typing.Any: ...
@@ -69,7 +67,6 @@ class LockCollector(collector.CaptureSamplerCollector):
     PROFILED_LOCK_CLASS: type[_ProfiledLock]
     MODULE: types.ModuleType
     PATCHED_LOCK_NAME: str
-    INTERNAL_MODULE_FILE: typing.Optional[str]
     tracer: typing.Optional[Tracer]
     _original_lock: typing.Optional[typing.Callable[..., typing.Any]]
 

--- a/ddtrace/profiling/collector/_lock.pyi
+++ b/ddtrace/profiling/collector/_lock.pyi
@@ -6,6 +6,7 @@ from ddtrace.trace import Tracer
 
 ACQUIRE_RELEASE_CO_NAMES: frozenset[str]
 ENTER_EXIT_CO_NAMES: frozenset[str]
+_ALWAYS_EXCLUDED_MODULES: frozenset[str]
 
 def _get_original_lock_class(module_name: str, class_name: str) -> typing.Callable[..., typing.Any]: ...
 def _create_original_lock_instance(module_name: str, class_name: str) -> typing.Any: ...

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -41,9 +41,7 @@ ENTER_EXIT_CO_NAMES: frozenset[str] = frozenset(
 )
 
 # Modules whose internal lock allocations are always excluded from profiling,
-# regardless of user config.  This replaces the old per-lock `is_internal` flag:
-# instead of wrapping-then-silencing these locks, we return native locks (zero overhead).
-# AIDEV-NOTE: do NOT remove stdlib entries — they prevent double-counting when
+# regardless of user config. Do NOT remove stdlib entries — they prevent double-counting when
 # multiple collectors (Lock + Semaphore + Condition) are active simultaneously.
 _ALWAYS_EXCLUDED_MODULES: frozenset = frozenset({
     "threading",
@@ -553,8 +551,7 @@ class LockCollector(collector.CaptureSamplerCollector):
 
         # Merge user-configured exclusions with the always-excluded stdlib modules.
         # _ALWAYS_EXCLUDED_MODULES prevents double-counting when multiple collectors
-        # (Lock + Semaphore + Condition) are active — the same role `is_internal` used
-        # to play, but with zero overhead (native lock returned, not wrapped-then-silenced).
+        # (Lock + Semaphore + Condition) are active.
         exclude_exact: frozenset[str] = (
             config.lock.exclude_modules | _ALWAYS_EXCLUDED_MODULES
         )

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -40,6 +40,17 @@ ENTER_EXIT_CO_NAMES: frozenset[str] = frozenset(
     ["acquire", "release", "__enter__", "__exit__", "__aenter__", "__aexit__"]
 )
 
+# Modules whose internal lock allocations are always excluded from profiling,
+# regardless of user config.  This replaces the old per-lock `is_internal` flag:
+# instead of wrapping-then-silencing these locks, we return native locks (zero overhead).
+# AIDEV-NOTE: do NOT remove stdlib entries — they prevent double-counting when
+# multiple collectors (Lock + Semaphore + Condition) are active simultaneously.
+_ALWAYS_EXCLUDED_MODULES: frozenset = frozenset({
+    "threading",
+    "asyncio",
+    "concurrent",
+})
+
 # Cython-compiled def/cpdef functions do not create Python frame objects
 # visible to sys._getframe(). All intermediate calls within this module
 # (_acquire -> _flush_sample, __call__ -> _profiled_allocate_lock -> __init__)
@@ -92,7 +103,6 @@ class _ProfiledLock:
         "init_location",
         "acquired_time",
         "name",
-        "is_internal",
     )
 
     def __init__(
@@ -100,7 +110,6 @@ class _ProfiledLock:
         wrapped: Any,
         tracer: Optional[Tracer],
         capture_sampler: collector.CaptureSampler,
-        is_internal: bool = False,
     ) -> None:
         self.__wrapped__: Any = wrapped
         self.tracer: Optional[Tracer] = tracer
@@ -118,9 +127,6 @@ class _ProfiledLock:
             self.init_location = "%s:%d" % (os.path.basename(code.co_filename), frame.f_lineno)
         self.acquired_time: Optional[int] = None
         self.name: Optional[str] = None
-        # If True, this lock is internal to another sync primitive (e.g., Lock inside Semaphore)
-        # and should not generate profile samples to avoid double-counting
-        self.is_internal: bool = is_internal
 
     # gevent compatibility — gevent's _patch_existing_locks calls
     # type(threading.RLock()) to determine the RLock type, then scans gc.get_objects()
@@ -208,16 +214,14 @@ class _ProfiledLock:
 
         cdef long long end = time.monotonic_ns()
         self.acquired_time = end
-        if not self.is_internal:
-            try:
-                self._update_name()
-                self._flush_sample(start, end, True)
-            except AssertionError:
-                if config.enable_asserts:
-                    raise
-            except Exception:
-                # Instrumentation must never crash user code
-                pass  # nosec
+        try:
+            self._update_name()
+            self._flush_sample(start, end, True)
+        except AssertionError:
+            if config.enable_asserts:
+                raise
+        except Exception:
+            pass  # nosec
         if error_info is not None:
             err: BaseException
             tb: Optional[TracebackType]
@@ -250,27 +254,18 @@ class _ProfiledLock:
         if start is None:
             return result
 
-        if self.is_internal:
-            return result
-
         try:
             self._flush_sample(start, time.monotonic_ns(), False)
         except AssertionError:
             if config.enable_asserts:
                 raise
         except Exception:
-            # Instrumentation must never crash user code
             pass  # nosec
 
         return result
 
     def _flush_sample(self, long long start, long long end, bint is_acquire) -> None:
         """Push lock profiling data to ddup."""
-        # Skip profiling for internal locks (e.g., Lock inside Semaphore/Condition)
-        # to avoid double-counting when multiple collectors are active
-        if self.is_internal:
-            return
-
         cdef long long duration_ns = end - start
         try:
             handle: ddup.SampleHandle = ddup.SampleHandle()
@@ -477,9 +472,6 @@ class LockCollector(collector.CaptureSamplerCollector):
     PROFILED_LOCK_CLASS: type[_ProfiledLock]
     MODULE: ModuleType  # e.g., threading module
     PATCHED_LOCK_NAME: str  # e.g., "Lock", "RLock", "Semaphore"
-    # Module file to check for internal lock detection (e.g., threading.__file__ or asyncio.locks.__file__)
-    # If None, defaults to threading.__file__ for backward compatibility
-    INTERNAL_MODULE_FILE: Optional[str] = None
 
     def __init__(
         self,
@@ -559,48 +551,23 @@ class LockCollector(collector.CaptureSamplerCollector):
             return
         self._original_lock = original_lock
 
-        # Determine which module file to check for internal lock detection
-        internal_module_file: Optional[str] = self.INTERNAL_MODULE_FILE
-        if internal_module_file is None:
-            # Default to threading.__file__ for backward compatibility
-            import threading as threading_module
-
-            internal_module_file = threading_module.__file__
-
-        # Precompute module exclusion structures once at patch time (not per lock creation).
-        # Two structures for fast matching:
-        #   exclude_exact  — frozenset for O(1) exact module name lookup
-        #   exclude_dotted — tuple of "prefix." strings for str.startswith
-        exclude_exact: frozenset[str] = config.lock.exclude_modules
+        # Merge user-configured exclusions with the always-excluded stdlib modules.
+        # _ALWAYS_EXCLUDED_MODULES prevents double-counting when multiple collectors
+        # (Lock + Semaphore + Condition) are active — the same role `is_internal` used
+        # to play, but with zero overhead (native lock returned, not wrapped-then-silenced).
+        exclude_exact: frozenset[str] = (
+            config.lock.exclude_modules | _ALWAYS_EXCLUDED_MODULES
+        )
         exclude_dotted: tuple[str, ...] = tuple(p + "." for p in exclude_exact)
 
         def _profiled_allocate_lock(*args: Any, **kwargs: Any) -> Any:
-            """Simple wrapper that returns profiled locks.
-
-            Detects if the lock is being created from within the stdlib module
-            (i.e., internal to Semaphore/Condition) to avoid double-counting.
-            Skips wrapping entirely for locks created from excluded modules.
-            """
-            cdef bint is_internal = False
-            cdef str caller_filename
-            cdef str internal_file
+            """Return a profiled lock, or a native lock for excluded modules."""
             cdef str caller_module
             try:
-                # In Cython, intermediate frames are invisible; caller is at index 0
                 caller_frame: FrameType = sys._getframe(0)
-                caller_filename = caller_frame.f_code.co_filename
-
-                # Module exclusion: return native lock with zero profiling overhead
-                if exclude_exact:
-                    caller_module = caller_frame.f_globals.get("__name__", "")
-                    if caller_module in exclude_exact or caller_module.startswith(exclude_dotted):
-                        return original_lock(*args, **kwargs)
-
-                # Internal lock detection (e.g., threading.Semaphore creating a Lock internally)
-                if internal_module_file and caller_filename:
-                    caller_filename = os.path.normpath(os.path.realpath(caller_filename))
-                    internal_file = os.path.normpath(os.path.realpath(internal_module_file))
-                    is_internal = caller_filename == internal_file
+                caller_module = caller_frame.f_globals.get("__name__", "")
+                if caller_module in exclude_exact or caller_module.startswith(exclude_dotted):
+                    return original_lock(*args, **kwargs)
             except (ValueError, AttributeError, OSError):
                 pass
 
@@ -608,7 +575,6 @@ class LockCollector(collector.CaptureSamplerCollector):
                 wrapped=original_lock(*args, **kwargs),
                 tracer=self.tracer,
                 capture_sampler=self._capture_sampler,
-                is_internal=is_internal,
             )
 
         self._set_patch_target(_LockAllocatorWrapper(_profiled_allocate_lock, original_class=original_lock))

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import asyncio.locks
 from types import ModuleType
-from typing import Optional
 
 from . import _lock
-
-
-# Internal module file for asyncio lock detection
-# This is used to detect locks created internally by Semaphore/Condition
-_ASYNCIO_LOCKS_FILE: Optional[str] = asyncio.locks.__file__
 
 
 class _ProfiledAsyncioLock(_lock._ProfiledLock):
@@ -35,7 +28,6 @@ class AsyncioLockCollector(_lock.LockCollector):
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioLock] = _ProfiledAsyncioLock
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "Lock"
-    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE
 
 
 class AsyncioSemaphoreCollector(_lock.LockCollector):
@@ -44,7 +36,6 @@ class AsyncioSemaphoreCollector(_lock.LockCollector):
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioSemaphore] = _ProfiledAsyncioSemaphore
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "Semaphore"
-    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE
 
 
 class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
@@ -53,7 +44,6 @@ class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioBoundedSemaphore] = _ProfiledAsyncioBoundedSemaphore
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "BoundedSemaphore"
-    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE
 
 
 class AsyncioConditionCollector(_lock.LockCollector):
@@ -62,4 +52,3 @@ class AsyncioConditionCollector(_lock.LockCollector):
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioCondition] = _ProfiledAsyncioCondition
     MODULE: ModuleType = asyncio
     PATCHED_LOCK_NAME: str = "Condition"
-    INTERNAL_MODULE_FILE: Optional[str] = _ASYNCIO_LOCKS_FILE

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -220,7 +220,7 @@ class _ProfilerInstance(service.Service):
         if self._lock_collector_enabled:
             # These collectors require the import of modules, so we create them
             # if their import is detected at runtime.
-            def start_lock_collector(collector_class: type[collector.Collector]) -> None:
+            def start_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
                     if any(type(c) is collector_class for c in self._collectors):
                         return
@@ -241,15 +241,15 @@ class _ProfilerInstance(service.Service):
                     self._collectors.append(col)
 
             self._collectors_on_import = [
-                ("threading", lambda _: start_lock_collector(threading.ThreadingLockCollector)),
-                ("threading", lambda _: start_lock_collector(threading.ThreadingRLockCollector)),
-                ("threading", lambda _: start_lock_collector(threading.ThreadingSemaphoreCollector)),
-                ("threading", lambda _: start_lock_collector(threading.ThreadingBoundedSemaphoreCollector)),
-                ("threading", lambda _: start_lock_collector(threading.ThreadingConditionCollector)),
-                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioLockCollector)),
-                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioSemaphoreCollector)),
-                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
-                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioConditionCollector)),
+                ("threading", lambda _: start_collector(threading.ThreadingLockCollector)),
+                ("threading", lambda _: start_collector(threading.ThreadingRLockCollector)),
+                ("threading", lambda _: start_collector(threading.ThreadingSemaphoreCollector)),
+                ("threading", lambda _: start_collector(threading.ThreadingBoundedSemaphoreCollector)),
+                ("threading", lambda _: start_collector(threading.ThreadingConditionCollector)),
+                ("asyncio", lambda _: start_collector(asyncio.AsyncioLockCollector)),
+                ("asyncio", lambda _: start_collector(asyncio.AsyncioSemaphoreCollector)),
+                ("asyncio", lambda _: start_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
+                ("asyncio", lambda _: start_collector(asyncio.AsyncioConditionCollector)),
             ]
 
             for module, hook in self._collectors_on_import:

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -220,7 +220,7 @@ class _ProfilerInstance(service.Service):
         if self._lock_collector_enabled:
             # These collectors require the import of modules, so we create them
             # if their import is detected at runtime.
-            def start_collector(collector_class: type[collector.Collector]) -> None:
+            def start_lock_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
                     if any(type(c) is collector_class for c in self._collectors):
                         return
@@ -241,15 +241,15 @@ class _ProfilerInstance(service.Service):
                     self._collectors.append(col)
 
             self._collectors_on_import = [
-                ("threading", lambda _: start_collector(threading.ThreadingLockCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingRLockCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingSemaphoreCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingBoundedSemaphoreCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingConditionCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioLockCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioSemaphoreCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioConditionCollector)),
+                ("threading", lambda _: start_lock_collector(threading.ThreadingLockCollector)),
+                ("threading", lambda _: start_lock_collector(threading.ThreadingRLockCollector)),
+                ("threading", lambda _: start_lock_collector(threading.ThreadingSemaphoreCollector)),
+                ("threading", lambda _: start_lock_collector(threading.ThreadingBoundedSemaphoreCollector)),
+                ("threading", lambda _: start_lock_collector(threading.ThreadingConditionCollector)),
+                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioLockCollector)),
+                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioSemaphoreCollector)),
+                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
+                ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioConditionCollector)),
             ]
 
             for module, hook in self._collectors_on_import:

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -2392,28 +2392,3 @@ def test_exclude_modules_multiple() -> None:
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
         assert not isinstance(lock, _ProfiledLock), "Lock from excluded module should be native"
-
-
-@pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES=""))
-def test_always_excluded_modules_cannot_be_overridden() -> None:
-    """Even with an empty user exclude list, stdlib modules (threading, asyncio, concurrent)
-    remain excluded via _ALWAYS_EXCLUDED_MODULES — the internal lock inside Condition
-    must be a native lock.
-    """
-    import threading
-
-    from ddtrace.profiling.collector._lock import _ProfiledLock
-    from ddtrace.profiling.collector.threading import ThreadingLockCollector
-    from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
-    from tests.profiling.collector.test_utils import init_ddup
-
-    init_ddup("test_always_excluded")
-
-    with ThreadingLockCollector(capture_pct=100), ThreadingSemaphoreCollector(capture_pct=100):
-        sem = threading.Semaphore(1)
-        assert isinstance(sem, _ProfiledLock), "User semaphore should be profiled"
-
-        internal_lock = sem._cond._lock
-        assert not isinstance(internal_lock, _ProfiledLock), (
-            "Stdlib-internal lock must remain native even when DD_PROFILING_LOCK_EXCLUDE_MODULES is empty"
-        )

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -20,6 +20,7 @@ from ddtrace import ext
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.profiling.collector import CaptureSampler
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -207,7 +207,7 @@ def test_lock_patching_survives_module_reimport():
     import sys
     import threading
 
-    from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
     from ddtrace.profiling.collector._lock import _ProfiledLock
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
@@ -244,7 +244,7 @@ def test_lock_unpatch_after_module_reimport():
     import sys
     import threading
 
-    from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
     collector = ThreadingLockCollector()
@@ -1740,7 +1740,6 @@ class TestGenericLockProfiling(LockCollectorTestBase):
                 "init_location",
                 "acquired_time",
                 "name",
-                "is_internal",
             }
             assert set(_ProfiledLock.__slots__) == expected_slots
 
@@ -2033,23 +2032,161 @@ class BaseSemaphoreTest(LockCollectorTestBase):
         )
 
     def test_stdlib_internal_lock_is_native(self) -> None:
-        """Verify that locks created internally by threading.py are native (unwrapped).
-
-        Because 'threading' is in _ALWAYS_EXCLUDED_MODULES, any lock allocated
-        from within the threading module should be returned as a raw _thread.lock,
-        not a _ProfiledLock wrapper.
+        """Locks created internally by threading.py (e.g., inside Condition/Semaphore) must be
+        native (not _ProfiledLock), because threading/asyncio are always-excluded modules.
+        This replaced the old is_internal flag with zero-overhead native locks.
         """
+        from ddtrace.profiling.collector._lock import _ProfiledLock
         from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
         with ThreadingLockCollector(capture_pct=100), self.collector_class(capture_pct=100):
-            sem: LockTypeInst = self.lock_class(1)  # type: ignore[call-arg, arg-type]
+            regular_lock: LockTypeInst = threading.Lock()
+            assert isinstance(regular_lock, _ProfiledLock), "User lock should be profiled"
 
-            # The Condition's internal lock (sem._cond._lock) is allocated by
-            # threading.py, so it must be a native lock, not a _ProfiledLock.
-            internal_lock = sem._cond._lock  # type: ignore[union-attr]
-            assert not hasattr(internal_lock, "_ProfiledLock__wrapped"), (
-                "Internal lock from threading stdlib should be a native lock, not a _ProfiledLock"
+            sem: LockTypeInst = self.lock_class(1)  # type: ignore[call-arg, arg-type]
+            assert isinstance(sem, _ProfiledLock), "User semaphore should be profiled"
+
+            # Internal lock (Semaphore -> Condition -> Lock, allocated inside threading.py)
+            # must be a native lock, NOT a _ProfiledLock
+            internal_lock = sem._cond._lock
+            assert not isinstance(internal_lock, _ProfiledLock), (
+                f"Lock created by threading.py (inside Condition) should be native, got {type(internal_lock).__name__}"
             )
+
+    def test_unsampled_acquire_bypasses_inner_acquire(self) -> None:
+        """Regression: on the unsampled path, acquire/enter entry points must NOT call _acquire.
+
+        The inline-dispatch optimization eliminates one function call per lock operation on the
+        hot (unsampled) path by checking capture_sampler.capture() directly in each entry point
+        and falling through to the wrapped lock without going through _acquire.
+
+        If someone refactors acquire/__enter__/__aenter__ back into a shared helper that calls
+        _acquire unconditionally, this test will catch it.
+        """
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=0)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
+            for _ in range(5):
+                profiled_lock.acquire()
+                profiled_lock.release()
+
+        assert spy.call_count == 0, (
+            f"_acquire was called {spy.call_count} times on the unsampled path (capture_pct=0). "
+            "The inline-dispatch optimization requires that unsampled acquires bypass _acquire entirely. "
+            "Do NOT refactor acquire/__enter__/__aenter__ to call _acquire unconditionally."
+        )
+
+    def test_sampled_acquire_calls_inner_acquire(self) -> None:
+        """Regression: on the sampled path, each entry point must delegate to _acquire exactly once.
+
+        Counterpart to test_unsampled_acquire_bypasses_inner_acquire -- ensures we don't accidentally
+        drop the _acquire delegation on the sampled path either.
+        """
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=100)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
+            for _ in range(3):
+                profiled_lock.acquire()
+                profiled_lock.release()
+
+        assert spy.call_count == 3, (
+            f"_acquire was called {spy.call_count} times instead of 3 on the sampled path (capture_pct=100)."
+        )
+
+    def test_unsampled_release_bypasses_inner_release(self) -> None:
+        """Regression: when acquired_time is None (unsampled acquire), release entry points must NOT call _release.
+
+        On the unsampled path, acquired_time is left as None. The inline-dispatch optimization
+        checks this directly in each release entry point and falls through to the wrapped lock
+        without going through _release.
+
+        If someone refactors release/__exit__/__aexit__ back into a shared helper that calls
+        _release unconditionally, this test will catch it.
+        """
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=0)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        # Acquire (unsampled -- acquired_time stays None)
+        profiled_lock.acquire()
+        assert profiled_lock.acquired_time is None, "precondition: acquired_time must be None after unsampled acquire"
+
+        with mock.patch.object(type(profiled_lock), "_release", wraps=profiled_lock._release) as spy:
+            profiled_lock.release()
+
+        assert spy.call_count == 0, (
+            f"_release was called {spy.call_count} times when acquired_time was None (unsampled path). "
+            "The inline-dispatch optimization requires that unsampled releases bypass _release entirely. "
+            "Do NOT refactor release/__exit__/__aexit__ to call _release unconditionally."
+        )
+
+    def test_sampled_release_calls_inner_release(self) -> None:
+        """Regression: on the sampled path, each release entry point must delegate to _release exactly once."""
+        real_lock: LockTypeInst = self.lock_class()
+        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=100)
+        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
+
+        profiled_lock.acquire()
+        assert profiled_lock.acquired_time is not None, "precondition: acquired_time must be set after sampled acquire"
+
+        with mock.patch.object(type(profiled_lock), "_release", wraps=profiled_lock._release) as spy:
+            profiled_lock.release()
+
+        assert spy.call_count == 1, (
+            f"_release was called {spy.call_count} times instead of 1 on the sampled path (capture_pct=100)."
+        )
+
+    def test_internal_module_file_realpath_called_once_at_patch_time(self) -> None:
+        """Verify that os.path.realpath() for the internal module file is computed once at patch() time,
+        not on every lock allocation.
+
+        Regression test for a bug where the constant internal module path was being resolved via
+        os.path.realpath() on every single lock instantiation, causing unnecessary filesystem syscalls
+        in hot paths (e.g. asyncio Semaphore/Condition allocations per request).
+        """
+        import os.path
+
+        realpath_call_counts: dict[str, int] = {"patch_time": 0, "alloc_time": 0}
+        in_patch: list[bool] = [False]
+        original_realpath = os.path.realpath
+
+        def counting_realpath(path: str, **kwargs: object) -> str:
+            if in_patch[0]:
+                realpath_call_counts["patch_time"] += 1
+            else:
+                realpath_call_counts["alloc_time"] += 1
+            return original_realpath(path, **kwargs)  # type: ignore[call-overload]
+
+        with mock.patch("os.path.realpath", side_effect=counting_realpath):
+            in_patch[0] = True
+            collector = self.collector_class(capture_pct=100)
+            collector._start_service()
+            in_patch[0] = False
+
+            try:
+                # Allocate several locks — realpath for the internal module file must NOT be called again
+                for _ in range(5):
+                    lock: LockTypeInst = self.lock_class()
+                    lock.acquire()
+                    lock.release()
+            finally:
+                collector._stop_service()
+
+        # realpath should have been called at least once at patch time (to resolve the internal module file)
+        assert realpath_call_counts["patch_time"] >= 1, (
+            "Expected os.path.realpath to be called at patch() time to precompute the internal module path"
+        )
+        # realpath may still be called at alloc time for the *caller* filename, but NOT for the constant
+        # internal module file. The alloc-time count should be exactly N allocations (one caller realpath each),
+        # not 2*N (which would indicate the internal file is still being resolved per allocation).
+        assert realpath_call_counts["alloc_time"] <= 5, (
+            f"os.path.realpath called {realpath_call_counts['alloc_time']} times during 5 allocations — "
+            "expected at most 5 (one per caller filename). The internal module file path may be recomputed per-call."
+        )
 
     def test_acquire_return_values_preserved(self) -> None:
         """Test that profiling wrapper preserves acquire() return values (transparency test).
@@ -2304,3 +2441,58 @@ def test_exclude_modules_multiple() -> None:
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
         assert not isinstance(lock, _ProfiledLock), "Lock from excluded module should be native"
+
+
+class TestExcludeModulesConfig:
+    """Unit tests for the exclude_modules config field type guarantees."""
+
+    def test_default_is_empty_frozenset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """exclude_modules must default to frozenset(), not '' or None."""
+        monkeypatch.delenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", raising=False)
+        from ddtrace.internal.settings.profiling import ProfilingConfigLock
+
+        cfg = ProfilingConfigLock()
+        assert cfg.exclude_modules == frozenset()
+        assert isinstance(cfg.exclude_modules, frozenset)
+
+    def test_parsed_value_is_frozenset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-empty env var must produce a frozenset[str], not a raw string."""
+        monkeypatch.setenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", "uvicorn,asyncio,sqlalchemy.pool")
+        from ddtrace.internal.settings.profiling import ProfilingConfigLock
+
+        cfg = ProfilingConfigLock()
+        assert isinstance(cfg.exclude_modules, frozenset)
+        assert cfg.exclude_modules == frozenset({"uvicorn", "asyncio", "sqlalchemy.pool"})
+
+    def test_whitespace_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Leading/trailing whitespace around module names must be stripped."""
+        monkeypatch.setenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", " uvicorn , asyncio ")
+        from ddtrace.internal.settings.profiling import ProfilingConfigLock
+
+        cfg = ProfilingConfigLock()
+        assert cfg.exclude_modules == frozenset({"uvicorn", "asyncio"})
+
+
+@pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES=""))
+def test_always_excluded_modules_cannot_be_overridden() -> None:
+    """Even with an empty user exclude list, stdlib modules (threading, asyncio, concurrent)
+    remain excluded via _ALWAYS_EXCLUDED_MODULES — the internal lock inside Condition
+    must be a native lock.
+    """
+    import threading
+
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
+    from tests.profiling.collector.test_utils import init_ddup
+
+    init_ddup("test_always_excluded")
+
+    with ThreadingLockCollector(capture_pct=100), ThreadingSemaphoreCollector(capture_pct=100):
+        sem = threading.Semaphore(1)
+        assert isinstance(sem, _ProfiledLock), "User semaphore should be profiled"
+
+        internal_lock = sem._cond._lock
+        assert not isinstance(internal_lock, _ProfiledLock), (
+            "Stdlib-internal lock must remain native even when DD_PROFILING_LOCK_EXCLUDE_MODULES is empty"
+        )

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -2033,8 +2033,7 @@ class BaseSemaphoreTest(LockCollectorTestBase):
 
     def test_stdlib_internal_lock_is_native(self) -> None:
         """Locks created internally by threading.py (e.g., inside Condition/Semaphore) must be
-        native (not _ProfiledLock), because threading/asyncio are always-excluded modules.
-        This replaced the old is_internal flag with zero-overhead native locks.
+        native (not _ProfiledLock), because threading/asyncio are always excluded from profiling.
         """
         from ddtrace.profiling.collector._lock import _ProfiledLock
         from ddtrace.profiling.collector.threading import ThreadingLockCollector
@@ -2138,54 +2137,6 @@ class BaseSemaphoreTest(LockCollectorTestBase):
 
         assert spy.call_count == 1, (
             f"_release was called {spy.call_count} times instead of 1 on the sampled path (capture_pct=100)."
-        )
-
-    def test_internal_module_file_realpath_called_once_at_patch_time(self) -> None:
-        """Verify that os.path.realpath() for the internal module file is computed once at patch() time,
-        not on every lock allocation.
-
-        Regression test for a bug where the constant internal module path was being resolved via
-        os.path.realpath() on every single lock instantiation, causing unnecessary filesystem syscalls
-        in hot paths (e.g. asyncio Semaphore/Condition allocations per request).
-        """
-        import os.path
-
-        realpath_call_counts: dict[str, int] = {"patch_time": 0, "alloc_time": 0}
-        in_patch: list[bool] = [False]
-        original_realpath = os.path.realpath
-
-        def counting_realpath(path: str, **kwargs: object) -> str:
-            if in_patch[0]:
-                realpath_call_counts["patch_time"] += 1
-            else:
-                realpath_call_counts["alloc_time"] += 1
-            return original_realpath(path, **kwargs)  # type: ignore[call-overload]
-
-        with mock.patch("os.path.realpath", side_effect=counting_realpath):
-            in_patch[0] = True
-            collector = self.collector_class(capture_pct=100)
-            collector._start_service()
-            in_patch[0] = False
-
-            try:
-                # Allocate several locks — realpath for the internal module file must NOT be called again
-                for _ in range(5):
-                    lock: LockTypeInst = self.lock_class()
-                    lock.acquire()
-                    lock.release()
-            finally:
-                collector._stop_service()
-
-        # realpath should have been called at least once at patch time (to resolve the internal module file)
-        assert realpath_call_counts["patch_time"] >= 1, (
-            "Expected os.path.realpath to be called at patch() time to precompute the internal module path"
-        )
-        # realpath may still be called at alloc time for the *caller* filename, but NOT for the constant
-        # internal module file. The alloc-time count should be exactly N allocations (one caller realpath each),
-        # not 2*N (which would indicate the internal file is still being resolved per allocation).
-        assert realpath_call_counts["alloc_time"] <= 5, (
-            f"os.path.realpath called {realpath_call_counts['alloc_time']} times during 5 allocations — "
-            "expected at most 5 (one per caller filename). The internal module file path may be recomputed per-call."
         )
 
     def test_acquire_return_values_preserved(self) -> None:
@@ -2441,36 +2392,6 @@ def test_exclude_modules_multiple() -> None:
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
         assert not isinstance(lock, _ProfiledLock), "Lock from excluded module should be native"
-
-
-class TestExcludeModulesConfig:
-    """Unit tests for the exclude_modules config field type guarantees."""
-
-    def test_default_is_empty_frozenset(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """exclude_modules must default to frozenset(), not '' or None."""
-        monkeypatch.delenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", raising=False)
-        from ddtrace.internal.settings.profiling import ProfilingConfigLock
-
-        cfg = ProfilingConfigLock()
-        assert cfg.exclude_modules == frozenset()
-        assert isinstance(cfg.exclude_modules, frozenset)
-
-    def test_parsed_value_is_frozenset(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A non-empty env var must produce a frozenset[str], not a raw string."""
-        monkeypatch.setenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", "uvicorn,asyncio,sqlalchemy.pool")
-        from ddtrace.internal.settings.profiling import ProfilingConfigLock
-
-        cfg = ProfilingConfigLock()
-        assert isinstance(cfg.exclude_modules, frozenset)
-        assert cfg.exclude_modules == frozenset({"uvicorn", "asyncio", "sqlalchemy.pool"})
-
-    def test_whitespace_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Leading/trailing whitespace around module names must be stripped."""
-        monkeypatch.setenv("DD_PROFILING_LOCK_EXCLUDE_MODULES", " uvicorn , asyncio ")
-        from ddtrace.internal.settings.profiling import ProfilingConfigLock
-
-        cfg = ProfilingConfigLock()
-        assert cfg.exclude_modules == frozenset({"uvicorn", "asyncio"})
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES=""))

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -207,7 +207,7 @@ def test_lock_patching_survives_module_reimport():
     import sys
     import threading
 
-    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
     from ddtrace.profiling.collector._lock import _ProfiledLock
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
@@ -244,7 +244,7 @@ def test_lock_unpatch_after_module_reimport():
     import sys
     import threading
 
-    from ddtrace.profiling.collector._lock import LockAllocatorWrapper
+    from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
 
     collector = ThreadingLockCollector()

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -20,7 +20,6 @@ from ddtrace import ext
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal.datadog.profiling import ddup
-from ddtrace.profiling.collector import CaptureSampler
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
@@ -2052,93 +2051,6 @@ class BaseSemaphoreTest(LockCollectorTestBase):
             assert not isinstance(internal_lock, _ProfiledLock), (
                 f"Lock created by threading.py (inside Condition) should be native, got {type(internal_lock).__name__}"
             )
-
-    def test_unsampled_acquire_bypasses_inner_acquire(self) -> None:
-        """Regression: on the unsampled path, acquire/enter entry points must NOT call _acquire.
-
-        The inline-dispatch optimization eliminates one function call per lock operation on the
-        hot (unsampled) path by checking capture_sampler.capture() directly in each entry point
-        and falling through to the wrapped lock without going through _acquire.
-
-        If someone refactors acquire/__enter__/__aenter__ back into a shared helper that calls
-        _acquire unconditionally, this test will catch it.
-        """
-        real_lock: LockTypeInst = self.lock_class()
-        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=0)
-        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
-
-        with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
-            for _ in range(5):
-                profiled_lock.acquire()
-                profiled_lock.release()
-
-        assert spy.call_count == 0, (
-            f"_acquire was called {spy.call_count} times on the unsampled path (capture_pct=0). "
-            "The inline-dispatch optimization requires that unsampled acquires bypass _acquire entirely. "
-            "Do NOT refactor acquire/__enter__/__aenter__ to call _acquire unconditionally."
-        )
-
-    def test_sampled_acquire_calls_inner_acquire(self) -> None:
-        """Regression: on the sampled path, each entry point must delegate to _acquire exactly once.
-
-        Counterpart to test_unsampled_acquire_bypasses_inner_acquire -- ensures we don't accidentally
-        drop the _acquire delegation on the sampled path either.
-        """
-        real_lock: LockTypeInst = self.lock_class()
-        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=100)
-        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
-
-        with mock.patch.object(type(profiled_lock), "_acquire", wraps=profiled_lock._acquire) as spy:
-            for _ in range(3):
-                profiled_lock.acquire()
-                profiled_lock.release()
-
-        assert spy.call_count == 3, (
-            f"_acquire was called {spy.call_count} times instead of 3 on the sampled path (capture_pct=100)."
-        )
-
-    def test_unsampled_release_bypasses_inner_release(self) -> None:
-        """Regression: when acquired_time is None (unsampled acquire), release entry points must NOT call _release.
-
-        On the unsampled path, acquired_time is left as None. The inline-dispatch optimization
-        checks this directly in each release entry point and falls through to the wrapped lock
-        without going through _release.
-
-        If someone refactors release/__exit__/__aexit__ back into a shared helper that calls
-        _release unconditionally, this test will catch it.
-        """
-        real_lock: LockTypeInst = self.lock_class()
-        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=0)
-        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
-
-        # Acquire (unsampled -- acquired_time stays None)
-        profiled_lock.acquire()
-        assert profiled_lock.acquired_time is None, "precondition: acquired_time must be None after unsampled acquire"
-
-        with mock.patch.object(type(profiled_lock), "_release", wraps=profiled_lock._release) as spy:
-            profiled_lock.release()
-
-        assert spy.call_count == 0, (
-            f"_release was called {spy.call_count} times when acquired_time was None (unsampled path). "
-            "The inline-dispatch optimization requires that unsampled releases bypass _release entirely. "
-            "Do NOT refactor release/__exit__/__aexit__ to call _release unconditionally."
-        )
-
-    def test_sampled_release_calls_inner_release(self) -> None:
-        """Regression: on the sampled path, each release entry point must delegate to _release exactly once."""
-        real_lock: LockTypeInst = self.lock_class()
-        capture_sampler: CaptureSampler = CaptureSampler(capture_pct=100)
-        profiled_lock: _ProfiledLock = _ProfiledLock(wrapped=real_lock, tracer=None, capture_sampler=capture_sampler)
-
-        profiled_lock.acquire()
-        assert profiled_lock.acquired_time is not None, "precondition: acquired_time must be set after sampled acquire"
-
-        with mock.patch.object(type(profiled_lock), "_release", wraps=profiled_lock._release) as spy:
-            profiled_lock.release()
-
-        assert spy.call_count == 1, (
-            f"_release was called {spy.call_count} times instead of 1 on the sampled path (capture_pct=100)."
-        )
 
     def test_acquire_return_values_preserved(self) -> None:
         """Test that profiling wrapper preserves acquire() return values (transparency test).

--- a/tests/profiling/test_profiling_config.py
+++ b/tests/profiling/test_profiling_config.py
@@ -102,3 +102,41 @@ class TestExcludeModulesConfig:
 
         cfg = ProfilingConfigLock()
         assert cfg.exclude_modules == frozenset({"uvicorn", "asyncio"})
+
+
+def test_always_excluded_modules_contains_required_entries() -> None:
+    """_ALWAYS_EXCLUDED_MODULES must always contain the core stdlib concurrency modules.
+
+    These modules are excluded unconditionally to prevent double-counting and
+    to ensure stdlib-internal locks (e.g. inside Condition/Semaphore) stay native.
+    """
+    from ddtrace.profiling.collector._lock import _ALWAYS_EXCLUDED_MODULES
+
+    assert "threading" in _ALWAYS_EXCLUDED_MODULES
+    assert "asyncio" in _ALWAYS_EXCLUDED_MODULES
+    assert "concurrent" in _ALWAYS_EXCLUDED_MODULES
+
+
+@pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES=""))
+def test_always_excluded_modules_cannot_be_overridden() -> None:
+    """Even with an empty user exclude list, stdlib modules (threading, asyncio, concurrent)
+    remain excluded via _ALWAYS_EXCLUDED_MODULES — the internal lock inside Condition
+    must be a native lock.
+    """
+    import threading
+
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
+    from tests.profiling.collector.test_utils import init_ddup
+
+    init_ddup("test_always_excluded")
+
+    with ThreadingLockCollector(capture_pct=100), ThreadingSemaphoreCollector(capture_pct=100):
+        sem = threading.Semaphore(1)
+        assert isinstance(sem, _ProfiledLock), "User semaphore should be profiled"
+
+        internal_lock = sem._cond._lock
+        assert not isinstance(internal_lock, _ProfiledLock), (
+            "Stdlib-internal lock must remain native even when DD_PROFILING_LOCK_EXCLUDE_MODULES is empty"
+        )


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/16775) |

## Description

Remove the `is_internal` per-lock flag from `_ProfiledLock` wrapper, since we will now have the concept of "excluded modules" (#16922). We can replaces it with `_ALWAYS_EXCLUDED_MODULES`, a list of stdlib modules implementing sync and async locks, which will never be profiled. This will effectively be the same behavior: no locks backing higher-level locks (Condition, Semaphore) will be profiled; no sample double-counting; and a perf win by removing now-unnecessary bookeeping.

### What changed

**Before:** When a stdlib primitive (e.g. `threading.Semaphore`) created an internal lock, `_profiled_allocate_lock` would still wrap it as a `_ProfiledLock`, and set `is_internal=True`. The wrapper would exit early on each call to `_acquire`, `_release`, and `_flush_sample`.

**After:** Internal stdlib locks are never wrapped at all thanks to `_ALWAYS_EXCLUDED_MODULES`. `_profiled_allocate_lock` checks the caller's `__name__` against the excluded modules and returns the **native** lock directly on a match.

### Why this is better

| | Before (`is_internal`) | After (`_ALWAYS_EXCLUDED_MODULES`) |
|---|---|---|
| Wrapper created for internal lock? | Yes | **No** |
| Runtime overhead per acquire/release | `self.is_internal` check on every call | **None** |
| Sample suppression sites | `_acquire`, `_release`, `_flush_sample` | — |
| Internal lock detection | Filename comparison (`realpath` per lock create) | Module name set lookup (O(1), done once at patch) |

## Testing
* CI
* 2 new unit tests

## Risks

n/a

> Replaces #17859 which was accidentally auto-merged with 0 commits.
