### PR TITLE
ci(botocore): ignore metrics.retry_attempts in snapshots

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -63,6 +63,7 @@ snapshot_ignores = [
     "meta.aws.response.body.HTTPHeaders.x-amzn-requestid",
     "meta.error.stack",
     "meta.aws.response.body.HTTPHeaders.x-amz-crc32",
+    "metrics.retry_attempts",
 ]
 
 


### PR DESCRIPTION
## Description

> metrics mismatch on 'retry_attempts': got '0.0' which does not match expected '4.0'.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
