### PR TITLE
test(debugger): remove 3.9 exploration runs [backport 4.7]

### DIFF
--- a/.gitlab/debugging-exploration.yml
+++ b/.gitlab/debugging-exploration.yml
@@ -24,9 +24,6 @@
       parallel:
         matrix:
           - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp39-cp39"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-          - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp310-cp310"
             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
@@ -78,7 +75,7 @@
     DD_DEBUGGER_EXPL_INCLUDE: "boto3"
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+      - PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   script: |
     git clone --depth 1 --branch ${BOTO3_TAG} https://github.com/boto/boto3.git
     cd boto3
@@ -105,7 +102,7 @@
     DD_DEBUGGER_EXPL_COVERAGE_INSTRUMENTATION_RATE: "0.01"
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+      - PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   script: |
     git clone --depth 1 --branch ${BOTO3_TAG} https://github.com/boto/boto3.git
     cd boto3


### PR DESCRIPTION
Backport #17777 to 4.7.

## Description

The `debugging/exploration/boto3` and `debugging/exploration/botocore` jobs are failing on the 4.7 branch because boto3 tag `1.38.44` pulls `botocore` from its `develop` branch, which now requires Python `>= 3.10`:

```
ERROR: Package 'botocore' requires a different Python: 3.9.25 not in '>=3.10'
```

Example failing job: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1660010147

This cherry-picks the same fix already applied to `main` (#17777) and `4.8` (#17779): drop Python 3.9 from the exploration test matrix, since boto has dropped 3.9 support and ddtrace hasn't changed bytecode handling for 3.9 in a long time.

## Testing

CI on this PR.

## Risks

None — only removes the failing 3.9 entry from the exploration matrix; the test still runs on 3.10+.

Made with [Cursor](https://cursor.com)