### PR TITLE
fix(tracing): handle env var values containing `=`

### DIFF
--- a/ddtrace/contrib/internal/subprocess/patch.py
+++ b/ddtrace/contrib/internal/subprocess/patch.py
@@ -284,7 +284,7 @@ class SubprocessCmdLine:
         """
         for idx, token in enumerate(tokens):
             if re.match(self._COMPILED_ENV_VAR_REGEXP, token):
-                var, value = token.split("=")
+                var, _ = token.split("=", 1)
                 if var in self.ENV_VARS_ALLOWLIST:
                     self.env_vars.append(token)
                 else:

--- a/ddtrace/contrib/internal/subprocess/patch.py
+++ b/ddtrace/contrib/internal/subprocess/patch.py
@@ -229,7 +229,7 @@ class SubprocessCmdLine:
         "*credentials*",
         "stripetoken",
     ]
-    _COMPILED_ENV_VAR_REGEXP = re.compile(r"\b[A-Z_]+=\w+")
+    _COMPILED_ENV_VAR_REGEXP = re.compile(r"\b[A-Z_][A-Z0-9_]*=\w+")
 
     def __init__(self, shell_args: Union[str, list[str]], shell: bool = False) -> None:
         """

--- a/releasenotes/notes/fix-subprocess-env-var-multi-equals-c8f20ac468cdd905.yaml
+++ b/releasenotes/notes/fix-subprocess-env-var-multi-equals-c8f20ac468cdd905.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    tracing: Fixes the subprocess integration silently spans for
+    any shell command whose env-var assignment contained ``=`` in the
+    value.

--- a/releasenotes/notes/fix-subprocess-env-var-multi-equals-c8f20ac468cdd905.yaml
+++ b/releasenotes/notes/fix-subprocess-env-var-multi-equals-c8f20ac468cdd905.yaml
@@ -4,3 +4,5 @@ fixes:
     tracing: Fixes the subprocess integration silently spans for
     any shell command whose env-var assignment contained ``=`` in the
     value.
+    tracing: The subprocess integration now correctly scrubs env-var
+    values for env-var names containing digits.

--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -113,6 +113,25 @@ for allowed in SubprocessCmdLine.ENV_VARS_ALLOWLIST:
             "lower=baz",
             ["dir", "-li", "/", "OTHER=any"],
         ),
+        # Regression: a value containing ``=`` (legal shell, e.g. base64 with
+        # padding, ``URL=...?k=v``, or just two ``=`` chained) made
+        # ``token.split("=")`` return 3 items, raising ``ValueError`` on the
+        # two-name unpack. The outer ``except Exception`` swallowed it and
+        # the subprocess span was dropped.
+        (
+            SubprocessCmdLine(["FOO=key=value", "BAR=baz", "dir", "-li", "/"], shell=True),
+            ["FOO=?", "BAR=?", "dir", "-li", "/"],
+            ["FOO=?", "BAR=?"],
+            "dir",
+            ["-li", "/"],
+        ),
+        (
+            SubprocessCmdLine(["BASE64=YWJjPT0=", "dir", "-li", "/"], shell=True),
+            ["BASE64=?", "dir", "-li", "/"],
+            ["BASE64=?"],
+            "dir",
+            ["-li", "/"],
+        ),
     ]
     + allowed_envvars_fixture_list,
 )

--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -142,6 +142,27 @@ def test_shellcmdline(cmdline_obj, full_list, env_vars, binary, arguments):
     assert cmdline_obj.arguments == arguments
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "BASE64",  # digit in the middle
+        "HTTP2",  # digit at the end
+        "S3_BUCKET",  # digit right after underscore
+        "A1B2C3",  # alternating letters and digits
+    ],
+)
+def test_shellcmdline_scrubs_env_var_names_with_digits(name: str) -> None:
+    """Env var names containing digits must be recognised and their values scrubbed.
+
+    Regression: _COMPILED_ENV_VAR_REGEXP used [A-Z_]+ which excludes digits,
+    so names like BASE64 were not matched and values were never redacted.
+    """
+    token = f"{name}=secret"
+    cmdline = SubprocessCmdLine([token, "ls"], shell=True)
+    assert cmdline.env_vars == [f"{name}=?"], f"value of {name} was not scrubbed"
+    assert cmdline.binary == "ls"
+
+
 denied_binaries_fixture_list = []
 for denied in SubprocessCmdLine.BINARIES_DENYLIST:
     denied_binaries_fixture_list.extend(


### PR DESCRIPTION
## Description

Previously, we would `split` without a component count limit, meaning if we had `ENV=something=else` an exception would be raised and we would fail to process it. Added a limit of 2 components so that we get the env variable name and discard all the rest, making it safer. 

On top of that, the PR adds support for env var names containing digits -- those didn't use to match the regex and were thus ignored from scrubbing. 