### PR TITLE
ci: pyclass-missing-traverse catches SpanData/SpanLink/SpanEvent (do not merge)

### DIFF
--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -34,10 +34,18 @@ rule:
             field: type
             stopBy: end
             regex: "Py<|PyObject|PyBackedString"
-    # No __traverse__ method exists in an `impl <THIS_STRUCT>` block in the
-    # same file. We bind the impl target to $NAME so a sibling pyclass with
-    # its own __traverse__ does not silently mask this one (which was the
-    # cross-pyclass false negative caught in code review).
+    # No __traverse__ method exists in a `#[pymethods] impl <THIS_STRUCT>`
+    # block in the same file.
+    #
+    # Three constraints on the impl block:
+    #   1. The impl target type must be $NAME (so a sibling pyclass's
+    #      __traverse__ does not satisfy this struct's check).
+    #   2. The impl must be annotated with #[pymethods]. PyO3 only wires
+    #      __traverse__ into tp_traverse from impls inside a #[pymethods]
+    #      block; a plain `impl Foo { fn __traverse__ ... }` is a regular
+    #      Rust method and the type's GC slot stays empty.
+    #   3. The impl must contain a function named __traverse__.
+    #
     # We check both directions because impl blocks may appear before or
     # after the struct definition.
     - not:
@@ -48,6 +56,12 @@ rule:
             - has:
                 field: type
                 pattern: $NAME
+            - follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                kind: attribute_item
+                regex: "pymethods"
             - has:
                 stopBy: end
                 kind: function_item
@@ -62,6 +76,12 @@ rule:
             - has:
                 field: type
                 pattern: $NAME
+            - follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                kind: attribute_item
+                regex: "pymethods"
             - has:
                 stopBy: end
                 kind: function_item

--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -1,0 +1,88 @@
+id: pyclass-missing-traverse
+message: "PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak"
+severity: warning
+language: rust
+files:
+  - "src/native/**/*.rs"
+rule:
+  all:
+    - kind: struct_item
+    - follows:
+        stopBy: end
+        kind: attribute_item
+        regex: "pyclass"
+    # Has at least one field whose type mentions a Python-owning reference.
+    # PyBackedString is included because it opaquely holds Option<Py<PyAny>>;
+    # without traversal, a str subclass with __dict__ stored in such a field
+    # can close an uncollectable cycle (see test_span_event_string_attribute_*
+    # cases in tests/tracer/test_span_data.py).
+    - has:
+        kind: field_declaration_list
+        has:
+          kind: field_declaration
+          has:
+            field: type
+            stopBy: end
+            regex: "Py<|PyObject|PyBackedString"
+    # No __traverse__ method exists in any sibling impl block in the same file.
+    # We check both directions (precedes / follows) because impl blocks may
+    # appear before or after the struct.
+    - not:
+        precedes:
+          stopBy: end
+          kind: impl_item
+          has:
+            stopBy: end
+            kind: function_item
+            has:
+              field: name
+              regex: "^__traverse__$"
+    - not:
+        follows:
+          stopBy: end
+          kind: impl_item
+          has:
+            stopBy: end
+            kind: function_item
+            has:
+              field: name
+              regex: "^__traverse__$"
+note: |
+  PyO3 does not auto-derive Python's cyclic-GC protocol. A #[pyclass] that
+  holds a Py<...>, PyObject, or PyBackedString field without implementing
+  __traverse__ is born without Py_TPFLAGS_HAVE_GC, so CPython's cyclic
+  collector never inspects its instances. Any reference cycle that passes
+  through such a field leaks for the lifetime of the process.
+
+  This was the root cause of the SpanData/SpanLink/SpanEvent leak fixed by
+  the PR that introduced this lint. See:
+  - releasenotes/notes/fix-span-cyclic-gc-leak-*.yaml
+  - tests/tracer/test_span_data.py (cyclic GC support tests)
+  - PyO3 RFC #5663 ("automatic garbage collector derives", open)
+
+  How to fix:
+
+    #[pymethods]
+    impl MyClass {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            // Visit every owned Py<...> / PyObject / wrapper that holds one.
+            visit.call(&self.some_py_dict)?;
+            self.some_pybacked_string.traverse(&visit)?;
+            Ok(())
+        }
+
+        // Only if the class is not `frozen`. If frozen, traversal alone is
+        // usually sufficient because the cycle can be broken on the mutable
+        // (Python-side) participant.
+        fn __clear__(&mut self) {
+            // Drop owned Python references that may participate in cycles.
+        }
+    }
+
+  If the field is known to hold only atomic Python objects (e.g. PyString,
+  PyLong, PyNone) AND will never be exposed to user-supplied subclasses with
+  a __dict__, traversal is technically optional for cycle-breaking — but it
+  is still required for correct refcount accounting from CPython's
+  perspective (`gc.get_referents`, debugger tooling). Implement it.

