### PR TITLE
chore(CI): update system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '24c2e96e7703a8128d5a29cae2e95776d86ef790'
+          ref: '1c483bf19facb9109d9debe58865b54b97ca4307'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '24c2e96e7703a8128d5a29cae2e95776d86ef790'
+          ref: '1c483bf19facb9109d9debe58865b54b97ca4307'
 
       - name: Build runner
         uses: ./.github/actions/install_runner

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "24c2e96e7703a8128d5a29cae2e95776d86ef790"
+  SYSTEM_TESTS_REF: "1c483bf19facb9109d9debe58865b54b97ca4307"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Description

Updating system tests pinned hash, using `scripts/update-system-tests-version.py`

## Motivation

[Remove test_config_telemetry_completeness](https://github.com/DataDog/system-tests/pull/6854)

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
