### PR TITLE
ci: avoid AttributeError on ddtrace.internal during circular import at startup

### DIFF
--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -39,7 +39,8 @@ from ddtrace.internal.core.event_hub import dispatch
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.settings.asm import config as asm_config
-import ddtrace.internal.utils.wrappers
+from ddtrace.internal.utils.wrappers import iswrapped
+from ddtrace.internal.utils.wrappers import unwrap
 from ddtrace.propagation.http import HTTPPropagator
 
 
@@ -52,8 +53,6 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 wrap = wrapt.wrap_function_wrapper
-unwrap = ddtrace.internal.utils.wrappers.unwrap
-iswrapped = ddtrace.internal.utils.wrappers.iswrapped
 
 REQUEST = "request"
 RESPONSE = "response"

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -39,8 +39,8 @@ from ddtrace.internal.core.event_hub import dispatch
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.settings.asm import config as asm_config
-from ddtrace.internal.utils.wrappers import iswrapped
-from ddtrace.internal.utils.wrappers import unwrap
+from ddtrace.internal.utils.wrappers import iswrapped  # noqa: F401
+from ddtrace.internal.utils.wrappers import unwrap  # noqa: F401
 from ddtrace.propagation.http import HTTPPropagator
 
 


### PR DESCRIPTION
## Summary

- When `ddtrace.internal` is partially initialized due to a circular import during `sitecustomize`, the attribute-chain access `ddtrace.internal.utils.wrappers.unwrap` raises `AttributeError: module 'ddtrace' has no attribute 'internal'`
- This crashes the test-client process before it can start its HTTP server, causing parametric system tests to time out
- Fix: replace `import ddtrace.internal.utils.wrappers` + attribute access with direct `from ddtrace.internal.utils.wrappers import unwrap, iswrapped`

Resolves: https://app.datadoghq.com/dashboard/eit-h7i-h4q?currentTab=trace&fromUser=false&graphType=flamegraph&historicalData=true&index=&refresh_mode=sliding&spanID=12980967670162765972&tpl_var_codeowner%5B0%5D=%40DataDog%2Fapm-sdk-capabilities-python&tpl_var_repo%5B0%5D=github.com%2Fdatadog%2Fdd-trace-py&from_ts=1777659490591&to_ts=1778264290591&live=true

```
2026-05-07T20:29:07.721031Z 01O   File "/app/apm_test_client/__main__.py", line 6, in <module>
2026-05-07T20:29:07.721034Z 01O     uvicorn.run(
2026-05-07T20:29:07.721038Z 01O   File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 569, in run
2026-05-07T20:29:07.721046Z 01O     server.run()
2026-05-07T20:29:07.721049Z 01O   File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 60, in run
2026-05-07T20:29:07.721054Z 01O     return asyncio.run(self.serve(sockets=sockets))
2026-05-07T20:29:07.721059Z 01O            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721062Z 01O   File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
2026-05-07T20:29:07.721066Z 01O     return runner.run(main)
2026-05-07T20:29:07.721070Z 01O            ^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721073Z 01O   File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
2026-05-07T20:29:07.721077Z 01O     return self._loop.run_until_complete(task)
2026-05-07T20:29:07.721082Z 01O            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721085Z 01O   File "/usr/local/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
2026-05-07T20:29:07.721089Z 01O     return future.result()
2026-05-07T20:29:07.721094Z 01O            ^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721097Z 01O   File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 67, in serve
2026-05-07T20:29:07.721100Z 01O     config.load()
2026-05-07T20:29:07.721106Z 01O   File "/usr/local/lib/python3.11/site-packages/uvicorn/config.py", line 477, in load
2026-05-07T20:29:07.721109Z 01O     self.loaded_app = import_from_string(self.app)
2026-05-07T20:29:07.721112Z 01O                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721117Z 01O   File "/usr/local/lib/python3.11/site-packages/uvicorn/importer.py", line 21, in import_from_string
2026-05-07T20:29:07.721123Z 01O     module = importlib.import_module(module_str)
2026-05-07T20:29:07.721125Z 01O              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721129Z 01O   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
2026-05-07T20:29:07.721135Z 01O     return _bootstrap._gcd_import(name[level:], package, level)
2026-05-07T20:29:07.721138Z 01O            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721142Z 01O   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
2026-05-07T20:29:07.721151Z 01O   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
2026-05-07T20:29:07.721153Z 01O   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
2026-05-07T20:29:07.721157Z 01O   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
2026-05-07T20:29:07.721162Z 01O   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
2026-05-07T20:29:07.721165Z 01O   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
2026-05-07T20:29:07.721169Z 01O   File "/app/apm_test_client/server.py", line 41, in <module>
2026-05-07T20:29:07.721177Z 01O     from ddtrace.contrib.trace_utils import set_http_meta
2026-05-07T20:29:07.721186Z 01O   File "/usr/local/lib/python3.11/site-packages/ddtrace/contrib/__init__.py", line 3, in <module>
2026-05-07T20:29:07.721192Z 01O     from ddtrace._trace import trace_handlers as _  # noqa: F401
2026-05-07T20:29:07.721210Z 01O     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721231Z 01O   File "/usr/local/lib/python3.11/site-packages/ddtrace/_trace/trace_handlers.py", line 31, in <module>
2026-05-07T20:29:07.721236Z 01O     from ddtrace.contrib import trace_utils
2026-05-07T20:29:07.721248Z 01O   File "/usr/local/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 5, in <module>
2026-05-07T20:29:07.721255Z 01O     from ddtrace.contrib.internal.trace_utils import IP_PATTERNS  # noqa: F401
2026-05-07T20:29:07.721259Z 01O     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T20:29:07.721272Z 01O   File "/usr/local/lib/python3.11/site-packages/ddtrace/contrib/internal/trace_utils.py", line 55, in <module>
2026-05-07T20:29:07.721281Z 01O     unwrap = ddtrace.internal.utils.wrappers.unwrap
2026-05-07T20:29:07.721285Z 01O              ^^^^^^^^^^^^^^^^
```

## Test plan
- [ ] Run parametric system tests with dd-trace-py to confirm the client container starts successfully
- [ ] Verify existing unit tests for `ddtrace/contrib/internal/trace_utils.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)