### PR TITLE
refactor(internal): safety improvements in threads

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -172,18 +172,26 @@ class GILGuard
     inline GILGuard(module_state* state)
       : _mstate(state)
     {
-        if (!_mstate->is_finalizing())
+        if (!_mstate->is_finalizing()) {
             _gil_state = PyGILState_Ensure();
+            _acquired = true;
+        }
     }
     inline ~GILGuard()
     {
-        if (!_mstate->is_finalizing() && PyGILState_Check())
+        if (_acquired && !_mstate->is_finalizing() && PyGILState_Check())
             PyGILState_Release(_gil_state);
     }
 
+    GILGuard(const GILGuard&) = delete;
+    GILGuard& operator=(const GILGuard&) = delete;
+    GILGuard(GILGuard&&) = delete;
+    GILGuard& operator=(GILGuard&&) = delete;
+
   private:
     module_state* _mstate;
-    PyGILState_STATE _gil_state;
+    PyGILState_STATE _gil_state{ PyGILState_UNLOCKED };
+    bool _acquired{ false };
 };
 
 // ----------------------------------------------------------------------------
@@ -206,6 +214,11 @@ class AllowThreads
         if (_thread_state != nullptr && !_mstate->is_finalizing())
             PyEval_RestoreThread(_thread_state);
     }
+
+    AllowThreads(const AllowThreads&) = delete;
+    AllowThreads& operator=(const AllowThreads&) = delete;
+    AllowThreads(AllowThreads&&) = delete;
+    AllowThreads& operator=(AllowThreads&&) = delete;
 
   private:
     module_state* _mstate;

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -66,7 +66,8 @@ truncate_at_class_name(char* dest, size_t dest_size, const char* name)
 
     // If the name fits, just copy it
     if (name_len < dest_size) {
-        strcpy(dest, name);
+        strncpy(dest, name, dest_size - 1);
+        dest[dest_size - 1] = '\0';
         return;
     }
 
@@ -79,7 +80,8 @@ truncate_at_class_name(char* dest, size_t dest_size, const char* name)
 
         // If the class name fits, use it; otherwise truncate it
         if (class_name_len < dest_size) {
-            strcpy(dest, class_name);
+            strncpy(dest, class_name, dest_size - 1);
+            dest[dest_size - 1] = '\0';
         } else {
             strncpy(dest, class_name, dest_size - 1);
             dest[dest_size - 1] = '\0';
@@ -199,13 +201,15 @@ class AllowThreads
     }
     inline ~AllowThreads()
     {
-        if (!_mstate->is_finalizing())
+        // Only restore if we actually saved: _thread_state is non-null iff
+        // is_finalizing() was false when the constructor ran.
+        if (_thread_state != nullptr && !_mstate->is_finalizing())
             PyEval_RestoreThread(_thread_state);
     }
 
   private:
     module_state* _mstate;
-    PyThreadState* _thread_state;
+    PyThreadState* _thread_state{ nullptr };
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This fixes two issues:
- Stop using `strcpy` (replaced with `strncpy`) -- probably OK in practice but just to be safe
- Make sure we never call `PyEval_RestoreThread` with a garbage pointer with would be undefined behaviour. We now set `_thread_state` to `nullptr` upon construction (we only set it to a non-null value if we do `PyEval_SaveThread`), and we check that the Thread State pointer is non-null before restoring state at destruction.

I also (as suggested by Brett/Claude) explicitly `= delete`'d copy constructors for `GILGuard` and `AllowThreads` since we wouldn't want to double-release the GIL or whatnot. We don't have this problem today, but I guess safety never hurts.