### PR TITLE
fix(tracing): revert INFERRED_SPANS_ENABLED setting

### DIFF
--- a/ddtrace/contrib/internal/google_cloud_pubsub/__init__.py
+++ b/ddtrace/contrib/internal/google_cloud_pubsub/__init__.py
@@ -22,6 +22,9 @@ Push subscriptions are also supported. When a push subscription delivers a messa
 via HTTP to your web server, the integration creates an inferred ``gcp.pubsub.receive``
 span that captures subscription and message metadata.
 
+The inferred span is only emitted when ``DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED`` is
+set to ``true`` (default: ``false``).
+
 For push subscription instrumentation to work, the subscription must be configured with:
 
 - **Enable payload unwrapping** (``--push-no-wrapper``): delivers the raw message data

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -687,15 +687,15 @@ class Config(object):
         # Telemetry for whether ssi instrumented an app is tracked by the `instrumentation_source` config
         self._lib_was_injected = _get_config("_DD_PY_SSI_INJECT", False, asbool, report_telemetry=False)
         self._inject_enabled = _get_config("DD_INJECTION_ENABLED")
-        if "DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED" in env:
+        if "DD_TRACE_INFERRED_SPANS_ENABLED" in env:
             deprecate(
-                "DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED is deprecated",
-                message="Please use DD_TRACE_INFERRED_SPANS_ENABLED instead.",
+                "DD_TRACE_INFERRED_SPANS_ENABLED is deprecated",
+                message="Please use DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED instead.",
                 removal_version="5.0.0",
                 category=DDTraceDeprecationWarning,
             )
         self._inferred_proxy_services_enabled = _get_config(
-            ["DD_TRACE_INFERRED_SPANS_ENABLED", "DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED"], False, asbool
+            ["DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED", "DD_TRACE_INFERRED_SPANS_ENABLED"], False, asbool
         )
         self._trace_safe_instrumentation_enabled = _get_config("DD_TRACE_SAFE_INSTRUMENTATION_ENABLED", False, asbool)
 

--- a/releasenotes/notes/deprecate-dd-trace-inferred-spans-enabled-03b0cbc96760d29e.yaml
+++ b/releasenotes/notes/deprecate-dd-trace-inferred-spans-enabled-03b0cbc96760d29e.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    Tracing: ``DD_TRACE_INFERRED_SPANS_ENABLED`` is deprecated and will be removed in 5.0.0.
+    Use ``DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED`` instead. The old environment variable continues to work
+    but emits a ``DDTraceDeprecationWarning`` when set.

--- a/tests/contrib/bottle/test_distributed.py
+++ b/tests/contrib/bottle/test_distributed.py
@@ -124,7 +124,7 @@ class TraceBottleDistributedTest(TracerTestCase):
         assert 123 != s.trace_id
         assert 456 != s.parent_id
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_SPANS_ENABLED="True"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED="True"))
     def test_inferred_spans_api_gateway_distributed_tracing_enabled(self):
         @self.app.route("/")
         def default_endpoint():
@@ -172,7 +172,7 @@ class TraceBottleDistributedTest(TracerTestCase):
             distributed_sampling_priority=USER_KEEP,
         )
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_SPANS_ENABLED="False"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED="False"))
     def test_inferred_spans_api_gateway_distributed_tracing_disabled(self):
         @self.app.route("/")
         def default_endpoint():

--- a/tests/contrib/falcon/test_distributed_tracing.py
+++ b/tests/contrib/falcon/test_distributed_tracing.py
@@ -81,7 +81,7 @@ class DistributedTracingTestCase(testing.TestCase, FalconTestMixin, TracerTestCa
         assert traces[0][0].parent_id != 42
         assert traces[0][0].trace_id != 100
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_SPANS_ENABLED="True"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED="True"))
     def test_inferred_spans_api_gateway_distributed_tracing_enabled(self):
         config.falcon["distributed_tracing"] = True
         distributed_headers = {
@@ -126,7 +126,7 @@ class DistributedTracingTestCase(testing.TestCase, FalconTestMixin, TracerTestCa
             distributed_sampling_priority=USER_KEEP,
         )
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_SPANS_ENABLED="False"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED="False"))
     def test_inferred_spans_api_gateway_distributed_tracing_disabled(self):
         # When inferred proxy is disabled, there should be no inferred span
         config.falcon["distributed_tracing"] = True

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -364,7 +364,7 @@ import opentelemetry
         {"name": "DD_TRACE_HEALTH_METRICS_ENABLED", "origin": "env_var", "value": True},
         {"name": "DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING", "origin": "default", "value": "true"},
         {"name": "DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "origin": "default", "value": "500-599"},
-        {"name": "DD_TRACE_INFERRED_SPANS_ENABLED", "origin": "default", "value": False},
+        {"name": "DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED", "origin": "default", "value": False},
         {"name": "DD_TRACE_LOG_FILE", "origin": "default", "value": None},
         {"name": "DD_TRACE_LOG_FILE_LEVEL", "origin": "default", "value": "DEBUG"},
         {"name": "DD_TRACE_LOG_FILE_SIZE_BYTES", "origin": "default", "value": 15728640},


### PR DESCRIPTION
## Description

The changes in [this PR](https://github.com/DataDog/dd-trace-py/pull/17487) assumed this setting was unique to python. It is not, it's the same in every tracer, also explained [in the docs](https://docs.datadoghq.com/tracing/trace_collection/proxy_setup/apigateway). Even if the name is not the most appropriate, it should be kept consistent.

Additionally document the variable in `__init__.py`

## Risks

Confusing users