### PR TITLE
chore(profiling): resolve test files lints after mypy strict mode enablement

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 files = ddtrace,
       docs
-exclude = ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/|ddtrace/appsec/_iast/_taint_tracking/_vendor/|ddtrace/appsec/_iast/_taint_tracking/_deps/|ddtrace/internal/datadog/profiling/build|ddtrace/profiling/collector/test/build/
+exclude = ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/|ddtrace/appsec/_iast/_taint_tracking/_vendor/|ddtrace/appsec/_iast/_taint_tracking/_deps/|ddtrace/internal/datadog/profiling/build|ddtrace/profiling/collector/test/build/|tests/profiling/collector/pprof_\d.*_pb2\.py
 # mypy thinks .pyx files are scripts and errors out if it finds multiple scripts
 scripts_are_modules = true
 show_error_codes = true
@@ -58,6 +58,8 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 disallow_subclassing_any = false
 check_untyped_defs = false
+disallow_untyped_decorators = false
+disallow_untyped_calls = false
 
 # ── Modules not yet compliant with strict mode ────────────────────────────────
 # Generated against mypy 1.15.

--- a/tests/profiling/_test_multiprocessing.py
+++ b/tests/profiling/_test_multiprocessing.py
@@ -6,7 +6,7 @@ import sys
 def f() -> None:
     import ddtrace.profiling.bootstrap
 
-    profiler = ddtrace.profiling.bootstrap.profiler  # pyright: ignore[reportAttributeAccessIssue]
+    profiler = ddtrace.profiling.bootstrap.profiler  # type: ignore[attr-defined]
     # Do some CPU work to ensure we get samples
     total = 0
     for i in range(5_000_000):

--- a/tests/profiling/collector/test_asyncio.py
+++ b/tests/profiling/collector/test_asyncio.py
@@ -228,7 +228,7 @@ class BaseAsyncioLockCollectorTest:
             assert isinstance(self.lock_class, LockAllocatorWrapper)
 
             # This should NOT raise TypeError
-            class CustomLock(self.lock_class):  # type: ignore[misc]
+            class CustomLock(self.lock_class):  # type: ignore[unreachable, name-defined]
                 def __init__(self) -> None:
                     super().__init__()
 

--- a/tests/profiling/collector/test_asyncio_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_coroutines.py
@@ -49,12 +49,10 @@ def test_asyncio_coroutines() -> None:
         math_task = loop.create_task(background_math_function(), name="background_math")
         assert background_task is not None
 
-        result = await main_coro()
+        await main_coro()
 
         await background_task
         await math_task
-
-        return result
 
     p = profiler.Profiler()
     p.start()

--- a/tests/profiling/collector/test_asyncio_deadlock.py
+++ b/tests/profiling/collector/test_asyncio_deadlock.py
@@ -18,8 +18,8 @@ def test_asyncio_deadlock() -> None:
     assert stack.is_available, stack.failure_msg
 
     # We'll assign these after creation so each coroutine can await the other.
-    t1: Optional[asyncio.Task] = None
-    t2: Optional[asyncio.Task] = None
+    t1: Optional[asyncio.Task[None]] = None
+    t2: Optional[asyncio.Task[None]] = None
 
     async def task_a() -> None:
         assert t2 is not None

--- a/tests/profiling/collector/test_asyncio_shield.py
+++ b/tests/profiling/collector/test_asyncio_shield.py
@@ -96,7 +96,7 @@ def test_asyncio_shield() -> None:
 
     if len(exceptions) > 0:
         pprof_utils.print_all_samples(profile)
-        for e in exceptions:
-            print(e)
+        for exc in exceptions:
+            print(exc)
 
         raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_taskgroup.py
+++ b/tests/profiling/collector/test_asyncio_taskgroup.py
@@ -31,9 +31,9 @@ def test_asyncio_taskgroup() -> None:
         return t
 
     async def task_with_taskgroup(delay: float) -> float:
-        async with asyncio.TaskGroup() as tg:
+        async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
             task = tg.create_task(wait_and_return_delay(delay))
-            return await task
+            return await task  # type: ignore[no-any-return]
 
     async def main() -> None:
         # Create tasks that will use TaskGroup
