### PR TITLE
ci(profiling): add fuzzing files to clang-tidy job

### DIFF
--- a/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
+++ b/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
@@ -70,7 +70,7 @@ fi
 
 echo "Using merged compile_commands.json from: ${BUILD_DIR}"
 
-# Collect all profiling source files (not headers, not test files, not build artifacts).
+# Collect all profiling source files, except for  headers, source files, build artifacts.
 # Fuzz sources are included so clang-tidy catches compilation regressions in the harnesses
 # without the overhead of a full libFuzzer build.
 SOURCE_FILES=()

--- a/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
+++ b/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
@@ -30,7 +30,7 @@ cmake \
     "${SCRIPT_DIR}/dd_wrapper"
 popd
 
-# Configure cmake for stack
+# Configure cmake for stack (including fuzz harnesses so they are covered by clang-tidy)
 echo "Configuring cmake for stack..."
 mkdir -p "${BUILD_DIR}/stack"
 pushd "${BUILD_DIR}/stack"
@@ -41,6 +41,8 @@ cmake \
     -DEXTENSION_SUFFIX=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))") \
     -DNATIVE_EXTENSION_LOCATION="${REPO_ROOT}/ddtrace/internal/native" \
     -DDD_WRAPPER_DIR="${BUILD_DIR}/dd_wrapper" \
+    -DBUILD_FUZZING=ON \
+    -DSTACK_USE_LIBFUZZER=OFF \
     "${SCRIPT_DIR}/stack"
 popd
 
@@ -68,8 +70,9 @@ fi
 
 echo "Using merged compile_commands.json from: ${BUILD_DIR}"
 
-# Collect all profiling source files (not headers, not test files, not build artifacts)
-# Also exclude fuzz sources since BUILD_FUZZING is OFF by default
+# Collect all profiling source files (not headers, not test files, not build artifacts).
+# Fuzz sources are included so clang-tidy catches compilation regressions in the harnesses
+# without the overhead of a full libFuzzer build.
 SOURCE_FILES=()
 while IFS= read -r -d '' file; do
     SOURCE_FILES+=("$file")
@@ -78,7 +81,6 @@ done < <(find "${SCRIPT_DIR}" \
     ! -path "*/build/*" \
     ! -path "*/CMakeFiles/*" \
     ! -path "*/test/*" \
-    ! -path "*/fuzz/*" \
     ! -path "*/_vendor/*" \
     -print0)
 

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_frame_create.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_frame_create.cpp
@@ -19,6 +19,7 @@
 #include <internal/pycore_code.h>
 #endif
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -68,3 +69,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_frame_read.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_frame_read.cpp
@@ -11,6 +11,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/frame.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -51,3 +52,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_greenlet.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_greenlet.cpp
@@ -11,6 +11,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/greenlets.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -71,3 +72,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_long.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_long.cpp
@@ -8,6 +8,7 @@
 
 #include <echion/long.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -34,3 +35,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 #endif
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_mirrors.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_mirrors.cpp
@@ -7,6 +7,7 @@
 
 #include <echion/mirrors.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -30,3 +31,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_pyunicode.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_pyunicode.cpp
@@ -9,6 +9,7 @@
 
 #include <echion/strings.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -31,3 +32,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_stacks.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_stacks.cpp
@@ -9,6 +9,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/stacks.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -56,3 +57,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_strings.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_strings.cpp
@@ -8,6 +8,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/strings.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -38,3 +39,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_task_unwind.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_task_unwind.cpp
@@ -11,6 +11,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/tasks.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -40,3 +41,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_tasks.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_tasks.cpp
@@ -10,6 +10,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/tasks.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -39,3 +40,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_thread_unwind.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_thread_unwind.cpp
@@ -5,6 +5,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/tasks.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -42,3 +43,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_thread_unwind_tasks.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_thread_unwind_tasks.cpp
@@ -5,6 +5,7 @@
 #include <echion/echion_sampler.h>
 #include <echion/tasks.h>
 
+// NOLINTBEGIN(performance-no-int-to-ptr)
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -56,3 +57,4 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     g_size = 0;
     return 0;
 }
+// NOLINTEND(performance-no-int-to-ptr)


### PR DESCRIPTION
## Description

`clang-tidy` is now catching incompatible API changes in the fuzzing harness and related files, e.g. for the problem we currently have (see #18104).

<img width="1356" height="414" alt="image" src="https://github.com/user-attachments/assets/3200663d-82d7-46e8-aeb7-d5b482a70e9d" />
