### PR TITLE
fix(llmobs): handle dict tool_input in Bedrock converse stream

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -1520,11 +1520,13 @@ def get_final_message_converse_stream_message(
         if not tool_block:
             continue
         tool_input = tool_block.get("input")
-        tool_args = {}
-        if tool_input is not None:
+        tool_args: Any = {}
+        if isinstance(tool_input, dict):
+            tool_args = tool_input
+        elif tool_input is not None:
             try:
                 tool_args = json.loads(tool_input)
-            except (json.JSONDecodeError, ValueError):
+            except (TypeError, json.JSONDecodeError, ValueError):
                 tool_args = {"input": tool_input}
         tool_call_info = ToolCall(
             name=tool_block.get("name", ""),

--- a/tests/llmobs/test_integrations_utils.py
+++ b/tests/llmobs/test_integrations_utils.py
@@ -1,6 +1,7 @@
 from ddtrace.llmobs._integrations.utils import _extract_chat_template_from_instructions
 from ddtrace.llmobs._integrations.utils import _normalize_prompt_variables
 from ddtrace.llmobs._integrations.utils import _openai_parse_input_response_messages
+from ddtrace.llmobs._integrations.utils import get_final_message_converse_stream_message
 
 
 def test_basic_functionality():
@@ -339,3 +340,23 @@ class TestOpenAIParseInputResponseMessages:
         assert len(processed) == 1
         assert processed[0]["role"] == "user"
         assert tool_call_ids == []
+
+
+class TestGetFinalMessageConverseStreamMessage:
+    def _build(self, tool_input):
+        message = {"role": "assistant", "content_block_indicies": [0]}
+        tool_blocks = {0: {"name": "search", "toolUseId": "tool_1", "input": tool_input}}
+        return get_final_message_converse_stream_message(message, {}, tool_blocks)
+
+    def test_tool_input_as_json_string(self):
+        result = self._build('{"q": "weather"}')
+        assert result["tool_calls"][0]["arguments"] == {"q": "weather"}
+
+    def test_tool_input_as_dict_is_used_directly(self):
+        # Bedrock can return already-parsed dict inputs; should not raise TypeError.
+        result = self._build({"q": "weather"})
+        assert result["tool_calls"][0]["arguments"] == {"q": "weather"}
+
+    def test_tool_input_invalid_json_string_is_wrapped(self):
+        result = self._build("not-json")
+        assert result["tool_calls"][0]["arguments"] == {"input": "not-json"}


### PR DESCRIPTION
## Description

Fixes #16356.

`get_final_message_converse_stream_message` in `ddtrace/llmobs/_integrations/utils.py` assumed `tool_input` was always a JSON string and called `json.loads()` on it. AWS Bedrock sometimes returns the Converse `toolUse` `input` as an already-parsed dict, which made `json.loads` raise `TypeError` (not a `ValueError`/`JSONDecodeError`), crashing the stream handler and disrupting the user's application.

The fix uses the dict directly when present, and also catches `TypeError` on the fall-through branch so any other unexpected non-string type degrades to the wrapped-input fallback instead of crashing.

## Testing

Added `TestGetFinalMessageConverseStreamMessage` in `tests/llmobs/test_integrations_utils.py` covering:
- JSON-string `tool_input` (existing behaviour)
- dict `tool_input` (the regression)
- invalid-JSON string `tool_input` (wrapped fallback)

## Risks

None — the change is a narrow guard before `json.loads` and an added `TypeError` in the existing except clause.

## Additional Notes

The Bedrock instrumentation entry path (`_converse_output_stream_processor` in `ddtrace/llmobs/_integrations/bedrock.py`) is unchanged.