### PR TITLE
chore(internal): minimal fix for PeriodicThread.awake() after stop()

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -715,14 +715,43 @@ PeriodicThread_awake(PeriodicThread* self, PyObject* Py_UNUSED(args))
         return NULL;
     }
 
+    // GIL-fast-path: a prior Python-thread stop() is fully ordered before us,
+    // so seeing _stopping here means the worker is permanently gone. The
+    // fork-paused window flips _stopping=true with _skip_shutdown=true; let
+    // those calls through so a queued AWAKE survives across _after_fork().
+    if (self->_stopping && !self->_skip_shutdown) {
+        PyErr_SetString(PyExc_RuntimeError, "Periodic thread is stopped");
+        return NULL;
+    }
+
+    bool was_stopped = false;
     {
         AllowThreads _(self->_state);
-        std::lock_guard<std::mutex> lock(*self->_awake_mutex);
 
-        self->_served->clear();
-        self->_request->set(REQUEST_REASON_AWAKE);
+        // Set up the wait under _awake_mutex. stop() also takes this mutex,
+        // so either we observe its _stopping write here, or our set(AWAKE)
+        // is ordered before its set(STOP) and the worker's cleanup
+        // _served->set() (loop exit, line 625) wakes us.
+        {
+            std::lock_guard<std::mutex> lock(*self->_awake_mutex);
 
-        self->_served->wait();
+            if (self->_stopping && !self->_skip_shutdown) {
+                was_stopped = true;
+            } else {
+                self->_served->clear();
+                self->_request->set(REQUEST_REASON_AWAKE);
+            }
+        }
+
+        // Wait *outside* the mutex so a periodic callback that calls
+        // stop() on itself (Timer._periodic) does not deadlock against us.
+        if (!was_stopped)
+            self->_served->wait();
+    }
+
+    if (was_stopped) {
+        PyErr_SetString(PyExc_RuntimeError, "Periodic thread is stopped");
+        return NULL;
     }
 
     Py_RETURN_NONE;
@@ -737,8 +766,16 @@ PeriodicThread_stop(PeriodicThread* self, PyObject* Py_UNUSED(args))
         return NULL;
     }
 
-    self->_stopping = true;
-    self->_request->set(REQUEST_REASON_STOP);
+    // Order _stopping + set(STOP) against awake()'s setup of (clear _served,
+    // set AWAKE). Without this, awake() could clear _served after the worker
+    // has already exited and set it on cleanup, then wait forever.
+    {
+        AllowThreads _(self->_state);
+        std::lock_guard<std::mutex> lock(*self->_awake_mutex);
+
+        self->_stopping = true;
+        self->_request->set(REQUEST_REASON_STOP);
+    }
 
     Py_RETURN_NONE;
 }

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -715,28 +715,26 @@ PeriodicThread_awake(PeriodicThread* self, PyObject* Py_UNUSED(args))
         return NULL;
     }
 
-    // GIL-fast-path: a prior Python-thread stop() is fully ordered before us,
-    // so seeing _stopping here means the worker is permanently gone. The
-    // fork-paused window flips _stopping=true with _skip_shutdown=true; let
-    // those calls through so a queued AWAKE survives across _after_fork().
-    if (self->_stopping && !self->_skip_shutdown) {
-        PyErr_SetString(PyExc_RuntimeError, "Periodic thread is stopped");
-        return NULL;
-    }
+    // GIL-fast-path: if the worker is permanently stopped (not fork-paused),
+    // awake() is a best-effort no-op. Surfacing a RuntimeError here would
+    // make a timing-dependent race (stop() vs in-flight awake()) visible
+    // to callers, which is worse than silently doing nothing.
+    if (self->_stopping && !self->_skip_shutdown)
+        Py_RETURN_NONE;
 
