### PR TITLE
chore(crashtracking): turn on errors intake upload by default

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -138,6 +138,8 @@ def _get_args(additional_tags: Optional[dict[str, str]]):
 
     # Don't pass all env vars to the receiver process, because there are
     # conflicts with export location derivation
+
+    # Errors intake is enabled by default in the libdatadog layer; only override if explicitly set
     crashtracking_enabled = env.get("DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED")
     if crashtracking_enabled is not None:
         receiver_env["DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED"] = crashtracking_enabled

--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -138,11 +138,9 @@ def _get_args(additional_tags: Optional[dict[str, str]]):
 
     # Don't pass all env vars to the receiver process, because there are
     # conflicts with export location derivation
-
-    # Errors intake is enabled by default in the libdatadog layer; only override if explicitly set
-    crashtracking_enabled = env.get("DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED")
-    if crashtracking_enabled is not None:
-        receiver_env["DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED"] = crashtracking_enabled
+    receiver_env["DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED"] = (
+        "true" if crashtracker_config.errors_intake_enabled else "false"
+    )
 
     # Crashtracker is supported only on Linux and macOS, so we only need to inherit
     # these library path environment variables.

--- a/ddtrace/internal/settings/crashtracker.py
+++ b/ddtrace/internal/settings/crashtracker.py
@@ -53,6 +53,14 @@ class CrashtrackingConfig(DDConfig):
 
     enabled = DDConfig.d(bool, _derive_crashtracking_enabled)
 
+    errors_intake_enabled = DDConfig.v(
+        bool,
+        "errors_intake_enabled",
+        default=True,
+        help_type="Boolean",
+        help="Whether to send crash reports to the errors intake.",
+    )
+
     debug_url = DDConfig.v(
         t.Optional[str],
         "debug_url",

--- a/ddtrace/internal/settings/crashtracker.pyi
+++ b/ddtrace/internal/settings/crashtracker.pyi
@@ -4,6 +4,7 @@ from ddtrace.internal.settings._core import DDConfig
 
 class CrashtrackingConfig(DDConfig):
     enabled: bool
+    errors_intake_enabled: bool
     debug_url: Optional[str]
     _test_token: Optional[str]
     stdout_filename: Optional[str]

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -976,9 +976,9 @@
     ],
     "DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED": [
       {
-        "implementation": "A",
+        "implementation": "B",
         "type": "boolean",
-        "default": "false"
+        "default": "true"
       }
     ],
     "DD_CRASHTRACKING_MAX_THREADS": [

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -217,6 +217,7 @@ import opentelemetry
         {"name": "DD_CRASHTRACKING_CREATE_ALT_STACK", "origin": "default", "value": True},
         {"name": "DD_CRASHTRACKING_DEBUG_URL", "origin": "default", "value": None},
         {"name": "DD_CRASHTRACKING_ENABLED", "origin": "default", "value": True},
+        {"name": "DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED", "origin": "default", "value": True},
         {"name": "DD_CRASHTRACKING_MAX_THREADS", "origin": "default", "value": 128},
         {
             "name": "DD_CRASHTRACKING_STACKTRACE_RESOLVER",


### PR DESCRIPTION
## Description

Updating config list to reflect config registry. We should also use DDConf, not raw env vars

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

None. All operations are post terminal crash, and upload happens on a sidecar receiver process. Crash upload bound by proven timeout; no issues from usage since november of 2025

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
