### PR TITLE
chore(bootstrap): keep reprlib get_ident picklable after module cleanup

### DIFF
--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -34,8 +34,8 @@ def cleanup_loaded_modules() -> None:
     if not enabled:
         return
 
-    stale_reprlib_module = sys.modules.get("reprlib")
-    stale_thread_module = sys.modules.get("_thread")
+    original_reprlib_module = sys.modules.get("reprlib")
+    original_thread_module = sys.modules.get("_thread")
 
     def drop(module_name: str) -> None:
         module = sys.modules.get(module_name)
@@ -104,11 +104,6 @@ def cleanup_loaded_modules() -> None:
             # CPython on boot.
             "threading",
             "_thread",
-            # reprlib binds _thread.get_ident at import time. If _thread gets
-            # re-imported but reprlib does not, pickle/cloudpickle can see two
-            # different builtin function objects and fail serializing classes
-            # that close over reprlib state.
-            "reprlib",
         ]
     )
     for u in UNLOAD_MODULES:
@@ -116,7 +111,7 @@ def cleanup_loaded_modules() -> None:
             if m == u or m.startswith(u + "."):
                 drop(m)
 
-    if stale_reprlib_module is not None or stale_thread_module is not None or "reprlib" in sys.modules:
+    if original_reprlib_module is not None or original_thread_module is not None or "reprlib" in sys.modules:
         # Modules imported before cleanup can keep direct references to the old
         # reprlib or _thread objects. If _thread is re-imported, stale reprlib
         # references can retain the old get_ident builtin and become
@@ -124,10 +119,10 @@ def cleanup_loaded_modules() -> None:
         import _thread
 
         current_get_ident = _thread.get_ident
-        if stale_thread_module is not None:
-            stale_thread_module.get_ident = current_get_ident  # type: ignore[attr-defined]
-        if stale_reprlib_module is not None:
-            stale_reprlib_module.get_ident = current_get_ident  # type: ignore[attr-defined]
+        if original_thread_module is not None:
+            original_thread_module.get_ident = current_get_ident  # type: ignore[attr-defined]
+        if original_reprlib_module is not None:
+            original_reprlib_module.get_ident = current_get_ident  # type: ignore[attr-defined]
         if "reprlib" in sys.modules:
             sys.modules["reprlib"].get_ident = current_get_ident  # type: ignore[attr-defined]
 

--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -34,9 +34,6 @@ def cleanup_loaded_modules() -> None:
     if not enabled:
         return
 
-    original_reprlib_module = sys.modules.get("reprlib")
-    original_thread_module = sys.modules.get("_thread")
-
     def drop(module_name: str) -> None:
         module = sys.modules.get(module_name)
         # Don't delete modules that are currently being imported (they might be None or incomplete)
@@ -104,27 +101,16 @@ def cleanup_loaded_modules() -> None:
             # CPython on boot.
             "threading",
             "_thread",
+            # reprlib does `from _thread import get_ident` at module level;
+            # unloading it ensures a fresh re-import binds the correct get_ident
+            # after _thread is reloaded, keeping it picklable.
+            "reprlib",
         ]
     )
     for u in UNLOAD_MODULES:
         for m in list(sys.modules):
             if m == u or m.startswith(u + "."):
                 drop(m)
-
-    if original_reprlib_module is not None or original_thread_module is not None or "reprlib" in sys.modules:
-        # Modules imported before cleanup can keep direct references to the old
-        # reprlib or _thread objects. If _thread is re-imported, stale reprlib
-        # references can retain the old get_ident builtin and become
-        # unpicklable.
-        import _thread
-
-        current_get_ident = _thread.get_ident
-        if original_thread_module is not None:
-            original_thread_module.get_ident = current_get_ident  # type: ignore[attr-defined]
-        if original_reprlib_module is not None:
-            original_reprlib_module.get_ident = current_get_ident  # type: ignore[attr-defined]
-        if "reprlib" in sys.modules:
-            sys.modules["reprlib"].get_ident = current_get_ident  # type: ignore[attr-defined]
 
     # Because we are not unloading it, the logging module requires a reference
     # to the newly imported threading module to allow it to retrieve the correct

--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -34,6 +34,9 @@ def cleanup_loaded_modules() -> None:
     if not enabled:
         return
 
+    stale_reprlib_module = sys.modules.get("reprlib")
+    stale_thread_module = sys.modules.get("_thread")
+
     def drop(module_name: str) -> None:
         module = sys.modules.get(module_name)
         # Don't delete modules that are currently being imported (they might be None or incomplete)
@@ -101,12 +104,32 @@ def cleanup_loaded_modules() -> None:
             # CPython on boot.
             "threading",
             "_thread",
