### PR TITLE
ci: fix ast-grep rule for unittest.TestCase usage

### DIFF
--- a/.sg/rules/no-unittest-test-classes.yml
+++ b/.sg/rules/no-unittest-test-classes.yml
@@ -4,12 +4,15 @@ severity: warning
 language: python
 files:
   - "tests/**/*.py"
+ignores:
+  - "tests/subprocesstest.py"
+  - "tests/contrib/unittest/test_unittest.py"
 rule:
   kind: class_definition
   has:
     field: superclasses
     kind: argument_list
-    regex: "TestCase"
+    regex: '\bTestCase\b'
 note: |
   pytest markers (@pytest.mark.*) and fixtures do not work reliably on methods
   inside unittest.TestCase subclasses. pytest discovers these tests via a

--- a/.sg/tests/__snapshots__/no-unittest-test-classes-snapshot.yml
+++ b/.sg/tests/__snapshots__/no-unittest-test-classes-snapshot.yml
@@ -1,38 +1,6 @@
 id: no-unittest-test-classes
 snapshots:
   ? |
-    class MyTest(BaseTestCase):
-        def test_something(self):
-            pass
-  : labels:
-    - source: |-
-        class MyTest(BaseTestCase):
-            def test_something(self):
-                pass
-      style: primary
-      start: 0
-      end: 70
-    - source: (BaseTestCase)
-      style: secondary
-      start: 12
-      end: 26
-  ? |
-    class MyTest(SubprocessTestCase):
-        def test_something(self):
-            pass
-  : labels:
-    - source: |-
-        class MyTest(SubprocessTestCase):
-            def test_something(self):
-                pass
-      style: primary
-      start: 0
-      end: 76
-    - source: (SubprocessTestCase)
-      style: secondary
-      start: 12
-      end: 32
-  ? |
     class MyTest(TestCase):
         def test_something(self):
             pass
@@ -48,22 +16,6 @@ snapshots:
       style: secondary
       start: 12
       end: 22
-  ? |
-    class MyTest(TracerTestCase):
-        def test_something(self):
-            pass
-  : labels:
-    - source: |-
-        class MyTest(TracerTestCase):
-            def test_something(self):
-                pass
-      style: primary
-      start: 0
-      end: 72
-    - source: (TracerTestCase)
-      style: secondary
-      start: 12
-      end: 28
   ? |
     class MyTest(unittest.TestCase):
         def test_something(self):

--- a/.sg/tests/no-unittest-test-classes-test.yml
+++ b/.sg/tests/no-unittest-test-classes-test.yml
@@ -14,6 +14,19 @@ valid:
     class TestSomething(SomeOtherBase):
         def test_something(self):
             assert True
+  # Subclass with TestCase as suffix but not a standalone word — OK (regex \bTestCase\b won't match)
+  - |
+    class MyTest(TracerTestCase):
+        def test_something(self):
+            pass
+  - |
+    class MyTest(BaseTestCase):
+        def test_something(self):
+            pass
+  - |
+    class MyTest(SubprocessTestCase):
+        def test_something(self):
+            pass
 invalid:
   # Direct unittest.TestCase subclass
   - |
@@ -23,20 +36,5 @@ invalid:
   # Bare TestCase (from `from unittest import TestCase`)
   - |
     class MyTest(TestCase):
-        def test_something(self):
-            pass
-  # TracerTestCase subclass
-  - |
-    class MyTest(TracerTestCase):
-        def test_something(self):
-            pass
-  # BaseTestCase subclass
-  - |
-    class MyTest(BaseTestCase):
-        def test_something(self):
-            pass
-  # SubprocessTestCase subclass
-  - |
-    class MyTest(SubprocessTestCase):
         def test_something(self):
             pass


### PR DESCRIPTION
## Description

The current rule is overeager and matches on non-unittest base test classes.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