--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -6,9 +6,19 @@ files:
   - "src/native/**/*.rs"
 rule:
   all:
+    # Capture the struct name so we can match impl blocks that target it.
     - kind: struct_item
+      has:
+        field: name
+        pattern: $NAME
+    # The #[pyclass] attribute must be attached to THIS struct: walk only
+    # through other attribute_items (e.g. #[derive(Default)]) and stop at
+    # anything else. Without the stopBy constraint, an unrelated helper
+    # struct after a pyclass would falsely match the earlier #[pyclass].
     - follows:
-        stopBy: end
+        stopBy:
+          not:
+            kind: attribute_item
         kind: attribute_item
         regex: "pyclass"
     # Has at least one field whose type mentions a Python-owning reference.
@@ -24,29 +34,40 @@ rule:
             field: type
             stopBy: end
             regex: "Py<|PyObject|PyBackedString"
-    # No __traverse__ method exists in any sibling impl block in the same file.
-    # We check both directions (precedes / follows) because impl blocks may
-    # appear before or after the struct.
+    # No __traverse__ method exists in an `impl <THIS_STRUCT>` block in the
+    # same file. We bind the impl target to $NAME so a sibling pyclass with
+    # its own __traverse__ does not silently mask this one (which was the
+    # cross-pyclass false negative caught in code review).
+    # We check both directions because impl blocks may appear before or
+    # after the struct definition.
     - not:
         precedes:
           stopBy: end
           kind: impl_item
-          has:
-            stopBy: end
-            kind: function_item
-            has:
-              field: name
-              regex: "^__traverse__$"
+          all:
+            - has:
+                field: type
+                pattern: $NAME
+            - has:
+                stopBy: end
+                kind: function_item
+                has:
+                  field: name
+                  regex: "^__traverse__$"
     - not:
         follows:
           stopBy: end
           kind: impl_item
-          has:
-            stopBy: end
-            kind: function_item
-            has:
-              field: name
-              regex: "^__traverse__$"
+          all:
+            - has:
+                field: type
+                pattern: $NAME
+            - has:
+                stopBy: end
+                kind: function_item
+                has:
+                  field: name
+                  regex: "^__traverse__$"
 note: |
   PyO3 does not auto-derive Python's cyclic-GC protocol. A #[pyclass] that
   holds a Py<...>, PyObject, or PyBackedString field without implementing

--- a/.sg/rules/pyclass-missing-traverse.yml
+++ b/.sg/rules/pyclass-missing-traverse.yml
@@ -1,6 +1,6 @@
 id: pyclass-missing-traverse
 message: "PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak"
-severity: warning
+severity: error
 language: rust
 files:
   - "src/native/**/*.rs"

