### PR TITLE
ci(dsm): propagate bucket-straddle race fixes across kafka/aiokafka/botocore DSM tests

### DIFF
--- a/tests/contrib/aiokafka/test_aiokafka_dsm.py
+++ b/tests/contrib/aiokafka/test_aiokafka_dsm.py
@@ -26,6 +26,33 @@ def patch_aiokafka():
     unpatch()
 
 
+# DSM aggregates checkpoints into 10s wall-clock buckets; produce and consume
+# can land in different buckets when a test straddles a boundary. Hold _lock
+# so the periodic flusher can't mutate _buckets mid-iteration.
+def _max_produce_offset(processor, key):
+    with processor._lock:
+        return max(
+            (bucket.latest_produce_offsets.get(key, 0) for bucket in processor._buckets.values()),
+            default=0,
+        )
+
+
+def _max_commit_offset(processor, key):
+    with processor._lock:
+        return max(
+            (bucket.latest_commit_offsets.get(key, 0) for bucket in processor._buckets.values()),
+            default=0,
+        )
+
+
+def _merged_pathway_stats(processor):
+    with processor._lock:
+        merged = {}
+        for bucket in processor._buckets.values():
+            merged.update(bucket.pathway_stats)
+        return merged
+
+
 @pytest.fixture
 def dsm_processor():
     processor = data_streams_processor(reset=True)
@@ -62,11 +89,7 @@ async def test_data_streams_pathway_stats(dsm_processor):
         await consumer.getone()
         await consumer.commit()
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-
-    bucket = list(buckets.values())[0]
-    pathway_stats = bucket.pathway_stats
+    pathway_stats = _merged_pathway_stats(dsm_processor)
 
     # Compute expected hashes based on edge tags to verify pathway continuity
     ctx = DataStreamsCtx(dsm_processor, 0, 0, 0)
@@ -111,19 +134,8 @@ async def test_data_streams_offset_monitoring_auto_commit(dsm_processor):
     async with consumer_ctx([topic], enable_auto_commit=True) as consumer:
         msg = await consumer.getone()
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-
-    bucket = list(buckets.values())[0]
-
-    # Check produce offsets were tracked
-    produce_offset = bucket.latest_produce_offsets.get(PartitionKey(topic, 0, ""))
-    assert produce_offset is not None and produce_offset == 1
-
-    # Check consume offsets were tracked
-    commit_key = ConsumerPartitionKey(GROUP_ID, topic, 0, "")
-    commit_offset = bucket.latest_commit_offsets.get(commit_key)
-    assert commit_offset is not None and commit_offset == msg.offset + 1
+    assert _max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
+    assert _max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
 
 
 @pytest.mark.asyncio
@@ -147,19 +159,8 @@ async def test_data_streams_offset_monitoring_commit(dsm_processor, offsets):
         msg = await consumer.getone()
         await consumer.commit(offsets)
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-
-    bucket = list(buckets.values())[0]
-
-    # Check produce offsets were tracked
-    produce_offset = bucket.latest_produce_offsets.get(PartitionKey(topic, 0, ""))
-    assert produce_offset is not None and produce_offset == 1
-
-    # Check consume offsets were tracked
-    commit_key = ConsumerPartitionKey(GROUP_ID, topic, 0, "")
-    commit_offset = bucket.latest_commit_offsets.get(commit_key)
-    assert commit_offset is not None and commit_offset == msg.offset + 1
+    assert _max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
+    assert _max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
 
 
 @pytest.mark.asyncio
@@ -176,21 +177,30 @@ async def test_data_streams_getmany(dsm_processor):
         await consumer.getmany(timeout_ms=2000)
         await consumer.commit()
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
+    # Same checkpoint can recur across DSM buckets when sends straddle a 10s boundary;
+    # collect keys and SUM full_pathway_latency.count per direction across all buckets.
+    with dsm_processor._lock:
+        all_keys = {k for b in dsm_processor._buckets.values() for k in b.pathway_stats.keys()}
+        producer_count = sum(
+            stats.full_pathway_latency.count
+            for b in dsm_processor._buckets.values()
+            for k, stats in b.pathway_stats.items()
+            if "direction:out" in k[0]
+        )
+        consumer_count = sum(
+            stats.full_pathway_latency.count
+            for b in dsm_processor._buckets.values()
+            for k, stats in b.pathway_stats.items()
+            if "direction:in" in k[0]
+        )
 