-    bool was_stopped = false;
+    bool stopped = false;
     {
         AllowThreads _(self->_state);
 
         // Set up the wait under _awake_mutex. stop() also takes this mutex,
         // so either we observe its _stopping write here, or our set(AWAKE)
         // is ordered before its set(STOP) and the worker's cleanup
-        // _served->set() (loop exit, line 625) wakes us.
+        // _served->set() (loop exit) wakes us.
         {
             std::lock_guard<std::mutex> lock(*self->_awake_mutex);
 
             if (self->_stopping && !self->_skip_shutdown) {
-                was_stopped = true;
+                stopped = true;
             } else {
                 self->_served->clear();
                 self->_request->set(REQUEST_REASON_AWAKE);
@@ -745,13 +743,8 @@ PeriodicThread_awake(PeriodicThread* self, PyObject* Py_UNUSED(args))
 
         // Wait *outside* the mutex so a periodic callback that calls
         // stop() on itself (Timer._periodic) does not deadlock against us.
-        if (!was_stopped)
+        if (!stopped)
             self->_served->wait();
-    }
-
-    if (was_stopped) {
-        PyErr_SetString(PyExc_RuntimeError, "Periodic thread is stopped");
-        return NULL;
     }
 
     Py_RETURN_NONE;

--- a/releasenotes/notes/fix-periodic-thread-awake-after-stop-4d632069433cd8df.yaml
+++ b/releasenotes/notes/fix-periodic-thread-awake-after-stop-4d632069433cd8df.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    internal: This fix resolves an issue where calling ``awake()`` on a
+    ``PeriodicThread`` after it had been stopped would block forever.
+    ``awake()`` now returns immediately in that case.

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -76,20 +76,24 @@ def test_periodic_join_positional_timeout_is_honored():
         t.join()
 
 
-def test_periodic_awake_after_stop_raises_not_hangs():
+def test_periodic_awake_after_stop_returns_not_hangs():
     """Regression: awake() after a completed stop() used to block forever.
 
     Once a worker has fully stopped, there is nothing left that can serve a
-    new awake request. The native awake() path must therefore reject the call
+    new awake request. The native awake() path must therefore short-circuit
     instead of waiting forever for a completion signal that will never come.
+
+    We deliberately make awake() a silent no-op (not a RuntimeError) so that
+    a racy stop()/awake() interleaving never surfaces a timing-dependent
+    exception to callers.
     """
     t = periodic.PeriodicThread(60.0, lambda: None)
     t.start()
     t.stop()
     t.join()  # fully drained
 
-    with pytest.raises(RuntimeError):
-        t.awake()
+    # Must return promptly. Before the fix this hung forever.
+    t.awake()
 
 
 def test_periodic_awake_does_not_deadlock_with_stop_from_callback():

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -76,6 +76,78 @@ def test_periodic_join_positional_timeout_is_honored():
         t.join()
 
 
+def test_periodic_awake_after_stop_raises_not_hangs():
+    """Regression: awake() after a completed stop() used to block forever.
+
+    Once a worker has fully stopped, there is nothing left that can serve a
+    new awake request. The native awake() path must therefore reject the call
+    instead of waiting forever for a completion signal that will never come.
+    """
+    t = periodic.PeriodicThread(60.0, lambda: None)
+    t.start()
+    t.stop()
+    t.join()  # fully drained
+
+    with pytest.raises(RuntimeError):
+        t.awake()
+
+
+def test_periodic_awake_does_not_deadlock_with_stop_from_callback():
+    """Regression: stop() called from inside a periodic callback must not
+    deadlock against a concurrent awake() holding the awake mutex.
+
+    Timer._periodic uses the pattern:
+
+        def _periodic(self):
+            self.timeout()
+            self.stop()
+
+    A naive fix that has stop() acquire _awake_mutex creates this deadlock:
+
+      1. Thread A calls t.awake() — takes _awake_mutex, publishes AWAKE,
+         then waits for completion.
+      2. The worker consumes AWAKE and runs the callback.
+      3. The callback calls t.stop() on the worker thread.
+      4. stop() blocks on _awake_mutex if awake() keeps it locked while
+         waiting.
+      5. The worker cannot finish the callback and cannot reach
+         the wake-completion path — both threads wait forever.
+
+    The middle-ground fix has awake() release _awake_mutex before waiting on
+    _served, so a worker-thread stop() can take the mutex freely.
+    """
+
+    def _target():
+        # Stop ourselves from the worker thread — this is exactly the
+        # Timer._periodic pattern.
+        t.stop()
+
+    t = periodic.PeriodicThread(60.0, _target)
+    t.start()
+
+    awake_done = Event()
+
+    def _do_awake():
+        try:
+            t.awake()
+        finally:
+            awake_done.set()
+
+    awaker = Thread(target=_do_awake)
+    awaker.start()
+
+    # The awake() call should return well within a second. Before the fix this
+    # deadlocked indefinitely because the worker-thread stop() tried to take
+    # _awake_mutex while awake() was blocked waiting for completion.
+    assert awake_done.wait(timeout=5.0), (
+        "awake() did not return within 5s — stop()-from-callback deadlocked "
+        "against a concurrent awake() holding the awake mutex"
+    )
+
+    awaker.join(timeout=1.0)
+    t.join(timeout=1.0)
+
+
 def test_periodic_error():
     x = {"OK": False}
 

--- a/tests/internal/test_periodic_race.py
+++ b/tests/internal/test_periodic_race.py
@@ -1,0 +1,155 @@
+"""Race-injection stress tests for the middle-ground PeriodicThread fix.
+
+These deliberately try to surface a hang in the awake()/stop() interleaving
+that the middle-ground design has to handle without an explicit
+condition_variable. Run is bounded so the harness fails fast (rather than
+hanging the test session) if a regression appears.
+"""
+
+import os
+import random
+import threading
+import time
+
+import pytest
+
+from ddtrace.internal import periodic
+
+
+# Conservative budget so the test suite stays fast in CI but the race window
+# gets enough chances. Override with PERIODIC_RACE_ITERATIONS=N for soaks.
+_ITERATIONS = int(os.environ.get("PERIODIC_RACE_ITERATIONS", "5000"))
+_PER_OP_DEADLINE = 5.0
+
+
+def _watchdog(deadline, what):
+    """Raise pytest.fail (rather than hang) if `what` does not complete in time."""
+    if not deadline.wait(timeout=_PER_OP_DEADLINE):
+        pytest.fail("watchdog: %s did not complete within %ss" % (what, _PER_OP_DEADLINE))
+
+
+def test_race_stop_concurrent_with_awake():
+    """Hammer the window where stop() races in-flight awake().
+
+    awake() releases the GIL after the early _stopping check, then competes
+    with stop() for _awake_mutex. The middle-ground design must:
+
+    1. If stop() wins the mutex first: awake() observes _stopping under the
+       mutex and bails with RuntimeError (does NOT touch _served).
+    2. If awake() wins: it publishes AWAKE; either the worker serves it
+       (then exits on STOP) or the worker's cleanup _served->set() wakes us.
+
+    Either branch must complete; nothing may hang.
+    """
+    rng = random.Random(0xBADBEEF)
+
+    for i in range(_ITERATIONS):
+        t = periodic.PeriodicThread(60.0, lambda: None)
+        t.start()
+
+        # Variable interleaving — sometimes stop fires before awake even
+        # enters the C function, sometimes during, sometimes after.
+        jitter_us = rng.randint(0, 500)
+
+        awake_done = threading.Event()
+        stop_done = threading.Event()
+        awake_raised = [None]  # captured exception, if any
+
+        def _awake_target():
+            try:
+                t.awake()
+            except RuntimeError as e:
+                awake_raised[0] = e
+            finally:
+                awake_done.set()
+
+        def _stop_target():
+            if jitter_us:
+                # Busy-spin for a short jitter to vary the race window.
+                deadline = time.perf_counter() + jitter_us / 1e6
+                while time.perf_counter() < deadline:
+                    pass
+            t.stop()
+            stop_done.set()
+
+        a = threading.Thread(target=_awake_target)
+        s = threading.Thread(target=_stop_target)
+        a.start()
+        s.start()
+
+        _watchdog(awake_done, "iter=%d awake()" % i)
+        _watchdog(stop_done, "iter=%d stop()" % i)
+
+        a.join(timeout=1.0)
+        s.join(timeout=1.0)
+        t.join(timeout=2.0)
+
+
+def test_race_awake_after_completed_stop_always_raises():
+    """Tight loop: stop+join+awake must always raise, never hang.
+
+    This is the case literally described in PR 17707. The early _stopping
+    check is GIL-serialized so it must always observe the prior stop().
+    """
+    for i in range(_ITERATIONS):
+        t = periodic.PeriodicThread(60.0, lambda: None)
+        t.start()
+        t.stop()
+        t.join(timeout=2.0)
+
+        with pytest.raises(RuntimeError):
+            t.awake()
+
+
+def test_race_callback_stop_with_concurrent_awakes():
+    """Timer._periodic pattern + many concurrent awakers.
+
+    The callback self-stops, and several outside threads call awake() in
+    parallel. None of them may deadlock or hang regardless of who wins the
+    race for _awake_mutex. The first awake() to be served triggers stop()
+    inside the callback; subsequent awake()s either complete (worker still
+    serving) or raise RuntimeError (worker gone).
+    """
+    NUM_AWAKERS = 8
+
+    for i in range(_ITERATIONS // 4 or 1):  # heavier per-iteration cost
+        called = threading.Event()
+        t_holder = [None]
+
+        def _target():
+            called.set()
+            t_holder[0].stop()
+
+        t = periodic.PeriodicThread(60.0, _target)
+        t_holder[0] = t
+        t.start()
+
+        done_events = [threading.Event() for _ in range(NUM_AWAKERS)]
+        outcomes = [None] * NUM_AWAKERS
+
+        def _awaker(idx):
+            try:
+                t.awake()
+                outcomes[idx] = "ok"
+            except RuntimeError as e:
+                outcomes[idx] = "raised: %s" % e
+            finally:
+                done_events[idx].set()
+
+        threads = [threading.Thread(target=_awaker, args=(j,)) for j in range(NUM_AWAKERS)]
+        for th in threads:
+            th.start()
+
+        for j, ev in enumerate(done_events):
+            _watchdog(ev, "iter=%d awaker[%d]" % (i, j))
+
+        for th in threads:
+            th.join(timeout=1.0)
+        t.join(timeout=2.0)
+
+        # At least one awaker must have produced the wake that triggered
+        # the callback. The callback signals `called` before calling stop().
+        assert called.is_set(), "iter=%d: callback never ran" % i
+        # Every outcome must be either an ok serve or a clean RuntimeError.
+        for j, o in enumerate(outcomes):
+            assert o is not None and (o == "ok" or o.startswith("raised:")), "iter=%d awaker[%d] outcome=%r" % (i, j, o)

--- a/tests/internal/test_periodic_race.py
+++ b/tests/internal/test_periodic_race.py
@@ -35,11 +35,11 @@ def test_race_stop_concurrent_with_awake():
     with stop() for _awake_mutex. The middle-ground design must:
 
     1. If stop() wins the mutex first: awake() observes _stopping under the
-       mutex and bails with RuntimeError (does NOT touch _served).
+       mutex and silently bails (does NOT touch _served).
     2. If awake() wins: it publishes AWAKE; either the worker serves it
        (then exits on STOP) or the worker's cleanup _served->set() wakes us.
 
-    Either branch must complete; nothing may hang.
+    Either branch must complete without hanging.
     """
     rng = random.Random(0xBADBEEF)
 
@@ -53,13 +53,10 @@ def test_race_stop_concurrent_with_awake():
 
         awake_done = threading.Event()
         stop_done = threading.Event()
-        awake_raised = [None]  # captured exception, if any
 
         def _awake_target():
             try:
                 t.awake()
-            except RuntimeError as e:
-                awake_raised[0] = e
             finally:
                 awake_done.set()
 
@@ -85,20 +82,21 @@ def test_race_stop_concurrent_with_awake():
         t.join(timeout=2.0)
 
 
-def test_race_awake_after_completed_stop_always_raises():
-    """Tight loop: stop+join+awake must always raise, never hang.
+def test_race_awake_after_completed_stop_does_not_hang():
+    """Tight loop: stop+join+awake must always return, never hang.
 
     This is the case literally described in PR 17707. The early _stopping
     check is GIL-serialized so it must always observe the prior stop().
+    awake() short-circuits silently instead of raising — see
+    test_periodic_awake_after_stop_returns_not_hangs.
     """
-    for i in range(_ITERATIONS):
+    for _ in range(_ITERATIONS):
         t = periodic.PeriodicThread(60.0, lambda: None)
         t.start()
         t.stop()
         t.join(timeout=2.0)
 
-        with pytest.raises(RuntimeError):
-            t.awake()
+        t.awake()
 
 
 def test_race_callback_stop_with_concurrent_awakes():
@@ -108,7 +106,7 @@ def test_race_callback_stop_with_concurrent_awakes():
     parallel. None of them may deadlock or hang regardless of who wins the
     race for _awake_mutex. The first awake() to be served triggers stop()
     inside the callback; subsequent awake()s either complete (worker still
-    serving) or raise RuntimeError (worker gone).
+    serving) or silently bail (worker gone).
     """
     NUM_AWAKERS = 8
 
@@ -125,14 +123,10 @@ def test_race_callback_stop_with_concurrent_awakes():
         t.start()
 
         done_events = [threading.Event() for _ in range(NUM_AWAKERS)]
-        outcomes = [None] * NUM_AWAKERS
 
         def _awaker(idx):
             try:
                 t.awake()
-                outcomes[idx] = "ok"
-            except RuntimeError as e:
-                outcomes[idx] = "raised: %s" % e
             finally:
                 done_events[idx].set()
 
@@ -150,6 +144,3 @@ def test_race_callback_stop_with_concurrent_awakes():
         # At least one awaker must have produced the wake that triggered
         # the callback. The callback signals `called` before calling stop().
         assert called.is_set(), "iter=%d: callback never ran" % i
-        # Every outcome must be either an ok serve or a clean RuntimeError.
-        for j, o in enumerate(outcomes):
-            assert o is not None and (o == "ok" or o.startswith("raised:")), "iter=%d awaker[%d] outcome=%r" % (i, j, o)


### PR DESCRIPTION
## Description

Alternative to #17707 for the same bug: `PeriodicThread.awake()` blocks
forever on `_served->wait()` when called after `stop()` has completed
(worker already exited, `_served` will never be set again).

### Approach

- **`awake()`**: GIL-fast-path early check on `_stopping` — a prior
  Python-thread `stop()` is fully ordered before us under the GIL.
  Then a re-check under `_awake_mutex` and `_served->wait()` *outside*
  the mutex so a worker callback that calls `stop()` on itself
  (the `Timer._periodic` pattern) cannot deadlock.
  On the stopped path `awake()` returns silently (no `RuntimeError`)
  so a racy `stop()` / `awake()` interleaving never surfaces a
  timing-dependent exception to callers.
- **`stop()`**: takes `_awake_mutex` around `_stopping = true` +
  `_request->set(STOP)`, ordering it against `awake()`'s
  `_served->clear()` + `set(AWAKE)` setup.
- **`_before_fork()`** already takes `_awake_mutex` on main; unchanged.
- **`_served` Event, worker loop and helpers** are all unchanged.

## Testing

Regression tests from #17707 are copied and adapted to the no-op
semantics:
- `test_periodic_awake_after_stop_returns_not_hangs`
- `test_periodic_awake_does_not_deadlock_with_stop_from_callback`

New `tests/internal/test_periodic_race.py` (race-injection stress;
default 5000 iterations, override with `PERIODIC_RACE_ITERATIONS`):
- `test_race_stop_concurrent_with_awake`
- `test_race_awake_after_completed_stop_does_not_hang`
- `test_race_callback_stop_with_concurrent_awakes`

Each test has a 5s per-operation watchdog so a regression fails fast.

## Risks

Low. `awake()` after a completed `stop()` + `join()` now returns
silently instead of hanging. Internal API; `changelog/no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)