### PR TITLE
[TEST] reproduce os tests macos FF_SCRIPT_SECTIONS failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
+# AIDEV-NOTE: Most jobs temporarily disabled for tart runner validation.
+# Only "pipeline variables", "build macos arm64", and "os tests macos" are active.
 stages:
   - package
   - tests
-  - system-tests
   - fuzz
   - shared-pipeline
   - benchmarks
@@ -16,7 +17,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7"
+  SYSTEM_TESTS_REF: "baa899e768859fce1be7e98cc2518d810745d65a"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"
@@ -33,7 +34,6 @@ default:
 
 .is_main: $CI_COMMIT_REF_NAME == "main"
 .is_release: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-.is_non_rc_release: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
 .is_release_branch: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
 .is_gh_merge_queue: $CI_COMMIT_BRANCH =~ /^gh-readonly-queue\/.*$/
 .is_devflow_merge_queue: $CI_COMMIT_BRANCH =~ /^mq-working-branch-.*$/
@@ -47,25 +47,23 @@ workflow:
       auto_cancel:
         on_new_commit: none
     - if: !reference [.is_release_branch]
-      variables:
-        DD_GIT_REPOSITORY_URL: "https://github.com/DataDog/dd-trace-py-release.git"
       auto_cancel:
         on_new_commit: none
     - when: always
 
 include:
   - local: ".gitlab/ci-templates.yml" # Reusable templates (setup_ci_deps, etc.)
-  - local: ".gitlab/one-pipeline.locked.yml"
-  - local: ".gitlab/services.yml" # Include early so others can use the definitions
+  # AIDEV-NOTE: Temporarily disabled includes for tart runner validation
+  # - local: ".gitlab/one-pipeline.locked.yml"
+  # - local: ".gitlab/services.yml" # Include early so others can use the definitions
   - local: ".gitlab/package.yml"
-  - local: ".gitlab/release.yml"
+  # - local: ".gitlab/release.yml"
   - local: ".gitlab/testrunner.yml"
-  - local: ".gitlab/debugging-exploration.yml"
+  # - local: ".gitlab/debugging-exploration.yml"
   - local: ".gitlab/multi-os-tests.yml"
-  - local: ".gitlab/benchmarks/serverless.yml"
-  - local: ".gitlab/native.yml"
-  - local: ".gitlab/system-tests.yml"
-  - local: ".gitlab/fuzz.yml"
+  # - local: ".gitlab/benchmarks/serverless.yml"
+  # - local: ".gitlab/native.yml"
+  # - local: ".gitlab/fuzz.yml"
 
 "pipeline variables":
   stage: .pre
@@ -81,589 +79,489 @@ include:
     reports:
       dotenv: pipeline_variables.env
 
