### PR TITLE
refactor(profiling): safety improvements

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -5,8 +5,6 @@
 #include "profiler_state.hpp"
 #include "profiler_stats.hpp"
 
-#include <cerrno>   // errno
-#include <cstring>  // strerror
 #include <fstream>  // ofstream
 #include <sstream>  // ostringstream
 #include <unistd.h> // getpid
@@ -59,7 +57,7 @@ Datadog::Uploader::export_to_file(ddog_prof_EncodedProfile& encoded, std::string
 
     std::ofstream out(pprof_filename, std::ios::binary);
     if (!out.is_open()) {
-        std::cerr << "Error opening output file " << pprof_filename << ": " << strerror(errno) << std::endl;
+        std::cerr << "Error opening output file " << pprof_filename << std::endl;
         return false;
     }
 
@@ -72,7 +70,7 @@ Datadog::Uploader::export_to_file(ddog_prof_EncodedProfile& encoded, std::string
     }
     out.write(reinterpret_cast<const char*>(bytes_res.ok.ptr), static_cast<std::streamsize>(bytes_res.ok.len));
     if (out.fail()) {
-        std::cerr << "Error writing to output file " << pprof_filename << ": " << strerror(errno) << std::endl;
+        std::cerr << "Error writing to output file " << pprof_filename << std::endl;
         return false;
     }
 
@@ -80,8 +78,7 @@ Datadog::Uploader::export_to_file(ddog_prof_EncodedProfile& encoded, std::string
     std::ofstream out_internal_metadata(internal_metadata_filename);
     out_internal_metadata << internal_metadata_json;
     if (out_internal_metadata.fail()) {
-        std::cerr << "Error writing to internal metadata file " << internal_metadata_filename << ": " << strerror(errno)
-                  << std::endl;
+        std::cerr << "Error writing to internal metadata file " << internal_metadata_filename << std::endl;
         return false;
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -6,6 +6,7 @@
 #include <cerrno>
 #include <csetjmp>
 #include <cstdio>
+#include <pthread.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -58,8 +59,12 @@ segv_handler(int signo, siginfo_t*, void*)
     if (!t_handler_armed) {
         struct sigaction* old = (signo == SIGSEGV) ? &g_old_segv : &g_old_bus;
         // Restore the previous handler and re-raise so default/old handling occurs.
+        // Use pthread_kill(pthread_self(), signo): thread-directed (targets the
+        // faulting thread, which is guaranteed to be the current thread for
+        // synchronous signals like SIGSEGV/SIGBUS) and async-signal-safe per POSIX,
+        // unlike raise which acquires a lock internally.
         sigaction(signo, old, nullptr);
-        raise(signo);
+        pthread_kill(pthread_self(), signo);
         return;
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -52,7 +52,10 @@ create_thread_with_stack(size_t stack_size, Sampler* sampler, uint64_t seq_num)
         return 0;
     }
     if (stack_size > 0) {
-        pthread_attr_setstacksize(&attr, stack_size);
+        if (pthread_attr_setstacksize(&attr, stack_size) != 0) {
+            std::cerr << "Failed to set sampling thread stack size (" << stack_size << " bytes): " << strerror(errno)
+                      << std::endl;
+        }
     }
 
     pthread_t thread_id{ 0 };


### PR DESCRIPTION
## Description

Code safety  improvements in the Profiling codebase. 
- Use `pthread_kill` instead of `raise` in our fault handler; `raise` is not async-signal-safe whereas `pthread_kill` is (and it _does_ target the faulting thread)
- Do not try to use `strerr` or `errno` when `ofstream` is not open since `ofstream` doesn't necessarily set them
- Check the return code for `pthread_attr_setstacksize` and log an error when it fails 
