### PR TITLE
chore(kakfa): fix flaky test_schematized_span_service

### DIFF
--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -264,7 +264,6 @@ def retry_until_not_none(factory):
 def _generate_in_subprocess(random_topic):
     import ddtrace
     from ddtrace.contrib.internal.kafka.patch import patch
-    from ddtrace.contrib.internal.kafka.patch import unpatch
 
     PAYLOAD = bytes("hueh hueh hueh", encoding="utf-8")
 
@@ -288,7 +287,6 @@ def _generate_in_subprocess(random_topic):
     fibonacci_backoff_with_jitter(5, until=lambda result: isinstance(result, int))(producer.flush)()
     consumer.poll()
 
-    unpatch()
     consumer.close()
 
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4769b946-cced-41af-aa4c-f11e5bca3e2c","source":"chat","resourceId":"208676ff-9a51-4c6b-829d-4322cfaf13c1","workflowId":"a5424e54-c547-4a41-a309-6afe35253a2f","codeChangeId":"a5424e54-c547-4a41-a309-6afe35253a2f","sourceType":"test-optimization"} -->
## Description

Fixing `test_schematized_span_service_and_operation[None-mysvc][py3.12]` • **Questions?** Ask in #code-gen-flaky-tests

### Motivation/Summary
`test_schematized_span_service_and_operation[None-mysvc][py3.12]` was flaky with an order-dependent failure during subprocess cleanup. The subprocess helper called `unpatch()`, which can hit a `TypeError` when Kafka patch state is not in the exact expected shape, causing intermittent failures unrelated to the schema/service assertions this test is meant to validate.

### Changes
- Removed the `unpatch()` call from `_generate_in_subprocess` in `tests/contrib/kafka/test_kafka.py`.
- Removed the now-unused local `unpatch` import in that helper.
- Kept the helper behavior otherwise unchanged (it still patches and closes the consumer).

This keeps the test focused on validating schematized span service/operation behavior while avoiding teardown logic that is unnecessary in an ephemeral subprocess.

## Testing

### Validation
- Attempted to reproduce by running the target kafka test via `scripts/run-tests` in the py3.12 kafka venv.
- Local validation of test execution was blocked because Kafka services could not start in this sandbox (podman/CNI plugin networking error).
- Ran repository formatting/linting tools on modified files:
  - `ruff format tests/contrib/kafka/test_kafka.py`
  - `ruff check --fix tests/contrib/kafka/test_kafka.py`

## Risks

Low. Change is limited to test code and only affects subprocess test cleanup path. The subprocess exits immediately after the helper returns, so removing `unpatch()` there does not affect production behavior.

## Additional Notes

Flaky category: order dependency. Failure signature observed in cleanup path:
`TypeError: descriptor 'produce' for 'cimpl.Producer' objects doesn't apply to a 'NoneType' object`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/208676ff-9a51-4c6b-829d-4322cfaf13c1)

Comment @datadog to request changes