### PR TITLE
chore(ci): restore ffe system-tests coverage

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -437,7 +437,6 @@ jobs:
       library: python
       ref: main
       scenarios_groups: tracer-release
-      excluded_scenarios: FEATURE_FLAGGING_AND_EXPERIMENTATION  # incident-54756
       _system_tests_dev_mode: true
       push_to_test_optimization: true
 


### PR DESCRIPTION
## Motivation

PR #18163 temporarily excludes FEATURE_FLAGGING_AND_EXPERIMENTATION from the Python tracer-release system-tests job for incident-54756. The system-tests-side mitigation is expected to let the Python weblog start without hanging on provider initialization, so we should restore this scenario as soon as the temporary exclusion lands.

## Changes

- Removes the FEATURE_FLAGGING_AND_EXPERIMENTATION exclusion from the Python tracer-release system-tests workflow.
- Keeps the change limited to the dd-trace-py system-tests workflow.

## Decisions

- Opened as a draft stacked on #18163 because #18163 is still in the merge queue and the exclusion is not on main yet.
- Once #18163 lands, retarget this PR to main and keep it as the revert PR.
- No release note is needed because this is CI-only.