### PR TITLE
fix(profiling): dedupe last-profile flush across atexit + exit-signal paths

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -89,6 +89,8 @@ class Profiler(object):
         # We register _stop_on_signal (not stop) to avoid deadlocking when SIGTERM arrives while
         # _active_lock is already held by the main thread (e.g. during start or stop).
         atexit.register_on_exit_signal(self._stop_on_signal)
+        import os as _os, sys as _sys  # DEBUG
+        print(f"[DD-DEBUG] pid={_os.getpid()} Profiler.start() REGISTERED id(self)={id(self)}", file=_sys.stderr, flush=True)  # DEBUG
 
         # Note: For regular fork(), native pthread_atfork handlers restart the sampling thread
         # and PeriodicThread auto-restart handles the Scheduler. No explicit forksafe hook needed.
@@ -107,15 +109,20 @@ class Profiler(object):
         here is strictly stronger and also dedupes against the exit-signal path added in
         #18041.
         """
+        import os, sys  # DEBUG
+        print(f"[DD-DEBUG] pid={os.getpid()} Profiler.stop() ENTRY id(self)={id(self)} flush={flush}", file=sys.stderr, flush=True)  # DEBUG
         if not self._shutdown_lock.acquire(blocking=True):
+            print(f"[DD-DEBUG] pid={os.getpid()} Profiler.stop() lock-fail", file=sys.stderr, flush=True)  # DEBUG
             return
         try:
             if self._did_shutdown:
+                print(f"[DD-DEBUG] pid={os.getpid()} Profiler.stop() ALREADY-SHUTDOWN id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
                 return
             self._did_shutdown = True
             atexit.unregister(self.stop)
             try:
                 with Profiler._active_lock:
+                    print(f"[DD-DEBUG] pid={os.getpid()} Profiler.stop() FLUSHING id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
                     self._profiler.stop(flush)
                     if Profiler._active_instance is self:
                         Profiler._active_instance = None
@@ -123,6 +130,7 @@ class Profiler(object):
             except service.ServiceStatusError:
                 # Underlying profiler instance is already stopped (e.g. user called
                 # _profiler.stop directly). Treat as success.
+                print(f"[DD-DEBUG] pid={os.getpid()} Profiler.stop() ServiceStatusError id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
                 pass
         finally:
             self._shutdown_lock.release()
@@ -145,14 +153,19 @@ class Profiler(object):
         (`_stop_on_signal`) regardless of which path wins the race, fixing the
         double-flush observed when uvicorn worker shutdown exercises both paths.
         """