@@ -107,7 +107,7 @@ def test_asyncio_taskgroup() -> None:
 
     if len(exceptions) > 0:
         pprof_utils.print_all_samples(profile)
-        for e in exceptions:
-            print(e)
+        for exc in exceptions:
+            print(exc)
 
         raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout.py
+++ b/tests/profiling/collector/test_asyncio_timeout.py
@@ -31,7 +31,7 @@ def test_asyncio_timeout() -> None:
         return t
 
     async def task_with_timeout(delay: float) -> float:
-        async with asyncio.timeout(10.0):  # Long timeout, won't trigger
+        async with asyncio.timeout(10.0):  # type: ignore[attr-defined]  # Long timeout, won't trigger
             return await wait_and_return_delay(delay)
 
     async def main() -> None:
@@ -105,7 +105,7 @@ def test_asyncio_timeout() -> None:
 
     if len(exceptions) > 0:
         pprof_utils.print_all_samples(profile)
-        for e in exceptions:
-            print(e)
+        for exc in exceptions:
+            print(exc)
 
         raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout_at.py
+++ b/tests/profiling/collector/test_asyncio_timeout_at.py
@@ -34,7 +34,7 @@ def test_asyncio_timeout_at() -> None:
     async def task_with_timeout_at(delay: float) -> float:
         # Set timeout far in the future
         when = time.time() + 10.0
-        async with asyncio.timeout_at(when):
+        async with asyncio.timeout_at(when):  # type: ignore[attr-defined]
             return await wait_and_return_delay(delay)
 
     async def main() -> None:
@@ -108,7 +108,7 @@ def test_asyncio_timeout_at() -> None:
 
     if len(exceptions) > 0:
         pprof_utils.print_all_samples(profile)
-        for e in exceptions:
-            print(e)
+        for exc in exceptions:
+            print(exc)
 
         raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_weak_links.py
+++ b/tests/profiling/collector/test_asyncio_weak_links.py
@@ -34,7 +34,7 @@ def test_asyncio_weak_links_wall_time() -> None:
     async def func_awaited() -> None:
         await asyncio.sleep(1)
 
-    async def parent() -> asyncio.Task:
+    async def parent() -> asyncio.Task[object]:
         await asyncio.sleep(0.5)
 
         t_not_awaited = asyncio.create_task(func_not_awaited(), name="Task-not_awaited")

--- a/tests/profiling/collector/test_lock_reflection.py
+++ b/tests/profiling/collector/test_lock_reflection.py
@@ -117,10 +117,10 @@ def is_accessible(obj: object, method_name: str) -> bool:
 @pytest.mark.parametrize("lock_class,collector_class,name", THREADING_LOCK_CONFIGS)
 def test_public_methods_accessible(lock_class: type[object], collector_class: type[object], name: str) -> None:
     """Verify wrapped lock exposes all public methods of the original."""
-    original: object = lock_class()  # type: ignore[operator]
+    original: object = lock_class()
     original_methods: set[str] = get_public_methods(original)
 
-    with collector_class(capture_pct=100):  # type: ignore[attr-defined]
+    with collector_class(capture_pct=100):  # type: ignore[call-arg, attr-defined]
         wrapped_class: Callable[[], _ProfiledLock] = getattr(threading, name)
         wrapped: _ProfiledLock = wrapped_class()
         missing: set[str] = {m for m in original_methods if not is_accessible(wrapped, m)}
