### PR TITLE
perf(appsec): reuse ASM context for nested web spans

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -136,6 +136,13 @@ def get_active_asm_context() -> Optional[ASM_Environment]:
     return env
 
 
+def get_active_asm_context_for_entry_span(entry_span: Span) -> Optional[ASM_Environment]:
+    env = _get_asm_context()
+    if env is not None and not env.finalized and env.entry_span is entry_span:
+        return env
+    return None
+
+
 def in_asm_context() -> bool:
     return core.find_item(_ASM_CONTEXT) is not None
 
@@ -576,11 +583,10 @@ def store_waf_results_data(data: "list[WafEvent]") -> None:
 
 def start_context(waf_callable: Optional[WafCallable], span: Span, rc_products: str) -> None:
     if asm_config._asm_enabled:
-        # Skip creating a new ASM context if one already exists in a parent context
-        # AND this is a sub-app span (e.g., mounted FastAPI/Starlette sub-application).
-        # The parent's ASM context already has the request data (body, headers, etc.)
-        # and is accessible via core.find_item thanks to context tree traversal.
-        if in_asm_context() and core.find_item("is_subapp"):
+        # AIDEV-NOTE: Nested framework WEB spans can share a service-entry span
+        # (e.g. mounted ASGI apps or WSGI start_response). Keep one ASM env per
+        # service-entry span so later request data still enriches the same analysis.
+        if get_active_asm_context_for_entry_span(span._service_entry_span):
             return
         core.set_item(
             _ASM_CONTEXT,
@@ -656,7 +662,7 @@ def _get_headers_if_appsec() -> Optional[Any]:
     return None
 
 
-## headers tags
+# headers tags
 
 _COLLECTED_REQUEST_HEADERS_ASM_ENABLED = {
     "accept",

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -224,6 +224,9 @@ class AppSecSpanProcessor(SpanProcessor):
             return
 
         entry_span = span._service_entry_span
+        if _asm_request_context.get_active_asm_context_for_entry_span(entry_span):
+            return
+
         entry_span._set_attribute(APPSEC.ENABLED, 1.0)
         entry_span._set_attribute(_RUNTIME_FAMILY, "python")
 

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -9,6 +9,7 @@ from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import DEFAULT
 from ddtrace.appsec._constants import FINGERPRINTING
+from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._constants import WAF_DATA_NAMES
 from ddtrace.appsec._ddwaf import DDWaf
 from ddtrace.appsec._ddwaf.ddwaf_types import py_ddwaf_builder_get_config_paths
@@ -81,6 +82,65 @@ def test_ddwaf_ctx(tracer):
         ctx = _asm_request_context._get_asm_context()
         assert ctx
         processor.on_span_finish(span)
+        assert _asm_request_context._get_asm_context() is None
+
+
+def test_nested_web_span_reuses_active_asm_context_for_same_entry_span(tracer):
+    with override_global_config(config_asm):
+        tracer._span_aggregator.writer._api_version = "v0.4"
+        tracer._recreate()
+        processor = AppSecSpanProcessor._instance
+        assert processor is not None
+        assert isinstance(processor._ddwaf, DDWaf)
+
+        with mock.patch.object(
+            processor._ddwaf,
+            "_at_request_start",
+            wraps=processor._ddwaf._at_request_start,
+        ) as at_request_start:
+            with (
+                core.context_with_data("test.parent", service="svc", headers={"user-agent": "parent"}),
+                tracer.trace("parent", service="svc", span_type=SpanTypes.WEB) as parent_span,
+            ):
+                parent_env = _asm_request_context._get_asm_context()
+                assert parent_env is not None
+                with tracer.trace("child", service="svc", span_type=SpanTypes.WEB) as child_span:
+                    assert child_span._service_entry_span is parent_span
+                    assert _asm_request_context._get_asm_context() is parent_env
+                    set_http_meta(child_span, rules.Config(), raw_uri="http://example.com/nested")
+                    assert parent_env.waf_addresses[SPAN_DATA_NAMES.REQUEST_URI_RAW] == "/nested"
+
+                assert _asm_request_context._get_asm_context() is parent_env
+
+        assert at_request_start.call_count == 1
+        assert _asm_request_context._get_asm_context() is None
+
+
+def test_nested_web_span_starts_new_asm_context_for_different_entry_span(tracer):
+    with override_global_config(config_asm):
+        tracer._span_aggregator.writer._api_version = "v0.4"
+        tracer._recreate()
+        processor = AppSecSpanProcessor._instance
+        assert processor is not None
+        assert isinstance(processor._ddwaf, DDWaf)
+
+        with mock.patch.object(
+            processor._ddwaf,
+            "_at_request_start",
+            wraps=processor._ddwaf._at_request_start,
+        ) as at_request_start:
+            with tracer.trace("parent", service="svc-parent", span_type=SpanTypes.WEB):
+                parent_env = _asm_request_context._get_asm_context()
+                assert parent_env is not None
+                with tracer.trace("child", service="svc-child", span_type=SpanTypes.WEB) as child_span:
+                    child_env = _asm_request_context._get_asm_context()
+                    assert child_env is not None
+                    assert child_env is not parent_env
+                    assert child_env.entry_span is child_span
+
+                assert _asm_request_context._get_asm_context() is parent_env
+
+        assert at_request_start.call_count == 2
         assert _asm_request_context._get_asm_context() is None
 
 


### PR DESCRIPTION
## Description

Fixes deterministic AppSec fingerprint corruption when an outer same-service WEB span starts before framework request headers are available, as in dogweb ProxyTraceMiddleware wrapping Flask.

Each tracer-defined service-entry span now owns one ASM environment and one ddwaf request context. Nested same-entry WEB spans enrich that environment instead of replacing it and later reviving a stale ancestor environment at span finish.

The regression reproduces the dogweb lifecycle with an outer proxy.request span, a nested flask.request span, and real request headers. It covers both a benign request fingerprint and a blocking scanner request, including preservation of event and blocking data.

Remote-config tests now model updates as applying to the next request context. An in-flight service entry keeps the WAF configuration it started with.

## Testing

- rt run 248da41 -- tests/appsec/appsec/test_processor.py -q
  - 97 passed on Python 3.13
- Focused dogweb and service-boundary regression selection
  - 3 passed
- Negative validation with the reuse guard removed
  - dogweb regression failed because Flask replaced the outer ASM environment
- scripts/lint typing -- ddtrace/appsec/_asm_request_context.py ddtrace/appsec/_processor.py
- scripts/lint spelling -- releasenotes/notes/fix-nested-asm-context-a13dbec2dbd139e2.yaml
- scripts/lint checks
- git diff --check

## Risks

Low to moderate.

The reuse boundary is the tracer service-entry span identity, not merely span type or nesting:

- Nested WEB spans whose service differs at creation have distinct service-entry spans and still create independent ASM environments.
- Same-service nested WEB spans share one request analysis context.
- Renaming span.service after creation does not create a new service-entry span; this is existing tracer behavior.
- WAF rule updates do not replace the context of an in-flight service entry and apply to request contexts created after the update.

The previous benchmark report included an apparent span-start regression alongside unrelated regressions. The revised implementation removes the original duplicate lookup: root requests retain the same number of context-tree lookups as main, while nested same-entry spans perform fewer lookups and avoid ddwaf context allocation. CI remains the authoritative performance comparison.

## Additional Notes

- APPSEC-69457
- Includes a customer-facing ASM fix release note.