### PR TITLE
fix(profiling): upload last profile on exit signal

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -76,6 +76,13 @@ class Profiler(object):
 
         atexit.register(self.stop)
 
+        # register_on_exit_signal is needed for processes terminated via SIGTERM (e.g.
+        # Ray workers, Kubernetes pods). Python atexit handlers do NOT run on SIGTERM by default,
+        # so without this the last partial profile window is silently lost.
+        # We register _stop_on_signal (not stop) to avoid deadlocking when SIGTERM arrives while
+        # _active_lock is already held by the main thread (e.g. during start or stop).
+        atexit.register_on_exit_signal(self._stop_on_signal)
+
         # Note: For regular fork(), native pthread_atfork handlers restart the sampling thread
         # and PeriodicThread auto-restart handles the Scheduler. No explicit forksafe hook needed.
         # For uWSGI, _start_on_fork is registered via uwsgidecorators.postfork() in check_uwsgi().
@@ -97,6 +104,40 @@ class Profiler(object):
         except service.ServiceStatusError:
             # Not a best practice, but for backward API compatibility that allowed to call `stop` multiple times.
             pass
+
+    def _stop_on_signal(self) -> None:
+        """Flush and stop the profiler when an exit signal (SIGTERM/SIGINT) is received.
+
+        Signal handlers run in the main thread between bytecodes. If the main thread already
+        holds _active_lock (e.g. SIGTERM races with start or stop), a blocking acquire
+        would deadlock. We use non-blocking acquire and bail out when the lock is unavailable:
+        in that case start/stop is already in progress and will handle cleanup itself.
+
+        This mirrors the pattern used by the tracer's shutdown method.
+        """
+        atexit.unregister(self.stop)
+
+        if not Profiler._active_lock.acquire(blocking=False):
+            # If the lock is unavailable, stop is already running on the main thread
+            # (signal handlers are delivered between bytecodes of the main thread, so the main
+            # thread itself holds the lock). A blocking acquire here would deadlock. We bail out
+            # and rely on the in-progress stop to complete the flush. The narrow race where
+            # _raise_default terminates the process before stop finishes is a known
+            # limitation: there is no safe way to wait for a lock held by the
+            # current thread from within a signal handler.
+            return
+
+        try:
+            self._profiler.stop(flush=True)
+        except service.ServiceStatusError:
+            pass
+        except Exception:
+            LOG.debug("Exception while stopping profiler on exit signal", exc_info=True)
+        finally:
+            if Profiler._active_instance is self:
+                Profiler._active_instance = None
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
+            Profiler._active_lock.release()
 
     def _start_on_fork(self) -> None:
         """Start a fresh profiler in child process after fork. This is needed for uWSGI support."""

--- a/releasenotes/notes/profiling-flush-profile-on-exit-signal-90aced08fad7ad40.yaml
+++ b/releasenotes/notes/profiling-flush-profile-on-exit-signal-90aced08fad7ad40.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: The Profiler now flushes the last profile on ``SIGINT`` and ``SIGTERM`` signals.

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -552,6 +552,49 @@ def test_same_profiler_restart_allowed() -> None:
     p.stop(flush=False)
 
 
+@pytest.mark.subprocess(err=None)
+def test_start_registers_sigterm_handler() -> None:
+    """Profiler.start must register _stop_on_signal as a SIGTERM/SIGINT handler via register_on_exit_signal."""
+    from unittest import mock
+
+    from ddtrace.internal import atexit
+    from ddtrace.profiling import profiler
+
+    with mock.patch.object(atexit, "register_on_exit_signal") as mock_reg:
+        p = profiler.Profiler()
+        p.start()
+        mock_reg.assert_called_once_with(p._stop_on_signal)
+        p.stop(flush=False)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM not supported on Windows")
+@pytest.mark.subprocess(status=-15, out=lambda s: s.count("flushed") == 1, err=None)
+def test_profiler_flushes_on_sigterm() -> None:
+    """Profiler must flush the last profile exactly once when the process receives SIGTERM.
+
+    Asserts:
+    - upload is called (flush happened).
+    - upload is called exactly once (no double-flush from atexit + signal, or scheduler race).
+
+    The process exits with status -15 (killed by SIGTERM) because register_on_exit_signal
+    chains onto _raise_default which re-raises SIGTERM with SIG_DFL after all handlers
+    complete, so atexit never runs.
+    """
+    import os
+    import signal
+    from unittest import mock
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling import profiler
+
+    with mock.patch.object(ddup, "upload", lambda *a, **kw: print("flushed", flush=True)):
+        p = profiler.Profiler()
+        p.start()
+        os.kill(os.getpid(), signal.SIGTERM)
+
+        # (unreachable: _raise_default re-raises SIGTERM with SIG_DFL, killing the process)
+
+
 @pytest.mark.subprocess(
     env=dict(DD_PROFILING_ENABLED="true"),
     ddtrace_run=True,


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-14041

This PR adds an at-exit handler _for exit signals_ (on top of the one that already exists for "regular" exits). 

This is useful for frameworks like [Ray](https://www.ray.io/) which rely on `SIGTERM` to exit worker processes. In those cases, if worker processes are running short-lived Tasks (in particular, Tasks that last less than the upload interval whose default is 60s), we would never get profiles uploaded at all.

The PR also adds tests to make sure:
- The at-exit handler _is_ called when the process is issued a `SIGTERM`
- The at-exit handler is called once and only once (no redundant, double-flush)

## Testing

This was tested on a live Ray cluster and is working as expected for a short-lived task with `DD_PROFILING_UPLOAD_INTERVAL=60`.

<img width="1218" height="349" alt="image" src="https://github.com/user-attachments/assets/9030fdfa-aca3-4689-8a85-004df8ab7e8d" />
