### PR TITLE
chore: bump to 4.8.4

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'adcd0e88eecd59a179f9470d76a5bc48eed14524'
+          ref: '2b1ec86ed721d610a6642e4243a54aefeaacd348'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'adcd0e88eecd59a179f9470d76a5bc48eed14524'
+          ref: '2b1ec86ed721d610a6642e4243a54aefeaacd348'
 
       - name: Build runner
         uses: ./.github/actions/install_runner

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "adcd0e88eecd59a179f9470d76a5bc48eed14524"
+  SYSTEM_TESTS_REF: "2b1ec86ed721d610a6642e4243a54aefeaacd348"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.8.3"
+version = "4.8.4"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
## Description

Release prep for 4.8.4:

- Bump `pyproject.toml` version from `4.8.3` to `4.8.4`.
- Update pinned system-tests SHA (`adcd0e88` → `2b1ec86e`) via `scripts/update-system-tests-version.py`

## Testing
CI is green

## Risks

None.

## Additional Notes
