### PR TITLE
refactor(iast): code safety and memory improvements

### DIFF
--- a/ddtrace/appsec/_iast/_ast/iastpatch.c
+++ b/ddtrace/appsec/_iast/_ast/iastpatch.c
@@ -250,7 +250,7 @@ static int
 str_in_list(const char* needle, const char** list, size_t count)
 {
     for (size_t i = 0; i < count; i++) {
-        if (strncmp(needle, list[i], strlen(list[i])) == 0) {
+        if (list[i] && strncmp(needle, list[i], strlen(list[i])) == 0) {
             return 1;
         }
     }
@@ -352,13 +352,21 @@ get_list_from_env(const char* env_var_name, size_t* count)
                 return NULL;
             }
             env_copy = strdup(env_value);
-            if (!env_copy)
+            if (!env_copy) {
+                free(modules_list);
+                modules_list = NULL;
                 return NULL;
+            }
             count_tmp = 0;
             token = strtok(env_copy, ",");
             while (token) {
                 char* dup = strdup(token);
                 if (!dup) {
+                    for (size_t j = 0; j < count_tmp; j++) {
+                        free(modules_list[j]);
+                    }
+                    free(modules_list);
+                    modules_list = NULL;
                     free(env_copy);
                     return NULL;
                 }
@@ -408,7 +416,12 @@ init_globals(void)
         return -1;
     }
 
-    builtin_count = (size_t)PyTuple_Size(builtin_names);
+    /* PyTuple_Size returns -1 on error; guard before casting to size_t */
+    Py_ssize_t builtin_count_s = PyTuple_Size(builtin_names);
+    if (builtin_count_s < 0) {
+        return -1;
+    }
+    builtin_count = (size_t)builtin_count_s;
     builtins_denylist_count = static_stdlib_denylist_count + builtin_count;
 
     builtins_denylist = (char**)malloc(builtins_denylist_count * sizeof(char*));
@@ -416,11 +429,19 @@ init_globals(void)
         PyErr_NoMemory();
         return -1;
     }
