### PR TITLE
chore(ci): update system-tests ref to 0c5de1b

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '1c483bf19facb9109d9debe58865b54b97ca4307'
+          ref: '0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '1c483bf19facb9109d9debe58865b54b97ca4307'
+          ref: '0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -392,7 +392,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7
     secrets: inherit
     with:
       library: python_lambda
@@ -422,7 +422,7 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@23941ab6de4122b7d0ca2b0d4aa7818def68a0d5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7
     secrets: inherit
     with:
       library: python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "1c483bf19facb9109d9debe58865b54b97ca4307"
+  SYSTEM_TESTS_REF: "0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Summary
- Bump `DataDog/system-tests` ref from `1c483bf` to `0c5de1b` (latest on `main`) in `.github/workflows/system-tests.yml` and `.gitlab-ci.yml` via `scripts/update-system-tests-version.py`.
- Also bump the `serverless-system-tests` and `integration-frameworks-system-tests` `uses:` refs (previously pinned at `23941ab6`) to the same SHA so all system-tests checkouts run against a single version.

## Test plan
- [ ] CI: system-tests workflow runs green against the new ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)