+            # reprlib binds _thread.get_ident at import time. If _thread gets
+            # re-imported but reprlib does not, pickle/cloudpickle can see two
+            # different builtin function objects and fail serializing classes
+            # that close over reprlib state.
+            "reprlib",
         ]
     )
     for u in UNLOAD_MODULES:
         for m in list(sys.modules):
             if m == u or m.startswith(u + "."):
                 drop(m)
+
+    if stale_reprlib_module is not None or stale_thread_module is not None or "reprlib" in sys.modules:
+        # Modules imported before cleanup can keep direct references to the old
+        # reprlib or _thread objects. If _thread is re-imported, stale reprlib
+        # references can retain the old get_ident builtin and become
+        # unpicklable.
+        import _thread
+
+        current_get_ident = _thread.get_ident
+        if stale_thread_module is not None:
+            stale_thread_module.get_ident = current_get_ident  # type: ignore[attr-defined]
+        if stale_reprlib_module is not None:
+            stale_reprlib_module.get_ident = current_get_ident  # type: ignore[attr-defined]
+        if "reprlib" in sys.modules:
+            sys.modules["reprlib"].get_ident = current_get_ident  # type: ignore[attr-defined]
 
     # Because we are not unloading it, the logging module requires a reference
     # to the newly imported threading module to allow it to retrieve the correct

--- a/ddtrace/contrib/ray.py
+++ b/ddtrace/contrib/ray.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 
 def setup_tracing():
     from ddtrace import patch
+    import ddtrace.auto  # noqa:F401
 
     patch(ray=True)
 

--- a/ddtrace/contrib/ray.py
+++ b/ddtrace/contrib/ray.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 
 def setup_tracing():
     from ddtrace import patch
-    import ddtrace.auto  # noqa:F401
 
     patch(ray=True)
 

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -461,6 +461,31 @@ def test_ddtrace_re_module():
     )
 
 
+@pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1"))
+def test_ddtrace_reprlib_get_ident_picklable():
+    import _thread
+    import pickle
+    import reprlib
+
+    assert reprlib.get_ident is _thread.get_ident
+    assert pickle.dumps(reprlib.get_ident)
+
+
+@pytest.mark.subprocess(ddtrace_run=False, env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1"))
+def test_ddtrace_auto_reprlib_stale_get_ident_picklable():
+    import pickle
+    import reprlib
+
+    stale_reprlib = reprlib
+
+    import _thread
+
+    import ddtrace.auto  # noqa: F401
+
+    assert stale_reprlib.get_ident is _thread.get_ident
+    assert pickle.dumps(stale_reprlib.get_ident)
+
+
 @pytest.mark.subprocess(ddtrace_run=True, err=None)
 def test_ddtrace_run_sitecustomize():
     """When using ddtrace-run we ensure ddtrace.bootstrap.sitecustomize is in sys.module cache"""

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -463,27 +463,20 @@ def test_ddtrace_re_module():
 
 @pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1"))
 def test_ddtrace_reprlib_get_ident_picklable():
-    import _thread
     import pickle
     import reprlib
 
-    assert reprlib.get_ident is _thread.get_ident
     assert pickle.dumps(reprlib.get_ident)
 
 
-@pytest.mark.subprocess(ddtrace_run=False, env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1"))
-def test_ddtrace_auto_reprlib_stale_get_ident_picklable():
+@pytest.mark.subprocess(env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="1"))
+def test_ddtrace_auto_reprlib_get_ident_picklable():
+    import ddtrace.auto  # noqa
+
     import pickle
     import reprlib
 
-    stale_reprlib = reprlib
-
-    import _thread
-
-    import ddtrace.auto  # noqa: F401
-
-    assert stale_reprlib.get_ident is _thread.get_ident
-    assert pickle.dumps(stale_reprlib.get_ident)
+    assert pickle.dumps(reprlib.get_ident)
 
 
 @pytest.mark.subprocess(ddtrace_run=True, err=None)


### PR DESCRIPTION
## Description

Fixes module cleanup so `reprlib.get_ident` stays aligned with the current `_thread.get_ident` after `_thread` is unloaded and re-imported.

This prevents pickle/cloudpickle failures when code keeps a reference to `reprlib` from before `ddtrace.auto` or `ddtrace-run` bootstrap cleanup.

This PR is preparing ray serve PR. Without this fixes, ray serve will crash with a cloudpickle issue when trying to instrument a ray serve application.

AI explaination:
>  Ray Serve can serialize objects that close over `reprlib` state. With module cleanup enabled, `_thread` may be re-imported while stale `reprlib` references still point at the old `_thread.get_ident`
builtin, causing cloudpickle serialization failures.

  ## Testing

- Added regression coverage for `ddtrace-run` bootstrap cleanup.
- Added regression coverage for stale `reprlib` references held
before `ddtrace.auto`.
