### PR TITLE
chore(celery): terminate processes if a timeout occurs correctly

### DIFF
--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -1,6 +1,7 @@
 from collections import Counter
 import os
 from pathlib import Path
+import signal
 import subprocess
 import sys
 import time
@@ -816,13 +817,14 @@ class CeleryDistributedTracingIntegrationTask(CeleryBaseTestCase):
                 ["ddtrace-run", "celery", "--app=tests.contrib.celery.tasks", "worker", "--beat", "--loglevel=info"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                start_new_session=True,
             )
             sleep(5)
             celery_proc.terminate()
             try:
                 output, stderr = celery_proc.communicate(timeout=60)
             except subprocess.TimeoutExpired:
-                celery_proc.kill()
+                os.killpg(celery_proc.pid, signal.SIGKILL)
                 output, stderr = celery_proc.communicate()
                 print(
                     "WARNING: celery beat process did not terminate within 60s.\n"


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

While waiting for https://github.com/DataDog/dd-trace-py/pull/18055 to get merged, I noticed it timed out for one of the suites multiple times. Looking at https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1681618756, there's another way to fix this problem by shutting down the children processes instead of only the parent process.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
