### PR TITLE
chore(pre-commit): resolve flaky test failures in hooks/tests/test-run

### DIFF
--- a/hooks/tests/test-run-fmt.sh
+++ b/hooks/tests/test-run-fmt.sh
@@ -29,7 +29,7 @@ mock_staged() {
 case "\$*" in
     "diff --staged --name-only HEAD --diff-filter=ACMR")
         printf '%s\n' $files ;;
-    "diff --name-only")
+    "diff --name-only"|"diff --name-only --diff-filter=ACMR")
         ;;  # no unstaged changes
     add\ *)
         echo "\$*" >> "$GIT_ADD_CALLS" ;;


### PR DESCRIPTION
## Description

The test mock for `run-fmt.sh` was missing a `git diff` variant, so
three tests would fail whenever the working tree had dirty `.py` files.
Added the missing pattern to the mock so all 22 tests pass regardless
of local tree state.

## Testing

`sh hooks/tests/test-run-fmt.sh` — 22 passed, 0 failed.