### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ pip_cache_shared_venvs/
 # Claude
 CLAUDE.local.md
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .claude/worktrees/
 
 # oh-my-claudecode


### PR DESCRIPTION
Ignore the local runtime lockfile created by Claude Code's scheduled-tasks feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)