### PR TITLE
refactor(iast): prevent out-of-bounds read in slice aspect with negative step

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_slice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_slice.cpp
@@ -65,38 +65,26 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
         index_range_map.emplace_back(nullptr);
         index++;
     }
+    PyObject* slice = PySlice_New(
+      (start != nullptr) ? start : Py_None, (stop != nullptr) ? stop : Py_None, (step != nullptr) ? step : Py_None);
+    if (slice == nullptr) {
+        return {};
+    }
+
+    Py_ssize_t norm_start, norm_stop, norm_step, slicelength;
+    if (PySlice_GetIndicesEx(slice, length_text, &norm_start, &norm_stop, &norm_step, &slicelength) < 0) {
+        Py_DECREF(slice);
+        return {};
+    }
+    Py_DECREF(slice);
+
     TaintRangeRefs index_range_map_result;
-    long start_int = 0;
-    if (start != nullptr and start != Py_None) {
-        start_int = PyLong_AsLong(start);
-        if (start_int < 0) {
-            start_int = length_text + start_int;
-            if (start_int < 0) {
-                start_int = 0;
-            }
+    Py_ssize_t map_size = static_cast<Py_ssize_t>(index_range_map.size());
+    for (Py_ssize_t i = 0; i < slicelength; i++) {
+        Py_ssize_t idx = norm_start + i * norm_step;
+        if (idx >= 0 && idx < map_size) {
+            index_range_map_result.emplace_back(index_range_map[idx]);
         }
-    }
-
-    long stop_int = length_text;
-    if (stop != nullptr and stop != Py_None) {
-        stop_int = PyLong_AsLong(stop);
-        if (stop_int > length_text) {
-            stop_int = length_text;
-        } else if (stop_int < 0) {
-            stop_int = length_text + stop_int;
-            if (stop_int < 0) {
-                stop_int = 0;
-            }
-        }
-    }
-
-    long step_int = 1;
-    if (step != nullptr and step != Py_None) {
-        step_int = PyLong_AsLong(step);
-    }
-
-    for (auto i = start_int; i < stop_int; i += step_int) {
-        index_range_map_result.emplace_back(index_range_map[i]);
     }
 
     return index_range_map_result;

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -288,6 +288,37 @@ def test_string_slice_negative():
     assert result == expected_result
 
 
+@pytest.mark.parametrize(
+    "input_str, start_pos, end_pos, step, expected_result",
+    [
+        # Regression: negative step triggered OOB read in build_index_range_map
+        # because start_int=0 < stop_int=len satisfied i<stop for all negative i.
+        ("hello", None, None, -1, "olleh"),
+        ("hello", None, None, -2, "olh"),
+        ("hello", 4, 0, -1, "olle"),
+    ],
+)
+def test_string_slice_negative_step_oob_regression(
+    input_str: str, start_pos: object, end_pos: object, step: int, expected_result: str
+) -> None:
+    """Regression test for out-of-bounds read in slice aspect with negative step."""
+    result = mod.do_slice(input_str, start_pos, end_pos, step)  # pylint: disable=no-member
+    assert result == expected_result
+
+    tainted_input = taint_pyobject(
+        pyobject=input_str,
+        source_name="input_str",
+        source_value="foo",
+        source_origin=OriginType.PARAMETER,
+    )
+    result = mod.do_slice(tainted_input, start_pos, end_pos, step)  # pylint: disable=no-member
+    assert result == expected_result
+    tainted_ranges = get_tainted_ranges(result)
+    assert len(tainted_ranges) == 1
+    assert tainted_ranges[0].start == 0
+    assert tainted_ranges[0].length == len(expected_result)
+
+
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context(caplog):
     tainted_input = taint_pyobject(


### PR DESCRIPTION
## Description

`build_index_range_map` executes a loop:

```cpp
for (auto i = start_int; i < stop_int; i += step_int) {
  index_range_map_result.emplace_back(index_range_map[i]);
}
```

... where `start_int`, `stop_int`, and `step_int` are all signed longs read directly from caller-controlled `PyLong` objects (via `PyLong_AsLong`) with no normalization through `PySlice_AdjustIndices`. When the application code uses a negative-step slice on a tainted string (e.g. `tainted[::-1]`), the AST visitor at `ddtrace/appsec/_iast/_ast/visitor.py` rewrites the expression to `slice_aspect(s, None, None, -1)`. 
Inside `build_index_range_map`, `start_int=0`, `stop_int=length_text`, `step_int=-1`. The first iteration uses  `i=0` (valid); the second iteration uses `i=-1`, then `-2`, etc. 

Each `index_range_map[i]` call invokes `std::vector<TaintRangePtr>::operator[](size_t)`, which converts the negative long to `(size_t)-1 = SIZE_MAX`, reading  out of bounds. The result is then `emplace_back`'ed into the result vector and used to build a `shared_ptr<TaintRange>` by dereferencing the obtained pointer.

Reproducer that crashes pre-fix/

<details>

```py
#!/usr/bin/env python3
"""
Reproducer for: out-of-bounds read in slice aspect with negative step.

With the buggy code, build_index_range_map looped:

    for (auto i = start_int; i < stop_int; i += step_int)

With step=-1: i = 0, -1, -2, ... all satisfy i < stop_int, so the loop never
terminates and reads past the beginning of the vector (UB / crash).

Run with:
    DD_IAST_ENABLED=1 python repro.py
"""
import os

os.environ.setdefault("DD_IAST_ENABLED", "1")
from ddtrace.appsec._iast._taint_tracking import OriginType
from ddtrace.appsec._iast._taint_tracking import initialize_native_state
from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
from tests.appsec.iast.iast_utils import (
    _end_iast_context_and_oce,
    _iast_patched_module,
    _start_iast_context_and_oce,
)

# initialize_native_state allocates the C++ TaintEngineContext singleton;
# without it start_request_context() always returns None.
initialize_native_state()

# The module must be loaded patched so that slicing goes through the aspect.
mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")


def main() -> None:
    _start_iast_context_and_oce()
    try:
        s: str = taint_pyobject(
            pyobject="hello",
            source_name="input",
            source_value="hello",
            source_origin=OriginType.PARAMETER,
        )

        # All three cases use a negative step → triggered the OOB read.
        # do_slice(text, first, second, third) maps to text[first:second:third];
        # passing None uses the default (same as omitting the index).
        cases: list[tuple[str, object, object, int]] = [
            ("s[::-1]",   None, None, -1),
            ("s[::-2]",   None, None, -2),
            ("s[4:0:-1]", 4,    0,    -1),
        ]

        for label, first, second, step in cases:
            print(f"trying {label} ...", flush=True)
            result = mod.do_slice(s, first, second, step)
            ranges = get_tainted_ranges(result)
            print(f"  result={result!r}, tainted_ranges={ranges}")
            assert len(ranges) == 1, f"expected 1 tainted range, got {ranges}"

        print("OK - all slices returned correct tainted ranges")
    finally:
        _end_iast_context_and_oce()


if __name__ == "__main__":
    main()
```

</details>