@@ -135,10 +135,10 @@ def test_dunders_accessible(lock_class: type[object], collector_class: type[obje
     """Verify wrapped lock exposes all dunders of the original."""
     init_ddup(f"test_dunders_{name}")
 
-    original: object = lock_class()  # type: ignore[operator]
+    original: object = lock_class()
     original_dunders: set[str] = get_dunders(original)
 
-    with collector_class(capture_pct=100):  # type: ignore[attr-defined]
+    with collector_class(capture_pct=100):  # type: ignore[call-arg, attr-defined]
         wrapped_class: Callable[[], _ProfiledLock] = getattr(threading, name)
         wrapped: _ProfiledLock = wrapped_class()
         wrapped_dunders: set[str] = get_dunders(wrapped)

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -19,9 +19,7 @@ import pytest
 
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.internal.settings.profiling import ProfilingConfig
-from ddtrace.internal.settings.profiling import (
-    _derive_default_heap_sample_size,  # pyright: ignore[reportAttributeAccessIssue]
-)
+from ddtrace.internal.settings.profiling import _derive_default_heap_sample_size  # type: ignore[attr-defined]
 from ddtrace.profiling.collector import memalloc
 from tests.profiling.collector import pprof_utils
 
@@ -75,7 +73,7 @@ def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
 def test_heap_samples_collected() -> None:
     import os
 
-    from ddtrace.profiling import Profiler
+    from ddtrace.profiling.profiler import Profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _allocate_1k
 
@@ -148,7 +146,7 @@ def test_memory_collector_ignore_profiler(tmp_path: Path) -> None:
             quit_thread.wait()
 
         alloc_thread = threading.Thread(name="allocator", target=alloc)
-        alloc_thread._ddtrace_profiling_ignore = True  # pyright: ignore[reportAttributeAccessIssue]
+        alloc_thread._ddtrace_profiling_ignore = True  # type: ignore[attr-defined]
         alloc_thread.start()
 
         mc.snapshot()
@@ -171,7 +169,7 @@ def test_memory_collector_ignore_profiler(tmp_path: Path) -> None:
 )
 def test_heap_profiler_large_heap_overhead() -> None:
     # NOTE: A regression test for integer arithmetic bugs.
-    from ddtrace.profiling import Profiler
+    from ddtrace.profiling.profiler import Profiler
     from tests.profiling.collector.test_memalloc import one
 
     p = Profiler()
@@ -250,7 +248,7 @@ class HeapInfo:
 
 
 def has_function_in_profile_sample(
-    profile: pprof_pb2.Profile, sample: pprof_pb2.Sample, function_or_name: Union[Callable, str]
+    profile: pprof_pb2.Profile, sample: pprof_pb2.Sample, function_or_name: Union[Callable[..., object], str]
 ) -> bool:
     """Check if a pprof profile sample contains a function in its stack trace.
 
@@ -278,7 +276,7 @@ def has_function_in_profile_sample(
 
 
 def get_tracemalloc_stats_per_func(
-    stats: Sequence[Statistic], funcs: Sequence[Callable]
+    stats: Sequence[Statistic], funcs: Sequence[Callable[..., object]]
 ) -> tuple[dict[str, int], dict[str, int]]:
     source_to_func: dict[str, str] = {}
 
@@ -290,8 +288,8 @@ def get_tracemalloc_stats_per_func(
     actual_sizes: dict[str, int] = {}
     actual_counts: dict[str, int] = {}
     for stat in stats:
-        f = stat.traceback[0]  # type: ignore[assignment]
-        key = f.filename + str(f.lineno)  # type: ignore[attr-defined]
+        frame = stat.traceback[0]
+        key = frame.filename + str(frame.lineno)
         if key in source_to_func:
             func_name = source_to_func[key]
             actual_sizes[func_name] = stat.size
@@ -314,7 +312,7 @@ def test_memalloc_data_race_regression() -> None:
     import threading
     import time
 
-    from ddtrace.profiling import Profiler
+    from ddtrace.profiling.profiler import Profiler
 
     gc.enable()
     # This threshold is controls when garbage collection is triggered. The
@@ -448,7 +446,9 @@ def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: 
     actual_count_total = sum(actual_counts.values())
 
     def get_allocation_info_from_profile(
-        profile: pprof_pb2.Profile, samples: Sequence[pprof_pb2.Sample], funcs: Sequence[Union[Callable, str]]
+        profile: pprof_pb2.Profile,
+        samples: Sequence[pprof_pb2.Sample],
+        funcs: Sequence[Union[Callable[..., object], str]],
     ) -> dict[str, HeapInfo]:
         got: dict[str, HeapInfo] = {}
         for sample in samples:
@@ -783,7 +783,7 @@ def test_memory_collector_exception_handling(tmp_path: Path) -> None:
             assert profile is not None
             raise ValueError("Test exception")
 
-    with mc:
+    with mc:  # type: ignore[unreachable]
         _allocate_1k()
         profile = mc.snapshot_and_parse_pprof(output_filename)
         assert profile is not None
@@ -1232,7 +1232,7 @@ def test_memalloc_allocator_hook_does_not_release_gil() -> None:
     _memalloc.start(64, 1, False)
 
     stop = threading.Event()
-    shared: dict = {}
+    shared: dict[str, object] = {}
 
     def mutate(tid: int) -> None:
         i = 0

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1103,7 +1103,7 @@ def test_span_id_in_profile_after_fork() -> None:
             while time.monotonic() < end:
                 time.sleep(0.05)
 
-            bootstrap.profiler._profiler._scheduler.flush()
+            bootstrap.profiler._profiler._scheduler.flush()  # type: ignore[attr-defined]
 
             child_output = pprof_prefix + "." + str(os.getpid())
             profile = pprof_utils.parse_newest_profile(child_output)

--- a/tests/profiling/collector/test_stack_native.py
+++ b/tests/profiling/collector/test_stack_native.py
@@ -17,12 +17,12 @@ def test_start_native_monitoring_raises_runtime_error() -> None:
     """start_native_monitoring raises RuntimeError when PROFILER_ID is already claimed."""
     from ddtrace.internal.datadog.profiling.stack._stack import start_native_monitoring
 
-    sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "conflict")
+    sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "conflict")  # type: ignore[attr-defined]
     try:
         with pytest.raises(RuntimeError, match="sys.monitoring PROFILER_ID is already claimed"):
             start_native_monitoring()
     finally:
-        sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)
+        sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)  # type: ignore[attr-defined]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -34,7 +34,7 @@ def test_start_catches_runtime_error(caplog: pytest.LogCaptureFixture) -> None:
 
     native_call_monitor._started = False
 
-    sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "conflict")
+    sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "conflict")  # type: ignore[attr-defined]
     try:
         with caplog.at_level(logging.ERROR, logger="ddtrace.internal.datadog.profiling.native_call_monitor"):
             native_call_monitor.start()
@@ -42,7 +42,7 @@ def test_start_catches_runtime_error(caplog: pytest.LogCaptureFixture) -> None:
         assert "conflict" in caplog.text
         assert "sys.monitoring already claimed by another tool" in caplog.text
     finally:
-        sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)
+        sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)  # type: ignore[attr-defined]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -611,6 +611,7 @@ def test_flush_sample_handles_shallow_stack() -> None:
     """
     import threading
     import time
+    from typing import cast
 
     from ddtrace.profiling.collector._lock import _ProfiledLock
     from ddtrace.profiling.collector.threading import ThreadingLockCollector

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -33,7 +33,7 @@ from tests.profiling.collector.lock_test_common import assert_pep604_type_union_
 from tests.profiling.collector.lock_utils import LineNo
 from tests.profiling.collector.lock_utils import get_lock_linenos
 from tests.profiling.collector.lock_utils import init_linenos
-from tests.profiling.collector.pprof_utils import pprof_pb2
+from tests.profiling.collector.pprof_utils import pprof_pb2  # type: ignore[attr-defined]
 from tests.profiling.collector.test_utils import init_ddup
 
 
@@ -623,8 +623,7 @@ def test_flush_sample_handles_shallow_stack() -> None:
         lock = threading.Lock()
 
     # Access the wrapped _ProfiledLock
-    profiled_lock = lock
-    assert isinstance(profiled_lock, _ProfiledLock)
+    profiled_lock = cast(_ProfiledLock, lock)
 
     # Simulate acquired state
     profiled_lock.acquired_time = time.monotonic_ns()
@@ -926,7 +925,7 @@ class TestGenericLockProfiling(LockCollectorTestBase):
         assert isinstance(obj, wrapped_type)
         unpickled = pickle.loads(pickle.dumps(obj))
         assert not isinstance(unpickled, wrapped_type)
-        return unpickled
+        return unpickled  # type: ignore[no-any-return]
 
     def test_lock_class_pickle(self) -> None:
         """Test that the wrapped lock class can be pickled (Python 3.14+ forkserver compat)."""
@@ -1940,7 +1939,7 @@ class BaseSemaphoreTest(LockCollectorTestBase):
             assert isinstance(self.lock_class, LockAllocatorWrapper)
 
             # This should NOT raise TypeError
-            class CustomLock(self.lock_class):  # type: ignore[name-defined]
+            class CustomLock(self.lock_class):  # type: ignore[unreachable, name-defined]
                 def __init__(self) -> None:
                     super().__init__()
 
@@ -2237,7 +2236,7 @@ def test_exclude_modules_skips_wrapping() -> None:
 
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
-        assert not isinstance(lock, _ProfiledLock), "Lock from excluded module should be native, got _ProfiledLock"
+        assert not isinstance(lock, _ProfiledLock)  # type: ignore[unreachable]
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES="some.nonexistent.module"))
@@ -2253,7 +2252,7 @@ def test_exclude_modules_wraps_non_excluded() -> None:
 
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
-        assert isinstance(lock, _ProfiledLock), f"Lock should be profiled, got {type(lock)}"
+        assert isinstance(lock, _ProfiledLock)  # type: ignore[unreachable]
 
 
 @pytest.mark.subprocess()