-    bucket = list(buckets.values())[0]
-    pathway_stats = bucket.pathway_stats
-
-    # Should have both producer and consumer checkpoints
-    producer_checkpoints = [k for k in pathway_stats.keys() if "direction:out" in k[0]]
-    consumer_checkpoints = [k for k in pathway_stats.keys() if "direction:in" in k[0]]
+    producer_checkpoints = [k for k in all_keys if "direction:out" in k[0]]
+    consumer_checkpoints = [k for k in all_keys if "direction:in" in k[0]]
 
     assert len(producer_checkpoints) == 1, "Should have one producer checkpoint"
     assert len(consumer_checkpoints) == 1, "Should have one consumer checkpoint"
-
-    for stats in pathway_stats.values():
-        assert stats.full_pathway_latency.count == 3, "Should track latency for all 3 messages"
+    assert producer_count == 3, "Should track latency for all 3 producer sends"
+    assert consumer_count == 3, "Should track latency for all 3 consumer reads"
 
 
 @pytest.mark.asyncio
@@ -271,11 +281,7 @@ async def test_data_streams_multiple_topics(dsm_processor):
     # Verify we got messages from both topics
     assert len(messages) >= 1, "Should receive messages"
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-
-    bucket = list(buckets.values())[0]
-    pathway_stats = bucket.pathway_stats
+    pathway_stats = _merged_pathway_stats(dsm_processor)
 
     # Extract all topics from pathway stats
     checkpoint_topics = set()

--- a/tests/contrib/aiokafka/test_aiokafka_dsm.py
+++ b/tests/contrib/aiokafka/test_aiokafka_dsm.py
@@ -9,6 +9,9 @@ from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsCtx
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.native import DDSketch
+from tests.datastreams.utils import max_commit_offset
+from tests.datastreams.utils import max_produce_offset
+from tests.datastreams.utils import pathway_stats_merged
 
 from .utils import BOOTSTRAP_SERVERS
 from .utils import GROUP_ID
@@ -24,25 +27,6 @@ def patch_aiokafka():
     patch()
     yield
     unpatch()
-
-
-# DSM aggregates checkpoints into 10s wall-clock buckets; produce and consume
-# can land in different buckets when a test straddles a boundary. Hold _lock
-# so the periodic flusher can't mutate _buckets mid-iteration.
-def _max_produce_offset(processor, key):
-    with processor._lock:
-        return max(
-            (bucket.latest_produce_offsets.get(key, 0) for bucket in processor._buckets.values()),
-            default=0,
-        )
-
-
-def _max_commit_offset(processor, key):
-    with processor._lock:
-        return max(
-            (bucket.latest_commit_offsets.get(key, 0) for bucket in processor._buckets.values()),
-            default=0,
-        )
 
 
 @pytest.fixture
@@ -81,11 +65,7 @@ async def test_data_streams_pathway_stats(dsm_processor):
         await consumer.getone()
         await consumer.commit()
 
-    # Producer and consumer checkpoints can land in different buckets when the test
-    # straddles a 10s boundary; this test produces 1 + consumes 1, so each key
-    # appears in at most one bucket and a plain dict merge is safe.
-    with dsm_processor._lock:
-        pathway_stats = {k: v for b in dsm_processor._buckets.values() for k, v in b.pathway_stats.items()}
+    pathway_stats = pathway_stats_merged(dsm_processor)
 
     # Compute expected hashes based on edge tags to verify pathway continuity
     ctx = DataStreamsCtx(dsm_processor, 0, 0, 0)
@@ -130,8 +110,8 @@ async def test_data_streams_offset_monitoring_auto_commit(dsm_processor):
     async with consumer_ctx([topic], enable_auto_commit=True) as consumer:
         msg = await consumer.getone()
 
-    assert _max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
-    assert _max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
+    assert max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
+    assert max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
 
 
 @pytest.mark.asyncio
@@ -155,8 +135,8 @@ async def test_data_streams_offset_monitoring_commit(dsm_processor, offsets):
         msg = await consumer.getone()
         await consumer.commit(offsets)
 
-    assert _max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
-    assert _max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
+    assert max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
+    assert max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
 
 
 @pytest.mark.asyncio
@@ -275,12 +255,10 @@ async def test_data_streams_multiple_topics(dsm_processor):
     # Extract all topics from pathway stats across DSM buckets (produce/consume can
     # straddle a 10s boundary).
     checkpoint_topics = set()
