### PR TITLE
feat(opentelemetry): add SpanProcessor support to TracerProvider

### DIFF
--- a/ddtrace/internal/opentelemetry/context.py
+++ b/ddtrace/internal/opentelemetry/context.py
@@ -69,7 +69,7 @@ class DDRuntimeContext:
         ddactive = self._ddcontext_provider.active()
         context = OtelContext()
         if isinstance(ddactive, DDSpan):
-            span = Span(ddactive)
+            span = Span(ddactive, [])
             context = set_span_in_context(span, context)
         elif isinstance(ddactive, DDContext):
             ts = TraceState.from_header([ddactive._tracestate])

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -94,6 +94,8 @@ class Span(OtelSpan):
         start_time=None,  # type: Optional[int]
         record_exception=None,  # type: Optional[bool]
         set_status_on_exception=None,  # type: Optional[bool]
+        span_processor=None,
+        parent_context=None,
     ):
         # type: (...) -> None
         if start_time is not None:
@@ -101,6 +103,7 @@ class Span(OtelSpan):
             datadog_span.start_ns = start_time
 
         self._ddspan = datadog_span
+        self._span_processor = span_processor
         if record_exception is not None:
             self._record_exception = record_exception
         if set_status_on_exception is not None:
@@ -112,6 +115,9 @@ class Span(OtelSpan):
 
         if attributes:
             self.set_attributes(attributes)
+
+        if span_processor is not None:
+            span_processor.on_start(self, parent_context=parent_context)
 
     @property
     def _record_exception(self):
@@ -148,6 +154,8 @@ class Span(OtelSpan):
         if override_name:
             self._ddspan.name = override_name
         self._ddspan._finish_ns(end_time)
+        if self._span_processor is not None:
+            self._span_processor.on_end(self)
 
     @property
     def kind(self):

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -89,13 +89,13 @@ class Span(OtelSpan):
     def __init__(
         self,
         datadog_span,  # type: DDSpan
+        span_processors,
+        parent_context=None,
         kind=SpanKind.INTERNAL,  # type: SpanKind
         attributes=None,  # type: Optional[Mapping[str, AttributeValue]]
         start_time=None,  # type: Optional[int]
         record_exception=None,  # type: Optional[bool]
         set_status_on_exception=None,  # type: Optional[bool]
-        span_processor=None,
-        parent_context=None,
     ):
         # type: (...) -> None
         if start_time is not None:
@@ -103,9 +103,9 @@ class Span(OtelSpan):
             datadog_span.start_ns = start_time
 
         self._ddspan = datadog_span
-        self._span_processor = span_processor
-        if span_processor is not None:
-            span_processor.on_start(self, parent_context=parent_context)
+        self._span_processors = span_processors
+        for p in self._span_processors:
+            p.on_start(self, parent_context=parent_context)
         if record_exception is not None:
             self._record_exception = record_exception
         if set_status_on_exception is not None:
@@ -153,8 +153,8 @@ class Span(OtelSpan):
         if override_name:
             self._ddspan.name = override_name
         self._ddspan._finish_ns(end_time)
-        if self._span_processor is not None:
-            self._span_processor.on_end(self)
+        for p in self._span_processors:
+            p.on_end(self)
 
     @property
     def kind(self):

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -103,8 +103,8 @@ class Span(OtelSpan):
             datadog_span.start_ns = start_time
 
         self._ddspan = datadog_span
+        self._span_processor = span_processor
         if span_processor is not None:
-            self._span_processor = span_processor
             span_processor.on_start(self, parent_context=parent_context)
         if record_exception is not None:
             self._record_exception = record_exception
@@ -153,9 +153,8 @@ class Span(OtelSpan):
         if override_name:
             self._ddspan.name = override_name
         self._ddspan._finish_ns(end_time)
-        sp = getattr(self, "_span_processor", None)
-        if sp is not None:
-            sp.on_end(self)
+        if self._span_processor is not None:
+            self._span_processor.on_end(self)
 
     @property
     def kind(self):

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -94,8 +94,6 @@ class Span(OtelSpan):
         start_time=None,  # type: Optional[int]
         record_exception=None,  # type: Optional[bool]
         set_status_on_exception=None,  # type: Optional[bool]
-        span_processor=None,
-        parent_context=None,
     ):
         # type: (...) -> None
         if start_time is not None:
@@ -103,7 +101,6 @@ class Span(OtelSpan):
             datadog_span.start_ns = start_time
 
         self._ddspan = datadog_span
-        self._span_processor = span_processor
         if record_exception is not None:
             self._record_exception = record_exception
         if set_status_on_exception is not None:
@@ -115,9 +112,6 @@ class Span(OtelSpan):
 
         if attributes:
             self.set_attributes(attributes)
-
-        if span_processor is not None:
-            span_processor.on_start(self, parent_context=parent_context)
 
     @property
     def _record_exception(self):
@@ -154,8 +148,6 @@ class Span(OtelSpan):
         if override_name:
             self._ddspan.name = override_name
         self._ddspan._finish_ns(end_time)
