### PR TITLE
feat(rand): use OS entropy in Lambda MicroVMs

### DIFF
--- a/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
+++ b/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
@@ -1,10 +1,10 @@
 ---
 features:
   - |
-    tracing: Adds the ``DD_TRACE_SECURE_RANDOM`` environment variable. When set to ``true``,
-    trace and span ID generation uses the operating system's cryptographic random number
-    generator (``getrandom(2)``) instead of the default fast pseudo-random number generator.
-    This guarantees ID uniqueness in environments where process memory may be duplicated after
-    seeding, such as VM snapshots or cloned containers, where the existing fork-safety reseed
-    hook cannot detect the duplication. Set ``DD_TRACE_SECURE_RANDOM=true`` to enable this
-    behavior at the cost of a small per-ID system call overhead.
+    tracing: Trace and span ID generation now automatically uses the operating system's
+    cryptographic random number generator (``getrandom(2)``) when running inside an AWS Lambda
+    MicroVM environment (detected via the ``AWS_LAMBDA_MICROVM_IMAGE_ARN`` environment variable).
+    This guarantees ID uniqueness in Firecracker-based environments where process memory is
+    cloned from a snapshot, and the existing fork-safety reseed hook cannot detect the
+    duplication. No configuration is required; the behavior activates automatically when
+    ``AWS_LAMBDA_MICROVM_IMAGE_ARN`` is set and non-empty. #18017

--- a/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
+++ b/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    tracing: Adds the ``DD_TRACE_SECURE_RANDOM`` environment variable. When set to ``true``,
+    trace and span ID generation uses the operating system's cryptographic random number
+    generator (``getrandom(2)``) instead of the default fast pseudo-random number generator.
+    This guarantees ID uniqueness in environments where process memory may be duplicated after
+    seeding, such as VM snapshots or cloned containers, where the existing fork-safety reseed
+    hook cannot detect the duplication. Set ``DD_TRACE_SECURE_RANDOM=true`` to enable this
+    behavior at the cost of a small per-ID system call overhead.

--- a/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
+++ b/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
@@ -1,10 +1,5 @@
 ---
 features:
   - |
-    tracing: Trace and span ID generation now automatically uses the operating system's
-    cryptographic random number generator (``getrandom(2)``) when running inside an AWS Lambda
-    MicroVM environment (detected via the ``AWS_LAMBDA_MICROVM_IMAGE_ARN`` environment variable).
-    This prevents deterministic ID duplication across Firecracker-based environments where process
-    memory is cloned from a snapshot, and the existing fork-safety reseed hook cannot detect the
-    duplication. No configuration is required; the behavior activates automatically when
-    ``AWS_LAMBDA_MICROVM_IMAGE_ARN`` is set and non-empty. #18017
+    tracing: Trace and span IDs are now generated more safely in AWS Lambda MicroVM environments,
+    reducing the risk of duplicate IDs. No configuration is required. #18017

--- a/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
+++ b/releasenotes/notes/add-dd-trace-secure-random-94df95219b33f509.yaml
@@ -4,7 +4,7 @@ features:
     tracing: Trace and span ID generation now automatically uses the operating system's
     cryptographic random number generator (``getrandom(2)``) when running inside an AWS Lambda
     MicroVM environment (detected via the ``AWS_LAMBDA_MICROVM_IMAGE_ARN`` environment variable).
-    This guarantees ID uniqueness in Firecracker-based environments where process memory is
-    cloned from a snapshot, and the existing fork-safety reseed hook cannot detect the
+    This prevents deterministic ID duplication across Firecracker-based environments where process
+    memory is cloned from a snapshot, and the existing fork-safety reseed hook cannot detect the
     duplication. No configuration is required; the behavior activates automatically when
     ``AWS_LAMBDA_MICROVM_IMAGE_ARN`` is set and non-empty. #18017

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -1,14 +1,17 @@
 use pyo3::{prelude::*, types::PyModule};
-use rand::{rngs::{OsRng, SmallRng}, Rng, TryRngCore, SeedableRng};
+use rand::{
+    rngs::{OsRng, SmallRng},
+    Rng, SeedableRng, TryRngCore,
+};
 use std::cell::RefCell;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-static SECURE_RANDOM: OnceLock<bool> = OnceLock::new();
+// Set once at module init from DD_TRACE_SECURE_RANDOM; reads are a single Relaxed load.
+static SECURE_RANDOM: AtomicBool = AtomicBool::new(false);
 
