### PR TITLE
fix(writer): serialize TraceExporter send/shutdown to prevent Already borrowed

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -22,6 +22,7 @@ from ddtrace.internal.settings._opentelemetry import _is_otlp_traces_exporter_en
 from ddtrace.internal.settings._opentelemetry import otel_config
 from ddtrace.internal.settings.asm import ai_guard_config
 from ddtrace.internal.settings.asm import config as asm_config
+from ddtrace.internal.threads import Lock as _UnpatchedLock
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.version import __version__
 
@@ -700,6 +701,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._stats_opt_out = stats_opt_out
 
         self._exporter = self._create_exporter()
+        self._exporter_lock = _UnpatchedLock()
 
     @staticmethod
     def _parse_otlp_headers() -> list:
@@ -780,7 +782,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         :param token: The test session token to use for authentication.
         """
         self._test_session_token = token
-        self._exporter = self._create_exporter()
+        with self._exporter_lock:
+            self._exporter = self._create_exporter()
 
     def recreate(self, appsec_enabled: Optional[bool] = None) -> "NativeWriter":
         # Ensure AppSec metadata is encoded by setting the API version to v0.4.
@@ -811,9 +814,10 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
 
     def _downgrade(self, status, client):
         if client.ENDPOINT == "v0.5/traces":
-            self._clients = [AgentWriterClientV4(self._buffer_size, self._max_payload_size)]
-            self._api_version = "v0.4"
-            self._exporter = self._create_exporter()
+            with self._exporter_lock:
+                self._clients = [AgentWriterClientV4(self._buffer_size, self._max_payload_size)]
+                self._api_version = "v0.4"
+                self._exporter = self._create_exporter()
 
             # Since we have to change the encoding in this case, the payload
             # would need to be converted to the downgraded encoding before
@@ -871,7 +875,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
 
     def _send_payload(self, payload: bytes, count: int, client: WriterClientBase):
         try:
-            response_body = self._exporter.send(payload)
+            with self._exporter_lock:
+                response_body = self._exporter.send(payload)
         except native.RequestError as e:
             try:
                 # Request errors are formatted as "Error code: {code}, Response: {response}"
@@ -1011,7 +1016,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         try:
             self.periodic()
         finally:
-            self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout
+            with self._exporter_lock:
+                self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout
 
 
 def _use_log_writer() -> bool:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -12,6 +12,7 @@ from typing import TextIO
 
 from ddtrace import config
 from ddtrace.internal.dist_computing.utils import in_ray_job
+from ddtrace.internal.forksafe import Lock as _ForksafeLock
 from ddtrace.internal.hostname import get_hostname
 import ddtrace.internal.native as native
 from ddtrace.internal.native_runtime import get_native_runtime
@@ -22,7 +23,6 @@ from ddtrace.internal.settings._opentelemetry import _is_otlp_traces_exporter_en
 from ddtrace.internal.settings._opentelemetry import otel_config
 from ddtrace.internal.settings.asm import ai_guard_config
 from ddtrace.internal.settings.asm import config as asm_config
-from ddtrace.internal.threads import Lock as _UnpatchedLock
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.version import __version__
 
@@ -701,7 +701,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._stats_opt_out = stats_opt_out
 
         self._exporter = self._create_exporter()
-        self._exporter_lock = _UnpatchedLock()
+        self._exporter_lock = _ForksafeLock()
 
     @staticmethod
     def _parse_otlp_headers() -> list:

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -671,6 +671,34 @@ def _make_server(port, request_handler):
     return server, t
 
 
+def _make_blocking_server():
+    request_started = threading.Event()
+    release_response = threading.Event()
+
+    class _BlockingRequestHandler(_BaseHTTPRequestHandler):
+        def do_PUT(self):
+            content_length = int(self.headers.get("Content-Length", 0))
+            if content_length:
+                self.rfile.read(content_length)
+            request_started.set()
+            release_response.wait(timeout=5)
+            body = b"{}"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self):
+            self.do_PUT()
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _BlockingRequestHandler)
+    t = threading.Thread(target=server.serve_forever)
+    t.daemon = True
+    t.start()
+    return server, t, request_started, release_response
+
+
 @pytest.fixture(scope="module")
 def endpoint_test_timeout_server():
     server, thread = _make_server(_TIMEOUT_PORT, _TimeoutAPIEndpointRequestHandlerTest)
@@ -831,6 +859,68 @@ def test_periodic_thread_uds_callback_unblocks_with_timeout():
         if os.path.exists(sock_path):
             os.unlink(sock_path)
         os.rmdir(sock_dir)
+
+
+def test_native_writer_on_shutdown_waits_for_in_flight_send():
+    # AIDEV-NOTE: Keep this test on the real NativeWriter. A mock exporter cannot
+    # reproduce PyO3's active shared borrow while TraceExporter.send() releases the GIL.
+    server, server_thread, request_started, release_response = _make_blocking_server()
+    writer = NativeWriter("http://127.0.0.1:%d" % server.server_port, api_version="v0.4")
+    periodic_can_return = threading.Event()
+    periodic_about_to_return = threading.Event()
+    flush_errors = []
+    shutdown_errors = []
+    original_periodic = writer.periodic
+
+    def blocked_periodic():
+        original_periodic()
+        periodic_about_to_return.set()
+        periodic_can_return.wait(timeout=5)
+
+    def flush_writer():
+        try:
+            writer.flush_queue(raise_exc=True)
+        except Exception as e:
+            flush_errors.append(e)
+
+    def shutdown_writer():
+        try:
+            writer.on_shutdown()
+        except Exception as e:
+            shutdown_errors.append(e)
+
+    writer.periodic = blocked_periodic
+    writer._encoder.put([Span("foobar")])
+    flush_thread = threading.Thread(target=flush_writer)
+    shutdown_thread = threading.Thread(target=shutdown_writer)
+
+    try:
+        flush_thread.start()
+        assert request_started.wait(timeout=2)
+
+        shutdown_thread.start()
+        assert periodic_about_to_return.wait(timeout=2)
+        periodic_can_return.set()
+
+        # Give on_shutdown() a chance to enter TraceExporter.shutdown() while
+        # TraceExporter.send() is still blocked in native I/O.
+        shutdown_thread.join(timeout=0.5)
+        assert shutdown_thread.is_alive()
+        release_response.set()
+        flush_thread.join(timeout=2)
+        shutdown_thread.join(timeout=5)
+
+        assert not flush_thread.is_alive()
+        assert not shutdown_thread.is_alive()
+        assert flush_errors == []
+        assert shutdown_errors == []
+    finally:
+        release_response.set()
+        periodic_can_return.set()
+        flush_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
+        server.shutdown()
+        server_thread.join()
 
 
 @pytest.mark.parametrize("writer_class", (CIVisibilityWriter, NativeWriter))

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -905,7 +905,7 @@ def test_native_writer_on_shutdown_waits_for_in_flight_send():
         # Give on_shutdown() a chance to enter TraceExporter.shutdown() while
         # TraceExporter.send() is still blocked in native I/O.
         shutdown_thread.join(timeout=0.5)
-        assert shutdown_thread.is_alive()
+        assert shutdown_thread.is_alive(), f"on_shutdown() exited early; shutdown_errors={shutdown_errors}"
         release_response.set()
         flush_thread.join(timeout=2)
         shutdown_thread.join(timeout=5)


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

The `test_long_running_websocket_session[py3.13]` test is failing CI jobs with `RuntimeError: Already borrowed` on this line and has been quarantined.

Error for the failing test: https://github.com/datadog/dd-trace-py/blob/6f83c57ef797d00b497035b72e6101dd076dc373/tests/contrib/fastapi/test_fastapi.py#L648-L666
```
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/tests/conftest.py", line 315, in snapshot
    mgr.__exit__(None, None, None)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/bits/.pyenv/versions/3.13.11/lib/python3.13/contextlib.py", line 148, in __exit__
    next(self.gen)
    ~~~~^^^^^^^^^^
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/tests/utils.py", line 1274, in snapshot_context
    tracer._span_aggregator.writer.set_test_session_token(None)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/writer/writer.py", line 783, in set_test_session_token
    self._shutdown_exporter()  # 3 seconds timeout
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/writer/writer.py", line 1012, in _shutdown_exporter
    self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
RuntimeError: Already borrowed
```

The code most likely responsible for this is 

```
       # FIXME: don't join() on stop(), let the caller handle this
        super(NativeWriter, self)._stop_service()
        self.join(timeout=timeout)

    def _shutdown_exporter(self) -> None:
        self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout

    def on_shutdown(self):
        try:
            self.periodic()
        finally:
```

IDMPL-432

Related to @VianneyRuhlmann 's https://github.com/DataDog/dd-trace-py/pull/17780

## Testing

<!-- Describe your testing strategy or note what tests are included -->

I had Codex and Claude try to create the failure in tests. We can see as of a46c735e615eb1ed0bf4e082f1e6969a47bf2947 that: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1666967981 has the error

```
FAILED tests/tracer/test_writer.py::test_native_writer_on_shutdown_waits_for_in_flight_send[py3.13] - AssertionError: on_shutdown() exited early; shutdown_errors=[RuntimeError('Already borrowed')]
```

However the "fix" in the later commits makes the error go away.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