-tests-gen:
-  stage: tests
-  extends: .testrunner
-  variables:
-    UNPIN_DEPENDENCIES: "${UNPIN_DEPENDENCIES:-}"
-    NIGHTLY_BUILD: "${NIGHTLY_BUILD:-}"
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
-  script:
-    - |
-      echo "UNPIN_DEPENDENCIES: ${UNPIN_DEPENDENCIES:-}"
-      echo "NIGHTLY_BUILD: ${NIGHTLY_BUILD:-}"
-    - |
-      if [ -z ${GH_TOKEN} ]
-      then
-        # Use dd-octo-sts to get GitHub token
-        export GH_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read)
-      fi
-    - scripts/gen_gitlab_config.py --verbose
-  needs: []
-  artifacts:
-    paths:
-      - .gitlab/tests-gen.yml
-      - .gitlab/benchmarks/microbenchmarks-gen.yml
-      - .gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
-
-run-tests-trigger:
- stage: tests
- needs: [ tests-gen ]
- variables:
-   UNPIN_DEPENDENCIES: "${UNPIN_DEPENDENCIES:-}"
-   NIGHTLY_BUILD: "${NIGHTLY_BUILD:-}"
- # Allow the child job to fail if explicitly asked
- rules:
-   - if: $RELEASE_ALLOW_TEST_FAILURES == "true"
-     allow_failure: true
-   - allow_failure: false
- trigger:
-   include:
-     - artifact: .gitlab/tests-gen.yml
-       job: tests-gen
-   strategy: depend
-
-serverless lambda tests:
-  stage: tests
-  trigger:
-    project: DataDog/datadog-lambda-python
-    strategy: depend
-    branch: main
-  needs:
-    - job: "upload serverless"
-  variables:
-    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
-    UPSTREAM_PROJECT_URL: $CI_PROJECT_URL
-    UPSTREAM_COMMIT_BRANCH: $CI_COMMIT_BRANCH
-    UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
-    UPSTREAM_COMMIT_TITLE: $CI_COMMIT_TITLE
-    UPSTREAM_COMMIT_TAG: $CI_COMMIT_TAG
-    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
-    UPSTREAM_GITLAB_USER_LOGIN: $GITLAB_USER_LOGIN
-    UPSTREAM_GITLAB_USER_EMAIL: $GITLAB_USER_EMAIL
-    SKIP_E2E_TESTS: "true"
-
-# Validate the ast-grep rule's test suite in .sg/tests
-"ast-grep rules":
-  extends: .testrunner
-  stage: tests
-  needs: []
-  script:
-  script:
-    - |
-      echo -e "\e[0Ksection_start:`date +%s`:sg_test[collapsed=true]\r\e[0KValidate ast-grep rules"
-      hatch run lint:sg-test
-      echo -e "\e[0Ksection_end:`date +%s`:sg_test\r\e[0K"
-    - |
-      echo -e "\e[0Ksection_start:`date +%s`:sg_scan[collapsed=true]\r\e[0Kast-grep scan"
-      hatch run lint:sg
-      echo -e "\e[0Ksection_end:`date +%s`:sg_scan\r\e[0K"
-
-microbenchmarks:
-  stage: benchmarks
-  needs:
-    - job: tests-gen
-    - job: "build linux"
-      parallel:
-        matrix:
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp39-cp39"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-  rules:
-    # Allow failures if explicitly asked
-    - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
-      allow_failure: true
-    - allow_failure: false
-  trigger:
-    include:
-      - artifact: .gitlab/benchmarks/microbenchmarks-gen.yml
-        job: tests-gen
-    strategy: depend
-  variables:
-    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
-    # Disable VPA for benchmarks
-    DD_DISABLE_VPA: true
-
-apm-sdk-benchmarks:
-  stage: benchmarks
-  when: manual
-  allow_failure: true
-  needs:
-    - job: "upload all"
-  trigger:
-    project: DataDog/apm-reliability/apm-sdks-benchmarks
-    branch: main
-  variables:
-    TARGET_REF: $CI_PIPELINE_ID
-
-macrobenchmarks:
-  stage: benchmarks
-  needs:
-    - job: "build linux"
-      parallel:
-        matrix:
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp39-cp39"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-  trigger:
-    include: .gitlab/benchmarks/macrobenchmarks.yml
-  variables:
-    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
-    # Disable VPA for benchmarks
-    DD_DISABLE_VPA: true
-  allow_failure: false
-  rules:
-    # Always run on nightly schedule or API triggered pipelines
-    - if: $NIGHTLY_BUILD == "true"
-      when: always
-    # Allow failures if explicitly asked
-    - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
-      allow_failure: true
-    # Always run on tagged releases and release branches
-    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
-      when: always
-    - if: !reference [.is_release]
-      when: always
-    # Otherwise, run manually
-    - when: manual
-      allow_failure: true
-
-check_new_flaky_tests:
-  stage: tests
-  needs: ["run-tests-trigger"]
-  extends: .testrunner
-  script:
-    - export DD_SITE=datadoghq.com
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-api-key-qualitygate --with-decryption --query "Parameter.Value" --out text)
-    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-app-key-qualitygate --with-decryption --query "Parameter.Value" --out text)
-    - datadog-ci gate evaluate
-  rules:
-    - if: !reference [.is_main]
-      when: never
-    - if: !reference [.is_release]
-      when: never
-    - if: !reference [.is_release_branch]
-      when: never
-    - if: !reference [.is_gh_merge_queue]
-      when: never
-    - if: !reference [.is_devflow_merge_queue]
-      when: never
-    - when: on_success
-
-codeql-scan:
-  timeout: 30m
-  stage: tests
-  needs: []
-  image:
-    name: registry.ddbuild.io/images/code-scanning:v76675231-865a08a-default
-  tags: [ "arch:amd64" ]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
-  rules:
-    - if: !reference [.is_release]
-      when: never
-    - if: $NIGHTLY_BUILD == "true"
-      when: never
-    - when: on_success
-  variables:
-    AWS_REGION: us-east-1
-    BASE_REF: main
-    GOMAXPROCS: 10
-    KUBERNETES_CPU_REQUEST: 10
-    KUBERNETES_CPU_LIMIT: 10
-    KUBERNETES_MEMORY_REQUEST: 96Gi
-    KUBERNETES_MEMORY_LIMIT: 96Gi
-    CI_PROJECT_NAMESPACE: DataDog
-    CODEQL: /usr/local/codeql/codeql
-    CODEQL_DB: /tmp/dd-trace-py.codeql
-    PYTHON_CUSTOM_QLPACK: /tmp/codescanning/qlpacks/python/codeql-suites/python-code-scanning.qls
-    DB_CONFIGS: --threads 8 --ram 96000 --language=python --quiet
-    SCAN_CONFIGS: --format sarifv2.1.0 --threads 8 --ram 96000 --no-tuple-counting --quiet
-    UPLOAD_CONFIGS: -upload_sarif=true
-  script:
-    - ./scripts/codeql_scan.sh
-
-requirements_json_test:
-  rules:
-    - when: on_success
-  variables:
-    REQUIREMENTS_BLOCK_JSON_PATH: ".gitlab/requirements_block.json"
-    REQUIREMENTS_ALLOW_JSON_PATH: ".gitlab/requirements_allow.json"
-
-check_requirements_lockfiles:
-  stage: tests
-  needs: []
-  extends: .testrunner
-  variables:
-    # DD_DISABLE_VPA is required: without it VPA overrides KUBERNETES_MEMORY_*
-    # (see "overridden by VPA" in runner logs) and clamps the build container
-    # down to ~4 GiB based on its learned model. compile-and-prune-test-
-    # requirements pip-compiles every riot lockfile sequentially and peaks
-    # above that when resolving the full venv matrix (including 3.15 venvs),
-    # causing OOMKilled (exit 137).
-    DD_DISABLE_VPA: "true"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "8Gi"
-  script:
-    - pip install toml==0.10.2
-    - scripts/compile-and-prune-test-requirements
-    - scripts/check-diff '.riot/requirements/' 'Mismatches found between .riot/requirements/*.txt and riotfile.py. Run scripts/compile-and-prune-test-requirements and commit the result.'
-    - python scripts/requirements_to_csv.py
-    - scripts/check-diff 'requirements.csv' 'Tracer dependency requirements in requirements.csv is out of date. Run `python scripts/requirements_to_csv.py` and commit the result.'
-
-check_ci_dependencies:
-  stage: tests
-  needs: []
-  extends: .testrunner
-  script:
-    - scripts/check-ci-dependencies
-
-codeowners:
-  stage: tests
-  needs: []
-  tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/ubuntu:25.04
-  script:
-    # Validate that each file entry only exists once in CODEOWNERS to prevent confusion about ownership.
-    # The file is evaluated from top to bottom where the last match wins, so duplicate entries can lead to unexpected owners being assigned.
-    # Normalize patterns before checking for duplicates:
-    #   - Remove trailing slashes (tests/tracer and tests/tracer/ are equivalent)
-    #   - Remove leading ./ (./path and path are equivalent)
-    #   - Collapse multiple consecutive slashes (path//file becomes path/file)
-    - |
-        # All non-comment/empty lines from .github/CODEOWNERS
-        awk '!/^#|^$/ {print $1}' .github/CODEOWNERS | \
-          # Remove any leading `./` in the line
-          sed 's|^\./||' | \
-          # Remove any duplicate `/`, e.g. `//` -> `/`
-          sed -E 's|/+|/|g' | \
-          # Remove any trailing `/`
-          sed 's:/*$::' | \
-          # Sort and return only duplicate entries
-          sort | uniq -d > /tmp/duplicate_codeowners.txt
-        if [ -s /tmp/duplicate_codeowners.txt ]; then
-            echo "Duplicate entries found in .github/CODEOWNERS for patterns (after normalization):"
-            cat /tmp/duplicate_codeowners.txt | sed 's/^/  - /'
-            echo ""
-            echo "Each file pattern should only be listed once to ensure clear ownership."
-            echo "Normalization applied: removed trailing slashes, leading './', and collapsed multiple slashes."
-            echo "Please remove duplicates from .github/CODEOWNERS."
-            exit 1
-        fi
-    - apt-get update && apt install ca-certificates git wget curl -y
-    - wget https://github.com/hmarr/codeowners/releases/download/v1.2.1/codeowners_1.2.1_linux_amd64.tar.gz
-    - tar -xvzf codeowners_1.2.1_linux_amd64.tar.gz
-    - git diff-tree --no-commit-id --name-only -r $CI_COMMIT_SHA > /tmp/changed_all.txt
-    # Filter to only files that exist on disk (deleted files cause codeowners to crash)
-    - |
-      > /tmp/changed_files.txt
-      while IFS= read -r f; do
-        [ -f "$f" ] && echo "$f" >> /tmp/changed_files.txt
-      done < /tmp/changed_all.txt
-    - |
-      if [ -s /tmp/changed_files.txt ]; then
-        echo '```' > codeowners.txt
-        xargs ./codeowners < /tmp/changed_files.txt | tee -a codeowners.txt
-        echo '```' >> codeowners.txt
-      fi
-    - .gitlab/scripts/post-pr-comment.sh "Codeowners resolved as" codeowners.txt
-
-detect_circular_imports:
-  stage: tests
-  needs: []
-  extends: .testrunner
-  script:
-    - pip install uv
-    - cd ..
-    # Keep copies of PR scripts so they survive the git checkout main below
-    - cp dd-trace-py/scripts/import-analysis/cycles.py cycles.py
-    - cp dd-trace-py/.gitlab/scripts/post-pr-comment.sh post-pr-comment.sh
-    - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-pr.json
-    - cat cycles-pr.json
-    - cd dd-trace-py && git checkout main && cd ..
-    # Analyse main branch ddtrace using the PR version of cycles.py (has uv metadata)
-    - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-base.json
-    - cat cycles-base.json
-    - |
-      set +e
-      uv run --script cycles.py compare cycles-base.json cycles-pr.json > cycles_report.txt
-      COMPARE_EXIT=$?
-      set -e
-    - cat cycles_report.txt
-    - ./post-pr-comment.sh "Circular import analysis" cycles_report.txt
-    - exit $COMPARE_EXIT
-
-
-"summarize failures":
-  stage: .post
-  extends: .testrunner
-  rules:
-    - if: !reference [.is_main]
-      when: on_failure
-      allow_failure: true
-    - if: !reference [.is_release]
-      when: on_failure
-      allow_failure: true
-    - if: !reference [.is_release_branch]
-      when: on_failure
-      allow_failure: true
-    - if: !reference [.is_gh_merge_queue]
-      when: on_failure
-      allow_failure: true
-    - if: !reference [.is_devflow_merge_queue]
-      when: on_failure
-      allow_failure: true
-    - when: manual
-      allow_failure: true
-  dependencies: []
-  timeout: 30m
-  retry: 0
-  variables:
-    CI_FAILURE_LOGS_DIR: "$CI_PROJECT_DIR/ci-failure-logs"
-  before_script:
-    - !reference [.testrunner, before_script]
-  script:
-    - .gitlab/scripts/summarize_failures.py
-  after_script: []
-  artifacts:
-    when: always
-    paths:
-      - ci-failure-logs/
-      - summary.md
-      - claude.stdout.log
-    expire_in: 1 month
-
-
-package-oci:
-  needs:
-    - job: "package version"
-      artifacts: true
-    - job: "build linux"
-      artifacts: true
-    - job: "download_dependency_wheels"
-      artifacts: true
-
-promote-oci-to-prod:
-  stage: release
-  rules:
-    - if: !reference [.is_non_rc_release]
-      when: on_success
-    - when: never
-  needs:
-    - job: release_pypi_prod
-    - job: package-oci
-      artifacts: true
-    - job: oci-internal-publish
-      artifacts: true
-
-promote-oci-to-prod-beta:
-  stage: release
-  needs:
-    - job: package-oci
-      artifacts: true
-    - job: oci-internal-publish
-      artifacts: true
-
-promote-oci-to-staging:
-  stage: release
-  needs:
-    - job: package-oci
-      artifacts: true
-    - job: oci-internal-publish
-      artifacts: true
-
-publish-lib-init-pinned-tags:
-  stage: release
-  rules:
-    - if: !reference [.is_non_rc_release]
-      when: on_success
-    - when: never
-  needs:
-    - job: release_pypi_prod
-    - job: create-multiarch-lib-injection-image
-    - job: generate-lib-init-pinned-tag-values
-      artifacts: true
-
-configure_system_tests:
-  needs: []
-  variables:
-    SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec,docker-ssi,lib-injection"
-
-system_tests:
-  needs: ["configure_system_tests", "oci-internal-test-publish", "kubernetes-injection-test-ecr-publish"]
-
-deploy_to_reliability_env:
-  needs: []
-  rules:
-    # Always deploy on main nightly builds
-    - if: $NIGHTLY_BUILD == "true" && $CI_COMMIT_REF_NAME == "main"
-      when: always
-    # Original rules from one-pipeline.yml
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: on_success
-    - when: manual
-      allow_failure: true
-
-deploy_to_di_backend:manual:
-  stage: shared-pipeline
-  rules:
-    - when: manual
-      allow_failure: true
-  trigger:
-    project: DataDog/debugger-demos
-    branch: main
-  variables:
-    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
-    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
-    UPSTREAM_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
-    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
-    UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
-    UPSTREAM_TAG: $CI_COMMIT_TAG
-    UPSTREAM_PACKAGE_JOB: build
-
-# Trigger profiling correctness tests with just-built wheels.
-# Runs the prof-correctness test suite (Python scenarios) against the wheels
-# uploaded to S3 for this commit.
-prof-correctness:
-  stage: shared-pipeline
-  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
-  tags: ["arch:amd64"]
-  needs:
-    - job: "upload all"
-  allow_failure: true
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "main"
-    - changes:
-        - .gitlab-ci.yml
-        - ddtrace/internal/datadog/profiling/**/*
-        - ddtrace/profiling/**/*
-        - src/native/**/*
-    - when: manual
-      allow_failure: true
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
-  script:
-    - |
-      if [ -z "${GH_TOKEN:-}" ]; then
-        export GH_TOKEN=$(dd-octo-sts token --scope DataDog/prof-correctness --policy dd-trace-py.gitlab.trigger-ci)
-      fi
-    - |
-      echo "Triggering prof-correctness for commit ${CI_COMMIT_SHA}"
-      # Trigger pipeline, but do not wait for the job to complete
-      gh workflow run downstream-python.yml \
-        --repo DataDog/prof-correctness \
-        -f dd_trace_py_commit_sha="${CI_COMMIT_SHA}"
-
-lib_injection_tests:
-  # tests for sitecustomize safety that intentionally run outside of riot to simulate a fresh system
-  needs: []
-  stage: tests
-  tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/dd-trace-py:v106957811-b912d74-lib_injection@sha256:d381042ec0c5d8ba617453feec7ccdffefca8ef0e3011d980728fe1a7a9425eb
-  script: |
-    echo -e "\e[0Ksection_start:`date +%s`:info[collapsed=true]\r\e[0KPython versions"
-    pyenv --version
-    pyenv versions --bare
-    echo -e "\e[0Ksection_end:`date +%s`:info\r\e[0K"
-
-    for python_version in $(pyenv versions --bare); do
-      echo -e "\e[0Ksection_start:`date +%s`:test_${python_version}[collapsed=true]\r\e[0KTesting with Python ${python_version}"
-      pyenv global "${python_version}"
-      pyenv exec python --version
-      pyenv exec python lib-injection/sources/sitecustomize.py
-      echo -e "\e[0Ksection_end:`date +%s`:test_${python_version}\r\e[0K"
-    done
-
-# Profiling native tests with sanitizers
-# Uses dedicated profiling-native image with Python, Rust, valgrind, and clang pre-installed
-# Image built from: dd/images/dd-trace-py/profiling_native
-# Only runs when profiling-related files change
-.profiling_native_base:
-  needs: []
-  stage: tests
-  tags: [ "arch:amd64" ]
-  image: ${PROFILING_NATIVE_IMAGE}
-  timeout: 15m
-  variables:
-    CMAKE_BUILD_PARALLEL_LEVEL: "12"
-    CARGO_BUILD_JOBS: "12"
-  before_script:
-    - ulimit -c unlimited
-    - git config --global --add safe.directory ${CI_PROJECT_DIR}
-    - export PYENV_VERSION=${PYTHON_VERSION}
-  script:
-    - python --version
-    # All profiling tests use EXPECT_EXIT (death tests) which fork child processes.
-    # LSAN's signal handler in forked children conflicts with gtest, causing spurious crashes.
-    # Disable leak detection for "safety" - Valgrind jobs already cover leak detection.
-    - if [ "${SANITIZER}" == "safety" ]; then export ASAN_OPTIONS=detect_leaks=0; fi
-    - ./ddtrace/internal/datadog/profiling/build_standalone.sh --${SANITIZER} RelWithDebInfo stack_test
-
-# Run on PRs where files in the native Profiling build graph changed.
-# build_standalone.sh compiles Rust (setup.py build_rust) then builds C++ tests
-# via CMake, so Rust, C/C++, Cython, and CMake files should all trigger it.
-# Extension-based patterns keep Python and docs out automatically; non-extension
-# build files (CMakeLists.txt, .sh, .supp) are listed separately.
-profiling_native:
-  extends: .profiling_native_base
-  retry: 2
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "main"
-    - changes:
-        - .gitlab-ci.yml
-        # Native source files by extension (C, C++, Cython, CMake modules)
-        - ddtrace/internal/datadog/profiling/**/*.cpp
-        - ddtrace/internal/datadog/profiling/**/*.cc
-        - ddtrace/internal/datadog/profiling/**/*.h
-        - ddtrace/internal/datadog/profiling/**/*.hpp
-        - ddtrace/internal/datadog/profiling/**/*.pyx
-        - ddtrace/internal/datadog/profiling/**/*.cmake
-        - ddtrace/profiling/**/*.cpp
-        - ddtrace/profiling/**/*.cc
-        - ddtrace/profiling/**/*.h
-        - ddtrace/profiling/**/*.hpp
-        - ddtrace/profiling/**/*.pyx
-        # Build/test config files (not matchable by extension alone)
-        - ddtrace/internal/datadog/profiling/**/CMakeLists.txt
-        - ddtrace/internal/datadog/profiling/**/*.sh
-        - ddtrace/internal/datadog/profiling/**/*.supp
-        - ddtrace/profiling/**/CMakeLists.txt
-        # Rust source (build_standalone.sh compiles Rust first; CMake links
-        # against generated FFI headers from src/native/target/.../include/)
-        - src/native/**/*.rs
-        - src/native/**/*.toml
-        - src/native/**/Cargo.lock
-        # Top-level build config
-        - setup.py
-        - pyproject.toml
-  parallel:
-    matrix:
-      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        SANITIZER: ["safety", "thread", ""]
-      # Valgrind on subset only: ASAN/LSAN (in "safety") already cover leaks, buffer overflows,
-      # and use-after-free. Valgrind's main added value is detecting uninitialized memory usage,
-      # which is worth checking on a few versions without the slowdown on all runs.
-      # If needed, please add more versions to the list.
-      - PYTHON_VERSION: ["3.12", "3.14"]
-        SANITIZER: ["valgrind"]
-
-test-dd-sts:
-  stage: tests
-  needs: []
-  tags: ["arch:amd64"]
-  when: manual
-  allow_failure: true
-  image: registry.ddbuild.io/images/mirror/ubuntu:24.04
-  id_tokens:
-    DD_STS_OIDC_TOKEN:
-      aud: rapid-seceng-sit
-  script:
-    - apt-get update && apt-get install -y curl
-    - 'curl -s -o /dev/null -w "API key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab"'
-    - 'curl -s -o /dev/null -w "APP key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab-app-key"'
+# AIDEV-NOTE: All jobs below are temporarily commented out for tart runner validation.
+# tests-gen:
+#   stage: tests
+#   extends: .testrunner
+#   variables:
+#     UNPIN_DEPENDENCIES: "${UNPIN_DEPENDENCIES:-}"
+#     NIGHTLY_BUILD: "${NIGHTLY_BUILD:-}"
+#   id_tokens:
+#     DDOCTOSTS_ID_TOKEN:
+#       aud: dd-octo-sts
+#   script:
+#     - |
+#       echo "UNPIN_DEPENDENCIES: ${UNPIN_DEPENDENCIES:-}"
+#       echo "NIGHTLY_BUILD: ${NIGHTLY_BUILD:-}"
+#     - |
+#       if [ -z ${GH_TOKEN} ]
+#       then
+#         # Use dd-octo-sts to get GitHub token
+#         export GH_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read)
+#       fi
+#     - scripts/gen_gitlab_config.py --verbose
+#   needs: []
+#   artifacts:
+#     paths:
+#       - .gitlab/tests-gen.yml
+#       - .gitlab/benchmarks/microbenchmarks-gen.yml
+#       - .gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+#
+# run-tests-trigger:
+#  stage: tests
+#  needs: [ tests-gen ]
+#  variables:
+#    UNPIN_DEPENDENCIES: "${UNPIN_DEPENDENCIES:-}"
+#    NIGHTLY_BUILD: "${NIGHTLY_BUILD:-}"
+#  # Allow the child job to fail if explicitly asked
+#  rules:
+#    - if: $RELEASE_ALLOW_TEST_FAILURES == "true"
+#      allow_failure: true
+#    - allow_failure: false
+#  trigger:
+#    include:
+#      - artifact: .gitlab/tests-gen.yml
+#        job: tests-gen
+#    strategy: depend
+#
+# serverless lambda tests:
+#   stage: tests
+#   trigger:
+#     project: DataDog/datadog-lambda-python
+#     strategy: depend
+#     branch: main
+#   needs:
+#     - job: "upload serverless"
+#   variables:
+#     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+#     UPSTREAM_PROJECT_URL: $CI_PROJECT_URL
+#     UPSTREAM_COMMIT_BRANCH: $CI_COMMIT_BRANCH
+#     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
+#     UPSTREAM_COMMIT_TITLE: $CI_COMMIT_TITLE
+#     UPSTREAM_COMMIT_TAG: $CI_COMMIT_TAG
+#     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+#     UPSTREAM_GITLAB_USER_LOGIN: $GITLAB_USER_LOGIN
+#     UPSTREAM_GITLAB_USER_EMAIL: $GITLAB_USER_EMAIL
+#     SKIP_E2E_TESTS: "true"
+#
+# # Validate the ast-grep rule's test suite in .sg/tests
+# "ast-grep rules":
+#   extends: .testrunner
+#   stage: tests
+#   needs: []
+#   script:
+#   script:
+#     - |
+#       echo -e "\e[0Ksection_start:`date +%s`:sg_test[collapsed=true]\r\e[0KValidate ast-grep rules"
+#       hatch run lint:sg-test
+#       echo -e "\e[0Ksection_end:`date +%s`:sg_test\r\e[0K"
+#     - |
+#       echo -e "\e[0Ksection_start:`date +%s`:sg_scan[collapsed=true]\r\e[0Kast-grep scan"
+#       hatch run lint:sg
+#       echo -e "\e[0Ksection_end:`date +%s`:sg_scan\r\e[0K"
+#
+# microbenchmarks:
+#   stage: benchmarks
+#   needs:
+#     - job: tests-gen
+#     - job: "build linux"
+#       parallel:
+#         matrix:
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: "cp39-cp39"
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#   rules:
+#     # Allow failures if explicitly asked
+#     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
+#       allow_failure: true
+#     - allow_failure: false
+#   trigger:
+#     include:
+#       - artifact: .gitlab/benchmarks/microbenchmarks-gen.yml
+#         job: tests-gen
+#     strategy: depend
+#   variables:
+#     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+#     # Disable VPA for benchmarks
+#     DD_DISABLE_VPA: true
+#
+# apm-sdk-benchmarks:
+#   stage: benchmarks
+#   when: manual
+#   allow_failure: true
+#   needs:
+#     - job: "upload all"
+#   trigger:
+#     project: DataDog/apm-reliability/apm-sdks-benchmarks
+#     branch: main
+#   variables:
+#     TARGET_REF: $CI_PIPELINE_ID
+#
+# macrobenchmarks:
+#   stage: benchmarks
+#   needs:
+#     - job: "build linux"
+#       parallel:
+#         matrix:
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: "cp39-cp39"
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#   trigger:
+#     include: .gitlab/benchmarks/macrobenchmarks.yml
+#   variables:
+#     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+#     # Disable VPA for benchmarks
+#     DD_DISABLE_VPA: true
+#   allow_failure: false
+#   rules:
+#     # Always run on nightly schedule or API triggered pipelines
+#     - if: $NIGHTLY_BUILD == "true"
+#       when: always
+#     # Allow failures if explicitly asked
+#     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
+#       allow_failure: true
+#     # Always run on tagged releases and release branches
+#     - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+#       when: always
+#     - if: !reference [.is_release]
+#       when: always
+#     # Otherwise, run manually
+#     - when: manual
+#       allow_failure: true
+#
+# check_new_flaky_tests:
+#   stage: tests
+#   needs: ["run-tests-trigger"]
+#   extends: .testrunner
+#   script:
+#     - export DD_SITE=datadoghq.com
+#     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-api-key-qualitygate --with-decryption --query "Parameter.Value" --out text)
+#     - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-app-key-qualitygate --with-decryption --query "Parameter.Value" --out text)
+#     - datadog-ci gate evaluate
+#   rules:
+#     - if: !reference [.is_main]
+#       when: never
+#     - if: !reference [.is_release]
+#       when: never
+#     - if: !reference [.is_release_branch]
+#       when: never
+#     - if: !reference [.is_gh_merge_queue]
+#       when: never
+#     - if: !reference [.is_devflow_merge_queue]
+#       when: never
+#     - when: on_success
+#
+# codeql-scan:
+#   timeout: 30m
+#   stage: tests
+#   needs: []
+#   image:
+#     name: registry.ddbuild.io/images/code-scanning:v76675231-865a08a-default
+#   tags: [ "arch:amd64" ]
+#   id_tokens:
+#     DDOCTOSTS_ID_TOKEN:
+#       aud: dd-octo-sts
+#   rules:
+#     - if: !reference [.is_release]
+#       when: never
+#     - if: $NIGHTLY_BUILD == "true"
+#       when: never
+#     - when: on_success
+#   variables:
+#     AWS_REGION: us-east-1
+#     BASE_REF: main
+#     GOMAXPROCS: 10
+#     KUBERNETES_CPU_REQUEST: 10
+#     KUBERNETES_CPU_LIMIT: 10
+#     KUBERNETES_MEMORY_REQUEST: 96Gi
+#     KUBERNETES_MEMORY_LIMIT: 96Gi
+#     CI_PROJECT_NAMESPACE: DataDog
+#     CODEQL: /usr/local/codeql/codeql
+#     CODEQL_DB: /tmp/dd-trace-py.codeql
+#     PYTHON_CUSTOM_QLPACK: /tmp/codescanning/qlpacks/python/codeql-suites/python-code-scanning.qls
+#     DB_CONFIGS: --threads 8 --ram 96000 --language=python --quiet
+#     SCAN_CONFIGS: --format sarifv2.1.0 --threads 8 --ram 96000 --no-tuple-counting --quiet
+#     UPLOAD_CONFIGS: -upload_sarif=true
+#   script:
+#     - ./scripts/codeql_scan.sh
+#
+# requirements_json_test:
+#   rules:
+#     - when: on_success
+#   variables:
+#     REQUIREMENTS_BLOCK_JSON_PATH: ".gitlab/requirements_block.json"
+#     REQUIREMENTS_ALLOW_JSON_PATH: ".gitlab/requirements_allow.json"
+#
+# check_requirements_lockfiles:
+#   stage: tests
+#   needs: []
+#   extends: .testrunner
+#   script:
+#     - pip install toml==0.10.2
+#     - scripts/compile-and-prune-test-requirements
+#     - scripts/check-diff '.riot/requirements/' 'Mismatches found between .riot/requirements/*.txt and riotfile.py. Run scripts/compile-and-prune-test-requirements and commit the result.'
+#     - python scripts/requirements_to_csv.py
+#     - scripts/check-diff 'requirements.csv' 'Tracer dependency requirements in requirements.csv is out of date. Run `python scripts/requirements_to_csv.py` and commit the result.'
+#
+# check_ci_dependencies:
+#   stage: tests
+#   needs: []
+#   extends: .testrunner
+#   script:
+#     - scripts/check-ci-dependencies
+#
+# codeowners:
+#   stage: tests
+#   needs: []
+#   tags: ["arch:amd64"]
+#   image: registry.ddbuild.io/images/mirror/ubuntu:25.04
+#   script:
+#     - |
+#         awk '!/^#|^$/ {print $1}' .github/CODEOWNERS | \
+#           sed 's|^\./||' | \
+#           sed -E 's|/+|/|g' | \
+#           sed 's:/*$::' | \
+#           sort | uniq -d > /tmp/duplicate_codeowners.txt
+#         if [ -s /tmp/duplicate_codeowners.txt ]; then
+#             echo "Duplicate entries found in .github/CODEOWNERS for patterns (after normalization):"
+#             cat /tmp/duplicate_codeowners.txt | sed 's/^/  - /'
+#             echo ""
+#             echo "Each file pattern should only be listed once to ensure clear ownership."
+#             echo "Normalization applied: removed trailing slashes, leading './', and collapsed multiple slashes."
+#             echo "Please remove duplicates from .github/CODEOWNERS."
+#             exit 1
+#         fi
+#     - apt-get update && apt install ca-certificates git wget curl -y
+#     - wget https://github.com/hmarr/codeowners/releases/download/v1.2.1/codeowners_1.2.1_linux_amd64.tar.gz
+#     - tar -xvzf codeowners_1.2.1_linux_amd64.tar.gz
+#     - git diff-tree --no-commit-id --name-only -r $CI_COMMIT_SHA > /tmp/changed_all.txt
+#     - |
+#       > /tmp/changed_files.txt
+#       while IFS= read -r f; do
+#         [ -f "$f" ] && echo "$f" >> /tmp/changed_files.txt
+#       done < /tmp/changed_all.txt
+#     - |
+#       if [ -s /tmp/changed_files.txt ]; then
+#         echo '```' > codeowners.txt
+#         xargs ./codeowners < /tmp/changed_files.txt | tee -a codeowners.txt
+#         echo '```' >> codeowners.txt
+#       fi
+#     - .gitlab/scripts/post-pr-comment.sh "Codeowners resolved as" codeowners.txt
+#
+# detect_circular_imports:
+#   stage: tests
+#   needs: []
+#   extends: .testrunner
+#   script:
+#     - pip install uv
+#     - cd ..
+#     - cp dd-trace-py/scripts/import-analysis/cycles.py cycles.py
+#     - cp dd-trace-py/.gitlab/scripts/post-pr-comment.sh post-pr-comment.sh
+#     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-pr.json
+#     - cat cycles-pr.json
+#     - cd dd-trace-py && git checkout main && cd ..
+#     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-base.json
+#     - cat cycles-base.json
+#     - |
+#       set +e
+#       uv run --script cycles.py compare cycles-base.json cycles-pr.json > cycles_report.txt
+#       COMPARE_EXIT=$?
+#       set -e
+#     - cat cycles_report.txt
+#     - ./post-pr-comment.sh "Circular import analysis" cycles_report.txt
+#     - exit $COMPARE_EXIT
+#
+# package-oci:
+#   needs:
+#     - job: "package version"
+#       artifacts: true
+#     - job: "build linux"
+#       artifacts: true
+#     - job: "download_dependency_wheels"
+#       artifacts: true
+#
+# promote-oci-to-prod:
+#   stage: release
+#   rules:
+#     - if: !reference [.is_release]
+#       when: on_success
+#     - when: never
+#   needs:
+#     - job: release_pypi_prod
+#     - job: package-oci
+#       artifacts: true
+#     - job: oci-internal-publish
+#       artifacts: true
+#
+# promote-oci-to-prod-beta:
+#   stage: release
+#   needs:
+#     - job: package-oci
+#       artifacts: true
+#     - job: oci-internal-publish
+#       artifacts: true
+#
+# promote-oci-to-staging:
+#   stage: release
+#   needs:
+#     - job: package-oci
+#       artifacts: true
+#     - job: oci-internal-publish
+#       artifacts: true
+#
+# publish-lib-init-pinned-tags:
+#   stage: release
+#   rules:
+#     - if: !reference [.is_release]
+#       when: on_success
+#     - when: never
+#   needs:
+#     - job: release_pypi_prod
+#     - job: create-multiarch-lib-injection-image
+#     - job: generate-lib-init-pinned-tag-values
+#       artifacts: true
+#
+# configure_system_tests:
+#   needs: []
+#   variables:
+#     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec,docker-ssi,lib-injection"
+#
+# system_tests:
+#   needs: ["configure_system_tests", "oci-internal-test-publish", "kubernetes-injection-test-ecr-publish"]
+#
+# deploy_to_reliability_env:
+#   needs: []
+#   rules:
+#     # Always deploy on main nightly builds
+#     - if: $NIGHTLY_BUILD == "true" && $CI_COMMIT_REF_NAME == "main"
+#       when: always
+#     # Original rules from one-pipeline.yml
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#       when: on_success
+#     - when: manual
+#       allow_failure: true
+#
+# deploy_to_di_backend:manual:
+#   stage: shared-pipeline
+#   rules:
+#     - when: manual
+#       allow_failure: true
+#   trigger:
+#     project: DataDog/debugger-demos
+#     branch: main
+#   variables:
+#     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+#     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+#     UPSTREAM_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
+#     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+#     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
+#     UPSTREAM_TAG: $CI_COMMIT_TAG
+#     UPSTREAM_PACKAGE_JOB: build
+#
+# prof-correctness:
+#   stage: shared-pipeline
+#   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+#   tags: ["arch:amd64"]
+#   needs:
+#     - job: "upload all"
+#   allow_failure: true
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "main"
+#     - changes:
+#         - .gitlab-ci.yml
+#         - ddtrace/internal/datadog/profiling/**/*
+#         - ddtrace/profiling/**/*
+#         - src/native/**/*
+#     - when: manual
+#       allow_failure: true
+#   id_tokens:
+#     DDOCTOSTS_ID_TOKEN:
+#       aud: dd-octo-sts
+#   script:
+#     - |
+#       if [ -z "${GH_TOKEN:-}" ]; then
+#         export GH_TOKEN=$(dd-octo-sts token --scope DataDog/prof-correctness --policy dd-trace-py.gitlab.trigger-ci)
+#       fi
+#     - |
+#       echo "Triggering prof-correctness for commit ${CI_COMMIT_SHA}"
+#       gh workflow run downstream-python.yml \
+#         --repo DataDog/prof-correctness \
+#         -f dd_trace_py_commit_sha="${CI_COMMIT_SHA}"
+#
+# lib_injection_tests:
+#   needs: []
+#   stage: tests
+#   tags: [ "arch:amd64" ]
+#   image: registry.ddbuild.io/images/mirror/ubuntu:25.04
+#   parallel:
+#     matrix:
+#       - PYTHON: [ "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev" ]
+#   script:
+#     - export PYENV_ROOT="${HOME}/.pyenv"
+#     - export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+#     - apt-get update && apt install build-essential zlib1g-dev libssl-dev curl git -y
+#     - for i in 1 2 3; do PYENV_GIT_TAG=v2.6.17 curl -sSf https://pyenv.run | bash && break; echo "pyenv install attempt $i failed, retrying..."; sleep 5; [ "$i" -eq 3 ] && { echo "Failed to install pyenv after 3 attempts"; exit 1; }; done
+#     - pyenv --version
+#     - pyenv install ${PYTHON} && pyenv global ${PYTHON}
+#     - python --version
+#     - python lib-injection/sources/sitecustomize.py
+#
+# .profiling_native_base:
+#   needs: []
+#   stage: tests
+#   tags: [ "arch:amd64" ]
+#   image: ${PROFILING_NATIVE_IMAGE}
+#   timeout: 15m
+#   variables:
+#     CMAKE_BUILD_PARALLEL_LEVEL: "12"
+#     CARGO_BUILD_JOBS: "12"
+#   before_script:
+#     - ulimit -c unlimited
+#     - git config --global --add safe.directory ${CI_PROJECT_DIR}
+#     - export PYENV_VERSION=${PYTHON_VERSION}
+#   script:
+#     - python --version
+#     - if [ "${MEMCPY_MODE}" == "fast" ]; then export ECHION_USE_FAST_COPY_MEMORY=1; else export ECHION_USE_FAST_COPY_MEMORY=0; fi
+#     - if [ "${SANITIZER}" == "safety" ]; then export ASAN_OPTIONS=detect_leaks=0; fi
+#     - ./ddtrace/internal/datadog/profiling/build_standalone.sh --${SANITIZER} RelWithDebInfo stack_test
+#
+# profiling_native:
+#   extends: .profiling_native_base
+#   retry: 2
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "main"
+#     - changes:
+#         - .gitlab-ci.yml
+#         - ddtrace/internal/datadog/profiling/**/*.cpp
+#         - ddtrace/internal/datadog/profiling/**/*.cc
+#         - ddtrace/internal/datadog/profiling/**/*.h
+#         - ddtrace/internal/datadog/profiling/**/*.hpp
+#         - ddtrace/internal/datadog/profiling/**/*.pyx
+#         - ddtrace/internal/datadog/profiling/**/*.cmake
+#         - ddtrace/profiling/**/*.cpp
+#         - ddtrace/profiling/**/*.cc
+#         - ddtrace/profiling/**/*.h
+#         - ddtrace/profiling/**/*.hpp
+#         - ddtrace/profiling/**/*.pyx
+#         - ddtrace/internal/datadog/profiling/**/CMakeLists.txt
+#         - ddtrace/internal/datadog/profiling/**/*.sh
+#         - ddtrace/internal/datadog/profiling/**/*.supp
+#         - ddtrace/profiling/**/CMakeLists.txt
+#         - src/native/**/*.rs
+#         - src/native/**/*.toml
+#         - src/native/**/Cargo.lock
+#         - setup.py
+#         - pyproject.toml
+#   parallel:
+#     matrix:
+#       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+#         MEMCPY_MODE: ["default"]
+#         SANITIZER: ["safety", "thread", ""]
+#       - PYTHON_VERSION: ["3.12", "3.14"]
+#         MEMCPY_MODE: ["default"]
+#         SANITIZER: ["valgrind"]
+#       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+#         MEMCPY_MODE: ["fast"]
+#         SANITIZER: ["safety", "thread"]

