### PR TITLE
chore(redis): add Protocol/TypedDict types for redis integration

### DIFF
--- a/ddtrace/contrib/internal/redis/asyncio_patch.py
+++ b/ddtrace/contrib/internal/redis/asyncio_patch.py
@@ -1,22 +1,44 @@
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+
 from ddtrace import config
+from ddtrace.contrib.internal.redis.types import RedisClient
+from ddtrace.contrib.internal.redis.types import RedisClusterPipeline
+from ddtrace.contrib.internal.redis.types import RedisPipeline
 from ddtrace.contrib.internal.redis_utils import _instrument_redis_cmd
 from ddtrace.contrib.internal.redis_utils import _instrument_redis_execute_pipeline
 from ddtrace.contrib.internal.redis_utils import _run_redis_command_async
 from ddtrace.internal.utils.formats import stringify_cache_args
 
 
-async def instrumented_async_execute_command(func, instance, args, kwargs):
+async def instrumented_async_execute_command(
+    func: Callable[..., Awaitable[Any]],
+    instance: RedisClient,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
     with _instrument_redis_cmd(config.redis, instance, args) as ctx:
         return await _run_redis_command_async(ctx=ctx, func=func, args=args, kwargs=kwargs)
 
 
-async def instrumented_async_execute_pipeline(func, instance, args, kwargs):
+async def instrumented_async_execute_pipeline(
+    func: Callable[..., Awaitable[Any]],
+    instance: RedisPipeline,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
     cmds = [stringify_cache_args(c, cmd_max_len=config.redis.cmd_max_length) for c, _ in instance.command_stack]
     with _instrument_redis_execute_pipeline(config.redis, cmds, instance):
         return await func(*args, **kwargs)
 
 
-async def instrumented_async_execute_cluster_pipeline(func, instance, args, kwargs):
+async def instrumented_async_execute_cluster_pipeline(
+    func: Callable[..., Awaitable[Any]],
+    instance: RedisClusterPipeline,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
     # Try to access command_stack, fallback to _command_stack for backward compatibility
     command_stack = getattr(instance, "command_stack", None)
     if command_stack is None:

--- a/ddtrace/contrib/internal/redis/patch.py
+++ b/ddtrace/contrib/internal/redis/patch.py
@@ -1,7 +1,14 @@
+from typing import Any
+from typing import Callable
+from typing import Union
+
 import redis
 import wrapt
 
 from ddtrace import config
+from ddtrace.contrib.internal.redis.types import RedisClient
+from ddtrace.contrib.internal.redis.types import RedisClusterPipeline
+from ddtrace.contrib.internal.redis.types import RedisPipeline
 from ddtrace.contrib.internal.redis_utils import ROW_RETURNING_COMMANDS
 from ddtrace.contrib.internal.redis_utils import _instrument_redis_cmd
 from ddtrace.contrib.internal.redis_utils import _instrument_redis_execute_pipeline
@@ -10,6 +17,7 @@ from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.internal import core
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.settings import env
+from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
@@ -103,7 +111,12 @@ def unpatch():
                 unwrap(redis.asyncio.cluster.ClusterPipeline, "execute")
 
 
-def _run_redis_command(ctx: core.ExecutionContext, func, args, kwargs):
+def _run_redis_command(
+    ctx: core.ExecutionContext,
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
     parsed_command = stringify_cache_args(args)
     redis_command = parsed_command.split(" ")[0]
     rowcount = None
@@ -125,16 +138,28 @@ def _run_redis_command(ctx: core.ExecutionContext, func, args, kwargs):
 #
 # tracing functions
 #
-def instrumented_execute_command(integration_config):
-    def _instrumented_execute_command(func, instance, args, kwargs):
+def instrumented_execute_command(integration_config: IntegrationConfig) -> Callable[..., Any]:
+    def _instrumented_execute_command(
+        func: Callable[..., Any],
+        instance: RedisClient,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
         with _instrument_redis_cmd(integration_config, instance, args) as ctx:
             return _run_redis_command(ctx=ctx, func=func, args=args, kwargs=kwargs)
 
     return _instrumented_execute_command
 
 
-def instrumented_execute_pipeline(integration_config, is_cluster=False):
-    def _instrumented_execute_pipeline(func, instance, args, kwargs):
+def instrumented_execute_pipeline(
+    integration_config: IntegrationConfig, is_cluster: bool = False
+) -> Callable[..., Any]:
+    def _instrumented_execute_pipeline(
+        func: Callable[..., Any],
+        instance: Union[RedisPipeline, RedisClusterPipeline],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
         if is_cluster:
             cmds = [
                 stringify_cache_args(c.args, cmd_max_len=integration_config.cmd_max_length)

--- a/ddtrace/contrib/internal/redis/types.py
+++ b/ddtrace/contrib/internal/redis/types.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import Protocol
+from typing import Sequence
+from typing import TypedDict
+from typing import Union
+
+
+class RedisConnectionKwargs(TypedDict, total=False):
+    host: str
+    port: int
+    db: int
+    client_name: str
+
+
+class RedisConnectionPool(Protocol):
+    @property
+    def connection_kwargs(self) -> RedisConnectionKwargs: ...
+
+
+class RedisClient(Protocol):
+    @property
+    def connection_pool(self) -> RedisConnectionPool: ...
+
+
+class RedisClusterCommand(Protocol):
+    @property
+    def args(self) -> Sequence[Any]: ...
+
+
+class RedisPipeline(RedisClient, Protocol):
+    @property
+    def command_stack(self) -> Sequence[tuple[Sequence[Any], Any]]: ...
+
+
+class RedisClusterPipeline(RedisClient, Protocol):
+    @property
+    def command_stack(self) -> Sequence[RedisClusterCommand]: ...
+
+
+RedisInstance = Union[RedisClient, RedisPipeline, RedisClusterPipeline]

--- a/ddtrace/contrib/internal/redis_utils.py
+++ b/ddtrace/contrib/internal/redis_utils.py
@@ -1,9 +1,16 @@
 from contextlib import contextmanager
+from typing import Any
+from typing import Callable
+from typing import Iterator
 from typing import Optional
+from typing import Sequence
 from typing import Union
 
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
+from ddtrace.contrib.internal.redis.types import RedisClient
+from ddtrace.contrib.internal.redis.types import RedisConnectionKwargs
+from ddtrace.contrib.internal.redis.types import RedisInstance
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
@@ -12,6 +19,7 @@ from ddtrace.ext import redis as redisx
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_cache_operation
+from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.utils.formats import stringify_cache_args
 
 
@@ -54,7 +62,12 @@ def determine_row_count(redis_command: str, result: Optional[Union[list, dict, s
         return 0
 
 
-async def _run_redis_command_async(ctx: core.ExecutionContext, func, args, kwargs):
+async def _run_redis_command_async(
+    ctx: core.ExecutionContext,
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
     parsed_command = stringify_cache_args(args)
     redis_command = parsed_command.split(" ")[0]
     rowcount = None
@@ -73,9 +86,9 @@ async def _run_redis_command_async(ctx: core.ExecutionContext, func, args, kwarg
         core.dispatch("redis.async_command.post", (ctx, rowcount))
 
 
-def _extract_conn_tags(conn_kwargs) -> dict[str, str]:
+def _extract_conn_tags(conn_kwargs: RedisConnectionKwargs) -> dict[str, Any]:
     try:
-        conn_tags = {
+        conn_tags: dict[str, Any] = {
             net.TARGET_HOST: conn_kwargs["host"],
             net.TARGET_PORT: conn_kwargs["port"],
             net.SERVER_ADDRESS: conn_kwargs["host"],
@@ -89,8 +102,8 @@ def _extract_conn_tags(conn_kwargs) -> dict[str, str]:
         return {}
 
 
-def _build_tags(query, instance, integration_name):
-    ret = dict()
+def _build_tags(query: Optional[str], instance: RedisInstance, integration_name: str) -> dict[str, Any]:
+    ret: dict[str, Any] = dict()
     ret[SPAN_KIND] = SpanKind.CLIENT
     ret[COMPONENT] = integration_name
     ret[db.SYSTEM] = redisx.APP
@@ -105,7 +118,11 @@ def _build_tags(query, instance, integration_name):
 
 
 @contextmanager
-def _instrument_redis_execute_pipeline(config_integration, cmds, instance):
+def _instrument_redis_execute_pipeline(
+    config_integration: IntegrationConfig,
+    cmds: Sequence[str],
+    instance: RedisInstance,
+) -> Iterator[Any]:
     cmd_string = resource = "\n".join(cmds)
     if config_integration.resource_only_command:
         resource = "\n".join([cmd.split(" ")[0] for cmd in cmds])
@@ -125,7 +142,11 @@ def _instrument_redis_execute_pipeline(config_integration, cmds, instance):
 
 
 @contextmanager
-def _instrument_redis_cmd(config_integration, instance, args):
+def _instrument_redis_cmd(
+    config_integration: IntegrationConfig,
+    instance: RedisClient,
+    args: Sequence[Any],
+) -> Iterator[core.ExecutionContext]:
     query = stringify_cache_args(args, cmd_max_len=config_integration.cmd_max_length)
     with core.context_with_data(
         "redis.command",


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

 Introduce a `types.py` module for the redis integration that describes the structural shape of redis client/pipeline objects via `typing.Protocol`, mirroring the pattern already established in `ddtrace/appsec/_contrib/stripe/types.py`.

The redis integration now declares what attributes it depends on instead of accepting opaque arguments — mypy validates the access, the dependency on external library shapes becomes self-documenting, and we set up a template that other integrations can adopt 

Motivation: catch upstream shape regressions in mypy rather than at test time, make the long-standing duck-typed contract explicit, and provide a reusable template for the aredis/yaaredis/rediscluster integrations to adopt in follow-up PRs.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
