### PR TITLE
fix(internal): do not mutate actual config for flare emission

### DIFF
--- a/ddtrace/internal/flare/flare.py
+++ b/ddtrace/internal/flare/flare.py
@@ -114,13 +114,14 @@ class Flare:
         config_file = self.flare_dir / f"tracer_config_{pid}.json"
         try:
             with open(config_file, "w") as f:
-                # Redact API key if present
-                api_key = self.ddconfig.get("_dd_api_key")
+                # Work on a shallow copy so the live config is never mutated
+                redacted_config = dict(self.ddconfig)
+                api_key = redacted_config.get("_dd_api_key")
                 if api_key:
-                    self.ddconfig["_dd_api_key"] = "*" * (len(api_key) - 4) + api_key[-4:]
+                    redacted_config["_dd_api_key"] = "*" * (len(api_key) - 4) + api_key[-4:]
 
                 tracer_configs = {
-                    "configs": self.ddconfig,
+                    "configs": redacted_config,
                 }
                 json.dump(
                     tracer_configs,

--- a/ddtrace/internal/flare/flare.py
+++ b/ddtrace/internal/flare/flare.py
@@ -104,7 +104,7 @@ class Flare:
         finally:
             self.clean_up_files()
 
-    def revert_configs(self):
+    def revert_configs(self) -> None:
         ddlogger = get_logger("ddtrace")
         if self.file_handler:
             ddlogger.removeHandler(self.file_handler)
@@ -172,7 +172,7 @@ class Flare:
         valid_original_level = 100 if self.original_log_level == 0 else self.original_log_level
         return min(valid_original_level, flare_log_level)
 
-    def clean_up_files(self):
+    def clean_up_files(self) -> None:
         """Clean up the flare directory using Python's shutil."""
         flare_lock = self.flare_dir / TRACER_FLARE_LOCK
         if flare_lock.exists():

--- a/releasenotes/notes/flare-api-key-redact-no-mutation-f3bd24e218351fa9.yaml
+++ b/releasenotes/notes/flare-api-key-redact-no-mutation-f3bd24e218351fa9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Flare: Fixes a bug where the live tracer configuration was mutated when redacting the API key
+    before writing the flare diagnostic file.

--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -474,6 +474,34 @@ class TracerFlareTests(unittest.TestCase):
         self.flare.send(empty_uuid_request)
         assert self._flare_upload_count() == uploads_before + 1
 
+    def test_api_key_redaction_does_not_mutate_live_config(self) -> None:
+        """_generate_config_file must not mutate the live ddconfig dict."""
+        api_key = "abcd1234efgh5678"
+        live_config = {"_dd_api_key": api_key, "other": "value"}
+        flare = Flare(
+            trace_agent_url=TRACE_AGENT_URL,
+            ddconfig=live_config,
+            flare_dir=str(self.shared_dir),
+        )
+        flare.prepare("DEBUG")
+        self.prepare_called = True
+
+        # The live dict must still hold the original, unredacted key
+        assert live_config["_dd_api_key"] == api_key, "live ddconfig was mutated: API key was overwritten in place"
+
+        # The config file written to disk must contain the redacted value
+        config_files = list(self.shared_dir.glob("tracer_config_*.json"))
+        assert config_files, "config file was not created"
+        with open(config_files[0]) as fh:
+            written = json.load(fh)
+        written_key: str = written["configs"]["_dd_api_key"]
+        assert written_key.endswith(api_key[-4:]), "last 4 chars of key must be preserved"
+        assert "*" in written_key, "API key must be partially redacted in the config file"
+        assert written_key != api_key, "API key must not be written in plain text"
+
+        flare.revert_configs()
+        flare.clean_up_files()
+
     def test_config_file_contents_validation(self):
         """
         Validate that flare preparation and log file creation works correctly.


### PR DESCRIPTION
## Description

This fixes a bug where the live tracer configuration was mutated when redacting the API key before writing the flare diagnostic file. This meant that any subsequent use of the API key in the configuration file would not work (since the API key was broken).
