### PR TITLE
test(appsec): fix flaky test_api_endpoint_discovery iteration race

### DIFF
--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -276,7 +276,9 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             interface.client.get("/")
             collection = endpoint_collection.endpoints
             assert collection, f"no collection {collection}"
-            for ep in collection:
+            # Iterate over a snapshot: the requests issued in the loop can
+            # register new endpoints, mutating the live set mid-iteration.
+            for ep in list(collection):
                 assert ep.method
                 # path could be empty, but must be a string
                 assert isinstance(ep.path, str)


### PR DESCRIPTION
APPSEC-64883

## Summary

- `tests.appsec.contrib_appsec.utils::Contrib_TestClass_For_Threats.test_api_endpoint_discovery` was quarantined by Datadog Flaky Tests Management (category: `concurrency`, ~0.1% failure rate) with `RuntimeError: Set changed size during iteration`.
- The test iterates `endpoint_collection.endpoints` (a live `set`) while issuing HTTP requests inside the loop; those requests can flow through ASM endpoint registration and call `endpoint_collection.add_endpoint(...)`, mutating the set being iterated.
- Fix: iterate over a snapshot (`list(collection)`) so concurrent mutation no longer breaks the loop. Order doesn't matter — the test only checks that every expected path is encountered.

Detected on commit `f383d81a97` (unrelated to the cause); flaky-test ID `M8ALZY`.

## Test plan

- [ ] CI green on `tests/appsec/contrib_appsec/test_django.py::Test_Django::test_api_endpoint_discovery[flat][py3.12]`
- [ ] Same test also passing for the other parametrizations / frameworks that share `utils.py` (Flask, FastAPI)
- [ ] No new flaky-test alerts for this test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)