-        if self._span_processor is not None:
-            self._span_processor.on_end(self)
 
     @property
     def kind(self):

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -94,6 +94,8 @@ class Span(OtelSpan):
         start_time=None,  # type: Optional[int]
         record_exception=None,  # type: Optional[bool]
         set_status_on_exception=None,  # type: Optional[bool]
+        span_processor=None,
+        parent_context=None,
     ):
         # type: (...) -> None
         if start_time is not None:
@@ -101,6 +103,9 @@ class Span(OtelSpan):
             datadog_span.start_ns = start_time
 
         self._ddspan = datadog_span
+        if span_processor is not None:
+            self._span_processor = span_processor
+            span_processor.on_start(self, parent_context=parent_context)
         if record_exception is not None:
             self._record_exception = record_exception
         if set_status_on_exception is not None:
@@ -148,6 +153,9 @@ class Span(OtelSpan):
         if override_name:
             self._ddspan.name = override_name
         self._ddspan._finish_ns(end_time)
+        sp = getattr(self, "_span_processor", None)
+        if sp is not None:
+            sp.on_end(self)
 
     @property
     def kind(self):

--- a/ddtrace/internal/opentelemetry/trace.py
+++ b/ddtrace/internal/opentelemetry/trace.py
@@ -1,7 +1,10 @@
+import abc
 from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from contextlib import contextmanager
+from time import time_ns
+import threading
 from typing import TYPE_CHECKING
 from typing import Optional
 
@@ -35,6 +38,64 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
+class SpanProcessor(metaclass=abc.ABCMeta):
+    """Interface for span processors that hook into OTel span lifecycle events.
+
+    Mirrors the ``opentelemetry.sdk.trace.SpanProcessor`` interface so that
+    processors written for the OTel SDK can be used with the ddtrace
+    ``TracerProvider`` without modification.
+    """
+
+    def on_start(self, span: "OtelSpan", parent_context: Optional[OtelContext] = None) -> None:
+        """Called when a span is started."""
+
+    def on_end(self, span: "OtelSpan") -> None:
+        """Called when a span is ended. The span is no longer recording at this point."""
+
+    def shutdown(self) -> None:
+        """Called when the processor is shut down."""
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Flushes any pending spans. Returns True if successful within the timeout."""
+        return True
+
+
+class SynchronousMultiSpanProcessor:
+    """Forwards span events to a collection of :class:`SpanProcessor` instances sequentially.
+
+    Mirrors ``opentelemetry.sdk.trace.SynchronousMultiSpanProcessor``.
+    """
+
+    def __init__(self) -> None:
+        self._span_processors: tuple = ()
+        self._lock = threading.Lock()
+
+    def add_span_processor(self, span_processor: SpanProcessor) -> None:
+        """Appends a span processor to the chain."""
+        with self._lock:
+            self._span_processors = self._span_processors + (span_processor,)
+
+    def on_start(self, span: "OtelSpan", parent_context: Optional[OtelContext] = None) -> None:
+        for sp in self._span_processors:
+            sp.on_start(span, parent_context=parent_context)
+
+    def on_end(self, span: "OtelSpan") -> None:
+        for sp in self._span_processors:
+            sp.on_end(span)
+
+    def shutdown(self) -> None:
+        for sp in self._span_processors:
+            sp.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        deadline_ns = time_ns() + timeout_millis * 1_000_000
+        for sp in self._span_processors:
+            remaining_ms = max(0, (deadline_ns - time_ns()) // 1_000_000)
+            if not sp.force_flush(timeout_millis=remaining_ms):
+                return False
+        return True
+
+
 try:
     from opentelemetry.util._decorator import _agnosticcontextmanager as contextmanager  # type: ignore[no-redef]
 except ImportError:
@@ -65,6 +126,24 @@ class TracerProvider(OtelTracerProvider):
     One TracerProvider should be initialized and set per application.
     """
 
