### PR TITLE
perf(profiling): don't double call get_code_from_frame in mem profiler

### DIFF
--- a/ddtrace/internal/datadog/profiling/profiling_helpers/frame_accessors.h
+++ b/ddtrace/internal/datadog/profiling/profiling_helpers/frame_accessors.h
@@ -79,29 +79,36 @@ get_code_from_frame(py_frame_t* frame)
 #endif
 }
 
-/* Return true for frames that should be skipped during stack walking:
+/*
+ * Returns the PyCodeObject* for the frame if it should be walked,
+ * or NULL if the frame should be skipped. Skipped frames are:
  *   - frames whose code slot is NULL or not a real PyCodeObject
  *   - Python 3.12+ "cstack"/interpreter shim frames
  *   - Python 3.11 incomplete frames (prev_instr < firsttraceable)
  *
  * IMPORTANT: Calls PyCode_Check() which dereferences the code object.
  * Only safe when the code object pointer is valid (GIL held or
- * object known to be alive). */
-inline bool
-should_skip_frame(py_frame_t* frame)
+ * object known to be alive).
+ */
+inline PyCodeObject*
+get_code_if_not_skip(py_frame_t* frame)
 {
-    PyObject* code = reinterpret_cast<PyObject*>(get_code_from_frame(frame));
-    if (code == NULL || !PyCode_Check(code)) {
-        return true;
+    PyCodeObject* code = get_code_from_frame(frame);
+    if (code == NULL || !PyCode_Check(reinterpret_cast<PyObject*>(code))) {
+        return NULL;
     }
 
 #if PY_VERSION_HEX >= 0x030c0000
-    return frame->owner != FRAME_OWNED_BY_THREAD && frame->owner != FRAME_OWNED_BY_GENERATOR;
+    if (frame->owner != FRAME_OWNED_BY_THREAD && frame->owner != FRAME_OWNED_BY_GENERATOR) {
+        return NULL;
+    }
 #elif PY_VERSION_HEX >= 0x030b0000
-    return _PyFrame_IsIncomplete(frame);
-#else
-    return false;
+    if (_PyFrame_IsIncomplete(frame)) {
+        return NULL;
+    }
 #endif
+
+    return code;
 }
 
 /* Return the best available function name for a code object.

--- a/ddtrace/internal/datadog/profiling/profiling_helpers/frame_accessors.h
+++ b/ddtrace/internal/datadog/profiling/profiling_helpers/frame_accessors.h
@@ -94,17 +94,16 @@ inline PyCodeObject*
 get_code_if_not_skip(py_frame_t* frame)
 {
     PyCodeObject* code = get_code_from_frame(frame);
-    if (code == NULL || !PyCode_Check(reinterpret_cast<PyObject*>(code))) {
-        return NULL;
+    if (code == nullptr || !PyCode_Check(reinterpret_cast<PyObject*>(code))) {
+        return nullptr;
     }
-
 #if PY_VERSION_HEX >= 0x030c0000
     if (frame->owner != FRAME_OWNED_BY_THREAD && frame->owner != FRAME_OWNED_BY_GENERATOR) {
-        return NULL;
+        return nullptr;
     }
 #elif PY_VERSION_HEX >= 0x030b0000
     if (_PyFrame_IsIncomplete(frame)) {
-        return NULL;
+        return nullptr;
     }
 #endif
 

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -95,11 +95,7 @@ push_stacktrace_to_sample_no_refcount(Datadog::Sample& sample, uint16_t max_nfra
             break;
         }
 
-        if (DataDog::should_skip_frame(frame)) {
-            continue;
-        }
-
-        PyCodeObject* code = DataDog::get_code_from_frame(frame);
+        PyCodeObject* code = DataDog::get_code_if_not_skip(frame);
         if (code == NULL) {
             continue;
         }


### PR DESCRIPTION
## Description

We called get_code_from_frame twice

```
 //  should_skip_frame calls get_code_from_frame internally
  if (DataDog::should_skip_frame(frame)) { 
      continue;
  }
  // Second call
  PyCodeObject* code = DataDog::get_code_from_frame(frame);
```

We can combine these with a helper that returns a code object or returns null instead of double reading memory

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