-    with dsm_processor._lock:
-        for bucket in dsm_processor._buckets.values():
-            for key in bucket.pathway_stats.keys():
-                for tag in key[0].split(","):
-                    if tag.startswith("topic:"):
-                        checkpoint_topics.add(tag.split(":", 1)[1])
+    for key in pathway_stats_merged(dsm_processor).keys():
+        for tag in key[0].split(","):
+            if tag.startswith("topic:"):
+                checkpoint_topics.add(tag.split(":", 1)[1])
 
     # Both topics should be tracked
     assert topic1 in checkpoint_topics, f"Topic {topic1} should be tracked"

--- a/tests/contrib/aiokafka/test_aiokafka_dsm.py
+++ b/tests/contrib/aiokafka/test_aiokafka_dsm.py
@@ -45,14 +45,6 @@ def _max_commit_offset(processor, key):
         )
 
 
-def _merged_pathway_stats(processor):
-    with processor._lock:
-        merged = {}
-        for bucket in processor._buckets.values():
-            merged.update(bucket.pathway_stats)
-        return merged
-
-
 @pytest.fixture
 def dsm_processor():
     processor = data_streams_processor(reset=True)
@@ -89,7 +81,11 @@ async def test_data_streams_pathway_stats(dsm_processor):
         await consumer.getone()
         await consumer.commit()
 
-    pathway_stats = _merged_pathway_stats(dsm_processor)
+    # Producer and consumer checkpoints can land in different buckets when the test
+    # straddles a 10s boundary; this test produces 1 + consumes 1, so each key
+    # appears in at most one bucket and a plain dict merge is safe.
+    with dsm_processor._lock:
+        pathway_stats = {k: v for b in dsm_processor._buckets.values() for k, v in b.pathway_stats.items()}
 
     # Compute expected hashes based on edge tags to verify pathway continuity
     ctx = DataStreamsCtx(dsm_processor, 0, 0, 0)
@@ -177,28 +173,23 @@ async def test_data_streams_getmany(dsm_processor):
         await consumer.getmany(timeout_ms=2000)
         await consumer.commit()
 
-    # Same checkpoint can recur across DSM buckets when sends straddle a 10s boundary;
-    # collect keys and SUM full_pathway_latency.count per direction across all buckets.
+    # Same checkpoint key can recur across DSM buckets when sends straddle a 10s
+    # boundary; collect keys and SUM full_pathway_latency.count per direction in
+    # a single pass.
+    producer_keys, consumer_keys = set(), set()
+    producer_count = consumer_count = 0
     with dsm_processor._lock:
-        all_keys = {k for b in dsm_processor._buckets.values() for k in b.pathway_stats.keys()}
-        producer_count = sum(
-            stats.full_pathway_latency.count
-            for b in dsm_processor._buckets.values()
-            for k, stats in b.pathway_stats.items()
-            if "direction:out" in k[0]
-        )
-        consumer_count = sum(
-            stats.full_pathway_latency.count
-            for b in dsm_processor._buckets.values()
-            for k, stats in b.pathway_stats.items()
-            if "direction:in" in k[0]
-        )
+        for bucket in dsm_processor._buckets.values():
+            for key, stats in bucket.pathway_stats.items():
+                if "direction:out" in key[0]:
+                    producer_keys.add(key)
+                    producer_count += stats.full_pathway_latency.count
+                elif "direction:in" in key[0]:
+                    consumer_keys.add(key)
+                    consumer_count += stats.full_pathway_latency.count
 
-    producer_checkpoints = [k for k in all_keys if "direction:out" in k[0]]
-    consumer_checkpoints = [k for k in all_keys if "direction:in" in k[0]]
-
-    assert len(producer_checkpoints) == 1, "Should have one producer checkpoint"
-    assert len(consumer_checkpoints) == 1, "Should have one consumer checkpoint"
+    assert len(producer_keys) == 1, "Should have one producer checkpoint"
+    assert len(consumer_keys) == 1, "Should have one consumer checkpoint"
     assert producer_count == 3, "Should track latency for all 3 producer sends"
     assert consumer_count == 3, "Should track latency for all 3 consumer reads"
 
@@ -281,15 +272,15 @@ async def test_data_streams_multiple_topics(dsm_processor):
     # Verify we got messages from both topics
     assert len(messages) >= 1, "Should receive messages"
 
-    pathway_stats = _merged_pathway_stats(dsm_processor)
-
-    # Extract all topics from pathway stats
+    # Extract all topics from pathway stats across DSM buckets (produce/consume can
+    # straddle a 10s boundary).
     checkpoint_topics = set()
