### PR TITLE
ci: save venvs + binaries from riot jobs

### DIFF
--- a/.gitlab/templates/build-base-venvs.yml
+++ b/.gitlab/templates/build-base-venvs.yml
@@ -30,8 +30,6 @@ build_base_venvs:
     riot -v run -s --python=$PYTHON_VERSION smoke_test
   artifacts:
     name: venv_$PYTHON_VERSION
+    when: always
     paths:
-      - .riot/venv_*
-      - ddtrace/_version.py
-      - ddtrace/**/*.so*
-      - ddtrace/internal/datadog/profiling/test/test_*
+      - !reference [.riot_job_artifacts, artifacts, paths]

--- a/.gitlab/templates/build-base-venvs.yml
+++ b/.gitlab/templates/build-base-venvs.yml
@@ -31,5 +31,4 @@ build_base_venvs:
   artifacts:
     name: venv_$PYTHON_VERSION
     when: always
-    paths:
-      - !reference [.riot_job_artifacts, artifacts, paths]
+    paths: !reference [.riot_job_artifacts, artifacts, paths]

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -12,6 +12,15 @@ include:
   - local: ".gitlab/services.yml"
   - local: ".gitlab/testrunner.yml"
 
+.riot_job_artifacts:
+  artifacts:
+    when: always
+    paths:
+      - core.*
+      - .riot/venv_*
+      - ddtrace/**/*.so*
+      - ddtrace/internal/datadog/profiling/test/test_*
+
 # Do not define a `needs:` in order to depend on the whole `precheck` stage
 .test_base_riot:
   extends: .testrunner
@@ -20,6 +29,13 @@ include:
   parallel: 4
   services:
     - !reference [.services, ddagent]
+  artifacts:
+    when: always
+    paths:
+      - !reference [.riot_job_artifacts, artifacts, paths]
+    reports:
+      junit: test-results/junit*.xml
+    expire_in: 1 week
   # DEV: This is the max retries that GitLab currently allows for
   before_script:
     - !reference [.testrunner, before_script]

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -31,8 +31,7 @@ include:
     - !reference [.services, ddagent]
   artifacts:
     when: always
-    paths:
-      - !reference [.riot_job_artifacts, artifacts, paths]
+    paths: !reference [.riot_job_artifacts, artifacts, paths]
     reports:
       junit: test-results/junit*.xml
     expire_in: 1 week

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -19,7 +19,6 @@ include:
       - core.*
       - .riot/venv_*
       - ddtrace/**/*.so*
-      - ddtrace/internal/datadog/profiling/test/test_*
 
 # Do not define a `needs:` in order to depend on the whole `precheck` stage
 .test_base_riot:


### PR DESCRIPTION
## Description

My goal is to see if we can make it easier to reproduce CI issues locally (e.g. segfaults). The one piece missing is being able to get the exact same binaries that are run by ddtrace + the test dependencies. Rebuilding native extensions locally is not always going to be 1:1 with what happens in CI.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
