### PR TITLE
ci: update system-tests version

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '0526d7eb6ad321c14f7d4c7574cf8970089757c6'
+          ref: '11cb332970ed1e41269a13a6cda797837966c6b0'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '0526d7eb6ad321c14f7d4c7574cf8970089757c6'
+          ref: '11cb332970ed1e41269a13a6cda797837966c6b0'
 
       - name: Build runner
         uses: ./.github/actions/install_runner

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "0526d7eb6ad321c14f7d4c7574cf8970089757c6"
+  SYSTEM_TESTS_REF: "11cb332970ed1e41269a13a6cda797837966c6b0"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Summary
- Bumps `DataDog/system-tests` pin from `0526d7eb` to `11cb3329` (latest `main`).
- Generated via `scripts/update-system-tests-version.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)