### PR TITLE
chore(asyncpg): avoid shadowing Protocol methods when unwrapping

### DIFF
--- a/ddtrace/contrib/internal/asyncpg/patch.py
+++ b/ddtrace/contrib/internal/asyncpg/patch.py
@@ -10,6 +10,7 @@ from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.trace_utils import ext_service
+from ddtrace.contrib.internal.trace_utils import iswrapped
 from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import wrap
@@ -33,6 +34,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 DBMS_NAME = "postgresql"
+
+_PROTOCOL_METHODS = ("execute", "bind_execute", "query", "bind_execute_many")
 
 
 config._add(
@@ -156,7 +159,7 @@ async def _traced_protocol_execute(asyncpg, pin, func, instance, args, kwargs):
 
 def _patch(asyncpg: ModuleType) -> None:
     wrap(asyncpg, "connect", _traced_connect(asyncpg))
-    for method in ("execute", "bind_execute", "query", "bind_execute_many"):
+    for method in _PROTOCOL_METHODS:
         wrap(asyncpg.protocol, "Protocol.%s" % method, _traced_protocol_execute(asyncpg))
 
 
@@ -174,8 +177,13 @@ def patch() -> None:
 
 def _unpatch(asyncpg: ModuleType) -> None:
     unwrap(asyncpg, "connect")
-    for method in ("execute", "bind_execute", "query", "bind_execute_many"):
-        unwrap(asyncpg.protocol.Protocol, method)
+    for method in _PROTOCOL_METHODS:
+        # DEV: Use delattr rather than unwrap()/setattr to avoid leaving a Cython descriptor
+        # shadow in Protocol.__dict__. unwrap() calls setattr which places the BaseProtocol
+        # descriptor directly into Protocol.__dict__; a subsequent patch() call then re-wraps
+        # that shadow instead of resolving the method naturally via MRO from BaseProtocol.
+        if iswrapped(asyncpg.protocol.Protocol, method):
+            delattr(asyncpg.protocol.Protocol, method)
 
 
 def unpatch() -> None:

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -5,6 +5,7 @@ import asyncpg
 import mock
 import pytest
 
+from ddtrace.contrib.internal.asyncpg.patch import _PROTOCOL_METHODS
 from ddtrace.contrib.internal.asyncpg.patch import patch
 from ddtrace.contrib.internal.asyncpg.patch import unpatch
 from ddtrace.contrib.internal.trace_utils import iswrapped
@@ -377,6 +378,47 @@ def test_patch_unpatch_asyncpg():
     assert not iswrapped(asyncpg.protocol.Protocol.bind_execute)
     assert not iswrapped(asyncpg.protocol.Protocol.query)
     assert not iswrapped(asyncpg.protocol.Protocol.bind_execute_many)
+
+
+def test_unpatch_removes_method_shadow():
+    # Regression: unpatch must not leave Cython descriptor shadows in Protocol.__dict__.
+    # unwrap() used setattr which placed the BaseProtocol descriptor directly into
+    # Protocol.__dict__, causing a subsequent patch() call to re-wrap the shadow instead
+    # of resolving the method naturally via MRO.
+    for method in _PROTOCOL_METHODS:
+        assert method in asyncpg.protocol.Protocol.__dict__
+
+    unpatch()
+
+    for method in _PROTOCOL_METHODS:
+        assert method not in asyncpg.protocol.Protocol.__dict__, (
+            f"Protocol.__dict__ has residual shadow for '{method}' after unpatch; "
+            "re-patching will wrap the shadow instead of the natural MRO method"
+        )
+
+
+def test_patch_unpatch_patch_cycle():
+    # Regression: patch/unpatch/patch must produce correctly wrapped Protocol methods
+    # without double-wrapping.
+    unpatch()
+    patch()
+
+    for method in _PROTOCOL_METHODS:
+        assert iswrapped(asyncpg.protocol.Protocol, method), (
+            f"Protocol.{method} not wrapped after patch/unpatch/patch cycle"
+        )
+        wrapper = asyncpg.protocol.Protocol.__dict__[method]
+        assert not iswrapped(wrapper.__wrapped__), (
+            f"Protocol.{method} is double-wrapped after patch/unpatch/patch cycle"
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_after_patch_unpatch_patch(patched_conn):
+    # Regression: executing a query must succeed after patch/unpatch/patch.
+    unpatch()
+    patch()
+    await patched_conn.execute("SELECT 1")
 
 
 class AsyncPgTestCase(AsyncioTestCase):


### PR DESCRIPTION
## Description

Fix an issue with property shadowing in asyncpg Protocol patching.

`asyncpg.protocol.Protocol` is a Python class, which inherits from the Cython/c-class BaseProtocol.

BaseProtocol is the class which defines all of the method we instrument for this integration.

When we wrap a method on `Protocol`, we wrap the original `BaseProtocol` method and then `setattr` it onto the Python `Protocol` class.

When we unwrap, we do `setattr` again to set the original `BaseProtocol` method directly onto the `Protocol` class.

This change ensures that we use `delattr` instead of `setattr` to restore the original state of `Protocol` and remove the shadowing of the `BaseProtocol` attributes on `Protocol`.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

I found this while investigating a segfault in our CI on teardown with `asyncpg`. This is a theoretical fix for the problem, but I was not able to reproduce the segfault locally to reproduce.


Skipping release note since unpatching integrations is not part of the public API, it is only from within our test suite that this behavior occurs.
