### PR TITLE
chore(ci): bump system-tests to deefa417

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '24c2e96e7703a8128d5a29cae2e95776d86ef790'
+          ref: 'deefa417c278a94b122a456e892b16b62169225a'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '24c2e96e7703a8128d5a29cae2e95776d86ef790'
+          ref: 'deefa417c278a94b122a456e892b16b62169225a'
 
       - name: Build runner
         uses: ./.github/actions/install_runner

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "24c2e96e7703a8128d5a29cae2e95776d86ef790"
+  SYSTEM_TESTS_REF: "deefa417c278a94b122a456e892b16b62169225a"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Description

Bumps the `DataDog/system-tests` pinned ref from `24c2e96e` to `deefa417c278a94b122a456e892b16b62169225a` (latest `main`, "Disable CSS in sampling test #6895").

Updated via `scripts/update-system-tests-version.py`:
- `.github/workflows/system-tests.yml` (2 `ref:` entries)
- `.gitlab-ci.yml` (`SYSTEM_TESTS_REF`)

## Testing

CI system-tests jobs will exercise the new ref.

## Risks

Low — routine pin bump. Any regression surfaces in the system-tests CI jobs on this PR.

## Additional Notes

CI-only change, no user-facing impact → `changelog/no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)