+        import os, sys  # DEBUG
+        print(f"[DD-DEBUG] pid={os.getpid()} _stop_on_signal() ENTRY id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
         if not self._shutdown_lock.acquire(blocking=False):
             # Shutdown is already running on another thread (or this same thread held
             # the lock when the signal fired). The in-progress shutdown will flush.
+            print(f"[DD-DEBUG] pid={os.getpid()} _stop_on_signal() lock-fail", file=sys.stderr, flush=True)  # DEBUG
             return
         try:
             if self._did_shutdown:
+                print(f"[DD-DEBUG] pid={os.getpid()} _stop_on_signal() ALREADY-SHUTDOWN id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
                 return
             if not Profiler._active_lock.acquire(blocking=False):
+                print(f"[DD-DEBUG] pid={os.getpid()} _stop_on_signal() active-lock-fail", file=sys.stderr, flush=True)  # DEBUG
                 # `start()`/`stop()` is in progress on the main thread between bytecodes.
                 # We're now running in that same thread via the signal handler; a blocking
                 # acquire would deadlock. The narrow race where `_raise_default`
@@ -162,8 +175,10 @@ class Profiler(object):
             self._did_shutdown = True
             atexit.unregister(self.stop)
             try:
+                print(f"[DD-DEBUG] pid={os.getpid()} _stop_on_signal() FLUSHING id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
                 self._profiler.stop(flush=True)
             except service.ServiceStatusError:
+                print(f"[DD-DEBUG] pid={os.getpid()} _stop_on_signal() ServiceStatusError id(self)={id(self)}", file=sys.stderr, flush=True)  # DEBUG
                 pass
             except Exception:
                 LOG.debug("Exception while stopping profiler on exit signal", exc_info=True)

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -48,6 +48,12 @@ class Profiler(object):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._profiler: "_ProfilerInstance" = _ProfilerInstance(*args, **kwargs)
+        # Per-instance shutdown coordination. Both `stop()` (atexit, explicit call) and
+        # `_stop_on_signal` (SIGTERM/SIGINT) funnel through the same idempotency guard so
+        # the last profile is flushed exactly once, regardless of which exit path fires
+        # first or whether several paths race. Mirrors the pattern in `Tracer.shutdown`.
+        self._shutdown_lock = Lock()
+        self._did_shutdown: bool = False
 
     def start(self) -> None:
         """Start the profiler."""
@@ -94,51 +100,80 @@ class Profiler(object):
         """Stop the profiler.
 
         :param flush: Flush last profile.
+
+        Idempotent: subsequent calls (including races with the SIGTERM/SIGINT handler and
+        atexit) are no-ops. For backward API compatibility, `stop()` previously allowed
+        repeated calls via a ServiceStatusError catch; the per-instance shutdown guard
+        here is strictly stronger and also dedupes against the exit-signal path added in
+        #18041.
         """
-        atexit.unregister(self.stop)
+        if not self._shutdown_lock.acquire(blocking=True):
+            return
         try:
-            with Profiler._active_lock:
-                self._profiler.stop(flush)
-                if Profiler._active_instance is self:
-                    Profiler._active_instance = None
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
-        except service.ServiceStatusError:
-            # Not a best practice, but for backward API compatibility that allowed to call `stop` multiple times.
-            pass
+            if self._did_shutdown:
+                return
+            self._did_shutdown = True
+            atexit.unregister(self.stop)
+            try:
+                with Profiler._active_lock:
+                    self._profiler.stop(flush)
+                    if Profiler._active_instance is self:
+                        Profiler._active_instance = None
+                telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
+            except service.ServiceStatusError:
+                # Underlying profiler instance is already stopped (e.g. user called
+                # _profiler.stop directly). Treat as success.
+                pass
+        finally:
+            self._shutdown_lock.release()
 
     def _stop_on_signal(self) -> None:
         """Flush and stop the profiler when an exit signal (SIGTERM/SIGINT) is received.
 
-        Signal handlers run in the main thread between bytecodes. If the main thread already
-        holds _active_lock (e.g. SIGTERM races with start or stop), a blocking acquire
-        would deadlock. We use non-blocking acquire and bail out when the lock is unavailable:
-        in that case start/stop is already in progress and will handle cleanup itself.
+        Signal handlers run in the main thread between bytecodes. To stay deadlock-free,
+        we use *non-blocking* lock acquires throughout:
 
-        This mirrors the pattern used by the tracer's shutdown method.
+        * `_shutdown_lock` (instance-level): dedup against `stop()` running on another
+          thread. If we can't grab it, shutdown is in progress and will complete the flush;
+          we bail out so we don't double-flush.
+        * `_active_lock` (class-level): same concern, plus avoids re-entrant deadlock if
+          SIGTERM arrives while the main thread is inside `start()`/`stop()` and already
+          holds the lock.
+
+        The combined `_shutdown_lock` + `_did_shutdown` flag is the source of truth for
+        "flush happened once"; it dedupes between atexit (`stop`) and signal
+        (`_stop_on_signal`) regardless of which path wins the race, fixing the
+        double-flush observed when uvicorn worker shutdown exercises both paths.
         """
-        atexit.unregister(self.stop)
-
-        if not Profiler._active_lock.acquire(blocking=False):
-            # If the lock is unavailable, stop is already running on the main thread
-            # (signal handlers are delivered between bytecodes of the main thread, so the main
-            # thread itself holds the lock). A blocking acquire here would deadlock. We bail out
-            # and rely on the in-progress stop to complete the flush. The narrow race where
-            # _raise_default terminates the process before stop finishes is a known
-            # limitation: there is no safe way to wait for a lock held by the
-            # current thread from within a signal handler.
+        if not self._shutdown_lock.acquire(blocking=False):
+            # Shutdown is already running on another thread (or this same thread held
+            # the lock when the signal fired). The in-progress shutdown will flush.
             return
-
         try:
-            self._profiler.stop(flush=True)
-        except service.ServiceStatusError:
-            pass
-        except Exception:
-            LOG.debug("Exception while stopping profiler on exit signal", exc_info=True)
+            if self._did_shutdown:
+                return
+            if not Profiler._active_lock.acquire(blocking=False):
+                # `start()`/`stop()` is in progress on the main thread between bytecodes.
+                # We're now running in that same thread via the signal handler; a blocking
+                # acquire would deadlock. The narrow race where `_raise_default`
+                # terminates the process before the in-progress stop completes is an
+                # accepted limitation (same as the pre-fix code).
+                return
+            self._did_shutdown = True
+            atexit.unregister(self.stop)
+            try:
+                self._profiler.stop(flush=True)
+            except service.ServiceStatusError:
+                pass
+            except Exception:
+                LOG.debug("Exception while stopping profiler on exit signal", exc_info=True)
+            finally:
+                if Profiler._active_instance is self:
+                    Profiler._active_instance = None
+                telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
+                Profiler._active_lock.release()
         finally:
-            if Profiler._active_instance is self:
-                Profiler._active_instance = None
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
-            Profiler._active_lock.release()
+            self._shutdown_lock.release()
 
     def _start_on_fork(self) -> None:
         """Start a fresh profiler in child process after fork. This is needed for uWSGI support."""

--- a/releasenotes/notes/profiling-fix-double-flush-on-exit-9d4e72c8a1bb12d0.yaml
+++ b/releasenotes/notes/profiling-fix-double-flush-on-exit-9d4e72c8a1bb12d0.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    profiling: fix double profile upload during process shutdown introduced in
+    #18041. The exit-signal path (``_stop_on_signal``) and the ``atexit`` path
+    (``stop``) could both run during the same shutdown — e.g. uvicorn workers
+    where a SIGTERM-driven graceful shutdown ends with a normal Python exit
+    that triggers ``atexit`` — producing a redundant flush and uploading
+    duplicate profiles. Both exit paths now coordinate through a per-instance
+    ``_shutdown_lock`` + ``_did_shutdown`` flag (mirroring
+    :meth:`Tracer.shutdown`), guaranteeing the last profile is uploaded
+    exactly once regardless of which path fires first.


### PR DESCRIPTION
## Description

PR #18041 added an exit-signal handler (`_stop_on_signal`) on top of the existing atexit-registered `self.stop`. **Both paths can fire during the same process shutdown** (e.g. uvicorn workers: SIGTERM triggers graceful shutdown → asyncio loop exits → Python exits normally → `atexit` runs), producing a **double profile upload per worker**.

### How it was found

Observed in DataDog/dd-trace-doe integration-test (`python, fastapi, dev`): `profiles=4` instead of expected `2` with `workers=2`. Bisected to commit `e0d9a25d` (#18041). Local repro (16 cores) inflates to `profiles=18` — roughly one extra flush per worker + supervisor.

| dd-trace-py SHA | PR | profiles (workers=2) | result |
|---|---|---|---|
| `f19ee88a` (parent) | — | 2 | ✅ |
| `e0d9a25d` | #18041 | 4 (CI) / 18 (local) | ❌ |
| **this PR** | — | (TBD — needs S3 wheel) | (expected ✅) |

### Why the previous dedupe attempt is insufficient

PR #18041 tried to dedupe via `atexit.unregister(self.stop)` at the start of `_stop_on_signal`. That covers "signal fires first" but **not**:

1. **atexit fires first** — `self.stop` doesn't unregister the exit-signal handler, so a later signal can re-flush (rare, but possible in misbehaving shutdown sequences).
2. **Signal-handler chain is replaced** by another framework (uvicorn workers install their own SIGTERM handler via asyncio, which calls `signal.signal` under the hood and replaces our `wrap_signals` chain). Our `_stop_on_signal` never runs → `atexit.unregister` never called → `atexit` still flushes. Combined with the parent supervisor's signal-path flush, two upload paths interleave per shutdown.

### Fix

Use a per-instance `_shutdown_lock` + `_did_shutdown` sentinel — the same pattern used by `Tracer.shutdown` (introduced in #16342). Both `stop()` and `_stop_on_signal` go through this guard, so the last-profile flush happens **exactly once** regardless of which path wins the race or whether both run.

The signal path keeps the **non-blocking** acquire on `_active_lock` to remain deadlock-free when SIGTERM races with `start()`/`stop()` on the main thread (signal handlers run in the main thread between bytecodes; a blocking acquire on a lock that thread already holds would deadlock).

### Behavior preserved

- Ray-style SIGTERM workers still flush their last profile (the original #18041 motivation).
- `Profiler.stop()` remains idempotent for backward API compatibility.
- No change to public API.

### Testing

- [x] Reproduced double-flush against `e0d9a25d` via dd-trace-doe (`profiles=18` locally, `profiles=4` in CI).
- [ ] Verify this branch produces `profiles=2` once the S3 wheel is published. Will re-run `./scripts/bisect-pr374.sh <this-sha>` from the doe worktree.
- [ ] Existing PR #18041 SIGTERM test (`test_profiler_flushes_on_sigterm`) should still pass — it asserts a single `ddup.upload` call after `SIGTERM`, which the new guard preserves.

### Risks

Low. The new code is strictly an additional idempotency guard on top of the existing logic; it cannot cause *fewer* flushes than before in any single-path scenario. Worst case if the guard is wrong: same behavior as today (still double-flushes), not a regression.

### Related

- Regression introduced by: #18041 `fix(profiling): upload last profile on exit signal`
- Pattern reference: #16342 `fix(tracer): resolve issue with not flushing during SIGTERM and SIGINT`
- Surfaced via: DataDog/dd-trace-doe#374