### PR TITLE
chore(debugger): add upload metadata fields to upload event message and attachment

### DIFF
--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -22,8 +22,10 @@ from types import CodeType
 from types import FunctionType
 from types import ModuleType
 import typing as t
+import uuid
 
 from ddtrace import config
+from ddtrace.internal import forksafe
 from ddtrace.internal import packages
 from ddtrace.internal.compat import singledispatchmethod
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
@@ -499,16 +501,41 @@ class ScopeContext:
         self._scopes: list[Scope] = scopes if scopes is not None else []
         self._scopes_lock = RLock()
 
-        self._event_data = {
+        self._timer: t.Optional[Timer] = None
+        self._timer_lock = RLock()
+
+        # upload_id is stable for the lifetime of this process; all batches
+        # uploaded by the process share it. A forked child gets a fresh
+        # upload_id and batch counter via _reset_on_fork below.
+        self._upload_id: str = str(uuid.uuid4())
+        self._batch_counter: int = 0
+
+        # Static portion of the event message. Dynamic fields (batchNum,
+        # attachmentSize) are set per upload. uploadId/runtimeId/parentId
+        # are refreshed by _reset_on_fork in forked children.
+        self._event_data: dict[str, t.Union[str, bool, int, None]] = {
             "ddsource": "python",
             "service": config.service or DEFAULT_SERVICE_NAME,
+            "version": config.version or "",
+            "language": "python",
             "runtimeId": get_runtime_id(),
             "parentId": get_ancestor_runtime_id(),
             "type": "symdb",
+            "uploadId": self._upload_id,
+            "final": False,
         }
 
-        self._timer: t.Optional[Timer] = None
-        self._timer_lock = RLock()
+        forksafe.register(self._reset_on_fork)
+
+    def _reset_on_fork(self) -> None:
+        # Runs after fork in the child. The runtime module's own forksafe
+        # hook regenerates the runtime_id first (registered earlier at
+        # import time), so the calls below return the post-fork values.
+        self._upload_id = str(uuid.uuid4())
+        self._batch_counter = 0
+        self._event_data["uploadId"] = self._upload_id
+        self._event_data["runtimeId"] = get_runtime_id()
+        self._event_data["parentId"] = get_ancestor_runtime_id()
 
     def _set_timer(self) -> None:
         with self._timer_lock:
@@ -516,12 +543,13 @@ class ScopeContext:
 
                 class BatchTimer(Timer):
                     def timeout(_timer) -> None:
-                        log.debug(
-                            "[PID %d] SymDB: Flushing batch of %d module scopes due to timeout",
-                            os.getpid(),
-                            len(self._scopes),
-                        )
-                        self.upload()
+                        with self._scopes_lock:
+                            log.debug(
+                                "[PID %d] SymDB: Flushing batch of %d module scopes due to timeout",
+                                os.getpid(),
+                                len(self._scopes),
+                            )
+                            self._upload_locked()
 
                         with self._timer_lock:
                             self._timer = None
@@ -537,7 +565,7 @@ class ScopeContext:
             # Flush the scopes if we reached the size limit.
             if (n := len(self._scopes)) >= self.__scope_limit__:
                 log.debug("[PID %d] SymDB: Flushing batch of %d module scopes due to size limit", os.getpid(), n)
-                self.upload()
+                self._upload_locked()
 
             # Add the new scope.
             self._scopes.append(scope)
@@ -556,20 +584,35 @@ class ScopeContext:
                 "scopes": [_.to_json() for _ in self._scopes],
             }
 
