### PR TITLE
chore(integrations): replace integration_registry code with tested_versions code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/python_315_bump.md
+++ b/.github/PULL_REQUEST_TEMPLATE/python_315_bump.md
@@ -23,7 +23,7 @@ This PR enables the **`<integration>`** integration on Python 3.15.
 - [ ] Lifted `max_version="3.13"` / `"3.14"` cap on the affected venv(s) (if present)
 - [ ] Ran `riot generate <suite-pattern>` and committed the regenerated `.riot/requirements/*.txt` lockfiles
 - [ ] Ran the suite locally on 3.15 via `scripts/run-tests <suite>` (paste a link or summary of the result)
-- [ ] Updated `supported_versions_table.csv` / `supported_versions_output.json` if integration min/max versions changed
+- [ ] Updated `tested_versions.json` if tested dependency versions changed
 - [ ] Release note added under `releasenotes/notes/`, **or** PR labeled `changelog/no-changelog` (test/CI-only changes)
 
 ## Testing

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -79,8 +79,6 @@ jobs:
       - name: Run regenerate-riot-latest
         run: scripts/regenerate-riot-latest.sh
 
-      - name: Run integration registry update
-        run: python scripts/integration_registry/update_and_format_registry.py
 
       - name: Get latest version
         id: new-latest
@@ -106,7 +104,7 @@ jobs:
           title: "chore: update ${{ env.VENV_NAME }} latest version to ${{ env.NEW_LATEST }}"
           labels: changelog/no-changelog
           body: |
-            Update ${{ env.VENV_NAME }} lockfiles and dependency package lockfiles.
+            Update ${{ env.VENV_NAME }} lockfiles, dependency package lockfiles, and tested dependency versions.
             This performs the following updates:
               1) Some ${{ env.VENV_NAME }} lockfiles use ${{ env.VENV_NAME }} `latest`. This will update ${{ env.VENV_NAME }} and dependencies.
               2) Some ${{ env.VENV_NAME }} lockfiles use a pinned (non-latest) version of ${{ env.VENV_NAME }}, but require the `latest` version of another package. This will update all such packages.

--- a/.github/workflows/generate-supported-versions.yml
+++ b/.github/workflows/generate-supported-versions.yml
@@ -1,11 +1,11 @@
-name: Generate Supported Integration Versions
+name: Generate Tested Integration Versions
 
 on:
   workflow_dispatch: # can be triggered manually
 
 jobs:
-  generate-supported-versions:
-    name: Generate supported integration versions
+  generate-tested-versions:
+    name: Generate tested integration versions
     runs-on: ubuntu-22.04
     permissions:
       actions: read
@@ -64,10 +64,8 @@ jobs:
         run: |
           curl https://dd-trace-py-builds.s3.amazonaws.com/main/install.sh | bash
 
-      - run: python scripts/freshvenvs.py generate
-
-      - name: Generate table
-        run: python scripts/generate_table.py
+      - name: Generate tested versions
+        run: python scripts/tested_versions/generate_tested_versions.py
 
       - run: git diff
 
@@ -82,13 +80,13 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.octo-sts.outputs.token }}
-          branch: "update-supported-versions"
-          commit-message: "Update supported versions table"
+          branch: "update-tested-versions"
+          commit-message: "Update tested versions"
           delete-branch: true
           base: main
-          title: "chore: update supported versions"
+          title: "chore: update tested versions"
           labels: changelog/no-changelog
           body: |
-            Generates / updates the supported versions table for integrations.
+            Generates / updates tested_versions.json for integrations.
             This should be tied to releases, or triggered manually.
