### PR TITLE
chore(ci): bump down Python version upper boundary to <3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { text = "LICENSE.BSD3" }
 # ddtrace has many sub-components which can break when CPython internals
 # change over versions, e.g. profiling. So we explicitly mark incompatibility
 # with versions we don't support yet.
-requires-python = ">=3.9,<3.16"
+requires-python = ">=3.9,<3.15"
 authors = [
     { name = "Datadog, Inc.", email = "dev@datadoghq.com" },
 ]


### PR DESCRIPTION
## Description

As titled - we don't want users to think that v3.15 is already supported. This was accidentally introduced in https://github.com/DataDog/dd-trace-py/commit/31b23df160a517b1bbe8d755f86498e2a29a1c95.

## Testing

* CI