### PR TITLE
chore: bump 4.9.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.0rc1"
+version = "4.9.0rc2"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Bump pyproject.toml to 4.9.0rc2.

Generated by `scripts/gh/create_gh_release_rc.py bump-rc`.
Once merged, run `scripts/gh/create_gh_release_rc.py draft-release` to create the GitHub draft.