@@ -2272,7 +2271,7 @@ def test_exclude_modules_empty_is_backward_compatible() -> None:
 
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
-        assert isinstance(lock, _ProfiledLock)
+        assert isinstance(lock, _ProfiledLock)  # type: ignore[unreachable]
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES="__main"))
@@ -2288,7 +2287,7 @@ def test_exclude_modules_prefix_requires_dot_boundary() -> None:
 
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
-        assert isinstance(lock, _ProfiledLock), "Prefix without dot boundary should not exclude"
+        assert isinstance(lock, _ProfiledLock)  # type: ignore[unreachable]
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_LOCK_EXCLUDE_MODULES="__main__,some.other.module"))
@@ -2304,4 +2303,4 @@ def test_exclude_modules_multiple() -> None:
 
     with ThreadingLockCollector(capture_pct=100):
         lock = threading.Lock()
-        assert not isinstance(lock, _ProfiledLock), "Lock from excluded module should be native"
+        assert not isinstance(lock, _ProfiledLock)  # type: ignore[unreachable]

--- a/tests/profiling/collector/test_utils.py
+++ b/tests/profiling/collector/test_utils.py
@@ -39,7 +39,7 @@ def async_run(coro: Coroutine[Any, Any, T]) -> T:
     if use_uvloop:
         import uvloop
 
