### PR TITLE
feat(llmobs): add memory package

### DIFF
--- a/ddtrace/llmobs/__init__.py
+++ b/ddtrace/llmobs/__init__.py
@@ -23,6 +23,20 @@ from ddtrace.llmobs._experiment import DatasetRecord
 from ddtrace.llmobs._experiment import EvaluatorResult
 from ddtrace.llmobs._llmobs import LLMObs
 from ddtrace.llmobs._llmobs import LLMObsSpan
+from ddtrace.llmobs._memory import DatadogMemoryBackend
+from ddtrace.llmobs._memory import EmptyMemoryBackend
+from ddtrace.llmobs._memory import Memory
+from ddtrace.llmobs._memory import MemoryBackend
+from ddtrace.llmobs._memory import MemoryBackendError
+from ddtrace.llmobs._memory import MemoryLink
+from ddtrace.llmobs._memory import MemoryNotConfiguredError
+from ddtrace.llmobs._memory import MemoryPersistUnsupportedError
+from ddtrace.llmobs._memory import MemoryRecord
+from ddtrace.llmobs._memory import MemoryScope
+from ddtrace.llmobs._memory import MemorySource
+from ddtrace.llmobs._memory import get_memory_scope
+from ddtrace.llmobs._memory import memory_scope
+from ddtrace.llmobs._memory import set_memory_scope
 from ddtrace.llmobs.types import Prompt
 
 
@@ -31,6 +45,17 @@ __all__ = [
     "LLMObsSpan",
     "Dataset",
     "DatasetRecord",
+    "DatadogMemoryBackend",
+    "EmptyMemoryBackend",
+    "Memory",
+    "MemoryBackend",
+    "MemoryBackendError",
+    "MemoryLink",
+    "MemoryNotConfiguredError",
+    "MemoryPersistUnsupportedError",
+    "MemoryRecord",
+    "MemoryScope",
+    "MemorySource",
     "Prompt",
     "BaseEvaluator",
     "BaseSummaryEvaluator",
@@ -45,4 +70,7 @@ __all__ = [
     "RemoteEvaluatorError",
     "ScoreStructuredOutput",
     "SummaryEvaluatorContext",
+    "get_memory_scope",
+    "memory_scope",
+    "set_memory_scope",
 ]

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -134,6 +134,11 @@ DEFAULT_PROMPTS_TIMEOUT = 5.0  # seconds for all prompt fetch operations
 # Managed Prompts API
 PROMPTS_ENDPOINT = "/api/unstable/llm-obs/v1/prompts"
 
+# Agent memory API
+MEMORY_SEARCH_ENDPOINT = "/api/unstable/agent_memories/agent/search"
+MEMORY_GET_ENDPOINT = "/api/unstable/agent_memories/agent/get_node"
+MEMORY_PERSIST_ENDPOINT = "/api/unstable/agent_memories/agent/persist"
+
 
 class LLMOBS_STRUCT:
     """Nested LLMObs struct keys in span._meta_struct."""

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -6,6 +6,7 @@ import json
 import math
 import sys
 import time
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Literal
@@ -151,6 +152,7 @@ from ddtrace.llmobs._writer import LLMObsAPIClient
 from ddtrace.llmobs._writer import LLMObsEvalMetricWriter
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
 from ddtrace.llmobs._writer import LLMObsExperimentsClient
+from ddtrace.llmobs._writer import LLMObsMemoryClient
 from ddtrace.llmobs._writer import LLMObsSpanEvent
 from ddtrace.llmobs._writer import LLMObsSpanWriter
 from ddtrace.llmobs._writer import should_use_agentless
@@ -168,6 +170,11 @@ from ddtrace.llmobs.utils import extract_tool_definitions
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.version import __version__
 
+
+if TYPE_CHECKING:
+    from ddtrace.llmobs._memory import Memory
+    from ddtrace.llmobs._memory import MemoryBackend
+    from ddtrace.llmobs._memory import MemoryScope
 
 log = get_logger(__name__)
 
@@ -491,6 +498,7 @@ class LLMObs(Service):
             is_agentless=True,  # agent proxy doesn't seem to work for experiments
         )
         self._api_client = LLMObsAPIClient(app_key=self._app_key)
+        self._memory_client = LLMObsMemoryClient(app_key=self._app_key)
 
         forksafe.register(self._child_after_fork)
 
@@ -960,6 +968,27 @@ class LLMObs(Service):
         base_url = _get_base_url()
         query = urllib.parse.urlencode({"evalName": evaluation_payload["eval_name"], "applicationName": ml_app.strip()})
         return {"ui_url": f"{base_url}/llm/evaluations/custom?{query}"}
