### PR TITLE
ci(fastapi): remove _dd.svc_src from background task

### DIFF
--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_background_task.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_background_task.json
@@ -12,7 +12,6 @@
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de531200000000",
       "_dd.span_links": "[{\"trace_id\": \"69de531200000000428252973eaf1842\", \"span_id\": \"bb6f224cb84fb9c8\", \"tracestate\": \"dd=s:1;t.dm:-0\", \"flags\": 1}]",
-      "_dd.svc_src": "tests.contrib.fastapi",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.fastapi",
       "language": "python",
       "runtime-id": "dadd78cb1d684e1e85f172be729d1a20"


### PR DESCRIPTION
## Description

#17712 removed `_dd.svc_src` from root spans, but at the time that PR was merged this test was was not, so the update to the snapshot file was missed.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes flaky tests: DD_0XKLHK DD_D30WIB DD_TY6LL2 DD_EMOSBW DD_C5VYBH DD_O1QYEP
