### PR TITLE
fix(writer, llmobs): suppress agent error log if llmobs and agentless are enabled

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1036,7 +1036,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
                 msg += ", payload %s"
                 log_args += (binascii.hexlify(encoded).decode(),)  # type: ignore
 
-            _safelog(log.error, msg, *log_args, extra={"send_to_telemetry": False})
+            if not (config._llmobs_enabled and config._llmobs_agentless_enabled):
+                _safelog(log.error, msg, *log_args, extra={"send_to_telemetry": False})
 
     def periodic(self):
         self.flush_queue(raise_exc=False)

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1036,8 +1036,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
                 msg += ", payload %s"
                 log_args += (binascii.hexlify(encoded).decode(),)  # type: ignore
 
-            if not (config._llmobs_enabled and config._llmobs_agentless_enabled):
-                _safelog(log.error, msg, *log_args, extra={"send_to_telemetry": False})
+            _safelog(log.error, msg, *log_args, extra={"send_to_telemetry": False})
 
     def periodic(self):
         self.flush_queue(raise_exc=False)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from dataclasses import field
 import inspect
 import json
+import logging
 import math
 import sys
 import time
@@ -183,6 +184,22 @@ _SUMMARY_EVALUATOR_REQUIRED_PARAMS = (
     "expected_outputs",
     "evaluators_results",
 )
+
+
+class _AgentConnectionFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not record.getMessage().startswith("failed to send, dropping")
+
+
+def _suppress_agent_connection_errors() -> None:
+    writer_logger = logging.getLogger("ddtrace.internal.writer.writer")
+    if not any(isinstance(f, _AgentConnectionFilter) for f in writer_logger.filters):
+        writer_logger.addFilter(_AgentConnectionFilter())
+
+
+def _restore_agent_connection_errors() -> None:
+    writer_logger = logging.getLogger("ddtrace.internal.writer.writer")
+    writer_logger.filters = [f for f in writer_logger.filters if not isinstance(f, _AgentConnectionFilter)]
 
 
 def _validate_task_signature(task: Callable, is_async: bool) -> None:
@@ -781,7 +798,6 @@ class LLMObs(Service):
         config.service = service or config.service
         config._llmobs_ml_app = ml_app or config._llmobs_ml_app
         config._llmobs_instrumented_proxy_urls = instrumented_proxy_urls or config._llmobs_instrumented_proxy_urls
-        config._llmobs_enabled = True
 
         error = None
         start_ns = time.time_ns()
@@ -814,6 +830,10 @@ class LLMObs(Service):
                 # Since the API key can be set programmatically and TelemetryWriter is already initialized by now,
                 # we need to force telemetry to use agentless configuration
                 telemetry_writer.enable_agentless_client(True)
+
+                # Suppress agent connection error logs from the trace writer in agentless mode — the
+                # agent is not expected to be running, so these errors are noise.
+                _suppress_agent_connection_errors()
 
             if integrations_enabled:
                 cls._patch_integrations()
@@ -1552,6 +1572,7 @@ class LLMObs(Service):
 
         cls._instance.stop()
         cls.enabled = False
+        _restore_agent_connection_errors()
         # Align config._llmobs_enabled with effective state for user-initiated calls.
         # When _auto=True, the caller (RC handler) has already written _rc_value;
         # stamping "code" here would mask env/code state when _rc_value later clears.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -781,6 +781,7 @@ class LLMObs(Service):
         config.service = service or config.service
         config._llmobs_ml_app = ml_app or config._llmobs_ml_app
         config._llmobs_instrumented_proxy_urls = instrumented_proxy_urls or config._llmobs_instrumented_proxy_urls
+        config._llmobs_enabled = True
 
         error = None
         start_ns = time.time_ns()

--- a/releasenotes/notes/llmobs-suppress-agentless-agent-connection-errors-7c52ce5e69ca1f8a.yaml
+++ b/releasenotes/notes/llmobs-suppress-agentless-agent-connection-errors-7c52ce5e69ca1f8a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Agent connection error logs are no longer logged when using agentless and not running a Datadog agent.


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

Suppresses the `failed to send, dropping %d traces to intake at %s: %s` log when there is no agent running but we try to submit a payload, specifically only when LLM Observability is enabled, and its agentless data submission configuration is set to `True`.

For the most part, these two conditions being met means that someone is trialing LLM Observability locally. In this case, the agent connection error log is a confusing source of friction. I can't think of a scenario where someone would be using agentless LLM Observability and potentially want to see that log, but open to suggestions!

Agentless LLM Observability can either be enabled manually (`agentless_enabled=True`), or it can be calculated by seeing if the agent is running. 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

Tested locally with no agent running, and this log was not printed.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

If folks are getting agentless LLM Observability from a calculated value (if the agent is running or not), then we could be suppressing this log unnecessarily...
