### PR TITLE
fix(tracing): add cyclic GC support to native Span classes [backport 4.7]

### DIFF
--- a/releasenotes/notes/fix-span-cyclic-gc-leak-6760a5369d335668.yaml
+++ b/releasenotes/notes/fix-span-cyclic-gc-leak-6760a5369d335668.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves a memory leak where reference cycles through a
+    span event's ``attributes`` were invisible to Python's cyclic garbage
+    collector and accumulated proportionally to the number of cyclic events
+    created. The native ``SpanData`` and ``SpanEvent`` classes now implement
+    the cyclic-GC protocol.

--- a/releasenotes/notes/fix-span-cyclic-gc-leak-6760a5369d335668.yaml
+++ b/releasenotes/notes/fix-span-cyclic-gc-leak-6760a5369d335668.yaml
@@ -1,8 +1,6 @@
 ---
 fixes:
   - |
-    tracing: This fix resolves a memory leak where reference cycles through a
-    span event's ``attributes`` were invisible to Python's cyclic garbage
-    collector and accumulated proportionally to the number of cyclic events
-    created. The native ``SpanData`` and ``SpanEvent`` classes now implement
-    the cyclic-GC protocol.
+    tracing: This fix resolves a memory leak where reference cycles through
+    a span's properties were invisible to Python's cyclic garbage collector
+    and accumulated proportionally to traced call volume.

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -399,4 +399,29 @@ impl SpanData {
     fn set_span_api(&mut self, value: &Bound<'_, PyAny>) {
         self.span_api = extract_backed_string_or_default(value);
     }
+
+    // --- Cyclic GC support ---
+    //
+    // Without these, any reference cycle that passes through a `Py<...>` slot
+    // owned by this Rust pyclass is invisible to CPython's cyclic GC and leaks
+    // forever. On 4.7, `_trace_id_py` is the only such slot directly on
+    // `SpanData` (the cached PyLong for `trace_id`); even though PyLong is
+    // atomic and cannot itself form a cycle, we visit it for refcount-
+    // accounting correctness so the type is properly registered as GC-
+    // tracked. The companion fix on `SpanEvent` covers the cycle-vector case
+    // (`SpanEvent.attributes: Py<PyDict>`).
+    //
+    // Backport of #17867 (4.x). The full upstream fix also traverses
+    // `meta_struct` and `SpanLink.attributes`, but those storages do not
+    // exist on this branch.
+    fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+        if let Some(o) = &self._trace_id_py {
+            visit.call(o)?;
+        }
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        self._trace_id_py = None;
+    }
 }

--- a/src/native/span/span_event.rs
+++ b/src/native/span/span_event.rs
@@ -112,4 +112,13 @@ impl SpanEvent {
         )?;
         Ok(PyTuple::new(py, [cls.into_any().unbind(), args.into_any().unbind()])?.unbind())
     }
+
+    // Cyclic GC traversal: `attributes: Py<PyDict>` is user-controlled and
+    // can hold references that close cycles back to the span. Frozen class
+    // so no `__clear__`; traversal alone is enough for GC to break the cycle
+    // on the other (mutable) side.
+    fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+        visit.call(&self.attributes)?;
+        Ok(())
+    }
 }

--- a/tests/tracer/test_span_data.py
+++ b/tests/tracer/test_span_data.py
@@ -1043,3 +1043,66 @@ def test_span_api_invalid_utf8_falls_back_to_empty_string(invalid_bytes):
     span = SpanData(name="test")
     span._span_api = invalid_bytes
     assert span._span_api == ""
+
+
+# =============================================================================
+# Cyclic GC support
+# =============================================================================
+#
+# Regression tests for the memory leak fix backported from #17867: native
+# pyclasses (SpanData, SpanEvent) used to hold `Py<...>` slots without
+# implementing `__traverse__` / `__clear__`, so any reference cycle that
+# passed through `SpanEvent.attributes` was invisible to CPython's cyclic
+# garbage collector and leaked.
+#
+# These tests build the canonical cycle (event -> attributes dict -> list ->
+# event) and assert that `gc.collect()` reclaims the events.
+
+
+def test_span_data_is_gc_tracked():
+    """Without `__traverse__`/`__clear__`, PyO3 leaves the class as a non-GC-
+    tracked type, hiding any cycles passing through its `Py<...>` fields.
+    """
+    import gc
+
+    assert gc.is_tracked(SpanData(name="probe"))
+
+
+def test_span_event_is_gc_tracked():
+    import gc
+
+    from ddtrace.internal.native._native import SpanEvent
+
+    assert gc.is_tracked(SpanEvent(name="evt"))
+
+
+def test_span_event_attributes_cycle_is_collectable():
+    """Cycles formed via SpanEvent.attributes must be reclaimable.
+
+    Pre-fix: `SpanEvent` held `attributes: Py<PyDict>` without GC traversal.
+    """
+    import gc
+
+    from ddtrace.internal.native._native import SpanEvent
+
+    initial = sum(1 for o in gc.get_objects() if type(o).__name__ == "SpanEvent")
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        N = 200
+        for _ in range(N):
+            event = SpanEvent(name="cycle.via.event_attrs")
+            cycle_list = []
+            event.attributes["self_ref"] = cycle_list
+            cycle_list.append(event)
+            del event
+            del cycle_list
+        live = sum(1 for o in gc.get_objects() if type(o).__name__ == "SpanEvent")
+        assert live - initial == N
+        freed = gc.collect()
+        assert freed > 0, "gc.collect freed nothing — SpanEvent is not GC-tracked"
+        live = sum(1 for o in gc.get_objects() if type(o).__name__ == "SpanEvent")
+        assert live == initial
+    finally:
+        if gc_was_enabled:
+            gc.enable()


### PR DESCRIPTION
Backport #17867 to 4.7. Note that the leak should be much smaller on this branch, since only `SpanData` and `SpanEvent` were migrated. Previous versions from 4.6 didn't have this leak at all.