### PR TITLE
fix(appsec): support for content-type parameters

### DIFF
--- a/ddtrace/appsec/_http_utils.py
+++ b/ddtrace/appsec/_http_utils.py
@@ -45,15 +45,21 @@ def parse_http_body(
         if not content_type:
             return None
 
-        if content_type in ("application/json", "application/vnd.api+json", "text/json"):
+        # Content-Type legally carries parameters (charset, boundary, ...),
+        # e.g. application/json; charset=utf-8 — many HTTP clients always
+        # add a charset. Match against the bare media type so a charset
+        # suffix doesn't silently skip body inspection.
+        base_content_type = content_type.split(";", 1)[0].strip()
+
+        if base_content_type in ("application/json", "application/vnd.api+json", "text/json"):
             return json.loads(body)
-        elif content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
+        elif base_content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
             return parse_qs(body)
-        elif content_type in ("application/xml", "text/xml"):
+        elif base_content_type in ("application/xml", "text/xml"):
             return xmltodict.parse(body)
-        elif content_type.startswith("multipart/form-data"):
+        elif base_content_type == "multipart/form-data":
             return http_utils.parse_form_multipart(body, normalized_headers)
-        elif content_type == "text/plain":
+        elif base_content_type == "text/plain":
             return None
         else:
             return None

--- a/releasenotes/notes/fix-appsec-parse-http-body-charset-3ee83cd474678d04.yaml
+++ b/releasenotes/notes/fix-appsec-parse-http-body-charset-3ee83cd474678d04.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ASM: Fixes body inspection silently skipping requests whose
+    ``Content-Type`` header carried a parameter (most commonly
+    ``charset=utf-8``).

--- a/tests/appsec/appsec/test_appsec_http_utils.py
+++ b/tests/appsec/appsec/test_appsec_http_utils.py
@@ -82,6 +82,22 @@ def test_normalize_headers(input_headers, expected):
             True,
             None,
         ),
+        # content-type may legally carry parameters (e.g. charset)
+        ({"content-type": "application/json; charset=utf-8"}, '{"key": "value"}', False, {"key": "value"}),
+        ({"content-type": "application/json;charset=utf-8"}, '{"key": "value"}', False, {"key": "value"}),
+        ({"content-type": "  application/json ; charset=utf-8 "}, '{"key": "value"}', False, {"key": "value"}),
+        (
+            {"content-type": "application/x-www-form-urlencoded; charset=utf-8"},
+            "key=value",
+            False,
+            {"key": ["value"]},
+        ),
+        (
+            {"content-type": "application/xml; charset=utf-8"},
+            "<root><key>value</key></root>",
+            False,
+            {"root": {"key": "value"}},
+        ),
     ],
 )
 def test_parse_http_body(headers, body, is_body_base64, expected_output, mocker):


### PR DESCRIPTION
## Description

This fixes a bug where AppSec would not scan bodies of `Content-Type` headers carrying parameters, e.g. `application/json; charset=utf-8`.