-            Workflow runs: [Generate Supported Integration Versions](https://github.com/DataDog/dd-trace-py/actions/workflows/generate-supported-versions.yml)
+            Workflow runs: [Generate Tested Integration Versions](https://github.com/DataDog/dd-trace-py/actions/workflows/generate-supported-versions.yml)

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -44,8 +44,8 @@ include:
       done
       ./scripts/check-diff ".riot/requirements/" \
         "Changes detected after running riot. Consider deleting changed files, running scripts/compile-and-prune-test-requirements and committing the result."
-      ./scripts/check-diff "scripts/integration_registry/registry.yaml" \
-        "Registry YAML file (scripts/integration_registry/registry.yaml) was modified. Please run: scripts/integration_registry/update_and_format_registry.py and commit the changes."
+      ./scripts/check-diff "tested_versions.json" \
+        "Tested dependency versions changed after running riot. Please run scripts/compile-and-prune-test-requirements and commit the changes."
 
 
 .test_base_riot_snapshot:

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -198,8 +198,8 @@ when the riotfile changes. Thus, if you make changes to the riotfile, you need t
 
   $ scripts/ddtest scripts/compile-and-prune-test-requirements
 
-You can commit and pull request the resulting changes to files in ``.riot/requirements`` alongside the
-changes you made to ``riotfile.py``.
+You can commit and pull request the resulting changes to files in ``.riot/requirements`` and
+``tested_versions.json`` alongside the changes you made to ``riotfile.py``.
 
 Why is my CI run failing with benchmark or Service Level Objective (SLO) threshold breaches?
 ---------------------------------------------------------------------------------------------
@@ -299,7 +299,7 @@ environment object.
 2. ``export VENV_NAME=<name_you_noted_above>``
 3. Delete all of the requirements lockfiles for the chosen environment, then regenerate them:
    ``for h in `riot list --hash-only "^${VENV_NAME}$"`; do rm .riot/requirements/${h}.txt; done; scripts/compile-and-prune-test-requirements``
-4. Commit the resulting changes to the ``.riot`` directory, and open a pull request against the trunk branch.
+4. Commit the resulting changes to the ``.riot`` directory and ``tested_versions.json``, and open a pull request against the trunk branch.
 
 Why isn't my hatch config change taking effect?
 -----------------------------------------------

--- a/scripts/freshvenvs.py
+++ b/scripts/freshvenvs.py
@@ -1,4 +1,3 @@
-import argparse
 from collections import defaultdict
 import datetime as dt
 from functools import lru_cache

--- a/scripts/freshvenvs.py
+++ b/scripts/freshvenvs.py
@@ -5,7 +5,6 @@ from functools import lru_cache
 from http.client import HTTPSConnection
 from io import StringIO
 import json
-from operator import itemgetter
 import pathlib
 import sys
 from typing import Any
@@ -15,20 +14,34 @@ from packaging.version import Version
 from pip import _internal
 
 
-# add project root to path to import riotfile, and scripts/ to import integration_registry
-sys.path.append(str(pathlib.Path(__file__).parent.parent.resolve()))
-sys.path.append(str(pathlib.Path(__file__).parent.resolve() / "integration_registry"))
-
-from mappings import DEPENDENCY_TO_INTEGRATION_MAPPING  # noqa: I001,E402
-from mappings import INTEGRATION_TO_DEPENDENCY_MAPPING  # noqa: I001,E402
+# add project root to path to import riotfile and scripts.tested_versions
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+sys.path.append(str(PROJECT_ROOT))
 
 import riotfile  # noqa: I001,E402
 
 CONTRIB_ROOT = pathlib.Path("ddtrace/contrib/internal")
+DEPENDENCY_NAMES_PATH = PROJECT_ROOT / "scripts" / "tested_versions" / "dependency_names.json"
 LATEST = ""
 
-supported_versions = []
 pinned_packages = set()
+
+
+def _load_dependency_name_mappings() -> tuple[dict[str, set[str]], dict[str, str]]:
+    dependency_names = json.loads(DEPENDENCY_NAMES_PATH.read_text())
+    integration_to_dependency_mapping = {
+        integration["integration_name"]: set(integration.get("dependency_names", []))
+        for integration in dependency_names.get("integrations", [])
+    }
+    dependency_to_integration_mapping = {
+        dependency: integration
+        for integration, dependencies in integration_to_dependency_mapping.items()
+        for dependency in dependencies
+    }
+    return integration_to_dependency_mapping, dependency_to_integration_mapping
+
+
+INTEGRATION_TO_DEPENDENCY_MAPPING, DEPENDENCY_TO_INTEGRATION_MAPPING = _load_dependency_name_mappings()
 
 
 class Capturing(list):
@@ -44,15 +57,6 @@ class Capturing(list):
         del self._stringio  # free up some memory
         sys.stdout = self._stdout
         sys.stderr = self._stderr
-
-
-def parse_args():
-    """
-    usage: python scripts/freshvenvs.py <output> OR <generate>
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument("mode", choices=["output", "generate"], help="mode: output or generate")
-    return parser.parse_args()
 
 
 def _get_contrib_modules() -> set[str]:
@@ -259,15 +263,6 @@ def _get_package_versions_from(
     return lock_packages
 
 
-def _is_module_autoinstrumented(module: str) -> bool:
-    import importlib
-
-    _monkey = importlib.import_module("ddtrace._monkey")
-    PATCH_MODULES = getattr(_monkey, "PATCH_MODULES")
-
-    return module in PATCH_MODULES and PATCH_MODULES[module]
-
-
 def _versions_fully_cover_bounds(bounds: tuple[str, str], versions: list[Version]) -> bool:
     """Return whether the tested versions cover the upper bound range of supported versions"""
     if not versions:
@@ -295,18 +290,6 @@ def _venv_sets_latest_for_package(venv: Any, suite_name: str) -> bool:
                 if _venv_sets_latest_for_package(child_venv, package):
                     return True
     return False
-
-
-def _get_all_used_versions(envs, contrib_modules, riot_hash_to_venv_name) -> dict:
-    """
-    Returns dict(module, set(versions)) for a venv, as defined from riot lockfiles.
-    """
-    all_used_versions = defaultdict(set)
-    for env in envs:
-        versions_used = _get_package_versions_from(env, contrib_modules, riot_hash_to_venv_name)
-        for package, version in versions_used:
-            all_used_versions[package].add(version)
-    return all_used_versions
 
 
 def _get_version_bounds(contrib_modules: set[str]) -> dict:
@@ -348,59 +331,13 @@ def output_outdated_packages(all_updatable_contribs, envs, bounds, riot_hash_to_
     print(" ".join(outdated_packages))
 
 
-def generate_supported_versions(contrib_modules, all_used_versions):
-    """
-    Generate supported versions JSON
-    """
-    patched = {}
-    for contrib_module in contrib_modules:
-        for dependency in sorted(INTEGRATION_TO_DEPENDENCY_MAPPING.get(contrib_module, [contrib_module])):
-            versions = []
-            if dependency not in all_used_versions:
-                # special case, some dependencies such as dogpile_cache can be installed
-                # e.g. dogpile.cache or dogpile-cache or dogpile_cache, just use the one with versions
-                for dep in INTEGRATION_TO_DEPENDENCY_MAPPING.get(contrib_module, [contrib_module]):
-                    if dep in all_used_versions:
-                        versions = all_used_versions[dep]
-                        break
-            else:
-                versions = all_used_versions[dependency]
-            ordered = sorted([Version(v) for v in versions], reverse=True)
-            if not ordered:
-                continue
-            json_format = {
-                "dependency": dependency or contrib_module,
-                "integration": contrib_module,
-                "minimum_tracer_supported": str(ordered[-1]),
-                "max_tracer_supported": str(ordered[0]),
-            }
-
-            if contrib_module in pinned_packages:
-                json_format["pinned"] = "true"
-
-            if contrib_module not in patched:
-                patched[contrib_module] = _is_module_autoinstrumented(contrib_module)
-            json_format["auto-instrumented"] = patched[contrib_module]
-            supported_versions.append(json_format)
-
-    supported_versions_output = sorted(supported_versions, key=itemgetter("integration"))
-    with open("supported_versions_output.json", "w") as file:
-        json.dump(supported_versions_output, file, indent=4)
-
-
 def main():
-    args = parse_args()
     contribs = _get_contrib_modules()
     all_updatable_contribs = _get_updatable_packages_implementing(contribs)  # MODULE names
     riot_hash_to_venv_name = _get_riot_hash_to_venv_name()
     envs = _get_riot_envs_including_any(contribs)
-
-    if args.mode == "output":
-        bounds = _get_version_bounds(contribs)
-        output_outdated_packages(all_updatable_contribs, envs, bounds, riot_hash_to_venv_name)
-    elif args.mode == "generate":
-        all_used_versions = _get_all_used_versions(envs, contribs, riot_hash_to_venv_name)
-        generate_supported_versions(contribs, all_used_versions)
+    bounds = _get_version_bounds(contribs)
+    output_outdated_packages(all_updatable_contribs, envs, bounds, riot_hash_to_venv_name)
 
 
 if __name__ == "__main__":

--- a/scripts/regenerate-riot-latest.sh
+++ b/scripts/regenerate-riot-latest.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DDTEST_CMD=scripts/ddtest
 
-pkgs=$(python scripts/freshvenvs.py output)
+pkgs=$(python scripts/freshvenvs.py)
 echo "Outdated packages: $pkgs"
 
 if [[ -z "$pkgs" ]]; then


### PR DESCRIPTION
## Overview
[3/4] PR :

https://github.com/DataDog/dd-trace-py/pull/17914 
https://github.com/DataDog/dd-trace-py/pull/17919 
https://github.com/DataDog/dd-trace-py/pull/17922 <- **you are here**
https://github.com/DataDog/dd-trace-py/pull/17923 

For additional context, you can look at this [RFC](https://docs.google.com/document/d/1JI5BUKXntrZgNEx5JXkOmLt6L-ObtuQbdweXtO5oDYs/edit?usp=sharin

## Description 
 
This PR updates location that were using the integration_registry code. To understand some changes better, it is important to note that regenerate the lockfiles with `scripts/compile-and-prune-requirements` are also generating the `tested_versions.json` file.

The `generate` arg was removed from `freshvenvs` as we can now use `generate_tested_versions` instead. 

## Risks

Low. This changes internal generation and CI workflow plumbing only, and stale callers to the old `freshvenvs.py generate` path will be removed in a follow up PR.