-    def upload(self) -> None:
-        with self._scopes_lock:
-            if not self._scopes:
-                return
-            payload = self.to_json()
-            n = len(self._scopes)
-            self._scopes.clear()
+    # The caller must hold _scopes_lock.
+    def _upload_locked(self) -> None:
+        if not self._scopes:
+            return
+
+        self._batch_counter += 1
+        batch_num = self._batch_counter
+
+        payload = self.to_json()
+        # Embed the upload metadata in the attachment too, so the
+        # attachment is self-contained.
+        payload["upload_id"] = self._upload_id
+        payload["batch_num"] = batch_num
+        payload["final"] = False
+        n = len(self._scopes)
+        self._scopes.clear()
+
+        compressed = gzip.compress(json.dumps(payload).encode("utf-8"))
+
+        self._event_data["batchNum"] = batch_num
+        self._event_data["attachmentSize"] = len(compressed)
+        event_json = json.dumps(self._event_data)
 
         body, headers = multipart(
             parts=[
                 FormData(
                     name="event",
                     filename="event.json",
-                    data=json.dumps(self._event_data),
+                    data=event_json,
                     content_type="json",
                 ),
                 FormData(
@@ -584,7 +627,7 @@ class ScopeContext:
         # DEV: The as_bytes method ends up writing the data line by line, which
         # breaks the final payload. We add a placeholder instead and manually
         # replace it with the compressed JSON.
-        body = body.replace(b"[symbols_placeholder]", gzip.compress(json.dumps(payload).encode("utf-8")))
+        body = body.replace(b"[symbols_placeholder]", compressed)
 
         with connector(agent_config.trace_agent_url, timeout=5.0)() as conn:
             log.debug("[PID %d] SymDB: Uploading symbols payload", os.getpid())

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -294,9 +294,88 @@ def test_scope_context_upload_skips_empty_batch():
     context = ScopeContext()
 
     with mock.patch("ddtrace.internal.symbol_db.symbols.connector") as mock_connector:
-        context.upload()
+        with context._scopes_lock:
+            context._upload_locked()
 
     mock_connector.assert_not_called()
+
+
+def test_scope_context_upload_metadata():
+    """ScopeContext exposes the upload metadata fields on the event envelope,
+    and _upload_locked populates per-batch fields on both the event and the
+    attachment payload, advancing batchNum across uploads.
+    """
+    import gzip
+    import json
+    from unittest import mock
+
+    from ddtrace.internal.symbol_db.symbols import ScopeContext
+
+    def make_scope(name: str) -> Scope:
+        return Scope(
+            scope_type=ScopeType.MODULE,
+            name=name,
+            source_file=__file__,
+            start_line=0,
+            end_line=0,
+            symbols=[],
+            scopes=[],
+        )
+
+    ctx = ScopeContext()
+    expected_upload_id = ctx._upload_id
+
+    # Static fields on the event envelope, set at construction time.
+    assert ctx._event_data["ddsource"] == "python"
+    assert ctx._event_data["type"] == "symdb"
+    assert ctx._event_data["language"] == "python"
+    assert "runtimeId" in ctx._event_data
+    assert "parentId" in ctx._event_data
+    assert ctx._event_data["uploadId"] == expected_upload_id
+    assert ctx._event_data["final"] is False
+
+    captured = {}
+    real_compress = gzip.compress
+
+    def capturing_compress(data, *args, **kwargs):
+        captured["bytes"] = data
+        return real_compress(data, *args, **kwargs)
+
+    mock_response = mock.MagicMock()
+    mock_response.status = 200
+    mock_conn = mock.MagicMock()
+    mock_conn.getresponse.return_value = mock_response
+
+    with (
+        mock.patch("ddtrace.internal.symbol_db.symbols.connector") as connector_mock,
+        mock.patch("ddtrace.internal.symbol_db.symbols.gzip.compress", side_effect=capturing_compress),
+    ):
+        connector_mock.return_value.return_value.__enter__.return_value = mock_conn
+
+        # First upload: batchNum starts at 1 and the attachment carries the
+        # same upload metadata as the event envelope.
+        with ctx._scopes_lock:
+            ctx._scopes.append(make_scope("first"))
+            ctx._upload_locked()
+
+        assert ctx._event_data["uploadId"] == expected_upload_id
+        assert ctx._event_data["batchNum"] == 1
+        assert ctx._event_data["attachmentSize"] > 0
+
+        attachment = json.loads(captured["bytes"].decode("utf-8"))
+        assert attachment["upload_id"] == expected_upload_id
+        assert attachment["batch_num"] == 1
+        assert attachment["final"] is False
+
+        # Second upload: batchNum must increment on both the event envelope
+        # and the attachment payload.
+        with ctx._scopes_lock:
+            ctx._scopes.append(make_scope("second"))
+            ctx._upload_locked()
+
+        assert ctx._event_data["batchNum"] == 2
+        attachment = json.loads(captured["bytes"].decode("utf-8"))
+        assert attachment["batch_num"] == 2
 
 
 @pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_SYMBOL_DATABASE_UPLOAD_ENABLED="1"))
@@ -369,35 +448,78 @@ def test_symbols_fork_uploads():
     """
     Test that we disable Symbol DB on processes that are not the main one nor
     the first fork child.
+
+    In the first fork child, where SymDB stays enabled, also verify that the
+    ScopeContext's upload metadata (uploadId, runtimeId, parentId) is
+    refreshed by the post-fork hook.
     """
     import os
+    import typing as t
 
     from ddtrace.internal import forksafe
     from ddtrace.internal.remoteconfig import ConfigMetadata
     from ddtrace.internal.remoteconfig import Payload
     from ddtrace.internal.runtime import get_ancestor_runtime_id
+    from ddtrace.internal.runtime import get_runtime_id
     from ddtrace.internal.symbol_db.remoteconfig import _rc_callback
     from ddtrace.internal.symbol_db.symbols import SymbolDatabaseUploader
 
     SymbolDatabaseUploader.install()
 
+    parent_runtime_id = get_runtime_id()
+    parent_context = t.cast(SymbolDatabaseUploader, SymbolDatabaseUploader._instance)._context
+    parent_upload_id = parent_context._upload_id
+
     pids = []
     rc_data = [Payload(ConfigMetadata("test", "symdb", "hash", 0, 0), "test", None)]
 
+    # Fork 10 children from the same parent. In each child, re-run the RC
+    # callback and verify the install/uninstall invariant (SymDB stays
+    # enabled only in the first fork child) and, where applicable, the
+    # post-fork ScopeContext metadata refresh.
     for _ in range(10):
-        if not (pid := os.fork()):
+        if pid := os.fork():
+            # Parent: record the child's pid and move on to the next fork.
+            pids.append(pid)
+            continue
+
+        # Child path.
+        try:
+            # We're in a forked child, so the ancestor runtime id must
+            # be set.
+            assert get_ancestor_runtime_id() is not None
             # Call the RC callback multiple times to check for stability
             for i in range(10):
                 _rc_callback(rc_data)
-                assert SymbolDatabaseUploader.is_installed() != (
-                    get_ancestor_runtime_id() is not None and forksafe.has_forked()
-                ), f"iteration {i} is stable"
-            os._exit(0)
+                # SymDB stays enabled in the first fork child and is
+                # disabled in any other (subsequent or deeper) fork
+                # child to avoid duplicate uploads.
+                #
+                # forksafe._forked flips to True in the parent via an
+                # after_in_parent hook on the first fork, so children #2..N
+                # of the same parent inherit _forked=True via the fork's
+                # memory copy. Only the first child observes False here.
+                first_child = not forksafe.has_forked()
+                assert SymbolDatabaseUploader.is_installed() == first_child, f"iteration {i} is stable"
 
-        pids.append(pid)
+            if SymbolDatabaseUploader.is_installed():
+                # First fork child: the ScopeContext forksafe hook must
+                # have refreshed the upload metadata to reflect this
+                # child's runtime rather than the parent's.
+                child_context = t.cast(SymbolDatabaseUploader, SymbolDatabaseUploader._instance)._context
+                assert child_context._event_data["runtimeId"] == get_runtime_id()
+                assert child_context._event_data["runtimeId"] != parent_runtime_id
+                assert child_context._event_data["parentId"] == parent_runtime_id
+                assert child_context._upload_id != parent_upload_id
+                assert child_context._event_data["uploadId"] == child_context._upload_id
+                assert child_context._batch_counter == 0
+        except BaseException:
+            os._exit(1)
+        os._exit(0)
 
     for pid in pids:
-        os.waitpid(pid, 0)
+        _, status = os.waitpid(pid, 0)
+        assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0, f"child {pid} exited with status {status}"
 
 
 @pytest.mark.subprocess(run_module=True, err=None)


### PR DESCRIPTION
Add the following fields to the SymDB upload event message that accompanies each multipart upload (camelCase, matching the rest of the EvP event schema):

- "version" (top-level): the service version
- "language" (top-level): "python"
- "uploadId" (top-level): a UUID generated once per process and shared by all batches uploaded by the process. The cache is keyed on runtime_id so a forked child gets a fresh uploadId (since runtime_id regenerates on fork via the forksafe hook).
- "batchNum" (top-level): 1-indexed counter incremented per upload, reset alongside uploadId when runtime_id changes.
- "final" (top-level): always false; the Python tracer continuously uploads new code as modules are imported, so there is no defined end-of-upload point.
- "attachmentSize" (top-level): size in bytes of the gzipped attachment.

Also add the same metadata to the attachment body in to_json (snake_case to match the rest of the attachment scope schema):

- "upload_id"
- "batch_num"
- "final"

uploadId/batchNum are computed once per upload() call so both the attachment and the event JSON carry the same values. The event_data dict is constructed lazily per upload (instead of captured in __init__), since batchNum and attachmentSize change with each batch.

Some of these fields are new, to be used by the backend in the future. Others duplicate info that was already included in the attachment; by duplicating some metadata out of the SymDB attachment body into the EvP event body, the backend can populate per-attachment bookkeeping without downloading the attachment.
