### PR TITLE
fix(llmobs): fix claude agent sdk llm span creation

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -85,8 +85,6 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         self._create_llm_span()
 
     def _create_llm_span(self) -> None:
-        if self.current_llm_span is not None:
-            self._finalize_llm_span(None)
         self.current_llm_span = self.integration.trace(
             "claude_agent_sdk.llm",
             submit_to_llmobs=True,
@@ -136,6 +134,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         if not isinstance(content, list):
             return
 
+        has_tool_result = False
         for block in content:
             block_type = type(block).__name__
 
@@ -156,6 +155,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                     "tool_id": tool_id,
                 }
             if block_type == "ToolResultBlock":
+                has_tool_result = True
                 tool_use_id = getattr(block, "tool_use_id", "")
                 if tool_use_id in self._active_tool_spans:
                     tool_data = self._active_tool_spans.pop(tool_use_id)
@@ -163,9 +163,12 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                     tool_output = safe_json(result_content) or str(result_content)
                     self._finalize_tool_span(tool_data, tool_output)
 
-        # After all tool results in a UserMessage are processed, append the tool results
-        # to the growing context and open the next LLM span.
-        if chunk_type == "UserMessage" and not self._active_tool_spans:
+        # Only open the next LLM span when this UserMessage actually concluded a
+        # tool turn. UserMessages without tool results (e.g. subagent context
+        # propagation) don't represent the start of a new LLM call, and opening
+        # a span for them would overwrite an already-open LLM span — dropping
+        # the previous one and hiding any descendants in the trace UI.
+        if chunk_type == "UserMessage" and not self._active_tool_spans and has_tool_result:
             if self._accumulated_input_messages is None:
                 self._accumulated_input_messages = self.integration.extract_llm_input_messages(
                     self.request_args, self.request_kwargs, self.primary_span

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -85,6 +85,8 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         self._create_llm_span()
 
     def _create_llm_span(self) -> None:
+        if self.current_llm_span is not None:
+            self._finalize_llm_span(None)
         self.current_llm_span = self.integration.trace(
             "claude_agent_sdk.llm",
             submit_to_llmobs=True,

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -164,10 +164,8 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                     self._finalize_tool_span(tool_data, tool_output)
 
         # Only open the next LLM span when this UserMessage actually concluded a
-        # tool turn. UserMessages without tool results (e.g. subagent context
-        # propagation) don't represent the start of a new LLM call, and opening
-        # a span for them would overwrite an already-open LLM span — dropping
-        # the previous one and hiding any descendants in the trace UI.
+        # tool turn. UserMessages without tool results don't represent the start of 
+        # a new LLM call.
         if chunk_type == "UserMessage" and not self._active_tool_spans and has_tool_result:
             if self._accumulated_input_messages is None:
                 self._accumulated_input_messages = self.integration.extract_llm_input_messages(

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -164,7 +164,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
                     self._finalize_tool_span(tool_data, tool_output)
 
         # Only open the next LLM span when this UserMessage actually concluded a
-        # tool turn. UserMessages without tool results don't represent the start of 
+        # tool turn. UserMessages without tool results don't represent the start of
         # a new LLM call.
         if chunk_type == "UserMessage" and not self._active_tool_spans and has_tool_result:
             if self._accumulated_input_messages is None:

--- a/releasenotes/notes/fix-unfinished-llm-span-f26555d45e70c31b.yaml
+++ b/releasenotes/notes/fix-unfinished-llm-span-f26555d45e70c31b.yaml
@@ -2,5 +2,8 @@
 fixes:
   - |
     LLM Observability: Resolves an issue in the Claude Agent SDK integration
-    where some LLM spans were not being properly finished. The handler now 
-    finalizes any open LLM span before opening a new one.
+    where some spans were missing from traces in the LLM Observability UI.
+    The handler now only opens a new LLM span after a ``UserMessage`` that
+    actually contained tool results, so messages without tool results (such
+    as subagent context propagation) no longer overwrite the in-flight LLM
+    span.

--- a/releasenotes/notes/fix-unfinished-llm-span-f26555d45e70c31b.yaml
+++ b/releasenotes/notes/fix-unfinished-llm-span-f26555d45e70c31b.yaml
@@ -2,8 +2,7 @@
 fixes:
   - |
     LLM Observability: Resolves an issue in the Claude Agent SDK integration
-    where some spans were missing from traces in the LLM Observability UI.
+    where unnecessary LLM spans were being created and affecting the trace structure.
     The handler now only opens a new LLM span after a ``UserMessage`` that
-    actually contained tool results, so messages without tool results (such
-    as subagent context propagation) no longer overwrite the in-flight LLM
-    span.
+    actually contained tool results, so messages without tool results no 
+    longer overwrite the in-flight LLM span.

--- a/releasenotes/notes/fix-unfinished-llm-span-f26555d45e70c31b.yaml
+++ b/releasenotes/notes/fix-unfinished-llm-span-f26555d45e70c31b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue in the Claude Agent SDK integration
+    where some LLM spans were not being properly finished. The handler now 
+    finalizes any open LLM span before opening a new one.


### PR DESCRIPTION
## Description

The Claude Agent SDK streaming handler eagerly opened a new LLM span on _any_ `UserMessage` that arrived without active tool spans — even when the `UserMessage` carried only text content (for example, subagent context propagated through the parent stream). Two such `UserMessage` chunks in a row would silently overwrite the in-flight LLM span, drop it from LLM Observability, and leave any descendants **hidden** in the trace UI.

This PR gates the next-LLM-span branch on the `UserMessage` actually containing a `ToolResultBlock`. `UserMessage` chunks without tool results no longer disturb the in-flight LLM span; the next `AssistantMessage` finalises it normally. This mirrors the `_step_response_chunk is not None` gate that #17655 uses on `main` / `4.9` to achieve the same effect, without requiring the larger step-span refactor — so it's suitable for the `4.8` patch release.

## Testing

### Before
<img width="347" height="154" alt="Screenshot 2026-05-12 at 4 09 44 PM" src="https://github.com/user-attachments/assets/e53c2dc6-3e34-4866-b376-906941a031c9" />

### After

<img width="350" height="281" alt="Screenshot 2026-05-12 at 4 09 26 PM" src="https://github.com/user-attachments/assets/c6d1e66f-0795-4070-bc17-4986bab776a7" />

## Risks

## Additional Notes

Claude session: `57b6ebe2-7b83-4ad6-8c2f-cbe1fb54a081`
Resume: `claude --resume 57b6ebe2-7b83-4ad6-8c2f-cbe1fb54a081`
