### PR TITLE
feat(tracing): collect Datadog security-testing headers on entry spans

### DIFF
--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -27,6 +27,7 @@ from ddtrace.contrib.internal.trace_utils_base import _get_header_value_case_ins
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
 from ddtrace.contrib.internal.trace_utils_base import _normalize_tag_name
 from ddtrace.contrib.internal.trace_utils_base import _set_url_tag
+from ddtrace.contrib.internal.trace_utils_base import _store_security_testing_headers
 from ddtrace.contrib.internal.trace_utils_base import set_user  # noqa:F401
 from ddtrace.ext import http
 from ddtrace.ext import net
@@ -488,6 +489,8 @@ def set_http_meta(
         referrer_host = _get_request_header_referrer_host(request_headers, headers_are_case_sensitive)
         if referrer_host:
             span._set_attribute(http.REFERRER_HOSTNAME, referrer_host)
+
+        _store_security_testing_headers(request_headers, span, headers_are_case_sensitive)
 
         if integration_config.is_header_tracing_configured:
             """We should store both http.<request_or_response>.headers.<header_name> and

--- a/ddtrace/contrib/internal/trace_utils_base.py
+++ b/ddtrace/contrib/internal/trace_utils_base.py
@@ -101,7 +101,7 @@ def _store_security_testing_headers(
             value = headers.get(header_name)
         else:
             value = _get_header_value_case_insensitive(headers, header_name)
-        if value:
+        if value is not None:
             span._set_attribute(_normalize_tag_name("request", header_name), value)
 
 

--- a/ddtrace/contrib/internal/trace_utils_base.py
+++ b/ddtrace/contrib/internal/trace_utils_base.py
@@ -71,6 +71,10 @@ def _get_header_value_case_insensitive(headers: Mapping[str, str], keyname: str)
 # Possible User Agent header.
 USER_AGENT_PATTERNS = ("http-user-agent", "user-agent")
 
+# Datadog scan/test markers, tagged unconditionally so the API endpoint
+# reducer can keep scan/test traffic out of the API inventory.
+SECURITY_TESTING_HEADERS = ("x-datadog-endpoint-scan", "x-datadog-security-test")
+
 
 def _get_request_header_user_agent(headers: Mapping[str, str], headers_are_case_sensitive: bool = False) -> str:
     """Get user agent from request headers
@@ -86,6 +90,19 @@ def _get_request_header_user_agent(headers: Mapping[str, str], headers_are_case_
         if user_agent:
             return user_agent
     return ""
+
+
+def _store_security_testing_headers(
+    headers: Mapping[str, str], span: Span, headers_are_case_sensitive: bool = False
+) -> None:
+    """Tag SECURITY_TESTING_HEADERS on the span, regardless of integration config."""
+    for header_name in SECURITY_TESTING_HEADERS:
+        if not headers_are_case_sensitive:
+            value = headers.get(header_name)
+        else:
+            value = _get_header_value_case_insensitive(headers, header_name)
+        if value:
+            span._set_attribute(_normalize_tag_name("request", header_name), value)
 
 
 def set_user(

--- a/releasenotes/notes/aap-collect-security-testing-headers-64eb4a1cbc7778b2.yaml
+++ b/releasenotes/notes/aap-collect-security-testing-headers-64eb4a1cbc7778b2.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    tracing: collect the ``x-datadog-endpoint-scan`` and ``x-datadog-security-test`` HTTP
+    request headers on service entry spans unconditionally as
+    ``http.request.headers.x-datadog-endpoint-scan`` and
+    ``http.request.headers.x-datadog-security-test`` tags. These markers identify
+    Datadog-originated endpoint scans and security tests so the API inventory pipeline
+    can distinguish scan/test traffic from real user traffic. The headers are tagged
+    regardless of ``DD_TRACE_HEADER_TAGS`` configuration or AppSec enablement, and are
+    not propagated to downstream services.

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -323,7 +323,9 @@ class TestHeaders(object):
         assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") == "scan-uuid-3"
         assert span.get_tag("http.request.headers.x-datadog-security-test") == "test-uuid-4"
 
-    def test_security_testing_headers_empty_value_not_tagged(self, span, integration_config):
+    def test_security_testing_headers_empty_value_still_tagged(self, span, integration_config):
+        # RFC: collect unconditionally — presence of the header with an empty
+        # value is still a valid signal.
         trace_utils.set_http_meta(
             span,
             integration_config,
@@ -332,7 +334,7 @@ class TestHeaders(object):
                 "x-datadog-security-test": "ok",
             },
         )
-        assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") is None
+        assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") == ""
         assert span.get_tag("http.request.headers.x-datadog-security-test") == "ok"
 
     def test_security_testing_headers_not_propagated_downstream(self, span, integration_config):

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -286,6 +286,69 @@ class TestHeaders(object):
         )
         assert span.get_tag("http.referrer_hostname") == expected_hostname
 
+    def test_security_testing_headers_collected_unconditionally(self, span, integration_config):
+        assert not integration_config.is_header_tracing_configured
+        trace_utils.set_http_meta(
+            span,
+            integration_config,
+            request_headers={
+                "x-datadog-endpoint-scan": "scan-uuid-1",
+                "x-datadog-security-test": "test-uuid-2",
+                "x-other-header": "ignored",
+            },
+        )
+        assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") == "scan-uuid-1"
+        assert span.get_tag("http.request.headers.x-datadog-security-test") == "test-uuid-2"
+        assert span.get_tag("http.request.headers.x-other-header") is None
+
+    def test_security_testing_headers_absent_when_not_in_request(self, span, integration_config):
+        trace_utils.set_http_meta(
+            span,
+            integration_config,
+            request_headers={"content-type": "application/json"},
+        )
+        assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") is None
+        assert span.get_tag("http.request.headers.x-datadog-security-test") is None
+
+    def test_security_testing_headers_case_sensitive_lookup(self, span, integration_config):
+        trace_utils.set_http_meta(
+            span,
+            integration_config,
+            request_headers={
+                "X-Datadog-Endpoint-Scan": "scan-uuid-3",
+                "X-Datadog-Security-Test": "test-uuid-4",
+            },
+            headers_are_case_sensitive=True,
+        )
+        assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") == "scan-uuid-3"
+        assert span.get_tag("http.request.headers.x-datadog-security-test") == "test-uuid-4"
+
+    def test_security_testing_headers_empty_value_not_tagged(self, span, integration_config):
+        trace_utils.set_http_meta(
+            span,
+            integration_config,
+            request_headers={
+                "x-datadog-endpoint-scan": "",
+                "x-datadog-security-test": "ok",
+            },
+        )
+        assert span.get_tag("http.request.headers.x-datadog-endpoint-scan") is None
+        assert span.get_tag("http.request.headers.x-datadog-security-test") == "ok"
+
+    def test_security_testing_headers_not_propagated_downstream(self, span, integration_config):
+        trace_utils.set_http_meta(
+            span,
+            integration_config,
+            request_headers={
+                "x-datadog-endpoint-scan": "scan-uuid",
+                "x-datadog-security-test": "test-uuid",
+            },
+        )
+        out_headers: dict = {}
+        HTTPPropagator.inject(span.context, out_headers)
+        assert "x-datadog-endpoint-scan" not in out_headers
+        assert "x-datadog-security-test" not in out_headers
+
 
 @pytest.mark.parametrize(
     "pin,config_val,default,global_service,expected",


### PR DESCRIPTION
APPSEC-62412

## Summary

Tags two new Datadog markers — `x-datadog-endpoint-scan` and `x-datadog-security-test` — on every span that goes through `set_http_meta`, as `http.request.headers.<name>`. Collection is unconditional: it happens regardless of `DD_TRACE_HEADER_TAGS` or AppSec being enabled. Scope intentionally matches the existing user-agent/referrer extraction.

These let the API endpoint reducer distinguish Datadog scan/test traffic from real user traffic and keep it out of the API inventory.

The dd-style tag name (`http.request.headers.<name>`) is what dd-trace-py emits; the OTel-style variant (`http.request.header.<name>`) is handled by the reducer, not by tracers.

RFC: [Security Testing: Trace Attribution for Inventory Enrichment and Pollution Prevention](https://docs.google.com/document/d/1uR4QQvU8pItEV2zFqr3-L6jO2jxzmvLrFTX_yyvqIOA)

## Test plan

- [x] Unit tests in `tests/tracer/test_trace_utils.py::TestHeaders` (5 new): unconditional collection, absent, case-sensitive lookup, empty-value, non-propagation via `HTTPPropagator.inject`
- [x] System tests: https://github.com/DataDog/system-tests/pull/6915

🤖 Generated with [Claude Code](https://claude.com/claude-code)