### PR TITLE
chore(codeowners): assign AI Guard paths to @DataDog/k9-ai-guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -322,6 +322,12 @@ tests/**/*appsec*                       @DataDog/asm-python
 tests/**/*iast*                         @DataDog/asm-python
 tests/tracer/test_propagation.py        @DataDog/apm-sdk-capabilities-python @DataDog/asm-python
 
+# AI Guard (order matters — overrides ASM)
+ddtrace/appsec/ai_guard/                  @DataDog/k9-ai-guard
+ddtrace/appsec/_ai_guard/                 @DataDog/k9-ai-guard
+tests/appsec/ai_guard/                    @DataDog/k9-ai-guard
+tests/appsec/integrations/langchain_tests @DataDog/k9-ai-guard
+
 # Fuzzing
 .gitlab/fuzz.yml                  @DataDog/chaos-engineering @DataDog/profiling-python
 .gitlab/scripts/fuzz_infra.py     @DataDog/chaos-engineering @DataDog/profiling-python


### PR DESCRIPTION
## Summary
- Adds CODEOWNERS overrides so `ddtrace/appsec/ai_guard/`, `ddtrace/appsec/_ai_guard/`, `tests/appsec/ai_guard/`, and `tests/appsec/integrations/langchain_tests` are owned by `@DataDog/k9-ai-guard` instead of `@DataDog/asm-python`.
- Placed after the ASM block so last-match-wins applies.

## Test plan
- [ ] CI confirms CODEOWNERS validates
- [ ] Verify PR review request routes to `@DataDog/k9-ai-guard` for ai_guard paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)