--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -36,10 +36,11 @@ os tests ubuntu:
 
 os tests macos:
   extends: .multi_os_test_base
-  tags: ["macos:sonoma-amd64", "specific:true"]
-  needs: [ "build macos" ]
+  image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
+  tags: ["macos:sonoma-tart"]
+  needs: [ "build macos arm64" ]
   variables:
-    WHEEL_PATTERN: "macosx*x86_64.whl"
+    WHEEL_PATTERN: "macosx*arm64.whl"
     PLATFORM: "macOS"
   script:
     - |

--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -1,5 +1,5 @@
 # Multi-OS Test Suite
-# Tests the application across Ubuntu, macOS, and Windows with multiple Python versions
+# AIDEV-NOTE: Ubuntu and Windows jobs temporarily commented out for tart runner validation.
 
 .multi_os_test_base:
   stage: tests
@@ -7,32 +7,32 @@
     DD_IAST_ENABLED: "false"
     DD_REMOTE_CONFIGURATION_ENABLED: "false"
 
-os tests ubuntu:
-  extends: .multi_os_test_base
-  image: registry.ddbuild.io/images/mirror/ubuntu:25.04
-  tags: ["arch:amd64"]
-  parallel:
-    matrix:
-      - PYTHON_VERSION: ["3.10", "3.12", "3.14"]
-  needs:
-    - job: "build linux"
-      parallel:
-        matrix:
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp310-cp310"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp312-cp312"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: "cp314-cp314"
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-  variables:
-    WHEEL_PATTERN: "manylinux2014*x86_64.whl"
-    PLATFORM: "Ubuntu"
-  script:
-    - apt-get update && apt-get install -y curl
-    - bash .gitlab/scripts/multi-os-tests.sh
+# os tests ubuntu:
+#   extends: .multi_os_test_base
+#   image: registry.ddbuild.io/images/mirror/ubuntu:25.04
+#   tags: ["arch:amd64"]
+#   parallel:
+#     matrix:
+#       - PYTHON_VERSION: ["3.10", "3.12", "3.14"]
+#   needs:
+#     - job: "build linux"
+#       parallel:
+#         matrix:
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: "cp310-cp310"
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: "cp312-cp312"
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: "cp314-cp314"
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#   variables:
+#     WHEEL_PATTERN: "manylinux2014*x86_64.whl"
+#     PLATFORM: "Ubuntu"
+#   script:
+#     - apt-get update && apt-get install -y curl
+#     - bash .gitlab/scripts/multi-os-tests.sh
 
 os tests macos:
   extends: .multi_os_test_base