+#[inline]
 fn secure_random() -> bool {
-    *SECURE_RANDOM.get_or_init(|| {
-        std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true")
-    })
+    SECURE_RANDOM.load(Ordering::Relaxed)
 }
 
 struct RngState {
@@ -74,30 +77,91 @@ pub fn generate_128bit_trace_id() -> u128 {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    // Serialize tests that mutate SECURE_RANDOM so they don't interfere with each other.
+    static SECURE_RANDOM_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    // Run `f` with SECURE_RANDOM set to `enabled`, restoring false even on panic.
+    fn with_secure_random<F: FnOnce()>(enabled: bool, f: F) {
+        let _guard = SECURE_RANDOM_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        SECURE_RANDOM.store(enabled, Ordering::Relaxed);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        SECURE_RANDOM.store(false, Ordering::Relaxed);
+        result.unwrap();
+    }
 
     // ── secure_random() ──────────────────────────────────────────────────────
 
     #[test]
     fn test_secure_random_returns_bool() {
-        // OnceLock is initialised once per process; just verify no panic.
+        // AtomicBool defaults to false; just verify the load doesn't panic.
         let v = secure_random();
         assert!(v == true || v == false);
     }
 
-    // ── rand64bits() ─────────────────────────────────────────────────────────
+    #[test]
+    fn test_secure_random_flag_reflects_stored_value() {
+        with_secure_random(true, || {
+            assert!(
+                secure_random(),
+                "secure_random() should return true after storing true"
+            );
+        });
+        assert!(
+            !secure_random(),
+            "secure_random() should return false after restoring false"
+        );
+    }
+
+    // ── rand64bits() — SmallRng path (SECURE_RANDOM = false) ─────────────────
 
     #[test]
     fn test_rand64bits_unique_values() {
         // 2^-64 ≈ 5e-20 collision probability per pair; 1000 samples is safe.
         let values: HashSet<u64> = (0..1000).map(|_| rand64bits()).collect();
-        assert!(values.len() > 990, "Expected unique rand64bits values, got {} distinct in 1000", values.len());
+        assert!(
+            values.len() > 990,
+            "Expected unique rand64bits values, got {} distinct in 1000",
+            values.len()
+        );
     }
 
     #[test]
     fn test_rand64bits_uses_full_range() {
         // If the RNG were stuck below 2^32, none of the high 32 bits would be set.
         let any_high_bit_set = (0..100).any(|_| rand64bits() >> 32 != 0);
-        assert!(any_high_bit_set, "rand64bits never set bits above 32 — RNG range is too narrow");
+        assert!(
+            any_high_bit_set,
+            "rand64bits never set bits above 32 — RNG range is too narrow"
+        );
+    }
+
+    // ── rand64bits() — OsRng path (SECURE_RANDOM = true) ─────────────────────
+
+    #[test]
+    fn test_rand64bits_osrng_path_produces_varied_values() {
+        with_secure_random(true, || {
+            let values: HashSet<u64> = (0..100).map(|_| rand64bits()).collect();
+            assert!(
+                values.len() > 90,
+                "OsRng path in rand64bits produced insufficient diversity: {} distinct in 100",
+                values.len()
+            );
+        });
+    }
+
+    #[test]
+    fn test_rand64bits_osrng_path_uses_full_range() {
+        with_secure_random(true, || {
+            let any_high_bit_set = (0..100).any(|_| rand64bits() >> 32 != 0);
+            assert!(
+                any_high_bit_set,
+                "OsRng path in rand64bits never set bits above 32"
+            );
+        });
     }
 
     // ── seed() ───────────────────────────────────────────────────────────────
@@ -115,7 +179,11 @@ mod tests {
     #[test]
     fn test_osrng_produces_varied_values() {
         let values: HashSet<u64> = (0..100).map(|_| OsRng.try_next_u64().unwrap()).collect();
-        assert!(values.len() > 90, "Expected diverse values from OsRng, got {}", values.len());
+        assert!(
+            values.len() > 90,
+            "Expected diverse values from OsRng, got {}",
+            values.len()
+        );
     }
 
     // ── generate_128bit_trace_id() ───────────────────────────────────────────
@@ -128,8 +196,14 @@ mod tests {
         let timestamp = (id >> 96) as u32;
         // 2020-01-01T00:00:00Z = 1_577_836_800
         // 2100-01-01T00:00:00Z = 4_102_444_800
-        assert!(timestamp > 1_577_836_800, "timestamp {timestamp} is before 2020");
-        assert!(timestamp < 4_102_444_800, "timestamp {timestamp} is after 2100");
+        assert!(
+            timestamp > 1_577_836_800,
+            "timestamp {timestamp} is before 2020"
+        );
+        assert!(
+            timestamp < 4_102_444_800,
+            "timestamp {timestamp} is after 2100"
+        );
     }
 
     #[test]
@@ -138,26 +212,45 @@ mod tests {
         for _ in 0..20 {
             let id = generate_128bit_trace_id();
             let middle = ((id >> 64) & 0xFFFF_FFFF) as u32;
-            assert_eq!(middle, 0, "middle 32 bits of trace ID should be zero, got {id:#034x}");
+            assert_eq!(
+                middle, 0,
+                "middle 32 bits of trace ID should be zero, got {id:#034x}"
+            );
         }
     }
 
     #[test]
     fn test_trace_id_low_bits_vary() {
         // The low 64 bits carry the random payload; they must not be constant.
-        let lows: HashSet<u64> = (0..100).map(|_| generate_128bit_trace_id() as u64).collect();
-        assert!(lows.len() > 90, "Low 64 bits of trace IDs are not random enough: {} distinct in 100", lows.len());
+        let lows: HashSet<u64> = (0..100)
+            .map(|_| generate_128bit_trace_id() as u64)
+            .collect();
+        assert!(
+            lows.len() > 90,
+            "Low 64 bits of trace IDs are not random enough: {} distinct in 100",
+            lows.len()
+        );
     }
 
     #[test]
     fn test_trace_id_ids_are_unique() {
         let ids: HashSet<u128> = (0..1000).map(|_| generate_128bit_trace_id()).collect();
-        assert!(ids.len() > 990, "Expected unique trace IDs, got {} distinct in 1000", ids.len());
+        assert!(
+            ids.len() > 990,
+            "Expected unique trace IDs, got {} distinct in 1000",
+            ids.len()
+        );
     }
 }
 
 /// Register the rand module functions and set up fork safety.
 pub fn register_rand(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Read DD_TRACE_SECURE_RANDOM once here so rand64bits() pays only a Relaxed load.
+    SECURE_RANDOM.store(
+        std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true"),
+        Ordering::Relaxed,
+    );
+
     m.add_function(wrap_pyfunction!(seed, m)?)?;
     m.add_function(wrap_pyfunction!(rand64bits, m)?)?;
     m.add_function(wrap_pyfunction!(generate_128bit_trace_id, m)?)?;

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -1,6 +1,15 @@
 use pyo3::{prelude::*, types::PyModule};
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{rngs::{OsRng, SmallRng}, Rng, TryRngCore, SeedableRng};
 use std::cell::RefCell;
+use std::sync::OnceLock;
+
+static SECURE_RANDOM: OnceLock<bool> = OnceLock::new();
+
+fn secure_random() -> bool {
+    *SECURE_RANDOM.get_or_init(|| {
+        std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true")
+    })
+}
 
 struct RngState {
     rng: SmallRng,
@@ -45,6 +54,9 @@ pub fn seed() {
 /// Generate a random 64-bit unsigned integer.
 #[pyfunction]
 pub fn rand64bits() -> u64 {
+    if secure_random() {
+        return OsRng.try_next_u64().expect("OsRng failed");
+    }
     RNG.with(|rng| rng.borrow_mut().gen())
 }
 
@@ -56,6 +68,92 @@ pub fn generate_128bit_trace_id() -> u128 {
         .unwrap_or_default()
         .as_secs() as u128;
     (timestamp << 96) | (rand64bits() as u128)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    // ── secure_random() ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_secure_random_returns_bool() {
+        // OnceLock is initialised once per process; just verify no panic.
+        let v = secure_random();
+        assert!(v == true || v == false);
+    }
+
+    // ── rand64bits() ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_rand64bits_unique_values() {
+        // 2^-64 ≈ 5e-20 collision probability per pair; 1000 samples is safe.
+        let values: HashSet<u64> = (0..1000).map(|_| rand64bits()).collect();
+        assert!(values.len() > 990, "Expected unique rand64bits values, got {} distinct in 1000", values.len());
+    }
+
+    #[test]
+    fn test_rand64bits_uses_full_range() {
+        // If the RNG were stuck below 2^32, none of the high 32 bits would be set.
+        let any_high_bit_set = (0..100).any(|_| rand64bits() >> 32 != 0);
+        assert!(any_high_bit_set, "rand64bits never set bits above 32 — RNG range is too narrow");
+    }
+
+    // ── seed() ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_seed_does_not_break_rng() {
+        // seed() reseeds the thread-local SmallRng; verify it still produces values.
+        seed();
+        let values: HashSet<u64> = (0..10).map(|_| rand64bits()).collect();
+        assert!(!values.is_empty());
+    }
+
+    // ── OsRng ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_osrng_produces_varied_values() {
+        let values: HashSet<u64> = (0..100).map(|_| OsRng.try_next_u64().unwrap()).collect();
+        assert!(values.len() > 90, "Expected diverse values from OsRng, got {}", values.len());
+    }
+
+    // ── generate_128bit_trace_id() ───────────────────────────────────────────
+
+    #[test]
+    fn test_trace_id_timestamp_in_high_bits() {
+        // Format: [32-bit unix seconds][32 zeros][64 random bits]
+        // Top 32 bits must be a plausible Unix timestamp.
+        let id = generate_128bit_trace_id();
+        let timestamp = (id >> 96) as u32;
+        // 2020-01-01T00:00:00Z = 1_577_836_800
+        // 2100-01-01T00:00:00Z = 4_102_444_800
+        assert!(timestamp > 1_577_836_800, "timestamp {timestamp} is before 2020");
+        assert!(timestamp < 4_102_444_800, "timestamp {timestamp} is after 2100");
+    }
+
+    #[test]
+    fn test_trace_id_middle_bits_zero() {
+        // Bits 95-64 (the 32 bits after the timestamp) must always be zero per the spec.
+        for _ in 0..20 {
+            let id = generate_128bit_trace_id();
+            let middle = ((id >> 64) & 0xFFFF_FFFF) as u32;
+            assert_eq!(middle, 0, "middle 32 bits of trace ID should be zero, got {id:#034x}");
+        }
+    }
+
+    #[test]
+    fn test_trace_id_low_bits_vary() {
+        // The low 64 bits carry the random payload; they must not be constant.
+        let lows: HashSet<u64> = (0..100).map(|_| generate_128bit_trace_id() as u64).collect();
+        assert!(lows.len() > 90, "Low 64 bits of trace IDs are not random enough: {} distinct in 100", lows.len());
+    }
+
+    #[test]
+    fn test_trace_id_ids_are_unique() {
+        let ids: HashSet<u128> = (0..1000).map(|_| generate_128bit_trace_id()).collect();
+        assert!(ids.len() > 990, "Expected unique trace IDs, got {} distinct in 1000", ids.len());
+    }
 }
 
 /// Register the rand module functions and set up fork safety.

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -6,13 +6,16 @@ use rand::{
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-// Set once at module init (Release) from DD_TRACE_SECURE_RANDOM; every read is an Acquire
-// load so the store is visible to threads that did not participate in module import.
+// Set once at module init (Release) when a MicroVM environment is detected; every read is an
+// Acquire load so the store is visible to threads that did not participate in module import.
 static SECURE_RANDOM: AtomicBool = AtomicBool::new(false);
 
-// Matches ddtrace's asbool() convention: "true", "True", "TRUE", and "1" are all truthy.
-fn parse_bool_env(val: Option<String>) -> bool {
-    val.map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
+// Returns true when running inside a Firecracker/Lambda MicroVM where process memory can be
+// cloned from a snapshot, making SmallRng state deterministic across resumed instances.
+// AWS Lambda sets AWS_LAMBDA_MICROVM_IMAGE_ARN in all MicroVM-based invocations.
+fn is_microvm_environment() -> bool {
+    std::env::var("AWS_LAMBDA_MICROVM_IMAGE_ARN")
+        .map(|v| !v.is_empty())
         .unwrap_or(false)
 }
 
@@ -100,29 +103,45 @@ mod tests {
         result.unwrap();
     }
 
-    // ── parse_bool_env() ─────────────────────────────────────────────────────
+    // Serialize tests that mutate env vars to avoid races between parallel test threads.
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    // ── is_microvm_environment() ──────────────────────────────────────────────
 
     #[test]
-    fn test_parse_bool_env_truthy_values() {
-        for val in &["true", "True", "TRUE", "1"] {
-            assert!(
-                parse_bool_env(Some(val.to_string())),
-                "expected parse_bool_env({val:?}) == true"
-            );
-        }
+    fn test_is_microvm_environment_when_set() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var(
+            "AWS_LAMBDA_MICROVM_IMAGE_ARN",
+            "arn:aws:lambda:us-east-1::runtime:python3.12",
+        );
+        let result = is_microvm_environment();
+        std::env::remove_var("AWS_LAMBDA_MICROVM_IMAGE_ARN");
+        assert!(
+            result,
+            "expected is_microvm_environment() == true when ARN is set"
+        );
     }
 
     #[test]
-    fn test_parse_bool_env_falsy_values() {
-        for val in &["false", "False", "FALSE", "0", "yes", ""] {
-            assert!(
-                !parse_bool_env(Some(val.to_string())),
-                "expected parse_bool_env({val:?}) == false"
-            );
-        }
+    fn test_is_microvm_environment_when_empty() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("AWS_LAMBDA_MICROVM_IMAGE_ARN", "");
+        let result = is_microvm_environment();
+        std::env::remove_var("AWS_LAMBDA_MICROVM_IMAGE_ARN");
         assert!(
-            !parse_bool_env(None),
-            "expected parse_bool_env(None) == false"
+            !result,
+            "expected is_microvm_environment() == false when ARN is empty"
+        );
+    }
+
+    #[test]
+    fn test_is_microvm_environment_when_unset() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("AWS_LAMBDA_MICROVM_IMAGE_ARN");
+        assert!(
+            !is_microvm_environment(),
+            "expected is_microvm_environment() == false when ARN is unset"
         );
     }
 
@@ -280,10 +299,7 @@ mod tests {
 pub fn register_rand(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Release store: any thread that subsequently does an Acquire load will see this value,
     // even if it was created before module import.
-    SECURE_RANDOM.store(
-        parse_bool_env(std::env::var("DD_TRACE_SECURE_RANDOM").ok()),
-        Ordering::Release,
-    );
+    SECURE_RANDOM.store(is_microvm_environment(), Ordering::Release);
 
     m.add_function(wrap_pyfunction!(seed, m)?)?;
     m.add_function(wrap_pyfunction!(rand64bits, m)?)?;

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -6,12 +6,13 @@ use rand::{
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-// Set once at module init from DD_TRACE_SECURE_RANDOM; reads are a single Relaxed load.
+// Set once at module init (Release) from DD_TRACE_SECURE_RANDOM; every read is an Acquire
+// load so the store is visible to threads that did not participate in module import.
 static SECURE_RANDOM: AtomicBool = AtomicBool::new(false);
 
 #[inline]
 fn secure_random() -> bool {
-    SECURE_RANDOM.load(Ordering::Relaxed)
+    SECURE_RANDOM.load(Ordering::Acquire)
 }
 
 struct RngState {
@@ -245,10 +246,11 @@ mod tests {
 
 /// Register the rand module functions and set up fork safety.
 pub fn register_rand(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Read DD_TRACE_SECURE_RANDOM once here so rand64bits() pays only a Relaxed load.
+    // Release store: any thread that subsequently does an Acquire load will see this value,
+    // even if it was created before module import.
     SECURE_RANDOM.store(
         std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true"),
-        Ordering::Relaxed,
+        Ordering::Release,
     );
 
     m.add_function(wrap_pyfunction!(seed, m)?)?;

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -197,20 +197,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_rand64bits_impl_flag_matches_secure_random() {
-        // The second element of rand64bits_impl() must echo the SECURE_RANDOM flag
-        // so callers (e.g. logging) can confirm which path was taken.
-        with_secure_random(false, || {
-            let (_, flag) = rand64bits_impl();
-            assert!(!flag, "flag should be false when SECURE_RANDOM=false");
-        });
-        with_secure_random(true, || {
-            let (_, flag) = rand64bits_impl();
-            assert!(flag, "flag should be true when SECURE_RANDOM=true");
-        });
-    }
-
     // ── seed() ───────────────────────────────────────────────────────────────
 
     #[test]

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -120,7 +120,10 @@ mod tests {
                 "expected parse_bool_env({val:?}) == false"
             );
         }
-        assert!(!parse_bool_env(None), "expected parse_bool_env(None) == false");
+        assert!(
+            !parse_bool_env(None),
+            "expected parse_bool_env(None) == false"
+        );
     }
 
     // ── secure_random() ──────────────────────────────────────────────────────

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -10,6 +10,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 // load so the store is visible to threads that did not participate in module import.
 static SECURE_RANDOM: AtomicBool = AtomicBool::new(false);
 
+// Matches ddtrace's asbool() convention: "true", "True", "TRUE", and "1" are all truthy.
+fn parse_bool_env(val: Option<String>) -> bool {
+    val.map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
+        .unwrap_or(false)
+}
+
 #[inline]
 fn secure_random() -> bool {
     SECURE_RANDOM.load(Ordering::Acquire)
@@ -94,6 +100,29 @@ mod tests {
         result.unwrap();
     }
 
+    // ── parse_bool_env() ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_bool_env_truthy_values() {
+        for val in &["true", "True", "TRUE", "1"] {
+            assert!(
+                parse_bool_env(Some(val.to_string())),
+                "expected parse_bool_env({val:?}) == true"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_bool_env_falsy_values() {
+        for val in &["false", "False", "FALSE", "0", "yes", ""] {
+            assert!(
+                !parse_bool_env(Some(val.to_string())),
+                "expected parse_bool_env({val:?}) == false"
+            );
+        }
+        assert!(!parse_bool_env(None), "expected parse_bool_env(None) == false");
+    }
+
     // ── secure_random() ──────────────────────────────────────────────────────
 
     #[test]
@@ -162,6 +191,20 @@ mod tests {
                 any_high_bit_set,
                 "OsRng path in rand64bits never set bits above 32"
             );
+        });
+    }
+
+    #[test]
+    fn test_rand64bits_impl_flag_matches_secure_random() {
+        // The second element of rand64bits_impl() must echo the SECURE_RANDOM flag
+        // so callers (e.g. logging) can confirm which path was taken.
+        with_secure_random(false, || {
+            let (_, flag) = rand64bits_impl();
+            assert!(!flag, "flag should be false when SECURE_RANDOM=false");
+        });
+        with_secure_random(true, || {
+            let (_, flag) = rand64bits_impl();
+            assert!(flag, "flag should be true when SECURE_RANDOM=true");
         });
     }
 
@@ -249,7 +292,7 @@ pub fn register_rand(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Release store: any thread that subsequently does an Acquire load will see this value,
     // even if it was created before module import.
     SECURE_RANDOM.store(
-        std::env::var("DD_TRACE_SECURE_RANDOM").as_deref() == Ok("true"),
+        parse_bool_env(std::env::var("DD_TRACE_SECURE_RANDOM").ok()),
         Ordering::Release,
     );
 

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -5,10 +5,12 @@ use rand::{
 };
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::warn;
 
 // Set once at module init (Release) when a MicroVM environment is detected; every read is an
 // Acquire load so the store is visible to threads that did not participate in module import.
 static SECURE_RANDOM: AtomicBool = AtomicBool::new(false);
+static OS_RNG_FAILURE_LOGGED: AtomicBool = AtomicBool::new(false);
 
 // Returns true when running inside a Firecracker/Lambda MicroVM where process memory can be
 // cloned from a snapshot, making SmallRng state deterministic across resumed instances.
@@ -71,6 +73,9 @@ pub fn rand64bits() -> u64 {
         if let Ok(value) = OsRng.try_next_u64() {
             return value;
         }
+        if !OS_RNG_FAILURE_LOGGED.swap(true, Ordering::Relaxed) {
+            warn!("OsRng failed in secure random mode; falling back to thread-local SmallRng");
+        }
     }
     RNG.with(|rng| rng.borrow_mut().gen())
 }
@@ -108,52 +113,29 @@ mod tests {
     // Serialize tests that mutate env vars to avoid races between parallel test threads.
     static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    // ── is_microvm_environment() ──────────────────────────────────────────────
-
     #[test]
-    fn test_is_microvm_environment_when_set() {
+    fn test_is_microvm_environment() {
         let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var(
             "AWS_LAMBDA_MICROVM_IMAGE_ARN",
             "arn:aws:lambda:us-east-1::runtime:python3.12",
         );
-        let result = is_microvm_environment();
-        std::env::remove_var("AWS_LAMBDA_MICROVM_IMAGE_ARN");
         assert!(
-            result,
+            is_microvm_environment(),
             "expected is_microvm_environment() == true when ARN is set"
         );
-    }
 
-    #[test]
-    fn test_is_microvm_environment_when_empty() {
-        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("AWS_LAMBDA_MICROVM_IMAGE_ARN", "");
-        let result = is_microvm_environment();
-        std::env::remove_var("AWS_LAMBDA_MICROVM_IMAGE_ARN");
         assert!(
-            !result,
+            !is_microvm_environment(),
             "expected is_microvm_environment() == false when ARN is empty"
         );
-    }
 
-    #[test]
-    fn test_is_microvm_environment_when_unset() {
-        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("AWS_LAMBDA_MICROVM_IMAGE_ARN");
         assert!(
             !is_microvm_environment(),
             "expected is_microvm_environment() == false when ARN is unset"
         );
-    }
-
-    // ── secure_random() ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_secure_random_returns_bool() {
-        // AtomicBool defaults to false; just verify the load doesn't panic.
-        let v = secure_random();
-        assert!(v == true || v == false);
     }
 
     #[test]
@@ -170,33 +152,24 @@ mod tests {
         );
     }
 
-    // ── rand64bits() — SmallRng path (SECURE_RANDOM = false) ─────────────────
-
     #[test]
-    fn test_rand64bits_unique_values() {
-        // 2^-64 ≈ 5e-20 collision probability per pair; 1000 samples is safe.
-        let values: HashSet<u64> = (0..1000).map(|_| rand64bits()).collect();
-        assert!(
-            values.len() > 990,
-            "Expected unique rand64bits values, got {} distinct in 1000",
-            values.len()
-        );
+    fn test_rand64bits_smallrng_path_produces_varied_64bit_values() {
+        with_secure_random(false, || {
+            let values: HashSet<u64> = (0..1000).map(|_| rand64bits()).collect();
+            assert!(
+                values.len() > 990,
+                "Expected unique rand64bits values, got {} distinct in 1000",
+                values.len()
+            );
+            assert!(
+                values.iter().any(|value| value >> 32 != 0),
+                "rand64bits never set bits above 32"
+            );
+        });
     }
 
     #[test]
-    fn test_rand64bits_uses_full_range() {
-        // If the RNG were stuck below 2^32, none of the high 32 bits would be set.
-        let any_high_bit_set = (0..100).any(|_| rand64bits() >> 32 != 0);
-        assert!(
-            any_high_bit_set,
-            "rand64bits never set bits above 32 — RNG range is too narrow"
-        );
-    }
-
-    // ── rand64bits() — OsRng path (SECURE_RANDOM = true) ─────────────────────
-
-    #[test]
-    fn test_rand64bits_osrng_path_produces_varied_values() {
+    fn test_rand64bits_osrng_path_produces_varied_64bit_values() {
         with_secure_random(true, || {
             let values: HashSet<u64> = (0..100).map(|_| rand64bits()).collect();
             assert!(
@@ -204,21 +177,12 @@ mod tests {
                 "OsRng path in rand64bits produced insufficient diversity: {} distinct in 100",
                 values.len()
             );
-        });
-    }
-
-    #[test]
-    fn test_rand64bits_osrng_path_uses_full_range() {
-        with_secure_random(true, || {
-            let any_high_bit_set = (0..100).any(|_| rand64bits() >> 32 != 0);
             assert!(
-                any_high_bit_set,
+                values.iter().any(|value| value >> 32 != 0),
                 "OsRng path in rand64bits never set bits above 32"
             );
         });
     }
-
-    // ── seed() ───────────────────────────────────────────────────────────────
 
     #[test]
     fn test_seed_does_not_break_rng() {
@@ -228,71 +192,33 @@ mod tests {
         assert!(!values.is_empty());
     }
 
-    // ── OsRng ────────────────────────────────────────────────────────────────
-
     #[test]
-    fn test_osrng_produces_varied_values() {
-        let values: HashSet<u64> = (0..100).map(|_| OsRng.try_next_u64().unwrap()).collect();
-        assert!(
-            values.len() > 90,
-            "Expected diverse values from OsRng, got {}",
-            values.len()
-        );
-    }
-
-    // ── generate_128bit_trace_id() ───────────────────────────────────────────
-
-    #[test]
-    fn test_trace_id_timestamp_in_high_bits() {
-        // Format: [32-bit unix seconds][32 zeros][64 random bits]
-        // Top 32 bits must be a plausible Unix timestamp.
-        let id = generate_128bit_trace_id();
-        let timestamp = (id >> 96) as u32;
-        // 2020-01-01T00:00:00Z = 1_577_836_800
-        // 2100-01-01T00:00:00Z = 4_102_444_800
-        assert!(
-            timestamp > 1_577_836_800,
-            "timestamp {timestamp} is before 2020"
-        );
-        assert!(
-            timestamp < 4_102_444_800,
-            "timestamp {timestamp} is after 2100"
-        );
-    }
-
-    #[test]
-    fn test_trace_id_middle_bits_zero() {
-        // Bits 95-64 (the 32 bits after the timestamp) must always be zero per the spec.
-        for _ in 0..20 {
+    fn test_generate_128bit_trace_id_layout_and_random_payload() {
+        let mut lows = HashSet::new();
+        for _ in 0..100 {
             let id = generate_128bit_trace_id();
+            let timestamp = (id >> 96) as u32;
             let middle = ((id >> 64) & 0xFFFF_FFFF) as u32;
+            lows.insert(id as u64);
+
+            assert!(
+                timestamp > 1_577_836_800,
+                "timestamp {timestamp} is before 2020"
+            );
+            assert!(
+                timestamp < 4_102_444_800,
+                "timestamp {timestamp} is after 2100"
+            );
             assert_eq!(
                 middle, 0,
                 "middle 32 bits of trace ID should be zero, got {id:#034x}"
             );
         }
-    }
 
-    #[test]
-    fn test_trace_id_low_bits_vary() {
-        // The low 64 bits carry the random payload; they must not be constant.
-        let lows: HashSet<u64> = (0..100)
-            .map(|_| generate_128bit_trace_id() as u64)
-            .collect();
         assert!(
             lows.len() > 90,
             "Low 64 bits of trace IDs are not random enough: {} distinct in 100",
             lows.len()
-        );
-    }
-
-    #[test]
-    fn test_trace_id_ids_are_unique() {
-        let ids: HashSet<u128> = (0..1000).map(|_| generate_128bit_trace_id()).collect();
-        assert!(
-            ids.len() > 990,
-            "Expected unique trace IDs, got {} distinct in 1000",
-            ids.len()
         );
     }
 }

--- a/src/native/rand.rs
+++ b/src/native/rand.rs
@@ -68,7 +68,9 @@ pub fn seed() {
 #[pyfunction]
 pub fn rand64bits() -> u64 {
     if secure_random() {
-        return OsRng.try_next_u64().expect("OsRng failed");
+        if let Ok(value) = OsRng.try_next_u64() {
+            return value;
+        }
     }
     RNG.with(|rng| rng.borrow_mut().gen())
 }

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -266,6 +266,34 @@ def test_secure_random_one_produces_unique_ids():
     assert len(ids) == 1000, f"Expected 1000 unique IDs under OsRng (=1), got {len(ids)}"
 
 
+@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true"})
+def test_secure_random_thread_safe():
+    """With DD_TRACE_SECURE_RANDOM=true, concurrent rand64bits() calls must not collide."""
+    import threading
+    from queue import Queue
+
+    from ddtrace.internal.native import rand64bits
+
+    def _generate(q):
+        q.put([rand64bits() for _ in range(10000)])
+
+    q = Queue()
+    threads = [threading.Thread(target=_generate, args=(q,)) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    all_ids = []
+    while not q.empty():
+        all_ids.extend(q.get())
+
+    unique_ids = set(all_ids)
+    assert len(all_ids) == len(unique_ids), (
+        f"Thread-safety collision under OsRng: {len(all_ids) - len(unique_ids)} duplicates in 50000 IDs"
+    )
+
+
 @pytest.mark.subprocess(
     env={"DD_TRACE_SECURE_RANDOM": "true", "PYTHONWARNINGS": "ignore::DeprecationWarning"}
 )

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -202,7 +202,7 @@ def test_threadsafe():
         assert ids & new_ids == set()
         ids = ids | new_ids
 
-    assert len(ids) > 0
+    assert len(ids) > 0  # pyright: ignore[reportUnknownArgumentType]
 
 
 @pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
@@ -269,8 +269,8 @@ def test_secure_random_one_produces_unique_ids():
 @pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true"})
 def test_secure_random_thread_safe():
     """With DD_TRACE_SECURE_RANDOM=true, concurrent rand64bits() calls must not collide."""
-    import threading
     from queue import Queue
+    import threading
 
     from ddtrace.internal.native import rand64bits
 
@@ -294,9 +294,7 @@ def test_secure_random_thread_safe():
     )
 
 
-@pytest.mark.subprocess(
-    env={"DD_TRACE_SECURE_RANDOM": "true", "PYTHONWARNINGS": "ignore::DeprecationWarning"}
-)
+@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true", "PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_secure_random_fork_no_collisions():
     """With DD_TRACE_SECURE_RANDOM=true, parent and child must not share IDs after fork."""
     import os

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -248,6 +248,48 @@ def _get_ids():
     return s.span_id, s.trace_id
 
 
+@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true"})
+def test_secure_random_true_produces_unique_ids():
+    """DD_TRACE_SECURE_RANDOM=true switches rand64bits to OsRng."""
+    from ddtrace.internal.native import rand64bits
+
+    ids = {rand64bits() for _ in range(1000)}
+    assert len(ids) == 1000, f"Expected 1000 unique IDs under OsRng, got {len(ids)}"
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "1"})
+def test_secure_random_one_produces_unique_ids():
+    """DD_TRACE_SECURE_RANDOM=1 must also activate OsRng (asbool convention)."""
+    from ddtrace.internal.native import rand64bits
+
+    ids = {rand64bits() for _ in range(1000)}
+    assert len(ids) == 1000, f"Expected 1000 unique IDs under OsRng (=1), got {len(ids)}"
+
+
+@pytest.mark.subprocess(
+    env={"DD_TRACE_SECURE_RANDOM": "true", "PYTHONWARNINGS": "ignore::DeprecationWarning"}
+)
+def test_secure_random_fork_no_collisions():
+    """With DD_TRACE_SECURE_RANDOM=true, parent and child must not share IDs after fork."""
+    import os
+
+    from ddtrace.internal.native import rand64bits
+    from tests.tracer.test_rand import MPQueue
+
+    q = MPQueue()
+    pid = os.fork()
+
+    if pid > 0:
+        parent_ids = {rand64bits() for _ in range(100)}
+        child_ids = q.get()
+        assert parent_ids & child_ids == set(), "Collision between parent and child under OsRng"
+    else:
+        try:
+            q.put({rand64bits() for _ in range(100)})
+        finally:
+            os._exit(0)
+
+
 def _test_tracer_usage_multiprocess_target(q):
     ids_list = list(chain.from_iterable(ids for ids in [_get_ids() for _ in range(100)]))
     q.put(ids_list)

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -248,27 +248,21 @@ def _get_ids():
     return s.span_id, s.trace_id
 
 
-@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true"})
-def test_secure_random_true_produces_unique_ids():
-    """DD_TRACE_SECURE_RANDOM=true switches rand64bits to OsRng."""
+_MICROVM_ENV = {"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}
+
+
+@pytest.mark.subprocess(env=_MICROVM_ENV)
+def test_microvm_produces_unique_ids():
+    """AWS_LAMBDA_MICROVM_IMAGE_ARN set → OsRng activated → IDs must be unique."""
     from ddtrace.internal.native import rand64bits
 
     ids = {rand64bits() for _ in range(1000)}
     assert len(ids) == 1000, f"Expected 1000 unique IDs under OsRng, got {len(ids)}"
 
 
-@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "1"})
-def test_secure_random_one_produces_unique_ids():
-    """DD_TRACE_SECURE_RANDOM=1 must also activate OsRng (asbool convention)."""
-    from ddtrace.internal.native import rand64bits
-
-    ids = {rand64bits() for _ in range(1000)}
-    assert len(ids) == 1000, f"Expected 1000 unique IDs under OsRng (=1), got {len(ids)}"
-
-
-@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true"})
-def test_secure_random_thread_safe():
-    """With DD_TRACE_SECURE_RANDOM=true, concurrent rand64bits() calls must not collide."""
+@pytest.mark.subprocess(env=_MICROVM_ENV)
+def test_microvm_thread_safe():
+    """With MicroVM detection active, concurrent rand64bits() calls must not collide."""
     from queue import Queue
     import threading
 
@@ -294,9 +288,9 @@ def test_secure_random_thread_safe():
     )
 
 
-@pytest.mark.subprocess(env={"DD_TRACE_SECURE_RANDOM": "true", "PYTHONWARNINGS": "ignore::DeprecationWarning"})
-def test_secure_random_fork_no_collisions():
-    """With DD_TRACE_SECURE_RANDOM=true, parent and child must not share IDs after fork."""
+@pytest.mark.subprocess(env={**_MICROVM_ENV, "PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_microvm_fork_no_collisions():
+    """With MicroVM detection active, parent and child must not share IDs after fork."""
     import os
 
     from ddtrace.internal.native import rand64bits

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -253,16 +253,17 @@ _MICROVM_ENV = {"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runti
 
 @pytest.mark.subprocess(env=_MICROVM_ENV)
 def test_microvm_produces_unique_ids():
-    """AWS_LAMBDA_MICROVM_IMAGE_ARN set → OsRng activated → IDs must be unique."""
+    """AWS_LAMBDA_MICROVM_IMAGE_ARN set -> OsRng activated -> IDs must have high diversity."""
     from ddtrace.internal.native import rand64bits
 
     ids = {rand64bits() for _ in range(1000)}
-    assert len(ids) == 1000, f"Expected 1000 unique IDs under OsRng, got {len(ids)}"
+    assert len(ids) > 990, f"Expected high ID diversity under OsRng, got {len(ids)} distinct IDs"
 
 
 @pytest.mark.subprocess(env=_MICROVM_ENV)
 def test_microvm_thread_safe():
     """With MicroVM detection active, concurrent rand64bits() calls must not collide."""
+    from itertools import chain
     from queue import Queue
     import threading
 
@@ -278,13 +279,11 @@ def test_microvm_thread_safe():
     for t in threads:
         t.join()
 
-    all_ids = []
-    while not q.empty():
-        all_ids.extend(q.get())
+    all_ids = list(chain.from_iterable(q.get(timeout=1) for _ in threads))
 
     unique_ids = set(all_ids)
-    assert len(all_ids) == len(unique_ids), (
-        f"Thread-safety collision under OsRng: {len(all_ids) - len(unique_ids)} duplicates in 50000 IDs"
+    assert len(unique_ids) > 49990, (
+        f"Unexpected collision rate under OsRng: {len(all_ids) - len(unique_ids)} duplicates in 50000 IDs"
     )
 
 

--- a/tests/tracer/test_rand.py
+++ b/tests/tracer/test_rand.py
@@ -262,29 +262,29 @@ def test_microvm_produces_unique_ids():
 
 @pytest.mark.subprocess(env=_MICROVM_ENV)
 def test_microvm_thread_safe():
-    """With MicroVM detection active, concurrent rand64bits() calls must not collide."""
-    from itertools import chain
+    """With MicroVM detection active, concurrent trace ID generation must not collide."""
     from queue import Queue
     import threading
 
-    from ddtrace.internal.native import rand64bits
+    from ddtrace._trace.span import Span
 
     def _generate(q):
-        q.put([rand64bits() for _ in range(10000)])
+        barrier.wait(timeout=5)
+        q.put(Span("s").trace_id)
 
+    barrier = threading.Barrier(10)
     q = Queue()
-    threads = [threading.Thread(target=_generate, args=(q,)) for _ in range(5)]
+    threads = [threading.Thread(target=_generate, args=(q,)) for _ in range(10)]
     for t in threads:
         t.start()
+
+    ids = [q.get(timeout=5) for _ in threads]
+
     for t in threads:
-        t.join()
+        t.join(timeout=1)
+        assert not t.is_alive()
 
-    all_ids = list(chain.from_iterable(q.get(timeout=1) for _ in threads))
-
-    unique_ids = set(all_ids)
-    assert len(unique_ids) > 49990, (
-        f"Unexpected collision rate under OsRng: {len(all_ids) - len(unique_ids)} duplicates in 50000 IDs"
-    )
+    assert len(set(ids)) == len(ids)
 
 
 @pytest.mark.subprocess(env={**_MICROVM_ENV, "PYTHONWARNINGS": "ignore::DeprecationWarning"})


### PR DESCRIPTION
## Description

Lambda MicroVMs can restore multiple instances from the same memory snapshot. If `SmallRng` is initialized before the snapshot, each restored process can continue from the same RNG state and generate the same trace/span ID sequence.

This updates `rand64bits()` to use `OsRng` when `AWS_LAMBDA_MICROVM_IMAGE_ARN` is set. Outside Lambda MicroVMs, the existing thread-local `SmallRng` path is unchanged.

`generate_128bit_trace_id()` inherits the same behavior because it delegates to `rand64bits()`.

## Testing

- `scripts/run-tests --venv c48b0f7 tests/tracer/test_rand.py -- -- tests/tracer/test_rand.py -q --tb=short`
- `scripts/lint checks`
- Rust unit tests cover MicroVM env detection, RNG path behavior, reseeding, and 128-bit trace ID format.

### Test manifest

- Lambda MicroVM verification: [AWS Log](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda-microvms$252Fsample-python-app-0515001421/log-events/1.0$252F1d8efd08-c36b-4d21-a16d-56683417a644$3FfilterPattern$3DLTN)

<img width="946" height="496" alt="Lambda MicroVM verification" src="https://github.com/user-attachments/assets/4251d56b-dceb-47c9-91e5-e3cc61015122" />

## Risks

In Lambda MicroVMs, ID generation now uses OS entropy per call, which adds a small syscall cost on span start. Non-MicroVM behavior is unchanged.

## Additional Notes

- [Jira](https://datadoghq.atlassian.net/browse/SVLS-9138)
- [AWS reference](https://github.com/aws/agent-toolkit-for-aws/blob/847f477649252b98f8fb828bbfeaf109b57b8cac/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/snapshots-and-uniqueness.md) 
- [Tech doc](https://docs.google.com/document/d/1s_nVu8eyR2BiIdHSQ8K1OZE5yji_lo5g7CuS5GmLFVg/edit?usp=sharing) 
