### PR TITLE
perf(profiling): allocate 512 capacity initially for alloc map

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -160,7 +160,7 @@ class heap_tracker_t
     std::vector<std::unique_ptr<traceback_t>> pool;
 
     /* Initial capacity of the allocations map */
-    static constexpr size_t INITAL_ALLOC_MAP_CAPACITY = 1024;
+    static constexpr size_t INITAL_ALLOC_MAP_CAPACITY = 512;
 };
 
 // Pool implementation

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -217,6 +217,7 @@ heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
   , allocated_memory(0)
 {
     pool.reserve(POOL_CAPACITY); // Pre-allocate pool capacity to avoid reallocations
+    allocs_m.reserve(1024);      // Pre-allocate map capacity to avoid rehashing during ramp-up.
 }
 
 void

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -219,8 +219,10 @@ heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
   , current_sample_size(next_sample_size_no_cpython(sample_size_val))
   , allocated_memory(0)
 {
-    pool.reserve(POOL_CAPACITY);                 // Pre-allocate pool capacity to avoid reallocations
-    allocs_m.reserve(INITAL_ALLOC_MAP_CAPACITY); // Pre-allocate map capacity to avoid rehashing during ramp-up.
+    // Pre-allocate pool capacity to avoid reallocations
+    pool.reserve(POOL_CAPACITY);
+    // Pre-allocate map capacity to avoid rehashing during ramp-up.
+    allocs_m.reserve(INITAL_ALLOC_MAP_CAPACITY);
 }
 
 void

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -158,6 +158,9 @@ class heap_tracker_t
     /* Traceback pool - reduces allocation overhead. Access is always under GIL. */
     static constexpr size_t POOL_CAPACITY = 128;
     std::vector<std::unique_ptr<traceback_t>> pool;
+
+    /* Initial capacity of the allocations map */
+    static constexpr size_t INITAL_ALLOC_MAP_CAPACITY = 1024;
 };
 
 // Pool implementation
@@ -216,8 +219,8 @@ heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
   , current_sample_size(next_sample_size_no_cpython(sample_size_val))
   , allocated_memory(0)
 {
-    pool.reserve(POOL_CAPACITY); // Pre-allocate pool capacity to avoid reallocations
-    allocs_m.reserve(1024);      // Pre-allocate map capacity to avoid rehashing during ramp-up.
+    pool.reserve(POOL_CAPACITY);                 // Pre-allocate pool capacity to avoid reallocations
+    allocs_m.reserve(INITAL_ALLOC_MAP_CAPACITY); // Pre-allocate map capacity to avoid rehashing during ramp-up.
 }
 
 void


### PR DESCRIPTION
## Description

flat_hash_map rehashes at 87.5% load (https://abseil.io/docs/cpp/guides/container#hash-tables) doubling capacity each time. Without this, growing from 0 to 1024 entries triggers ~8 rehashes:
capacity:  4 -> 8 -> 16 -> 32 -> 64 -> 128 -> 256 -> 512 -> 1024
rehash at: 4     7        14    28       56       112     224      448

p99 live heap count is ~350

Each rehash at capacity N copies all N existing entries.

This only minorly improves startup, but this is a cheap non-negative change

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