-    for key in pathway_stats.keys():
-        edge_tags = key[0]
-        for tag in edge_tags.split(","):
-            if tag.startswith("topic:"):
-                checkpoint_topics.add(tag.split(":", 1)[1])
+    with dsm_processor._lock:
+        for bucket in dsm_processor._buckets.values():
+            for key in bucket.pathway_stats.keys():
+                for tag in key[0].split(","):
+                    if tag.startswith("topic:"):
+                        checkpoint_topics.add(tag.split(":", 1)[1])
 
     # Both topics should be tracked
     assert topic1 in checkpoint_topics, f"Topic {topic1} should be tracked"

--- a/tests/contrib/botocore/test_dsm.py
+++ b/tests/contrib/botocore/test_dsm.py
@@ -18,6 +18,7 @@ from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.internal.datastreams import data_streams_processor
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ddtrace.internal.utils.version import parse_version
+from tests.datastreams.utils import pathway_stats_merged
 from tests.utils import TracerTestCase
 
 
@@ -154,9 +155,7 @@ class BotocoreDSMTest(TracerTestCase):
 
             processor = data_streams_processor()
             assert processor is not None, "Datastream Monitoring is not enabled"
-            buckets = processor._buckets
-            assert len(buckets) == 1, "Expected 1 bucket but found {}".format(len(buckets))
-            first = list(buckets.values())[0].pathway_stats
+            first = pathway_stats_merged(processor)
 
             out_tags = "direction:out,topic:arn:aws:sns:us-east-1:000000000000:testTopic,type:sns"
             in_tags = "direction:in,topic:Test,type:sqs"
@@ -202,9 +201,7 @@ class BotocoreDSMTest(TracerTestCase):
 
             processor = data_streams_processor()
             assert processor is not None, "Datastream Monitoring is not enabled"
-            buckets = processor._buckets
-            assert len(buckets) == 1
-            first = list(buckets.values())[0].pathway_stats
+            first = pathway_stats_merged(processor)
 
             out_tags = "direction:out,topic:Test,type:sqs"
             in_tags = "direction:in,topic:Test,type:sqs"
@@ -255,9 +252,7 @@ class BotocoreDSMTest(TracerTestCase):
 
             processor = data_streams_processor()
             assert processor is not None, "Datastream Monitoring is not enabled"
-            buckets = processor._buckets
-            assert len(buckets) == 1
-            first = list(buckets.values())[0].pathway_stats
+            first = pathway_stats_merged(processor)
 
             out_tags = "direction:out,topic:Test,type:sqs"
             in_tags = "direction:in,topic:Test,type:sqs"
@@ -318,9 +313,7 @@ class BotocoreDSMTest(TracerTestCase):
 
             processor = data_streams_processor()
             assert processor is not None, "Datastream Monitoring is not enabled"
-            buckets = processor._buckets
-            assert len(buckets) == 1
-            first = list(buckets.values())[0].pathway_stats
+            first = pathway_stats_merged(processor)
 
             out_tags = "direction:out,topic:Test,type:sqs"
             in_tags = "direction:in,topic:Test,type:sqs"

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -18,6 +18,25 @@ class CustomError(Exception):
     pass
 
 
+# DSM aggregates checkpoints into 10s wall-clock buckets; produce and consume
+# can land in different buckets when a test straddles a boundary. Hold _lock
+# so the periodic flusher can't mutate _buckets mid-iteration.
+def _max_produce_offset(processor, key):
+    with processor._lock:
+        return max(
+            (bucket.latest_produce_offsets.get(key, 0) for bucket in processor._buckets.values()),
+            default=0,
+        )
+
+
+def _max_commit_offset(processor, key):
+    with processor._lock:
+        return max(
+            (bucket.latest_commit_offsets.get(key, 0) for bucket in processor._buckets.values()),
+            default=0,
+        )
+
+
 @pytest.fixture
 def dsm_processor():
     processor = data_streams_processor(reset=True)
@@ -70,8 +89,9 @@ def test_data_streams_kafka_serializing(dsm_processor, deserializing_consumer, s
     message = None
     while message is None or str(message.value()) != str(PAYLOAD):
         message = deserializing_consumer.poll()
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
+    with dsm_processor._lock:
+        has_stats = any(bucket.pathway_stats for bucket in dsm_processor._buckets.values())
+    assert has_stats, "no DSM pathway stats recorded for produce/consume"
 
 
 def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic, group_id):
