### PR TITLE
fix(llmobs): drop APM traces for agentless LLMObs users

### DIFF
--- a/ddtrace/_trace/apm_filter.py
+++ b/ddtrace/_trace/apm_filter.py
@@ -2,20 +2,14 @@ from typing import Optional
 
 from ddtrace._trace.processor import TraceProcessor
 from ddtrace._trace.span import Span
-from ddtrace.internal.settings import env
-from ddtrace.internal.utils.formats import asbool
 
 
-class APMTracingEnabledFilter(TraceProcessor):
+class APMTracingDisabledFilter(TraceProcessor):
+    """Trace processor that drops every APM trace it sees.
+
+    The decision to install this filter lives with the caller (e.g. LLMObs.enable()
+    when ``DD_APM_TRACING_ENABLED`` is falsy or LLMObs is running agentless).
     """
-    Trace processor that drops all APM traces when DD_APM_TRACING_ENABLED is set to a falsy value.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._apm_tracing_enabled = asbool(env.get("DD_APM_TRACING_ENABLED", "true"))
 
     def process_trace(self, trace: list[Span]) -> Optional[list[Span]]:
-        if not self._apm_tracing_enabled:
-            return None
-        return trace
+        return None

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -18,7 +18,7 @@ import urllib.parse
 import ddtrace
 from ddtrace import config
 from ddtrace import patch
-from ddtrace._trace.apm_filter import APMTracingEnabledFilter
+from ddtrace._trace.apm_filter import APMTracingDisabledFilter
 from ddtrace._trace.context import Context
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
@@ -820,9 +820,11 @@ class LLMObs(Service):
             # override the default _instance with a new tracer
             cls._instance = cls(tracer=_tracer, span_processor=span_processor)
 
-            # Add APM trace filter to drop all APM traces when DD_APM_TRACING_ENABLED is falsy
-            apm_filter = APMTracingEnabledFilter()
-            cls._instance.tracer._span_aggregator.dd_processors.append(apm_filter)
+            # Drop APM traces when DD_APM_TRACING_ENABLED is falsy, or when LLMObs is running
+            # agentless — without a reachable Agent the APM writer would otherwise repeatedly
+            # log "failed to send, dropping N traces to intake at ..." warnings.
+            if config._llmobs_agentless_enabled or not asbool(_env.get("DD_APM_TRACING_ENABLED", "true")):
+                cls._instance.tracer._span_aggregator.dd_processors.append(APMTracingDisabledFilter())
 
             cls.enabled = True
             # Align config._llmobs_enabled with effective state for user-initiated calls.

--- a/releasenotes/notes/llmobs-agentless-drop-apm-traces-6595af3a419484d0.yaml
+++ b/releasenotes/notes/llmobs-agentless-drop-apm-traces-6595af3a419484d0.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: drops APM traces when LLM Observability runs in agentless mode, suppressing
+    the ``failed to send, dropping N traces to intake at ...`` warnings that occur with no reachable Agent.

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -722,3 +722,36 @@ def test_apm_traces_dropped_when_disabled(llmobs, llmobs_events, tracer, llmobs_
     llm_event = llmobs_events[0]
     assert llm_event["meta"]["span"]["kind"] == "llm"
     assert llm_event["meta"]["model_name"] == "test-model"
+
+
+@pytest.mark.subprocess(
+    env={
+        "DD_LLMOBS_AGENTLESS_ENABLED": "true",
+        "DD_API_KEY": "<not-a-real-key>",
+        "DD_SITE": "datadoghq.com",
+        "DD_LLMOBS_ML_APP": "test-app",
+    }
+)
+def test_apm_traces_dropped_when_llmobs_agentless():
+    """When LLMObs is running agentless, the APM writer has no reachable destination,
+    so APM traces are dropped at the filter stage instead of generating
+    "failed to send, dropping N traces" warnings.
+
+    Runs in a subprocess so DD_LLMOBS_AGENTLESS_ENABLED is in the environment
+    before ddtrace is imported — config snapshots the value at import time.
+    """
+    import ddtrace
+    from ddtrace.llmobs import LLMObs as llmobs_service
+    from tests.utils import DummyWriter
+
+    dummy_writer = DummyWriter()
+    ddtrace.tracer._span_aggregator.writer = dummy_writer
+
+    llmobs_service.enable(_tracer=ddtrace.tracer)
+
+    with ddtrace.tracer.trace("apm_span") as apm_span:
+        apm_span.set_tag("operation", "test")
+
+    assert len(dummy_writer.traces) == 0, "APM traces should be dropped when LLMObs is agentless"
+
+    llmobs_service.disable()


### PR DESCRIPTION
Without a reachable Agent, the APM trace writer repeatedly fails and logs "failed to send, dropping N traces to intake at ..." warnings for every agentless LLMObs customer. Extend the existing APMTracingEnabledFilter with a force_drop flag and pass config._llmobs_agentless_enabled at LLMObs.enable() time so those traces are dropped at the processor stage instead.

This is an interim fix that stops the noise; PR #17854 is the longer-term solution that routes APM traces to the agentless intake instead of dropping them.

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
