### PR TITLE
fix(claude_agent_sdk): defer step span creation to prevent phantom LLMObs events

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -271,7 +271,8 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                 if type(block).__name__ == "ToolResultBlock":
                     self._handle_tool_result_block(block)
 
-        # Once all tool results are in, finalize the deferred step and open the next step+llm span
+        # Once all tool results are in, finalize the deferred step and accumulate the user turn context.
+        # The next step+llm span is created lazily when the next AssistantMessage arrives.
         if not self._active_tool_spans and self._step_response_chunk is not None:
             self._finalize_step_span(self._step_response_chunk)
             self._step_response_chunk = None
@@ -281,7 +282,6 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                 )
             user_content = getattr(chunk, "content", []) or []
             self._accumulated_input_messages.extend(self.integration.parse_content_blocks("user", user_content))
-            self._create_step_span()
 
     def _handle_tool_use_block(self, block: Any) -> None:
         """Open a tool span for a ToolUseBlock and register it as awaiting a result."""

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -1,4 +1,5 @@
 import inspect
+import time
 from typing import Any
 from typing import Optional
 
@@ -85,6 +86,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         self._step_response_chunk: Any = None  # deferred AssistantMessage for steps with tool calls
         self._step_input_snapshot: Optional[list[Message]] = None  # input captured before llm extension
         self._accumulated_input_messages: Optional[list[Message]] = None
+        self._next_turn_start_ns: Optional[int] = None  # timestamp recorded when tool results arrive
         self._create_step_span()
 
     async def process_chunk(self, chunk, iterator=None):
@@ -147,7 +149,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         finally:
             self.primary_span.finish()
 
-    def _create_step_span(self) -> None:
+    def _create_step_span(self, start_ns: Optional[int] = None) -> None:
         """Open a step span and an llm child span for the next inference cycle."""
         self.current_step_span = self.integration.trace(
             "claude_agent_sdk.step",
@@ -155,12 +157,16 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
             span_name="claude_agent_sdk.step",
             instance=self.instance,
         )
+        if start_ns is not None:
+            self.current_step_span.start_ns = start_ns
         self.current_llm_span = self.integration.trace(
             "claude_agent_sdk.llm",
             submit_to_llmobs=True,
             span_name="claude_agent_sdk.llm",
             instance=self.instance,
         )
+        if start_ns is not None:
+            self.current_llm_span.start_ns = start_ns
 
     def _finalize_llm_span(self, chunk: Any, exception: BaseException | None = None) -> None:
         """Close the llm span with the AssistantMessage data."""
@@ -243,7 +249,8 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
     def _handle_assistant_message(self, chunk: Any, content: Any) -> None:
         """Snapshot step input, finalize the llm span, open tool spans, and finalize or defer the step."""
         if self.current_step_span is None:
-            self._create_step_span()
+            self._create_step_span(start_ns=self._next_turn_start_ns)
+            self._next_turn_start_ns = None
 
         if self._accumulated_input_messages is None:
             self._accumulated_input_messages = self.integration.extract_llm_input_messages(
@@ -272,10 +279,11 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                     self._handle_tool_result_block(block)
 
         # Once all tool results are in, finalize the deferred step and accumulate the user turn context.
-        # The next step+llm span is created lazily when the next AssistantMessage arrives.
+        # Record the current time so the lazily-created next step+llm span reflects actual model latency.
         if not self._active_tool_spans and self._step_response_chunk is not None:
             self._finalize_step_span(self._step_response_chunk)
             self._step_response_chunk = None
+            self._next_turn_start_ns = time.monotonic_ns()
             if self._accumulated_input_messages is None:
                 self._accumulated_input_messages = self.integration.extract_llm_input_messages(
                     self.request_args, self.request_kwargs, self.primary_span

--- a/releasenotes/notes/claude-agent-sdk-phantom-span-fix-1a2b3c4d5e6f7890.yaml
+++ b/releasenotes/notes/claude-agent-sdk-phantom-span-fix-1a2b3c4d5e6f7890.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    claude_agent_sdk: Fixed phantom LLMObs events with empty model name and missing token metrics
+    that were emitted when a ``ResultMessage`` arrived immediately after tool results with no
+    follow-up ``AssistantMessage`` (e.g., StructuredOutput terminal tool). The speculative
+    step+llm span pair is now created lazily when the next ``AssistantMessage`` actually arrives.

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -16,6 +16,7 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_GREP_TOOL_RESPONSE_SEQUENC
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE
 from tests.contrib.claude_agent_sdk.utils import MOCK_STRUCTURED_OUTPUT_RESPONSE_SEQUENCE
+from tests.contrib.claude_agent_sdk.utils import MOCK_TERMINAL_TOOL_USE_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_ERROR_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_USE_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_USE_WITH_FOLLOWUP_SEQUENCE
@@ -104,6 +105,12 @@ def mock_internal_client_structured_output(claude_agent_sdk):
 @pytest.fixture
 def mock_internal_client_tool_use_with_followup(claude_agent_sdk):
     with _create_mock_internal_client(MOCK_TOOL_USE_WITH_FOLLOWUP_SEQUENCE):
+        yield
+
+
+@pytest.fixture
+def mock_internal_client_terminal_tool_use(claude_agent_sdk):
+    with _create_mock_internal_client(MOCK_TERMINAL_TOOL_USE_RESPONSE_SEQUENCE):
         yield
 
 

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -843,6 +843,28 @@ class TestLLMObsClaudeAgentSdk:
             tags=COMMON_TAGS,
         )
 
+    async def test_llmobs_no_phantom_spans_after_terminal_tool_use(
+        self, claude_agent_sdk, mock_internal_client_terminal_tool_use, claude_agent_sdk_llmobs, test_spans
+    ):
+        """When ResultMessage follows tool results with no follow-up AssistantMessage, no phantom
+        step or llm spans should be created. The next step+llm pair is created lazily on the
+        next AssistantMessage, so a terminal tool use produces only agent+step+llm+tool = 4 spans.
+        """
+        prompt = "Read /etc/hostname"
+        async for _ in claude_agent_sdk.query(prompt=prompt):
+            pass
+
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        # agent + step + llm + tool = 4 spans (no phantom step/llm)
+        assert len(spans) == 4
+
+        step_spans = [s for s in spans if s.name == "claude_agent_sdk.step"]
+        llm_spans = [s for s in spans if s.name == "claude_agent_sdk.llm"]
+        assert len(step_spans) == 1
+        assert len(llm_spans) == 1
+        assert _get_llmobs_data_metastruct(step_spans[0]) is not None
+        assert _get_llmobs_data_metastruct(llm_spans[0]) is not None
+
     async def test_llmobs_tool_error_marks_tool_span_as_error(
         self, claude_agent_sdk, mock_internal_client_tool_error, claude_agent_sdk_llmobs, test_spans
     ):

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -4,6 +4,8 @@ Since claude-agent-sdk uses subprocess/CLI transport (not HTTP), we mock
 the internal transport layer and provide mock message responses.
 """
 
+from typing import Optional
+
 from claude_agent_sdk import AssistantMessage
 from claude_agent_sdk import ResultMessage
 from claude_agent_sdk import SystemMessage
@@ -75,7 +77,7 @@ EXPECTED_ASSISTANT_USAGE = {
 }
 
 
-def create_mock_assistant_message(text: str, model: str = MOCK_MODEL, usage: dict = None) -> AssistantMessage:
+def create_mock_assistant_message(text: str, model: str = MOCK_MODEL, usage: Optional[dict] = None) -> AssistantMessage:
     """Create a mock AssistantMessage for testing."""
     msg = AssistantMessage(
         content=[TextBlock(text=text)],
@@ -110,8 +112,8 @@ def create_mock_result_message(
     num_turns: int = 1,
     session_id: str = "test-session-id",
     total_cost_usd: float = 0.0484227,
-    result: str = "4",
-    usage: dict = None,
+    result: Optional[str] = "4",
+    usage: Optional[dict] = None,
     stop_reason: str = "end_turn",
     structured_output: object = None,
 ) -> ResultMessage:
@@ -253,6 +255,13 @@ MOCK_TOOL_ERROR_RESPONSE_SEQUENCE = [
     MOCK_MULTI_TURN_RESULT_MESSAGE,
 ]
 
+
+MOCK_TERMINAL_TOOL_USE_RESPONSE_SEQUENCE = [
+    MOCK_SYSTEM_MESSAGE,
+    MOCK_TOOL_USE_ASSISTANT,  # AssistantMessage with ToolUseBlock
+    MOCK_TOOL_RESULT_USER_READ,  # UserMessage with ToolResultBlock → opens phantom step+llm
+    MOCK_RESULT_MESSAGE,  # ResultMessage arrives with no follow-up AssistantMessage
+]
 
 MOCK_STRUCTURED_OUTPUT = {"answer": 4, "unit": "integer"}
 MOCK_STRUCTURED_RESULT_MESSAGE = create_mock_result_message(


### PR DESCRIPTION
## Summary

- **Bug**: When a `ResultMessage` arrives immediately after tool results with no follow-up `AssistantMessage` (e.g., StructuredOutput terminal tool), a speculative `step`+`llm` span pair was eagerly opened in `_handle_user_message()` anticipating another LLM turn that never came. `finalize_stream()` then closed those spans with `response=None`, emitting LLMObs events with `model_name=""` and no token metrics — causing `"Unsupported model name | Missing token counts"` errors in Datadog cost estimation.
- **Fix**: Remove the eager `_create_step_span()` call from `_handle_user_message()`. The next `step`+`llm` span pair is now created lazily when the next `AssistantMessage` actually arrives. `_handle_assistant_message()` already has an existing `if self.current_step_span is None` guard that handles this correctly — no new logic needed.
- **Tests**: Added `MOCK_TERMINAL_TOOL_USE_RESPONSE_SEQUENCE` (tool use followed directly by `ResultMessage`) and a test verifying only 4 spans are produced (agent + step + llm + tool) with no phantom spans.

## Test plan

- [x] `pytest tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py` — all 16 tests pass including new `test_llmobs_no_phantom_spans_after_terminal_tool_use`
- [x] Existing multi-turn test (`test_llmobs_multi_turn_produces_two_step_spans`) still passes — deferred creation works correctly when a follow-up `AssistantMessage` does arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)