### PR TITLE
chore(valkey): wait until cluster is ready before running tests

### DIFF
--- a/tests/contrib/valkey/conftest.py
+++ b/tests/contrib/valkey/conftest.py
@@ -1,3 +1,4 @@
+import socket
 import time
 
 import pytest
@@ -10,6 +11,15 @@ from tests.contrib.config import VALKEY_CLUSTER_CONFIG
 def wait_for_valkey_cluster():
     host = VALKEY_CLUSTER_CONFIG["host"]
     port = int(VALKEY_CLUSTER_CONFIG["ports"].split(",")[0])
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(1)
+    try:
+        if s.connect_ex((host, port)) != 0:
+            return
+    except Exception:
+        return
+    finally:
+        s.close()
     timeout = 20
     client = valkey.Valkey(host=host, port=port)
     deadline = time.time() + timeout

--- a/tests/contrib/valkey/conftest.py
+++ b/tests/contrib/valkey/conftest.py
@@ -16,7 +16,7 @@ def wait_for_valkey_cluster():
     while time.time() < deadline:
         try:
             info = client.execute_command("CLUSTER INFO")
-            if b"cluster_state:ok" in info:
+            if info.get("cluster_state") == "ok":
                 return
         except Exception:
             pass

--- a/tests/contrib/valkey/conftest.py
+++ b/tests/contrib/valkey/conftest.py
@@ -1,0 +1,24 @@
+import time
+
+import pytest
+import valkey
+
+from tests.contrib.config import VALKEY_CLUSTER_CONFIG
+
+
+@pytest.fixture(scope="session", autouse=True)
+def wait_for_valkey_cluster():
+    host = VALKEY_CLUSTER_CONFIG["host"]
+    port = int(VALKEY_CLUSTER_CONFIG["ports"].split(",")[0])
+    timeout = 20
+    client = valkey.Valkey(host=host, port=port)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            info = client.execute_command("CLUSTER INFO")
+            if b"cluster_state:ok" in info:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError("Valkey cluster at %s:%d not ready after %ds" % (host, port, timeout))


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

We have some flaky tests as seen in https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1654587765 related to the valkey cluster being down:

```
FAILED tests/contrib/valkey/test_valkey_cluster.py::TestValkeyClusterPatch::test_pipeline[py3.10] - valkey.exceptions.ClusterDownError: Command # 1 (SET blah 32) of pipeline caused error: The cluster is down
============================= Datadog Test Reports =============================
View detailed reports in Datadog (they may take a few minutes to become available):
```

I'm not sure what the best way to fix this is and the only other example I am aware of is https://github.com/DataDog/dd-trace-py/pull/17888/changes, which uses `try_until_timeout`.


Addresses IDMPL-431 , DD_0M57Q5
## Testing

<!-- Describe your testing strategy or note what tests are included -->

If successful, CI should keep working.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
