### PR TITLE
chore(ai): add apm-integrations and llmobs-integrations Claude Code skills

### DIFF
--- a/.claude/skills/apm-integrations/SKILL.md
+++ b/.claude/skills/apm-integrations/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: apm-integrations
+description: |
+  dd-trace-py integration development guide. Use when creating, modifying, or
+  debugging contrib integrations in the Python tracer. Covers the patch module
+  system, context_with_data, context_with_event (new), BaseLLMIntegration,
+  LLMObs integration layer, streaming, message extraction, testing with riot,
+  VCR cassettes, and common anti-patterns. Pin is DEPRECATED.
+  Triggers: "dd-trace-py", "ddtrace", "contrib", "integration", "patch.py",
+  "trace_handlers", "PATCH_MODULES", "context_with_data", "context_with_event",
+  "TracingEvent", "BaseLLMIntegration", "integration.trace", "llmobs_set_tags",
+  "_llmobs_set_tags", "BaseStreamHandler", "submit_to_llmobs", "LLM span",
+  "VCR", "cassette", "anthropic", "openai", "google_genai", "claude_agent_sdk",
+  "generative-ai", "LLM integration", "llmobs_enabled", "llmobs", "LLMObs",
+  "riot", "riotfile", "suitespec", "new integration", "wrap", "unwrap".
+---
+
+# dd-trace-py APM Integrations
+
+dd-trace-py provides automatic tracing for 90+ third-party libraries. Each integration uses monkey-patching via `wrapt` to intercept library calls and create spans.
+
+## Architecture
+
+```
+Patch Module (ddtrace/contrib/internal/)  -->  Spans + Tags
+  Wraps library methods, creates spans via Pin/tracer or integration.trace()
+```
+
+**Standard integrations** use one of these patterns:
+- **`context_with_data()` + `trace_handlers.py`** (preferred for existing): Wrappers emit events via `core.context_with_data()`, listeners in `trace_handlers.py` create spans (e.g., botocore, flask, httpx, django).
+- **`context_with_event()` + `TracingEvent`** (NEW — preferred for new integrations): Typed event-driven pattern using `core.context_with_event()` with `TracingEvent` subclasses and `TracingSubscriber`. Infrastructure exists in `ddtrace/_trace/events.py` and `ddtrace/_trace/subscribers/`. No contrib integrations use this yet, but new ones should adopt it.
+- **`Pin` + `tracer.trace()`** (DEPRECATED — do not use in new integrations): Many existing integrations use `Pin.get_from()` + `tracer.trace()` (e.g., redis, kafka, grpc). Do NOT use Pin in new code.
+
+**LLM integrations** use `BaseLLMIntegration.trace()` and have a two-layer architecture (see LLM section below).
+
+## Key Concepts
+
+- **`_datadog_patch` guard** -- prevents double-patching on repeated `patch()` calls
+- **Pin is DEPRECATED** -- many existing integrations still use `Pin.get_from()` and `Pin().onto()`, but do NOT use Pin in new integrations. Prefer `context_with_event` (new) or `context_with_data` (existing)
+- **`config._add()`** -- registers integration config at module level, before `patch()` runs
+- **`get_version()` / `_supported_versions()`** -- required exports for version detection
+- **`PATCH_MODULES`** -- registration dict in `ddtrace/_monkey.py` for `patch_all()` discovery
+- **`INTEGRATION_CONFIGS`** -- frozenset in `ddtrace/internal/settings/_config.py`, required for config to work
+- **`registry.yaml`** -- dependency names and tested version range in `ddtrace/contrib/integration_registry/`
+
+## Type Annotations
+
+dd-trace-py uses mypy for type checking. All new integration code must pass `hatch run lint:typing`.
+
+**Rules:**
+- Every function and method must have full type annotations (parameters + return type)
+- `patch() -> None`, `unpatch() -> None`, `get_version() -> str`
+- Wrapper functions use the wrapt signature: `def traced_func(wrapped: Callable[..., Any], instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:`
+- Use `Optional[X]` for nullable parameters and return values
+- Use parameterized generics: `dict[str, Any]`, `list[str]`, `tuple[Any, ...]` — not bare `dict`, `list`, `tuple`
+- Avoid `# type: ignore` unless absolutely necessary (document the reason inline, e.g. `# type: ignore[attr-defined]  # wrapt proxy lacks stubs`)
+- Import types from `typing` where needed: `Any`, `Callable`, `Optional`
+- Read reference integrations for correct type patterns — match their style
+
+## Reference Integrations
+
+**Always read 1-2 references of the same type before writing or modifying code.**
+
+All patch modules live in `ddtrace/contrib/internal/{name}/`. See [Reference Integrations](references/reference-integrations.md) for secondary examples and detailed notes.
+
+| Category | Canonical Integration | Pattern |
+|----------|----------------------|---------|
+| cache | `redis/patch.py` | Pin + `context_with_data` |
+| cloud-provider | `botocore/patch.py` | Pin + `context_with_data` |
+| database | `psycopg/patch.py` | Pin + dbapi |
+| faas | `aws_lambda/patch.py` | `wrapping.wrap` + tracer |
+| generative-ai | `anthropic/patch.py` | `BaseLLMIntegration.trace()` |
+| graphql | `graphql/patch.py` | Pin + `tracer.trace` |
+| http-client | `httpx/patch.py` | `context_with_data` |
+| http-server | `flask/patch.py` | Pin + `context_with_data` |
+| logging | `logging/patch.py` | log correlation (no spans) |
+| messaging | `kafka/patch.py` | Pin + `tracer.trace` |
+| object-store | `botocore/patch.py` (S3) | Pin + `context_with_data` |
+| orchestration | `celery/patch.py` | Pin + `tracer.trace` (signals) |
+| rpc | `grpc/patch.py` | Pin + `tracer.trace` |
+
+---
+
+## LLM Integrations (LLMObs)
+
+LLM integrations have a **two-layer architecture**:
+
+1. **Patch Layer** (`ddtrace/contrib/internal/{name}/patch.py`) -- wraps library functions and creates spans. LLM integrations are migrating to the **LLM events system** using `LLMEvent` subclasses (see [PR #16533](https://github.com/DataDog/dd-trace-py/pull/16533)). Read `ddtrace/contrib/internal/anthropic/patch.py` for the current events-based pattern.
+2. **Integration Layer** (`ddtrace/llmobs/_integrations/{name}.py`) -- extends `BaseLLMIntegration`, implements `_set_base_span_tags()` and `_llmobs_set_tags()` to extract and set LLMObs metadata. This layer remains the same regardless of the patch pattern.
+
+### LLM Key Files
+
+| Purpose | File |
+|---------|------|
+| Base LLM integration class | `ddtrace/llmobs/_integrations/base.py` (`BaseLLMIntegration`) |
+| Stream handler base classes | `ddtrace/llmobs/_integrations/base_stream_handler.py` |
+| LLMObs constants | `ddtrace/llmobs/_constants.py` |
+| LLMObs types | `ddtrace/llmobs/types.py` (`Message`, `ToolCall`, `ToolResult`, `ToolDefinition`) |
+| Integration registry | `ddtrace/llmobs/_integrations/__init__.py` |
+
+### LLM Reference Integrations
+
+| Provider | Patch File | LLMObs Integration | Tests |
+|----------|-----------|-------------------|-------|
+| **Anthropic** (canonical) | `contrib/internal/anthropic/patch.py` | `llmobs/_integrations/anthropic.py` | `tests/contrib/anthropic/test_anthropic_llmobs.py` |
+| **Claude Agent SDK** (agent pattern) | `contrib/internal/claude_agent_sdk/patch.py` | `llmobs/_integrations/claude_agent_sdk.py` | `tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py` |
+| OpenAI | `contrib/internal/openai/patch.py` | `llmobs/_integrations/openai.py` | `tests/contrib/openai/test_openai_llmobs.py` |
+| Google GenAI | `contrib/internal/google_genai/patch.py` | `llmobs/_integrations/google_genai.py` | `tests/contrib/google_genai/test_google_genai_llmobs.py` |
+
+### LLM Context Items
+
+Subclass `BaseLLMIntegration` and implement `_llmobs_set_tags()` to set:
+
+| Context Item | Description |
+|-------------|-------------|
+| `SPAN_KIND` | `"llm"` for LLM calls, `"agent"` for agent calls, `"tool"` for tool calls |
+| `MODEL_NAME` | Model identifier (e.g., `"claude-3-sonnet-20240229"`) |
+| `MODEL_PROVIDER` | Provider name (e.g., `"anthropic"`, `"openai"`) |
+| `INPUT_MESSAGES` | List of `Message` objects from request |
+| `OUTPUT_MESSAGES` | List of `Message` objects from response |
+| `METADATA` | Dict of request parameters (temperature, top_p, etc.) |
+| `METRICS` | Token usage dict with `INPUT_TOKENS_METRIC_KEY`, `OUTPUT_TOKENS_METRIC_KEY`, `TOTAL_TOKENS_METRIC_KEY` |
+| `TOOL_DEFINITIONS` | List of `ToolDefinition` objects if tools are passed |
+
+### LLM Key Constraints
+
+- **LLM events system** -- new LLM integrations should use `LLMEvent` subclasses in the patch layer (see anthropic for the events-based pattern). LLMObs tag setting is handled by the event, not directly in the patch wrapper.
+- **Streaming** must use `BaseStreamHandler`/`AsyncStreamHandler` -- never consume streams directly
+- **Error handling** uses `span.set_exc_info()` in the except block
+- **Integration instance** stored on module: `module._datadog_integration = Integration(tracer, config)`
+
+---
+
+## Implementation Workflow
+
+1. **Investigate** -- Read 1-2 reference integrations of the same type (see tables above)
+2. **Create patch module** -- `ddtrace/contrib/internal/{name}/patch.py` with `patch()`, `unpatch()`, `get_version()`
+3. **Register** -- Add to `PATCH_MODULES`, `registry.yaml`, and `INTEGRATION_CONFIGS`
+4. **LLM only: Create integration class** -- Subclass `BaseLLMIntegration` in `ddtrace/llmobs/_integrations/`. See the **llmobs-integrations** skill's [Implementation Guide](../llmobs-integrations/references/implementation-guide.md) for full patterns.
+5. **Write tests** -- Add `Venv()` to `riotfile.py`, entries to suitespec, test files
+6. **Run tests** -- Use `scripts/run-tests` (see `run-tests` skill)
+7. **Verify** -- `ruff check ddtrace/` passes, `patch()`/`unpatch()` cycle works, spans correct
+
+See [Implementation Guide](references/implementation-guide.md) for detailed step-by-step.
+
+## Debugging
+
+- `DD_TRACE_DEBUG=true` to see patching activity and span creation
+- Missing spans -- verify `_datadog_patch` guard, check `PATCH_MODULES` entry exists
+- Wrong service name -- verify `config._add()` at module level
+- **LLM-specific**: see the **llmobs-integrations** skill for failure modes and debugging
+
+### Native Extension Build Issues
+
+If `pip install -e .` fails with Rust compilation errors, `target3.1*` path errors, or stale cached artifacts causing builds to break, clean the cache and retry:
+
+```bash
+rm -rf .download_cache .cache src/native/target3.1*
+pip install -e .
+```
+
+This clears the Rust target directory and pip's download/build caches. Run this before retrying any `pip install` that fails with native extension errors.
+
+## Reference Files
+
+- [Implementation Guide](references/implementation-guide.md) -- Step-by-step new integration (all types)
+- [Reference Integrations](references/reference-integrations.md) -- All 13 categories with canonical examples
+- [Design Decisions](references/design-decisions.md) -- Why integrations are structured this way
+- [Anti-Patterns](references/anti-patterns.md) -- Silent failures and common gotchas

--- a/.claude/skills/apm-integrations/references/anti-patterns.md
+++ b/.claude/skills/apm-integrations/references/anti-patterns.md
@@ -1,0 +1,61 @@
+# Anti-Patterns & Silent Failures
+
+Common mistakes that don't produce errors but break tracing functionality.
+
+## Patching
+
+**Forgetting `_datadog_patch` guard** -- `patch()` wraps methods multiple times
+on repeated calls, creating duplicate spans. Always check
+`getattr(module, '_datadog_patch', False)` before wrapping.
+
+**Wrong module path in `wrap_function_wrapper`** -- Wrapping silently does nothing
+if the import path doesn't match the actual module structure.
+
+**Not calling `unpatch()` symmetrically** -- Every `wrap_function_wrapper` in
+`patch()` needs a corresponding `unwrap()` in `unpatch()`. Missing unwraps
+produce orphaned spans after `unpatch()`.
+
+**Patching before import completes** -- Deferred/lazy-loaded classes may not
+exist at `patch()` time. The wrap succeeds but wraps a stale reference.
+
+## Configuration
+
+**Forgetting `config._add()` at module level** -- Config must be registered
+before `patch()` runs, not inside `patch()`.
+
+**Using Pin in new integrations** -- Pin is DEPRECATED. Do NOT use
+`Pin().onto()` / `Pin.get_from()` in new integrations. Use `context_with_event`
+(preferred for new code) or `context_with_data` instead. Pin remains in many
+existing integrations but should not be added to new ones.
+
+**Using `context_with_data` when `context_with_event` is available** -- For new
+integrations, prefer the typed `context_with_event()` + `TracingEvent` pattern
+over `context_with_data()`. The events API provides better type safety and
+decoupling. Infrastructure: `ddtrace/_trace/events.py`, `ddtrace/_trace/subscribers/`.
+
+## Span Lifecycle
+
+**Forgetting `span.finish()` in non-streaming paths** -- LLM integrations must
+call `span.finish()` in the `finally` block for non-streaming responses.
+Streaming responses finish the span when the iterator is exhausted.
+
+**Not calling `span.set_exc_info()` on exceptions** -- Without this, error spans
+won't have exception details. Always use `span.set_exc_info(*sys.exc_info())`
+in except blocks.
+
+**Missing `integration.llmobs_set_tags()` in finally block** -- Without this,
+LLMObs won't capture response data. Must be called before `span.finish()`.
+
+**Setting items on context after it exits** -- `ctx.set_item()` calls after the
+`with core.context_with_data(...)` block exits are silently dropped.
+
+## Testing
+
+**Not adding to both component AND suite in suitespec** -- Both entries required;
+missing either means CI won't run tests or detect source changes.
+
+**Using the wrong suitespec file** -- LLM/AI: `tests/llmobs/suitespec.yml`.
+Standard: `tests/contrib/suitespec.yml`.
+
+**VCR cassettes containing real API keys** -- Ensure `filter_headers` includes
+the library's auth header name.

--- a/.claude/skills/apm-integrations/references/design-decisions.md
+++ b/.claude/skills/apm-integrations/references/design-decisions.md
@@ -1,0 +1,68 @@
+# Design Decisions
+
+Why dd-trace-py integrations are structured the way they are.
+
+## Patch Modules
+
+Integrations use monkey-patching via `wrapt.wrap_function_wrapper` to intercept
+library calls at runtime. Each integration registers in `ddtrace/_monkey.py`
+(`PATCH_MODULES` dict) so `ddtrace.patch_all()` and `ddtrace-run` can auto-enable it.
+
+The `_datadog_patch` flag on the module prevents double-patching. Always check
+`getattr(mylib, '_datadog_patch', False)` before wrapping and set it to `True`.
+
+## Pin System (DEPRECATED)
+
+`Pin` attaches tracing metadata (service name, tracer) to library instances.
+Many existing integrations use `Pin().onto(module)` and `Pin.get_from(instance)`.
+Pin is DEPRECATED -- do NOT use it in new integrations. It remains in existing
+integrations (redis, kafka, grpc, graphql, psycopg, flask, celery, etc.) but
+new code should use `context_with_event` or `context_with_data` instead.
+
+## The contrib/internal/ Split
+
+Integration code lives in `ddtrace/contrib/internal/{name}/` (not `ddtrace/contrib/{name}/`).
+The public API is `patch()`, `unpatch()`, and `get_version()` from `__init__.py`.
+Each `__init__.py` contains RST docstrings for documentation generation --
+read `ddtrace/contrib/internal/anthropic/__init__.py` for an example.
+
+## Three Standard Patterns
+
+**`context_with_event()` + `TracingEvent`** (NEW — preferred for new integrations):
+Typed event-driven pattern using `core.context_with_event()` with `TracingEvent`
+subclasses and `TracingSubscriber`. Infrastructure exists in `ddtrace/_trace/events.py`
+and `ddtrace/_trace/subscribers/`. No contrib integrations use this yet, but new
+ones should adopt it. See `ddtrace/internal/core/__init__.py:311` for the API.
+
+**`context_with_data()` + `trace_handlers.py`** (preferred for existing): Wrappers use
+`with core.context_with_data(...)` to emit events that `trace_handlers.py`
+listeners consume (~80+ event listeners that create spans). Used by botocore,
+flask, httpx, django. This pattern decouples patch code from span creation.
+
+**Pin + tracer.trace** (DEPRECATED — do not use in new code): Patch code attaches
+a `Pin` to the library module/instance, wrapper functions call
+`Pin.get_from(instance)` to get the tracer, then use `tracer.trace()` to create
+spans directly. Still used by redis, kafka, grpc, graphql, requests, celery, etc.
+
+## LLM Integration Pattern
+
+LLM integrations use `BaseLLMIntegration` (in `ddtrace/llmobs/_integrations/base.py`):
+- Patch code creates a subclass instance and stores it on the module
+- `integration.trace()` creates spans via `tracer.start_span()`
+- Patch code directly manages span lifecycle: `span.set_exc_info()`, `span.finish()`
+- `integration.llmobs_set_tags(span, ...)` handles LLMObs tag extraction
+- LLMObs subclasses in `ddtrace/llmobs/_integrations/` handle message/token extraction
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `ddtrace/_monkey.py` | PATCH_MODULES registry |
+| `ddtrace/_trace/pin.py` | Pin system (DEPRECATED for new code) |
+| `ddtrace/_trace/trace_handlers.py` | Span creation for context_with_data integrations |
+| `ddtrace/_trace/events.py` | TracingEvent base class (NEW events API) |
+| `ddtrace/_trace/subscribers/_base.py` | TracingSubscriber base (NEW events API) |
+| `ddtrace/internal/core/__init__.py` | Core API (context_with_data, context_with_event) |
+| `ddtrace/internal/core/events.py` | Event + event_field() primitives |
+| `ddtrace/llmobs/_integrations/base.py` | BaseLLMIntegration |
+| `riotfile.py` | Test environment matrix |

--- a/.claude/skills/apm-integrations/references/implementation-guide.md
+++ b/.claude/skills/apm-integrations/references/implementation-guide.md
@@ -1,0 +1,215 @@
+# Implementation Guide
+
+Step-by-step for creating a new dd-trace-py integration.
+Each step points to a real file -- read it, don't guess the pattern.
+
+## 1. Create the patch module
+
+Create `ddtrace/contrib/internal/{name}/__init__.py` with RST docstrings
+and exports. See `ddtrace/contrib/internal/anthropic/__init__.py` for format.
+
+Create `ddtrace/contrib/internal/{name}/patch.py` with `get_version()`, `_supported_versions`,
+`patch()`, and `unpatch()`. Choose the right pattern:
+- **Events API (NEW — preferred for new standard integrations)**: Use `context_with_event()` + `TracingEvent` subclasses + `TracingSubscriber`. No existing contrib integration uses this yet, so read the infrastructure files directly:
+  - `ddtrace/_trace/events.py` — `TracingEvent` base class (subclass this per-event)
+  - `ddtrace/_trace/subscribers/_base.py` — `TracingSubscriber` base class (handles span creation)
+  - `ddtrace/internal/core/__init__.py` line 311+ — `context_with_event()` API
+  - `ddtrace/internal/core/events.py` — `Event` base + `event_field()` descriptor
+- **`context_with_data()` (existing pattern)**: Use `context_with_data()` + `trace_handlers.py`. Read `ddtrace/contrib/internal/httpx/patch.py`. Use this when extending or mirroring an existing `context_with_data` integration.
+- **Pin + `tracer.trace()` (DEPRECATED)**: Do NOT use in new integrations.
+- **LLM**: Use `BaseLLMIntegration.trace()` with the **LLM events system** (`LLMEvent` subclasses). Read `ddtrace/contrib/internal/anthropic/patch.py` for the current events-based pattern.
+
+### Type Annotations
+
+All functions in the patch module must have full type annotations. Follow the typing patterns from the reference integration you read in the step above.
+
+```python
+from typing import Any, Callable, Optional
+
+def get_version() -> str:
+    ...
+
+def _supported_versions() -> str:
+    ...
+
+def patch() -> None:
+    ...
+
+def unpatch() -> None:
+    ...
+
+# Wrapper functions use the wrapt signature:
+def traced_request(
+    wrapped: Callable[..., Any],
+    instance: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    ...
+```
+
+## 2. Register the integration
+
+Add to `ddtrace/_monkey.py` `PATCH_MODULES` dict in alphabetical order.
+If the module name we patched is different than the contrib name, e.g. we patched `snowflake.core`, but the main package is `snowflake`, add it to `MODULES_FOR_CONTRIB` as well.
+Add to `ddtrace/contrib/integration_registry/registry.yaml` with dependency
+names and tested version range.
+Add to `INTEGRATION_CONFIGS` frozenset in `ddtrace/internal/settings/_config.py`
+in alphabetical order — this allows users to configure the integration before
+it's patched. **Without this entry, integration config settings are silently ignored.**
+
+## 3. Create LLMObs integration (LLM only)
+
+Create `ddtrace/llmobs/_integrations/{name}.py` subclassing `BaseLLMIntegration`.
+Read `ddtrace/llmobs/_integrations/anthropic.py` for the canonical pattern.
+Register in `ddtrace/llmobs/_integrations/__init__.py` (import + `__all__`).
+
+See the **llmobs-integrations** skill for the full LLM-specific implementation guide.
+
+## 4. Add test environment
+
+### riotfile.py
+
+Add a `Venv()` entry to `riotfile.py` near similar integrations. Place it alphabetically within the appropriate section.
+
+```python
+Venv(
+    name="{name}",
+    command="pytest {cmdargs} tests/contrib/{name}",
+    pkgs={
+        "pytest-asyncio": latest,  # if async support
+        "vcrpy": latest,           # REQUIRED for LLM integrations
+    },
+    venvs=[
+        # Pin oldest supported version
+        Venv(
+            pys=select_pys(min_version="3.9", max_version="3.13"),
+            pkgs={"{package}": "~=1.0.0"},
+        ),
+        # Latest version
+        Venv(
+            pys=select_pys(),
+            pkgs={"{package}": latest},
+        ),
+    ],
+),
+```
+
+Key rules:
+- `name` must match the integration name used in `PATCH_MODULES`
+- `command` points to the test directory
+- Add `"vcrpy": latest` to top-level `pkgs` for LLM integrations
+- Use `select_pys()` for Python version ranges
+- Pin oldest supported + latest in separate nested `Venv()` entries
+- Check neighboring entries in the file for consistent formatting
+
+### suitespec.yml
+
+Add **component** and **suite** entries to the correct suitespec file:
+- LLM/AI integrations: `tests/llmobs/suitespec.yml`
+- Standard integrations: `tests/contrib/suitespec.yml`
+
+Look at a similar integration's entry in the same suitespec file and follow the same pattern for both the `components:` and `suites:` sections.
+
+## 5. Write tests
+
+Create `tests/contrib/{name}/` with:
+
+| File | Purpose | Pattern to follow |
+|------|---------|-------------------|
+| `test_{name}_patch.py` | Patch/unpatch cycle | `tests/contrib/anthropic/test_anthropic_patch.py` |
+| `test_{name}.py` | APM span assertions | Prefer `@pytest.mark.snapshot` |
+| `test_{name}_llmobs.py` | LLMObs (LLM only) | `tests/contrib/anthropic/test_anthropic_llmobs.py` |
+
+LLMObs tests MUST use `_expected_llmobs_llm_span_event` from `tests/llmobs/_utils.py`.
+See the **llmobs-integrations** skill's Testing Guide for VCR cassette setup and assertion patterns.
+
+## 6. Add documentation (non-LLM only)
+
+Add automodule entry to `docs/integrations.rst` in alphabetical order.
+
+## 7. Generate release note
+
+```bash
+riot run reno new add-{name}-integration
+```
+
+## Verification
+
+Read the **run-tests** skill before running tests. Never use `pytest`, `riot`, or `scripts/ddtest` directly.
+
+```bash
+# 1. Discover available venvs and their hashes
+scripts/run-tests --list tests/contrib/{name}/
+
+# 2. Pick 1 hashes (latest Python, one per major package version)
+
+# 3. First run (installs dd-trace-py in venv)
+scripts/run-tests --venv <hash>
+
+# 4. Subsequent runs (skip install, much faster)
+scripts/run-tests --venv <hash> -- -s -vv
+```
+
+**Key flags:**
+- `-- -s` = skip base dd-trace-py install (use on every run after the first)
+- `-vv` = verbose pytest output
+- Only omit `-s` on the very first run or after changing `setup.py`/`riotfile.py`/C extensions
+
+**Without `--venv`, tests run against ALL Python versions and package combos — this takes hours. Always use a specific hash.**
+
+Other checks:
+- `ruff check ddtrace/` passes
+- `patch()` / `unpatch()` cycle works without errors
+
+## Recent PRs as Examples
+
+- vLLM (#14732) -- LLM integration
+- Azure EventHubs (#14636) -- message queue
+- httpx revamp (#15522) -- HTTP client
+
+## Complete Checklist
+
+Every new integration must complete ALL applicable items:
+
+### Registration
+- [ ] `ddtrace/_monkey.py` -- `PATCH_MODULES` entry in alphabetical order
+- [ ] `ddtrace/contrib/integration_registry/registry.yaml` -- dependency names and tested version range
+- [ ] `ddtrace/internal/settings/_config.py` -- `INTEGRATION_CONFIGS` frozenset entry
+- [ ] `ddtrace/llmobs/_integrations/__init__.py` -- import + `__all__` entry (LLM only)
+
+### Patch Code
+- [ ] `ddtrace/contrib/internal/{name}/patch.py` -- `patch()`, `unpatch()`, `get_version()`
+- [ ] Patch code uses `integration.trace()` — **no direct `tracer.trace()` or `span` creation**
+- [ ] Prefer class-based events API (`TracingEvent` + `TracingSubscriber`) for new standard integrations
+- [ ] LLM integrations use **LLM events system** (`LLMEvent` subclasses) — see anthropic for the pattern
+
+### Integration Layer
+- [ ] `ddtrace/llmobs/_integrations/{name}.py` -- `BaseLLMIntegration` subclass (LLM only)
+- [ ] `_set_base_span_tags()` implemented
+- [ ] `_llmobs_set_tags()` implemented with all context items (LLM only)
+
+### Test Environment
+- [ ] `riotfile.py` -- `Venv()` entry with pinned + latest package versions
+- [ ] Suitespec entry -- component + suite in correct file (`tests/llmobs/suitespec.yml` or `tests/contrib/suitespec.yml`)
+- [ ] Compile and prune test requirements -- run `riot -v generate` to regenerate `.riot/requirements/`
+
+### Tests
+- [ ] `tests/contrib/{name}/test_{name}_patch.py` -- patch/unpatch cycle tests
+- [ ] `tests/contrib/{name}/test_{name}.py` -- APM span snapshot tests
+- [ ] `tests/contrib/{name}/test_{name}_llmobs.py` -- LLMObs assertion tests (LLM only)
+- [ ] Tests use `@pytest.mark.snapshot` for APM assertions where possible
+- [ ] LLMObs tests use `_expected_llmobs_llm_span_event` from `tests/llmobs/_utils.py`
+
+### Type Annotations
+- [ ] All function signatures have type annotations (parameters + return type)
+- [ ] No bare `dict`, `list`, `tuple` — use `dict[str, Any]`, `list[str]`, etc.
+- [ ] `Optional[X]` used for nullable parameters and return values
+- [ ] Wrapper functions use typed wrapt signature (`Callable[..., Any]`, `tuple[Any, ...]`, etc.)
+- [ ] No unjustified `# type: ignore` comments
+- [ ] `hatch run lint:typing -- <files>` passes with no errors
+
+### Documentation
+- [ ] `docs/integrations.rst` -- automodule entry in alphabetical order (non-LLM only)
+- [ ] `docs/index.rst` -- add integration to the docs index
+- [ ] Release note -- `riot run reno new add-{name}-integration`

--- a/.claude/skills/apm-integrations/references/reference-integrations.md
+++ b/.claude/skills/apm-integrations/references/reference-integrations.md
@@ -1,0 +1,36 @@
+# Reference Integrations
+
+Canonical dd-trace-py integrations organized by the 13 integration categories.
+**Read the canonical integration for your category before writing code.**
+
+All patch modules live in `ddtrace/contrib/internal/{name}/`.
+
+## By Category
+
+| Category | Canonical | Secondary | Notes |
+|----------|-----------|-----------|-------|
+| cache | `redis/patch.py` | `pymemcache/patch.py` | Key-value stores, `cache.*` span tags, uses Pin + `context_with_data` via redis_utils |
+| cloud-provider | `botocore/patch.py` | `google_genai/patch.py` | AWS services via botocore (Pin + `context_with_data`), GCP via google libs (LLM pattern) |
+| database | `psycopg/patch.py` | `mysql/patch.py` | SQL clients, `db.*` span tags, DBM support, uses Pin + dbapi helpers |
+| faas | `aws_lambda/patch.py` | `azure_functions/patch.py` | Serverless function wrappers, uses `ddtrace.internal.wrapping` |
+| generative-ai | `anthropic/patch.py` | `litellm/patch.py` | `BaseLLMIntegration.trace()`, `integration.llmobs_set_tags()`, streaming support |
+| graphql | `graphql/patch.py` | -- | GraphQL resolvers and operations, Pin + `tracer.trace` |
+| http-client | `httpx/patch.py` | `requests/connection.py` | Outbound HTTP, `http.*` span tags. httpx uses `context_with_data`; requests uses Pin + `tracer.trace` |
+| http-server | `flask/patch.py` | `django/patch.py` | Web frameworks, request/response spans, Pin + `context_with_data` |
+| logging | `logging/patch.py` | `loguru/patch.py` | Log correlation injection (trace ID, span ID) -- no spans created |
+| messaging | `kafka/patch.py` | `kombu/patch.py` | Message brokers, DSM support, Pin + `tracer.trace` |
+| object-store | `botocore/patch.py` (S3) | -- | S3 via botocore service-specific handlers |
+| orchestration | `celery/patch.py` | -- | Task orchestration, distributed tracing, Pin + `tracer.trace` via signals |
+| rpc | `grpc/patch.py` | -- | RPC frameworks, client + server spans, Pin + `tracer.trace` |
+
+## LLM / Generative AI Detail
+
+LLM integrations use `BaseLLMIntegration` for span management. Key characteristics:
+
+- Patch code creates a `BaseLLMIntegration` subclass instance and stores it on the module (e.g., `anthropic._datadog_integration`)
+- Patch code calls `integration.trace()` to create spans (internally uses `tracer.start_span()`)
+- Patch code directly manages spans: `span.set_exc_info(*sys.exc_info())`, `span.finish()`
+- Patch code calls `integration.llmobs_set_tags(span, args=[], kwargs=kwargs, response=result)` for LLMObs
+- LLMObs subclass in `ddtrace/llmobs/_integrations/{name}.py` handles message/token extraction
+- Streaming uses span handoff to stream handlers (span is not finished until iterator exhausted)
+- For streaming pattern, read `litellm/patch.py`; for agentic/multi-op, read `crewai/patch.py`

--- a/.claude/skills/llmobs-integrations/SKILL.md
+++ b/.claude/skills/llmobs-integrations/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: llmobs-integrations
+description: |
+  dd-trace-py LLMObs integration development guide. Use when creating, modifying,
+  or debugging LLMObs integrations for LLM/AI libraries in the Python tracer.
+  Covers BaseLLMIntegration, stream handling, message extraction, token counting,
+  tool call parsing, and VCR-based testing patterns.
+  Triggers: "llmobs", "LLMObs", "BaseLLMIntegration", "llmobs_set_tags",
+  "_llmobs_set_tags", "BaseStreamHandler", "submit_to_llmobs", "integration.trace",
+  "LLM span", "VCR", "cassette", "anthropic", "openai", "google_genai",
+  "claude_agent_sdk", "generative-ai", "LLM integration", "llmobs_enabled".
+---
+
+# dd-trace-py LLMObs Integrations
+
+LLMObs integrations enable Datadog LLM Observability for AI/LLM libraries. They extract model inputs, outputs, token usage, and tool calls from traced spans.
+
+## Two-Layer Architecture
+
+LLMObs integrations consist of two cooperating layers:
+
+1. **Patch Layer** (`ddtrace/contrib/internal/{name}/patch.py`) -- wraps library functions, creates spans via `integration.trace(submit_to_llmobs=True)`, and calls `integration.llmobs_set_tags()` in the finally block.
+2. **Integration Layer** (`ddtrace/llmobs/_integrations/{name}.py`) -- extends `BaseLLMIntegration`, implements `_set_base_span_tags()` and `_llmobs_set_tags()` to extract and set LLMObs-specific metadata.
+
+Both layers must work together. The patch layer controls span lifecycle; the integration layer controls what data is extracted.
+
+## Key Files
+
+| Purpose | File |
+|---------|------|
+| Base LLM integration class | `ddtrace/llmobs/_integrations/base.py` (`BaseLLMIntegration`) |
+| Stream handler base classes | `ddtrace/llmobs/_integrations/base_stream_handler.py` (`BaseStreamHandler`, `StreamHandler`, `AsyncStreamHandler`) |
+| Shared utilities | `ddtrace/llmobs/_integrations/utils.py` |
+| LLMObs constants | `ddtrace/llmobs/_constants.py` |
+| LLMObs types | `ddtrace/llmobs/types.py` (`Message`, `ToolCall`, `ToolResult`, `ToolDefinition`) |
+| Integration registry | `ddtrace/llmobs/_integrations/__init__.py` |
+
+## Reference Integrations
+
+**Always read 1-2 references before writing or modifying LLMObs code.**
+
+| Provider | Patch File | LLMObs Integration | LLMObs Tests |
+|----------|-----------|-------------------|--------------|
+| **Anthropic** (canonical) | `ddtrace/contrib/internal/anthropic/patch.py` | `ddtrace/llmobs/_integrations/anthropic.py` | `tests/contrib/anthropic/test_anthropic_llmobs.py` |
+| **Claude Agent SDK** (latest, agent pattern) | `ddtrace/contrib/internal/claude_agent_sdk/patch.py` | `ddtrace/llmobs/_integrations/claude_agent_sdk.py` | `tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py` |
+| OpenAI | `ddtrace/contrib/internal/openai/patch.py` | `ddtrace/llmobs/_integrations/openai.py` | `tests/contrib/openai/test_openai_llmobs.py` |
+| Google GenAI | `ddtrace/contrib/internal/google_genai/patch.py` | `ddtrace/llmobs/_integrations/google_genai.py` | `tests/contrib/google_genai/test_google_genai_llmobs.py` |
+
+Use **Anthropic** as the canonical reference for standard LLM integrations. Use **Claude Agent SDK** for agent-pattern integrations (agent spans, tool child spans, thinking blocks).
+
+## Abstract Methods to Implement
+
+Subclass `BaseLLMIntegration` and implement:
+
+### `_set_base_span_tags(span, **kwargs)`
+Set provider-specific APM tags on the span (e.g., `{name}.request.model`).
+
+### `_llmobs_set_tags(span, args, kwargs, response, operation)`
+Extract and set all LLMObs context items on the span:
+
+| Context Item | Description |
+|-------------|-------------|
+| `SPAN_KIND` | `"llm"` for LLM calls, `"agent"` for agent calls, `"tool"` for tool calls |
+| `MODEL_NAME` | Model identifier (e.g., `"claude-3-sonnet-20240229"`) |
+| `MODEL_PROVIDER` | Provider name (e.g., `"anthropic"`, `"openai"`) |
+| `INPUT_MESSAGES` | List of `Message` objects from request |
+| `OUTPUT_MESSAGES` | List of `Message` objects from response |
+| `METADATA` | Dict of request parameters (temperature, top_p, etc.) |
+| `METRICS` | Token usage dict with `INPUT_TOKENS_METRIC_KEY`, `OUTPUT_TOKENS_METRIC_KEY`, `TOTAL_TOKENS_METRIC_KEY` |
+| `TOOL_DEFINITIONS` | List of `ToolDefinition` objects if tools are passed |
+
+Context items are set via `span._set_ctx_items({...})`.
+
+## Key Constraints
+
+- **`submit_to_llmobs=True`** must be passed to `integration.trace()` in the patch layer
+- **`integration.llmobs_set_tags()`** must be called in the **finally** block (not try or except)
+- **Streaming** must use `BaseStreamHandler`/`AsyncStreamHandler` -- never consume streams directly
+- **Error handling** uses `span.set_exc_info()` in the except block, before the finally block
+- **Integration instance** must be stored on the module: `module._datadog_integration = Integration(tracer, config)`
+
+## Type Annotations
+
+All LLMObs integration code must pass `hatch run lint:typing` (mypy). Key signatures:
+
+- `_set_base_span_tags(self, span: Span, **kwargs: Any) -> None`
+- `_llmobs_set_tags(self, span: Span, args: list[Any], kwargs: dict[str, Any], response: Optional[Any], operation: str) -> None`
+- Extraction helpers must have return type annotations: `-> list[Message]`, `-> dict[str, int]`, `-> list[ToolDefinition]`
+- Stream handlers: `process_chunk(self, chunk: Any) -> None`, `finalize_stream(self, exception: Optional[BaseException]) -> None`, `initialize_chunk_storage(self) -> None`
+
+See the [Implementation Guide](references/implementation-guide.md) for fully-typed code examples.
+
+## Message Types
+
+```python
+from ddtrace.llmobs.types import Message, ToolCall, ToolResult, ToolDefinition
+
+# Input/output messages
+Message(content="text", role="user")
+Message(content="response", role="assistant", tool_calls=[...])
+
+# Tool calls (in output messages)
+ToolCall(name="get_weather", arguments={"city": "NYC"}, tool_id="toolu_123", type="tool")
+
+# Tool results (in input messages)
+ToolResult(result="72F sunny", tool_id="toolu_123", type="tool_result")
+
+# Tool definitions (from request parameters)
+ToolDefinition(name="get_weather", description="...", schema={...})
+```
+
+## Debugging Quick Tips
+
+- **No LLMObs spans** -- check `submit_to_llmobs=True` and `llmobs_set_tags()` in finally block
+- **Wrong messages** -- check message extraction handles multi-part content and tool blocks
+- **Wrong tokens** -- check field name mapping (libraries use different names for token counts)
+- **Streaming broken** -- verify `BaseStreamHandler` subclass, check `finalize_stream()` calls `span.finish()`
+- **DD_TRACE_DEBUG=true** to see patching activity and span creation
+
+See [Failure Modes](references/failure-modes.md) for detailed debugging guide.
+
+## Reference Files
+
+- [Implementation Guide](references/implementation-guide.md) -- LLM-specific steps (references apm-integrations guide for the full workflow)
+- [Failure Modes](references/failure-modes.md) -- All 8 failure modes with causes and fixes
+- [Testing Guide](references/testing-guide.md) -- LLMObs test patterns, VCR cassettes, suitespec

--- a/.claude/skills/llmobs-integrations/references/failure-modes.md
+++ b/.claude/skills/llmobs-integrations/references/failure-modes.md
@@ -1,0 +1,188 @@
+# LLMObs Failure Modes
+
+Comprehensive debugging guide for all known LLMObs integration failure modes. Each entry includes symptoms, causes, and fixes.
+
+---
+
+## `llmobs_not_enabled` -- LLMObs Not Recording
+
+**Symptoms:**
+- No LLMObs spans appear in Datadog
+- APM spans exist but have no LLMObs context items
+- `llmobs_writer.enqueue()` never called
+
+**Causes:**
+1. `submit_to_llmobs=True` not passed to `integration.trace()` in patch code
+2. `integration.llmobs_set_tags()` not called (or not in the finally block)
+3. Integration not instantiated -- `module._datadog_integration` is `None`
+4. `llmobs_enabled` returns `False` -- LLMObs not configured in tracer config
+
+**Fix:**
+- Verify `integration.trace(..., submit_to_llmobs=True)` in patch wrapper
+- Verify `integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=resp, operation=...)` is called in the **finally** block
+- Verify `patch()` stores integration: `module._datadog_integration = MyIntegration(tracer, config)`
+- Check `DD_LLMOBS_ENABLED=1` is set
+
+---
+
+## `wrong_messages` -- Input/Output Messages Incorrect
+
+**Symptoms:**
+- LLMObs spans exist but `input_messages` or `output_messages` are empty, truncated, or malformed
+- Tool calls appear as raw text instead of structured `ToolCall` objects
+- Multi-part content shows only the first block
+
+**Causes:**
+1. Library's message format differs from expected -- content is a list of blocks, not a string
+2. Multi-part content not iterated (only first block extracted)
+3. Tool use blocks not parsed into `ToolCall` objects
+4. Tool result blocks not parsed into `ToolResult` objects
+5. System message handled differently (separate kwarg vs first message)
+
+**Fix:**
+- Read the library's API response objects to understand the actual structure
+- Handle both string and list content: `isinstance(content, list)` check
+- Parse all content block types: `text`, `image`, `tool_use`, `tool_result`
+- Use `Message(content=..., role=..., tool_calls=[...])` for outputs with tool calls
+- Use `Message(content=..., role=..., tool_results=[...])` for inputs with tool results
+- Check system message handling (anthropic uses separate `system` kwarg)
+
+---
+
+## `wrong_tokens` -- Token Metrics Incorrect
+
+**Symptoms:**
+- Token counts are 0 or missing in LLMObs spans
+- Input/output token split is wrong
+- Total tokens doesn't match sum of input + output
+
+**Causes:**
+1. Library uses different field names (e.g., `prompt_tokens` vs `input_tokens`)
+2. Usage object is nested differently (attribute vs dict)
+3. Cache tokens not included in total (anthropic has `cache_creation_input_tokens`, `cache_read_input_tokens`)
+4. Streaming responses don't include usage in every chunk (only final chunk)
+
+**Fix:**
+- Check library docs/source for exact usage field names
+- Use `getattr(usage, "field_name", 0)` for attribute access
+- Include cache tokens: `total_input = input_tokens + cache_creation + cache_read`
+- For streaming: capture usage from the final event/chunk type
+- Map to standard keys: `INPUT_TOKENS_METRIC_KEY`, `OUTPUT_TOKENS_METRIC_KEY`, `TOTAL_TOKENS_METRIC_KEY`
+
+---
+
+## `wrong_model` -- Model Name Not Captured
+
+**Symptoms:**
+- LLMObs spans show empty or `"unknown"` model name
+- Model appears in APM tags but not in LLMObs context
+
+**Causes:**
+1. Model name is in a different kwarg (e.g., `model_id` vs `model`)
+2. Model name is on the response object, not in kwargs
+3. Model name is on the client instance, not per-request
+4. Model name includes version suffix that needs normalization
+
+**Fix:**
+- Check kwargs first: `kwargs.get("model", "")`
+- Fall back to response: `getattr(response, "model", "")`
+- Fall back to instance: `getattr(instance, "_model", "")`
+- Set in both `_set_base_span_tags()` (APM) and `_llmobs_set_tags()` (LLMObs)
+
+---
+
+## `streaming_not_handled` -- Streaming Responses Broken
+
+**Symptoms:**
+- Streaming requests produce no LLMObs data
+- Span finishes before stream is consumed
+- Stream appears to work but output messages are empty
+- Application hangs or stream is consumed twice
+
+**Causes:**
+1. Not using `BaseStreamHandler` subclass -- raw iteration loses trace context
+2. Stream consumed in wrapper before returning to caller
+3. `span.finish()` called before stream is exhausted
+4. `finalize_stream()` doesn't call `integration.llmobs_set_tags()` or `span.finish()`
+5. Token usage not captured from final stream event
+
+**Fix:**
+- Subclass `StreamHandler` (sync) or `AsyncStreamHandler` (async)
+- Implement `process_chunk()` to accumulate data without consuming the stream
+- Implement `finalize_stream()` to: build response object, call `llmobs_set_tags()`, call `span.finish()`
+- Use `make_traced_stream(response, handler)` to wrap the response
+- In patch code: return the traced stream instead of the raw response
+- Capture usage from final chunk type (varies by library)
+
+---
+
+## `async_not_working` -- Async Calls Not Traced
+
+**Symptoms:**
+- Async API calls produce no spans
+- Sync calls work fine, async calls are invisible
+- `RuntimeWarning: coroutine was never awaited`
+
+**Causes:**
+1. Using sync wrapper function for async method
+2. Not awaiting `wrapped(*args, **kwargs)` in async wrapper
+3. Missing async stream handler (using sync `StreamHandler` for async stream)
+4. Patch didn't wrap the async client methods
+
+**Fix:**
+- Create separate `traced_async_*` wrapper functions with `async def`
+- Use `await wrapped(*args, **kwargs)` in async wrappers
+- Subclass `AsyncStreamHandler` for async streams
+- Verify `patch()` wraps both sync and async client methods:
+  - `wrapt.wrap_function_wrapper("lib", "Client.create", traced_create)`
+  - `wrapt.wrap_function_wrapper("lib", "AsyncClient.create", traced_async_create)`
+
+---
+
+## `tool_calls_missing` -- Tool Use Not Captured
+
+**Symptoms:**
+- LLMObs spans exist but tool calls/results are missing
+- Tool definitions not shown in span metadata
+- Agent workflows appear as simple LLM calls
+
+**Causes:**
+1. Tool use blocks in response not parsed into `ToolCall` objects
+2. Tool result blocks in input not parsed into `ToolResult` objects
+3. Tool definitions from request `tools` kwarg not extracted
+4. Content block iteration skips non-text types
+
+**Fix:**
+- In `_extract_output_messages()`: parse `tool_use` blocks into `ToolCall(name, arguments, tool_id, type="tool")`
+- In `_extract_input_messages()`: parse `tool_result` blocks into `ToolResult(result, tool_id, type="tool_result")`
+- In `_extract_tools()`: convert request `tools` kwarg to `ToolDefinition` list
+- Set `TOOL_DEFINITIONS` context item when tools are present
+- For agent patterns: create child tool spans with `SPAN_KIND: "tool"`
+
+---
+
+## `vcr_not_working` -- VCR Cassettes Not Recording/Replaying
+
+Tests use the [dd-apm-test-agent VCR feature](https://github.com/DataDog/dd-apm-test-agent#recording-3rd-party-api-requests) -- the client's base URL is pointed at `http://127.0.0.1:9126/vcr/{provider}` instead of the real API.
+
+**Symptoms:**
+- Tests fail with network errors when cassettes should replay
+- Cassette files are empty or not created
+- Tests pass locally but fail in CI
+- `ConnectionError` or `APIError` during test execution
+
+**Causes:**
+1. Client base URL not pointed at test agent VCR endpoint (`http://127.0.0.1:9126/vcr/{provider}`)
+2. APM test agent not running or not reachable
+3. Cassette recorded with different library version -- request format changed, matching fails
+4. `VCR_CI_MODE=true` in CI but cassette doesn't exist (returns 404)
+5. API key env var not set -- client validates key before sending even when VCR replays
+6. Custom provider not registered in `VCR_PROVIDER_MAP`
+
+**Fix:**
+- Verify client uses `base_url="http://127.0.0.1:9126/vcr/{provider}"` in tests
+- Ensure test agent is running (`docker run ... ddapm-test-agent`)
+- Re-record cassettes when upgrading library version (unset `VCR_CI_MODE`, set real API key, run tests)
+- Set placeholder API key env vars: `ANTHROPIC_API_KEY=test-key`
+- For custom providers, set `VCR_PROVIDER_MAP="myprovider=http://api.example.com/"`
+- Ensure cassette files are committed to the repository

--- a/.claude/skills/llmobs-integrations/references/implementation-guide.md
+++ b/.claude/skills/llmobs-integrations/references/implementation-guide.md
@@ -1,0 +1,128 @@
+# LLMObs Integration Guide
+
+Follow the **apm-integrations** skill's [Implementation Guide](../../apm-integrations/references/implementation-guide.md) for the full step-by-step. This guide expands on the LLM-specific steps.
+
+## Overview
+
+An LLM integration is an APM integration with an extra layer. You do everything in the apm-integrations guide, but:
+- **Step 1 (patch module)**: Use `BaseLLMIntegration.trace()` with **LLM events system** (`LLMEvent` subclasses)
+- **Step 3 (LLMObs integration)**: Create the `BaseLLMIntegration` subclass (this guide)
+- **Step 4 (test environment)**: Add `vcrpy: latest` to riotfile, use `tests/llmobs/suitespec.yml`
+- **Step 5 (tests)**: Add `test_{name}_llmobs.py` using VCR cassettes and `_expected_llmobs_llm_span_event`
+
+## Step 3 Expanded: Create the Integration Class
+
+Before writing anything, read the existing implementation that most closely matches your library's pattern:
+
+| Pattern | Reference Integration | When to use |
+|---------|----------------------|-------------|
+| Standard LLM (chat completion) | `anthropic.py` | Library generates text responses from messages |
+| Agent runs + tool child spans | `claude_agent_sdk.py` | Library manages an agentic loop with tool calls |
+| Embeddings | `openai.py` | Library generates vector embeddings |
+| Tool-only calls | `openai.py` | Library wraps discrete tool/function invocations |
+
+Create `ddtrace/llmobs/_integrations/{name}.py`:
+
+```python
+from typing import Any, Optional
+
+from ddtrace import Span
+from ddtrace.llmobs._constants import (
+    INPUT_MESSAGES, INPUT_TOKENS_METRIC_KEY, METADATA, METRICS,
+    MODEL_NAME, MODEL_PROVIDER, OUTPUT_MESSAGES, OUTPUT_TOKENS_METRIC_KEY,
+    SPAN_KIND, TOOL_DEFINITIONS, TOTAL_TOKENS_METRIC_KEY,
+)
+from ddtrace.llmobs._integrations.base import BaseLLMIntegration
+from ddtrace.llmobs.types import Message, ToolCall, ToolDefinition, ToolResult
+
+
+class MyLibIntegration(BaseLLMIntegration):
+    _integration_name: str = "mylib"
+
+    def _set_base_span_tags(self, span: Span, **kwargs: Any) -> None:
+        """Set APM tags on span."""
+        span.set_tag_str("mylib.request.model", kwargs.get("model", ""))
+
+    def _llmobs_set_tags(
+        self,
+        span: Span,
+        args: list[Any],
+        kwargs: dict[str, Any],
+        response: Optional[Any],
+        operation: str,
+    ) -> None:
+        """Extract and set all LLMObs context items."""
+        tools = self._extract_tools(kwargs)
+        ctx_items: dict[str, Any] = {
+            SPAN_KIND: "llm",
+            MODEL_NAME: kwargs.get("model", ""),
+            MODEL_PROVIDER: "mylib",
+            INPUT_MESSAGES: self._extract_input_messages(kwargs),
+            OUTPUT_MESSAGES: self._extract_output_messages(response),
+            METADATA: self._extract_metadata(kwargs),
+            METRICS: self._extract_usage(response),
+        }
+        if tools:
+            ctx_items[TOOL_DEFINITIONS] = tools
+        span._set_ctx_items(ctx_items)
+```
+
+Common helpers (implement only what applies):
+
+- `_extract_input_messages(self, kwargs: dict[str, Any]) -> list[Message]` — convert `messages` array to `Message` list; handle system message, multi-part content blocks, tool results
+- `_extract_output_messages(self, response: Any) -> list[Message]` — convert response content blocks to `Message` list; handle text, tool_use, thinking blocks
+- `_extract_usage(self, response: Any) -> dict[str, int]` — map library token field names to `INPUT_TOKENS_METRIC_KEY` / `OUTPUT_TOKENS_METRIC_KEY` / `TOTAL_TOKENS_METRIC_KEY`
+- `_extract_tools(self, kwargs: dict[str, Any]) -> list[ToolDefinition]` — convert `tools` list to `ToolDefinition` list
+- `_extract_metadata(self, kwargs: dict[str, Any]) -> dict[str, Any]` — pick scalar request params: `temperature`, `top_p`, `max_tokens`, etc.
+
+Register in `ddtrace/llmobs/_integrations/__init__.py` (import + `__all__` entry).
+
+## Step 1 Expanded: Patch Layer (LLM Events System)
+
+LLM integrations are migrating to the **LLM events system** using `LLMEvent` subclasses. Read `ddtrace/contrib/internal/anthropic/patch.py` for the current events-based pattern — the patch layer uses LLM event classes instead of directly calling `integration.llmobs_set_tags()` in a finally block.
+
+Key points:
+- Uses `integration.trace()` — **no direct `tracer.trace()` or span creation**
+- LLMObs tag setting is handled by the LLM event, not directly in the patch wrapper
+- Streaming delegates to `StreamHandler` subclass instead of finishing span inline
+- The async variant is identical but uses `async def` / `await`
+
+## Streaming
+
+Subclass `StreamHandler`/`AsyncStreamHandler` from `ddtrace/llmobs/_integrations/base_stream_handler.py`:
+
+- `initialize_chunk_storage()` — set up accumulators for content, usage, role
+- `process_chunk(chunk)` — accumulate text, tool blocks, usage from each chunk
+- `finalize_stream(exception)` — build response, call `llmobs_set_tags()`, call `span.finish()`
+
+Wire into patch with `make_traced_stream(response, handler)`.
+
+For the agent pattern (tool child spans within streams), see `ddtrace/llmobs/_integrations/claude_agent_sdk.py`.
+
+## Message Extraction
+
+Different libraries structure messages differently — implement only the helpers you need. Read `ddtrace/llmobs/_integrations/anthropic.py` for full code examples.
+
+- `_extract_input_messages(kwargs)` — handle system message, multi-part content blocks, tool results
+- `_extract_output_messages(response)` — handle text blocks, tool use blocks, thinking blocks
+- `_extract_usage(response)` — map library-specific token field names to metric keys
+- `_extract_tools(kwargs)` — convert `tools` kwarg to `ToolDefinition` list
+
+### Token Field Mapping
+
+| Library | Input | Output | Cache Fields |
+|---------|-------|--------|-------------|
+| Anthropic | `input_tokens` | `output_tokens` | `cache_creation_input_tokens`, `cache_read_input_tokens` |
+| OpenAI | `prompt_tokens` | `completion_tokens` | N/A |
+| Google GenAI | `prompt_token_count` | `candidates_token_count` | `cached_content_token_count` |
+
+## LLM-Specific Registration Checklist
+
+In addition to the full checklist in the apm-integrations guide:
+
+- [ ] `ddtrace/llmobs/_integrations/{name}.py` — `BaseLLMIntegration` subclass
+- [ ] `ddtrace/llmobs/_integrations/__init__.py` — import + `__all__` entry
+- [ ] `ddtrace/contrib/internal/{name}/patch.py` — uses LLM events system (see anthropic for pattern)
+- [ ] `tests/llmobs/suitespec.yml` — LLMObs test suite entry
+- [ ] `riotfile.py` — `"vcrpy": latest` in top-level `pkgs`
+- [ ] `docs/index.rst` — add integration to the docs index

--- a/.claude/skills/llmobs-integrations/references/testing-guide.md
+++ b/.claude/skills/llmobs-integrations/references/testing-guide.md
@@ -1,0 +1,235 @@
+# LLMObs Testing Guide
+
+Patterns and practices for testing LLMObs integrations in dd-trace-py.
+
+## Test File Organization
+
+LLMObs tests live separately from APM integration tests:
+
+| Test Type | File Pattern | Location |
+|-----------|-------------|----------|
+| LLMObs integration | `test_{name}_llmobs.py` | `tests/contrib/{name}/` |
+| APM snapshots | `test_{name}.py` | `tests/contrib/{name}/` |
+| Patch/unpatch | `test_{name}_patch.py` | `tests/contrib/{name}/` |
+
+Example for `anthropic`:
+```
+tests/contrib/anthropic/
+├── test_anthropic.py           # APM snapshot tests
+├── test_anthropic_llmobs.py    # LLMObs integration tests
+├── test_anthropic_patch.py     # Patch/unpatch tests
+```
+
+## VCR Cassettes via APM Test Agent
+
+**Do not mock response objects.** LLMObs tests use the [dd-apm-test-agent VCR feature](https://github.com/DataDog/dd-apm-test-agent#recording-3rd-party-api-requests) to record and replay real provider API responses.
+
+### How It Works
+
+The APM test agent acts as a VCR proxy. Instead of calling the real provider URL, tests point the client at `http://127.0.0.1:9126/vcr/{provider}`. The test agent:
+
+1. **First run (recording):** Proxies the request to the real provider, records the response as a cassette file
+2. **Subsequent runs (replay):** Matches incoming requests against stored cassettes by path, HTTP method, and request body, and returns the recorded response
+
+This means tests exercise the **real client library code** end-to-end, including serialization, headers, and response parsing -- no mocks needed.
+
+### Client Setup
+
+Replace the provider's base URL with the test agent VCR endpoint:
+
+```python
+import anthropic
+
+# Point at APM test agent VCR proxy instead of real Anthropic API
+client = anthropic.Anthropic(base_url="http://127.0.0.1:9126/vcr/anthropic")
+
+# For OpenAI:
+from openai import OpenAI
+client = OpenAI(base_url="http://127.0.0.1:9126/vcr/openai")
+```
+
+### Test-Specific Cassette Naming
+
+Register test context so cassette files are named per-test:
+
+```python
+import requests
+
+# Before test
+requests.post("http://127.0.0.1:9126/vcr/test/start", json={"test_name": request.node.name})
+
+# Run test...
+
+# After test
+requests.post("http://127.0.0.1:9126/vcr/test/stop")
+```
+
+### Test Agent Configuration
+
+| Env Variable | Default | Description |
+|-------------|---------|-------------|
+| `VCR_CASSETTES_DIRECTORY` | `vcr-cassettes` | Where cassette files are stored |
+| `VCR_CI_MODE` | `false` | When `true`, returns 404 for missing cassettes (enforces all cassettes pre-recorded) |
+| `VCR_PROVIDER_MAP` | built-in providers | Register custom providers: `"myprovider=http://api.example.com/"` |
+| `VCR_IGNORE_HEADERS` | none | Comma-separated headers to exclude from recordings |
+
+Built-in providers: OpenAI, Azure OpenAI, DeepSeek, Anthropic, Google GenAI, AWS Bedrock Runtime.
+
+### Recording New Cassettes
+
+1. Set real API key: `export ANTHROPIC_API_KEY=sk-ant-...`
+2. Ensure `VCR_CI_MODE` is not set (or `false`)
+3. Run the test -- the test agent proxies to the real provider and records the cassette
+4. Commit the cassette files
+5. Enable `VCR_CI_MODE=true` in CI to prevent accidental re-recording
+
+### API Keys
+
+Clients still need an API key set (for client-side validation), but it doesn't need to be valid when replaying from cassettes. Use a placeholder:
+
+```python
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+```
+
+Full documentation: [dd-apm-test-agent VCR](https://github.com/DataDog/dd-apm-test-agent#recording-3rd-party-api-requests)
+
+## Using `_expected_llmobs_llm_span_event()`
+
+The canonical assertion helper is `_expected_llmobs_llm_span_event` from `tests/llmobs/_utils.py`. **Always use this helper -- never write manual field-by-field checks.**
+
+```python
+from tests.llmobs._utils import _expected_llmobs_llm_span_event
+
+def test_chat_completion(self, llmobs):
+    """Test basic chat completion produces correct LLMObs span."""
+    client = anthropic.Anthropic(base_url="http://127.0.0.1:9126/vcr/anthropic")
+    resp = client.messages.create(
+        model="claude-3-sonnet-20240229",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+
+    expected = _expected_llmobs_llm_span_event(
+        span,
+        span_kind="llm",
+        model_name="claude-3-sonnet-20240229",
+        model_provider="anthropic",
+        input_messages=[{"content": "Hello", "role": "user"}],
+        output_messages=[{"content": "Hi there!", "role": "assistant"}],
+        metadata={"temperature": 1.0, "max_tokens": 100},
+        token_metrics={
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        },
+        tags={"ml_app": "test-app"},
+    )
+    llmobs_writer = llmobs._instance._llmobs_writer
+    llmobs_writer.enqueue.assert_called_with(expected)
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `span` | Span | The traced span object |
+| `span_kind` | str | `"llm"`, `"agent"`, or `"tool"` |
+| `model_name` | str | Model identifier |
+| `model_provider` | str | Provider name |
+| `input_messages` | list[dict] | Input message dicts |
+| `output_messages` | list[dict] | Output message dicts |
+| `metadata` | dict | Request metadata |
+| `token_metrics` | dict | Token usage metrics |
+| `tags` | dict | Additional tags |
+| `tool_definitions` | list[dict] | Tool definition dicts (optional) |
+
+### Message Format in Assertions
+
+Messages in test assertions use plain dicts, not `Message` objects:
+
+```python
+# Input with tool result
+input_messages=[
+    {"content": "Hello", "role": "user"},
+    {
+        "content": "",
+        "role": "user",
+        "tool_results": [{"result": "72F", "tool_id": "toolu_123", "type": "tool_result"}],
+    },
+]
+
+# Output with tool call
+output_messages=[
+    {
+        "content": "",
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "name": "get_weather",
+                "arguments": {"city": "NYC"},
+                "tool_id": "toolu_456",
+                "type": "tool",
+            }
+        ],
+    },
+]
+```
+
+## Suitespec Configuration
+
+LLMObs tests go in `tests/llmobs/suitespec.yml`, NOT in `tests/contrib/suitespec.yml`:
+
+```yaml
+# tests/llmobs/suitespec.yml
+mylib:
+  parallelism: 1
+  paths:
+    - tests/contrib/mylib/test_mylib_llmobs.py
+  env:
+    MYLIB_API_KEY: "test-key"
+  dependencies:
+    - mylib>=1.0
+```
+
+## Snapshot vs Manual Assertions
+
+| Approach | When to Use | Pros | Cons |
+|----------|------------|------|------|
+| Snapshot (`.json` files) | APM span structure | Exact match, easy to update | Brittle to formatting changes |
+| `_expected_llmobs_llm_span_event()` | LLMObs span content | Flexible, focused on data | Requires VCR setup |
+| Direct `assert` | Simple checks | Quick, readable | Verbose for complex objects |
+
+**For LLMObs tests, always prefer `_expected_llmobs_llm_span_event()`** -- it handles the boilerplate span event structure and lets you focus on the integration-specific data.
+
+## Running Tests
+
+Read the **run-tests** skill. Never use `pytest`, `riot`, or `scripts/ddtest` directly.
+
+```bash
+# Discover venvs and pick a hash (latest Python version)
+scripts/run-tests --list tests/contrib/{name}/
+scripts/run-tests --venv <hash>
+
+# Re-runs: skip dd-trace-py install (much faster)
+scripts/run-tests --venv <hash> -- -s -vv
+
+# Run specific test
+scripts/run-tests --venv <hash> -- -s -- -vv -k test_chat_completion
+```
+
+**Always use `--venv <hash>`** — without it, tests run against ALL Python versions and package combos, which takes hours. Use `-- -s` on every run after the first to skip reinstalling dd-trace-py dependencies.
+
+## Test Categories
+
+Cover these scenarios for every LLMObs integration:
+
+1. **Basic completion** -- simple request/response, verify all context items
+2. **Streaming** -- streamed response, verify chunks are accumulated correctly
+3. **Tool use** -- request with tools, verify tool calls in output and tool results in input
+4. **Error handling** -- API error, verify span has error info and LLMObs still records
+5. **Multi-turn** -- conversation with history, verify all messages captured
+6. **Token counting** -- verify all token metrics are correct (including cache tokens)
+7. **Model extraction** -- verify model name is captured from various sources
+8. **Async** -- async client calls, same assertions as sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Use the Skill tool to invoke these. **Always prefer skills over raw commands.**
 | `review-ci` | Reviewing CI results for a branch/commit/PR. Use when CI is failing or to understand what's blocking a PR from merging. Requires Datadog MCP. |
 | `run-benchmarks` | Running performance benchmarks to measure the impact of code changes. Use when touching performance-sensitive code or asked about perf impact. |
 | `debug-build-times` | Diagnosing slow base venv builds or warm rebuild regressions. Use when ext_cache isn't saving time or when CI venv builds are unexpectedly slow. |
+| `apm-integrations` | Creating or modifying contrib integrations (`ddtrace/contrib/internal/`). Covers patch module system, context_with_event, BaseLLMIntegration, streaming, testing with riot, VCR cassettes, and anti-patterns. Use when touching any integration. |
+| `llmobs-integrations` | Creating or modifying LLMObs integrations (`ddtrace/llmobs/_integrations/`). Covers BaseLLMIntegration, stream handling, message/tool extraction, token counting, and VCR-based test patterns. Use when touching LLM/AI library integrations. |
 
 ## Domain Guides
 


### PR DESCRIPTION
## Summary

Adds two Claude Code skills for AI-assisted integration development in dd-trace-py:

- **`apm-integrations`** — covers the full contrib integration lifecycle: patch module system, `context_with_event` (new preferred pattern), `BaseLLMIntegration`, streaming, riot/VCR testing, anti-patterns, and reference integrations for all 13 categories
- **`llmobs-integrations`** — covers the LLMObs integration layer: `BaseLLMIntegration`, stream handlers, message/tool/token extraction, VCR test patterns, and an 8-mode failure guide

These skills were developed, tested, and refined in the [APM Instrumentation AI Toolkit](https://github.com/DataDog/apm-instrumentation-toolkit), where they've been used to autonomously generate several LLMObs integrations including llama-index and claude-agent-sdk tracing. They're considered stable — this PR graduates them from toolkit-internal to living directly in the repo so any contributor or AI agent working in dd-trace-py gets them automatically.

`AGENTS.md` updated to surface them in the Skills table so they auto-load when working on integrations.

## Test plan

- [x] Skills load correctly via Claude Code (`/apm-integrations`, `/llmobs-integrations`)
- [x] Content is accurate against current codebase (reference integrations, file paths, API signatures)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)