### PR TITLE
fix(profiling): fix span to profile link post fork

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -399,13 +399,7 @@ class Tracer(object):
         self._pid = getpid()
         self._recreate(reset_buffer=True)
         self._new_process = True
-        # Re-dispatch the span activation event for the currently active span.
-        # The native pthread_atfork child handler (ThreadSpanLinks::postfork_child)
-        # clears all thread to span_id mappings so the profiler starts fresh.
-        # However, the context provider still holds the inherited active span and
-        # context_provider.activate() is never called again for it. Without this
-        # dispatch, profile samples collected in the child carry no span_id /
-        # local_root_span_id labels, breaking the Trace to Profile link in the UI.
+        # Re-dispatch activation post-fork: native code clears profiler span links; inherited context is unchanged.
         active = self.context_provider.active()
         if active is not None:
             core.dispatch("ddtrace.context_provider.activate", (active,))

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -399,6 +399,16 @@ class Tracer(object):
         self._pid = getpid()
         self._recreate(reset_buffer=True)
         self._new_process = True
+        # Re-dispatch the span activation event for the currently active span.
+        # The native pthread_atfork child handler (ThreadSpanLinks::postfork_child)
+        # clears all thread to span_id mappings so the profiler starts fresh.
+        # However, the context provider still holds the inherited active span and
+        # context_provider.activate() is never called again for it. Without this
+        # dispatch, profile samples collected in the child carry no span_id /
+        # local_root_span_id labels, breaking the Trace to Profile link in the UI.
+        active = self.context_provider.active()
+        if active is not None:
+            core.dispatch("ddtrace.context_provider.activate", (active,))
 
     def _recreate(
         self,

--- a/releasenotes/notes/post-fork-span-prof-link-744f7060a8f97604.yaml
+++ b/releasenotes/notes/post-fork-span-prof-link-744f7060a8f97604.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Tracing and Profiling: This fixes a bug where uploaded profiles would not have a linked span post fork

--- a/releasenotes/notes/post-fork-span-prof-link-744f7060a8f97604.yaml
+++ b/releasenotes/notes/post-fork-span-prof-link-744f7060a8f97604.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Tracing and Profiling: This fixes a bug where uploaded profiles would not have a linked span post fork
+    Profiling: This fixes a bug where uploaded profiles would not have a linked span post fork

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1065,3 +1065,96 @@ def test_stress_trace_collection(tracer_and_collector: tuple[Tracer, stack.Stack
 
     for t in threads:
         t.join()
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork test only on linux")
+@pytest.mark.subprocess(err=None)
+def test_span_id_in_profile_after_fork() -> None:
+    """
+    Verify that profile samples from a forked child carry span_id labels.
+    """
+    import os
+    import pathlib
+    import tempfile
+    import time
+
+    import ddtrace
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+
+    tracer = ddtrace.tracer
+    tracer._endpoint_call_counter_span_processor.enable()
+
+    tmp_path = pathlib.Path(tempfile.mkdtemp())
+    test_name = "test_span_id_in_profile_after_fork"
+    pprof_prefix = str(tmp_path / test_name)
+
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
+    ddup.start()
+    ddup.upload(tracer=tracer)
+
+    collector = stack.StackCollector(tracer=tracer)
+    collector.start()
+
+    # Open a span before forking so the child inherits the active context.
+    with tracer.trace("job", resource="delancie-job") as root_span:
+        span_id = root_span.span_id
+        local_root_span_id = root_span._local_root.span_id
+
+        pid = os.fork()
+        if pid == 0:
+            # child process
+            # Reconfigure ddup so the child writes to its own file.
+            child_pprof_prefix = str(tmp_path / (test_name + "_child"))
+            child_output = child_pprof_prefix + "." + str(os.getpid())
+
+            ddup.config(
+                env="test",
+                service=test_name,
+                version="my_version",
+                output_filename=child_pprof_prefix,
+            )
+            ddup.start()
+            ddup.upload(tracer=tracer)
+
+            # Let the sampler collect samples while the inherited span is active.
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                time.sleep(0.05)
+
+            ddup.upload(tracer=tracer)
+
+            profile = pprof_utils.parse_newest_profile(child_output)
+            samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
+
+            try:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples=samples_with_span_id,
+                    expected_sample=pprof_utils.StackEvent(
+                        span_id=span_id,
+                        local_root_span_id=local_root_span_id,
+                    ),
+                    print_samples_on_failure=True,
+                )
+            except AssertionError as e:
+                print(
+                    f"FAIL: no profile sample in child carries span_id={span_id} / "
+                    f"local_root_span_id={local_root_span_id}.\n"
+                    "ThreadSpanLinks was not repopulated after fork.\n"
+                    f"AssertionError: {e}"
+                )
+                os._exit(1)
+            os._exit(0)
+        else:
+            # parent process
+            _, status = os.waitpid(pid, 0)
+            exit_code = os.waitstatus_to_exitcode(status)
+            assert exit_code == 0, (
+                "Child process failed: profile samples after fork did not contain the expected span_id. "
+                "The Trace to Profile link is broken for forked processes."
+            )
+
+    collector.stop()

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1068,64 +1068,44 @@ def test_stress_trace_collection(tracer_and_collector: tuple[Tracer, stack.Stack
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork test only on linux")
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env=dict(
+        DD_PROFILING_ENABLED="true",
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_span_id_in_profile_after_fork_ddtrace_run",
+    ),
+    err=None,
+)
 def test_span_id_in_profile_after_fork() -> None:
-    """
-    Verify that profile samples from a forked child carry span_id labels.
+    """Same as test_span_id_in_profile_after_fork but exercising the real user path:
+    ddtrace-run with DD_PROFILING_ENABLED=true.  The profiler and tracer are both
+    bootstrapped automatically; no manual ddup/StackCollector setup is needed.
     """
     import os
-    import pathlib
-    import tempfile
     import time
 
     import ddtrace
-    from ddtrace.internal.datadog.profiling import ddup
-    from ddtrace.profiling.collector import stack
+    import ddtrace.profiling.bootstrap as bootstrap
     from tests.profiling.collector import pprof_utils
 
     tracer = ddtrace.tracer
-    tracer._endpoint_call_counter_span_processor.enable()
+    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
-    test_name = "test_span_id_in_profile_after_fork"
-    pprof_prefix = str(tmp_path / test_name)
-
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload(tracer=tracer)
-
-    collector = stack.StackCollector(tracer=tracer)
-    collector.start()
-
-    # Open a span before forking so the child inherits the active context.
     with tracer.trace("job", resource="delancie-job") as root_span:
         span_id = root_span.span_id
         local_root_span_id = root_span._local_root.span_id
 
         pid = os.fork()
         if pid == 0:
-            # child process
-            # Reconfigure ddup so the child writes to its own file.
-            child_pprof_prefix = str(tmp_path / (test_name + "_child"))
-            child_output = child_pprof_prefix + "." + str(os.getpid())
-
-            ddup.config(
-                env="test",
-                service=test_name,
-                version="my_version",
-                output_filename=child_pprof_prefix,
-            )
-            ddup.start()
-            ddup.upload(tracer=tracer)
-
-            # Let the sampler collect samples while the inherited span is active.
+            # child
+            # Give some time for the sampler to capture samples
             end = time.monotonic() + 2
             while time.monotonic() < end:
                 time.sleep(0.05)
 
-            ddup.upload(tracer=tracer)
+            bootstrap.profiler._profiler._scheduler.flush()
 
+            child_output = pprof_prefix + "." + str(os.getpid())
             profile = pprof_utils.parse_newest_profile(child_output)
             samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
 
@@ -1156,5 +1136,3 @@ def test_span_id_in_profile_after_fork() -> None:
                 "Child process failed: profile samples after fork did not contain the expected span_id. "
                 "The Trace to Profile link is broken for forked processes."
             )
-
-    collector.stop()


### PR DESCRIPTION
## Description

When a Python process forks, the native C++ `pthread_atfork` child handler runs `ThreadSpanLinks::postfork_child()`, which clears all thread to span_id mappings..

The child inherits the parent's Python state, including `_DD_CONTEXTVAR`. That span is still "active" in the child's context, but since `context_provider.activate()` is never called again for it, the profiler's `link_span` hook never fires.

`link_span` is what populates `ThreadSpanLinks`.

[PROF-14374](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/27442?selectedIssue=PROF-14374)


1. Fork -> `ThreadSpanLinks` cleared, inherited span still active in context vars             
2. The fix (in `_child_after_fork`) -> dispatches `activate(inherited_span)` -> `link_span` re-populates `ThreadSpanLinks` immediately                                                  
3. First `tracer.trace()` in child -> `context_provider.activate(new_ctx)` fires again, but with a Context object so link_span no-ops, then the new Span is activated -> `link_span` fires again with the new span


the issue was between step 1 and 3, adding 2 immediately in the child after fork minimizes the window




## Testing

The included unit test fails without the fix

## Risks

I think the ordering should be fine here. `pthread_atfork` child handlers run LIFO. The native `stack_atfork_child` (which clears `ThreadSpanLinks`) was registered after Python's `os.register_at_fork`, so it runs first. By the time `_child_after_fork` runs and we call `link_span`, the map is already cleared and ready to receive the new entry.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[PROF-14374]: https://datadoghq.atlassian.net/browse/PROF-14374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