-        return uvloop.run(coro)
+        return uvloop.run(coro)  # type: ignore[no-any-return]
     else:
         return asyncio.run(coro)
 

--- a/tests/profiling/gevent_fork.py
+++ b/tests/profiling/gevent_fork.py
@@ -9,7 +9,8 @@ gevent.monkey.patch_all()
 from ddtrace.profiling import profiler  # noqa:E402,F401
 
 
-p = profiler.Profiler().start()
+p = profiler.Profiler()
+p.start()
 
 pid = os.fork()
 if pid == 0:

--- a/tests/profiling/gunicorn-app.py
+++ b/tests/profiling/gunicorn-app.py
@@ -10,9 +10,8 @@ def fib(n: int) -> int:
 
 
 def app(environ: dict[str, str], start_response: Callable[[str, list[tuple[str, str]]], None]) -> list[bytes]:
-    response_body = f"fib(35) is {fib(35)} at pid {os.getpid()} tid {threading.get_ident()}"
-
-    response_body = response_body.encode("utf-8")
+    response_str = f"fib(35) is {fib(35)} at pid {os.getpid()} tid {threading.get_ident()}"
+    response_body = response_str.encode("utf-8")
 
     status = "200 OK" if response_body else "404 Not Found"
     headers = [("Content-type", "text/plain")]

--- a/tests/profiling/simple_program.py
+++ b/tests/profiling/simple_program.py
@@ -7,7 +7,7 @@ from ddtrace.profiling import bootstrap
 from ddtrace.profiling.collector import stack
 
 
