### PR TITLE
chore(debugger): fix capture expression limits field

### DIFF
--- a/ddtrace/debugging/_probe/model.py
+++ b/ddtrace/debugging/_probe/model.py
@@ -244,7 +244,7 @@ class StringTemplate:
 class CaptureExpression:
     name: str
     expr: DDExpression
-    limits: CaptureLimits = field(compare=False)
+    capture: CaptureLimits = field(compare=False)
 
 
 @dataclass

--- a/ddtrace/debugging/_signal/snapshot.py
+++ b/ddtrace/debugging/_signal/snapshot.py
@@ -102,10 +102,10 @@ def _capture_expressions(
             "captureExpressions": {
                 e.name: utils.capture_value(
                     e.expr.eval(scope),
-                    e.limits.max_level,
-                    e.limits.max_len,
-                    e.limits.max_size,
-                    e.limits.max_fields,
+                    e.capture.max_level,
+                    e.capture.max_len,
+                    e.capture.max_size,
+                    e.capture.max_fields,
                     timeout,
                 )
                 for e in exprs

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1075,6 +1075,123 @@ def test_debugger_capture_expressions_function_probe(stuff):
             assert snapshot.return_capture["captureExpressions"]["retval"] == {"isNull": True, "type": "NoneType"}
 
 
+def test_debugger_capture_expressions_max_level(stuff):
+    from ddtrace.debugging._probe.model import CaptureLimits
+
+    with debugger(upload_flush_interval=float("inf")) as d:
+        d.add_probes(
+            create_capture_expressions_line_probe(
+                probe_id="foo",
+                source_file="tests/submod/stuff.py",
+                line=36,
+                rate=float("inf"),
+                **compile_capture_expressions(
+                    [{"name": "val", "expr": {"dsl": "bar", "json": {"ref": "bar"}}}],
+                    capture=CaptureLimits(max_level=1),
+                ),
+            ),
+        )
+
+        nested = {"a": {"b": {"c": 42}}}
+        stuff.Stuff().instancestuff(nested)
+
+        (msg,) = d.uploader.wait_for_payloads(1)
+        captured_val = msg["debugger"]["snapshot"]["captures"]["lines"]["36"]["captureExpressions"]["val"]
+
+        # At max_level=1 the top-level dict entries are expanded one level but their
+        # nested values are not — the deepest dict should be truncated with "depth"
+        inner = captured_val["entries"][0][1]
+        assert inner["type"] == "dict"
+        inner2 = inner["entries"][0][1]
+        assert inner2.get("notCapturedReason") == "depth", inner2
+
+
+def test_debugger_capture_expressions_max_len(stuff):
+    from ddtrace.debugging._probe.model import CaptureLimits
+
+    with debugger(upload_flush_interval=float("inf")) as d:
+        d.add_probes(
+            create_capture_expressions_line_probe(
+                probe_id="foo",
+                source_file="tests/submod/stuff.py",
+                line=36,
+                rate=float("inf"),
+                **compile_capture_expressions(
+                    [{"name": "val", "expr": {"dsl": "bar", "json": {"ref": "bar"}}}],
+                    capture=CaptureLimits(max_len=5),
+                ),
+            ),
+        )
+
+        stuff.Stuff().instancestuff("hello world")
+
+        (msg,) = d.uploader.wait_for_payloads(1)
+        captured_val = msg["debugger"]["snapshot"]["captures"]["lines"]["36"]["captureExpressions"]["val"]
+
+        # String is truncated at max_len=5
+        assert captured_val.get("notCapturedReason") == "truncated" or len(captured_val["value"].strip("'")) <= 5
+
+
+def test_debugger_capture_expressions_max_size(stuff):
+    from ddtrace.debugging._probe.model import CaptureLimits
+
+    with debugger(upload_flush_interval=float("inf")) as d:
+        d.add_probes(
+            create_capture_expressions_line_probe(
+                probe_id="foo",
+                source_file="tests/submod/stuff.py",
+                line=36,
+                rate=float("inf"),
+                **compile_capture_expressions(
+                    [{"name": "val", "expr": {"dsl": "bar", "json": {"ref": "bar"}}}],
+                    capture=CaptureLimits(max_size=2),
+                ),
+            ),
+        )
+
+        stuff.Stuff().instancestuff({i: i for i in range(10)})
+
+        (msg,) = d.uploader.wait_for_payloads(1)
+        captured_val = msg["debugger"]["snapshot"]["captures"]["lines"]["36"]["captureExpressions"]["val"]
+
+        # Collection truncated at max_size=2
+        assert len(captured_val["entries"]) == 2
+        assert captured_val.get("notCapturedReason") == "collectionSize"
+
+
+def test_debugger_capture_expressions_max_fields(stuff):
+    from ddtrace.debugging._probe.model import CaptureLimits
+
+    class MyObj:
+        def __init__(self):
+            self.a = 1
+            self.b = 2
+            self.c = 3
+
+    with debugger(upload_flush_interval=float("inf")) as d:
+        d.add_probes(
+            create_capture_expressions_line_probe(
+                probe_id="foo",
+                source_file="tests/submod/stuff.py",
+                line=36,
+                rate=float("inf"),
+                **compile_capture_expressions(
+                    [{"name": "val", "expr": {"dsl": "bar", "json": {"ref": "bar"}}}],
+                    capture=CaptureLimits(max_fields=2),
+                ),
+            ),
+        )
+
+        stuff.Stuff().instancestuff(MyObj())
+
+        (msg,) = d.uploader.wait_for_payloads(1)
+        captured_val = msg["debugger"]["snapshot"]["captures"]["lines"]["36"]["captureExpressions"]["val"]
+
+        # Object fields truncated at max_fields=2
+        assert len(captured_val["fields"]) == 2
+        assert captured_val.get("notCapturedReason") == "fieldCount"
+
+
 class SpanProbeTestCase(TracerTestCase):
     def setUp(self):
         super(SpanProbeTestCase, self).setUp()

--- a/tests/debugging/utils.py
+++ b/tests/debugging/utils.py
@@ -38,11 +38,13 @@ def compile_template(*args):
     return {"template": template, "segments": segments}
 
 
-def compile_capture_expressions(exprs):
+def compile_capture_expressions(exprs, capture=None):
     return {
         "capture_expressions": [
             CaptureExpression(
-                name=expr["name"], expr=DDRedactedExpression.compile(expr["expr"]), limits=DEFAULT_CAPTURE_LIMITS
+                name=expr["name"],
+                expr=DDRedactedExpression.compile(expr["expr"]),
+                capture=capture if capture is not None else DEFAULT_CAPTURE_LIMITS,
             )
             for expr in exprs
         ],


### PR DESCRIPTION
## Description

We fix the field name used to carry the capture expression capture limits in configuration payloads.

Refs: [DEBUG-5601](https://datadoghq.atlassian.net/browse/DEBUG-5601)

[DEBUG-5601]: https://datadoghq.atlassian.net/browse/DEBUG-5601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