### PR TITLE
ci(internal): accept http git URLs [backport 4.7] (#17583)

### DIFF
--- a/tests/sourcecode/test_source_code_link.py
+++ b/tests/sourcecode/test_source_code_link.py
@@ -8,6 +8,6 @@ def test_get_source_code_link():
     reporsitory_url, commit_hash = source_code_link.split("#")
 
     # can be github.com or gitlab.ddbuild.io
-    assert reporsitory_url.startswith("https://git")
+    assert reporsitory_url.startswith(("http://git", "https://git"))
     assert reporsitory_url.endswith("/dd-trace-py")
     assert re.match(r"\b[a-f0-9]{5,40}\b", commit_hash) is not None


### PR DESCRIPTION
## Description

Backport of [#17583](https://github.com/DataDog/dd-trace-py/pull/17583) to the `4.7` branch (already backported to `4.6` in #17590).

The CI clone infrastructure now provides `http://git...` remotes in some environments (e.g. `http://gitretriever.codesync.all-clusters.local-dc.fabric.dog:8080/...`), while `tests/sourcecode/test_source_code_link.py::test_get_source_code_link` only accepted `https://git...` URLs. `normalize_repository_url()` intentionally preserves HTTP/HTTPS schemes, so the stricter assertion caused a false failure.

This PR updates the test to accept both `http://git` and `https://git` prefixes. The rest of the test, including domain-related expectations, is unchanged.

## Testing

The change is test-only. Verified that the assertion now matches the URL produced by the GitLab CI clone infrastructure (`http://gitretriever...`) which was the failure observed on `4.7` backport branches.

## Risks

None. Test-only relaxation of a string-prefix assertion that was overly strict for the current CI environment.

## Additional Notes

Cherry-pick of commit `222a31400e236163b2547ba1f4069f502ba7a02b` from `main`. No code changes outside the test.

Made with [Cursor](https://cursor.com)