@@ -82,9 +102,6 @@ def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic, grou
     message = None
     while message is None or str(message.value()) != str(PAYLOAD):
         message = consumer.poll()
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-    first = list(buckets.values())[0].pathway_stats
     ctx = DataStreamsCtx(dsm_processor, 0, 0, 0)
     parent_hash = ctx._compute_hash(
         sorted(
@@ -104,8 +121,12 @@ def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic, grou
         ),
         parent_hash,
     )
-    assert (parent_hash, 0) in [(tag[1], tag[2]) for tag in first.keys()]
-    assert (child_hash, parent_hash) in [(tag[1], tag[2]) for tag in first.keys()]
+    with dsm_processor._lock:
+        hash_pairs = [
+            (tag[1], tag[2]) for bucket in dsm_processor._buckets.values() for tag in bucket.pathway_stats.keys()
+        ]
+    assert (parent_hash, 0) in hash_pairs
+    assert (child_hash, parent_hash) in hash_pairs
 
 
 def test_data_streams_kafka_offset_monitoring_messages(
@@ -121,29 +142,23 @@ def test_data_streams_kafka_offset_monitoring_messages(
 
     PAYLOAD = bytes("data streams", encoding="utf-8")
     consumer = non_auto_commit_consumer
-    buckets = dsm_processor._buckets
     producer.produce(kafka_topic, PAYLOAD, key="test_key_1")
     producer.produce(kafka_topic, PAYLOAD, key="test_key_2")
     producer.flush()
 
     _message = _read_single_message(consumer)  # noqa: F841
 
-    assert len(buckets) == 1
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
-    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0, cluster_id)] > 0
+    produce_key = PartitionKey(kafka_topic, 0, cluster_id)
+    commit_key = ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)
+    assert _max_produce_offset(dsm_processor, produce_key) > 0
     first_offset = consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset
     assert first_offset
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)]
-        == first_offset
-    )
+    assert _max_commit_offset(dsm_processor, commit_key) == first_offset
 
     _message = _read_single_message(consumer)  # noqa: F841
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == first_offset + 1
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)]
-        == first_offset + 1
-    )
+    assert _max_commit_offset(dsm_processor, commit_key) == first_offset + 1
 
 
 def test_data_streams_kafka_offset_monitoring_offsets(
@@ -170,22 +185,16 @@ def test_data_streams_kafka_offset_monitoring_offsets(
     _message = _read_single_message(consumer)  # noqa: F841
 
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
-    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0, cluster_id)] > 0
+    produce_key = PartitionKey(kafka_topic, 0, cluster_id)
+    commit_key = ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)
+    assert _max_produce_offset(dsm_processor, produce_key) > 0
     first_offset = consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset
     assert first_offset > 0
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)]
-        == first_offset
-    )
+    assert _max_commit_offset(dsm_processor, commit_key) == first_offset
 
     _message = _read_single_message(consumer)  # noqa: F841
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == first_offset + 1
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)]
-        == first_offset + 1
-    )
+    assert _max_commit_offset(dsm_processor, commit_key) == first_offset + 1
 
 
 def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consumer, producer, kafka_topic, group_id):
@@ -202,15 +211,16 @@ def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consume
     producer.produce(kafka_topic, PAYLOAD, key="test_key_1")
     producer.flush()
 
-    buckets = dsm_processor._buckets
     # Read a single message, which should commit it automatically since auto commit is true
     _message = _read_single_message(consumer)  # noqa: F841
 
-    assert len(buckets) == 1
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
-    assert PartitionKey(kafka_topic, 0, cluster_id) in list(buckets.values())[0].latest_produce_offsets, (
-        "DSM did not track the produce — delivery callback may not have fired"
-    )
+    produce_key = PartitionKey(kafka_topic, 0, cluster_id)
+    with dsm_processor._lock:
+        produce_tracked = any(
+            produce_key in bucket.latest_produce_offsets for bucket in dsm_processor._buckets.values()
+        )
+    assert produce_tracked, "DSM did not track the produce — delivery callback may not have fired"
 
     def _wait_for_auto_commit_and_fetch_offset(timeout=5.0):
         start_time = time.time()
@@ -230,9 +240,7 @@ def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consume
     # Auto commit is enabled so we want to wait for the commit event to fire
     first_offset = _wait_for_auto_commit_and_fetch_offset()
     assert first_offset is not None, "Auto-commit did not complete within 5 seconds"