-for running_collector in bootstrap.profiler._profiler._collectors:  # pyright: ignore[reportAttributeAccessIssue]
+for running_collector in bootstrap.profiler._profiler._collectors:  # type: ignore[attr-defined]
     if isinstance(running_collector, stack.StackCollector):
         break
 else:

--- a/tests/profiling/simple_program_fork.py
+++ b/tests/profiling/simple_program_fork.py
@@ -12,7 +12,7 @@ lock = threading.Lock()
 lock.acquire()
 
 
-assert ddtrace.profiling.bootstrap.profiler.status == service.ServiceStatus.RUNNING  # pyright: ignore[reportAttributeAccessIssue]
+assert ddtrace.profiling.bootstrap.profiler.status == service.ServiceStatus.RUNNING  # type: ignore[attr-defined]
 
 
 child_pid = os.fork()
@@ -26,7 +26,7 @@ if child_pid == 0:
     lock.release()
 else:
     lock.release()
-    assert ddtrace.profiling.bootstrap.profiler.status == service.ServiceStatus.RUNNING  # pyright: ignore[reportAttributeAccessIssue]
+    assert ddtrace.profiling.bootstrap.profiler.status == service.ServiceStatus.RUNNING  # type: ignore[attr-defined]
     print(child_pid)
     pid, status = os.waitpid(child_pid, 0)
     sys.exit(os.WEXITSTATUS(status))

--- a/tests/profiling/simple_program_pytorch_gpu.py
+++ b/tests/profiling/simple_program_pytorch_gpu.py
@@ -21,7 +21,7 @@ class FakeImageDataset(torch.utils.data.Dataset):
     def __len__(self) -> int:
         return self.size
 
-    def __getitem__(self, idx: int) -> tuple:
+    def __getitem__(self, idx: int) -> tuple[object, object]:
         return self.images[idx], self.labels[idx]
 
 

--- a/tests/profiling/test_code_provenance.py
+++ b/tests/profiling/test_code_provenance.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import sys
 import sysconfig
+from typing import Any
 
 import jsonschema
 from jsonschema.exceptions import ValidationError
@@ -61,9 +62,10 @@ def is_valid_json(s: str) -> bool:
         return False
 
 
-def _read_json(file_path: str) -> dict:
+def _read_json(file_path: str) -> dict[str, Any]:
     with open(file_path, encoding="utf-8") as f:
-        return json.load(f)
+        result: dict[str, Any] = json.load(f)
+        return result
 
 
 class TestCodeProvenance:
@@ -97,6 +99,7 @@ class TestCodeProvenance:
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix only")
     def test_lib_paths_are_absolute(self) -> None:
         file_path = get_code_provenance_file()
+        assert file_path is not None
         json_obj = _read_json(file_path)
 
         site_packages_path = sysconfig.get_path("purelib")
@@ -110,6 +113,7 @@ class TestCodeProvenance:
     @pytest.mark.skipif(sys.version_info < (3, 10), reason="Python 3.10+ only")
     def test_stdlib_paths(self) -> None:
         file_path = get_code_provenance_file()
+        assert file_path is not None
         json_obj = _read_json(file_path)
 
         # Check that the obj has stdlib

--- a/tests/profiling/test_process_role.py
+++ b/tests/profiling/test_process_role.py
@@ -101,9 +101,9 @@ def test_uwsgi_postfork_worker_role_via_mock(monkeypatch: pytest.MonkeyPatch) ->
     import ddtrace.internal.runtime as _runtime_mod
 
     def _raise_main(*args: object, **kwargs: object) -> None:
-        raise profiler.uwsgi.uWSGIMasterProcess()
+        raise profiler.uwsgi.uWSGIMasterProcess()  # type: ignore[attr-defined]
 
-    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _raise_main)
+    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _raise_main)  # type: ignore[attr-defined]
 
     # Simulate what happens to _PARENT_RUNTIME_ID after a real fork in a worker.
     monkeypatch.setattr(_runtime_mod, "_PARENT_RUNTIME_ID", "fake-parent-id")

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -539,7 +539,7 @@ def test_stop_then_start_new_profiler() -> None:
     p2 = profiler.Profiler()
     p2.start()
     assert profiler.Profiler._active_instance is p2
