### PR TITLE
chore(version): fix version.py for python3.9

### DIFF
--- a/ddtrace/version.py
+++ b/ddtrace/version.py
@@ -9,6 +9,10 @@ __version__: str
 
 try:
     distributions = importlib.metadata.packages_distributions().get(__package__ or __name__)
+except AttributeError:
+    distributions = None
+
+try:
     __version__ = importlib.metadata.version(distributions[0] if distributions else "ddtrace")
 except Exception:
     __version__ = "0.0.0"

--- a/ddtrace/version.py
+++ b/ddtrace/version.py
@@ -9,7 +9,7 @@ __version__: str
 
 try:
     distributions = importlib.metadata.packages_distributions().get(__package__ or __name__)
-except AttributeError:
+except Exception:
     distributions = None
 
 try:


### PR DESCRIPTION
## Description

This PR: https://github.com/DataDog/dd-trace-py/pull/17964 broke main because it introduced code that is incompatible with python3.9. However, microbenchmarks are running on python3.9 which broke http microbenchmarks.

This PR fixes the issue 