### PR TITLE
feat(openfeature): decrease default initialization timeout to 10s

### DIFF
--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -96,7 +96,7 @@ class DataDogProvider(AbstractProvider):
         self._metadata = Metadata(name="Datadog")
         self._status = ProviderStatus.NOT_READY
 
-        # Initialization timeout: constructor arg takes priority, then env var (default 30s)
+        # Initialization timeout: constructor arg takes priority, then env var
         if initialization_timeout is not None:
             self._initialization_timeout = initialization_timeout
         else:

--- a/ddtrace/internal/settings/openfeature.py
+++ b/ddtrace/internal/settings/openfeature.py
@@ -32,11 +32,11 @@ class OpenFeatureConfig(DDConfig):
 
     # Provider initialization timeout in milliseconds.
     # Controls how long initialize() blocks waiting for the first Remote Config payload.
-    # Default is 30000ms (30 seconds), matching Java, Go, and Node.js SDKs.
+    # Default is 10000ms (10 seconds).
     initialization_timeout_ms = DDConfig.var(
         int,
         "DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS",
-        default=30000,
+        default=10000,
     )
 
     _openfeature_config_keys = [

--- a/releasenotes/notes/fix-openfeature-init-blocking-70c8d5a99287cc49.yaml
+++ b/releasenotes/notes/fix-openfeature-init-blocking-70c8d5a99287cc49.yaml
@@ -9,6 +9,6 @@ features:
   - |
     openfeature: This introduces a configurable initialization timeout for ``DataDogProvider``.
     The timeout controls how long ``initialize()`` waits for configuration before returning,
-    and defaults to 30 seconds. Set it via the
+    and defaults to 10 seconds. Set it via the
     ``DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS`` environment variable or the
     ``init_timeout`` constructor parameter.

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -1554,7 +1554,7 @@
       {
         "implementation": "A",
         "type": "int",
-        "default": "30000",
+        "default": "10000",
         "experimental": true
       }
     ],


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->
We found that 30s timeout doesn't play well with gunicorn, which has 30s initialization timout for the worker.

If the user naively calls `openfeature.api.set_provider()` at the top-level, RC failing to deliver configuration may bring their whole application down with hard-to-debug `[CRITICAL] WORKER TIMEOUT` error message.

Decrease default timeout to 10s, which is enough when RC is working but not too long to cause other issues/upstream timeouts.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
Part of incident-54756, follow up to https://github.com/DataDog/dd-trace-py/pull/16650