+    /* Initialize all entries to NULL so str_in_list never reads garbage */
+    memset(builtins_denylist, 0, builtins_denylist_count * sizeof(char*));
+
     /* Copy static stdlib names */
     for (i = 0; i < static_stdlib_denylist_count; i++) {
         char* dup = strdup(static_stdlib_denylist[i]);
-        if (!dup)
+        if (!dup) {
+            PyErr_NoMemory();
+            free_list(builtins_denylist, builtins_denylist_count);
+            builtins_denylist = NULL;
+            builtins_denylist_count = 0;
             return -1;
+        }
         for (char* p = dup; *p; p++) {
             *p = tolower(*p);
         }
@@ -430,17 +451,23 @@ init_globals(void)
     /* Copy built-in module names */
     for (size_t i = 0; i < builtin_count; i++) {
         PyObject* item = PyTuple_GetItem(builtin_names, i); /* borrowed reference */
-        if (PyUnicode_Check(item)) {
+        if (item && PyUnicode_Check(item)) {
             const char* s = PyUnicode_AsUTF8(item);
             if (s) {
                 char* dup = strdup(s);
-                if (!dup)
+                if (!dup) {
+                    PyErr_NoMemory();
+                    free_list(builtins_denylist, builtins_denylist_count);
+                    builtins_denylist = NULL;
+                    builtins_denylist_count = 0;
                     return -1;
+                }
                 for (char* p = dup; *p; p++) {
                     *p = tolower(*p);
                 }
                 builtins_denylist[static_stdlib_denylist_count + i] = dup;
             }
+            /* NULL entries left as NULL (from memset above) when s is NULL */
         }
     }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_extend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_extend.cpp
@@ -32,12 +32,14 @@ api_extend_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
     auto ctx_map = safe_get_tainted_object_map_from_list_of_pyobjects({ candidate_text, to_add });
     if (not ctx_map or ctx_map->empty()) {
         auto method_name = PyUnicode_FromString("extend");
-        PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
-        if (has_pyerr()) {
-            Py_DecRef(method_name);
+        if (method_name == nullptr) {
             return nullptr;
         }
+        PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
         Py_DecRef(method_name);
+        if (has_pyerr()) {
+            return nullptr;
+        }
     } else {
         const auto& to_candidate = get_tainted_object(candidate_text, ctx_map);
         auto to_result = safe_allocate_tainted_object_copy(to_candidate);
@@ -45,12 +47,14 @@ api_extend_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
 
         // Ensure no returns are done before this method call
         auto method_name = PyUnicode_FromString("extend");
-        PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
-        if (has_pyerr()) {
-            Py_DecRef(method_name);
+        if (method_name == nullptr) {
             return nullptr;
         }
+        PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
         Py_DecRef(method_name);
+        if (has_pyerr()) {
+            return nullptr;
+        }
 
         if (to_result == nullptr) {
             Py_RETURN_NONE;

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_format.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_format.cpp
@@ -59,6 +59,9 @@ api_format_aspect(StrType& candidate_text,
     StrType result_text = get<0>(result);
     TaintRangeRefs result_ranges = get<1>(result);
     PyObject* new_result = new_pyobject_id(result_text.ptr());
+    if (new_result == nullptr) {
+        return result_text;
+    }
     set_ranges(new_result, result_ranges, tx_map);
     return py::reinterpret_steal<StrType>(new_result);
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_join.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_join.cpp
@@ -154,6 +154,10 @@ api_join_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
         if (iterator != nullptr) {
             PyObject* item;
             PyObject* list_aux = PyList_New(0);
+            if (list_aux == nullptr) {
+                Py_DECREF(iterator);
+                return nullptr;
+            }
             while ((item = PyIter_Next(iterator))) {
                 PyList_Append(list_aux, item);
                 Py_DECREF(item);

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_operator_add.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_operator_add.cpp
@@ -48,6 +48,9 @@ add_aspect(PyObject* result_o,
 
     if (!to_candidate_text) {
         const auto tainted = safe_allocate_tainted_object();
+        if (tainted == nullptr) {
+            return result_o;
+        }
         tainted->add_ranges_shifted(to_text_to_add, static_cast<RANGE_START>(len_candidate_text));
         set_tainted_object(result_o, tainted, tx_taint_map);
         return result_o;
@@ -56,6 +59,9 @@ add_aspect(PyObject* result_o,
     // At this point we have both to_candidate_text and to_text_to_add so we add the
     // ranges from both to result_o
     const auto tainted = safe_allocate_tainted_object_copy(to_candidate_text);
+    if (tainted == nullptr) {
+        return result_o;
+    }
     tainted->add_ranges_shifted(to_text_to_add, static_cast<RANGE_START>(len_candidate_text));
     set_tainted_object(result_o, tainted, tx_taint_map);
 

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_str.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_str.cpp
@@ -35,8 +35,8 @@ call_original_function(PyObject* orig_function,
     py::args py_args(py_args_list);
 
     PyObject* kwargs = kwnames_to_kwargs(args, nargs, kwnames);
-    auto res = PyObject_Call(orig_function, py_args.ptr(), kwnames_to_kwargs(args, nargs, kwnames));
-    Py_DECREF(kwargs);
+    auto res = PyObject_Call(orig_function, py_args.ptr(), kwargs);
+    Py_XDECREF(kwargs);
     return res;
 }
 
@@ -166,7 +166,13 @@ api_str_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs, Py
         }
 
         const char* encoding = has_encoding ? PyUnicode_AsUTF8(pyo_encoding) : "utf-8";
+        if (has_encoding && encoding == nullptr) {
+            return nullptr; // PyUnicode_AsUTF8 failed; exception already set
+        }
         const char* errors = has_errors ? PyUnicode_AsUTF8(pyo_errors) : "strict";
+        if (has_errors && errors == nullptr) {
+            return nullptr; // PyUnicode_AsUTF8 failed; exception already set
+        }
         result_o = PyUnicode_Decode(text_raw_bytes, text_raw_bytes_size, encoding, errors);
 
         if (PyErr_Occurred()) {

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/helpers.cpp
@@ -135,7 +135,9 @@ api_convert_escaped_text_to_taint_text(const py::bytearray& taint_escaped_text, 
 
     const std::tuple result = convert_escaped_text_to_taint_text<py::bytes>(bytes_text, ranges_orig);
     PyObject* new_result = new_pyobject_id((py::bytearray() + get<0>(result)).ptr());
-
+    if (new_result == nullptr) {
+        return taint_escaped_text;
+    }
     set_ranges(new_result, get<1>(result), tx_map);
 
     return py::reinterpret_steal<py::bytearray>(new_result);
@@ -153,7 +155,9 @@ api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, const 
     }
     auto [result_text, result_ranges] = convert_escaped_text_to_taint_text<StrType>(taint_escaped_text, ranges_orig);
     PyObject* new_result = new_pyobject_id(result_text.ptr());
-
+    if (new_result == nullptr) {
+        return taint_escaped_text;
+    }
     set_ranges(new_result, result_ranges, tx_map);
     return py::reinterpret_steal<StrType>(new_result);
 }
@@ -256,8 +260,10 @@ convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, const Tain
                     id_evidence = get<0>(previous_context);
                     const shared_ptr<TaintRange>& original_range =
                       get_range_by_hash(getNum(id_evidence), optional_ranges_orig);
-                    ranges.emplace_back(
-                      safe_allocate_taint_range(start, length, original_range->source, original_range->secure_marks));
+                    if (original_range != nullptr) {
+                        ranges.emplace_back(safe_allocate_taint_range(
+                          start, length, original_range->source, original_range->secure_marks));
+                    }
                 }
                 latest_end = end;
             }
@@ -288,8 +294,10 @@ convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, const Tain
                 id_evidence = get<0>(context);
                 const shared_ptr<TaintRange>& original_range =
                   get_range_by_hash(getNum(id_evidence), optional_ranges_orig);
-                ranges.emplace_back(
-                  safe_allocate_taint_range(start, end - start, original_range->source, original_range->secure_marks));
+                if (original_range != nullptr) {
+                    ranges.emplace_back(safe_allocate_taint_range(
+                      start, end - start, original_range->source, original_range->secure_marks));
+                }
             }
             latest_end = end;
         }

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/helpers.h
@@ -201,6 +201,9 @@ process_flag_added_args(PyObject* orig_function, const int flag_added_args, PyOb
         if (flag_added_args > 0) {
             const Py_ssize_t num_args = PyTuple_Size(args);
             PyObject* sliced_args = PyTuple_New(num_args - flag_added_args);
+            if (sliced_args == nullptr) {
+                return nullptr;
+            }
             for (Py_ssize_t i = 0; i < num_args - flag_added_args; ++i) {
                 // PyTuple_SET_ITEM(sliced_args, i, PyTuple_GET_ITEM(args, i + flag_added_args));
                 PyObject* item = PyTuple_GetItem(args, i + flag_added_args);


### PR DESCRIPTION
## Description

This PR updates the AppSec code to harden it against previously-unhandled errors:
- Uninitialized `builtins_denylist` entries read by `str_in_list`
- `strdup` failure returns -1 without `PyErr_NoMemory` call
- `PyList_New returning` NULL but proceeding with `PyList_Append`
- `PyUnicode_FromString` returning NULL being passed to `PyObject_CallMethodObjArgs`
- `new_pyobject_id` returning NULL but being used for `set_ranges`
- `PyTuple_New` returning NULL but being used for `PyTuple_SET_ITEM`
- `safe_allocate_tainted_object` unchecked NULL values
- `get_range_by_hash` unchecked nullptr dereference
- `PyTuple_Size` error -1 cast to `SIZE_MAX`, hiding original exception
- NULL `PyUnicode_AsUTF8` silently becomes default encoding
- Duplicate call to `kwnames_to_kwargs` resulting in one leaked dict every call
- `modules_list` and `strdup`'d tokens leaked on `strdup` error paths