@@ -42,6 +42,10 @@ os tests macos:
   variables:
     WHEEL_PATTERN: "macosx*arm64.whl"
     PLATFORM: "macOS"
+    # AIDEV-NOTE: this test PR disables one-pipeline.locked.yml (which
+    # normally sets FF_SCRIPT_SECTIONS=true globally), so set it here to
+    # reproduce the same runtime environment as in PR #17501.
+    FF_SCRIPT_SECTIONS: "true"
   script:
     - |
       for PYTHON_VERSION in 3.10 3.12 3.14; do
@@ -49,18 +53,18 @@ os tests macos:
         bash .gitlab/scripts/multi-os-tests.sh
       done
 
-os tests windows:
-  extends: .multi_os_test_base
-  tags: ["windows-v2:2022"]
-  needs:
-    - job: "build windows"
-      artifacts: true
-      parallel:
-        matrix:
-          - PYTHON_VERSION: ["3.10", "3.12", "3.14"]
-            WINDOWS_ARCH: "amd64"
-  parallel:
-    matrix:
-      - PYTHON_VERSION: ["3.10", "3.12", "3.14"]
-  script:
-    - powershell -File .gitlab/scripts/multi-os-tests.ps1
+# os tests windows:
+#   extends: .multi_os_test_base
+#   tags: ["windows-v2:2022"]
+#   needs:
+#     - job: "build windows"
+#       artifacts: true
+#       parallel:
+#         matrix:
+#           - PYTHON_VERSION: ["3.10", "3.12", "3.14"]
+#             WINDOWS_ARCH: "amd64"
+#   parallel:
+#     matrix:
+#       - PYTHON_VERSION: ["3.10", "3.12", "3.14"]
+#   script:
+#     - powershell -File .gitlab/scripts/multi-os-tests.ps1

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -1,3 +1,5 @@
+# AIDEV-NOTE: Most jobs temporarily commented out for tart runner validation.
+# Only "build macos arm64" and its base templates are active.
 variables:
   IMAGE_BASE_URL: "registry.ddbuild.io/dd-trace-py"
   MANYLINUX_AMD64_IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