+
+    @classmethod
+    def memory(
+        cls,
+        scope: Optional["MemoryScope"] = None,
+        backend: Optional["MemoryBackend"] = None,
+        backend_name: str = "internal",
+        default_limit: int = 10,
+    ) -> "Memory":
+        """Create a memory client for the active LLMObs ML app."""
+        from ddtrace.llmobs._memory import DatadogMemoryBackend
+        from ddtrace.llmobs._memory import Memory
+        from ddtrace.llmobs._memory import MemoryNotConfiguredError
+
+        if backend is None:
+            if not cls._instance or not cls.enabled:
+                raise MemoryNotConfiguredError(
+                    "LLMObs.memory() requires LLMObs.enable(...) unless a custom backend is provided."
+                )
+            backend = DatadogMemoryBackend(client=cls._instance._memory_client, ml_app=resolve_ml_app())
+        return Memory(scope=scope, backend=backend, backend_name=backend_name, default_limit=default_limit)
 
     @classmethod
     def pull_dataset(

--- a/ddtrace/llmobs/_memory.py
+++ b/ddtrace/llmobs/_memory.py
@@ -1,0 +1,647 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from contextvars import Token
+from dataclasses import dataclass
+import json
+from typing import Any
+from typing import Iterator
+from typing import Optional
+from typing import Protocol
+from typing import Union
+
+from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.internal.utils.http import Response
+from ddtrace.llmobs._constants import MEMORY_GET_ENDPOINT
+from ddtrace.llmobs._constants import MEMORY_PERSIST_ENDPOINT
+from ddtrace.llmobs._constants import MEMORY_SEARCH_ENDPOINT
+from ddtrace.llmobs._utils import get_llmobs_session_id
+from ddtrace.llmobs._utils import get_llmobs_trace_id
+from ddtrace.llmobs._utils import resolve_ml_app
+
+
+MEMORY_KIND = "memory"
+BACKEND_INTERNAL = "internal"
+OP_READ = "read"
+OP_WRITE = "write"
+ACTION_SEARCH = "search"
+ACTION_GET = "get"
+ACTION_PERSIST = "persist"
+RESULT_NOT_FOUND = "not_found"
+
+MEMORY_TOOL_SEARCH_NAME = "memory_search"
+MEMORY_TOOL_GET_NAME = "memory_get"
+MEMORY_TOOL_PERSIST_NAME = "memory_persist"
+
+
+class MemoryBackendError(Exception):
+    """Raised when a memory backend request fails."""
+
+
+class MemoryNotConfiguredError(MemoryBackendError):
+    """Raised when the Datadog memory backend is missing required configuration."""
+
+
+class MemoryPersistUnsupportedError(MemoryBackendError):
+    """Raised when the configured backend does not support memory persistence yet."""
+
+
+@dataclass(frozen=True)
+class MemoryScope:
+    kind: str
+    id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, str) or not self.kind.strip():
+            raise ValueError("MemoryScope.kind must be a non-empty string.")
+        if not isinstance(self.id, str) or not self.id.strip():
+            raise ValueError("MemoryScope.id must be a non-empty string.")
+
+    def to_wire(self) -> str:
+        return "{}:{}".format(self.kind, self.id)
+
+
+_memory_scope: ContextVar[Optional[MemoryScope]] = ContextVar("ddtrace_llmobs_memory_scope", default=None)
+
+
+def set_memory_scope(scope: MemoryScope) -> Token:
+    return _memory_scope.set(_validate_scope(scope))
+
+
+def get_memory_scope() -> Optional[MemoryScope]:
+    return _memory_scope.get()
+
+
+@contextmanager
+def memory_scope(scope: MemoryScope) -> Iterator[MemoryScope]:
+    token = set_memory_scope(scope)
+    try:
+        yield scope
+    finally:
+        _memory_scope.reset(token)
+
+
+@dataclass(frozen=True)
+class MemoryLink:
+    type: str
+    target_id: str
+    token_count: int = 0
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "target_id": self.target_id,
+            "token_count": self.token_count,
+        }
+
+
+@dataclass(frozen=True)
+class MemorySource:
+    type: str
+    agent: Optional[dict[str, str]] = None
+    user: Optional[dict[str, str]] = None
+    reflection: Optional[dict[str, Any]] = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"type": self.type}
+        if self.agent is not None:
+            out["agent"] = self.agent
+        if self.user is not None:
+            out["user"] = self.user
+        if self.reflection is not None:
+            out["reflection"] = self.reflection
+        return out
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    id: str
+    content: str
+    kind: str = MEMORY_KIND
+    source: Optional[Union[MemorySource, dict[str, Any]]] = None
+    links: tuple[MemoryLink, ...] = ()
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    state: Optional[str] = None
+    metadata: Optional[dict[str, Any]] = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "id": self.id,
+            "kind": self.kind,
+            "content": self.content,
+        }
+        if self.source is not None:
+            out["source"] = self.source.to_json() if isinstance(self.source, MemorySource) else dict(self.source)
+        if self.links:
+            out["links"] = [link.to_json() for link in self.links]
+        if self.created_at is not None:
+            out["created_at"] = self.created_at
+        if self.updated_at is not None:
+            out["updated_at"] = self.updated_at
+        if self.state is not None:
+            out["state"] = self.state
+        if self.metadata is not None:
+            out["metadata"] = self.metadata
+        return out
+
+
+class MemoryBackend(Protocol):
+    def search(self, scope: MemoryScope, query: str, limit: int) -> list[MemoryRecord]:
+        ...
+
+    def get(self, scope: MemoryScope, id: str) -> Optional[MemoryRecord]:
+        ...
+
+    def persist(self, scope: MemoryScope, content: str, source: MemorySource) -> MemoryRecord:
+        ...
+
+
+class EmptyMemoryBackend:
+    def search(self, scope: MemoryScope, query: str, limit: int) -> list[MemoryRecord]:
+        return []
+
+    def get(self, scope: MemoryScope, id: str) -> Optional[MemoryRecord]:
+        return None
+
+    def persist(self, scope: MemoryScope, content: str, source: MemorySource) -> MemoryRecord:
+        raise MemoryPersistUnsupportedError("EmptyMemoryBackend does not support durable memory persistence.")
+
+
+class DatadogMemoryBackend:
+    def __init__(self, client: Any, ml_app: Optional[str] = None) -> None:
+        self._client = client
+        self._ml_app = resolve_ml_app(ml_app)
+
+    def search(self, scope: MemoryScope, query: str, limit: int) -> list[MemoryRecord]:
+        data = self._post(
+            MEMORY_SEARCH_ENDPOINT,
+            {
+                "ml_app": self._ml_app,
+                "scope": scope.to_wire(),
+                "query": query,
+                "limit": limit,
+            },
+            expected_statuses=(200,),
+        )
+        if not isinstance(data, list):
+            raise MemoryBackendError("Memory search response data must be a list.")
+        return [_memory_record_from_backend(item) for item in data]
+
+    def get(self, scope: MemoryScope, id: str) -> Optional[MemoryRecord]:
+        response = self._request(
+            MEMORY_GET_ENDPOINT,
+            {
+                "ml_app": self._ml_app,
+                "scope": scope.to_wire(),
+                "id": id,
+            },
+        )
+        if response.status == 404:
+            return None
+        data = self._data_from_response(response, MEMORY_GET_ENDPOINT, expected_statuses=(200,))
+        return _memory_record_from_backend(data)
+
+    def persist(self, scope: MemoryScope, content: str, source: MemorySource) -> MemoryRecord:
+        data = self._post(
+            MEMORY_PERSIST_ENDPOINT,
+            {
+                "ml_app": self._ml_app,
+                "scope": scope.to_wire(),
+                "source": source.to_json(),
+                "content": content,
+            },
+            expected_statuses=(200, 201),
+        )
+        return _memory_record_from_backend(data)
+
+    def _post(self, path: str, body: dict[str, Any], expected_statuses: tuple[int, ...]) -> Any:
+        response = self._request(path, body)
+        return self._data_from_response(response, path, expected_statuses)
+
+    def _request(self, path: str, body: dict[str, Any]) -> Response:
+        self._ensure_configured()
+        try:
+            return self._client.request("POST", path, body)
+        except MemoryBackendError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendError("Memory backend request failed for {}: {}".format(path, exc)) from exc
+
+    def _ensure_configured(self) -> None:
+        api_key = getattr(self._client, "_api_key", None)
+        app_key = getattr(self._client, "_app_key", None)
+        if api_key == "":
+            raise MemoryNotConfiguredError(
+                "DD_API_KEY is required when using the Datadog LLMObs memory backend."
+            )
+        if app_key == "":
+            raise MemoryNotConfiguredError(
+                "DD_APP_KEY is required when using the Datadog LLMObs memory backend."
+            )
+
+    def _data_from_response(self, response: Response, path: str, expected_statuses: tuple[int, ...]) -> Any:
+        if response.status not in expected_statuses:
+            body = _response_body_text(response)
+            if path == MEMORY_PERSIST_ENDPOINT and "not implemented" in body.lower():
+                raise MemoryPersistUnsupportedError(
+                    "The configured Datadog memory backend does not support persistence yet."
+                )
+            raise MemoryBackendError(
+                "Memory backend request to {} failed with status {}: {}".format(path, response.status, body)
+            )
+        payload = response.get_json() or {}
+        if not isinstance(payload, dict) or "data" not in payload:
+            raise MemoryBackendError("Memory backend response from {} did not contain a data envelope.".format(path))
+        return payload["data"]
+
+
+class Memory:
+    def __init__(
+        self,
+        scope: Optional[MemoryScope] = None,
+        backend: Optional[MemoryBackend] = None,
+        backend_name: str = BACKEND_INTERNAL,
+        default_limit: int = 10,
+    ) -> None:
+        self.scope = _resolve_scope(scope)
+        self.backend = backend or EmptyMemoryBackend()
+        self.backend_name = backend_name
+        self.default_limit = _validate_limit(default_limit, field="default_limit")
+
+    def search(self, query: str, limit: Optional[int] = None) -> str:
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("memory.search: query is required")
+        resolved_limit = self.default_limit if limit in (None, 0) else _validate_limit(limit, field="limit")
+
+        with _memory_tool_span(MEMORY_TOOL_SEARCH_NAME) as span:
+            _annotate_memory_tool_start(
+                span=span,
+                action=ACTION_SEARCH,
+                op=OP_READ,
+                backend=self.backend_name,
+                scope=self.scope,
+                input_data={"query": query, "limit": resolved_limit},
+                extra={"memory.query": query, "memory.limit": resolved_limit},
+            )
+            records = self.backend.search(self.scope, query, resolved_limit)
+            output = _tool_json([record.to_json() for record in records])
+            _annotate_memory_read_result(span=span, records=records, output_data=output)
+            return output
+
+    def get(self, id: str) -> str:
+        if not isinstance(id, str) or not id.strip():
+            raise ValueError("memory.get: id is required")
+
+        with _memory_tool_span(MEMORY_TOOL_GET_NAME) as span:
+            _annotate_memory_tool_start(
+                span=span,
+                action=ACTION_GET,
+                op=OP_READ,
+                backend=self.backend_name,
+                scope=self.scope,
+                input_data={"id": id},
+            )
+            record = self.backend.get(self.scope, id)
+            if record is None:
+                output = _tool_json({"result": RESULT_NOT_FOUND, "id": id})
+                _annotate_memory_read_result(
+                    span=span,
+                    records=[],
+                    output_data=output,
+                    extra={
+                        "memory.id": id,
+                        "memory.result": RESULT_NOT_FOUND,
+                        "memory.state": RESULT_NOT_FOUND,
+                    },
+                )
+                return output
+
+            output = _tool_json(record.to_json())
+            _annotate_memory_read_result(
+                span=span,
+                records=[record],
+                output_data=output,
+                extra={"memory.kind": record.kind},
+            )
+            return output
+
+    def persist(self, content: str) -> str:
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("memory.persist: content is required")
+
+        with _memory_tool_span(MEMORY_TOOL_PERSIST_NAME) as span:
+            _annotate_memory_tool_start(
+                span=span,
+                action=ACTION_PERSIST,
+                op=OP_WRITE,
+                backend=self.backend_name,
+                scope=self.scope,
+                input_data={"content": content},
+            )
+            source = _agent_source_from_span(span)
+            record = self.backend.persist(self.scope, content, source)
+            output = _tool_json(record.to_json())
+            _annotate_memory_write_result(span=span, record=record, source=source, output_data=output)
+            return output
+
+
+MEMORY_SEARCH_TOOL_SCHEMA = {
+    "name": MEMORY_TOOL_SEARCH_NAME,
+    "description": (
+        "Search durable memories by semantic query. Returns matching memories with outbound links such as related "
+        "memories or source transcripts. Scope is resolved automatically by the runtime; do not supply it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Maximum results. Default 10."},
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+MEMORY_GET_TOOL_SCHEMA = {
+    "name": MEMORY_TOOL_GET_NAME,
+    "description": (
+        "Fetch the full content of a memory or artifact by id. Use to drill into targets returned by memory_search. "
+        "Returns the node content and its outbound links for further traversal."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"id": {"type": "string", "description": "Memory or artifact id from memory_search."}},
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+}
+
+MEMORY_PERSIST_TOOL_SCHEMA = {
+    "name": MEMORY_TOOL_PERSIST_NAME,
+    "description": (
+        "Save a durable memory, such as a stable preference, recurring goal, or constraint. Not for transient "
+        "one-off requests. Scope and session are resolved automatically."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"content": {"type": "string", "description": "Durable memory content to save."}},
+        "required": ["content"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _resolve_scope(scope: Optional[MemoryScope]) -> MemoryScope:
+    resolved = scope if scope is not None else get_memory_scope()
+    if resolved is None:
+        raise ValueError("Memory requires a scope. Pass scope=... or use memory_scope(...).")
+    return _validate_scope(resolved)
+
+
+def _validate_scope(scope: MemoryScope) -> MemoryScope:
+    if not isinstance(scope, MemoryScope):
+        raise TypeError("memory scope must be a MemoryScope.")
+    return scope
+
+
+def _validate_limit(limit: Optional[int], field: str) -> int:
+    try:
+        resolved = int(limit)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise ValueError("memory.{} must be a positive integer.".format(field)) from None
+    if resolved <= 0:
+        raise ValueError("memory.{} must be a positive integer.".format(field))
+    return resolved
+
+
+@contextmanager
+def _memory_tool_span(name: str) -> Iterator[Any]:
+    from ddtrace.llmobs import LLMObs
+
+    # AIDEV-NOTE: Direct Memory(..., backend=...) construction is allowed for tests and offline tools before
+    # LLMObs.enable(); tracing is a no-op in that mode, but backend operations still run.
+    if not LLMObs.enabled:
+        yield None
+        return
+
+    with LLMObs.tool(name=name) as span:
+        yield span
+
+
+def _annotate_memory_tool_start(
+    span: Any,
+    action: str,
+    op: str,
+    backend: str,
+    scope: MemoryScope,
+    input_data: dict[str, Any],
+    extra: Optional[dict[str, Any]] = None,
+) -> None:
+    if span is None:
+        return
+    metadata = {
+        "kind": MEMORY_KIND,
+        "memory.op": op,
+        "memory.action": action,
+        "memory.backend": backend,
+        "memory.scope": scope.kind,
+        "memory.scope_id": scope.id,
+    }
+    if extra:
+        metadata.update(extra)
+    tags = {
+        "tool.kind": MEMORY_KIND,
+        "memory.op": op,
+        "memory.action": action,
+        "memory.backend": backend,
+        "memory.scope": scope.kind,
+    }
+    _annotate(span=span, input_data=input_data, metadata=metadata, tags=tags)
+
+
+def _annotate_memory_read_result(
+    span: Any,
+    records: list[MemoryRecord],
+    output_data: str,
+    extra: Optional[dict[str, Any]] = None,
+) -> None:
+    if span is None:
+        return
+    ids = [record.id for record in records]
+    metadata: dict[str, Any] = {
+        "memory.count": len(ids),
+        "memory.ids": ids,
+    }
+    if len(ids) == 1:
+        metadata["memory.id"] = ids[0]
+    if extra:
+        metadata.update(extra)
+    metrics = _total_tokens_metric(record.content for record in records)
+    _annotate(span=span, output_data=output_data, metadata=metadata, metrics=metrics)
+
+
+def _annotate_memory_write_result(span: Any, record: MemoryRecord, source: MemorySource, output_data: str) -> None:
+    if span is None:
+        return
+    metadata: dict[str, Any] = {
+        "memory.id": record.id,
+        "memory.source": _source_type(record.source) or source.type,
+    }
+    state = record.state
+    if state is not None:
+        metadata["memory.state"] = state
+    agent = source.agent or {}
+    for key in ("session_id", "trace_id", "span_id"):
+        if agent.get(key):
+            metadata["memory.source.{}".format(key)] = agent[key]
+    metrics = _total_tokens_metric([record.content])
+    _annotate(span=span, output_data=output_data, metadata=metadata, metrics=metrics)
+
+
+def _annotate(
+    span: Any,
+    input_data: Optional[Any] = None,
+    output_data: Optional[Any] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    metrics: Optional[dict[str, float]] = None,
+    tags: Optional[dict[str, str]] = None,
+) -> None:
+    from ddtrace.llmobs import LLMObs
+
+    kwargs = {
+        "span": span,
+        "input_data": input_data,
+        "output_data": output_data,
+        "metadata": metadata,
+        "tags": tags,
+    }
+    if metrics:
+        kwargs["metrics"] = metrics
+    LLMObs.annotate(**kwargs)
+
+
+def _agent_source_from_span(span: Any) -> MemorySource:
+    agent: dict[str, str] = {}
+    if span is not None:
+        session_id = get_llmobs_session_id(span)
+        trace_id = get_llmobs_trace_id(span) or format_trace_id(span.trace_id)
+        span_id = str(span.span_id)
+        if session_id:
+            agent["session_id"] = session_id
+        if trace_id:
+            agent["trace_id"] = trace_id
+        if span_id:
+            agent["span_id"] = span_id
+    return MemorySource(type="agent", agent=agent)
+
+
+def _total_tokens_metric(contents: Any) -> Optional[dict[str, float]]:
+    total = sum(_estimated_tokens(content) for content in contents)
+    if total <= 0:
+        return None
+    return {"total_tokens": float(total)}
+
+
+def _estimated_tokens(content: str) -> int:
+    return len(content) // 4
+
+
+def _tool_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _memory_record_from_backend(payload: Any) -> MemoryRecord:
+    if not isinstance(payload, dict):
+        raise MemoryBackendError("Memory backend record must be a JSON object.")
+    links = payload.get("links") or payload.get("memory_links") or ()
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+    return MemoryRecord(
+        id=str(payload.get("id") or ""),
+        content=str(payload.get("content") or ""),
+        kind=str(payload.get("kind") or MEMORY_KIND),
+        source=_memory_source_from_backend(payload.get("source")),
+        links=tuple(_memory_link_from_backend(link) for link in links),
+        created_at=_string_or_none(payload.get("created_at")),
+        updated_at=_string_or_none(payload.get("updated_at")),
+        state=_string_or_none(payload.get("state")),
+        metadata=metadata,
+    )
+
+
+def _memory_link_from_backend(payload: Any) -> MemoryLink:
+    if not isinstance(payload, dict):
+        raise MemoryBackendError("Memory backend link must be a JSON object.")
+    return MemoryLink(
+        type=str(payload.get("type") or ""),
+        target_id=str(payload.get("target_id") or ""),
+        token_count=int(payload.get("token_count") or 0),
+    )
+
+
+def _memory_source_from_backend(payload: Any) -> Optional[Union[MemorySource, dict[str, Any]]]:
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise MemoryBackendError("Memory backend source must be a JSON object.")
+    source_type = payload.get("type")
+    if not source_type:
+        return dict(payload)
+    return MemorySource(
+        type=str(source_type),
+        agent=_string_dict_or_none(payload.get("agent")),
+        user=_string_dict_or_none(payload.get("user")),
+        reflection=payload.get("reflection") if isinstance(payload.get("reflection"), dict) else None,
+    )
+
+
+def _source_type(source: Optional[Union[MemorySource, dict[str, Any]]]) -> Optional[str]:
+    if source is None:
+        return None
+    if isinstance(source, MemorySource):
+        return source.type
+    source_type = source.get("type")
+    return str(source_type) if source_type else None
+
+
+def _string_dict_or_none(value: Any) -> Optional[dict[str, str]]:
+    if not isinstance(value, dict):
+        return None
+    return {str(k): str(v) for k, v in value.items()}
+
+
+def _string_or_none(value: Any) -> Optional[str]:
+    return None if value is None else str(value)
+
+
+def _response_body_text(response: Response) -> str:
+    body = response.body
+    if isinstance(body, bytes):
+        return body.decode("utf-8", errors="replace")
+    return str(body)
+
+
+__all__ = [
+    "BACKEND_INTERNAL",
+    "MEMORY_GET_TOOL_SCHEMA",
+    "MEMORY_PERSIST_TOOL_SCHEMA",
+    "MEMORY_SEARCH_TOOL_SCHEMA",
+    "MEMORY_TOOL_GET_NAME",
+    "MEMORY_TOOL_PERSIST_NAME",
+    "MEMORY_TOOL_SEARCH_NAME",
+    "DatadogMemoryBackend",
+    "EmptyMemoryBackend",
+    "Memory",
+    "MemoryBackend",
+    "MemoryBackendError",
+    "MemoryLink",
+    "MemoryNotConfiguredError",
+    "MemoryPersistUnsupportedError",
+    "MemoryRecord",
+    "MemoryScope",
+    "MemorySource",
+    "get_memory_scope",
+    "memory_scope",
+    "set_memory_scope",
+]

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -984,6 +984,36 @@ class LLMObsAPIClient:
         return spans
 
 
+class LLMObsMemoryClient:
+    """Synchronous HTTP client for the LLMObs agent memory API."""
+
+    TIMEOUT = 10.0
+
+    def __init__(self, api_key: str = "", app_key: str = "", site: str = "", override_url: str = "") -> None:
+        self._api_key: str = api_key or config._dd_api_key
+        self._app_key: str = app_key
+        _site: str = site or config._dd_site
+        _override_url: str = override_url or env.get("DD_LLMOBS_OVERRIDE_ORIGIN", "")
+        self._base_url: str = _override_url or "https://api.{}".format(_site)
+
+    def request(self, method: str, path: str, body: Optional[dict[str, Any]] = None) -> Response:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.api+json",
+            "DD-API-KEY": self._api_key,
+            "DD-APPLICATION-KEY": self._app_key,
+        }
+        encoded_body = json.dumps(body).encode("utf-8") if body is not None else b""
+        logger.debug("LLMObsMemoryClient requesting %s%s", self._base_url, path)
+        conn = get_connection(self._base_url, timeout=self.TIMEOUT)
+        try:
+            conn.request(method, path, encoded_body, headers)
+            resp = conn.getresponse()
+            return Response.from_http_response(resp)
+        finally:
+            conn.close()
+
+
 class LLMObsSpanWriter(BaseLLMObsWriter):
     """Writes span events to the LLMObs Span Endpoint."""
 

--- a/ddtrace/llmobs/memory.py
+++ b/ddtrace/llmobs/memory.py
@@ -1,0 +1,46 @@
+from ddtrace.llmobs._memory import BACKEND_INTERNAL
+from ddtrace.llmobs._memory import MEMORY_GET_TOOL_SCHEMA
+from ddtrace.llmobs._memory import MEMORY_PERSIST_TOOL_SCHEMA
+from ddtrace.llmobs._memory import MEMORY_SEARCH_TOOL_SCHEMA
+from ddtrace.llmobs._memory import MEMORY_TOOL_GET_NAME
+from ddtrace.llmobs._memory import MEMORY_TOOL_PERSIST_NAME
+from ddtrace.llmobs._memory import MEMORY_TOOL_SEARCH_NAME
+from ddtrace.llmobs._memory import DatadogMemoryBackend
+from ddtrace.llmobs._memory import EmptyMemoryBackend
+from ddtrace.llmobs._memory import Memory
+from ddtrace.llmobs._memory import MemoryBackend
+from ddtrace.llmobs._memory import MemoryBackendError
+from ddtrace.llmobs._memory import MemoryLink
+from ddtrace.llmobs._memory import MemoryNotConfiguredError
+from ddtrace.llmobs._memory import MemoryPersistUnsupportedError
+from ddtrace.llmobs._memory import MemoryRecord
+from ddtrace.llmobs._memory import MemoryScope
+from ddtrace.llmobs._memory import MemorySource
+from ddtrace.llmobs._memory import get_memory_scope
+from ddtrace.llmobs._memory import memory_scope
+from ddtrace.llmobs._memory import set_memory_scope
+
+
+__all__ = [
+    "BACKEND_INTERNAL",
+    "MEMORY_GET_TOOL_SCHEMA",
+    "MEMORY_PERSIST_TOOL_SCHEMA",
+    "MEMORY_SEARCH_TOOL_SCHEMA",
+    "MEMORY_TOOL_GET_NAME",
+    "MEMORY_TOOL_PERSIST_NAME",
+    "MEMORY_TOOL_SEARCH_NAME",
+    "DatadogMemoryBackend",
+    "EmptyMemoryBackend",
+    "Memory",
+    "MemoryBackend",
+    "MemoryBackendError",
+    "MemoryLink",
+    "MemoryNotConfiguredError",
+    "MemoryPersistUnsupportedError",
+    "MemoryRecord",
+    "MemoryScope",
+    "MemorySource",
+    "get_memory_scope",
+    "memory_scope",
+    "set_memory_scope",
+]

--- a/releasenotes/notes/add-llmobs-memory-package-3c8b4e2f17d9a6c0.yaml
+++ b/releasenotes/notes/add-llmobs-memory-package-3c8b4e2f17d9a6c0.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    LLM Observability: Adds a first-class memory package for tracing and calling durable memory operations with ``LLMObs.memory()``, ``MemoryScope``, and the ``ddtrace.llmobs.memory`` module.

--- a/tests/llmobs/test_memory.py
+++ b/tests/llmobs/test_memory.py
@@ -1,0 +1,310 @@
+import json
+
+import pytest
+
+from ddtrace.internal.utils.http import Response
+from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs._memory import DatadogMemoryBackend
+from ddtrace.llmobs._memory import EmptyMemoryBackend
+from ddtrace.llmobs._memory import MEMORY_GET_TOOL_SCHEMA
+from ddtrace.llmobs._memory import MEMORY_PERSIST_TOOL_SCHEMA
+from ddtrace.llmobs._memory import MEMORY_SEARCH_TOOL_SCHEMA
+from ddtrace.llmobs._memory import Memory
+from ddtrace.llmobs._memory import MemoryBackendError
+from ddtrace.llmobs._memory import MemoryLink
+from ddtrace.llmobs._memory import MemoryNotConfiguredError
+from ddtrace.llmobs._memory import MemoryPersistUnsupportedError
+from ddtrace.llmobs._memory import MemoryRecord
+from ddtrace.llmobs._memory import MemoryScope
+from ddtrace.llmobs._memory import MemorySource
+from ddtrace.llmobs._memory import get_memory_scope
+from ddtrace.llmobs._memory import memory_scope
+from ddtrace.llmobs._utils import get_llmobs_input_value
+from ddtrace.llmobs._utils import get_llmobs_metadata
+from ddtrace.llmobs._utils import get_llmobs_metrics
+from ddtrace.llmobs._utils import get_llmobs_output_value
+from ddtrace.llmobs._utils import get_llmobs_span_kind
+from ddtrace.llmobs._utils import get_llmobs_span_name
+from ddtrace.llmobs._utils import get_llmobs_tags
+from ddtrace.llmobs._utils import get_llmobs_trace_id
+from tests.utils import override_global_config
+
+
+def test_public_memory_imports():
+    from ddtrace.llmobs import Memory as TopLevelMemory
+    from ddtrace.llmobs import MemoryScope as TopLevelMemoryScope
+    from ddtrace.llmobs.memory import Memory as ModuleMemory
+    from ddtrace.llmobs.memory import MemoryScope as ModuleMemoryScope
+
+    assert TopLevelMemory is ModuleMemory
+    assert TopLevelMemoryScope is ModuleMemoryScope
+
+
+class RecordingMemoryBackend:
+    def __init__(self):
+        self.search_calls = []
+        self.get_calls = []
+        self.persist_calls = []
+        self.get_record = None
+        self.search_records = [
+            MemoryRecord(
+                id="mem_1",
+                content="User prefers green tea in the afternoon.",
+                links=(MemoryLink(type="source", target_id="artifact_1", token_count=12),),
+            )
+        ]
+
+    def search(self, scope, query, limit):
+        self.search_calls.append((scope, query, limit))
+        return self.search_records
+
+    def get(self, scope, id):
+        self.get_calls.append((scope, id))
+        return self.get_record
+
+    def persist(self, scope, content, source):
+        self.persist_calls.append((scope, content, source))
+        return MemoryRecord(id="mem_new", content=content, source=source, state="active")
+
+
+class FakeMemoryClient:
+    def __init__(self, *responses, api_key="api", app_key="app"):
+        self._api_key = api_key
+        self._app_key = app_key
+        self.responses = list(responses)
+        self.requests = []
+
+    def request(self, method, path, body):
+        self.requests.append((method, path, body))
+        return self.responses.pop(0)
+
+
+def _response(status, body):
+    return Response(status=status, body=json.dumps(body))
+
+
+def _llmobs_spans(test_spans):
+    return [span for trace in test_spans.pop_traces() for span in trace if get_llmobs_span_kind(span)]
+
+
+def _span_by_name(spans, name):
+    return next(span for span in spans if get_llmobs_span_name(span) == name)
+
+
+def test_memory_scope_validation_and_context():
+    scope = MemoryScope(kind="user", id="user_1")
+    assert scope.to_wire() == "user:user_1"
+    assert get_memory_scope() is None
+    with memory_scope(scope):
+        assert get_memory_scope() == scope
+        assert Memory().scope == scope
+    assert get_memory_scope() is None
+    with pytest.raises(ValueError, match="requires a scope"):
+        Memory()
+    with pytest.raises(ValueError, match="kind"):
+        MemoryScope(kind="", id="user_1")
+    with pytest.raises(ValueError, match="id"):
+        MemoryScope(kind="user", id="")
+
+
+def test_memory_search_get_and_persist_validate_and_call_backend_without_llmobs():
+    backend = RecordingMemoryBackend()
+    memory = Memory(scope=MemoryScope(kind="user", id="user_1"), backend=backend, default_limit=7)
+
+    assert json.loads(memory.search("tea", limit=0))[0]["id"] == "mem_1"
+    assert backend.search_calls == [(memory.scope, "tea", 7)]
+
+    assert json.loads(memory.get("missing")) == {"result": "not_found", "id": "missing"}
+    assert backend.get_calls == [(memory.scope, "missing")]
+
+    persisted = json.loads(memory.persist("User prefers washable cotton bedding."))
+    assert persisted["id"] == "mem_new"
+    assert backend.persist_calls[0][2] == MemorySource(type="agent", agent={})
+
+    with pytest.raises(ValueError, match="query is required"):
+        memory.search("")
+    with pytest.raises(ValueError, match="id is required"):
+        memory.get("")
+    with pytest.raises(ValueError, match="content is required"):
+        memory.persist("")
+    with pytest.raises(ValueError, match="positive integer"):
+        memory.search("tea", limit=-1)
+
+
+def test_empty_memory_backend_persist_is_explicitly_unsupported():
+    memory = Memory(scope=MemoryScope(kind="user", id="user_1"), backend=EmptyMemoryBackend())
+    with pytest.raises(MemoryPersistUnsupportedError):
+        memory.persist("User likes tea.")
+
+
+def test_tool_schemas_do_not_expose_scope():
+    for schema in (MEMORY_SEARCH_TOOL_SCHEMA, MEMORY_GET_TOOL_SCHEMA, MEMORY_PERSIST_TOOL_SCHEMA):
+        assert "scope" not in schema["parameters"]["properties"]
+        assert schema["parameters"]["additionalProperties"] is False
+    assert MEMORY_SEARCH_TOOL_SCHEMA["parameters"]["required"] == ["query"]
+    assert MEMORY_GET_TOOL_SCHEMA["parameters"]["required"] == ["id"]
+    assert MEMORY_PERSIST_TOOL_SCHEMA["parameters"]["required"] == ["content"]
+
+
+def test_datadog_memory_backend_search_maps_memory_links():
+    client = FakeMemoryClient(
+        _response(
+            200,
+            {
+                "data": [
+                    {
+                        "id": "mem_1",
+                        "kind": "memory",
+                        "content": "User likes tea.",
+                        "memory_links": [{"type": "source", "target_id": "artifact_1", "token_count": 11}],
+                        "created_at": "2026-05-08T00:00:00Z",
+                        "metadata": {"rank": 1},
+                    }
+                ]
+            },
+        )
+    )
+
+    records = DatadogMemoryBackend(client=client, ml_app="shopping").search(MemoryScope("user", "user_1"), "tea", 5)
+
+    assert client.requests[0][1] == "/api/unstable/agent_memories/agent/search"
+    assert client.requests[0][2] == {"ml_app": "shopping", "scope": "user:user_1", "query": "tea", "limit": 5}
+    assert records[0].links == (MemoryLink(type="source", target_id="artifact_1", token_count=11),)
+    assert records[0].to_json()["links"][0]["target_id"] == "artifact_1"
+
+
+def test_datadog_memory_backend_get_404_returns_none():
+    client = FakeMemoryClient(Response(status=404, body=b'{"errors":["node not found"]}'))
+
+    assert DatadogMemoryBackend(client=client, ml_app="shopping").get(MemoryScope("user", "user_1"), "mem_1") is None
+
+
+def test_datadog_memory_backend_persist_parses_memory_record():
+    source = MemorySource(type="agent", agent={"session_id": "sess_1", "trace_id": "trace_1", "span_id": "span_1"})
+    client = FakeMemoryClient(
+        _response(
+            201,
+            {
+                "data": {
+                    "id": "mem_2",
+                    "content": "User likes tea.",
+                    "state": "active",
+                    "source": source.to_json(),
+                    "created_at": "2026-05-08T00:00:00Z",
+                    "updated_at": "2026-05-08T00:00:00Z",
+                }
+            },
+        )
+    )
+
+    record = DatadogMemoryBackend(client=client, ml_app="shopping").persist(
+        MemoryScope("user", "user_1"), "User likes tea.", source
+    )
+
+    assert client.requests[0][1] == "/api/unstable/agent_memories/agent/persist"
+    assert client.requests[0][2]["source"] == source.to_json()
+    assert record.state == "active"
+    assert record.source == source
+
+
+def test_datadog_memory_backend_errors_are_clear():
+    with pytest.raises(MemoryNotConfiguredError, match="DD_APP_KEY"):
+        DatadogMemoryBackend(client=FakeMemoryClient(api_key="api", app_key=""), ml_app="shopping").search(
+            MemoryScope("user", "user_1"), "tea", 5
+        )
+
+    with pytest.raises(MemoryBackendError, match="status 500"):
+        DatadogMemoryBackend(client=FakeMemoryClient(Response(status=500, body=b"boom")), ml_app="shopping").search(
+            MemoryScope("user", "user_1"), "tea", 5
+        )
+
+    with pytest.raises(MemoryPersistUnsupportedError, match="does not support persistence"):
+        DatadogMemoryBackend(
+            client=FakeMemoryClient(Response(status=500, body=b"not implemented")), ml_app="shopping"
+        ).persist(MemoryScope("user", "user_1"), "User likes tea.", MemorySource(type="agent", agent={}))
+
+
+def test_memory_search_traces_tool_span(llmobs, test_spans):
+    backend = RecordingMemoryBackend()
+    memory = Memory(scope=MemoryScope(kind="user", id="user_1"), backend=backend)
+
+    assert json.loads(memory.search("tea", limit=2))[0]["id"] == "mem_1"
+
+    span = _span_by_name(_llmobs_spans(test_spans), "memory_search")
+    assert get_llmobs_span_kind(span) == "tool"
+    assert json.loads(get_llmobs_input_value(span)) == {"limit": 2, "query": "tea"}
+    assert json.loads(get_llmobs_output_value(span))[0]["links"][0]["target_id"] == "artifact_1"
+    assert get_llmobs_tags(span)["tool.kind"] == "memory"
+    assert get_llmobs_tags(span)["memory.action"] == "search"
+    assert get_llmobs_tags(span)["memory.scope"] == "user"
+    metadata = get_llmobs_metadata(span)
+    assert metadata["kind"] == "memory"
+    assert metadata["memory.scope_id"] == "user_1"
+    assert metadata["memory.query"] == "tea"
+    assert metadata["memory.limit"] == 2
+    assert metadata["memory.count"] == 1
+    assert metadata["memory.ids"] == ["mem_1"]
+    assert get_llmobs_metrics(span)["total_tokens"] > 0
+
+
+def test_memory_get_traces_not_found(llmobs, test_spans):
+    memory = Memory(scope=MemoryScope(kind="user", id="user_1"), backend=RecordingMemoryBackend())
+
+    assert json.loads(memory.get("missing")) == {"result": "not_found", "id": "missing"}
+
+    span = _span_by_name(_llmobs_spans(test_spans), "memory_get")
+    assert json.loads(get_llmobs_input_value(span)) == {"id": "missing"}
+    assert json.loads(get_llmobs_output_value(span)) == {"result": "not_found", "id": "missing"}
+    metadata = get_llmobs_metadata(span)
+    assert metadata["memory.id"] == "missing"
+    assert metadata["memory.result"] == "not_found"
+    assert metadata["memory.state"] == "not_found"
+    assert metadata["memory.count"] == 0
+
+
+def test_memory_persist_traces_source_provenance(llmobs, test_spans):
+    backend = RecordingMemoryBackend()
+    memory = Memory(scope=MemoryScope(kind="user", id="user_1"), backend=backend)
+
+    with llmobs.workflow("parent", session_id="sess_1"):
+        assert json.loads(memory.persist("User prefers washable cotton bedding."))["id"] == "mem_new"
+
+    spans = _llmobs_spans(test_spans)
+    span = _span_by_name(spans, "memory_persist")
+    source = backend.persist_calls[0][2]
+    assert source.agent["session_id"] == "sess_1"
+    assert source.agent["trace_id"] == get_llmobs_trace_id(span)
+    assert source.agent["span_id"] == str(span.span_id)
+    assert json.loads(get_llmobs_input_value(span)) == {"content": "User prefers washable cotton bedding."}
+    assert json.loads(get_llmobs_output_value(span))["state"] == "active"
+    assert get_llmobs_tags(span)["memory.op"] == "write"
+    assert get_llmobs_tags(span)["memory.action"] == "persist"
+    metadata = get_llmobs_metadata(span)
+    assert metadata["memory.id"] == "mem_new"
+    assert metadata["memory.source"] == "agent"
+    assert metadata["memory.state"] == "active"
+    assert metadata["memory.source.session_id"] == "sess_1"
+    assert metadata["memory.source.trace_id"] == get_llmobs_trace_id(span)
+    assert metadata["memory.source.span_id"] == str(span.span_id)
+
+
+def test_llmobs_memory_factory_requires_enabled_without_custom_backend():
+    with pytest.raises(MemoryNotConfiguredError, match="requires LLMObs.enable"):
+        llmobs_service.memory(scope=MemoryScope("user", "user_1"))
+
+    memory = llmobs_service.memory(scope=MemoryScope("user", "user_1"), backend=RecordingMemoryBackend())
+    assert isinstance(memory, Memory)
+
+
+def test_llmobs_memory_factory_uses_service_memory_client(tracer):
+    with override_global_config(dict(_dd_api_key="api-key", _dd_site="datadoghq.com", _llmobs_ml_app="shopping")):
+        llmobs_service.enable(_tracer=tracer, integrations_enabled=False, app_key="app-key", agentless_enabled=True)
+        try:
+            memory = llmobs_service.memory(scope=MemoryScope("user", "user_1"))
+            assert isinstance(memory.backend, DatadogMemoryBackend)
+            assert memory.backend._client is llmobs_service._instance._memory_client
+            assert memory.backend._client._api_key == "api-key"
+            assert memory.backend._client._app_key == "app-key"
+            assert memory.backend._ml_app == "shopping"
+        finally:
+            llmobs_service.disable()


### PR DESCRIPTION
## Description

**EARLY experiment** related to https://dd.enterprise.slack.com/archives/C0AV112KK41

Adds a first-class LLMObs memory package under `ddtrace.llmobs._memory` with public exports through `ddtrace.llmobs` and `ddtrace.llmobs.memory`.

The new package includes:
- `Memory`, `MemoryScope`, `MemoryRecord`, `MemoryLink`, and `MemorySource` models.
- Context-based memory scope helpers.
- `EmptyMemoryBackend` and `DatadogMemoryBackend` behind a shared `MemoryBackend` protocol.
- Framework-agnostic `memory_search`, `memory_get`, and `memory_persist` tool schemas.
- LLMObs tool-span tracing and metadata for search, get, and persist operations.
- `LLMObs.memory(...)` factory wiring and a synchronous memory API client.

## Testing

- Added focused unit coverage in `tests/llmobs/test_memory.py` for scope validation, public imports, operation validation, backend parsing, tool schemas, tracing annotations, and `LLMObs.memory(...)` wiring.
- `python -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in [...]]"`
- `git diff --cached --check`
- `scripts/run-tests --list ddtrace/llmobs/_memory.py ddtrace/llmobs/memory.py ddtrace/llmobs/_constants.py ddtrace/llmobs/_writer.py ddtrace/llmobs/_llmobs.py ddtrace/llmobs/__init__.py tests/llmobs/test_memory.py`
- `uv run python -c "import json; from ddtrace.llmobs import Memory, MemoryScope; from ddtrace.llmobs.memory import EmptyMemoryBackend; m=Memory(scope=MemoryScope('user','u1'), backend=EmptyMemoryBackend()); assert json.loads(m.search('tea')) == []; assert json.loads(m.get('missing')) == {'result': 'not_found', 'id': 'missing'}; print('memory import smoke ok')"`

Unable to complete before opening draft:
- `hatch run lint:fmt -- ...` failed because `hatch` is not installed locally.
- `scripts/ddtest hatch run lint:fmt -- ...` failed because Docker is not running.
- `scripts/run-tests --venv 642bd78 -- -- tests/llmobs/test_memory.py` selected the `llmobs::llmobs` suite but failed to start the required `testagent` service because Docker is not running.

## Risks

Low to moderate. The feature adds a new public LLMObs surface and backend client, but keeps backend behavior injectable and covered by tests. Live Datadog persistence depends on the backend persist endpoint being available.

## Additional Notes

A release note is included under `releasenotes/notes/`.

`ddtrace/llmobs/plan.md` is intentionally not included in this PR.