### PR TITLE
bug/feat(llmobs): expose input_documents/output_documents on span processor

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -320,9 +320,9 @@ class LLMObsSpan:
 
     input: list[Message] = field(default_factory=list)
     output: list[Message] = field(default_factory=list)
+    _tags: dict[str, str] = field(default_factory=dict)
     input_documents: list[Document] = field(default_factory=list)
     output_documents: list[Document] = field(default_factory=list)
-    _tags: dict[str, str] = field(default_factory=dict)
 
     def get_tag(self, key: str) -> Optional[str]:
         """Get a tag from the span.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -153,6 +153,7 @@ from ddtrace.llmobs._writer import LLMObsExperimentsClient
 from ddtrace.llmobs._writer import LLMObsSpanEvent
 from ddtrace.llmobs._writer import LLMObsSpanWriter
 from ddtrace.llmobs._writer import should_use_agentless
+from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import ExportedLLMObsSpan
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import Prompt
@@ -319,6 +320,8 @@ class LLMObsSpan:
 
     input: list[Message] = field(default_factory=list)
     output: list[Message] = field(default_factory=list)
+    input_documents: list[Document] = field(default_factory=list)
+    output_documents: list[Document] = field(default_factory=list)
     _tags: dict[str, str] = field(default_factory=dict)
 
     def get_tag(self, key: str) -> Optional[str]:
@@ -370,6 +373,12 @@ def _build_llmobs_span(
     if span_kind == "llm" and output_messages is not None:
         output_type = "messages"
         llmobs_span.output = enforce_message_role(output_messages)
+
+    if (input_documents := llmobs_input.get(LLMOBS_STRUCT.DOCUMENTS)) is not None:
+        llmobs_span.input_documents = input_documents
+
+    if (output_documents := llmobs_output.get(LLMOBS_STRUCT.DOCUMENTS)) is not None:
+        llmobs_span.output_documents = output_documents
 
     return llmobs_span, input_type, output_type
 
@@ -430,6 +439,10 @@ def _normalize_llmobs_meta(
         meta_input[LLMOBS_STRUCT.MESSAGES] = llmobs_span.input
     elif input_type == "value" and llmobs_span.input:
         meta_input[LLMOBS_STRUCT.VALUE] = llmobs_span.input[0].get("content", "")
+    if llmobs_span.input_documents:
+        meta_input[LLMOBS_STRUCT.DOCUMENTS] = llmobs_span.input_documents
+    else:
+        meta_input.pop(LLMOBS_STRUCT.DOCUMENTS, None)
     if meta_input:
         llmobs_meta[LLMOBS_STRUCT.INPUT] = meta_input
     else:
@@ -439,6 +452,10 @@ def _normalize_llmobs_meta(
         meta_output[LLMOBS_STRUCT.MESSAGES] = llmobs_span.output
     elif output_type == "value" and llmobs_span.output:
         meta_output[LLMOBS_STRUCT.VALUE] = llmobs_span.output[0].get("content", "")
+    if llmobs_span.output_documents:
+        meta_output[LLMOBS_STRUCT.DOCUMENTS] = llmobs_span.output_documents
+    else:
+        meta_output.pop(LLMOBS_STRUCT.DOCUMENTS, None)
     if meta_output:
         llmobs_meta[LLMOBS_STRUCT.OUTPUT] = meta_output
     else:

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -24,6 +24,7 @@ from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_cost_tags
 from ddtrace.llmobs._utils import get_llmobs_input
+from ddtrace.llmobs._utils import get_llmobs_input_documents
 from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_input_prompt
 from ddtrace.llmobs._utils import get_llmobs_input_value
@@ -32,6 +33,7 @@ from ddtrace.llmobs._utils import get_llmobs_metrics
 from ddtrace.llmobs._utils import get_llmobs_model_name
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_output
+from ddtrace.llmobs._utils import get_llmobs_output_documents
 from ddtrace.llmobs._utils import get_llmobs_output_messages
 from ddtrace.llmobs._utils import get_llmobs_output_value
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -270,6 +272,44 @@ class TestLLMIOProcessing:
         with llmobs.llm("openai.request") as unscrubbed_span:
             llmobs.annotate(unscrubbed_span, input_data="value")
         assert get_llmobs_input_messages(unscrubbed_span)[0]["content"] == "value"
+
+    def _redact_documents(span: LLMObsSpan):
+        for doc in span.input_documents:
+            doc["text"] = ""
+        for doc in span.output_documents:
+            doc["text"] = ""
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_redact_documents)])
+    def test_document_processor_redact(self, llmobs, llmobs_enable_opts):
+        with llmobs.embedding(model_name="test_model") as emb_span:
+            llmobs.annotate(emb_span, input_data=[{"text": "secret document"}])
+
+        documents = get_llmobs_input_documents(emb_span)
+        assert documents == [{"text": ""}]
+
+        with llmobs.retrieval() as ret_span:
+            llmobs.annotate(ret_span, output_data=[{"text": "secret result", "name": "doc.pdf"}])
+
+        documents = get_llmobs_output_documents(ret_span)
+        assert documents == [{"text": "", "name": "doc.pdf"}]
+
+    def _drop_documents(span: LLMObsSpan):
+        span.input_documents = []
+        span.output_documents = []
+        return span
+
+    @pytest.mark.parametrize("llmobs_enable_opts", [dict(span_processor=_drop_documents)])
+    def test_document_processor_remove(self, llmobs, llmobs_enable_opts):
+        with llmobs.embedding(model_name="test_model") as emb_span:
+            llmobs.annotate(emb_span, input_data=[{"text": "secret"}])
+
+        assert get_llmobs_input_documents(emb_span) is None
+
+        with llmobs.retrieval() as ret_span:
+            llmobs.annotate(ret_span, output_data=[{"text": "secret"}])
+
+        assert get_llmobs_output_documents(ret_span) is None
 
     def test_processor_error_is_logged(self, ddtrace_run_python_code_in_subprocess, llmobs_backend):
         """Ensure that when an exception is raised an exception is logged."""


### PR DESCRIPTION
## Description

The span processor (`register_processor` / `enable(span_processor=...)`) exposes `input` and `output` (messages/values) for mutation, but not documents. Embedding and retrieval span documents pass through to Datadog without any way for users to redact or modify them.

This adds `input_documents` and `output_documents` fields to `LLMObsSpan`, following the same populate-before/write-back-after pattern used by `input` and `output`.

#### Usage

```python
def redact_processor(span: LLMObsSpan) -> LLMObsSpan:
    for doc in span.input_documents:
        doc["text"] = ""
    for doc in span.output_documents:
        doc["text"] = ""
    return span

LLMObs.register_processor(redact_processor)
```

## Testing

Added two tests in `TestLLMIOProcessing`:
- `test_document_processor_redact` — mutate document text in place
- `test_document_processor_remove` — clear documents by setting to `[]`

## Risks

None. The change is backward-compatible — `input_documents` and `output_documents` default to `[]`, so existing processors that do not reference them are unaffected.

## Additional Notes

Related issues: https://github.com/DataDog/dd-trace-py/issues/11179

The fix in https://github.com/DataDog/dd-trace-py/pull/13479 was only partial. For enterprise use-cases, being able to redact sensitive information is critical.