-    p2.stop(flush=False)
+    p2.stop(flush=False)  # type: ignore[unreachable]
 
 
 def test_same_profiler_restart_allowed() -> None:

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -87,7 +87,7 @@ def test_uwsgi_postfork_start_sets_active_instance(monkeypatch: pytest.MonkeyPat
     def _raise_master(*args, **kwargs):
         raise profiler.uwsgi.uWSGIMasterProcess()
 
-    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _raise_master)
+    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _raise_master)  # type: ignore[attr-defined]
 
     p = profiler.Profiler()
     p.start()
@@ -99,7 +99,7 @@ def test_uwsgi_postfork_start_sets_active_instance(monkeypatch: pytest.MonkeyPat
     p._start_on_fork()
     assert profiler.Profiler._active_instance is p
 
-    p.stop(flush=False)
+    p.stop(flush=False)  # type: ignore[unreachable]
 
 
 def test_uwsgi_worker_blocks_second_profiler_start(
@@ -113,7 +113,7 @@ def test_uwsgi_worker_blocks_second_profiler_start(
         callback_holder["callback"] = callback
         raise profiler.uwsgi.uWSGIMasterProcess()
 
-    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _register_postfork)
+    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _register_postfork)  # type: ignore[attr-defined]
 
     p1 = profiler.Profiler()
     p1.start()
@@ -123,7 +123,7 @@ def test_uwsgi_worker_blocks_second_profiler_start(
     assert profiler.Profiler._active_instance is p1
 
     # In workers, check_uwsgi should return normally.
-    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", lambda *args, **kwargs: None)
+    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", lambda *args, **kwargs: None)  # type: ignore[attr-defined]
 
     p2 = profiler.Profiler()
     with caplog.at_level(logging.ERROR, logger="ddtrace.profiling.profiler"):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -545,14 +545,14 @@ class TracerTestCase(TestSpanContainer, BaseTestCase):
         """Pop and return all spans from the writer"""
         writer = self.tracer._span_aggregator.writer
         if hasattr(writer, "pop"):
-            return writer.pop()
+            return writer.pop()  # type: ignore[no-any-return]
         return []
 
     def pop_traces(self) -> list[list[Span]]:
         """Pop and return all traces from the writer"""
         writer = self.tracer._span_aggregator.writer
         if hasattr(writer, "pop_traces"):
-            return writer.pop_traces()
+            return writer.pop_traces()  # type: ignore[no-any-return]
         return []
 
     def reset(self):
@@ -583,8 +583,8 @@ class TracerTestCase(TestSpanContainer, BaseTestCase):
 
 class DummyWriterMixin:
     def __init__(self, *args, **kwargs):
-        self.spans = []
-        self.traces = []
+        self.spans: list[Span] = []
+        self.traces: list[list[Span]] = []
         self.json_encoder = JSONEncoder()
         self.msgpack_encoder = Encoder(4 << 20, 4 << 20)
 
@@ -645,17 +645,17 @@ class DummyWriter(DummyWriterMixin, AgentWriterInterface):
         return DummyWriter(trace_flush_enabled=self.trace_flush_enabled)
 
     def flush_queue(self, raise_exc: bool = False) -> None:
-        return self._inner_writer.flush_queue(raise_exc)
+        self._inner_writer.flush_queue(raise_exc)
 
     def set_test_session_token(self, token: Optional[str]) -> None:
-        return self._inner_writer.set_test_session_token(token)
+        self._inner_writer.set_test_session_token(token)
 
     def stop(self, timeout: Optional[float] = None) -> None:
         self._inner_writer.stop(timeout=timeout)
 
     @property
     def interval(self) -> float:
-        return self._inner_writer._interval
+        return self._inner_writer._interval  # type: ignore[no-any-return]
 
     @interval.setter
     def interval(


### PR DESCRIPTION
## Description

PR #18077 enabled strict mypy settings. As a result, many profiling tests files now fail the pre-commit hook with old lints. This PR fixes them.

## Testing

* CI