--- a/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
+++ b/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
@@ -1,0 +1,200 @@
+id: pyclass-missing-traverse
+snapshots:
+  ? |
+    #[pyclass(frozen)]
+    pub struct LeakBacked {
+        name: PyBackedString,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakBacked {
+            name: PyBackedString,
+        }
+      style: primary
+      start: 19
+      end: 70
+    - source: '#[pyclass(frozen)]'
+      style: secondary
+      start: 0
+      end: 18
+    - source: PyBackedString
+      style: secondary
+      start: 53
+      end: 67
+    - source: 'name: PyBackedString'
+      style: secondary
+      start: 47
+      end: 67
+    - source: |-
+        {
+            name: PyBackedString,
+        }
+      style: secondary
+      start: 41
+      end: 70
+  ? |
+    #[pyclass]
+    #[derive(Default)]
+    pub struct LeakDerive {
+        attrs: Option<Py<PyDict>>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakDerive {
+            attrs: Option<Py<PyDict>>,
+        }
+      style: primary
+      start: 30
+      end: 86
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Option<Py<PyDict>>
+      style: secondary
+      start: 65
+      end: 83
+    - source: 'attrs: Option<Py<PyDict>>'
+      style: secondary
+      start: 58
+      end: 83
+    - source: |-
+        {
+            attrs: Option<Py<PyDict>>,
+        }
+      style: secondary
+      start: 52
+      end: 86
+  ? |
+    #[pyclass]
+    pub struct LeakAny {
+        cached: Option<Py<PyAny>>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakAny {
+            cached: Option<Py<PyAny>>,
+        }
+      style: primary
+      start: 11
+      end: 64
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Option<Py<PyAny>>
+      style: secondary
+      start: 44
+      end: 61
+    - source: 'cached: Option<Py<PyAny>>'
+      style: secondary
+      start: 36
+      end: 61
+    - source: |-
+        {
+            cached: Option<Py<PyAny>>,
+        }
+      style: secondary
+      start: 30
+      end: 64
+  ? |
+    #[pyclass]
+    pub struct LeakDict {
+        attrs: Py<PyDict>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakDict {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 11
+      end: 57
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Py<PyDict>
+      style: secondary
+      start: 44
+      end: 54
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 37
+      end: 54
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 31
+      end: 57
+  ? |
+    #[pyclass]
+    pub struct LeakWrongImpl {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakWrongImpl {
+        fn other(&self) {}
+    }
+  : labels:
+    - source: |-
+        pub struct LeakWrongImpl {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 11
+      end: 62
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Py<PyDict>
+      style: secondary
+      start: 49
+      end: 59
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 42
+      end: 59
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 36
+      end: 62
+  ? |
+    #[pyo3::pyclass(name = "Leaky", module = "x")]
+    pub struct LeakQualified {
+        attrs: Py<PyDict>,
+    }
+  : labels:
+    - source: |-
+        pub struct LeakQualified {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 47
+      end: 98
+    - source: '#[pyo3::pyclass(name = "Leaky", module = "x")]'
+      style: secondary
+      start: 0
+      end: 46
+    - source: Py<PyDict>
+      style: secondary
+      start: 85
+      end: 95
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 78
+      end: 95
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 72
+      end: 98

--- a/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
+++ b/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
@@ -13,6 +13,10 @@ snapshots:
       style: primary
       start: 19
       end: 70
+    - source: LeakBacked
+      style: secondary
+      start: 30
+      end: 40
     - source: '#[pyclass(frozen)]'
       style: secondary
       start: 0
@@ -46,6 +50,10 @@ snapshots:
       style: primary
       start: 30
       end: 86
+    - source: LeakDerive
+      style: secondary
+      start: 41
+      end: 51
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -67,6 +75,62 @@ snapshots:
       end: 86
   ? |
     #[pyclass]
+    pub struct GoodOne {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl GoodOne {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+
+    #[pyclass]
+    pub struct LeakySibling {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakySibling {
+        fn other(&self) {}
+    }
+  : labels:
+    - source: |-
+        pub struct LeakySibling {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 259
+      end: 309
+    - source: LeakySibling
+      style: secondary
+      start: 270
+      end: 282
+    - source: '#[pyclass]'
+      style: secondary
+      start: 248
+      end: 258
+    - source: Py<PyDict>
+      style: secondary
+      start: 296
+      end: 306
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 289
+      end: 306
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 283
+      end: 309
+  ? |
+    #[pyclass]
     pub struct LeakAny {
         cached: Option<Py<PyAny>>,
     }
@@ -78,6 +142,10 @@ snapshots:
       style: primary
       start: 11
       end: 64
+    - source: LeakAny
+      style: secondary
+      start: 22
+      end: 29
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -110,6 +178,10 @@ snapshots:
       style: primary
       start: 11
       end: 57
+    - source: LeakDict
+      style: secondary
+      start: 22
+      end: 30
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -147,6 +219,10 @@ snapshots:
       style: primary
       start: 11
       end: 62
+    - source: LeakWrongImpl
+      style: secondary
+      start: 22
+      end: 35
     - source: '#[pyclass]'
       style: secondary
       start: 0
@@ -179,6 +255,10 @@ snapshots:
       style: primary
       start: 47
       end: 98
+    - source: LeakQualified
+      style: secondary
+      start: 58
+      end: 71
     - source: '#[pyo3::pyclass(name = "Leaky", module = "x")]'
       style: secondary
       start: 0

--- a/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
+++ b/.sg/tests/__snapshots__/pyclass-missing-traverse-snapshot.yml
@@ -243,6 +243,51 @@ snapshots:
       start: 36
       end: 62
   ? |
+    #[pyclass]
+    pub struct LeakyPlainImpl {
+        attrs: Py<PyDict>,
+    }
+
+    impl LeakyPlainImpl {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+  : labels:
+    - source: |-
+        pub struct LeakyPlainImpl {
+            attrs: Py<PyDict>,
+        }
+      style: primary
+      start: 11
+      end: 63
+    - source: LeakyPlainImpl
+      style: secondary
+      start: 22
+      end: 36
+    - source: '#[pyclass]'
+      style: secondary
+      start: 0
+      end: 10
+    - source: Py<PyDict>
+      style: secondary
+      start: 50
+      end: 60
+    - source: 'attrs: Py<PyDict>'
+      style: secondary
+      start: 43
+      end: 60
+    - source: |-
+        {
+            attrs: Py<PyDict>,
+        }
+      style: secondary
+      start: 37
+      end: 63
+  ? |
     #[pyo3::pyclass(name = "Leaky", module = "x")]
     pub struct LeakQualified {
         attrs: Py<PyDict>,

--- a/.sg/tests/pyclass-missing-traverse-test.yml
+++ b/.sg/tests/pyclass-missing-traverse-test.yml
@@ -1,0 +1,112 @@
+id: pyclass-missing-traverse
+valid:
+  # pyclass with no Python-owning fields — OK
+  - |
+    #[pyclass]
+    pub struct PureRust {
+        value: String,
+        count: u64,
+    }
+  # pyclass with Py<PyDict> AND a __traverse__ impl in the same file — OK
+  - |
+    #[pyclass]
+    pub struct WithTraverse {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl WithTraverse {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+  # pyclass with PyBackedString field plus __traverse__ — OK
+  - |
+    #[pyclass(frozen)]
+    pub struct FrozenWithTraverse {
+        name: PyBackedString,
+    }
+
+    #[pymethods]
+    impl FrozenWithTraverse {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            self.name.traverse(&visit)?;
+            Ok(())
+        }
+    }
+  # __traverse__ defined in a separately attributed impl block — OK
+  - |
+    #[pyclass]
+    pub struct SplitImpl {
+        attrs: Py<PyDict>,
+    }
+
+    impl SplitImpl {
+        fn helper(&self) {}
+    }
+
+    #[pymethods]
+    impl SplitImpl {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+  # Plain (non-pyclass) struct that happens to hold Py<...> — OK,
+  # not exposed to Python so no GC protocol concern.
+  - |
+    pub struct NotAPyclass {
+        attrs: Py<PyDict>,
+    }
+invalid:
+  # Owned Py<PyDict> field, no __traverse__
+  - |
+    #[pyclass]
+    pub struct LeakDict {
+        attrs: Py<PyDict>,
+    }
+  # Owned Py<PyAny> wrapped in Option, no __traverse__
+  - |
+    #[pyclass]
+    pub struct LeakAny {
+        cached: Option<Py<PyAny>>,
+    }
+  # PyBackedString field, no __traverse__ (the str-subclass-with-__dict__
+  # cycle is real — see test_span_event_string_attribute_value_cycle_*)
+  - |
+    #[pyclass(frozen)]
+    pub struct LeakBacked {
+        name: PyBackedString,
+    }
+  # Fully-qualified pyo3::pyclass attribute — also covered
+  - |
+    #[pyo3::pyclass(name = "Leaky", module = "x")]
+    pub struct LeakQualified {
+        attrs: Py<PyDict>,
+    }
+  # Multiple attributes between #[pyclass] and the struct (e.g. derive)
+  # — `follows: stopBy: end` must walk past them.
+  - |
+    #[pyclass]
+    #[derive(Default)]
+    pub struct LeakDerive {
+        attrs: Option<Py<PyDict>>,
+    }
+  # Sibling impl exists but does NOT define __traverse__
+  - |
+    #[pyclass]
+    pub struct LeakWrongImpl {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakWrongImpl {
+        fn other(&self) {}
+    }

--- a/.sg/tests/pyclass-missing-traverse-test.yml
+++ b/.sg/tests/pyclass-missing-traverse-test.yml
@@ -65,6 +65,29 @@ valid:
     pub struct NotAPyclass {
         attrs: Py<PyDict>,
     }
+  # Plain Rust helper struct following a correctly-traversed pyclass —
+  # OK. Regression test: an earlier version of this rule used
+  # `follows: stopBy: end` for the pyclass attribute, which made this
+  # helper match the earlier struct's #[pyclass] attribute.
+  - |
+    #[pyclass]
+    pub struct PyExposed {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl PyExposed {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+
+    pub struct InternalHelper {
+        cached: Py<PyAny>,
+    }
 invalid:
   # Owned Py<PyDict> field, no __traverse__
   - |
@@ -108,5 +131,36 @@ invalid:
 
     #[pymethods]
     impl LeakWrongImpl {
+        fn other(&self) {}
+    }
+  # Two pyclasses in the same file: one correctly traverses, the other
+  # does not. Regression test: an earlier version of this rule treated
+  # any sibling __traverse__ in the file as satisfying every pyclass,
+  # so adding a leaky pyclass next to an already-fixed one went
+  # undetected. The rule must now match __traverse__ to the specific
+  # impl target.
+  - |
+    #[pyclass]
+    pub struct GoodOne {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl GoodOne {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }
+
+    #[pyclass]
+    pub struct LeakySibling {
+        attrs: Py<PyDict>,
+    }
+
+    #[pymethods]
+    impl LeakySibling {
         fn other(&self) {}
     }

--- a/.sg/tests/pyclass-missing-traverse-test.yml
+++ b/.sg/tests/pyclass-missing-traverse-test.yml
@@ -164,3 +164,21 @@ invalid:
     impl LeakySibling {
         fn other(&self) {}
     }
+  # __traverse__ defined in a plain `impl` block (no #[pymethods]).
+  # PyO3 only wires __traverse__ into tp_traverse when it lives inside a
+  # #[pymethods] block; a regular impl method is invisible to the GC
+  # slot, so the type still leaks. Regression test for Codex P2 #3.
+  - |
+    #[pyclass]
+    pub struct LeakyPlainImpl {
+        attrs: Py<PyDict>,
+    }
+
+    impl LeakyPlainImpl {
+        fn __traverse__(&self, visit: pyo3::PyVisit<'_>)
+            -> Result<(), pyo3::PyTraverseError>
+        {
+            visit.call(&self.attrs)?;
+            Ok(())
+        }
+    }


### PR DESCRIPTION
## Description

**Demo PR for #17869.** Demonstrates that the `pyclass-missing-traverse`
ast-grep rule catches the exact violations that motivated it.

This branch is `lint/pyclass-missing-traverse` rebased onto the commit
**immediately before** #17867 was merged into main:

- Base: [`a7013499c7`](https://github.com/DataDog/dd-trace-py/commit/a7013499c7)
  (`chore(config): register DD_PROFILING_LOCK_EXCLUDE_MODULES…`)
- Then the 4 lint commits cherry-picked on top.

At this base, `SpanData`, `SpanLink`, and `SpanEvent` all hold
`Py<…>` / `PyBackedString` fields *without* `__traverse__`. The lint
rule should flag all three and CI should fail.

## Expected CI behaviour

- `hatch run lint:sg` fails with **3 errors** in:
  - `src/native/span/span_data.rs`
  - `src/native/span/span_link.rs`
  - `src/native/span/span_event.rs`

Local verification:

```
$ hatch run lint:sg
error[pyclass-missing-traverse]: PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak
error[pyclass-missing-traverse]: PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak
error[pyclass-missing-traverse]: PyO3 #[pyclass] holds Python references (Py<...>, PyObject, or PyBackedString) but does not implement __traverse__ — cycles through this type will leak
$ echo $?
1
```

## Why #17869's CI is currently green despite the rule being correct

Brett asked on #17869: *"was CI meant to fail for it? it didn't seem to
catch it?"*

#17869's branch is rebased onto current `main`, which **already
contains #17867**. So the rule has nothing to flag in that tree —
it's correctly silent because all three pyclasses now have
`__traverse__`. To confirm the rule actually fires, we need a base
that predates #17867; that's what this PR provides.

## Risks / merge plan

**Do not merge.** This PR exists only to make CI flag the violations.
Once we're satisfied (or once Brett is), close it and delete the
branch.

`changelog/no-changelog`.
