### PR TITLE
fix(langchain, botocore): resolve Bedrock inference-profile ARN to base models [backport 4.8]

### DIFF
--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -11,6 +11,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import lookup_inference_profile
 from ddtrace.llmobs._integrations.base_stream_handler import StreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._integrations.bedrock_utils import _AI21
@@ -453,11 +454,30 @@ def handle_bedrock_response(
     return result
 
 
+def _resolve_application_inference_profile(model_id, model_provider, model_name):
+    """If model_id is an application-inference-profile ARN whose base model is known
+    (cached by the langchain integration), return the resolved
+    (model_id, model_provider, model_name) where model_id is now the base model
+    id string instead of the opaque ARN. Otherwise return the inputs unchanged.
+
+    Overriding model_id matters because the LLM Obs annotator reads
+    ``ctx.get_item("model_id")`` first and only falls back to ``model_name``.
+    """
+    if not isinstance(model_id, str) or "application-inference-profile/" not in model_id:
+        return model_id, model_provider, model_name
+    cached_base_model_id = lookup_inference_profile(model_id)
+    if not cached_base_model_id:
+        return model_id, model_provider, model_name
+    new_provider, new_name = parse_model_id(cached_base_model_id)
+    return cached_base_model_id, new_provider, new_name
+
+
 def patched_bedrock_api_call(original_func, instance, args, kwargs, function_vars):
     params = function_vars.get("params")
     pin = function_vars.get("pin")
     model_id = params.get("modelId")
     model_provider, model_name = parse_model_id(model_id)
+    model_id, model_provider, model_name = _resolve_application_inference_profile(model_id, model_provider, model_name)
     integration = function_vars.get("integration")
     submit_to_llmobs = integration.llmobs_enabled and "embed" not in model_name
     with core.context_with_data(

--- a/ddtrace/contrib/internal/langchain/patch.py
+++ b/ddtrace/contrib/internal/langchain/patch.py
@@ -14,6 +14,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._integrations import LangChainIntegration
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import record_inference_profile
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.trace import Span
 
@@ -33,10 +34,37 @@ config._add("langchain", {})
 
 
 def _extract_model_name(instance: Any) -> Optional[str]:
-    """Extract model name or ID from llm instance."""
-    for attr in ("model", "model_name", "model_id", "model_key", "repo_id"):
-        if hasattr(instance, attr):
-            return getattr(instance, attr)
+    """Extract model name or ID from llm instance.
+
+    Strips path prefixes (e.g. "models/gemini-2.5-flash" → "gemini-2.5-flash")
+    since some providers use resource paths rather than bare model names.
+
+    `base_model_id` is checked first so that langchain-aws ChatBedrockConverse
+    instances using an inference profile (where `model_id` is the profile ARN
+    and `base_model_id` is the underlying foundation model) report the
+    foundation model rather than the opaque profile identifier.
+
+    When the instance carries both an application-inference-profile
+    ARN in `model_id` and a `base_model_id`, the mapping is stored in a shared
+    process-local cache so the botocore Bedrock integration can resolve the
+    same ARN on its own span without an extra AWS call.
+    """
+    model_id_attr = getattr(instance, "model_id", None)
+    base_model_id_attr = getattr(instance, "base_model_id", None)
+    if (
+        isinstance(model_id_attr, str)
+        and isinstance(base_model_id_attr, str)
+        and "application-inference-profile/" in model_id_attr
+    ):
+        record_inference_profile(model_id_attr, base_model_id_attr)
+
+    for attr in ("base_model_id", "model", "model_name", "model_id", "model_key", "repo_id"):
+        model_name = getattr(instance, attr, None)
+        if not model_name:
+            continue
+        if isinstance(model_name, str) and "/" in model_name:
+            model_name = model_name.split("/")[-1]
+        return model_name
     return None
 
 

--- a/ddtrace/llmobs/_integrations/_bedrock_inference_profiles.py
+++ b/ddtrace/llmobs/_integrations/_bedrock_inference_profiles.py
@@ -1,0 +1,36 @@
+"""Process-local cache mapping AWS Bedrock application-inference-profile ARNs to
+their underlying base model ids.
+
+Populated by the langchain integration when it sees a ChatBedrockConverse instance
+that carries both `model_id` (the profile ARN) and `base_model_id` (the underlying
+model), and consulted by the botocore integration when it processes a Bedrock API
+call whose `modelId` is an application-inference-profile ARN. This lets the
+botocore span report the resolved base model without having to call
+`bedrock:GetInferenceProfile` or construct its own boto3 client.
+"""
+
+import threading
+from typing import Optional
+
+
+_INFERENCE_PROFILE_CACHE: dict[str, str] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def record_inference_profile(profile_arn: str, base_model_id: str) -> None:
+    if not profile_arn or not base_model_id:
+        return
+    with _CACHE_LOCK:
+        _INFERENCE_PROFILE_CACHE[profile_arn] = base_model_id
+
+
+def lookup_inference_profile(profile_arn: str) -> Optional[str]:
+    if not profile_arn:
+        return None
+    with _CACHE_LOCK:
+        return _INFERENCE_PROFILE_CACHE.get(profile_arn)
+
+
+def _clear_inference_profile_cache() -> None:
+    with _CACHE_LOCK:
+        _INFERENCE_PROFILE_CACHE.clear()

--- a/releasenotes/notes/fix-langchain-bedrock-converse-base-model-id-2cab8072e48dec85.yaml
+++ b/releasenotes/notes/fix-langchain-bedrock-converse-base-model-id-2cab8072e48dec85.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    langchain, botocore: This fix resolves an issue where auto-instrumented
+    ``langchain_aws.ChatBedrockConverse`` spans reported an opaque inference-profile
+    ARN identifier as the model name when an inference profile was used.
+    ``base_model_id`` which represents the underlying foundation model is now
+    checked first when extracting model names, and the botocore Bedrock
+    integration reads the resolved base model from a shared in-process cache
+    populated by langchain so the same resolution applies to the underlying
+    ``bedrock-runtime`` span.

--- a/tests/contrib/langchain/test_langchain_patch.py
+++ b/tests/contrib/langchain/test_langchain_patch.py
@@ -1,6 +1,11 @@
+import pytest
+
+from ddtrace.contrib.internal.langchain.patch import _extract_model_name
 from ddtrace.contrib.internal.langchain.patch import get_version
 from ddtrace.contrib.internal.langchain.patch import patch
 from ddtrace.contrib.internal.langchain.patch import unpatch
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import _clear_inference_profile_cache
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import lookup_inference_profile
 from tests.contrib.patch import PatchTestCase
 
 
@@ -88,3 +93,93 @@ class TestLangchainPatch(PatchTestCase.Base):
         self.assert_not_double_wrapped(langchain_core.runnables.base.RunnableLambda.abatch)
         self.assert_not_double_wrapped(langchain_core.embeddings.Embeddings.__init_subclass__)
         self.assert_not_double_wrapped(langchain_core.vectorstores.VectorStore.__init_subclass__)
+
+
+class _FakeInstance:
+    """Minimal stand-in for a langchain LLM/chat-model instance."""
+
+    def __init__(self, **attrs):
+        for name, value in attrs.items():
+            setattr(self, name, value)
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            (
+                {"model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0"},
+                "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            ),
+            id="model_id",
+        ),
+        pytest.param(
+            (
+                {
+                    "model_id": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile",
+                    "base_model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                },
+                "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            ),
+            id="base_model_id",
+        ),
+        pytest.param(
+            (
+                {"base_model_id": None, "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0"},
+                "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            ),
+            id="base_model_id_none",
+        ),
+        pytest.param(
+            (
+                {"base_model_id": "", "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0"},
+                "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            ),
+            id="base_model_id_empty",
+        ),
+        pytest.param(({"model": "models/gemini-2.5-flash"}, "gemini-2.5-flash"), id="path_prefix"),
+        pytest.param(({}, None), id="no_model_attrs"),
+    ]
+)
+def extract_model_name_case(request):
+    attrs, expected_model_name = request.param
+    return _FakeInstance(**attrs), expected_model_name
+
+
+def test_extract_model_name(extract_model_name_case):
+    instance, expected_model_name = extract_model_name_case
+    assert _extract_model_name(instance) == expected_model_name
+
+
+@pytest.fixture
+def clear_inference_profile_cache():
+    _clear_inference_profile_cache()
+    yield
+    _clear_inference_profile_cache()
+
+
+def test_extract_model_name_records_inference_profile_mapping(clear_inference_profile_cache):
+    arn = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/p7aksl2pa6w7"
+    base = "anthropic.claude-haiku-4-5-20251001-v1:0"
+    instance = _FakeInstance(model_id=arn, base_model_id=base)
+
+    _extract_model_name(instance)
+
+    assert lookup_inference_profile(arn) == base
+
+
+def test_extract_model_name_without_base_model_id_does_not_record(clear_inference_profile_cache):
+    arn = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/p7aksl2pa6w7"
+    instance = _FakeInstance(model_id=arn)
+
+    _extract_model_name(instance)
+
+    assert lookup_inference_profile(arn) is None
+
+
+def test_extract_model_name_non_application_arn_does_not_record(clear_inference_profile_cache):
+    arn = "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-tg1-large"
+    instance = _FakeInstance(model_id=arn, base_model_id="amazon.titan-tg1-large")
+
+    _extract_model_name(instance)
+
+    assert lookup_inference_profile(arn) is None

--- a/tests/llmobs/test_bedrock_inference_profiles.py
+++ b/tests/llmobs/test_bedrock_inference_profiles.py
@@ -1,0 +1,88 @@
+import threading
+
+import pytest
+
+from ddtrace.contrib.internal.botocore.services.bedrock import _resolve_application_inference_profile
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import _clear_inference_profile_cache
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import lookup_inference_profile
+from ddtrace.llmobs._integrations._bedrock_inference_profiles import record_inference_profile
+
+
+PROFILE_ARN = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/p7aksl2pa6w7"
+BASE_MODEL = "anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    _clear_inference_profile_cache()
+    yield
+    _clear_inference_profile_cache()
+
+
+def test_record_and_lookup_roundtrip():
+    record_inference_profile(PROFILE_ARN, BASE_MODEL)
+    assert lookup_inference_profile(PROFILE_ARN) == BASE_MODEL
+
+
+def test_lookup_miss_returns_none():
+    assert lookup_inference_profile(PROFILE_ARN) is None
+
+
+def test_empty_args_are_noops():
+    record_inference_profile("", BASE_MODEL)
+    record_inference_profile(PROFILE_ARN, "")
+    record_inference_profile("", "")
+    assert lookup_inference_profile(PROFILE_ARN) is None
+    assert lookup_inference_profile("") is None
+
+
+def test_record_overwrites_existing_value():
+    record_inference_profile(PROFILE_ARN, "older-model")
+    record_inference_profile(PROFILE_ARN, BASE_MODEL)
+    assert lookup_inference_profile(PROFILE_ARN) == BASE_MODEL
+
+
+def test_concurrent_writes_do_not_lose_data():
+    arns = [f"arn:aws:bedrock:us-east-2:111122223333:application-inference-profile/p{i:04d}" for i in range(50)]
+
+    def writer(arn):
+        record_inference_profile(arn, BASE_MODEL)
+
+    threads = [threading.Thread(target=writer, args=(arn,)) for arn in arns]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for arn in arns:
+        assert lookup_inference_profile(arn) == BASE_MODEL
+
+
+def test_resolve_application_inference_profile_cache_hit():
+    record_inference_profile(PROFILE_ARN, BASE_MODEL)
+    model_id, provider, name = _resolve_application_inference_profile(PROFILE_ARN, "custom", "p7aksl2pa6w7")
+    assert model_id == BASE_MODEL
+    assert provider == "anthropic"
+    assert name == "claude-haiku-4-5-20251001-v1:0"
+
+
+def test_resolve_application_inference_profile_cache_miss_returns_inputs():
+    model_id, provider, name = _resolve_application_inference_profile(PROFILE_ARN, "custom", "p7aksl2pa6w7")
+    assert model_id == PROFILE_ARN
+    assert provider == "custom"
+    assert name == "p7aksl2pa6w7"
+
+
+def test_resolve_application_inference_profile_non_application_arn_passes_through():
+    arn = "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-tg1-large"
+    model_id, provider, name = _resolve_application_inference_profile(arn, "amazon", "titan-tg1-large")
+    assert model_id == arn
+    assert provider == "amazon"
+    assert name == "titan-tg1-large"
+
+
+def test_resolve_application_inference_profile_non_string_input_passes_through():
+    model_id, provider, name = _resolve_application_inference_profile(None, "custom", "foo")
+    assert model_id is None
+    assert provider == "custom"
+    assert name == "foo"


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/pull/18111 to 4.8
