### PR TITLE
fix(tracing): set resource on httpx, urllib3, httplib, and aiohttp client spans

### DIFF
--- a/ddtrace/_trace/subscribers/http_client.py
+++ b/ddtrace/_trace/subscribers/http_client.py
@@ -1,6 +1,7 @@
 from types import TracebackType
 from typing import Optional
 from typing import cast
+from urllib import parse
 
 from ddtrace._trace.subscribers._base import TracingSubscriber
 from ddtrace.contrib import trace_utils
@@ -26,6 +27,14 @@ class HttpClientTracingSubscriber(TracingSubscriber):
     @classmethod
     def on_started(cls, ctx: core.ExecutionContext) -> None:
         event: HttpClientRequestEvent = ctx.event
+
+        # Set resource from request method and URL path if not explicitly provided by the integration
+        if event.resource is None and event.request_method and event.request_url:
+            try:
+                parsed_url = parse.urlparse(event.request_url)
+                ctx.span.resource = f"{event.request_method.upper()} {parsed_url.path}"
+            except Exception:
+                log.debug("error computing resource from request URL", exc_info=True)
 
         if trace_utils.distributed_tracing_enabled(event.integration_config) and event.request_headers is not None:
             HTTPPropagator.inject(ctx.span.context, cast(dict[str, str], event.request_headers))

--- a/ddtrace/contrib/internal/aiohttp/patch.py
+++ b/ddtrace/contrib/internal/aiohttp/patch.py
@@ -90,6 +90,7 @@ async def _traced_clientsession_request(func, instance, args, kwargs):
         schematize_url_operation("aiohttp.request", protocol="http", direction=SpanDirection.OUTBOUND),
         span_type=SpanTypes.HTTP,
     ) as span:
+        span.resource = f"{method.upper()} {url.path}"
         set_service_and_source(span, service, config.aiohttp_client)
 
         if config.aiohttp_client.distributed_tracing:

--- a/ddtrace/contrib/internal/httplib/patch.py
+++ b/ddtrace/contrib/internal/httplib/patch.py
@@ -168,6 +168,7 @@ def _wrap_putrequest(func, instance, args, kwargs):
         trace_utils.set_http_meta(
             span, config.httplib, method=method, url=sanitized_url, target_host=instance.host, query=parsed.query
         )
+        span.resource = f"{method} {parsed.path}"
 
     except Exception:
         log.debug("error applying request tags", exc_info=True)

