### PR TITLE
refactor(iast): use `Py_XDECREF` when pointer can be null

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_str.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects/aspect_str.cpp
@@ -214,7 +214,7 @@ api_str_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs, Py
                     copy_and_shift_ranges_from_strings(text, result_o, offset, len_result_o, tx_map);
                 }
             }
-            Py_DECREF(check_offset);
+            Py_XDECREF(check_offset);
         }
         return result_o;
     });


### PR DESCRIPTION
## Description

In this context, we don't know whether `check_offset` is null or not, so use `XDECREF` for safety reasons. 