### PR TITLE
fix(pydantic_ai): swap operation/resource names to match APM convention

### DIFF
--- a/ddtrace/contrib/internal/pydantic_ai/patch.py
+++ b/ddtrace/contrib/internal/pydantic_ai/patch.py
@@ -28,13 +28,20 @@ def _supported_versions() -> dict[str, str]:
 PYDANTIC_AI_VERSION = parse_version(get_version())
 
 
+def _agent_resource(instance) -> str:
+    return getattr(instance, "name", None) or "Pydantic Agent"
+
+
 def traced_agent_run_stream(func, instance, args, kwargs):
     integration = pydantic_ai._datadog_integration
     integration._run_stream_active = True
     span = integration.trace(
-        "Pydantic Agent", submit_to_llmobs=True, model=getattr(instance, "model", None), kind="agent"
+        _agent_resource(instance),
+        span_name="pydantic_ai.agent",
+        submit_to_llmobs=True,
+        model=getattr(instance, "model", None),
+        kind="agent",
     )
-    span.name = getattr(instance, "name", None) or "Pydantic Agent"
 
     result = func(*args, **kwargs)
     kwargs["instance"] = instance
@@ -48,9 +55,12 @@ def traced_agent_iter(func, instance, args, kwargs):
         integration._run_stream_active = False
         return func(*args, **kwargs)
     span = integration.trace(
-        "Pydantic Agent", submit_to_llmobs=True, model=getattr(instance, "model", None), kind="agent"
+        _agent_resource(instance),
+        span_name="pydantic_ai.agent",
+        submit_to_llmobs=True,
+        model=getattr(instance, "model", None),
+        kind="agent",
     )
-    span.name = getattr(instance, "name", None) or "Pydantic Agent"
 
     result = func(*args, **kwargs)
     kwargs["instance"] = instance
@@ -88,8 +98,9 @@ async def traced_tool_run(func, instance, args, kwargs, tool_name):
     integration = pydantic_ai._datadog_integration
     resp = None
     try:
-        span = integration.trace("Pydantic Tool", submit_to_llmobs=True, kind="tool")
-        span.name = tool_name
+        span = integration.trace(
+            tool_name, span_name="pydantic_ai.tool", submit_to_llmobs=True, kind="tool"
+        )
         resp = await func(*args, **kwargs)
         return resp
     except Exception:

--- a/releasenotes/notes/fix-pydantic-ai-apm-span-naming-3746b4f51b9538e0.yaml
+++ b/releasenotes/notes/fix-pydantic-ai-apm-span-naming-3746b4f51b9538e0.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    pydantic_ai: This fix resolves an issue where ``operation_name`` and ``resource_name``
+    were reversed on Pydantic AI spans. Spans now follow the standard APM convention, with
+    ``operation_name`` set to ``pydantic_ai.agent`` / ``pydantic_ai.tool`` and ``resource_name``
+    set to the specific agent or tool name, so service pages and resource breakdowns group
+    correctly.

--- a/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run.json
+++ b/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "test_agent",
+    "name": "pydantic_ai.agent",
     "service": "tests.contrib.pydantic_ai",
-    "resource": "Pydantic Agent",
+    "resource": "test_agent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run_error.json
+++ b/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run_error.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "test_agent",
+    "name": "pydantic_ai.agent",
     "service": "tests.contrib.pydantic_ai",
-    "resource": "Pydantic Agent",
+    "resource": "test_agent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_with_tools.json
+++ b/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_with_tools.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "test_agent",
+    "name": "pydantic_ai.agent",
     "service": "tests.contrib.pydantic_ai",
-    "resource": "Pydantic Agent",
+    "resource": "test_agent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -28,9 +28,9 @@
     "start": 1776698460779545137
   },
      {
-       "name": "calculate_square_tool",
+       "name": "pydantic_ai.tool",
        "service": "tests.contrib.pydantic_ai",
-       "resource": "Pydantic Tool",
+       "resource": "calculate_square_tool",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,


### PR DESCRIPTION
## AI;DR
The Pydantic AI contrib swaps the span's name and resource. This MR fixes that. 

This closes this issue: https://github.com/DataDog/dd-trace-py/issues/18148

## Description

The Pydantic AI contrib emits APM spans with `operation_name` and `resource_name` reversed from Datadog convention:

| Before | After |
|---|---|
| `op=bash,                  res="Pydantic Tool"`  | `op=pydantic_ai.tool,  res=bash` |
| `op=read_file,             res="Pydantic Tool"`  | `op=pydantic_ai.tool,  res=read_file` |
| `op=merge_bot,             res="Pydantic Agent"` | `op=pydantic_ai.agent, res=merge_bot` |

Per the [Datadog APM convention](https://docs.datadoghq.com/tracing/glossary/#span-tags), `operation_name` is the generic category and `resource_name` is the specific instance. Today the contrib does the inverse: `span.name = tool_name` after `integration.trace("Pydantic Tool", ...)` sets `resource="Pydantic Tool"`. Service pages and resource breakdowns therefore lose the per-tool/per-workflow dimension.

This PR:
1. Removes the post-hoc `span.name = <specific>` overrides in `traced_agent_run_stream`, `traced_agent_iter`, and `traced_tool_run`.
2. Passes the specific tool/agent name as `operation_id` (which becomes `resource_name`), and an explicit `span_name="pydantic_ai.tool"` / `"pydantic_ai.agent"` for `operation_name`.

### Why LLM Observability is unaffected

The LLMObs UI reads the displayed name from `get_llmobs_span_name(span)`, which looks up the metastruct's `_llmobs.name` field with a fallback to `span.name`. In this contrib, `_llmobs_set_tags_agent` and `_llmobs_set_tags_tool` already call `_annotate_llmobs_span_data(span, name=<tool/agent name>, ...)`, so the metastruct already carries the specific name. The fallback to `span.name` no longer fires in this code path.

Closes #18148

## Testing

- Updated three snapshot fixtures to match the new shape:
  - `test_agent_run.json`: `name=test_agent`, `resource="Pydantic Agent"` → `name=pydantic_ai.agent`, `resource=test_agent`
  - `test_agent_run_error.json`: same swap
  - `test_agent_with_tools.json`: same swap for the agent span; `name=calculate_square_tool`, `resource="Pydantic Tool"` → `name=pydantic_ai.tool`, `resource=calculate_square_tool` for the tool span
- Existing LLMObs tests in `test_pydantic_ai_llmobs.py` are unchanged and continue to assert on the metastruct `name` field — they should still pass because `_llmobs_set_tags_agent`/`_tool` populate that field with the specific name.

## Risks

- **Span name change is observable to anyone querying by `operation_name`/`resource_name`.** Dashboards and monitors filtering `operation_name:bash` or `resource_name:"Pydantic Tool"` will need to update. Mitigated by the release note flagging the change.
- Snapshot regenerate paths: if the dd-trace-py snapshot generator runs against a freshly built workload (gpt-4o + pydantic-ai), the new fixtures should match.

## Additional Notes

A separate concern (out of scope for this PR) is that the LLMObs SDK's `LLMObs.agent(name=...)` / `LLMObs.tool(name=...)` in `ddtrace/llmobs/_llmobs.py` exhibits the same swapped convention via `tracer.trace(name, resource=operation_kind, ...)`. Fixing that would touch every LLMObs integration, so I'm raising it as a discussion point rather than including it here. Happy to file a separate issue if useful.