--- a/releasenotes/notes/fix-http-client-resource-2af5098bbb69f3c5.yaml
+++ b/releasenotes/notes/fix-http-client-resource-2af5098bbb69f3c5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Fixes ``httpx``, ``urllib3``, ``httplib``, and ``aiohttp`` client integrations to set span resource to ``METHOD /path`` (e.g. ``GET /api/users``), matching the existing ``requests`` integration behavior. Previously these integrations defaulted resource to the operation name, which caused all endpoints to be aggregated together in the Datadog UI.

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "POST /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/500",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_base_url.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_base_url.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "global-service-name",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "global-service-name",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "global-service-name",
-    "resource": "http.client.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_split_by_domain.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_split_by_domain.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "localhost",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -53,7 +53,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
@@ -104,7 +104,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
@@ -28,7 +28,7 @@
      {
        "name": "aiohttp.request",
        "service": "tests.contrib.aiohttp",
-       "resource": "aiohttp.request",
+       "resource": "GET /status/200",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "tests.contrib.aiohttp",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200/",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -2,7 +2,7 @@
   {
     "name": "aiohttp.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "aiohttp.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.client.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_activity_trigger_end_to_end.json
+++ b/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_activity_trigger_end_to_end.json
@@ -36,7 +36,7 @@
      {
        "name": "aiohttp.request",
        "service": "test-durable-func",
-       "resource": "aiohttp.request",
+       "resource": "POST /durabletask/orchestrators/activity_orchestrator",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
@@ -72,7 +72,7 @@
      {
        "name": "aiohttp.request",
        "service": "test-durable-func",
-       "resource": "aiohttp.request",
+       "resource": "GET /durabletask/instances/e9526e0b78dd42a3b4226c2b62dbfb4b",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
@@ -109,7 +109,7 @@
      {
        "name": "aiohttp.request",
        "service": "test-durable-func",
-       "resource": "aiohttp.request",
+       "resource": "GET /durabletask/instances/e9526e0b78dd42a3b4226c2b62dbfb4b",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,

--- a/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_entity_trigger_end_to_end.json
+++ b/tests/snapshots/tests.contrib.azure_durable_functions.test_azure_durable_functions_snapshot.test_entity_trigger_end_to_end.json
@@ -36,7 +36,7 @@
      {
        "name": "aiohttp.request",
        "service": "test-durable-func",
-       "resource": "aiohttp.request",
+       "resource": "POST /durabletask/orchestrators/entity_orchestrator",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
@@ -72,7 +72,7 @@
      {
        "name": "aiohttp.request",
        "service": "test-durable-func",
-       "resource": "aiohttp.request",
+       "resource": "GET /durabletask/instances/85bd4673d0c042728048361061549c26",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
@@ -109,7 +109,7 @@
      {
        "name": "aiohttp.request",
        "service": "test-durable-func",
-       "resource": "aiohttp.request",
+       "resource": "GET /durabletask/instances/85bd4673d0c042728048361061549c26",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.request",
+    "resource": "GET /sub-app/hello/name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.request",
+    "resource": "GET /sub-app/hello/name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.client.request",
+    "resource": "GET /sub-app/hello/name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "mysvc",
-    "resource": "http.request",
+    "resource": "GET /sub-app/hello/name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "mysvc",
-    "resource": "http.request",
+    "resource": "GET /sub-app/hello/name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "mysvc",
-    "resource": "http.client.request",
+    "resource": "GET /sub-app/hello/name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "test-httpx-service-name",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name_env.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name_env.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "env-overridden-service-name",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "tests.contrib.httpx",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_500.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_500.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "tests.contrib.httpx",
-    "resource": "http.request",
+    "resource": "GET /status/500",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_httpx_service_name.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_httpx_service_name.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "localhost:8001",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "tests.contrib.httpx",
-    "resource": "http.request",
+    "resource": "GET /response-headers",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "global-service-name",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "global-service-name",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "global-service-name",
-    "resource": "http.client.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.client.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
@@ -2,7 +2,7 @@
   {
     "name": "http.client.request",
     "service": "ddtrace_subprocess_dir",
-    "resource": "http.client.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_split_by_domain.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_split_by_domain.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "localhost:8001",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
@@ -2,7 +2,7 @@
   {
     "name": "http.request",
     "service": "tests.contrib.httpx",
-    "resource": "http.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.pytest.snapshot.test_pytest_snapshot_v2.test_pytest_with_ddtrace_patch_all.json
+++ b/tests/snapshots/tests.contrib.pytest.snapshot.test_pytest_snapshot_v2.test_pytest_with_ddtrace_patch_all.json
@@ -55,7 +55,7 @@
      {
        "name": "http.request",
        "service": "pytest",
-       "resource": "http.request",
+       "resource": "GET /bad_path.cgi",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,

--- a/tests/snapshots/tests.contrib.pytest.snapshot.test_pytest_xdist_snapshot.test_pytest_xdist_with_ddtrace_patch_all.json
+++ b/tests/snapshots/tests.contrib.pytest.snapshot.test_pytest_xdist_snapshot.test_pytest_xdist_with_ddtrace_patch_all.json
@@ -100,7 +100,7 @@
      {
        "name": "http.request",
        "service": "pytest",
-       "resource": "http.request",
+       "resource": "GET /bad_path.cgi",
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,

--- a/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_connectionpool_snapshot.json
+++ b/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_connectionpool_snapshot.json
@@ -2,7 +2,7 @@
   {
     "name": "urllib3.request",
     "service": "urllib3",
-    "resource": "urllib3.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_poolmanager_snapshot.json
+++ b/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_poolmanager_snapshot.json
@@ -2,7 +2,7 @@
   {
     "name": "urllib3.request",
     "service": "urllib3",
-    "resource": "urllib3.request",
+    "resource": "GET /status/200",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,


### PR DESCRIPTION
Tracking PR for https://github.com/DataDog/dd-trace-py/pull/17718 by @CamW.

---

HTTP client integrations other than requests defaulted the span resource to the operation name (e.g. "http.request"), causing all endpoints to be aggregated together in the Datadog UI. Set resource to "METHOD /path" consistently across all HTTP client integrations.

## Description

The httpx, urllib3, httplib, and aiohttp client integrations set span resource to the operation name (e.g. `http.request`, `urllib3.request`, `aiohttp.request`). This means all outbound HTTP requests on a service aggregate into a single resource in the Datadog UI, making latency percentiles, error rates, and throughput stats meaningless.

The requests integration already correctly sets `resource=f"{method} {path}"` (e.g. `GET /api/users`). This PR brings the other four HTTP client integrations in line.

**Approach:**
- Central fix in `HttpClientTracingSubscriber.on_started()` - if the integration didn't explicitly set resource, compute it from `event.request_method` and `event.request_url`. This fixes httpx and urllib3 automatically.
- Individual fixes for httplib and aiohttp - these use the legacy `tracer.trace()` pattern, so they need `span.resource` set directly in their patch code.

Fixes #17670