### PR TITLE
ci(profiling): fix fuzzing harness

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
@@ -91,9 +91,10 @@ echion_fuzz_copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void
 // Stubs for symbols from vm.cc that sampler.cpp references.
 // We cannot compile vm.cc with ECHION_FUZZING because it defines copy_memory(),
 // which conflicts with the inline fuzz version from vm.h.
-void
+bool
 set_fast_copy_enabled(bool)
 {
+    return true;
 }
 
 void

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
@@ -91,6 +91,9 @@ echion_fuzz_copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void
 // Stubs for symbols from vm.cc that sampler.cpp references.
 // We cannot compile vm.cc with ECHION_FUZZING because it defines copy_memory(),
 // which conflicts with the inline fuzz version from vm.h.
+// Fuzzing stub: the real implementation enables/disables fast copy
+// and returns the previous state. Under normal (non-error) circumstances fast
+// copy is enabled, so returning true here accurately reflects that default.
 bool
 set_fast_copy_enabled(bool)
 {

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_interp.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_interp.cpp
@@ -21,9 +21,10 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     // Point interpreters.head into the fuzz buffer so for_each_interp
     // reads interpreter nodes from fuzzer-controlled memory.
-    _PyRuntimeState runtime;
-    std::memset(&runtime, 0, sizeof(runtime));
+    _PyRuntimeState runtime{};
     uintptr_t p0 = addr_from_u64(load_u64_le(data, size, 0));
+
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
     runtime.interpreters.head = reinterpret_cast<PyInterpreterState*>(p0);
 
     size_t interp_count = 0;


### PR DESCRIPTION
## Description

This fixes a Profiling C++ API breaking change currently preventing us from building the fuzzing harness. 

```
/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h:95:1: error: functions that differ only in their return type cannot be overloaded [clang-diagnostic-error]
   94 | void
      | ~~~~
   95 | set_fast_copy_enabled(bool)
      | ^
```