### PR TITLE
feat(llmobs): add optional version field to tool definitions

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2350,7 +2350,8 @@ class LLMObs(Service):
         :param tool_definitions: list of tool definition dictionaries for tool calling scenarios.
                             - This argument is only applicable to LLM spans.
                             - Each tool definition is a dictionary containing a required "name" (string),
-                                   and optional "description" (string) and "schema" (JSON serializable dictionary) keys.
+                                   and optional "description" (string), "schema" (JSON serializable dictionary),
+                                   and "version" (string) keys.
         :param metrics: Dictionary of JSON serializable key-value metric pairs,
                         such as `{prompt,completion,total}_tokens`.
         """

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -39,6 +39,7 @@ class ToolDefinition(TypedDict, total=False):
     name: str
     description: str
     schema: dict[str, Any]
+    version: str
 
 
 class Message(TypedDict, total=False):

--- a/ddtrace/llmobs/utils.py
+++ b/ddtrace/llmobs/utils.py
@@ -108,6 +108,14 @@ def extract_tool_definitions(tool_definitions: list[dict[str, Any]]) -> list[Too
             else:
                 validated_tool_def["schema"] = schema
 
+        # version is optional
+        version = tool_def.get("version")
+        if version is not None:
+            if not isinstance(version, str):
+                log.warning("Tool definition 'version' at index %s must be a string. Skipping version field.", i)
+            else:
+                validated_tool_def["version"] = version
+
         validated_tool_definitions.append(validated_tool_def)
 
     return validated_tool_definitions

--- a/releasenotes/notes/llmobs-tool-definitions-version-b665c7adb156c71b.yaml
+++ b/releasenotes/notes/llmobs-tool-definitions-version-b665c7adb156c71b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: Adds support for an optional ``version`` (string) field on each tool definition dictionary passed to ``LLMObs.annotate()`` via the ``tool_definitions`` parameter.

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -531,6 +531,7 @@ def test_annotate_with_tool_definitions(llmobs, llmobs_backend):
                 "type": "object",
                 "properties": {"location": {"type": "string"}},
             },
+            "version": "1.0.0",
         }
     ]
 
@@ -607,6 +608,16 @@ def test_annotate_with_tool_definitions_non_dict(llmobs, llmobs_backend):
     events = llmobs_backend.wait_for_num_events(num=1)
     assert len(events) == 1
     assert "tool_definitions" not in events[0][0]["spans"][0]["meta"]
+
+
+def test_annotate_with_tool_definitions_invalid_version_type(llmobs, llmobs_backend):
+    """Test that tool_definitions with non-string version field have version skipped but are otherwise kept."""
+    with llmobs.llm() as span:
+        llmobs.annotate(span, tool_definitions=[{"name": "my_tool", "version": 1}])
+
+    events = llmobs_backend.wait_for_num_events(num=1)
+    assert len(events) == 1
+    assert events[0][0]["spans"][0]["meta"]["tool_definitions"] == [{"name": "my_tool"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Extends the `tool_definitions` parameter on `LLMObs.annotate()` — added in #14393 — with an optional `version` (string) field on each tool definition. Each tool definition dictionary now accepts an optional `version` alongside the existing optional `description` and `schema` fields.

Jira: [MLOB-7432](https://datadoghq.atlassian.net/browse/MLOB-7432)
Follows up on: #14393

## Testing

- Updated `test_annotate_with_tool_definitions` to round-trip the new `version` field end-to-end.
- Added `test_annotate_with_tool_definitions_invalid_version_type` to confirm a non-string `version` is dropped with a warning while the rest of the tool definition is preserved (mirroring how invalid `description`/`schema` values are handled).

## Risks

None — `version` is a new optional field; existing tool definitions without it are unaffected, and invalid types are skipped rather than raising.

## Additional Notes

Release note added under `features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)