### PR TITLE
ci: fix flaky test_data_streams_kafka_enabled

### DIFF
--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -352,18 +352,28 @@ def test_data_streams_kafka_enabled():
 
     producer = confluent_kafka.Producer({"bootstrap.servers": BOOTSTRAP_SERVERS})
     consumer = confluent_kafka.Consumer(
-        {"bootstrap.servers": BOOTSTRAP_SERVERS, "group.id": "test_group", "auto.offset.reset": "earliest"}
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": "test_group_data_streams_kafka_enabled",
+            "auto.offset.reset": "earliest",
+        }
     )
 
     try:
         consumer.subscribe([topic_name])
+
+        assignment_deadline = time.time() + 5
+        while not consumer.assignment() and time.time() < assignment_deadline:
+            consumer.poll(timeout=0.1)
+
         producer.produce(topic_name, b"test")
         producer.flush()
 
-        import time
+        message = None
+        message_deadline = time.time() + 5
+        while message is None and time.time() < message_deadline:
+            message = consumer.poll(timeout=0.5)
 
-        time.sleep(0.5)
-        message = consumer.poll(timeout=5.0)
         assert message is not None
         assert "dd-pathway-ctx-base64" in [h[0] for h in message.headers()]
 

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -360,6 +360,8 @@ def test_data_streams_kafka_enabled():
     )
 
     try:
+        import time
+
         consumer.subscribe([topic_name])
 
         assignment_deadline = time.time() + 5


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a89534d4-f6cc-4543-aed0-5ed15e2bed20","source":"chat","resourceId":"327f9293-9c5c-4564-a269-cd9283c8f309","workflowId":"6fa8db80-5f60-4d4f-97b5-0b9e205d6a42","codeChangeId":"6fa8db80-5f60-4d4f-97b5-0b9e205d6a42","sourceType":"test-optimization"} -->
## Description

Fixing `test_data_streams_kafka_enabled[py3.13]` • DD_JOK2P6

This change stabilizes `test_data_streams_kafka_enabled` in `tests/contrib/kafka/test_kafka_dsm.py` by removing nondeterministic Kafka consumer timing and group coordination behavior that can cause intermittent `message is None` failures in CI.

The flaky failure showed consumer group coordination timeouts (`JoinGroupRequest`/`LeaveGroupRequest`) followed by an assertion failure before the message was consumed. The test previously used a shared group id (`test_group`), a fixed sleep, and a single poll attempt, which made it sensitive to rebalance timing.

Changes made:
- Use a test-specific consumer group id (`test_group_data_streams_kafka_enabled`) to isolate this subprocess test from other Kafka tests using `test_group`.
- Replace the fixed `time.sleep(0.5)` with deterministic synchronization by waiting for consumer assignment.
- Replace the single `poll(timeout=5.0)` with a bounded polling loop that waits for message arrival.

Impact context: this flake category is `network`, with reported impact of 2.3% flake rate, ~18 minutes CI time wasted, and failed pipelines.

## Testing

- Attempted to reproduce and validate via `scripts/run-tests` using the `contrib::kafka` py3.13 venv (`167bd61`) and target test path.
- Could not execute the suite in this sandbox because Docker/Podman support is unavailable (`docker compose up` for `kafka`/`testagent` fails before test execution).
- Ran repository formatting/lint checks on the modified file:
  - `ruff format tests/contrib/kafka/test_kafka_dsm.py` (no changes needed)
  - `ruff check --fix tests/contrib/kafka/test_kafka_dsm.py` (passed)

## Risks

Low. Change is scoped to a single test and preserves test intent (verifying DSM header propagation). It only improves synchronization and test isolation.

## Additional Notes

No production code was changed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/327f9293-9c5c-4564-a269-cd9283c8f309)

Comment @datadog to request changes