### PR TITLE
chore(crashtracker):  turn on collecting all threads crashtracker

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -120,6 +120,8 @@ def _get_args(additional_tags: Optional[dict[str, str]]):
         crashtracker_config.use_alt_stack,
         5000,  # timeout_ms
         stacktrace_resolver,
+        crashtracker_config.collect_all_threads,
+        crashtracker_config.max_threads,
         crashtracker_config.debug_url or agent_config.trace_agent_url,
         None,  # unix_socket_path
         crashtracker_config._test_token,

--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -1,3 +1,4 @@
+# pyright: reportPossiblyUnboundVariable=false
 import importlib.util
 import platform
 import sys
@@ -19,7 +20,8 @@ from ddtrace.internal.settings.profiling import config_str
 
 log = get_logger(__name__)
 
-is_available = True
+# Native bindings exist only when this import succeeds. Call sites gate on ``is_available``
+# or return immediately from ``_get_args`` when native is absent (pyright cannot prove that).
 try:
     from ddtrace.internal.native._native import CrashtrackerConfiguration
     from ddtrace.internal.native._native import CrashtrackerMetadata
@@ -29,7 +31,9 @@ try:
     from ddtrace.internal.native._native import crashtracker_init
     from ddtrace.internal.native._native import crashtracker_on_fork
     from ddtrace.internal.native._native import crashtracker_status
-except ImportError:
+
+    is_available = True
+except ImportError:  # pragma: no cover
     is_available = False
 
 
@@ -83,6 +87,9 @@ def _get_tags(additional_tags: Optional[dict[str, str]]) -> dict[str, str]:
 
 
 def _get_args(additional_tags: Optional[dict[str, str]]):
+    if not is_available:
+        return (None, None, None)
+
     # Instead of searching PATH for the receiver binary, invoke the receiver script
     # directly with the current Python interpreter. This is more reliable and doesn't
     # depend on PATH configuration.

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -79,6 +79,8 @@ class CrashtrackerConfiguration:
         use_alt_stack: bool,
         timeout_ms: int,
         resolve_frames: StacktraceCollection,
+        collect_all_threads: bool,
+        max_threads: int,
         endpoint: Optional[str] = None,
         unix_socket_path: Optional[str] = None,
         test_token: Optional[str] = None,

--- a/ddtrace/internal/settings/_agent.pyi
+++ b/ddtrace/internal/settings/_agent.pyi
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from ddtrace.internal.settings._core import DDConfig
+
+class AgentConfig(DDConfig):
+    trace_agent_url: str
+    dogstatsd_url: str
+    trace_agent_timeout_seconds: float
+    trace_native_span_events: bool
+    _trace_agent_hostname: Optional[str]
+    _trace_agent_port: Optional[int]
+    _trace_agent_url: Optional[str]
+    _dogstatsd_host: Optional[str]
+    _dogstatsd_port: Optional[int]
+    _dogstatsd_url: Optional[str]
+    _agent_host: Optional[str]
+    _agent_port: Optional[int]
+
+config: AgentConfig
+
+def get_agent_hostname() -> str: ...
+def get_agent_port() -> int: ...

--- a/ddtrace/internal/settings/crashtracker.py
+++ b/ddtrace/internal/settings/crashtracker.py
@@ -134,6 +134,22 @@ class CrashtrackingConfig(DDConfig):
         help="Whether to wait for the crashtracking receiver",
     )
 
+    collect_all_threads = DDConfig.v(
+        bool,
+        "collect_all_threads",
+        default=True,
+        help_type="Boolean",
+        help="Whether to collect stack traces from all threads when a crash is handled.",
+    )
+
+    max_threads = DDConfig.v(
+        int,
+        "max_threads",
+        default=128,
+        help_type="Integer",
+        help="Maximum number of threads to collect stack traces for when collect_all_threads is enabled.",
+    )
+
 
 config = CrashtrackingConfig()
 report_configuration(config)

--- a/ddtrace/internal/settings/crashtracker.pyi
+++ b/ddtrace/internal/settings/crashtracker.pyi
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from ddtrace.internal.settings._core import DDConfig
+
+class CrashtrackingConfig(DDConfig):
+    enabled: bool
+    debug_url: Optional[str]
+    _test_token: Optional[str]
+    stdout_filename: Optional[str]
+    stderr_filename: Optional[str]
+    use_alt_stack: bool
+    create_alt_stack: bool
+    stacktrace_resolver: Optional[str]
+    tags: dict[str, str]
+    wait_for_receiver: bool
+    collect_all_threads: bool
+    max_threads: int
+
+config: CrashtrackingConfig

