### PR TITLE
chore: do not crash on method names with a colon

### DIFF
--- a/ddtrace/internal/tracemethods.py
+++ b/ddtrace/internal/tracemethods.py
@@ -32,8 +32,11 @@ def _parse_trace_methods(raw_dd_trace_methods: str) -> list[tuple[str, str]]:
             return []
 
         # Store the prefix and the methods  (eg. for "foo.bar.baz:qux,quux",
-        # this is "foo.bar.baz" for the prefix and "qux,quux" for the methods)
-        qualified_method_prefix, methods = qualified_methods.split(":")
+        # this is "foo.bar.baz" for the prefix and "qux,quux" for the methods).
+        # Use split(":", 1) so a typo like "mymod:method1:method2" reaches the
+        # per-method validation and produces an "Invalid method name" warning,
+        # instead of raising an unhandled ``ValueError`` during tracer startup.
+        qualified_method_prefix, methods = qualified_methods.split(":", 1)
 
         if qualified_method_prefix == "__main__":
             # __main__ cannot be used since the __main__ that exists now is not the same as the __main__ that the user

--- a/tests/integration/test_tracemethods.py
+++ b/tests/integration/test_tracemethods.py
@@ -29,6 +29,9 @@ pytestmark = pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only
         ("module.", []),
         ("module.method", []),
         ("module.method;module.method", []),
+        ("module:method1:method2", []),
+        ("module::method", []),
+        ("module:method;mod2:m1:m2", []),
     ],
 )
 def test_trace_methods_parse(dd_trace_methods: str, expected_output: list[tuple[str, str]]):


### PR DESCRIPTION
## Description

This is a pretty contrived case but I believe it is technically possible using `setattr`: 

```py
class MyClass:
    pass

setattr(MyClass, "foo:function", lambda self: "foo")

f = getattr(MyClass, "foo:function")
print(f(MyClass()))
```