### PR TITLE
perf(profiling): optimize 'free' hot path in heap via Cuckoo hash filter

### DIFF
--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -138,3 +138,16 @@ endif()
 
 # Install the extension
 install(TARGETS ${FULL_EXTENSION_NAME} LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+
+# Optional unit tests for the cuckoo filter. Off by default; enable with
+# -DBUILD_TESTING=ON. Self-contained executable (no gtest dependency); fails
+# via assert() if any invariant is violated.
+if(BUILD_TESTING)
+    enable_testing()
+    add_executable(test_cuckoo test/test_cuckoo.cpp)
+    # Asserts must fire in tests, regardless of the surrounding build type.
+    target_compile_definitions(test_cuckoo PRIVATE DONT_COMPILE_ABSEIL)
+    target_compile_options(test_cuckoo PRIVATE -UNDEBUG)
+    target_include_directories(test_cuckoo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME test_cuckoo COMMAND test_cuckoo)
+endif()

--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -139,9 +139,8 @@ endif()
 # Install the extension
 install(TARGETS ${FULL_EXTENSION_NAME} LIBRARY DESTINATION ${LIB_INSTALL_DIR})
 
-# Optional unit tests for the cuckoo filter. Off by default; enable with
-# -DBUILD_TESTING=ON. Self-contained executable (no gtest dependency); fails
-# via assert() if any invariant is violated.
+# Optional unit tests for the cuckoo filter. Off by default; enable with -DBUILD_TESTING=ON. Self-contained executable
+# (no gtest dependency); fails via assert() if any invariant is violated.
 if(BUILD_TESTING)
     enable_testing()
     add_executable(test_cuckoo test/test_cuckoo.cpp)

--- a/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
+++ b/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <utility>
+
+/* Use absl::Hash when available (release builds with abseil) and fall back
+ * to std::hash otherwise. Mirrors the HeapMapType pattern in
+ * _memalloc_heap.cpp so debug builds compile without abseil. */
+#if defined(NDEBUG) && !defined(DONT_COMPILE_ABSEIL)
+#include "absl/hash/hash.h"
+template<typename T>
+using filter_hash_t = absl::Hash<T>;
+#else
+#include <functional>
+template<typename T>
+using filter_hash_t = std::hash<T>;
+#endif
+
+/* AIDEV-NOTE: Cuckoo filter for fast-reject on the heap profiler free path.
+ *
+ * The heap profiler samples ~1% of allocations. Without a filter, every
+ * free() must probe allocs_m (an absl::flat_hash_map) to find out, paying
+ * 50-100 cycles even for the 99% of frees that aren't sampled. This filter
+ * answers "is this pointer sampled?" in ~10-15 cycles by checking two
+ * candidate buckets containing 16-bit fingerprints.
+ *
+ * Critical invariant: the filter MUST be a superset of allocs_m's keys.
+ *   - False positives are tolerated (extract returns an empty node).
+ *   - False negatives MUST NOT occur — they would skip a real entry and
+ *     leak heap-tracker state.
+ *
+ * To preserve the invariant on saturation: insert() returns false when
+ * eviction reaches MAX_KICKS, and the caller MUST drop the sample (must
+ * NOT add to allocs_m without a filter entry).
+ *
+ * Sizing rationale:
+ *   - 4 slots per bucket × 32768 buckets = 131072 slots
+ *   - The heap tracker stops accepting new samples once allocs_m exceeds
+ *     TRACEBACK_ARRAY_MAX_COUNT (65535), so live entries top out at 65536
+ *   - Worst-case load factor ≈ 50%, well below the 95% where eviction
+ *     failure becomes likely. At 50% load the literature puts the
+ *     per-insert MAX_KICKS=500 failure probability below 1e-10
+ *   - 16-bit fingerprints stored as uint16_t (no bit-packing). With b=4
+ *     slots per bucket and f=16 fingerprint bits, the standard cuckoo
+ *     filter False Positive Rate formula is: `2b/2^f = 8/65536 ≈ 1/8192 ≈ 0.012%`
+ *     per probe of an absent key. Table footprint = 32768 × 4 × 2 bytes
+ *     = 256 KB, fits in L2 on every target platform.
+ *
+ * Hashing uses the standard partial-key cuckoo trick (Fan et al. 2014):
+ *   h1 = hash(ptr) mod NUM_BUCKETS
+ *   h2 = h1 ^ (hash(fp) mod NUM_BUCKETS)
+ * Because XOR is involutive, alt_bucket(alt_bucket(i, fp), fp) == i. This
+ * is what makes deletion possible without storing the full key in the slot.
+ *
+ * Thread safety: not thread-safe. Same constraint as allocs_m, which
+ * assumes the GIL is held. When PEP 703 free-threading lands, both will
+ * need to migrate to atomics together.
+ */
+class CuckooFilter
+{
+  public:
+    static constexpr size_t NUM_BUCKETS = 1u << 15; /* 32768 */
+    static constexpr size_t SLOTS_PER_BUCKET = 4;
+    static constexpr size_t MAX_KICKS = 500;
+    static constexpr uint32_t BUCKET_MASK = static_cast<uint32_t>(NUM_BUCKETS - 1);
+    static constexpr uint16_t EMPTY_SLOT = 0;
+
+    CuckooFilter() noexcept
+      : evict_rng_(0x9e3779b9U)
+    {
+        clear();
+    }
+
+    /* Returns false if eviction failed after MAX_KICKS. Caller MUST drop
+     * the sample to preserve the filter-superset invariant. */
+    bool insert(const void* ptr) noexcept
+    {
+        const Hashed h = hash_ptr(ptr);
+        uint16_t fp = h.fp;
+
+        if (bucket_insert(h.bucket, fp)) {
+            size_++;
+            return true;
+        }
+        const uint32_t b2 = alt_bucket(h.bucket, fp);
+        if (bucket_insert(b2, fp)) {
+            size_++;
+            return true;
+        }
+
+        /* Both buckets full. Evict a random slot from b2 and walk the
+         * displaced fingerprint to its alternate bucket. */
+        uint32_t b = b2;
+        for (size_t i = 0; i < MAX_KICKS; i++) {
+            const size_t slot = static_cast<size_t>(evict_rng_()) & (SLOTS_PER_BUCKET - 1);
+            std::swap(fp, table_[b].slots[slot]);
+            b = alt_bucket(b, fp);
+            if (bucket_insert(b, fp)) {
+                size_++;
+                return true;
+            }
+        }
+        /* AIDEV-NOTE: Saturated. The very first swap at b2 already placed
+         * the *new* fingerprint and started kicking older ones along the
+         * chain. What we end up unable to relocate (the value still in `fp`
+         * here) is an *earlier-tracked* fingerprint, not the new one. That
+         * orphan corresponds to some existing allocs_m entry: the filter no
+         * longer remembers it, so a future untrack of its pointer will be a
+         * false negative and leak that entry — the filter ⊇ allocs_m
+         * invariant is broken for that single pointer. The new pointer's
+         * fingerprint, conversely, is still in the filter with no allocs_m
+         * counterpart, which is harmless (extra slack on the safe side).
+         * Caller MUST drop the new sample to avoid compounding the
+         * asymmetry by adding a fresh allocs_m entry on top.
+         *
+         * AIDEV-TODO: at 50% load this branch is essentially unreachable
+         * (per-insert failure probability < 1e-10). If we ever observe it
+         * in production, fix with a single-slot victim cache: store
+         * (orphan_b, orphan_fp) here and have contains()/erase() check it.
+         * ~10 LoC, O(1) memory, restores the strict invariant. */
+        return false;
+    }
+
+    bool contains(const void* ptr) const noexcept
+    {
+        const Hashed h = hash_ptr(ptr);
+        if (bucket_contains(h.bucket, h.fp)) {
+            return true;
+        }
+        return bucket_contains(alt_bucket(h.bucket, h.fp), h.fp);
+    }
+
+    /* Clears one slot matching the pointer's fingerprint, if any. No-op if
+     * no slot matches. AIDEV-NOTE: callers must only erase pointers that
+     * were previously inserted — otherwise, in the rare same-fp/same-bucket
+     * collision, this could clear an unrelated tracked entry's slot and
+     * induce a false negative on its eventual untrack. */
+    void erase(const void* ptr) noexcept
+    {
+        const Hashed h = hash_ptr(ptr);
+        if (bucket_erase(h.bucket, h.fp)) {
+            size_--;
+            return;
+        }
+        if (bucket_erase(alt_bucket(h.bucket, h.fp), h.fp)) {
+            size_--;
+        }
+    }
+
+    void clear() noexcept
+    {
+        std::memset(table_.data(), 0, sizeof(table_));
+        size_ = 0;
+    }
+
+    size_t size() const noexcept { return size_; }
+
+  private:
+    struct Bucket
+    {
+        uint16_t slots[SLOTS_PER_BUCKET];
+    };
+    static_assert(sizeof(Bucket) == 8, "expect 8-byte bucket");
+
+    struct Hashed
+    {
+        uint32_t bucket;
+        uint16_t fp;
+    };
+
+    static Hashed hash_ptr(const void* p) noexcept
+    {
+        const uint64_t h = static_cast<uint64_t>(filter_hash_t<const void*>{}(p));
+        /* Lower 32 bits → bucket index; upper 32 bits → fingerprint.
+         * Both halves come from the same well-mixed hash, so they're
+         * effectively independent for our purposes. */
+        uint16_t fp = static_cast<uint16_t>(h >> 32);
+        if (fp == EMPTY_SLOT) {
+            fp = 1; /* reserve 0 for empty slots */
+        }
+        return Hashed{ static_cast<uint32_t>(h) & BUCKET_MASK, fp };
+    }
+
+    static uint32_t alt_bucket(uint32_t i, uint16_t fp) noexcept
+    {
+        const uint64_t fp_h = static_cast<uint64_t>(filter_hash_t<uint16_t>{}(fp));
+        return (i ^ static_cast<uint32_t>(fp_h)) & BUCKET_MASK;
+    }
+
+    bool bucket_contains(uint32_t b, uint16_t fp) const noexcept
+    {
+        const Bucket& bk = table_[b];
+        for (size_t i = 0; i < SLOTS_PER_BUCKET; i++) {
+            if (bk.slots[i] == fp) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool bucket_insert(uint32_t b, uint16_t fp) noexcept
+    {
+        Bucket& bk = table_[b];
+        for (size_t i = 0; i < SLOTS_PER_BUCKET; i++) {
+            if (bk.slots[i] == EMPTY_SLOT) {
+                bk.slots[i] = fp;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool bucket_erase(uint32_t b, uint16_t fp) noexcept
+    {
+        Bucket& bk = table_[b];
+        for (size_t i = 0; i < SLOTS_PER_BUCKET; i++) {
+            if (bk.slots[i] == fp) {
+                bk.slots[i] = EMPTY_SLOT;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::array<Bucket, NUM_BUCKETS> table_;
+    std::minstd_rand evict_rng_;
+    size_t size_ = 0;
+};

--- a/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
+++ b/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
@@ -6,18 +6,38 @@
 #include <random>
 #include <utility>
 
-/* Use absl::Hash when available (release builds with abseil) and fall back
- * to std::hash otherwise. Mirrors the HeapMapType pattern in
- * _memalloc_heap.cpp so debug builds compile without abseil. */
-#if defined(NDEBUG) && !defined(DONT_COMPILE_ABSEIL)
-#include "absl/hash/hash.h"
-template<typename T>
-using filter_hash_t = absl::Hash<T>;
-#else
-#include <functional>
-template<typename T>
-using filter_hash_t = std::hash<T>;
-#endif
+/* AIDEV-NOTE: We hand-roll the hash instead of using absl::Hash or
+ * std::hash. Reasons:
+ *   - Pointers come from malloc, not user input, so we don't need
+ *     DOS-resistance or per-process salting.
+ *   - The free path runs once per Python free(), so per-call overhead
+ *     matters: splitmix64 is ~5 cycles vs ~10–15 for absl::Hash.
+ *   - The fingerprint mix only has to spread 16 bits across NUM_BUCKETS;
+ *     a single multiply by a Murmur magic constant is enough.
+ *
+ * splitmix64: Sebastian Vigna's variant, used as the SplittableRandom
+ * finalizer. Two multiplies + three XOR-shifts; bijective, no input
+ * value collapses to 0 unless the input itself is 0.
+ *
+ * Murmur fingerprint mix: 0x5bd1e995U is the Murmur2 magic constant —
+ * a 32-bit prime with good avalanche when used as `x * k`. Sufficient
+ * to fan a 16-bit fingerprint into a uniformly-distributed 15-bit
+ * bucket index (NUM_BUCKETS = 32768). */
+namespace memalloc_cuckoo_detail {
+static inline uint64_t
+splitmix64(uint64_t x) noexcept
+{
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    return x ^ (x >> 31);
+}
+
+static inline uint32_t
+fingerprint_mix(uint16_t fp) noexcept
+{
+    return static_cast<uint32_t>(fp) * 0x5bd1e995U;
+}
+} // namespace memalloc_cuckoo_detail
 
 /* AIDEV-NOTE: Cuckoo filter for fast-reject on the heap profiler free path.
  *
@@ -209,10 +229,9 @@ class CuckooFilterImpl
 
     static Hashed hash_ptr(const void* p) noexcept
     {
-        const uint64_t h = static_cast<uint64_t>(filter_hash_t<const void*>{}(p));
+        const uint64_t h = memalloc_cuckoo_detail::splitmix64(reinterpret_cast<uintptr_t>(p));
         /* Lower 32 bits → bucket index; upper 32 bits → fingerprint.
-         * Both halves come from the same well-mixed hash, so they're
-         * effectively independent for our purposes. */
+         * splitmix64 is bijective so both halves are independent. */
         uint16_t fp = static_cast<uint16_t>(h >> 32);
         if (fp == EMPTY_SLOT) {
             fp = 1; /* reserve 0 for empty slots */
@@ -222,8 +241,7 @@ class CuckooFilterImpl
 
     static uint32_t alt_bucket(uint32_t i, uint16_t fp) noexcept
     {
-        const uint64_t fp_h = static_cast<uint64_t>(filter_hash_t<uint16_t>{}(fp));
-        return (i ^ static_cast<uint32_t>(fp_h)) & BUCKET_MASK;
+        return (i ^ memalloc_cuckoo_detail::fingerprint_mix(fp)) & BUCKET_MASK;
     }
 
     bool bucket_contains(uint32_t b, uint16_t fp) const noexcept

--- a/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
+++ b/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
@@ -32,9 +32,16 @@ using filter_hash_t = std::hash<T>;
  *   - False negatives MUST NOT occur — they would skip a real entry and
  *     leak heap-tracker state.
  *
- * To preserve the invariant on saturation: insert() returns false when
- * eviction reaches MAX_KICKS, and the caller MUST drop the sample (must
- * NOT add to allocs_m without a filter entry).
+ * Saturation handling: when the eviction chain can't terminate within
+ * MAX_KICKS, the displaced fingerprint is parked in a single-slot victim
+ * cache (instead of being orphaned). contains() and erase() consult both
+ * the table and the victim. This restores the strict superset invariant
+ * for the first saturation. If a SECOND saturation occurs while the
+ * victim is still occupied, insert() returns false WITHOUT mutating the
+ * table (we refuse before starting the eviction chain), and the caller
+ * MUST drop the sample. At our 50% load both events are essentially
+ * unreachable; the victim closes the rare-but-nonzero leak window of the
+ * naive cuckoo filter.
  *
  * Sizing rationale:
  *   - 4 slots per bucket × 32768 buckets = 131072 slots
@@ -59,23 +66,33 @@ using filter_hash_t = std::hash<T>;
  * assumes the GIL is held. When PEP 703 free-threading lands, both will
  * need to migrate to atomics together.
  */
-class CuckooFilter
+/* Template parameters expose the filter's geometry so tests can instantiate
+ * tiny variants (e.g. CuckooFilterImpl<2, 2, 4>) and exercise the
+ * saturation/victim-cache paths deterministically. Production code uses
+ * the default parameters via the `CuckooFilter` alias below. */
+template<size_t NumBuckets = (1u << 15) /* 32768 */, size_t SlotsPerBucket = 4, size_t MaxKicks = 500>
+class CuckooFilterImpl
 {
+    static_assert((NumBuckets & (NumBuckets - 1)) == 0, "NumBuckets must be a power of 2");
+    static_assert(SlotsPerBucket > 0 && (SlotsPerBucket & (SlotsPerBucket - 1)) == 0,
+                  "SlotsPerBucket must be a power of 2");
+
   public:
-    static constexpr size_t NUM_BUCKETS = 1u << 15; /* 32768 */
-    static constexpr size_t SLOTS_PER_BUCKET = 4;
-    static constexpr size_t MAX_KICKS = 500;
-    static constexpr uint32_t BUCKET_MASK = static_cast<uint32_t>(NUM_BUCKETS - 1);
+    static constexpr size_t NUM_BUCKETS = NumBuckets;
+    static constexpr size_t SLOTS_PER_BUCKET = SlotsPerBucket;
+    static constexpr size_t MAX_KICKS = MaxKicks;
+    static constexpr uint32_t BUCKET_MASK = static_cast<uint32_t>(NumBuckets - 1);
     static constexpr uint16_t EMPTY_SLOT = 0;
 
-    CuckooFilter() noexcept
+    CuckooFilterImpl() noexcept
       : evict_rng_(0x9e3779b9U)
     {
         clear();
     }
 
-    /* Returns false if eviction failed after MAX_KICKS. Caller MUST drop
-     * the sample to preserve the filter-superset invariant. */
+    /* Returns false only if a second saturation would occur while the victim
+     * slot is already in use. In that case the table is left untouched and
+     * the caller MUST drop the sample to preserve filter ⊇ allocs_m. */
     bool insert(const void* ptr) noexcept
     {
         const Hashed h = hash_ptr(ptr);
@@ -91,8 +108,16 @@ class CuckooFilter
             return true;
         }
 
-        /* Both buckets full. Evict a random slot from b2 and walk the
-         * displaced fingerprint to its alternate bucket. */
+        /* Both buckets are full; eviction is the only way to place fp.
+         * If the victim slot is already occupied, refuse BEFORE we
+         * disturb the table — otherwise an unsuccessful chain would
+         * orphan another original entry beyond our recovery. */
+        if (victim_occupied_) {
+            return false;
+        }
+
+        /* Evict a random slot from b2 and walk the displaced fingerprint
+         * to its alternate bucket. */
         uint32_t b = b2;
         for (size_t i = 0; i < MAX_KICKS; i++) {
             const size_t slot = static_cast<size_t>(evict_rng_()) & (SLOTS_PER_BUCKET - 1);
@@ -103,25 +128,20 @@ class CuckooFilter
                 return true;
             }
         }
-        /* AIDEV-NOTE: Saturated. The very first swap at b2 already placed
-         * the *new* fingerprint and started kicking older ones along the
-         * chain. What we end up unable to relocate (the value still in `fp`
-         * here) is an *earlier-tracked* fingerprint, not the new one. That
-         * orphan corresponds to some existing allocs_m entry: the filter no
-         * longer remembers it, so a future untrack of its pointer will be a
-         * false negative and leak that entry — the filter ⊇ allocs_m
-         * invariant is broken for that single pointer. The new pointer's
-         * fingerprint, conversely, is still in the filter with no allocs_m
-         * counterpart, which is harmless (extra slack on the safe side).
-         * Caller MUST drop the new sample to avoid compounding the
-         * asymmetry by adding a fresh allocs_m entry on top.
-         *
-         * AIDEV-TODO: at 50% load this branch is essentially unreachable
-         * (per-insert failure probability < 1e-10). If we ever observe it
-         * in production, fix with a single-slot victim cache: store
-         * (orphan_b, orphan_fp) here and have contains()/erase() check it.
-         * ~10 LoC, O(1) memory, restores the strict invariant. */
-        return false;
+        /* AIDEV-NOTE: Eviction chain didn't terminate within MAX_KICKS.
+         * The new fingerprint was successfully placed at the start of the
+         * chain (b2[slot]); what we couldn't relocate (still in `fp` here)
+         * is an *earlier-tracked* fingerprint. Park it in the victim slot
+         * along with `b` (one of its two valid buckets) so future
+         * contains()/erase() can still locate it. This preserves the
+         * strict superset invariant. At 50% load, reaching this branch
+         * has probability < 1e-10 per insert; reaching it with the victim
+         * already occupied is effectively impossible. */
+        victim_fp_ = fp;
+        victim_bucket_ = b;
+        victim_occupied_ = true;
+        size_++;
+        return true;
     }
 
     bool contains(const void* ptr) const noexcept
@@ -130,14 +150,23 @@ class CuckooFilter
         if (bucket_contains(h.bucket, h.fp)) {
             return true;
         }
-        return bucket_contains(alt_bucket(h.bucket, h.fp), h.fp);
+        const uint32_t b2 = alt_bucket(h.bucket, h.fp);
+        if (bucket_contains(b2, h.fp)) {
+            return true;
+        }
+        /* AIDEV-NOTE: A fingerprint's two valid buckets are (b, alt(b, fp))
+         * for any b in the pair. If the victim's fp matches and its stored
+         * bucket equals either of the query's two candidate buckets, the
+         * victim represents a logically-present entry for this ptr. */
+        return victim_occupied_ && victim_fp_ == h.fp && (victim_bucket_ == h.bucket || victim_bucket_ == b2);
     }
 
-    /* Clears one slot matching the pointer's fingerprint, if any. No-op if
-     * no slot matches. AIDEV-NOTE: callers must only erase pointers that
-     * were previously inserted — otherwise, in the rare same-fp/same-bucket
-     * collision, this could clear an unrelated tracked entry's slot and
-     * induce a false negative on its eventual untrack. */
+    /* Clears one slot matching the pointer's fingerprint, if any. Checks
+     * the table first, then the victim. AIDEV-NOTE: callers must only
+     * erase pointers that were previously inserted — otherwise, in the
+     * rare same-fp/same-bucket-pair collision, this could clear an
+     * unrelated tracked entry and induce a false negative on its
+     * eventual untrack. */
     void erase(const void* ptr) noexcept
     {
         const Hashed h = hash_ptr(ptr);
@@ -145,7 +174,13 @@ class CuckooFilter
             size_--;
             return;
         }
-        if (bucket_erase(alt_bucket(h.bucket, h.fp), h.fp)) {
+        const uint32_t b2 = alt_bucket(h.bucket, h.fp);
+        if (bucket_erase(b2, h.fp)) {
+            size_--;
+            return;
+        }
+        if (victim_occupied_ && victim_fp_ == h.fp && (victim_bucket_ == h.bucket || victim_bucket_ == b2)) {
+            victim_occupied_ = false;
             size_--;
         }
     }
@@ -153,6 +188,7 @@ class CuckooFilter
     void clear() noexcept
     {
         std::memset(table_.data(), 0, sizeof(table_));
+        victim_occupied_ = false;
         size_ = 0;
     }
 
@@ -163,7 +199,7 @@ class CuckooFilter
     {
         uint16_t slots[SLOTS_PER_BUCKET];
     };
-    static_assert(sizeof(Bucket) == 8, "expect 8-byte bucket");
+    static_assert(sizeof(Bucket) == sizeof(uint16_t) * SLOTS_PER_BUCKET, "Bucket must be tightly packed");
 
     struct Hashed
     {
@@ -228,4 +264,13 @@ class CuckooFilter
     std::array<Bucket, NUM_BUCKETS> table_;
     std::minstd_rand evict_rng_;
     size_t size_ = 0;
+    /* Single-slot victim cache for fingerprints displaced by a saturated
+     * eviction chain. See class-level docs and insert() for semantics. */
+    uint16_t victim_fp_ = 0;
+    uint32_t victim_bucket_ = 0;
+    bool victim_occupied_ = false;
 };
+
+/* Default-parameter alias used by the heap profiler. Tests instantiate
+ * CuckooFilterImpl<...> directly with smaller geometry. */
+using CuckooFilter = CuckooFilterImpl<>;

--- a/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
+++ b/ddtrace/profiling/collector/_memalloc_cuckoo.hpp
@@ -39,52 +39,34 @@ fingerprint_mix(uint16_t fp) noexcept
 }
 } // namespace memalloc_cuckoo_detail
 
-/* AIDEV-NOTE: Cuckoo filter for fast-reject on the heap profiler free path.
+/* Cuckoo filter for fast-reject on the heap profiler free path.
  *
- * The heap profiler samples ~1% of allocations. Without a filter, every
- * free() must probe allocs_m (an absl::flat_hash_map) to find out, paying
- * 50-100 cycles even for the 99% of frees that aren't sampled. This filter
- * answers "is this pointer sampled?" in ~10-15 cycles by checking two
- * candidate buckets containing 16-bit fingerprints.
+ * ~99% of frees aren't sampled. The filter answers "is this pointer
+ * sampled?" in ~10-15 cycles by probing two buckets of 16-bit fingerprints,
+ * versus 50-100 cycles for an allocs_m miss.
  *
- * Critical invariant: the filter MUST be a superset of allocs_m's keys.
- *   - False positives are tolerated (extract returns an empty node).
- *   - False negatives MUST NOT occur — they would skip a real entry and
- *     leak heap-tracker state.
+ * Invariant: filter ⊇ allocs_m keys. False positives fall through to an
+ * empty extract; false negatives would leak heap-tracker state.
  *
- * Saturation handling: when the eviction chain can't terminate within
- * MAX_KICKS, the displaced fingerprint is parked in a single-slot victim
- * cache (instead of being orphaned). contains() and erase() consult both
- * the table and the victim. This restores the strict superset invariant
- * for the first saturation. If a SECOND saturation occurs while the
- * victim is still occupied, insert() returns false WITHOUT mutating the
- * table (we refuse before starting the eviction chain), and the caller
- * MUST drop the sample. At our 50% load both events are essentially
- * unreachable; the victim closes the rare-but-nonzero leak window of the
- * naive cuckoo filter.
+ * Saturation: when the eviction chain can't terminate within MAX_KICKS,
+ * the displaced fingerprint is parked in a single-slot victim cache so the
+ * superset invariant survives. contains()/erase() consult both. A second
+ * back-to-back saturation while the victim is occupied returns false from
+ * insert() without mutating the table; the caller must drop the sample.
+ * At 50% load both events have probability < 1e-10 per insert.
  *
- * Sizing rationale:
- *   - 4 slots per bucket × 32768 buckets = 131072 slots
- *   - The heap tracker stops accepting new samples once allocs_m exceeds
- *     TRACEBACK_ARRAY_MAX_COUNT (65535), so live entries top out at 65536
- *   - Worst-case load factor ≈ 50%, well below the 95% where eviction
- *     failure becomes likely. At 50% load the literature puts the
- *     per-insert MAX_KICKS=500 failure probability below 1e-10
- *   - 16-bit fingerprints stored as uint16_t (no bit-packing). With b=4
- *     slots per bucket and f=16 fingerprint bits, the standard cuckoo
- *     filter False Positive Rate formula is: `2b/2^f = 8/65536 ≈ 1/8192 ≈ 0.012%`
- *     per probe of an absent key. Table footprint = 32768 × 4 × 2 bytes
- *     = 256 KB, fits in L2 on every target platform.
+ * Sizing: 32768 buckets × 4 slots × 2 bytes = 256 KB (fits in L2). Load
+ * factor caps at ~50% because the heap tracker stops at
+ * TRACEBACK_ARRAY_MAX_COUNT (65535) live entries. With f=16, b=4 the
+ * standard false-positive-rate formula 2b/2^f ≈ 1/8192 (~0.012%) per absent-key probe.
  *
- * Hashing uses the standard partial-key cuckoo trick (Fan et al. 2014):
+ * Hashing: standard partial-key cuckoo (Fan et al. 2014):
  *   h1 = hash(ptr) mod NUM_BUCKETS
  *   h2 = h1 ^ (hash(fp) mod NUM_BUCKETS)
- * Because XOR is involutive, alt_bucket(alt_bucket(i, fp), fp) == i. This
- * is what makes deletion possible without storing the full key in the slot.
+ * XOR is involutive, so deletion works without storing the full key.
  *
- * Thread safety: not thread-safe. Same constraint as allocs_m, which
- * assumes the GIL is held. When PEP 703 free-threading lands, both will
- * need to migrate to atomics together.
+ * Not thread-safe (GIL-protected like allocs_m). PEP 703 will require
+ * migrating both to atomics together.
  */
 /* Template parameters expose the filter's geometry so tests can instantiate
  * tiny variants (e.g. CuckooFilterImpl<2, 2, 4>) and exercise the
@@ -148,15 +130,11 @@ class CuckooFilterImpl
                 return true;
             }
         }
-        /* AIDEV-NOTE: Eviction chain didn't terminate within MAX_KICKS.
-         * The new fingerprint was successfully placed at the start of the
-         * chain (b2[slot]); what we couldn't relocate (still in `fp` here)
-         * is an *earlier-tracked* fingerprint. Park it in the victim slot
-         * along with `b` (one of its two valid buckets) so future
-         * contains()/erase() can still locate it. This preserves the
-         * strict superset invariant. At 50% load, reaching this branch
-         * has probability < 1e-10 per insert; reaching it with the victim
-         * already occupied is effectively impossible. */
+        /* Eviction saturated. The new fingerprint already landed at the
+         * start of the chain; `fp` here is an earlier-tracked fingerprint
+         * we couldn't relocate. Park it with one of its valid buckets in
+         * the victim slot so contains()/erase() still find it, preserving
+         * the superset invariant. */
         victim_fp_ = fp;
         victim_bucket_ = b;
         victim_occupied_ = true;
@@ -174,19 +152,15 @@ class CuckooFilterImpl
         if (bucket_contains(b2, h.fp)) {
             return true;
         }
-        /* AIDEV-NOTE: A fingerprint's two valid buckets are (b, alt(b, fp))
-         * for any b in the pair. If the victim's fp matches and its stored
-         * bucket equals either of the query's two candidate buckets, the
-         * victim represents a logically-present entry for this ptr. */
+        /* Victim hit only if its fp matches and its parked bucket is one
+         * of this ptr's two candidate buckets. */
         return victim_occupied_ && victim_fp_ == h.fp && (victim_bucket_ == h.bucket || victim_bucket_ == b2);
     }
 
-    /* Clears one slot matching the pointer's fingerprint, if any. Checks
-     * the table first, then the victim. AIDEV-NOTE: callers must only
-     * erase pointers that were previously inserted — otherwise, in the
-     * rare same-fp/same-bucket-pair collision, this could clear an
-     * unrelated tracked entry and induce a false negative on its
-     * eventual untrack. */
+    /* Clears one slot matching the pointer's fingerprint (table first,
+     * then victim). Caller must only erase previously-inserted pointers:
+     * a same-fp/same-bucket collision could otherwise clear an unrelated
+     * tracked entry and induce a false negative on its later untrack. */
     void erase(const void* ptr) noexcept
     {
         const Hashed h = hash_ptr(ptr);

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -286,13 +286,13 @@ heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb
     memalloc_gil_debug_guard_t guard(gil_guard);
 
     /* AIDEV-NOTE: Maintain the filter-superset invariant (filter ⊇ allocs_m
-     * keys). Insert into the filter FIRST: if it saturates (returns false),
-     * drop the sample. Adding to allocs_m without a filter entry would
-     * create a false negative — untrack_no_cpython would early-return on
-     * the real pointer and leak the traceback. At ~50% load (worst case at
-     * the 65535 cap) saturation is essentially unreachable; see the
-     * AIDEV-TODO in CuckooFilter::insert for the residual edge case
-     * (an orphaned fp from the eviction chain). */
+     * keys). Insert into the filter FIRST: if it returns false (a second
+     * back-to-back saturation while the victim slot is still occupied,
+     * effectively unreachable at our 50% load), drop the sample. Adding
+     * to allocs_m without a filter entry would otherwise create a false
+     * negative — untrack_no_cpython would early-return on the real
+     * pointer and leak the traceback. The first saturation is absorbed
+     * by the filter's victim slot; see CuckooFilter::insert for details. */
     assert(!live_filter.contains(ptr) && "filter saw duplicate insert; missed untrack?");
     if (!live_filter.insert(ptr)) {
         pool_put_no_cpython(std::move(tb));

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -282,7 +282,6 @@ heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb
     /* Filter-first to preserve filter ⊇ allocs_m. If the filter refuses
      * (back-to-back saturation), drop the sample — adding to allocs_m
      * without a filter entry would create a false negative on untrack. */
-    assert(!live_filter.contains(ptr) && "filter saw duplicate insert; missed untrack?");
     if (!live_filter.insert(ptr)) {
         pool_put_no_cpython(std::move(tb));
         reset_sampling_state_no_cpython();

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -153,11 +153,8 @@ class heap_tracker_t
     uint64_t current_sample_size;
     /* Tracked allocations - using unique_ptr for automatic memory management */
     HeapMapType<void*, std::unique_ptr<traceback_t>> allocs_m;
-    /* AIDEV-NOTE: Fast-reject filter for the free path. MUST be a superset
-     * of allocs_m's keys: if the filter says "absent", we can skip the
-     * allocs_m probe. False positives fall through harmlessly to an empty
-     * extract; false negatives would leak heap-tracker state. See
-     * _memalloc_cuckoo.hpp for invariant details. */
+    /* Fast-reject filter for the free path. Must remain a superset of
+     * allocs_m's keys; see _memalloc_cuckoo.hpp for invariant details. */
     CuckooFilter live_filter;
     /* Bytes allocated since the last sample was collected */
     uint64_t allocated_memory;
@@ -241,11 +238,8 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
 
-    /* AIDEV-NOTE: 99% of frees aren't sampled. The filter rejects them in
-     * ~10-15 cycles vs 50-100 cycles for an allocs_m miss. False positives
-     * (FPR ≈ 1/8192 — see _memalloc_cuckoo.hpp for derivation) fall through
-     * harmlessly: extract returns an empty node and we leave both the
-     * filter and map untouched. */
+    /* Skip the allocs_m probe for the ~99% of frees that weren't sampled.
+     * False positives fall through to an empty extract. */
     if (!live_filter.contains(ptr)) {
         return;
     }
@@ -285,14 +279,9 @@ heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
 
-    /* AIDEV-NOTE: Maintain the filter-superset invariant (filter ⊇ allocs_m
-     * keys). Insert into the filter FIRST: if it returns false (a second
-     * back-to-back saturation while the victim slot is still occupied,
-     * effectively unreachable at our 50% load), drop the sample. Adding
-     * to allocs_m without a filter entry would otherwise create a false
-     * negative — untrack_no_cpython would early-return on the real
-     * pointer and leak the traceback. The first saturation is absorbed
-     * by the filter's victim slot; see CuckooFilter::insert for details. */
+    /* Filter-first to preserve filter ⊇ allocs_m. If the filter refuses
+     * (back-to-back saturation), drop the sample — adding to allocs_m
+     * without a filter entry would create a false negative on untrack. */
     assert(!live_filter.contains(ptr) && "filter saw duplicate insert; missed untrack?");
     if (!live_filter.insert(ptr)) {
         pool_put_no_cpython(std::move(tb));

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -8,6 +8,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include "_memalloc_cuckoo.hpp"
 #include "_memalloc_debug.h"
 #include "_memalloc_gc_guard.hpp"
 #include "_memalloc_heap.h"
@@ -152,6 +153,12 @@ class heap_tracker_t
     uint64_t current_sample_size;
     /* Tracked allocations - using unique_ptr for automatic memory management */
     HeapMapType<void*, std::unique_ptr<traceback_t>> allocs_m;
+    /* AIDEV-NOTE: Fast-reject filter for the free path. MUST be a superset
+     * of allocs_m's keys: if the filter says "absent", we can skip the
+     * allocs_m probe. False positives fall through harmlessly to an empty
+     * extract; false negatives would leak heap-tracker state. See
+     * _memalloc_cuckoo.hpp for invariant details. */
+    CuckooFilter live_filter;
     /* Bytes allocated since the last sample was collected */
     uint64_t allocated_memory;
 
@@ -234,8 +241,17 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
 
+    /* AIDEV-NOTE: 99% of frees aren't sampled. The filter rejects them in
+     * ~10-15 cycles vs 50-100 cycles for an allocs_m miss. False positives
+     * (FPR ≈ 1/8192 — see _memalloc_cuckoo.hpp for derivation) fall through
+     * harmlessly: extract returns an empty node and we leave both the
+     * filter and map untouched. */
+    if (!live_filter.contains(ptr)) {
+        return;
+    }
     auto node = allocs_m.extract(ptr);
     if (!node.empty()) {
+        live_filter.erase(ptr);
         pool_put_no_cpython(std::move(node.mapped()));
     }
 }
@@ -268,6 +284,21 @@ void
 heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
+
+    /* AIDEV-NOTE: Maintain the filter-superset invariant (filter ⊇ allocs_m
+     * keys). Insert into the filter FIRST: if it saturates (returns false),
+     * drop the sample. Adding to allocs_m without a filter entry would
+     * create a false negative — untrack_no_cpython would early-return on
+     * the real pointer and leak the traceback. At ~50% load (worst case at
+     * the 65535 cap) saturation is essentially unreachable; see the
+     * AIDEV-TODO in CuckooFilter::insert for the residual edge case
+     * (an orphaned fp from the eviction chain). */
+    assert(!live_filter.contains(ptr) && "filter saw duplicate insert; missed untrack?");
+    if (!live_filter.insert(ptr)) {
+        pool_put_no_cpython(std::move(tb));
+        reset_sampling_state_no_cpython();
+        return;
+    }
 
     auto [it, inserted] = allocs_m.insert_or_assign(ptr, std::move(tb));
     (void)it; // Unused, but needed for structured binding
@@ -317,6 +348,10 @@ heap_tracker_t::postfork_child()
     // Allocations map may contain data from the parent process, and also
     // traceback_t objects may reference invalid Profile state.
     allocs_m.clear();
+
+    // Filter must be reset alongside allocs_m to maintain the superset
+    // invariant.
+    live_filter.clear();
 
     // Reset the sampling state to start fresh after fork.
     reset_sampling_state_no_cpython();

--- a/ddtrace/profiling/collector/test/test_cuckoo.cpp
+++ b/ddtrace/profiling/collector/test/test_cuckoo.cpp
@@ -1,0 +1,348 @@
+/* Unit tests for CuckooFilterImpl.
+ *
+ * Self-contained — no gtest dependency. Uses <cassert>; failures abort()
+ * the process with the line number, which is plenty when read in CI logs.
+ *
+ * Build & run locally:
+ *   clang++ -std=c++20 -O2 -I.. -DDONT_COMPILE_ABSEIL test_cuckoo.cpp \
+ *     -o /tmp/test_cuckoo && /tmp/test_cuckoo
+ *
+ * Wired into CMakeLists.txt under -DBUILD_TESTING=ON; CTest discovers it.
+ */
+
+#undef NDEBUG /* assert() must always fire here, regardless of build type */
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include "_memalloc_cuckoo.hpp"
+
+namespace {
+
+/* Small helper: a deterministic stream of distinct, well-distributed
+ * "pointer" values for testing. We don't actually dereference them; the
+ * filter only cares about their hash. */
+class FakePtrSource
+{
+  public:
+    explicit FakePtrSource(uint64_t seed)
+      : rng_(seed)
+    {
+    }
+    const void* next()
+    {
+        /* Drop the bottom 4 bits to mimic 16-byte alignment of real
+         * malloc output, exercising hash robustness against low-entropy
+         * pointer bottoms. */
+        uintptr_t v = static_cast<uintptr_t>(rng_()) & ~uintptr_t{ 0xF };
+        return reinterpret_cast<const void*>(v);
+    }
+
+  private:
+    std::mt19937_64 rng_;
+};
+
+/* ---------- Test 1: empty filter never reports membership ---------- */
+void
+test_empty_never_contains()
+{
+    CuckooFilter f;
+    FakePtrSource src(1);
+    for (int i = 0; i < 1000; i++) {
+        assert(!f.contains(src.next()));
+    }
+    assert(f.size() == 0);
+    std::printf("  test_empty_never_contains: PASS\n");
+}
+
+/* ---------- Test 2: insert then contains returns true ---------- */
+void
+test_insert_then_contains()
+{
+    CuckooFilter f;
+    FakePtrSource src(2);
+    std::vector<const void*> ptrs;
+    for (int i = 0; i < 1000; i++) {
+        ptrs.push_back(src.next());
+    }
+    for (auto p : ptrs) {
+        assert(f.insert(p));
+    }
+    for (auto p : ptrs) {
+        assert(f.contains(p));
+    }
+    assert(f.size() == ptrs.size());
+    std::printf("  test_insert_then_contains: PASS\n");
+}
+
+/* ---------- Test 3: erase removes one matching slot ---------- */
+void
+test_insert_erase_round_trip()
+{
+    CuckooFilter f;
+    FakePtrSource src(3);
+    std::vector<const void*> ptrs;
+    for (int i = 0; i < 1000; i++) {
+        ptrs.push_back(src.next());
+    }
+    for (auto p : ptrs) {
+        assert(f.insert(p));
+    }
+    for (auto p : ptrs) {
+        f.erase(p);
+    }
+    /* size_ may be slightly above zero if there were any same-fp/same-bucket
+     * collisions where erase cleared one and the other remained, but for
+     * 1000 random keys against a 32K-bucket filter the expected residual is
+     * essentially zero. Allow some slack for randomness. */
+    assert(f.size() <= 5);
+    std::printf("  test_insert_erase_round_trip: PASS (residual=%zu)\n", f.size());
+}
+
+/* ---------- Test 4: erase on never-inserted ptr is benign ---------- */
+void
+test_erase_unknown_no_op()
+{
+    CuckooFilter f;
+    FakePtrSource src(4);
+    /* Insert 100 ptrs */
+    std::vector<const void*> inserted;
+    for (int i = 0; i < 100; i++) {
+        inserted.push_back(src.next());
+        assert(f.insert(inserted.back()));
+    }
+    const size_t before = f.size();
+
+    /* Try to erase 100 different ptrs we never inserted */
+    FakePtrSource src2(0xDEAD);
+    for (int i = 0; i < 100; i++) {
+        f.erase(src2.next());
+    }
+
+    /* Most of these are no-ops. A few might have collided with inserted
+     * fingerprints and decremented size_, but it's bounded by FPR ~ 1/8192
+     * across 100 tries: expected < 0.02 false positives. Allow generous
+     * slack. */
+    assert(f.size() >= before - 2);
+
+    /* All originally-inserted ptrs should still be findable (modulo any
+     * unfortunate collision-driven erasure). */
+    size_t still_found = 0;
+    for (auto p : inserted) {
+        if (f.contains(p)) {
+            still_found++;
+        }
+    }
+    assert(still_found >= inserted.size() - 2);
+    std::printf("  test_erase_unknown_no_op: PASS\n");
+}
+
+/* ---------- Test 5: clear() resets state ---------- */
+void
+test_clear_resets()
+{
+    CuckooFilter f;
+    FakePtrSource src(5);
+    std::vector<const void*> ptrs;
+    for (int i = 0; i < 5000; i++) {
+        ptrs.push_back(src.next());
+        assert(f.insert(ptrs.back()));
+    }
+    assert(f.size() == 5000);
+
+    f.clear();
+    assert(f.size() == 0);
+    /* contains() should now return false for everything. Some FPs are
+     * possible against a fresh filter, but at FPR ~ 1/8192 across 5000
+     * queries the expected count is < 1. Allow tiny slack. */
+    size_t residual = 0;
+    for (auto p : ptrs) {
+        if (f.contains(p)) {
+            residual++;
+        }
+    }
+    assert(residual <= 2);
+    std::printf("  test_clear_resets: PASS (residual=%zu)\n", residual);
+}
+
+/* ---------- Test 6: heavy random churn at production load ---------- */
+void
+test_random_churn_no_false_negatives()
+{
+    CuckooFilter f;
+    FakePtrSource src(6);
+    /* Build a working set up to ~50% load (the production worst case). */
+    constexpr size_t TARGET = 60000;
+    std::unordered_set<const void*> live;
+    live.reserve(TARGET);
+    while (live.size() < TARGET) {
+        const void* p = src.next();
+        if (live.insert(p).second) {
+            assert(f.insert(p) && "filter rejected an insert at 50% load");
+        }
+    }
+    assert(f.size() >= TARGET); /* size_ may exceed TARGET if duplicate fps occurred */
+
+    /* No false negatives: every live ptr must be reported as present. */
+    for (auto p : live) {
+        assert(f.contains(p) && "false negative on a live key — corruption!");
+    }
+
+    /* Erase half, verify remaining half still present. */
+    size_t erased = 0;
+    auto it = live.begin();
+    while (it != live.end() && erased < TARGET / 2) {
+        f.erase(*it);
+        it = live.erase(it);
+        erased++;
+    }
+    for (auto p : live) {
+        assert(f.contains(p) && "false negative after partial erase");
+    }
+    std::printf("  test_random_churn_no_false_negatives: PASS\n");
+}
+
+/* ---------- Test 7: tiny filter, normal inserts up to capacity ---------- */
+void
+test_tiny_filter_fills_to_capacity()
+{
+    /* 2 buckets × 2 slots × max-4-kicks: 4 slots total. */
+    CuckooFilterImpl<2, 2, 4> tiny;
+    FakePtrSource src(7);
+
+    /* Insert up to 4 ptrs — each should succeed (normal inserts fill
+     * empty slots). */
+    std::vector<const void*> ptrs;
+    for (int i = 0; i < 4; i++) {
+        ptrs.push_back(src.next());
+        const bool ok = tiny.insert(ptrs.back());
+        assert(ok && "inserts within slot capacity must succeed");
+    }
+    assert(tiny.size() == 4);
+    std::printf("  test_tiny_filter_fills_to_capacity: PASS\n");
+}
+
+/* ---------- Test 8: tiny filter, saturation engages the victim cache ---------- */
+void
+test_tiny_filter_saturation_uses_victim()
+{
+    CuckooFilterImpl<2, 2, 4> tiny;
+    FakePtrSource src(8);
+
+    /* Fill to capacity. */
+    std::vector<const void*> ptrs;
+    for (int i = 0; i < 4; i++) {
+        ptrs.push_back(src.next());
+        assert(tiny.insert(ptrs.back()));
+    }
+
+    /* Now the (b1, b2) pair is full. Any further insert triggers the
+     * eviction chain. With only 4 slots and MaxKicks=4, every kick fails
+     * to find an empty slot and the orphan ends up in the victim cache.
+     * insert() must return TRUE — the entry is logically present. */
+    const void* p_new = src.next();
+    const bool ok = tiny.insert(p_new);
+    assert(ok && "first saturation must succeed via the victim cache");
+    assert(tiny.size() == 5);
+
+    /* The new pointer must be findable. */
+    assert(tiny.contains(p_new));
+
+    /* All originally-inserted pointers must STILL be findable: the victim
+     * cache absorbed the orphan from the eviction chain. This is the key
+     * property the cache exists to guarantee. */
+    for (auto p : ptrs) {
+        assert(tiny.contains(p) && "victim cache failed: a previously-inserted entry is now missing");
+    }
+    std::printf("  test_tiny_filter_saturation_uses_victim: PASS\n");
+}
+
+/* ---------- Test 9: second saturation refused while victim occupied ------- */
+void
+test_tiny_filter_second_saturation_refused()
+{
+    CuckooFilterImpl<2, 2, 4> tiny;
+    FakePtrSource src(9);
+
+    /* Fill + first saturation (occupies the victim). */
+    for (int i = 0; i < 5; i++) {
+        const bool ok = tiny.insert(src.next());
+        assert(ok);
+    }
+    /* Snapshot size_ before the refused insert. */
+    const size_t size_before = tiny.size();
+
+    /* A 6th insert hits both buckets full AND victim occupied. Must
+     * return false WITHOUT touching size_ or the table contents. */
+    const bool ok = tiny.insert(src.next());
+    assert(!ok && "second saturation must be refused");
+    assert(tiny.size() == size_before && "refused insert must not change size_");
+    std::printf("  test_tiny_filter_second_saturation_refused: PASS\n");
+}
+
+/* ---------- Test 10: erase reaches the victim slot ---------- */
+void
+test_tiny_filter_erase_via_victim()
+{
+    CuckooFilterImpl<2, 2, 4> tiny;
+    FakePtrSource src(10);
+
+    std::vector<const void*> ptrs;
+    for (int i = 0; i < 5; i++) {
+        ptrs.push_back(src.next());
+        assert(tiny.insert(ptrs.back()));
+    }
+    /* size_ is 5 (4 in table, 1 in victim — we don't know which ptr is
+     * where, but the invariant is all 5 must be findable and erasable). */
+    assert(tiny.size() == 5);
+
+    /* Erase every pointer. After all erasures, every contains() should
+     * return false (modulo the rare same-fp/same-bucket aliasing case
+     * which is plausible at 5 entries in a 4-slot filter; allow tiny
+     * residual). */
+    for (auto p : ptrs) {
+        tiny.erase(p);
+    }
+    size_t residual_found = 0;
+    for (auto p : ptrs) {
+        if (tiny.contains(p)) {
+            residual_found++;
+        }
+    }
+    assert(residual_found <= 1);
+
+    /* After clearing, the victim slot should be free again so we can
+     * trigger another saturation. */
+    tiny.clear();
+    assert(tiny.size() == 0);
+    FakePtrSource src2(11);
+    for (int i = 0; i < 5; i++) {
+        assert(tiny.insert(src2.next()));
+    }
+    /* We made it through another saturation, meaning the victim was
+     * properly reset by clear(). */
+    std::printf("  test_tiny_filter_erase_via_victim: PASS\n");
+}
+
+} // namespace
+
+int
+main()
+{
+    std::printf("Running CuckooFilter tests...\n");
+    test_empty_never_contains();
+    test_insert_then_contains();
+    test_insert_erase_round_trip();
+    test_erase_unknown_no_op();
+    test_clear_resets();
+    test_random_churn_no_false_negatives();
+    test_tiny_filter_fills_to_capacity();
+    test_tiny_filter_saturation_uses_victim();
+    test_tiny_filter_second_saturation_refused();
+    test_tiny_filter_erase_via_victim();
+    std::printf("All CuckooFilter tests passed.\n");
+    return 0;
+}

--- a/releasenotes/notes/profiling-heap-cuckoo-filter-fast-reject-d10a4e7791d8680e.yaml
+++ b/releasenotes/notes/profiling-heap-cuckoo-filter-fast-reject-d10a4e7791d8680e.yaml
@@ -1,0 +1,5 @@
+---
+perf:
+  - |
+    profiling: Improves efficiency of the ``free`` function in the heap profiler.
+    All unsampled allocations (99% by default) will terminate early, avoiding unncessary work.

--- a/releasenotes/notes/profiling-heap-cuckoo-filter-fast-reject-d10a4e7791d8680e.yaml
+++ b/releasenotes/notes/profiling-heap-cuckoo-filter-fast-reject-d10a4e7791d8680e.yaml
@@ -1,5 +1,5 @@
 ---
-perf:
+other:
   - |
     profiling: Improves efficiency of the ``free`` function in the heap profiler.
-    All unsampled allocations (99% by default) will terminate early, avoiding unncessary work.
+    All unsampled allocations (99% by default) will terminate early, avoiding unnecessary work.

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1167,68 +1167,118 @@ def test_heap_stress() -> None:
         _memalloc.stop()
 
 
-def test_heap_filter_high_churn() -> None:
+def _alloc_in_named_function(n: int, size: int) -> list[Union[tuple[None, ...], bytearray]]:
+    """Allocate n objects of `size`. Named so the heap profile can attribute samples back to it."""
+    return [one(size) for _ in range(n)]
+
+
+def test_heap_filter_high_churn(tmp_path: Path) -> None:
     """Heavy insert+erase pressure on the cuckoo filter.
 
-    Allocates 200K objects in batches and frees each batch immediately. With
-    aggressive sampling (small heap_sample_size) every allocation is a
-    candidate for tracking, exercising the filter's insert path on alloc
-    and erase path on free. After the run, no live samples should remain.
+    Allocates many batches and frees each batch immediately. With
+    aggressive sampling, every allocation is a candidate for tracking,
+    exercising the filter's insert path on alloc and erase path on free.
+    Asserts: after the churn, NO live samples remain attributed to the
+    allocator function — i.e. the filter and the hashmap both correctly
+    erased every entry on free.
     """
-    from ddtrace.profiling.collector import _memalloc
+    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_filter_high_churn")
+    mc = memalloc.MemoryCollector(heap_sample_size=256)
 
-    _memalloc.start(64, 256)  # max 64 frames, 256-byte sampling interval
-    try:
-        for _ in range(200):
-            batch: list[object] = [bytearray(1024) for _ in range(1000)]
+    with mc:
+        for _ in range(50):
+            batch = _alloc_in_named_function(500, 256)
             del batch
         gc.collect()
-        # Filter and allocs_m should both be drained. heap() is a no-op
-        # observation, but we call it to ensure no crash and to flush.
-        _memalloc.heap()
-    finally:
-        _memalloc.stop()
+        profile = mc.snapshot_and_parse_pprof(output_filename)
+
+    heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+    assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+
+    live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+    live_from_allocator = [
+        s for s in live_samples if has_function_in_profile_sample(profile, s, _alloc_in_named_function)
+    ]
+    # Every batch was freed, so no live samples from this function should remain.
+    assert len(live_from_allocator) == 0, (
+        f"after high-churn alloc/free, expected no live samples from allocator, "
+        f"got {len(live_from_allocator)} (filter or map leaked entries)"
+    )
 
 
-def test_heap_filter_address_reuse() -> None:
-    """Python's free lists reuse addresses across allocations.
+def test_heap_filter_address_reuse(tmp_path: Path) -> None:
+    """Python's free lists reuse pointers across allocations.
 
-    When the same pointer is freed and immediately re-allocated, the
-    cuckoo filter must correctly transition (erase then insert) without
-    leaving stale fingerprints. Validated by alternating alloc/free of
-    similarly-sized objects in a tight loop.
+    A tight alloc/free loop of identically-sized objects almost always
+    reuses the same underlying address. The cuckoo filter must correctly
+    transition state (erase then insert at the same ptr) without leaving
+    stale fingerprints behind. Asserts: zero live samples from the
+    allocator function after the loop completes.
     """
-    from ddtrace.profiling.collector import _memalloc
+    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_filter_address_reuse")
+    mc = memalloc.MemoryCollector(heap_sample_size=128)
 
-    _memalloc.start(64, 128)  # very aggressive sampling
-    try:
-        for _ in range(5000):
-            obj = bytearray(512)  # likely reused address from prior iter
+    with mc:
+        for _ in range(2000):
+            obj = one(512)  # likely reused address from prior iter
             del obj
         gc.collect()
-        _memalloc.heap()
-    finally:
-        _memalloc.stop()
+        profile = mc.snapshot_and_parse_pprof(output_filename)
+
+    heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+    live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+    live_from_allocator = [s for s in live_samples if has_function_in_profile_sample(profile, s, one)]
+    assert len(live_from_allocator) == 0, (
+        f"after address-reuse churn, expected no live samples from allocator, "
+        f"got {len(live_from_allocator)} (filter erase failed at reused addresses)"
+    )
 
 
-def test_heap_filter_high_water_then_drain() -> None:
-    """Push the live working set toward the cap, then drain it.
+def test_heap_filter_high_water_then_drain(tmp_path: Path) -> None:
+    """Hold a large working set, then drain it.
 
-    Holds onto a large pool of allocations to grow the filter, then
-    releases them all and confirms the heap profiler returns to a quiet
-    state. Validates that erase paths correctly reclaim filter capacity.
+    Snapshots the heap at the high-water mark, releases everything,
+    then snapshots again. Asserts: the second snapshot reports zero
+    live samples attributed to the allocator. This proves erase paths
+    actually reclaim filter slots — without working erase, the second
+    snapshot would still show all entries.
     """
-    from ddtrace.profiling.collector import _memalloc
+    output_filename_high = _setup_profiling_prelude(tmp_path, "test_heap_filter_high_water_then_drain_high")
+    mc = memalloc.MemoryCollector(heap_sample_size=1024)
 
-    _memalloc.start(64, 1024)
-    try:
-        live: list[bytearray] = [bytearray(2048) for _ in range(50_000)]
-        _memalloc.heap()  # snapshot at high-water mark
+    with mc:
+        live: list[Union[tuple[None, ...], bytearray]] = _alloc_in_named_function(20_000, 1024)
+        # Snapshot at high-water mark — should report many live samples.
+        profile_high = mc.snapshot_and_parse_pprof(output_filename_high)
+
         del live[:]
         gc.collect()
-        _memalloc.heap()  # snapshot after drain — must not crash
-    finally:
-        _memalloc.stop()
+
+        # Reset the prelude for the second snapshot so the pprof file is fresh.
+        output_filename_drained = _setup_profiling_prelude(tmp_path, "test_heap_filter_high_water_then_drain_drained")
+        profile_drained = mc.snapshot_and_parse_pprof(output_filename_drained)
+
+    heap_space_idx_high = pprof_utils.get_sample_type_index(profile_high, "heap-space")
+    heap_space_idx_drained = pprof_utils.get_sample_type_index(profile_drained, "heap-space")
+
+    high_live = [
+        s
+        for s in profile_high.sample
+        if s.value[heap_space_idx_high] > 0
+        and has_function_in_profile_sample(profile_high, s, _alloc_in_named_function)
+    ]
+    drained_live = [
+        s
+        for s in profile_drained.sample
+        if s.value[heap_space_idx_drained] > 0
+        and has_function_in_profile_sample(profile_drained, s, _alloc_in_named_function)
+    ]
+
+    assert len(high_live) > 0, "high-water snapshot should have at least one live sample from allocator"
+    assert len(drained_live) == 0, (
+        f"drained snapshot should have zero live samples from allocator, got {len(drained_live)} "
+        f"(erase did not reclaim filter+map entries)"
+    )
 
 
 @pytest.mark.parametrize("heap_sample_size", (0, 512 * 1024, 1024 * 1024, 2048 * 1024, 4096 * 1024))

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1167,6 +1167,70 @@ def test_heap_stress() -> None:
         _memalloc.stop()
 
 
+def test_heap_filter_high_churn() -> None:
+    """Heavy insert+erase pressure on the cuckoo filter.
+
+    Allocates 200K objects in batches and frees each batch immediately. With
+    aggressive sampling (small heap_sample_size) every allocation is a
+    candidate for tracking, exercising the filter's insert path on alloc
+    and erase path on free. After the run, no live samples should remain.
+    """
+    from ddtrace.profiling.collector import _memalloc
+
+    _memalloc.start(64, 256)  # max 64 frames, 256-byte sampling interval
+    try:
+        for _ in range(200):
+            batch: list[object] = [bytearray(1024) for _ in range(1000)]
+            del batch
+        gc.collect()
+        # Filter and allocs_m should both be drained. heap() is a no-op
+        # observation, but we call it to ensure no crash and to flush.
+        _memalloc.heap()
+    finally:
+        _memalloc.stop()
+
+
+def test_heap_filter_address_reuse() -> None:
+    """Python's free lists reuse addresses across allocations.
+
+    When the same pointer is freed and immediately re-allocated, the
+    cuckoo filter must correctly transition (erase then insert) without
+    leaving stale fingerprints. Validated by alternating alloc/free of
+    similarly-sized objects in a tight loop.
+    """
+    from ddtrace.profiling.collector import _memalloc
+
+    _memalloc.start(64, 128)  # very aggressive sampling
+    try:
+        for _ in range(5000):
+            obj = bytearray(512)  # likely reused address from prior iter
+            del obj
+        gc.collect()
+        _memalloc.heap()
+    finally:
+        _memalloc.stop()
+
+
+def test_heap_filter_high_water_then_drain() -> None:
+    """Push the live working set toward the cap, then drain it.
+
+    Holds onto a large pool of allocations to grow the filter, then
+    releases them all and confirms the heap profiler returns to a quiet
+    state. Validates that erase paths correctly reclaim filter capacity.
+    """
+    from ddtrace.profiling.collector import _memalloc
+
+    _memalloc.start(64, 1024)
+    try:
+        live: list[bytearray] = [bytearray(2048) for _ in range(50_000)]
+        _memalloc.heap()  # snapshot at high-water mark
+        del live[:]
+        gc.collect()
+        _memalloc.heap()  # snapshot after drain — must not crash
+    finally:
+        _memalloc.stop()
+
+
 @pytest.mark.parametrize("heap_sample_size", (0, 512 * 1024, 1024 * 1024, 2048 * 1024, 4096 * 1024))
 def test_memalloc_speed(benchmark, heap_sample_size) -> None:
     if heap_sample_size:


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-14716

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

* A/B for [smoke test](https://ddstaging.datadoghq.com/profiling/comparison?query=service%3Arapid_python_http_smoke_test%20version%3Av114153596-834e19c&compare_end_A=1779762089000&compare_end_B=1779804973000&compare_query_A=service%3Arapid_python_http_smoke_test&compare_query_B=service%3Arapid_python_http_smoke_test&compare_start_A=1779750328000&compare_start_B=1779793445000&compareValuesMode=absolute&comparisonViz=flamegraph&my_code=disabled&profile_type=ebpf-cpu-time&viz=stream&from_ts=1779202836739&to_ts=1779289236739&live=true)

**_CPU time: -19%_**
<img width="1600" height="918" alt="Screenshot 2026-05-26 at 10 30 18 AM" src="https://github.com/user-attachments/assets/c652a7aa-ea7e-4680-a033-fd25f7904dad" />

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