--- a/src/native/crashtracker.rs
+++ b/src/native/crashtracker.rs
@@ -66,25 +66,29 @@ pub struct CrashtrackerConfigurationPy {
     config: Option<CrashtrackerConfiguration>,
 }
 
-// additional_files: Vec<String>,
-// create_alt_stack: bool,
-// use_alt_stack: bool,
-// endpoint: Option<Endpoint>,
-// resolve_frames: StacktraceCollection,
-// mut signals: Vec<i32>,
-// timeout_ms: u32,
-// unix_socket_path: Option<String>,
-
 #[pymethods]
 impl CrashtrackerConfigurationPy {
     #[new]
-    #[pyo3(signature = (additional_files, create_alt_stack, use_alt_stack, timeout_ms, resolve_frames, endpoint=None, unix_socket_path=None, test_token=None))]
+    #[pyo3(signature = (
+        additional_files,
+        create_alt_stack,
+        use_alt_stack,
+        timeout_ms,
+        resolve_frames,
+        collect_all_threads,
+        max_threads,
+        endpoint=None,
+        unix_socket_path=None,
+        test_token=None,
+    ))]
     pub fn new(
         additional_files: Vec<String>,
         create_alt_stack: bool,
         use_alt_stack: bool,
         timeout_ms: u64,
         resolve_frames: StacktraceCollectionPy,
+        collect_all_threads: bool,
+        max_threads: usize,
         endpoint: Option<&str>,
         unix_socket_path: Option<String>,
         test_token: Option<String>,
@@ -92,6 +96,8 @@ impl CrashtrackerConfigurationPy {
         let resolve_frames: StacktraceCollection = resolve_frames.into();
         let mut builder = CrashtrackerConfiguration::builder()
             .additional_files(additional_files)
+            .collect_all_threads(collect_all_threads)
+            .max_threads(max_threads)
             .create_alt_stack(create_alt_stack)
             .use_alt_stack(use_alt_stack)
             .timeout(Duration::from_millis(timeout_ms))

--- a/tests/crashtracker/test_crashtracker.py
+++ b/tests/crashtracker/test_crashtracker.py
@@ -512,6 +512,64 @@ def test_crashtracker_runtime_stacktrace_required(run_python_code_in_subprocess)
         assert "string_at" in json.dumps(message["experimental"])
 
 
+code_all_threads = """
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+import ctypes
+import sys
+import threading
+import time
+
+import ddtrace.auto
+
+_hold = threading.Event()
+
+def _set_os_thread_name(name: str) -> None:
+    # Crashtracker reads Linux task comm; set it explicitly (not only Thread.name).
+    libc = ctypes.CDLL("libc.so.6")
+    libc.pthread_self.restype = ctypes.c_void_p
+    libc.pthread_setname_np.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    libc.pthread_setname_np.restype = ctypes.c_int
+    libc.pthread_setname_np(libc.pthread_self(), name.encode("utf-8", "replace"))
+
+
+def _worker(name: str) -> None:
+    _set_os_thread_name(name)
+    _hold.wait()
+
+for i in range(3):
+    threading.Thread(target=_worker, args=(f"test_thread_{i}",), daemon=False).start()
+
+time.sleep(0.1)
+
+ctypes.string_at(0)
+sys.exit(-1)
+"""
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+def test_crashtracker_all_threads(run_python_code_in_subprocess):
+    service = "test_crashtracker_all_threads"
+    with utils.with_test_agent() as client:
+        env = os.environ.copy()
+        env["DD_SERVICE"] = service
+        stdout, stderr, exitcode, _ = run_python_code_in_subprocess(code_all_threads, env=env)
+
+        assert not stdout
+        assert not stderr
+        assert exitcode == -11
+
+        _ping = utils.get_crash_ping(client, service=service)
+
+        report = utils.get_crash_report(client, service=service)
+
+        assert b"test_thread_0" in report["body"]
+        assert b"test_thread_1" in report["body"]
+        assert b"test_thread_2" in report["body"]
+        assert b"string_at" in report["body"]
+
+
 # Subprocess code for test_crashtracker_native_extension_crash.
 #
 # Using C++ means the symbol is name-mangled in the binary

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -213,9 +213,11 @@ import opentelemetry
         {"name": "DD_CIVISIBILITY_ITR_ENABLED", "origin": "default", "value": True},
         {"name": "DD_CIVISIBILITY_LOG_LEVEL", "origin": "default", "value": "info"},
         {"name": "DD_CODE_ORIGIN_FOR_SPANS_ENABLED", "origin": "env_var", "value": False},
+        {"name": "DD_CRASHTRACKING_COLLECT_ALL_THREADS", "origin": "default", "value": True},
         {"name": "DD_CRASHTRACKING_CREATE_ALT_STACK", "origin": "default", "value": True},
         {"name": "DD_CRASHTRACKING_DEBUG_URL", "origin": "default", "value": None},
         {"name": "DD_CRASHTRACKING_ENABLED", "origin": "default", "value": True},
+        {"name": "DD_CRASHTRACKING_MAX_THREADS", "origin": "default", "value": 128},
         {
             "name": "DD_CRASHTRACKING_STACKTRACE_RESOLVER",
             "origin": "default",


### PR DESCRIPTION
## Description
Crashtracking now allows collection of all threads for crash reports. We should turn it on. Also adding `pyi` files for CT config

## Testing
```
{
  "threads": {
    "threads": [
      {
        "crashed": false,
        "name": "tokio-rt-worker",
        "state": "R",
        "stack": {
          "format": "Datadog Crashtracker 1.0",
          "incomplete": false,
          "frames": [
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000009a9ee"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000008f668"
            },
            "...",
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "function": "std::sys::thread::unix::Thread::new::thread_start"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x00000000001107f8"
            }
          ]
        }
      },
      {
        "crashed": false,
        "name": "tokio-rt-worker",
        "state": "S",
        "stack": {
          "format": "Datadog Crashtracker 1.0",
          "incomplete": false,
          "frames": [
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "function": "syscall"
            },
            {
              "path": "/_native.cpython-313-x86_64-linux-gnu.so",
              "function": "std::sys::sync::condvar::futex::Condvar::wait_optional_timeout",
              "file": "library/std/src/sys/sync/condvar/futex.rs",
              "line": 49
            },
            "...",
            {
              "path": "/_native.cpython-313-x86_64-linux-gnu.so",
              "function": "std::sys::thread::unix::Thread::new::thread_start",
              "file": "library/std/src/sys/thread/unix.rs",
              "line": 127
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x00000000001107f8"
            }
          ]
        }
      },
      {
        "crashed": false,
        "name": "RemoteConfigSub",
        "state": "R",
        "stack": {
          "format": "Datadog Crashtracker 1.0",
          "incomplete": false,
          "frames": [
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000009a9ee"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000008f668"
            },
            "...",
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x0000000000092b7b"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x00000000001107f8"
            }
          ]
        }
      },
      {
        "crashed": false,
        "name": "test_thread_0",
        "state": "S",
        "stack": {
          "format": "Datadog Crashtracker 1.0",
          "incomplete": false,
          "frames": [
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000009a9ee"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000008f668"
            },
            "...",
            {
              "path": "/home/bits/.pyenv/versions/3.13.11/lib/libpython3.13.so.1.0",
              "function": "pythread_wrapper",
              "file": "Python/thread_pthread.h",
              "line": 244
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x00000000001107f8"
            }
          ]
        }
      },
      {
        "crashed": false,
        "name": "test_thread_1",
        "state": "S",
        "stack": {
          "format": "Datadog Crashtracker 1.0",
          "incomplete": false,
          "frames": [
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000009a9ee"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000008f668"
            },
            "...",
            {
              "path": "/home/bits/.pyenv/versions/3.13.11/lib/libpython3.13.so.1.0",
              "function": "pythread_wrapper",
              "file": "Python/thread_pthread.h",
              "line": 244
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x00000000001107f8"
            }
          ]
        }
      },
      {
        "crashed": false,
        "name": "test_thread_2",
        "state": "S",
        "stack": {
          "format": "Datadog Crashtracker 1.0",
          "incomplete": false,
          "frames": [
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000009a9ee"
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x000000000008f668"
            },
            "...",
            {
              "path": "/home/bits/.pyenv/versions/3.13.11/lib/libpython3.13.so.1.0",
              "function": "pythread_wrapper",
              "file": "Python/thread_pthread.h",
              "line": 244
            },
            {
              "path": "/usr/lib/x86_64-linux-gnu/libc.so.6",
              "relative_address": "0x00000000001107f8"
            }
          ]
        }
      }
    ],
    "count": 6,
    "incomplete": false
  }
}
```

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