-    dsm_offset = list(buckets.values())[0].latest_commit_offsets[
-        ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)
-    ]
+    dsm_offset = _max_commit_offset(dsm_processor, ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id))
     # DSM tracks offsets at poll time while the broker commits asynchronously,
     # so the DSM offset may be >= the broker's reported committed offset.
     assert dsm_offset >= first_offset
@@ -252,10 +260,8 @@ def test_data_streams_kafka_produce_api_compatibility(dsm_processor, consumer, p
     producer.produce(kafka_topic, key="test_key_3")
     producer.flush()
 
-    buckets = dsm_processor._buckets
-    assert len(buckets) == 1
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
-    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0, cluster_id)] == 5
+    assert _max_produce_offset(dsm_processor, PartitionKey(kafka_topic, 0, cluster_id)) == 5
 
 
 def test_data_streams_kafka_offset_backlog_has_cluster_id(
@@ -280,7 +286,9 @@ def test_data_streams_kafka_offset_backlog_has_cluster_id(
 
     serialized = dsm_processor._serialize_buckets()
     assert len(serialized) >= 1
-    backlogs = serialized[0].get("Backlogs", [])
+    # Produce and commit backlogs can land in different serialized buckets when the
+    # test straddles a 10s wall-clock boundary; flatten across all buckets.
+    backlogs = [b for s in serialized for b in s.get("Backlogs", [])]
     commit_backlogs = [b for b in backlogs if "type:kafka_commit" in b["Tags"]]
     produce_backlogs = [b for b in backlogs if "type:kafka_produce" in b["Tags"]]
     assert len(commit_backlogs) >= 1, "Expected at least one kafka_commit backlog entry"

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -9,6 +9,9 @@ from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsCtx
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.native import DDSketch
+from tests.datastreams.utils import all_pathway_stat_keys
+from tests.datastreams.utils import max_commit_offset
+from tests.datastreams.utils import max_produce_offset
 
 
 DSM_TEST_PATH_HEADER_SIZE = 28
@@ -16,25 +19,6 @@ DSM_TEST_PATH_HEADER_SIZE = 28
 
 class CustomError(Exception):
     pass
-
-
-# DSM aggregates checkpoints into 10s wall-clock buckets; produce and consume
-# can land in different buckets when a test straddles a boundary. Hold _lock
-# so the periodic flusher can't mutate _buckets mid-iteration.
-def _max_produce_offset(processor, key):
-    with processor._lock:
-        return max(
-            (bucket.latest_produce_offsets.get(key, 0) for bucket in processor._buckets.values()),
-            default=0,
-        )
-
-
-def _max_commit_offset(processor, key):
-    with processor._lock:
-        return max(
-            (bucket.latest_commit_offsets.get(key, 0) for bucket in processor._buckets.values()),
-            default=0,
-        )
 
 
 @pytest.fixture
@@ -89,9 +73,9 @@ def test_data_streams_kafka_serializing(dsm_processor, deserializing_consumer, s
     message = None
     while message is None or str(message.value()) != str(PAYLOAD):
         message = deserializing_consumer.poll()
-    with dsm_processor._lock:
-        has_stats = any(bucket.pathway_stats for bucket in dsm_processor._buckets.values())
-    assert has_stats, "no DSM pathway stats recorded for produce/consume"
+    edge_tags = [key[0] for key in all_pathway_stat_keys(dsm_processor)]
+    assert any("direction:out" in tags for tags in edge_tags), "Producer DSM checkpoint missing"
+    assert any("direction:in" in tags for tags in edge_tags), "Consumer DSM checkpoint missing"
 
 
 def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic, group_id):
@@ -121,10 +105,7 @@ def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic, grou
         ),
         parent_hash,
     )
-    with dsm_processor._lock:
-        hash_pairs = {
-            (tag[1], tag[2]) for bucket in dsm_processor._buckets.values() for tag in bucket.pathway_stats.keys()
-        }
+    hash_pairs = {(key[1], key[2]) for key in all_pathway_stat_keys(dsm_processor)}
     assert (parent_hash, 0) in hash_pairs
     assert (child_hash, parent_hash) in hash_pairs
 
@@ -151,14 +132,14 @@ def test_data_streams_kafka_offset_monitoring_messages(
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
     produce_key = PartitionKey(kafka_topic, 0, cluster_id)
     commit_key = ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)
-    assert _max_produce_offset(dsm_processor, produce_key) > 0
+    assert max_produce_offset(dsm_processor, produce_key) > 0
     first_offset = consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset
     assert first_offset