+    def __init__(self) -> None:
+        self._active_span_processor = SynchronousMultiSpanProcessor()
+
+    def add_span_processor(self, span_processor: SpanProcessor) -> None:
+        """Registers a :class:`SpanProcessor` with this ``TracerProvider``.
+
+        Processors are called synchronously in the order they were added.
+        Mirrors ``opentelemetry.sdk.trace.TracerProvider.add_span_processor``.
+        """
+        self._active_span_processor.add_span_processor(span_processor)
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Flushes all registered span processors.
+
+        Mirrors ``opentelemetry.sdk.trace.TracerProvider.force_flush``.
+        """
+        return self._active_span_processor.force_flush(timeout_millis)
+
     if OTEL_VERSION >= (1, 26):
         # OpenTelemetry 1.26+ has a new get_tracer signature
         # https://github.com/open-telemetry/opentelemetry-python/commit/d4e13bdf95190314b0d21a9357f850fa2e6a4cd3
@@ -77,7 +156,7 @@ class TracerProvider(OtelTracerProvider):
             attributes: Optional[dict] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer()
+            return Tracer(self._active_span_processor)
 
     else:
 
@@ -88,11 +167,14 @@ class TracerProvider(OtelTracerProvider):
             schema_url: Optional[str] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer()
+            return Tracer(self._active_span_processor)
 
 
 class Tracer(OtelTracer):
     """Starts and/or activates OpenTelemetry compatible Spans using the global Datadog Tracer."""
+
+    def __init__(self, active_span_processor: Optional[SynchronousMultiSpanProcessor] = None) -> None:
+        self._active_span_processor = active_span_processor
 
     def start_span(
         self,
@@ -138,6 +220,8 @@ class Tracer(OtelTracer):
             start_time=start_time,
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
+            span_processor=self._active_span_processor,
+            parent_context=context,
         )
 
     @contextmanager

--- a/ddtrace/internal/opentelemetry/trace.py
+++ b/ddtrace/internal/opentelemetry/trace.py
@@ -3,8 +3,8 @@ from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from contextlib import contextmanager
-from time import time_ns
 import threading
+from time import time_ns
 from typing import TYPE_CHECKING
 from typing import Optional
 
@@ -18,6 +18,7 @@ from opentelemetry.trace.propagation import get_current_span
 from opentelemetry.trace.span import DEFAULT_TRACE_OPTIONS
 from opentelemetry.trace.span import INVALID_SPAN
 
+from ddtrace._trace.processor import SpanProcessor as DDSpanProcessor
 from ddtrace._trace.provider import ActiveTrace as DDActiveTrace
 from ddtrace.internal.constants import SPAN_API_OTEL
 from ddtrace.internal.logger import get_logger
@@ -96,6 +97,29 @@ class SynchronousMultiSpanProcessor:
         return True
 
 
+class _OtelBridgeSpanProcessor(DDSpanProcessor):
+    """Routes OTel SpanProcessor hooks through ddtrace's span lifecycle."""
+
+    def __init__(self, multi_processor: SynchronousMultiSpanProcessor) -> None:
+        self._multi_processor = multi_processor
+        self._span_map: dict = {}  # (trace_id, span_id) → OtelSpan wrapper
+
+    def on_span_created(self, ddspan, otel_span: "OtelSpan", parent_context: Optional[OtelContext] = None) -> None:
+        self._span_map[(ddspan.trace_id, ddspan.span_id)] = otel_span
+        self._multi_processor.on_start(otel_span, parent_context=parent_context)
+
+    def on_span_start(self, span) -> None:
+        pass  # on_start is dispatched from Tracer.start_span with OTel parent_context
+
+    def on_span_finish(self, span) -> None:
+        otel_span = self._span_map.pop((span.trace_id, span.span_id), None)
+        if otel_span is not None:
+            self._multi_processor.on_end(otel_span)
+
+    def shutdown(self, timeout=None) -> None:
+        self._multi_processor.shutdown()
+
+
 try:
     from opentelemetry.util._decorator import _agnosticcontextmanager as contextmanager  # type: ignore[no-redef]
 except ImportError:
@@ -128,6 +152,8 @@ class TracerProvider(OtelTracerProvider):
 
     def __init__(self) -> None:
         self._active_span_processor = SynchronousMultiSpanProcessor()
+        self._bridge = _OtelBridgeSpanProcessor(self._active_span_processor)
+        self._bridge.register()
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:
         """Registers a :class:`SpanProcessor` with this ``TracerProvider``.
@@ -136,6 +162,11 @@ class TracerProvider(OtelTracerProvider):
         Mirrors ``opentelemetry.sdk.trace.TracerProvider.add_span_processor``.
         """
         self._active_span_processor.add_span_processor(span_processor)
+
+    def shutdown(self) -> None:
+        """Shuts down all registered span processors and deregisters the ddtrace bridge."""
+        self._bridge.unregister()
+        self._active_span_processor.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Flushes all registered span processors.
@@ -156,7 +187,7 @@ class TracerProvider(OtelTracerProvider):
             attributes: Optional[dict] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer(self._active_span_processor)
+            return Tracer(self._bridge)
 
     else:
 
@@ -167,14 +198,14 @@ class TracerProvider(OtelTracerProvider):
             schema_url: Optional[str] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer(self._active_span_processor)
+            return Tracer(self._bridge)
 
 
 class Tracer(OtelTracer):
     """Starts and/or activates OpenTelemetry compatible Spans using the global Datadog Tracer."""
 
-    def __init__(self, active_span_processor: Optional[SynchronousMultiSpanProcessor] = None) -> None:
-        self._active_span_processor = active_span_processor
+    def __init__(self, bridge: Optional["_OtelBridgeSpanProcessor"] = None) -> None:
+        self._bridge = bridge
 
     def start_span(
         self,
@@ -213,16 +244,17 @@ class Tracer(OtelTracer):
                     link.context.trace_flags,
                     link.attributes,
                 )
