### PR TITLE
chore(ci): restore ffe system-tests coverage

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -144,7 +144,6 @@ jobs:
       desired_execution_time: 900
       scenarios_groups: tracer-release
       skip_empty_scenarios: ${{github.event_name == 'pull_request'}}
-      excluded_scenarios: FEATURE_FLAGGING_AND_EXPERIMENTATION  # incident-54756
       push_to_test_optimization: true
 
 


### PR DESCRIPTION
## Motivation

#18163 was closed in favor of #18160, which also excludes the FEATURE_FLAGGING_AND_EXPERIMENTATION scenario from the tracer-release system-tests group. That exclusion is no longer the desired rollback path because it hides the FFE coverage we need while validating the Python startup issue.

## Changes

Remove the `excluded_scenarios: FEATURE_FLAGGING_AND_EXPERIMENTATION` override from the #18160 system-tests workflow migration so the tracer-release group includes the FFE scenario again.

## Decisions

This PR is stacked on #18160 instead of #18163 because #18163 was closed unmerged. It keeps the official system-tests workflow migration intact and only reverts the FFE scenario exclusion.