### PR TITLE
fix(appsec): emit telemetry when Django user auth events are missing user_id or user_login

### DIFF
--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from ddtrace._trace.pin import Pin
 from ddtrace.appsec import _asm_request_context
+from ddtrace.appsec import _metrics
 from ddtrace.appsec._asm_request_context import _call_waf
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _get_headers_if_appsec
@@ -34,6 +35,8 @@ from ddtrace.trace import tracer
 
 log = get_logger(__name__)
 
+TELEMETRY_FRAMEWORK_NAME = "django"
+
 
 def _on_django_login(
     _pin: Pin,
@@ -51,7 +54,15 @@ def _on_django_login(
             email=django_config.include_user_email,
             name=django_config.include_user_realname,
         )
+        user_login = user_extra.get("login")
         if user_is_authenticated(user_obj):
+            _metrics.report_user_auth_missing(
+                TELEMETRY_FRAMEWORK_NAME,
+                "login_success",
+                user_id,
+                user_login,
+                django_config.include_user_login,
+            )
             with tracer.trace("django.contrib.auth.login", span_type=SpanTypes.AUTH):
                 session_key = getattr(getattr(request, "session", None), "session_key", None)
                 track_user_login_success_event(
@@ -65,9 +76,14 @@ def _on_django_login(
         else:
             # Login failed and the user is unknown (may exist or not)
             # DEV: DEAD CODE?
-            track_user_login_failure_event(
-                None, user_id=user_id, login_events_mode=mode, login=user_extra.get("login", None)
+            _metrics.report_user_auth_missing(
+                TELEMETRY_FRAMEWORK_NAME,
+                "login_failure",
+                user_id,
+                user_login,
+                django_config.include_user_login,
             )
+            track_user_login_failure_event(None, user_id=user_id, login_events_mode=mode, login=user_login)
 
 
 def _on_django_auth(
@@ -101,8 +117,16 @@ def _on_django_auth(
             if user_extra.get("login") is None:
                 user_extra["login"] = user_id
             user_id = user_id_found or user_id
+            user_login = user_extra.get("login")
 
             track_user_login_failure_event(None, user_id=user_id, login_events_mode=mode, exists=exists, **user_extra)
+            _metrics.report_user_auth_missing(
+                TELEMETRY_FRAMEWORK_NAME,
+                "login_failure",
+                user_id,
+                user_login,
+                django_config.include_user_login,
+            )
 
     return False, None
 
@@ -147,6 +171,8 @@ def _on_django_process(
     user_login = user_extra.get("login")
     res = None
     if result_user and result_user.is_authenticated:
+        if _metrics._is_user_auth_value_missing(user_id):
+            _metrics.report_user_auth_missing_user_id(TELEMETRY_FRAMEWORK_NAME, "authenticated_request")
         span = _asm_request_context.get_entry_span()
         if span is None:
             return
@@ -206,6 +232,14 @@ def _on_django_signup_user(
         return
     user_id, user_extra = get_user_info(info_retriever, django_config)
     if user_obj:
+        user_login = user_extra.get("login")
+        _metrics.report_user_auth_missing(
+            TELEMETRY_FRAMEWORK_NAME,
+            "signup",
+            user_id,
+            user_login,
+            django_config.include_user_login,
+        )
         span = _asm_request_context.get_entry_span()
         if span is None:
             return

--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -119,7 +119,6 @@ def _on_django_auth(
             user_id = user_id_found or user_id
             user_login = user_extra.get("login")
 
-            track_user_login_failure_event(None, user_id=user_id, login_events_mode=mode, exists=exists, **user_extra)
             _metrics.report_user_auth_missing(
                 TELEMETRY_FRAMEWORK_NAME,
                 "login_failure",
@@ -127,6 +126,7 @@ def _on_django_auth(
                 user_login,
                 django_config.include_user_login,
             )
+            track_user_login_failure_event(None, user_id=user_id, login_events_mode=mode, exists=exists, **user_extra)
 
     return False, None
 

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -1,6 +1,7 @@
 import functools
 from typing import Any
 from typing import Callable
+from typing import Literal
 from typing import Optional
 
 from ddtrace.appsec import _constants
@@ -223,3 +224,66 @@ def report_ato_sdk_usage(event_type: str, v2: bool = True) -> None:
     version = "v2" if v2 else "v1"
     tags = (("event_type", event_type), ("sdk_version", version))
     telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "sdk.event", 1, tags=tags)
+
+
+@_safe_metric(WARNING_TAGS.TELEMETRY_METRICS, ":user_auth:missing_user_login")
+def report_user_auth_missing_user_login(
+    framework: str,
+    event_type: Literal[
+        "login_success",
+        "login_failure",
+        "signup",
+    ],
+) -> None:
+    tags = (("framework", framework), ("event_type", event_type))
+    telemetry.telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.APPSEC,
+        "instrum.user_auth.missing_user_login",
+        1,
+        tags=tags,
+    )
+
+
+def _is_user_auth_value_missing(value: Any) -> bool:
+    return value is None or value == ""
+
+
+def report_user_auth_missing(
+    framework: str,
+    event_type: Literal[
+        "login_success",
+        "login_failure",
+        "signup",
+    ],
+    user_id: Any,
+    user_login: Any,
+    report_missing_login: bool,
+) -> None:
+    has_no_user_login = _is_user_auth_value_missing(user_login)
+    has_no_user_id = _is_user_auth_value_missing(user_id)
+
+    if report_missing_login and has_no_user_login:
+        report_user_auth_missing_user_login(framework, event_type)
+
+    login_unavailable = not report_missing_login or has_no_user_login
+    if has_no_user_id and login_unavailable:
+        report_user_auth_missing_user_id(framework, event_type)
+
+
+@_safe_metric(WARNING_TAGS.TELEMETRY_METRICS, ":user_auth:missing_user_id")
+def report_user_auth_missing_user_id(
+    framework: str,
+    event_type: Literal[
+        "login_success",
+        "login_failure",
+        "signup",
+        "authenticated_request",
+    ],
+) -> None:
+    tags = (("framework", framework), ("event_type", event_type))
+    telemetry.telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.APPSEC,
+        "instrum.user_auth.missing_user_id",
+        1,
+        tags=tags,
+    )

--- a/releasenotes/notes/appsec-django-user-auth-missing-telemetry-e2f9202487773a28.yaml
+++ b/releasenotes/notes/appsec-django-user-auth-missing-telemetry-e2f9202487773a28.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    appsec: Adds telemetry metrics ``instrum.user_auth.missing_user_login`` and
+    ``instrum.user_auth.missing_user_id`` when Django auth events cannot resolve
+    the expected identity fields, enabling detection of misconfigured user model
+    field mappings.

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -164,6 +164,38 @@ def test_metrics_when_appsec_block_custom(telemetry_writer, tracer):
     )
 
 
+@pytest.mark.parametrize(
+    "user_id,user_login,report_missing_login,expected_metric_names",
+    [
+        # both absent, login reporting enabled → both fire
+        (None, None, True, {"instrum.user_auth.missing_user_login", "instrum.user_auth.missing_user_id"}),
+        # both absent, login reporting disabled → only missing_user_id fires
+        (None, None, False, {"instrum.user_auth.missing_user_id"}),
+        # id present, login absent → only missing_user_login (present id suppresses missing_user_id)
+        ("123", None, True, {"instrum.user_auth.missing_user_login"}),
+        # login present, id absent → no metrics (login is a valid fallback for id)
+        (None, "fred", True, set()),
+        # both present → no metrics (happy path)
+        ("123", "fred", True, set()),
+    ],
+)
+def test_report_user_auth_missing(telemetry_writer, user_id, user_login, report_missing_login, expected_metric_names):
+    from ddtrace.appsec import _metrics
+
+    telemetry_writer._namespace.flush()
+    _metrics.report_user_auth_missing("django", "login_failure", user_id, user_login, report_missing_login)
+
+    flushed = telemetry_writer._namespace.flush()
+    metrics = flushed.get(TELEMETRY_EVENT_TYPE.METRICS, {}).get(TELEMETRY_NAMESPACE.APPSEC.value, [])
+    user_auth_metrics = [m for m in metrics if m["metric"].startswith("instrum.user_auth.")]
+    assert {m["metric"] for m in user_auth_metrics} == expected_metric_names
+    assert len(user_auth_metrics) == len(expected_metric_names), user_auth_metrics
+    for metric in user_auth_metrics:
+        assert "framework:django" in metric["tags"]
+        assert "event_type:login_failure" in metric["tags"]
+        assert len(metric["tags"]) == 2
+
+
 def test_log_metric_error_ddwaf_init(telemetry_writer):
     with override_global_config(
         dict(

--- a/tests/appsec/integrations/django_tests/test_appsec_django.py
+++ b/tests/appsec/integrations/django_tests/test_appsec_django.py
@@ -14,6 +14,8 @@ from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import constants
 from ddtrace.internal.settings.asm import config as asm_config
+from ddtrace.internal.telemetry.constants import TELEMETRY_EVENT_TYPE
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from tests.appsec.integrations.django_tests.utils import _aux_appsec_get_root_span
 import tests.appsec.rules as rules
 from tests.utils import override_global_config
@@ -131,6 +133,81 @@ def test_request_userblock_403(client, test_spans, tracer):
         assert root.get_tag(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES + ".content-type") == "application/json"
         if hasattr(result, "headers"):
             assert result.headers["content-type"] == "application/json"
+
+
+def _flush_user_auth_metrics(telemetry_writer):
+    metrics = (
+        telemetry_writer._namespace.flush()
+        .get(TELEMETRY_EVENT_TYPE.METRICS, {})
+        .get(TELEMETRY_NAMESPACE.APPSEC.value, [])
+    )
+    return [m for m in metrics if m["metric"].startswith("instrum.user_auth.")]
+
+
+def _assert_user_auth_metrics(telemetry_writer, event_type, expected_metric_names):
+    metrics = _flush_user_auth_metrics(telemetry_writer)
+    assert {m["metric"] for m in metrics} == expected_metric_names
+    assert len(metrics) == len(expected_metric_names), metrics
+    for metric in metrics:
+        assert "framework:django" in metric["tags"]
+        assert f"event_type:{event_type}" in metric["tags"]
+        assert len(metric["tags"]) == 2
+
+
+@pytest.mark.django_db
+def test_django_user_auth_missing_telemetry_real_flows(client, telemetry_writer):
+    from django.contrib.auth import get_user
+    from django.contrib.auth.models import User
+
+    User.objects.create_user(username="fred", password="secret")
+
+    telemetry_writer._namespace.flush()
+    with (
+        override_global_config(
+            dict(
+                _asm_enabled=True,
+                _auto_user_instrumentation_local_mode=LOGIN_EVENTS_MODE.IDENT,
+                # Default Django User exposes `pk`/`id` and `get_username()`,
+                # so absent field names would fall back to real identity data. To exercise
+                # missing data without mocks or a custom user model, point ddtrace at
+                # real fields that are blank by default. Empty strings short-circuit those
+                # fallbacks and are treated as missing identity values.
+                _user_model_login_field="first_name",
+                _user_model_name_field="last_name",
+            )
+        ),
+        update_django_config(),
+    ):
+        assert not client.login(username="fred", password="wrong")
+        _assert_user_auth_metrics(
+            telemetry_writer,
+            "login_failure",
+            {"instrum.user_auth.missing_user_login"},
+        )
+
+        response = client.get("/appsec/signup/?login=john&pwd=secret")
+        assert response.status_code == 200
+        _assert_user_auth_metrics(
+            telemetry_writer,
+            "signup",
+            {"instrum.user_auth.missing_user_login", "instrum.user_auth.missing_user_id"},
+        )
+
+        assert client.login(username="fred", password="secret")
+        assert get_user(client).is_authenticated
+        _assert_user_auth_metrics(
+            telemetry_writer,
+            "login_success",
+            {"instrum.user_auth.missing_user_login", "instrum.user_auth.missing_user_id"},
+        )
+
+        response = client.get("/")
+        assert response.status_code == 200
+        _assert_user_auth_metrics(
+            telemetry_writer,
+            "authenticated_request",
+            {"instrum.user_auth.missing_user_id"},
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
APPSEC-62666

## Description

Emits two telemetry counters when Django auth events (`login_success`, `login_failure`, `signup`, `authenticated_request`) cannot resolve identity fields from the user model:

- `instrum.user_auth.missing_user_login` — `user_login` is absent and login reporting is enabled
- `instrum.user_auth.missing_user_id` — both `user_id` and `user_login` are absent

Useful for detecting misconfigured `AUTH_USER_MODEL` field mappings.

## Testing

Unit test parametrized over all branches of the decision logic. Integration test covers three Django login-failure scenarios (no credentials, wrong password for existing user, unknown user).

## Risks

Additive only — telemetry behind the existing `_safe_metric` guard.