-    assert _max_commit_offset(dsm_processor, commit_key) == first_offset
+    assert max_commit_offset(dsm_processor, commit_key) == first_offset
 
     _message = _read_single_message(consumer)  # noqa: F841
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == first_offset + 1
-    assert _max_commit_offset(dsm_processor, commit_key) == first_offset + 1
+    assert max_commit_offset(dsm_processor, commit_key) == first_offset + 1
 
 
 def test_data_streams_kafka_offset_monitoring_offsets(
@@ -187,14 +168,14 @@ def test_data_streams_kafka_offset_monitoring_offsets(
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
     produce_key = PartitionKey(kafka_topic, 0, cluster_id)
     commit_key = ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id)
-    assert _max_produce_offset(dsm_processor, produce_key) > 0
+    assert max_produce_offset(dsm_processor, produce_key) > 0
     first_offset = consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset
     assert first_offset > 0
-    assert _max_commit_offset(dsm_processor, commit_key) == first_offset
+    assert max_commit_offset(dsm_processor, commit_key) == first_offset
 
     _message = _read_single_message(consumer)  # noqa: F841
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == first_offset + 1
-    assert _max_commit_offset(dsm_processor, commit_key) == first_offset + 1
+    assert max_commit_offset(dsm_processor, commit_key) == first_offset + 1
 
 
 def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consumer, producer, kafka_topic, group_id):
@@ -240,7 +221,7 @@ def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consume
     # Auto commit is enabled so we want to wait for the commit event to fire
     first_offset = _wait_for_auto_commit_and_fetch_offset()
     assert first_offset is not None, "Auto-commit did not complete within 5 seconds"
-    dsm_offset = _max_commit_offset(dsm_processor, ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id))
+    dsm_offset = max_commit_offset(dsm_processor, ConsumerPartitionKey(group_id, kafka_topic, 0, cluster_id))
     # DSM tracks offsets at poll time while the broker commits asynchronously,
     # so the DSM offset may be >= the broker's reported committed offset.
     assert dsm_offset >= first_offset
