### PR TITLE
ci(workflows): replace secrets.GITHUB_TOKEN with dd-octo-sts

### DIFF
--- a/.github/chainguard/self.backport-validate.sts.yaml
+++ b/.github/chainguard/self.backport-validate.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-py:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  ref: ".+"
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/backport-validate\.yml@.+
+
+permissions:
+  pull_requests: write

--- a/.github/chainguard/self.build-windows-docker.sts.yaml
+++ b/.github/chainguard/self.build-windows-docker.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-py:(pull_request|ref:refs/heads/.+)"
+
+claim_pattern:
+  event_name: (push|workflow_dispatch|pull_request)
+  repository: DataDog/dd-trace-py
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/build-windows-docker\.yml@.+
+
+permissions:
+  packages: write

--- a/.github/chainguard/self.lib-inject-prune.sts.yaml
+++ b/.github/chainguard/self.lib-inject-prune.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-py:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  ref: refs/heads/.+
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/lib-inject-prune\.yml@refs/heads/.+
+
+permissions:
+  packages: write

--- a/.github/chainguard/self.testrunner.sts.yaml
+++ b/.github/chainguard/self.testrunner.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-py:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (push|workflow_dispatch)
+  ref: refs/heads/.+
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/build-and-publish-image\.yml@refs/heads/.+
+
+permissions:
+  packages: write

--- a/.github/workflows/backport-validate.yml
+++ b/.github/workflows/backport-validate.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      id-token: write
     if: >
       github.event.action == 'labeled' && contains(github.event.label.name, 'backport')
     steps:
@@ -18,11 +19,18 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.backport-validate
+
       - name: Check Conflicts
         env:
           BACKPORT_LABEL: ${{ github.event.label.name }}
           PR_BRANCH: ${{ github.head_ref }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         id: backport_validation
         run: |
 
@@ -58,6 +66,7 @@ jobs:
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           file-path: comment.txt
           message: |
             ${{ steps.backport_validation.outputs.results }}

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -19,9 +19,9 @@ on:
         required: false
         type: string
         default: Dockerfile
-    secrets:
-      token:
+      octo-sts-policy:
         required: true
+        type: string
 
 jobs:
   build_push:
@@ -29,26 +29,33 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      with:
-        # Images after this version (>=v0.10) are incompatible with gcr and aws.
-        version: v0.9.1  # https://github.com/docker/buildx/issues/1533
-    - name: Login to Docker
-      run: echo "${{ secrets.token }}" | docker login -u publisher --password-stdin ghcr.io
-    - name: Docker Build
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-      with:
-        push: true
-        tags: ${{ inputs.tags }}
-        platforms: ${{ inputs.platforms }}
-        build-args: ${{ inputs.build-args }}
-        context: ${{ inputs.context }}
-        file: ${{ inputs.context }}/${{ inputs.file }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-py
+          policy: ${{ inputs.octo-sts-policy }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          # Images after this version (>=v0.10) are incompatible with gcr and aws.
+          version: v0.9.1 # https://github.com/docker/buildx/issues/1533
+      - name: Login to Docker
+        run: echo "${{ steps.generate-token.outputs.token }}" | docker login -u publisher --password-stdin ghcr.io
+      - name: Docker Build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          push: true
+          tags: ${{ inputs.tags }}
+          platforms: ${{ inputs.platforms }}
+          build-args: ${{ inputs.build-args }}
+          context: ${{ inputs.context }}
+          file: ${{ inputs.context }}/${{ inputs.file }}

--- a/.github/workflows/build-windows-docker.yml
+++ b/.github/workflows/build-windows-docker.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,8 +34,15 @@ jobs:
             if ($timeout -le 0) { throw "Docker daemon did not start in time" }
           }
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.build-windows-docker
+
       - name: Log in to GHCR
-        run: docker login ghcr.io -u publisher -p ${{ secrets.GITHUB_TOKEN }}
+        run: docker login ghcr.io -u publisher -p ${{ steps.generate-token.outputs.token }}
         shell: powershell
 
       - name: Build Windows Docker image

--- a/.github/workflows/lib-inject-prune.yml
+++ b/.github/workflows/lib-inject-prune.yml
@@ -1,7 +1,7 @@
 name: Prune Lib Injection images
 on:
   schedule:
-    - cron: '15 3 * * *'
+    - cron: "15 3 * * *"
   workflow_dispatch:
 
 jobs:
@@ -12,20 +12,27 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
-    - name: Prune registry
-      uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 #v0.6.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        organization: Datadog
-        container: dd-trace-py/dd-lib-python-init
-        keep-younger-than: 7 # days
-        keep-last: 10
-        keep-tags: |
-          latest_snapshot
-        prune-tags-regexes: |
-          ^[a-z0-9]{40}$
-        prune-untagged: true
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.lib-inject-prune
+      - name: Prune registry
+        uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 #v0.6.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          organization: Datadog
+          container: dd-trace-py/dd-lib-python-init
+          keep-younger-than: 7 # days
+          keep-last: 10
+          keep-tags: |
+            latest_snapshot
+          prune-tags-regexes: |
+            ^[a-z0-9]{40}$
+          prune-untagged: true
 
   prune-init-test-app-images:
     name: Prune test app docker images
@@ -34,26 +41,33 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     strategy:
       matrix:
         image:
-          - 'dd-lib-python-init-test-django'
-          - 'dd-lib-python-init-test-django-gunicorn'
-          - 'dd-lib-python-init-test-django-uvicorn'
-          - 'dd-lib-python-init-test-django-uwsgi'
-          - 'dd-lib-python-init-test-app'
-          - 'dd-python-agent-init'
+          - "dd-lib-python-init-test-django"
+          - "dd-lib-python-init-test-django-gunicorn"
+          - "dd-lib-python-init-test-django-uvicorn"
+          - "dd-lib-python-init-test-django-uwsgi"
+          - "dd-lib-python-init-test-app"
+          - "dd-python-agent-init"
     steps:
-    - name: Prune registry
-      uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 #v0.6.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        organization: Datadog
-        container: dd-trace-py/${{ matrix.image }}
-        keep-younger-than: 15 # days
-        keep-last: 5
-        keep-tags: |
-          latest_snapshot
-        prune-tags-regexes: |
-          ^[a-z0-9]{40}$
-        prune-untagged: true
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.lib-inject-prune
+      - name: Prune registry
+        uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 #v0.6.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          organization: Datadog
+          container: dd-trace-py/${{ matrix.image }}
+          keep-younger-than: 15 # days
+          keep-last: 5
+          keep-tags: |
+            latest_snapshot
+          prune-tags-regexes: |
+            ^[a-z0-9]{40}$
+          prune-untagged: true

--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - 'docker/**'
+      - "docker/**"
 
 jobs:
   build-and-publish:
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
-      tags: 'ghcr.io/datadog/dd-trace-py/testrunner:${{ github.sha }},ghcr.io/datadog/dd-trace-py/testrunner:latest'
-      platforms: 'linux/amd64,linux/arm64/v8'
-      build-args: ''
+      tags: "ghcr.io/datadog/dd-trace-py/testrunner:${{ github.sha }},ghcr.io/datadog/dd-trace-py/testrunner:latest"
+      platforms: "linux/amd64,linux/arm64/v8"
+      build-args: ""
       context: ./docker
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      octo-sts-policy: self.testrunner


### PR DESCRIPTION
> **Stacked on #18042** (chainguard policies — merge first).

## Description

Replace all `secrets.GITHUB_TOKEN` usage across GitHub Actions workflows with OIDC tokens minted by `DataDog/dd-octo-sts-action`.

The reusable `build-and-publish-image.yml` workflow replaces its `secrets.token` input with an `octo-sts-policy` string input so it can mint its own token internally (required because dd-octo-sts tokens are scoped to the job that creates them).

Added 4 Chainguard policy files under `.github/chainguard/`.

No functional changes.

## Testing

Watch CI.

## Additional Notes

Affected workflows: `backport-validate.yml`, `build-and-publish-image.yml`, `build-windows-docker.yml`, `lib-inject-prune.yml`, `testrunner.yml`.

## Jira

- [APMLP-1606](https://datadoghq.atlassian.net/browse/APMLP-1606)


[APMLP-1606]: https://datadoghq.atlassian.net/browse/APMLP-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