### PR TITLE
chore: properly return result of wrapped `protobuf` functions

### DIFF
--- a/ddtrace/contrib/internal/protobuf/patch.py
+++ b/ddtrace/contrib/internal/protobuf/patch.py
@@ -81,10 +81,10 @@ def _traced_build(func, instance, args, kwargs):
 
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():
-        func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     try:
-        func(*args, **kwargs)
+        return func(*args, **kwargs)
     finally:
         if config._data_streams_enabled:
             generated_message_classes = args[2]
@@ -99,12 +99,12 @@ def _traced_build(func, instance, args, kwargs):
 def _traced_deserialize_message(func, instance, args, kwargs, msg_descriptor):
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():
-        func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     active = tracer.current_span()
 
     try:
-        func(*args, **kwargs)
+        return func(*args, **kwargs)
     finally:
         if config._data_streams_enabled and active:
             SchemaExtractor.attach_schema_on_span(msg_descriptor, active, SchemaExtractor.DESERIALIZATION)

--- a/tests/contrib/protobuf/test_protobuf.py
+++ b/tests/contrib/protobuf/test_protobuf.py
@@ -206,3 +206,33 @@ def test_advanced_schema_deserialize(protobuf, tracer, test_spans):
     assert tags[SCHEMA_TAGS.SCHEMA_OPERATION] == "deserialization"
     assert tags[SCHEMA_TAGS.SCHEMA_ID] == MESSAGE_SCHEMA_ID
     assert metrics[SCHEMA_TAGS.SCHEMA_WEIGHT] == 1
+
+
+def test_parse_from_string_preserves_return_value(protobuf, tracer, test_spans):
+    """Regression: ``_traced_deserialize_message`` swallowed
+    ``ParseFromString``'s return value (the number of bytes consumed) by
+    not ``return``-ing through ``func(*args, **kwargs)``. Callers got
+    ``None`` instead of an ``int``. The wrapper also called the underlying
+    method twice when the pin was disabled (no ``return`` on the early
+    bail-out branch either).
+    """
+    importlib.reload(other_message_pb2)
+    OtherMessage = other_message_pb2.OtherMessage
+
+    msg = OtherMessage()
+    msg.name.append("Alice")
+    msg.age = 30
+    bytes_data = msg.SerializeToString()
+
+    decoded = OtherMessage()
+    unwrapped_result = OtherMessage().ParseFromString(bytes_data)
+    assert isinstance(unwrapped_result, int)
+
+    with tracer.trace("other_message.deserialize") as span:
+        span.context.sampling_priority = AUTO_KEEP
+        wrapped_result = decoded.ParseFromString(bytes_data)
+
+    # Wrapped call must pass through the original return value.
+    assert wrapped_result == unwrapped_result
+    assert decoded.name == msg.name
+    assert decoded.age == msg.age

--- a/tests/contrib/protobuf/test_protobuf.py
+++ b/tests/contrib/protobuf/test_protobuf.py
@@ -132,7 +132,7 @@ def test_basic_schema_deserialize(protobuf, tracer, test_spans):
     # Deserialize
     with tracer.trace("other_message.deserialize") as span:
         span.context.sampling_priority = AUTO_KEEP
-        other_message.ParseFromString(bytes_data)
+        result = other_message.ParseFromString(bytes_data)
 
     assert len(test_spans.spans) == 1, "There should be exactly one span"
 
@@ -150,6 +150,7 @@ def test_basic_schema_deserialize(protobuf, tracer, test_spans):
     assert tags[SCHEMA_TAGS.SCHEMA_OPERATION] == "deserialization"
     assert tags[SCHEMA_TAGS.SCHEMA_ID] == OTHER_MESSAGE_SCHEMA_ID
     assert metrics[SCHEMA_TAGS.SCHEMA_WEIGHT] == 1
+    assert isinstance(result, int)
 
 
 def test_advanced_schema_deserialize(protobuf, tracer, test_spans):
@@ -206,33 +207,3 @@ def test_advanced_schema_deserialize(protobuf, tracer, test_spans):
     assert tags[SCHEMA_TAGS.SCHEMA_OPERATION] == "deserialization"
     assert tags[SCHEMA_TAGS.SCHEMA_ID] == MESSAGE_SCHEMA_ID
     assert metrics[SCHEMA_TAGS.SCHEMA_WEIGHT] == 1
-
-
-def test_parse_from_string_preserves_return_value(protobuf, tracer, test_spans):
-    """Regression: ``_traced_deserialize_message`` swallowed
-    ``ParseFromString``'s return value (the number of bytes consumed) by
-    not ``return``-ing through ``func(*args, **kwargs)``. Callers got
-    ``None`` instead of an ``int``. The wrapper also called the underlying
-    method twice when the pin was disabled (no ``return`` on the early
-    bail-out branch either).
-    """
-    importlib.reload(other_message_pb2)
-    OtherMessage = other_message_pb2.OtherMessage
-
-    msg = OtherMessage()
-    msg.name.append("Alice")
-    msg.age = 30
-    bytes_data = msg.SerializeToString()
-
-    decoded = OtherMessage()
-    unwrapped_result = OtherMessage().ParseFromString(bytes_data)
-    assert isinstance(unwrapped_result, int)
-
-    with tracer.trace("other_message.deserialize") as span:
-        span.context.sampling_priority = AUTO_KEEP
-        wrapped_result = decoded.ParseFromString(bytes_data)
-
-    # Wrapped call must pass through the original return value.
-    assert wrapped_result == unwrapped_result
-    assert decoded.name == msg.name
-    assert decoded.age == msg.age


### PR DESCRIPTION
## Description

Properly returns the result of wrapped functions and avoids calling them twice. 