@@ -67,68 +69,66 @@ variables:
       .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_SHA}" ${UPLOAD_SUFFIX:-}
       .gitlab/scripts/upload-wheels-to-s3.sh "${CI_PIPELINE_ID}" ${UPLOAD_SUFFIX:-}
 
-"build sdist":
-  extends: .build_base
-  image: "${IMAGE_BASE_URL}:${IMAGE_TAG}"
-  tags: [ "arch:${ARCH_TAG}" ]
-  variables:
-    DD_CYTHONIZE: "0"
-    ARCH_TAG: "amd64"
-    PYTHON_TAG: "cp314-cp314"
-    UV_PYTHON: "/opt/python/cp314-cp314/bin/python"
-    IMAGE_TAG: "${MANYLINUX_AMD64_IMAGE_TAG}"
-    # S3-backed sccache
-    SCCACHE_BUCKET: "dd-trace-py-builds"
-    SCCACHE_S3_KEY_PREFIX: "sccache"
-    SCCACHE_REGION: "us-east-1"
-  script:
-    - .gitlab/scripts/build-sdist.sh
-
-"build linux":
-  extends: .build_base
-  image: ${IMAGE_BASE_URL}:${IMAGE_TAG}
-  tags: [ "arch:$ARCH_TAG" ]
-  variables:
-    # S3-backed sccache for Linux builds
-    SCCACHE_BUCKET: "dd-trace-py-builds"
-    SCCACHE_S3_KEY_PREFIX: "sccache"
-    SCCACHE_REGION: "us-east-1"
-  parallel:
-    matrix:
-      - ARCH_TAG: "amd64"
-        PYTHON_TAG: *PYTHON_TAGS
-        IMAGE_TAG: *X86_64_IMAGES
-      - ARCH_TAG: "arm64"
-        PYTHON_TAG: *PYTHON_TAGS
-        IMAGE_TAG: *AARCH64_IMAGES
-  script:
-    - manylinux-interpreters ensure "${PYTHON_TAG}"
-    - |
-      if [[ "${UNPIN_DEPENDENCIES:-"false"}" == "true" ]]; then
-        manylinux-interpreters ensure "cp314-cp314"  # NB unpinning script requires Py>=311
-      fi
-    - export UV_PYTHON="/opt/python/${PYTHON_TAG}/bin/python"
-    - export DD_SERVERLESS_BUILD="${DD_SERVERLESS_BUILD:-0}"
-    - |
-      find src/native -type f -exec touch -t 202401010000 {} \;
-      find ddtrace/ -type f -name "*.pyx" -exec touch -t 202401010000 {} \;
-      find ddtrace/ -type f -name "*.c" -exec touch -t 202401010000 {} \;
-      find ddtrace/ -type f -name "*.cpp" -exec touch -t 202401010000 {} \;
-      find ddtrace/ -type f -name "*.h" -exec touch -t 202401010000 {} \;
-    - .gitlab/scripts/build-wheel.sh
-
-"build linux serverless":
-  extends: "build linux"
-  parallel:
-    matrix:
-      - ARCH_TAG: "amd64"
-        PYTHON_TAG: *PYTHON_TAGS
-        IMAGE_TAG: *X86_64_IMAGES
-        DD_SERVERLESS_BUILD: "1"
-      - ARCH_TAG: "arm64"
-        PYTHON_TAG: *PYTHON_TAGS
-        IMAGE_TAG: *AARCH64_IMAGES
-        DD_SERVERLESS_BUILD: "1"
+# "build sdist":
+#   extends: .build_base
+#   image: "${IMAGE_BASE_URL}:${IMAGE_TAG}"
+#   tags: [ "arch:${ARCH_TAG}" ]
+#   variables:
+#     DD_CYTHONIZE: "0"
+#     ARCH_TAG: "amd64"
+#     PYTHON_TAG: "cp314-cp314"
+#     UV_PYTHON: "/opt/python/cp314-cp314/bin/python"
+#     IMAGE_TAG: "${MANYLINUX_AMD64_IMAGE_TAG}"
+#     SCCACHE_BUCKET: "dd-trace-py-builds"
+#     SCCACHE_S3_KEY_PREFIX: "sccache"
+#     SCCACHE_REGION: "us-east-1"
+#   script:
+#     - .gitlab/scripts/build-sdist.sh
+#
+# "build linux":
+#   extends: .build_base
+#   image: ${IMAGE_BASE_URL}:${IMAGE_TAG}
+#   tags: [ "arch:$ARCH_TAG" ]
+#   variables:
+#     SCCACHE_BUCKET: "dd-trace-py-builds"
+#     SCCACHE_S3_KEY_PREFIX: "sccache"
+#     SCCACHE_REGION: "us-east-1"
+#   parallel:
+#     matrix:
+#       - ARCH_TAG: "amd64"
+#         PYTHON_TAG: *PYTHON_TAGS
+#         IMAGE_TAG: *X86_64_IMAGES
+#       - ARCH_TAG: "arm64"
+#         PYTHON_TAG: *PYTHON_TAGS
+#         IMAGE_TAG: *AARCH64_IMAGES
+#   script:
+#     - manylinux-interpreters ensure "${PYTHON_TAG}"
+#     - |
+#       if [[ "${UNPIN_DEPENDENCIES:-"false"}" == "true" ]]; then
+#         manylinux-interpreters ensure "cp314-cp314"
+#       fi
+#     - export UV_PYTHON="/opt/python/${PYTHON_TAG}/bin/python"
+#     - export DD_SERVERLESS_BUILD="${DD_SERVERLESS_BUILD:-0}"
+#     - |
+#       find src/native -type f -exec touch -t 202401010000 {} \;
+#       find ddtrace/ -type f -name "*.pyx" -exec touch -t 202401010000 {} \;
+#       find ddtrace/ -type f -name "*.c" -exec touch -t 202401010000 {} \;
+#       find ddtrace/ -type f -name "*.cpp" -exec touch -t 202401010000 {} \;
+#       find ddtrace/ -type f -name "*.h" -exec touch -t 202401010000 {} \;
+#     - .gitlab/scripts/build-wheel.sh
+#
+# "build linux serverless":
+#   extends: "build linux"
+#   parallel:
+#     matrix:
+#       - ARCH_TAG: "amd64"
+#         PYTHON_TAG: *PYTHON_TAGS
+#         IMAGE_TAG: *X86_64_IMAGES
+#         DD_SERVERLESS_BUILD: "1"
+#       - ARCH_TAG: "arm64"
+#         PYTHON_TAG: *PYTHON_TAGS
+#         IMAGE_TAG: *AARCH64_IMAGES
+#         DD_SERVERLESS_BUILD: "1"
 
 .build_macos_base:
   extends: .build_base