@@ -261,7 +242,7 @@ def test_data_streams_kafka_produce_api_compatibility(dsm_processor, consumer, p
     producer.flush()
 
     cluster_id = getattr(producer, "_dd_cluster_id", "") or ""
-    assert _max_produce_offset(dsm_processor, PartitionKey(kafka_topic, 0, cluster_id)) == 5
+    assert max_produce_offset(dsm_processor, PartitionKey(kafka_topic, 0, cluster_id)) == 5
 
 
 def test_data_streams_kafka_offset_backlog_has_cluster_id(

--- a/tests/contrib/kafka/test_kafka_dsm.py
+++ b/tests/contrib/kafka/test_kafka_dsm.py
@@ -122,9 +122,9 @@ def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic, grou
         parent_hash,
     )
     with dsm_processor._lock:
-        hash_pairs = [
+        hash_pairs = {
             (tag[1], tag[2]) for bucket in dsm_processor._buckets.values() for tag in bucket.pathway_stats.keys()
-        ]
+        }
     assert (parent_hash, 0) in hash_pairs
     assert (child_hash, parent_hash) in hash_pairs
 

--- a/tests/datastreams/utils.py
+++ b/tests/datastreams/utils.py
@@ -1,0 +1,51 @@
+"""Test helpers for asserting against DataStreamsProcessor state.
+
+DSM aggregates checkpoints into 10s wall-clock buckets keyed by
+``now_ns - (now_ns % bucket_size_ns)`` (see
+``ddtrace/internal/datastreams/processor.py``). Tests that produce + consume in
+quick succession can straddle a 10s boundary, splitting state across two
+buckets — so any assertion that indexes ``list(buckets.values())[0]`` will
+flake.
+
+These helpers iterate all buckets under ``processor._lock`` so the periodic
+flusher can't mutate ``_buckets`` mid-read.
+"""
+
+
+def max_produce_offset(processor, key):
+    """Max ``latest_produce_offsets[key]`` across all DSM buckets."""
+    with processor._lock:
+        return max(
+            (bucket.latest_produce_offsets.get(key, 0) for bucket in processor._buckets.values()),
+            default=0,
+        )
+
+
+def max_commit_offset(processor, key):
+    """Max ``latest_commit_offsets[key]`` across all DSM buckets."""
+    with processor._lock:
+        return max(
+            (bucket.latest_commit_offsets.get(key, 0) for bucket in processor._buckets.values()),
+            default=0,
+        )
+
+
+def all_pathway_stat_keys(processor):
+    """Set of all pathway_stats keys across DSM buckets."""
+    with processor._lock:
+        return {key for bucket in processor._buckets.values() for key in bucket.pathway_stats.keys()}
+
+
+def pathway_stats_merged(processor):
+    """Merged ``pathway_stats`` dict across all DSM buckets.
+
+    Uses ``dict.update()`` semantics — for the same key in multiple buckets, the
+    last bucket's value wins, which silently loses count/sketch data. Safe for
+    tests that produce one event per checkpoint key. Tests with multiple events
+    per key (e.g. multi-message getmany) must aggregate counts manually instead.
+    """
+    with processor._lock:
+        merged = {}
+        for bucket in processor._buckets.values():
+            merged.update(bucket.pathway_stats)
+        return merged


### PR DESCRIPTION
## Summary

The 10s DSM bucket-boundary race fixed for `test_data_streams_payload_size` in #17762 still tripped **15 other tests** that assume `list(buckets.values())[0]` returns the only bucket. Auto-quarantine (April 24) + the xdist switch in #17783 (May 7) surfaced the kafka/aiokafka ones as new flakes — the 4 reported in `@DataDog/data-streams-monitoring` overnight (`test_data_streams_kafka`, `_kafka_serializing`, `_kafka_produce_api_compatibility`, plus the auto-quarantined `_serializing`).

Iterate / merge state across all DSM buckets under `_lock` so produce and consume straddling a 10s boundary no longer breaks assertions.

## Sites updated

**`tests/contrib/kafka/test_kafka_dsm.py`** (7 sites)
- `test_data_streams_kafka_serializing`, `_kafka`, `_kafka_offset_monitoring_messages/_offsets/_auto_commit`, `_kafka_produce_api_compatibility`, `_kafka_offset_backlog_has_cluster_id` (was indexing only `serialized[0]`).

**`tests/contrib/aiokafka/test_aiokafka_dsm.py`** (5 sites)
- `test_data_streams_pathway_stats`, `_offset_monitoring_auto_commit/_commit`, `_getmany` (sums counts across buckets — 3 sequential sends can land in 2 buckets), `_multiple_topics`.

**`tests/contrib/botocore/test_dsm.py`** (4 sites)
- `test_data_streams_sns_to_sqs_raw_delivery`, `_sqs`, `_sqs_batch`, `_sqs_no_header`. The two `test_kinesis_data_streams_enabled_*` sites and all kombu sites already mock `time.time`, so produce/consume can't straddle a boundary; left untouched.

## Shared helpers

New `tests/datastreams/utils.py` with `max_produce_offset`, `max_commit_offset`, `all_pathway_stat_keys`, `pathway_stats_merged`. The merged-stats helper has an explicit docstring noting that `dict.update()` semantics drop counts when the same key recurs across buckets — multi-event-per-key tests (like `_getmany`) must aggregate manually.

No production code changed.

## Reproduction & validation

Reproduced the race locally by temporarily forcing `_bucket_size_ns = 100ms` in the `dsm_processor` fixture (kept the flusher interval default so this isolated the bucket-alignment race from the flusher race):

| Setup | Result |
| --- | --- |
| OLD code, kafka, 100ms buckets | 6/6 target tests fail (`assert 2 == 1` from straddle) |
| NEW code, kafka, 100ms buckets, 10 iterations | 170/170 (17 tests × 10 iter) |
| OLD code, aiokafka, 100ms buckets, 10 iterations | 2/10 iterations had `getmany` flake (cross-bucket count) |
| NEW code (with `getmany` count fix), aiokafka, 100ms buckets, 10 iterations | 120/120 (12 tests × 10 iter) |
| Botocore DSM tests | 12/12 |

A separate synthetic harness covering all 11 kafka+aiokafka sites confirmed: every old assertion pattern fails and every new pattern passes against forced two-bucket state.

## Datadog Attempt-to-Fix wiring

Latest commit on this PR includes `Fix flaky test 00_<KEY>` footers for the 28 currently-quarantined parametrized variants (per Federico's screenshot). After merge, Datadog Test Optimization will auto-retry each linked test and promote to **Fixed** if they stay green; otherwise they remain **Quarantined**. py3.11 isn't listed because no `attempt_to_fix_id` exists for any of the targeted tests on that variant. aiokafka/botocore sites were latent (same race pattern, not flagged today) so no keys were issued.

## Risks

Test-only change. No production code modified.

## Labels

`changelog/no-changelog` — test-only stabilization.

> [!NOTE]
> This fix was developed with the assistance of an LLM (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)