### PR TITLE
fix(starlette): handle middleware=None in traced_init

### DIFF
--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -69,7 +69,7 @@ def _supported_versions() -> dict[str, str]:
 
 
 def traced_init(wrapped, instance, args, kwargs):
-    mw = kwargs.pop("middleware", [])
+    mw = list(kwargs.pop("middleware", None) or [])
     mw.insert(0, Middleware(TraceMiddleware, integration_config=config.starlette))
     kwargs.update({"middleware": mw})
 

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -626,3 +626,47 @@ def test_inferred_spans_api_gateway(client, test_spans):
             url="https://local/",
             start=1736973768,
         )
+
+
+def _trace_middleware_present(app):
+    from ddtrace.contrib.asgi import TraceMiddleware
+
+    return any(mw.cls is TraceMiddleware for mw in app.user_middleware)
+
+
+def test_traced_init_with_middleware_none(tracer):
+    """Regression test: Starlette(middleware=None) must not crash traced_init.
+
+    Starlette's documented public API treats middleware=None as equivalent to
+    no middleware. A subclass that forwards middleware=None (e.g. AWS
+    bedrock-agentcore) previously triggered:
+        AttributeError: 'NoneType' object has no attribute 'insert'
+    """
+    from starlette.applications import Starlette
+
+    app = Starlette(middleware=None)
+    assert _trace_middleware_present(app)
+
+
+def test_traced_init_with_middleware_tuple(tracer):
+    """Regression test: Starlette(middleware=()) must not crash traced_init.
+
+    Starlette's signature accepts Sequence[Middleware]; a tuple has no
+    .insert(), so the wrapper must coerce to list before inserting.
+    """
+    from starlette.applications import Starlette
+
+    app = Starlette(middleware=())
+    assert _trace_middleware_present(app)
+
+
+def test_traced_init_preserves_user_middleware(tracer):
+    """Regression test: user-supplied middleware is preserved after TraceMiddleware."""
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+    user_mw = Middleware(TrustedHostMiddleware, allowed_hosts=["*"])
+    app = Starlette(middleware=[user_mw])
+    assert _trace_middleware_present(app)
+    assert any(mw is user_mw for mw in app.user_middleware)

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -635,13 +635,7 @@ def _trace_middleware_present(app):
 
 
 def test_traced_init_with_middleware_none(tracer):
-    """Regression test: Starlette(middleware=None) must not crash traced_init.
-
-    Starlette's documented public API treats middleware=None as equivalent to
-    no middleware. A subclass that forwards middleware=None (e.g. AWS
-    bedrock-agentcore) previously triggered:
-        AttributeError: 'NoneType' object has no attribute 'insert'
-    """
+    """Starlette(middleware=None) must not crash traced_init."""
     from starlette.applications import Starlette
 
     app = Starlette(middleware=None)
@@ -649,11 +643,7 @@ def test_traced_init_with_middleware_none(tracer):
 
 
 def test_traced_init_with_middleware_tuple(tracer):
-    """Regression test: Starlette(middleware=()) must not crash traced_init.
-
-    Starlette's signature accepts Sequence[Middleware]; a tuple has no
-    .insert(), so the wrapper must coerce to list before inserting.
-    """
+    """Starlette(middleware=()) must not crash traced_init."""
     from starlette.applications import Starlette
 
     app = Starlette(middleware=())


### PR DESCRIPTION
## Description

Fixes #17997.

`traced_init` for the Starlette integration calls `kwargs.pop("middleware", [])` and then `.insert(0, ...)` on the result. `dict.pop(key, default)` only returns the default when the key is absent; when a subclass forwards `middleware=None` (the documented default in Starlette's public API), `pop` returns `None` and the next line raises `AttributeError: 'NoneType' object has no attribute 'insert'`.

The motivating case is AWS Bedrock AgentCore Runtime: `BedrockAgentCoreApp()` subclasses `Starlette` and forwards `middleware=None` unconditionally, so users following the published AWS quickstart who also `pip install ddtrace` cannot start their app.

Starlette itself handles `middleware=None` ([`starlette/applications.py:26-54`](https://github.com/Kludex/starlette/blob/1.0.0/starlette/applications.py#L26-L54)) as `[] if middleware is None else list(middleware)`, so honoring that contract is the right behavior.

The fix is one line in `ddtrace/contrib/internal/starlette/patch.py`:

```diff
-    mw = kwargs.pop("middleware", [])
+    mw = list(kwargs.pop("middleware", None) or [])
```

`list(... or [])` also fixes a latent crash when callers pass a tuple (which Starlette's `Sequence[Middleware]` type hint allows but the current code would crash on at `.insert`).

## Testing

Three regression tests added to `tests/contrib/starlette/test_starlette.py`:

1. `test_traced_init_with_middleware_none` - `Starlette(middleware=None)` constructs without error and `TraceMiddleware` is still injected.
2. `test_traced_init_with_middleware_tuple` - `Starlette(middleware=())` constructs without error.
3. `test_traced_init_preserves_user_middleware` - user-supplied middleware is preserved with `TraceMiddleware` inserted at index 0.

## Risks

Low. The change is strictly more permissive: it accepts inputs (None, tuple) that previously crashed, and behaves identically on existing input shapes (absent key, list).

## Additional Notes

No public API change, so `no-changelog` applies.