@@ -137,31 +137,33 @@ variables:
     MACOSX_DEPLOYMENT_TARGET: "14.7"
     DD_USE_SCCACHE: "1"
 
-"build macos amd64":
-  extends: .build_macos_base
-  tags: [ "macos:sonoma-amd64", "specific:true" ]
-  variables:
-    ARCH_TAG: "amd64"
-  parallel:
-    matrix:
-      # amd64 runners are slower
-      - PYTHON_VERSIONS:
-          - "3.9 3.10 3.11"
-          - "3.12 3.13 3.14"
-  script: |
-    set -euo pipefail
-    if ! command -v sccache &> /dev/null; then
-      brew install sccache
-    fi
-    for python_version in ${PYTHON_VERSIONS}; do
-      echo -e "\e[0Ksection_start:`date +%s`:build_macos_${python_version}\r\e[0KBuilding macOS wheel for Python ${python_version}"
-
-      export UV_PYTHON="${python_version}"
-      .gitlab/scripts/build-wheel.sh
-
-      echo -e "\e[0Ksection_end:`date +%s`:build_macos_${python_version}\r\e[0K"
-    done
-    sccache --show-stats
+# "build macos amd64":
+#   extends: .build_macos_base
+#   tags: [ "macos:sonoma-amd64", "specific:true" ]
+#   variables:
+#     ARCH_TAG: "amd64"
+#   parallel:
+#     matrix:
+#       # amd64 runners are slower
+#       - PYTHON_VERSIONS:
+#           - "3.9 3.10 3.11"
+#           - "3.12 3.13 3.14"
+#   script: |
+#     # Forces word splitting in zsh
+#     setopt shwordsplit 2>/dev/null || true
+#     set -euo pipefail
+#     if ! command -v sccache &> /dev/null; then
+#       brew install sccache
+#     fi
+#     for python_version in ${PYTHON_VERSIONS}; do
+#       echo -e "\e[0Ksection_start:`date +%s`:build_macos_${python_version}\r\e[0KBuilding macOS wheel for Python ${python_version}"
+#
+#       export UV_PYTHON="${python_version}"
+#       .gitlab/scripts/build-wheel.sh
+#
+#       echo -e "\e[0Ksection_end:`date +%s`:build_macos_${python_version}\r\e[0K"
+#     done
+#     sccache --show-stats
 
 "build macos arm64":
   extends: .build_macos_base
@@ -169,23 +171,22 @@ variables:
   tags: [ "macos:sonoma-tart" ]
   variables:
     ARCH_TAG: "arm64"
-    # The script section wrapper doesn't play nicely with zsh `setopt shwordsplit`
-    FF_SCRIPT_SECTIONS: "false"
+    PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
+    # Tart VMs are ephemeral; point sccache at the shared bucket the Tart
+    # IAM role has access to so the arm64 job gets cross-job cache reuse.
     SCCACHE_BUCKET: "dd-sccache-storage-us1-ddbuild-io"
     SCCACHE_REGION: "us-east-1"
-  parallel:
-    matrix:
-      - PYTHON_VERSIONS:
-          - "3.9 3.10 3.11"
-          - "3.12 3.13 3.14"
   script: |
+    # Forces word splitting in zsh
     setopt shwordsplit 2>/dev/null || true
     set -euo pipefail
     if ! command -v sccache &> /dev/null; then
       brew install sccache
     fi
-    # sccache hardcodes the IMDS IP (169.254.169.254) and ignores $AWS_EC2_METADATA_SERVICE_ENDPOINT,
-    # so resolve creds from the tart iam-proxy beforehand
+    # sccache's reqsign credential loader hardcodes the IMDS IP
+    # (169.254.169.254) and ignores $AWS_EC2_METADATA_SERVICE_ENDPOINT,
+    # so resolve creds from the tart iam-proxy once and export them as
+    # static AWS_* env vars for sccache.
     role=$(curl -sS "${AWS_EC2_METADATA_SERVICE_ENDPOINT}/latest/meta-data/iam/security-credentials/")
     creds=$(curl -sS "${AWS_EC2_METADATA_SERVICE_ENDPOINT}/latest/meta-data/iam/security-credentials/${role}")
     export AWS_ACCESS_KEY_ID=$(python3 -c 'import sys,json;print(json.load(sys.stdin)["AccessKeyId"])' <<<"$creds")
@@ -201,233 +202,214 @@ variables:
     done
     sccache --show-stats
 
