### PR TITLE
ci: make span start max_rss SLO consistent across scenarios

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -1025,15 +1025,15 @@ experiments:
           - name: span-start-finish
             thresholds:
               - execution_time < 60 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 53.00 MB
           - name: span-start-finish-telemetry
             thresholds:
               - execution_time < 60.00 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 53.00 MB
           - name: span-start-finish-traceid128
             thresholds:
               - execution_time < 62.00 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 53.00 MB
           - name: span-start-traceid128
             thresholds:
               - execution_time < 22.50 ms


### PR DESCRIPTION
## Description

We are seeing some wider ranges than these SLOs, so updating the max_rss to be consistent across all the SLOs. Seems some of them need a slightly higher limit anyway.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
