### PR TITLE
fix(debugger): retry agent /info on 5xx

### DIFF
--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -7,6 +7,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import ForksafeAwakeablePeriodicService
 from ddtrace.internal.process_tags import compute_base_hash
 from ddtrace.internal.settings._agent import config
+from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 
 from .utils.http import get_connection
 
@@ -46,6 +47,44 @@ def info(url=None):
     return json.loads(data)
 
 
+class _RetryableInfoError(Exception):
+    """Raised by _info_with_retry on 5xx so the retry decorator triggers another attempt."""
+
+    def __init__(self, status, reason):
+        super().__init__("HTTP %s %s" % (status, reason))
+        self.status = status
+        self.reason = reason
+
+
+@fibonacci_backoff_with_jitter(
+    attempts=3,
+    initial_wait=0.2,
+    until=lambda result: isinstance(result, tuple),
+)
+def _info_with_retry():
+    """Variant of info() that retries on transient 5xx failures.
+
+    Scoped to AgentCheckPeriodicService so info() callers keep their existing
+    single-attempt semantics. Returns (status, reason, data) on a non-5xx
+    response; raises _RetryableInfoError on persistent 5xx after all attempts.
+    """
+    agent_url = config.trace_agent_url
+    timeout = config.trace_agent_timeout_seconds
+    _conn = get_connection(agent_url, timeout=timeout)
+    try:
+        _conn.request("GET", "info", headers={"content-type": "application/json"})
+        resp = _conn.getresponse()
+        process_info_headers(resp)
+        data = resp.read()
+    finally:
+        _conn.close()
+
+    if 500 <= resp.status < 600:
+        raise _RetryableInfoError(resp.status, resp.reason)
+
+    return resp.status, resp.reason, data
+
+
 class AgentCheckPeriodicService(ForksafeAwakeablePeriodicService, metaclass=abc.ABCMeta):
     def __init__(self, interval: float = 0.0):
         super().__init__(interval=interval)
@@ -56,8 +95,11 @@ class AgentCheckPeriodicService(ForksafeAwakeablePeriodicService, metaclass=abc.
     def info_check(self, agent_info: t.Optional[dict]) -> bool: ...
 
     def _agent_check(self) -> None:
+        agent_info: t.Optional[dict] = None
         try:
-            agent_info = info()
+            status, _, data = _info_with_retry()
+            if 200 <= status < 300:
+                agent_info = json.loads(data)
         except Exception:
             agent_info = None
 

--- a/releasenotes/notes/agent-info-retry-0a8acdda8d13a505.yaml
+++ b/releasenotes/notes/agent-info-retry-0a8acdda8d13a505.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: This fix makes the tracer resilient to transient failures
+    from the local trace agent.

--- a/tests/tracer/test_agent.py
+++ b/tests/tracer/test_agent.py
@@ -557,3 +557,87 @@ def test_info(mock_connection, request_response, read_response, status_response,
 
     mock_connection.return_value = MockConn()
     assert info() == expected
+
+
+@mock.patch("ddtrace.internal.agent.get_connection")
+def test_info_does_not_retry_on_5xx(mock_connection):
+    """info() itself must keep its single-attempt semantics so existing callers are unaffected."""
+    call_count = [0]
+
+    class MockResponse(object):
+        def read(self):
+            return "{}"
+
+        @property
+        def status(self):
+            return 500
+
+        @property
+        def reason(self):
+            return "Internal Server Error"
+
+    class MockConn:
+        def request(self, *args, **kwargs):
+            return None
+
+        def getresponse(self):
+            call_count[0] += 1
+            return MockResponse()
+
+        def close(self):
+            return None
+
+    mock_connection.return_value = MockConn()
+
+    assert info() is None
+    assert call_count[0] == 1
+
+
+@mock.patch("ddtrace.internal.agent.get_connection")
+def test_agent_check_retries_info_on_5xx(mock_connection):
+    """AgentCheckPeriodicService._agent_check retries /info on transient 5xx."""
+    call_count = [0]
+
+    class MockResponse(object):
+        def read(self):
+            return "{}"
+
+        @property
+        def status(self):
+            return 500
+
+        @property
+        def reason(self):
+            return "Internal Server Error"
+
+    class MockConn:
+        def request(self, *args, **kwargs):
+            return None
+
+        def getresponse(self):
+            call_count[0] += 1
+            return MockResponse()
+
+        def close(self):
+            return None
+
+    mock_connection.return_value = MockConn()
+
+    class _Service(agent.AgentCheckPeriodicService):
+        def __init__(self):
+            super().__init__(interval=0.0)
+            self.received = "unset"
+
+        def info_check(self, agent_info):
+            self.received = agent_info
+            return False
+
+        def online(self):
+            pass
+
+    service = _Service()
+    service._agent_check()
+
+    # fibonacci_backoff_with_jitter(attempts=3) issues 3 total requests before giving up
+    assert call_count[0] == 3
+    assert service.received is None


### PR DESCRIPTION
## Description

Adds a private `_info_with_retry` helper in `ddtrace/internal/agent.py` that wraps the `/info` HTTP call with the same fibonacci backoff already used by the Remote Config client. `AgentCheckPeriodicService._agent_check` now calls the retrying helper directly, so a single transient 5xx from the local trace agent no longer flips subclasses (most visibly the Dynamic Instrumentation signal uploader) back to `_agent_check` state until the next periodic interval. Snapshots/diagnostics keep flushing and the instance stops looking "not heartbeating" in the UI.

The public `agent.info()` helper is intentionally left unchanged (single attempt, returns `None` and logs a warning on non-2xx). It is shared with Remote Config polling, CI Visibility, LLM Obs and the LLM Obs writer, which all have their own scheduling and timing expectations; adding implicit retries there would change those callers' behavior.

Context: observed on a single staging instance whose local agent intermittently returned 500 on `/info`. RC polling itself was healthy end-to-end; the DI uploader on that host was the blast radius.

## Testing

- `tests/tracer/test_agent.py::test_info_does_not_retry_on_5xx` pins that `info()` keeps its single-attempt semantics.
- `tests/tracer/test_agent.py::test_agent_check_retries_info_on_5xx` exercises the retry through `AgentCheckPeriodicService._agent_check` (3 total attempts before giving up, `info_check` receives `None`).
- Existing `test_info` parametrization (incl. 500 case) still passes the contract: persistent 5xx returns `None`.
- Both new tests verified locally on py3.10.

## Risks

Low. Worst case is up to ~0.5s of added latency on the periodic agent health check when the agent is persistently failing 5xx. Other callers of `agent.info()` (Remote Config, CI Visibility, LLM Obs) are unaffected because their code path is untouched.

## Additional Notes

None.