-# Only amd64 manylinux2014 wheels
-"upload manylinux2014_x86_64":
-  extends: .upload_wheels_base
-  needs:
-    - job: "build linux"
-      artifacts: true
-      parallel:
-        matrix:
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-    - job: "package version"
-  variables:
-    UPLOAD_SUFFIX: "manylinux2014_x86_64"
-
-# All manylinux2014 wheels
-"upload manylinux2014":
-  extends: .upload_wheels_base
-  needs:
-    - job: "build linux"
-      artifacts: true
-      parallel:
-        matrix:
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
-          - ARCH_TAG: "arm64"
-            PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v85383414-751efc0-manylinux2014_aarch64"
-    - job: "package version"
-  variables:
-    UPLOAD_SUFFIX: "manylinux2014"
-
-# Only the limited artifacts needed by downstream serverless jobs
-"upload serverless":
-  extends: .upload_wheels_base
-  needs:
-    - job: "build linux serverless"
-      artifacts: true
-      parallel:
-        matrix:
-          - ARCH_TAG: "amd64"
-            PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: *X86_64_IMAGES
-            DD_SERVERLESS_BUILD: "1"
-          - ARCH_TAG: "arm64"
-            PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: *AARCH64_IMAGES
-            DD_SERVERLESS_BUILD: "1"
-    - job: "package version"
-  variables:
-    UPLOAD_SUFFIX: "serverless"
-  script:
-    - !reference [.upload_wheels_base, script]
-    - |
-      set -euo pipefail
-
-      # Upload to branch path (only for main/release branches)
-      if [ "${CI_COMMIT_BRANCH:-}" = "main" ] || [[ "${CI_COMMIT_BRANCH:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-        .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_BRANCH}" ${UPLOAD_SUFFIX:-}
-      fi
-
-
-"test sdist":
-  image: "${IMAGE_BASE_URL}:${ALPINE_BUILD_IMAGE_TAG}"
-  tags: [ "arch:arm64" ]
-  stage: package
-  variables:
-    CARGO_BUILD_JOBS: "12"
-    CMAKE_BUILD_PARALLEL_LEVEL: "12"
-    KUBERNETES_CPU_REQUEST: "6"
-    KUBERNETES_MEMORY_REQUEST: "10Gi"
-    KUBERNETES_MEMORY_LIMIT: "10Gi"
-    DD_DISABLE_VPA: true
-  needs:
-    - job: "build sdist"
-      artifacts: true
-  script:
-    - SDIST_FILE=$(ls ${CI_PROJECT_DIR}/pywheels/*.tar.gz | head -n 1)
-    - TMP_DIR=$(mktemp -d) && cd $TMP_DIR
-    - twine check ${SDIST_FILE}
-    - pip install ${SDIST_FILE}
-    - python ${CI_PROJECT_DIR}/tests/smoke_test.py
-
-"build windows":
-  stage: package
-  tags: ["windows-v2:2022"]
-  parallel:
-    matrix:
-      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        WINDOWS_ARCH: ["amd64", "x86"]
-  variables:
-    WINDOWS_BUILD_IMAGE: "registry.ddbuild.io/images/mirror/dd-trace-py/windows-build:d4d18a67d43d400d3ecc6bda777a5e233a24f434@sha256:58c3e28646ddf8a1021a079a380c8840e51f0b88c1489a522beee6ec99413019"
-  script:
-    - bash .gitlab/scripts/build-wheel-windows.sh
-  artifacts:
-    paths:
-      - "pywheels/*.whl"
-      - "debugwheelhouse/*.log"
-
-# Downloads win_arm64 wheels from GitHub Actions (arm64 cannot be cross-compiled
-# from the amd64 Windows runners available in GitLab).
-"download win_arm64 wheels":
-  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
-  tags: [ "arch:amd64" ]
-  stage: package
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
-  script: |
-    if [ -z ${GH_TOKEN} ]
-    then
-      # Use dd-octo-sts to get GitHub token
-      dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read > token
-      gh auth login --with-token < token
-      rm token
-    fi
-    # Prevent git operation errors:
-    #   failed to determine base repo: failed to run git: fatal: detected dubious ownership in repository at ...
-    git config --global --add safe.directory "${CI_PROJECT_DIR}"
-    .gitlab/download-wheels-from-gh-actions.sh
-  artifacts:
-    paths:
-      - "pywheels/*.whl"
-      - "pywheels/*.tar.gz"
-
-download_dependency_wheels:
-  image: registry.ddbuild.io/images/mirror/python:$PYTHON_IMAGE_TAG
-  tags: [ "arch:amd64" ]
-  stage: package
-  needs:
-    - job: "build linux"
-      artifacts: true
-  variables:
-    PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.cache/pip"
-  parallel:
-    matrix: # The image tags that are mirrored are in: https://github.com/DataDog/images/blob/master/mirror.yaml
-      - PYTHON_IMAGE_TAG: "3.9.13"
-        PYTHON_VERSION: "3.9"
-      - PYTHON_IMAGE_TAG: "3.10.13"
-        PYTHON_VERSION: "3.10"
-      - PYTHON_IMAGE_TAG: "3.11.6"
-        PYTHON_VERSION: "3.11"
-      - PYTHON_IMAGE_TAG: "3.12.0"
-        PYTHON_VERSION: "3.12"
-      - PYTHON_IMAGE_TAG: "3.13.0"
-        PYTHON_VERSION: "3.13"
-      - PYTHON_IMAGE_TAG: "3.14.0"
-        PYTHON_VERSION: "3.14"
-  script:
-    - .gitlab/download-dependency-wheels.sh
-  cache:
-    - key: v0-download-dep-wheels-cache
-      paths:
-        - ${CI_PROJECT_DIR}/.cache/
-  artifacts:
-    paths:
-      - "pywheels-dep/"
-
-"upload all":
-  extends: .upload_wheels_base
-  needs: [ "ddtrace package", "package version" ]
-  script:
-    - !reference [.upload_wheels_base, script]
-    - |
-      set -euo pipefail
-
-      # Upload to branch path (only for main/release branches)
-      if [ "${CI_COMMIT_BRANCH:-}" = "main" ] || [[ "${CI_COMMIT_BRANCH:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-        .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_BRANCH}" ${UPLOAD_SUFFIX:-}
-      fi
-
-# Upload ELF debug symbols to the Datadog symbols backend for crashtracker symbolication.
-# Runs automatically on releases/RCs, available as manual trigger for other pipelines.
-"upload debug symbols to backend":
-  stage: release
-  extends: .testrunner
-  needs:
-    - job: "build linux"
-      artifacts: true
-  rules:
-    # Automatically run on releases/RCs
-    - if: !reference [.is_release]
-      when: on_success
-    # Manual trigger for any other pipeline
-    - when: manual
-      allow_failure: true
-  script:
-    - .gitlab/scripts/upload-debug-symbols-to-backend.sh
-
-# Extract package version from pyproject.toml and save to dotenv artifact
-"package version":
-  image: registry.ddbuild.io/images/mirror/python:3.14.0
-  tags: [ "arch:amd64" ]
-  stage: package
-  script:
-    - PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-    - echo "PACKAGE_VERSION=${PACKAGE_VERSION}" | tee -a package_version.env
-    # Validate commit tag matches version if tag is set
-    - |
-      if [ -n "${CI_COMMIT_TAG:-}" ]; then
-        EXPECTED_TAG="v${PACKAGE_VERSION}"
-        if [ "${CI_COMMIT_TAG}" != "${EXPECTED_TAG}" ]; then
-          echo "[ERROR] CI_COMMIT_TAG (${CI_COMMIT_TAG}) does not match expected tag (${EXPECTED_TAG})"
-          exit 1
-        fi
-      fi
-  artifacts:
-    reports:
-      dotenv: package_version.env
-
-# Aggregates all Windows wheel artifacts
-# DEV: "ddtrace package" has a limit of 50 jobs it can depend on
-"collect windows wheels":
-  image: registry.ddbuild.io/images/mirror/python:3.14.0
-  tags: [ "arch:amd64" ]
-  stage: package
-  needs:
-    - job: "build windows"
-      artifacts: true
-    - job: "download win_arm64 wheels"
-      artifacts: true
-  script:
-    - echo "Collected $(ls pywheels/*.whl 2>/dev/null | wc -l) Windows wheels"
-  artifacts:
-    paths:
-      - "pywheels/*.whl"
+# "upload manylinux2014_x86_64":
+#   extends: .upload_wheels_base
+#   needs:
+#     - job: "build linux"
+#       artifacts: true
+#       parallel:
+#         matrix:
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: *PYTHON_TAGS
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#     - job: "package version"
+#   variables:
+#     UPLOAD_SUFFIX: "manylinux2014_x86_64"
+#
+# "upload manylinux2014":
+#   extends: .upload_wheels_base
+#   needs:
+#     - job: "build linux"
+#       artifacts: true
+#       parallel:
+#         matrix:
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: *PYTHON_TAGS
+#             IMAGE_TAG: "v85383392-751efc0-manylinux2014_x86_64"
+#           - ARCH_TAG: "arm64"
+#             PYTHON_TAG: *PYTHON_TAGS
+#             IMAGE_TAG: "v85383414-751efc0-manylinux2014_aarch64"
+#     - job: "package version"
+#   variables:
+#     UPLOAD_SUFFIX: "manylinux2014"
+#
+# "upload serverless":
+#   extends: .upload_wheels_base
+#   needs:
+#     - job: "build linux serverless"
+#       artifacts: true
+#       parallel:
+#         matrix:
+#           - ARCH_TAG: "amd64"
+#             PYTHON_TAG: *PYTHON_TAGS
+#             IMAGE_TAG: *X86_64_IMAGES
+#             DD_SERVERLESS_BUILD: "1"
+#           - ARCH_TAG: "arm64"
+#             PYTHON_TAG: *PYTHON_TAGS
+#             IMAGE_TAG: *AARCH64_IMAGES
+#             DD_SERVERLESS_BUILD: "1"
+#     - job: "package version"
+#   variables:
+#     UPLOAD_SUFFIX: "serverless"
+#   script:
+#     - !reference [.upload_wheels_base, script]
+#     - |
+#       set -euo pipefail
+#       if [ "${CI_COMMIT_BRANCH:-}" = "main" ] || [[ "${CI_COMMIT_BRANCH:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+#         .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_BRANCH}" ${UPLOAD_SUFFIX:-}
+#       fi
+#
+# "test sdist":
+#   image: "${IMAGE_BASE_URL}:${ALPINE_BUILD_IMAGE_TAG}"
+#   tags: [ "arch:arm64" ]
+#   stage: package
+#   variables:
+#     CARGO_BUILD_JOBS: "12"
+#     CMAKE_BUILD_PARALLEL_LEVEL: "12"
+#     KUBERNETES_CPU_REQUEST: "6"
+#     KUBERNETES_MEMORY_REQUEST: "10Gi"
+#     KUBERNETES_MEMORY_LIMIT: "10Gi"
+#     DD_DISABLE_VPA: true
+#   needs:
+#     - job: "build sdist"
+#       artifacts: true
+#   script:
+#     - SDIST_FILE=$(ls ${CI_PROJECT_DIR}/pywheels/*.tar.gz | head -n 1)
+#     - TMP_DIR=$(mktemp -d) && cd $TMP_DIR
+#     - twine check ${SDIST_FILE}
+#     - pip install ${SDIST_FILE}
+#     - python ${CI_PROJECT_DIR}/tests/smoke_test.py
+#
+# "build windows":
+#   stage: package
+#   tags: ["windows-v2:2022"]
+#   parallel:
+#     matrix:
+#       - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+#         WINDOWS_ARCH: ["amd64", "x86"]
+#   retry: 2
+#   variables:
+#     CMAKE_BUILD_PARALLEL_LEVEL: "6"
+#     CARGO_BUILD_JOBS: "6"
+#   script:
+#     - bash .gitlab/scripts/build-wheel-windows.sh
+#   artifacts:
+#     paths:
+#       - "pywheels/*.whl"
+#       - "debugwheelhouse/*.log"
+#
+# "download win_arm64 wheels":
+#   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+#   tags: [ "arch:amd64" ]
+#   stage: package
+#   id_tokens:
+#     DDOCTOSTS_ID_TOKEN:
+#       aud: dd-octo-sts
+#   script: |
+#     if [ -z ${GH_TOKEN} ]
+#     then
+#       dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read > token
+#       gh auth login --with-token < token
+#       rm token
+#     fi
+#     git config --global --add safe.directory "${CI_PROJECT_DIR}"
+#     .gitlab/download-wheels-from-gh-actions.sh
+#   artifacts:
+#     paths:
+#       - "pywheels/*.whl"
+#       - "pywheels/*.tar.gz"
+#
+# download_dependency_wheels:
+#   image: registry.ddbuild.io/images/mirror/python:$PYTHON_IMAGE_TAG
+#   tags: [ "arch:amd64" ]
+#   stage: package
+#   needs:
+#     - job: "build linux"
+#       artifacts: true
+#   variables:
+#     PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.cache/pip"
+#   parallel:
+#     matrix:
+#       - PYTHON_IMAGE_TAG: "3.9.13"
+#         PYTHON_VERSION: "3.9"
+#       - PYTHON_IMAGE_TAG: "3.10.13"
+#         PYTHON_VERSION: "3.10"
+#       - PYTHON_IMAGE_TAG: "3.11.6"
+#         PYTHON_VERSION: "3.11"
+#       - PYTHON_IMAGE_TAG: "3.12.0"
+#         PYTHON_VERSION: "3.12"
+#       - PYTHON_IMAGE_TAG: "3.13.0"
+#         PYTHON_VERSION: "3.13"
+#       - PYTHON_IMAGE_TAG: "3.14.0"
+#         PYTHON_VERSION: "3.14"
+#   script:
+#     - .gitlab/download-dependency-wheels.sh
+#   cache:
+#     - key: v0-download-dep-wheels-cache
+#       paths:
+#         - ${CI_PROJECT_DIR}/.cache/
+#   artifacts:
+#     paths:
+#       - "pywheels-dep/"
+#
+# "upload all":
+#   extends: .upload_wheels_base
+#   needs: [ "ddtrace package", "package version" ]
+#   script:
+#     - !reference [.upload_wheels_base, script]
+#     - |
+#       set -euo pipefail
+#       if [ "${CI_COMMIT_BRANCH:-}" = "main" ] || [[ "${CI_COMMIT_BRANCH:-}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+#         .gitlab/scripts/upload-wheels-to-s3.sh "${CI_COMMIT_BRANCH}" ${UPLOAD_SUFFIX:-}
+#       fi
+#
+# "upload debug symbols to backend":
+#   stage: release
+#   extends: .testrunner
+#   needs:
+#     - job: "build linux"
+#       artifacts: true
+#   rules:
+#     - if: !reference [.is_release]
+#       when: on_success
+#     - when: manual
+#       allow_failure: true
+#   script:
+#     - .gitlab/scripts/upload-debug-symbols-to-backend.sh
+#
+# "package version":
+#   image: registry.ddbuild.io/images/mirror/python:3.14.0
+#   tags: [ "arch:amd64" ]
+#   stage: package
+#   script:
+#     - PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+#     - echo "PACKAGE_VERSION=${PACKAGE_VERSION}" | tee -a package_version.env
+#     - |
+#       if [ -n "${CI_COMMIT_TAG:-}" ]; then
+#         EXPECTED_TAG="v${PACKAGE_VERSION}"
+#         if [ "${CI_COMMIT_TAG}" != "${EXPECTED_TAG}" ]; then
+#           echo "[ERROR] CI_COMMIT_TAG (${CI_COMMIT_TAG}) does not match expected tag (${EXPECTED_TAG})"
+#           exit 1
+#         fi
+#       fi
+#   artifacts:
+#     reports:
+#       dotenv: package_version.env
+#
+# "collect windows wheels":
+#   image: registry.ddbuild.io/images/mirror/python:3.14.0
+#   tags: [ "arch:amd64" ]
+#   stage: package
+#   needs:
+#     - job: "build windows"
+#       artifacts: true
+#     - job: "download win_arm64 wheels"
+#       artifacts: true
+#   script:
+#     - echo "Collected $(ls pywheels/*.whl 2>/dev/null | wc -l) Windows wheels"
+#   artifacts:
+#     paths:
+#       - "pywheels/*.whl"
 
 # Aggregate and validate all built wheels
 .package_base:
@@ -441,22 +423,22 @@ download_dependency_wheels:
       - "pywheels/*.whl"
       - "pywheels/*.tar.gz"
 
-"ddtrace package":
-  extends: .package_base
-  needs:
-    - "build linux"
-    - "build macos amd64"
-    - "build macos arm64"
-    - "build sdist"
-    - "collect windows wheels"
-    - "package version"
-  script:
-    - .gitlab/validate-ddtrace-package.py pywheels
-
-"ddtrace package serverless":
-  extends: .package_base
-  needs:
-    - "build linux serverless"
-    - "package version"
-  script:
-    - .gitlab/validate-ddtrace-package.py pywheels --mode=serverless
+# "ddtrace package":
+#   extends: .package_base
+#   needs:
+#     - "build linux"
+#     - "build macos amd64"
+#     - "build macos arm64"
+#     - "build sdist"
+#     - "collect windows wheels"
+#     - "package version"
+#   script:
+#     - .gitlab/validate-ddtrace-package.py pywheels
+#
+# "ddtrace package serverless":
+#   extends: .package_base
+#   needs:
+#     - "build linux serverless"
+#     - "package version"
+#   script:
+#     - .gitlab/validate-ddtrace-package.py pywheels --mode=serverless

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -174,6 +174,10 @@ variables:
     ARCH_TAG: "arm64"
     # The script section wrapper doesn't play nicely with zsh `setopt shwordsplit`
     FF_SCRIPT_SECTIONS: "false"
+    # Tart VMs are ephemeral; point sccache at the shared bucket the Tart
+    # IAM role has access to so the arm64 job gets cross-job cache reuse.
+    SCCACHE_BUCKET: "dd-sccache-storage-us1-ddbuild-io"
+    SCCACHE_REGION: "us-east-1"
   parallel:
     matrix:
       - PYTHON_VERSIONS:

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -134,12 +134,21 @@ variables:
   extends: .build_base
   variables:
     SYSTEM_VERSION_COMPAT: "0"
-      # Pin the deployment target as the tart VM image may run a different minor version
     MACOSX_DEPLOYMENT_TARGET: "14.7"
     DD_USE_SCCACHE: "1"
+
+"build macos amd64":
+  extends: .build_macos_base
+  tags: [ "macos:sonoma-amd64", "specific:true" ]
+  variables:
+    ARCH_TAG: "amd64"
+  parallel:
+    matrix:
+      # amd64 runners are slower
+      - PYTHON_VERSIONS:
+          - "3.9 3.10 3.11"
+          - "3.12 3.13 3.14"
   script: |
-    # Forces word splitting in zsh
-    setopt shwordsplit 2>/dev/null || true
     set -euo pipefail
     if ! command -v sccache &> /dev/null; then
       brew install sccache
@@ -154,18 +163,6 @@ variables:
     done
     sccache --show-stats
 
-"build macos amd64":
-  extends: .build_macos_base
-  tags: [ "macos:sonoma-amd64", "specific:true" ]
-  variables:
-    ARCH_TAG: "amd64"
-  parallel:
-    matrix:
-      # amd64 runners are slower
-      - PYTHON_VERSIONS:
-          - "3.9 3.10 3.11"
-          - "3.12 3.13 3.14"
-
 "build macos arm64":
   extends: .build_macos_base
   image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
@@ -174,8 +171,6 @@ variables:
     ARCH_TAG: "arm64"
     # The script section wrapper doesn't play nicely with zsh `setopt shwordsplit`
     FF_SCRIPT_SECTIONS: "false"
-    # Tart VMs are ephemeral; point sccache at the shared bucket the Tart
-    # IAM role has access to so the arm64 job gets cross-job cache reuse.
     SCCACHE_BUCKET: "dd-sccache-storage-us1-ddbuild-io"
     SCCACHE_REGION: "us-east-1"
   parallel:
@@ -183,6 +178,28 @@ variables:
       - PYTHON_VERSIONS:
           - "3.9 3.10 3.11"
           - "3.12 3.13 3.14"
+  script: |
+    setopt shwordsplit 2>/dev/null || true
+    set -euo pipefail
+    if ! command -v sccache &> /dev/null; then
+      brew install sccache
+    fi
+    # sccache hardcodes the IMDS IP (169.254.169.254) and ignores $AWS_EC2_METADATA_SERVICE_ENDPOINT,
+    # so resolve creds from the tart iam-proxy beforehand
+    role=$(curl -sS "${AWS_EC2_METADATA_SERVICE_ENDPOINT}/latest/meta-data/iam/security-credentials/")
+    creds=$(curl -sS "${AWS_EC2_METADATA_SERVICE_ENDPOINT}/latest/meta-data/iam/security-credentials/${role}")
+    export AWS_ACCESS_KEY_ID=$(python3 -c 'import sys,json;print(json.load(sys.stdin)["AccessKeyId"])' <<<"$creds")
+    export AWS_SECRET_ACCESS_KEY=$(python3 -c 'import sys,json;print(json.load(sys.stdin)["SecretAccessKey"])' <<<"$creds")
+    export AWS_SESSION_TOKEN=$(python3 -c 'import sys,json;print(json.load(sys.stdin)["Token"])' <<<"$creds")
+    for python_version in ${PYTHON_VERSIONS}; do
+      echo -e "\e[0Ksection_start:`date +%s`:build_macos_${python_version}\r\e[0KBuilding macOS wheel for Python ${python_version}"
+
+      export UV_PYTHON="${python_version}"
+      .gitlab/scripts/build-wheel.sh
+
+      echo -e "\e[0Ksection_end:`date +%s`:build_macos_${python_version}\r\e[0K"
+    done
+    sccache --show-stats
 
 # Only amd64 manylinux2014 wheels
 "upload manylinux2014_x86_64":

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -172,6 +172,10 @@ variables:
   variables:
     ARCH_TAG: "arm64"
     PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
+    # Disable runner-wrapped script sections so the multi-line script's
+    # stdout/stderr stream inline instead of being swallowed by the
+    # collapsed section wrapper.
+    FF_SCRIPT_SECTIONS: "false"
 
 # Only amd64 manylinux2014 wheels
 "upload manylinux2014_x86_64":

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -134,6 +134,7 @@ variables:
   extends: .build_base
   variables:
     SYSTEM_VERSION_COMPAT: "0"
+      # Pin the deployment target as the tart VM image may run a different minor version
     MACOSX_DEPLOYMENT_TARGET: "14.7"
     DD_USE_SCCACHE: "1"
   script: |
@@ -171,11 +172,13 @@ variables:
   tags: [ "macos:sonoma-tart" ]
   variables:
     ARCH_TAG: "arm64"
-    PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
-    # Disable runner-wrapped script sections so the multi-line script's
-    # stdout/stderr stream inline instead of being swallowed by the
-    # collapsed section wrapper.
+    # The script section wrapper doesn't play nicely with zsh `setopt shwordsplit`
     FF_SCRIPT_SECTIONS: "false"
+  parallel:
+    matrix:
+      - PYTHON_VERSIONS:
+          - "3.9 3.10 3.11"
+          - "3.12 3.13 3.14"
 
 # Only amd64 manylinux2014 wheels
 "upload manylinux2014_x86_64":

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -130,22 +130,15 @@ variables:
         IMAGE_TAG: *AARCH64_IMAGES
         DD_SERVERLESS_BUILD: "1"
 
-"build macos":
+.build_macos_base:
   extends: .build_base
-  tags: [ "macos:sonoma-$ARCH_TAG", "specific:true" ]
-  parallel:
-    matrix:
-      # amd64 runners are slower
-      - ARCH_TAG: "amd64"
-        PYTHON_VERSIONS:
-          - "3.9 3.10 3.11"
-          - "3.12 3.13 3.14"
-      - ARCH_TAG: "arm64"
-        PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
   variables:
     SYSTEM_VERSION_COMPAT: "0"
+    MACOSX_DEPLOYMENT_TARGET: "14.7"
     DD_USE_SCCACHE: "1"
   script: |
+    # Forces word splitting in zsh
+    setopt shwordsplit 2>/dev/null || true
     set -euo pipefail
     if ! command -v sccache &> /dev/null; then
       brew install sccache
@@ -159,6 +152,26 @@ variables:
       echo -e "\e[0Ksection_end:`date +%s`:build_macos_${python_version}\r\e[0K"
     done
     sccache --show-stats
+
+"build macos amd64":
+  extends: .build_macos_base
+  tags: [ "macos:sonoma-amd64", "specific:true" ]
+  variables:
+    ARCH_TAG: "amd64"
+  parallel:
+    matrix:
+      # amd64 runners are slower
+      - PYTHON_VERSIONS:
+          - "3.9 3.10 3.11"
+          - "3.12 3.13 3.14"
+
+"build macos arm64":
+  extends: .build_macos_base
+  image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
+  tags: [ "macos:sonoma-tart" ]
+  variables:
+    ARCH_TAG: "arm64"
+    PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
 
 # Only amd64 manylinux2014 wheels
 "upload manylinux2014_x86_64":
@@ -404,7 +417,8 @@ download_dependency_wheels:
   extends: .package_base
   needs:
     - "build linux"
-    - "build macos"
+    - "build macos amd64"
+    - "build macos arm64"
     - "build sdist"
     - "collect windows wheels"
     - "package version"


### PR DESCRIPTION
## Summary

Draft test PR to reproduce the \`os tests macos\` failure observed on PR #17501 in isolation. Structurally based on PR #17436's "disable everything except the macos jobs" overlay.

## Setup

- Most CI includes and inline jobs are commented out — only \`pipeline variables\`, \`build macos arm64\`, and \`os tests macos\` run
- \`build macos arm64\` mirrors PR #17501 (tart VM image, sccache + IMDS workaround) so it succeeds and produces the wheel artifact \`os tests macos\` depends on
- \`os tests macos\` mirrors PR #17501 — same image, tags, script, and \`needs\` — but explicitly sets \`FF_SCRIPT_SECTIONS=true\` in its \`variables:\` block

## Why FF_SCRIPT_SECTIONS=true is set here

PR #17436 disables \`one-pipeline.locked.yml\`, which is the file that normally sets \`FF_SCRIPT_SECTIONS=true\` globally. Without that include, the flag wouldn't be set in this test PR, and the failure wouldn't reproduce. Setting it on the \`os tests macos\` job recreates the production runtime environment for just that job.

## Expected outcome

- \`pipeline variables\`: ✅ pass
- \`build macos arm64\`: ✅ pass (FF_SCRIPT_SECTIONS not set on this job)
- \`os tests macos\`: ❌ fail with the same script-section / zsh issue seen on PR #17501

## Do not merge

This is purely a reproduction PR — keep it as draft.