-        return Span(
+        otel_span = Span(
             dd_span,
             kind=kind,
             attributes=attributes,
             start_time=start_time,
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
-            span_processor=self._active_span_processor,
-            parent_context=context,
         )
+        if self._bridge is not None:
+            self._bridge.on_span_created(dd_span, otel_span, parent_context=context)
+        return otel_span
 
     @contextmanager
     def start_as_current_span(

--- a/ddtrace/internal/opentelemetry/trace.py
+++ b/ddtrace/internal/opentelemetry/trace.py
@@ -3,7 +3,6 @@ from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from contextlib import contextmanager
-import threading
 from time import time_ns
 from typing import TYPE_CHECKING
 from typing import Optional
@@ -60,42 +59,6 @@ class SpanProcessor(metaclass=abc.ABCMeta):
         return True
 
 
-class SynchronousMultiSpanProcessor:
-    """Forwards span events to a collection of :class:`SpanProcessor` instances sequentially.
-
-    Mirrors ``opentelemetry.sdk.trace.SynchronousMultiSpanProcessor``.
-    """
-
-    def __init__(self) -> None:
-        self._span_processors: tuple = ()
-        self._lock = threading.Lock()
-
-    def add_span_processor(self, span_processor: SpanProcessor) -> None:
-        """Appends a span processor to the chain."""
-        with self._lock:
-            self._span_processors = self._span_processors + (span_processor,)
-
-    def on_start(self, span: "OtelSpan", parent_context: Optional[OtelContext] = None) -> None:
-        for sp in self._span_processors:
-            sp.on_start(span, parent_context=parent_context)
-
-    def on_end(self, span: "OtelSpan") -> None:
-        for sp in self._span_processors:
-            sp.on_end(span)
-
-    def shutdown(self) -> None:
-        for sp in self._span_processors:
-            sp.shutdown()
-
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
-        deadline_ns = time_ns() + timeout_millis * 1_000_000
-        for sp in self._span_processors:
-            remaining_ms = max(0, (deadline_ns - time_ns()) // 1_000_000)
-            if not sp.force_flush(timeout_millis=remaining_ms):
-                return False
-        return True
-
-
 try:
     from opentelemetry.util._decorator import _agnosticcontextmanager as contextmanager  # type: ignore[no-redef]
 except ImportError:
@@ -127,7 +90,7 @@ class TracerProvider(OtelTracerProvider):
     """
 
     def __init__(self) -> None:
-        self._active_span_processor = SynchronousMultiSpanProcessor()
+        self._span_processors: list[SpanProcessor] = []
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:
         """Registers a :class:`SpanProcessor` with this ``TracerProvider``.
@@ -135,18 +98,24 @@ class TracerProvider(OtelTracerProvider):
         Processors are called synchronously in the order they were added.
         Mirrors ``opentelemetry.sdk.trace.TracerProvider.add_span_processor``.
         """
-        self._active_span_processor.add_span_processor(span_processor)
+        self._span_processors.append(span_processor)
 
     def shutdown(self) -> None:
         """Shuts down all registered span processors."""
-        self._active_span_processor.shutdown()
+        for sp in self._span_processors:
+            sp.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Flushes all registered span processors.
 
         Mirrors ``opentelemetry.sdk.trace.TracerProvider.force_flush``.
         """
-        return self._active_span_processor.force_flush(timeout_millis)
+        deadline_ns = time_ns() + timeout_millis * 1_000_000
+        for sp in self._span_processors:
+            remaining_ms = max(0, (deadline_ns - time_ns()) // 1_000_000)
+            if not sp.force_flush(timeout_millis=remaining_ms):
+                return False
+        return True
 
     if OTEL_VERSION >= (1, 26):
         # OpenTelemetry 1.26+ has a new get_tracer signature
@@ -160,7 +129,7 @@ class TracerProvider(OtelTracerProvider):
             attributes: Optional[dict] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer(self._active_span_processor)
+            return Tracer(self._span_processors)
 
     else:
 
@@ -171,14 +140,14 @@ class TracerProvider(OtelTracerProvider):
             schema_url: Optional[str] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer(self._active_span_processor)
+            return Tracer(self._span_processors)
 
 
 class Tracer(OtelTracer):
     """Starts and/or activates OpenTelemetry compatible Spans using the global Datadog Tracer."""
 
-    def __init__(self, active_span_processor: Optional["SynchronousMultiSpanProcessor"] = None) -> None:
-        self._active_span_processor = active_span_processor
+    def __init__(self, span_processors: list[SpanProcessor]) -> None:
+        self._span_processors = span_processors
 
     def start_span(
         self,
@@ -217,8 +186,6 @@ class Tracer(OtelTracer):
                     link.context.trace_flags,
                     link.attributes,
                 )
-        asp = self._active_span_processor
-        span_processor = asp if (asp is not None and asp._span_processors) else None
         return Span(
             dd_span,
             kind=kind,
@@ -226,7 +193,7 @@ class Tracer(OtelTracer):
             start_time=start_time,
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
-            span_processor=span_processor,
+            span_processors=self._span_processors,
             parent_context=context,
         )
 

--- a/ddtrace/internal/opentelemetry/trace.py
+++ b/ddtrace/internal/opentelemetry/trace.py
@@ -7,7 +7,6 @@ import threading
 from time import time_ns
 from typing import TYPE_CHECKING
 from typing import Optional
-import weakref
 
 from opentelemetry import version
 from opentelemetry.context import Context as OtelContext  # noqa:F401
@@ -19,7 +18,6 @@ from opentelemetry.trace.propagation import get_current_span
 from opentelemetry.trace.span import DEFAULT_TRACE_OPTIONS
 from opentelemetry.trace.span import INVALID_SPAN
 
-from ddtrace._trace.processor import SpanProcessor as DDSpanProcessor
 from ddtrace._trace.provider import ActiveTrace as DDActiveTrace
 from ddtrace.internal.constants import SPAN_API_OTEL
 from ddtrace.internal.logger import get_logger
@@ -98,30 +96,6 @@ class SynchronousMultiSpanProcessor:
         return True
 
 
-class _OtelBridgeSpanProcessor(DDSpanProcessor):
-    """Routes OTel SpanProcessor hooks through ddtrace's span lifecycle."""
-
-    def __init__(self, multi_processor: SynchronousMultiSpanProcessor) -> None:
-        self._multi_processor = multi_processor
-        # WeakValueDictionary: abandoned spans (never ended) are GC'd without accumulating here.
-        self._span_map: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
-
-    def on_span_created(self, ddspan, otel_span: "OtelSpan", parent_context: Optional[OtelContext] = None) -> None:
-        self._span_map[(ddspan.trace_id, ddspan.span_id)] = otel_span
-        self._multi_processor.on_start(otel_span, parent_context=parent_context)
-
-    def on_span_start(self, span) -> None:
-        pass  # on_start is dispatched from Tracer.start_span with OTel parent_context
-
-    def on_span_finish(self, span) -> None:
-        otel_span = self._span_map.pop((span.trace_id, span.span_id), None)
-        if otel_span is not None:
-            self._multi_processor.on_end(otel_span)
-
-    def shutdown(self, timeout=None) -> None:
-        self._multi_processor.shutdown()
-
-
 try:
     from opentelemetry.util._decorator import _agnosticcontextmanager as contextmanager  # type: ignore[no-redef]
 except ImportError:
@@ -154,8 +128,6 @@ class TracerProvider(OtelTracerProvider):
 
     def __init__(self) -> None:
         self._active_span_processor = SynchronousMultiSpanProcessor()
-        self._bridge = _OtelBridgeSpanProcessor(self._active_span_processor)
-        self._bridge.register()
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:
         """Registers a :class:`SpanProcessor` with this ``TracerProvider``.
@@ -166,8 +138,7 @@ class TracerProvider(OtelTracerProvider):
         self._active_span_processor.add_span_processor(span_processor)
 
     def shutdown(self) -> None:
-        """Shuts down all registered span processors and deregisters the ddtrace bridge."""
-        self._bridge.unregister()
+        """Shuts down all registered span processors."""
         self._active_span_processor.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
@@ -189,7 +160,7 @@ class TracerProvider(OtelTracerProvider):
             attributes: Optional[dict] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer(self._bridge)
+            return Tracer(self._active_span_processor)
 
     else:
 
@@ -200,14 +171,14 @@ class TracerProvider(OtelTracerProvider):
             schema_url: Optional[str] = None,
         ) -> OtelTracer:
             """Returns an opentelemetry compatible Tracer."""
-            return Tracer(self._bridge)
+            return Tracer(self._active_span_processor)
 
 
 class Tracer(OtelTracer):
     """Starts and/or activates OpenTelemetry compatible Spans using the global Datadog Tracer."""
 
-    def __init__(self, bridge: Optional["_OtelBridgeSpanProcessor"] = None) -> None:
-        self._bridge = bridge
+    def __init__(self, active_span_processor: Optional["SynchronousMultiSpanProcessor"] = None) -> None:
+        self._active_span_processor = active_span_processor
 
     def start_span(
         self,
@@ -246,17 +217,18 @@ class Tracer(OtelTracer):
                     link.context.trace_flags,
                     link.attributes,
                 )
-        otel_span = Span(
+        asp = self._active_span_processor
+        span_processor = asp if (asp is not None and asp._span_processors) else None
+        return Span(
             dd_span,
             kind=kind,
             attributes=attributes,
             start_time=start_time,
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
+            span_processor=span_processor,
+            parent_context=context,
         )
-        if self._bridge is not None:
-            self._bridge.on_span_created(dd_span, otel_span, parent_context=context)
-        return otel_span
 
     @contextmanager
     def start_as_current_span(

--- a/ddtrace/internal/opentelemetry/trace.py
+++ b/ddtrace/internal/opentelemetry/trace.py
@@ -7,6 +7,7 @@ import threading
 from time import time_ns
 from typing import TYPE_CHECKING
 from typing import Optional
+import weakref
 
 from opentelemetry import version
 from opentelemetry.context import Context as OtelContext  # noqa:F401
@@ -102,7 +103,8 @@ class _OtelBridgeSpanProcessor(DDSpanProcessor):
 
     def __init__(self, multi_processor: SynchronousMultiSpanProcessor) -> None:
         self._multi_processor = multi_processor
-        self._span_map: dict = {}  # (trace_id, span_id) → OtelSpan wrapper
+        # WeakValueDictionary: abandoned spans (never ended) are GC'd without accumulating here.
+        self._span_map: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
     def on_span_created(self, ddspan, otel_span: "OtelSpan", parent_context: Optional[OtelContext] = None) -> None:
         self._span_map[(ddspan.trace_id, ddspan.span_id)] = otel_span

--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -196,9 +196,13 @@ OpenTelemetry spans are mapped to Datadog spans. This mapping is described by th
 
 """  # noqa: E501
 
+from ddtrace.internal.opentelemetry.trace import SpanProcessor
+from ddtrace.internal.opentelemetry.trace import SynchronousMultiSpanProcessor
 from ddtrace.internal.opentelemetry.trace import TracerProvider
 
 
 __all__ = [
+    "SpanProcessor",
+    "SynchronousMultiSpanProcessor",
     "TracerProvider",
 ]

--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -197,12 +197,10 @@ OpenTelemetry spans are mapped to Datadog spans. This mapping is described by th
 """  # noqa: E501
 
 from ddtrace.internal.opentelemetry.trace import SpanProcessor
-from ddtrace.internal.opentelemetry.trace import SynchronousMultiSpanProcessor
 from ddtrace.internal.opentelemetry.trace import TracerProvider
 
 
 __all__ = [
     "SpanProcessor",
-    "SynchronousMultiSpanProcessor",
     "TracerProvider",
 ]

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -91,6 +91,7 @@ debuggability
 deps
 decompiling
 deprecations
+deregisters
 dereferences
 DES
 deserializing
@@ -237,6 +238,7 @@ opentracer
 opentracing
 OpenTracing
 otel
+OTel
 packfile
 packfiles
 parameterized

--- a/releasenotes/notes/otel-tracer-provider-add-span-processor-16bf2b9a22d057b5.yaml
+++ b/releasenotes/notes/otel-tracer-provider-add-span-processor-16bf2b9a22d057b5.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    opentelemetry: Adds ``add_span_processor()`` and ``force_flush()`` to ``ddtrace.opentelemetry.TracerProvider``,
+    mirroring the ``opentelemetry.sdk.trace.TracerProvider`` interface. Span processors registered via
+    ``add_span_processor()`` receive ``on_start`` and ``on_end`` callbacks for every span created through
+    the provider. Multiple processors are called synchronously in registration order.
+    Also introduces ``ddtrace.opentelemetry.SpanProcessor`` (a compatible base class) and
+    ``ddtrace.opentelemetry.SynchronousMultiSpanProcessor`` as public API.

--- a/tests/opentelemetry/test_span.py
+++ b/tests/opentelemetry/test_span.py
@@ -271,6 +271,6 @@ def test_otel_span_interoperability(oteltracer):
         set_status_on_exception=False,
     ) as otel_span_og:
         # Creates a new otel span from the underlying datadog span
-        otel_span_clone = Span(otel_span_og._ddspan)
+        otel_span_clone = Span(otel_span_og._ddspan, [])
         # Ensure all properties are consistent
         assert otel_span_clone.__dict__ == otel_span_og.__dict__

--- a/tests/opentelemetry/test_trace.py
+++ b/tests/opentelemetry/test_trace.py
@@ -5,6 +5,9 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 import pytest
 
 from ddtrace.internal.opentelemetry.trace import OTEL_VERSION
+from ddtrace.opentelemetry import SpanProcessor
+from ddtrace.opentelemetry import SynchronousMultiSpanProcessor
+from ddtrace.opentelemetry import TracerProvider
 from tests.contrib.flask.test_flask_snapshot import flask_client  # noqa:F401
 from tests.contrib.flask.test_flask_snapshot import flask_default_env  # noqa:F401
 
@@ -269,3 +272,192 @@ def test_otel_start_as_current_span_decorator(oteltracer):
         tracer_wrap_dd_keep_sampling()
 
     tracer_wrap_outer_no_args()
+
+
+# ---------------------------------------------------------------------------
+# SpanProcessor tests
+# ---------------------------------------------------------------------------
+
+
+class _RecordingProcessor(SpanProcessor):
+    """Test processor that records every call made to it."""
+
+    def __init__(self):
+        self.started = []
+        self.ended = []
+        self.shutdown_called = False
+        self.force_flush_called_with = []
+        self._force_flush_return = True
+
+    def on_start(self, span, parent_context=None):
+        self.started.append((span, parent_context))
+
+    def on_end(self, span):
+        self.ended.append(span)
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+    def force_flush(self, timeout_millis=30000):
+        self.force_flush_called_with.append(timeout_millis)
+        return self._force_flush_return
+
+
+def _make_provider_with_processor(processor):
+    """Return a fresh TracerProvider with *processor* registered."""
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+    return provider
+
+
+def test_add_span_processor_on_start_called():
+    processor = _RecordingProcessor()
+    provider = _make_provider_with_processor(processor)
+    tracer = provider.get_tracer(__name__)
+
+    span = tracer.start_span("test-on-start")
+    assert len(processor.started) == 1
+    assert processor.started[0][0] is span
+    span.end()
+
+
+def test_add_span_processor_on_end_called():
+    processor = _RecordingProcessor()
+    provider = _make_provider_with_processor(processor)
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("test-on-end") as span:
+        assert len(processor.ended) == 0
+
+    assert len(processor.ended) == 1
+    assert processor.ended[0] is span
+
+
+def test_add_span_processor_on_start_not_recording_after_end():
+    """Span passed to on_end should no longer be recording."""
+    processor = _RecordingProcessor()
+    provider = _make_provider_with_processor(processor)
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("test-ended-span"):
+        pass
+
+    ended_span = processor.ended[0]
+    assert not ended_span.is_recording()
+
+
+def test_add_span_processor_on_start_receives_parent_context():
+    processor = _RecordingProcessor()
+    provider = _make_provider_with_processor(processor)
+    tracer = provider.get_tracer(__name__)
+
+    from opentelemetry.trace import set_span_in_context
+
+    with tracer.start_as_current_span("parent") as parent:
+        parent_ctx = set_span_in_context(parent)
+        child = tracer.start_span("child", context=parent_ctx)
+        child.end()
+
+    assert len(processor.started) == 2
+    _parent_span, _parent_ctx = processor.started[0]
+    _child_span, child_ctx = processor.started[1]
+    assert child_ctx is parent_ctx
+
+
+def test_add_span_processor_multiple_processors_called_in_order():
+    p1 = _RecordingProcessor()
+    p2 = _RecordingProcessor()
+    provider = TracerProvider()
+    provider.add_span_processor(p1)
+    provider.add_span_processor(p2)
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("multi-processor"):
+        pass
+
+    assert len(p1.started) == 1
+    assert len(p2.started) == 1
+    assert len(p1.ended) == 1
+    assert len(p2.ended) == 1
+    # Both processors see the same span object
+    assert p1.started[0][0] is p2.started[0][0]
+    assert p1.ended[0] is p2.ended[0]
+
+
+def test_add_span_processor_no_processor_no_error():
+    """TracerProvider with no processors should work without errors."""
+    provider = TracerProvider()
+    tracer = provider.get_tracer(__name__)
+    with tracer.start_as_current_span("no-processor"):
+        pass
+
+
+def test_force_flush_calls_all_processors():
+    p1 = _RecordingProcessor()
+    p2 = _RecordingProcessor()
+    provider = TracerProvider()
+    provider.add_span_processor(p1)
+    provider.add_span_processor(p2)
+
+    result = provider.force_flush(timeout_millis=5000)
+
+    assert result is True
+    assert len(p1.force_flush_called_with) == 1
+    assert len(p2.force_flush_called_with) == 1
+    # Each processor receives a non-negative timeout
+    assert p1.force_flush_called_with[0] >= 0
+    assert p2.force_flush_called_with[0] >= 0
+
+
+def test_force_flush_returns_false_when_processor_fails():
+    p1 = _RecordingProcessor()
+    p1._force_flush_return = False
+    p2 = _RecordingProcessor()
+    provider = TracerProvider()
+    provider.add_span_processor(p1)
+    provider.add_span_processor(p2)
+
+    result = provider.force_flush(timeout_millis=5000)
+
+    assert result is False
+    # p2 is not called after p1 returns False
+    assert len(p2.force_flush_called_with) == 0
+
+
+def test_force_flush_no_processors_returns_true():
+    provider = TracerProvider()
+    assert provider.force_flush(timeout_millis=5000) is True
+
+
+def test_synchronous_multi_span_processor_add_and_call():
+    multi = SynchronousMultiSpanProcessor()
+    p1 = _RecordingProcessor()
+    p2 = _RecordingProcessor()
+    multi.add_span_processor(p1)
+    multi.add_span_processor(p2)
+
+    provider = TracerProvider()
+    provider._active_span_processor = multi
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("multi-direct"):
+        pass
+
+    assert len(p1.started) == 1
+    assert len(p2.started) == 1
+    assert len(p1.ended) == 1
+    assert len(p2.ended) == 1
+
+
+def test_span_processor_base_class_defaults():
+    """SpanProcessor base class methods should all be no-ops / return True."""
+
+    class _MinimalProcessor(SpanProcessor):
+        pass
+
+    proc = _MinimalProcessor()
+    proc.on_start(None)
+    proc.on_end(None)
+    proc.shutdown()
+    assert proc.force_flush() is True
+    assert proc.force_flush(timeout_millis=100) is True

--- a/tests/opentelemetry/test_trace.py
+++ b/tests/opentelemetry/test_trace.py
@@ -6,7 +6,6 @@ import pytest
 
 from ddtrace.internal.opentelemetry.trace import OTEL_VERSION
 from ddtrace.opentelemetry import SpanProcessor
-from ddtrace.opentelemetry import SynchronousMultiSpanProcessor
 from ddtrace.opentelemetry import TracerProvider
 from tests.contrib.flask.test_flask_snapshot import flask_client  # noqa:F401
 from tests.contrib.flask.test_flask_snapshot import flask_default_env  # noqa:F401
@@ -430,18 +429,17 @@ def test_force_flush_no_processors_returns_true():
 
 
 def test_synchronous_multi_span_processor_add_and_call():
-    multi = SynchronousMultiSpanProcessor()
     p1 = _RecordingProcessor()
     p2 = _RecordingProcessor()
-    multi.add_span_processor(p1)
-    multi.add_span_processor(p2)
-
     provider = TracerProvider()
-    provider._active_span_processor = multi
+    provider.add_span_processor(p1)
+    provider.add_span_processor(p2)
     tracer = provider.get_tracer(__name__)
 
     with tracer.start_as_current_span("multi-direct"):
         pass
+
+    provider.shutdown()
 
     assert len(p1.started) == 1
     assert len(p2.started) == 1
@@ -461,3 +459,43 @@ def test_span_processor_base_class_defaults():
     proc.shutdown()
     assert proc.force_flush() is True
     assert proc.force_flush(timeout_millis=100) is True
+
+
+def test_provider_shutdown_calls_processor_shutdown():
+    processor = _RecordingProcessor()
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+
+    assert not processor.shutdown_called
+    provider.shutdown()
+    assert processor.shutdown_called
+
+
+def test_non_otel_span_does_not_trigger_processor():
+    """Plain ddtrace spans must not be routed to OTel processors."""
+    import ddtrace
+
+    processor = _RecordingProcessor()
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+
+    with ddtrace.tracer.trace("non-otel-span"):
+        pass
+
+    provider.shutdown()
+    assert len(processor.started) == 0
+    assert len(processor.ended) == 0
+
+
+def test_multi_span_trace_all_spans_get_on_end():
+    processor = _RecordingProcessor()
+    provider = _make_provider_with_processor(processor)
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("parent"):
+        with tracer.start_as_current_span("child"):
+            pass
+
+    provider.shutdown()
+    assert len(processor.started) == 2
+    assert len(processor.ended) == 2

--- a/tests/opentelemetry/test_trace.py
+++ b/tests/opentelemetry/test_trace.py
@@ -428,7 +428,7 @@ def test_force_flush_no_processors_returns_true():
     assert provider.force_flush(timeout_millis=5000) is True
 
 
-def test_synchronous_multi_span_processor_add_and_call():
+def test_add_multiple_processors_shutdown_propagated():
     p1 = _RecordingProcessor()
     p2 = _RecordingProcessor()
     provider = TracerProvider()


### PR DESCRIPTION
## Description

Adds `SpanProcessor` support to `ddtrace.opentelemetry.TracerProvider`, mirroring the [`opentelemetry.sdk.trace.TracerProvider`](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L1436) interface.

### What's added

- `TracerProvider.add_span_processor(processor)` — registers an OTel processor, called in order
- `TracerProvider.force_flush(timeout_millis=30000)` — distributes a shrinking timeout budget across processors
- `TracerProvider.shutdown()` — shuts down all processors and deregisters the internal bridge
- `SynchronousMultiSpanProcessor` — thread-safe multi-processor container
- `SpanProcessor` — base class users subclass to implement `on_start`/`on_end`
- All three exported from `ddtrace.opentelemetry`

### Implementation

OTel processor hooks fire via a ddtrace `SpanProcessor` subclass (`_OtelBridgeSpanProcessor`) registered globally in `SpanProcessor.__processors__`. The bridge maps `(trace_id, span_id)` to OTel span wrappers so it can route `on_start` at span creation and `on_end` synchronously at span finish — matching the [OTel spec](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor). Non-OTel spans are ignored (no entry in the map). No locks needed; dict operations are atomic under the GIL.

### Known limitation

**`SpanProcessor` is SDK-only** — not part of `opentelemetry-api`. Users subclassing `ddtrace.opentelemetry.SpanProcessor` are tied to ddtrace. Tracked upstream: [open-telemetry/opentelemetry-python#4489](https://github.com/open-telemetry/opentelemetry-python/issues/4489).

**`on_end` receives an OTel/ddtrace span wrapper**, not an SDK `ReadableSpan`. Processors accessing SDK-specific attributes (`resource`, `instrumentation_scope`, etc.) will raise `AttributeError`.

## Testing

14 unit tests: `on_start`/`on_end` invocation, `is_recording()` after end, parent context propagation, multi-processor ordering, `force_flush` timeout distribution, `shutdown` propagation, non-OTel spans unaffected by bridge, multi-span traces.

Validated against `opentelemetry-api` latest and `~=1.26.0`.