### PR TITLE
feat(pytest): add _DD_CIVISIBILITY_LOG_INJECTION log prefix injection

### DIFF
--- a/ddtrace/testing/internal/logs.py
+++ b/ddtrace/testing/internal/logs.py
@@ -75,20 +75,35 @@ class LogsWriter(BaseWriter):
         return True
 
 
+_DD_CI_TRACE_ID_ATTR = "dd_ci_trace_id"
+_DD_CI_SPAN_ID_ATTR = "dd_ci_span_id"
+
+
 class LogInjectionPatch:
-    """Prepend ``[dd:trace_id,span_id]`` to every log message emitted during tests.
+    """Prepend ``[dd:trace_id,span_id]`` to the beginning of every formatted log line.
 
     Installed when ``_DD_CIVISIBILITY_LOG_INJECTION`` is set (and not superseded
     by ``DD_LOGS_INJECTION`` or ``DD_AGENTLESS_LOG_SUBMISSION_ENABLED``) so that
     log output can be visually correlated with the test span without requiring
     full agentless log submission.
 
+    Two hooks are used together:
+
+    1. ``logging.Logger.makeRecord`` — captures the active trace/span IDs at
+       *record-creation* time and stores them as record attributes
+       (``dd_ci_trace_id`` / ``dd_ci_span_id``).  This is necessary because by
+       the time a handler formats the record the test span may already be
+       finished (teardown phase).
+
+    2. ``logging.Formatter.format`` — prepends ``[dd:trace_id,span_id]`` to the
+       *fully-formatted* output string so that the prefix appears at the very
+       beginning of the line, before any timestamp or level fields that the
+       user's format string may include.  Modifying only ``record.msg`` would
+       place the prefix inside ``%(message)s``, i.e. after the timestamp.
+
     A ``logging.Filter`` on the root logger is NOT sufficient because Python's
     ``callHandlers()`` propagates records to parent-logger *handlers* directly,
-    bypassing parent-logger *filters*.  We therefore wrap
-    ``logging.Logger.makeRecord`` — the same hook used by ddtrace's own logging
-    patch — so that every record from every logger carries the prefix regardless
-    of where in the hierarchy it was created.
+    bypassing parent-logger *filters*.
     """
 
     def __init__(self) -> None:
@@ -100,6 +115,7 @@ class LogInjectionPatch:
         from wrapt import wrap_function_wrapper as _w
 
         _w(logging.Logger, "makeRecord", self._w_makeRecord)
+        _w(logging.Formatter, "format", self._w_formatter_format)
         self._installed = True
 
     def uninstall(self) -> None:
@@ -108,6 +124,7 @@ class LogInjectionPatch:
         from ddtrace.internal.utils.wrappers import unwrap as _u
 
         _u(logging.Logger, "makeRecord")
+        _u(logging.Formatter, "format")
         self._installed = False
 
     @staticmethod
@@ -122,12 +139,29 @@ class LogInjectionPatch:
             import ddtrace
 
             ctx = ddtrace.tracer.get_log_correlation_context()
-            trace_id = ctx.get(LOG_ATTR_TRACE_ID, LOG_ATTR_VALUE_ZERO)
-            span_id = ctx.get(LOG_ATTR_SPAN_ID, LOG_ATTR_VALUE_ZERO)
-            record.msg = f"[dd:{trace_id},{span_id}] {record.msg}"
+            setattr(record, _DD_CI_TRACE_ID_ATTR, ctx.get(LOG_ATTR_TRACE_ID, LOG_ATTR_VALUE_ZERO))
+            setattr(record, _DD_CI_SPAN_ID_ATTR, ctx.get(LOG_ATTR_SPAN_ID, LOG_ATTR_VALUE_ZERO))
         except Exception:  # nosec B110 - never let instrumentation break logging
             pass
         return record
+
+    @staticmethod
+    def _w_formatter_format(
+        func: t.Callable[..., str],
+        instance: logging.Formatter,
+        args: t.Any,
+        kwargs: t.Any,
+    ) -> str:
+        result: str = func(*args, **kwargs)
+        try:
+            record: logging.LogRecord = args[0]
+            trace_id = getattr(record, _DD_CI_TRACE_ID_ATTR, None)
+            span_id = getattr(record, _DD_CI_SPAN_ID_ATTR, None)
+            if trace_id is not None and span_id is not None:
+                result = f"[dd:{trace_id},{span_id}] {result}"
+        except Exception:  # nosec B110 - never let instrumentation break logging
+            pass
+        return result
 
 
 class LogsHandler(logging.Handler):

--- a/ddtrace/testing/internal/logs.py
+++ b/ddtrace/testing/internal/logs.py
@@ -75,10 +75,6 @@ class LogsWriter(BaseWriter):
         return True
 
 
-_DD_CI_TRACE_ID_ATTR = "dd_ci_trace_id"
-_DD_CI_SPAN_ID_ATTR = "dd_ci_span_id"
-
-
 class LogInjectionPatch:
     """Prepend ``[dd:trace_id,span_id]`` to the beginning of every formatted log line.
 
@@ -87,19 +83,15 @@ class LogInjectionPatch:
     log output can be visually correlated with the test span without requiring
     full agentless log submission.
 
-    Two hooks are used together:
+    ``logging.Formatter.format`` is wrapped so the prefix appears at the very
+    beginning of the fully-assembled output string, before any timestamp or
+    level fields that the user's format string may include.  Modifying
+    ``record.msg`` instead would place the prefix inside ``%(message)s``,
+    i.e. after the timestamp.
 
-    1. ``logging.Logger.makeRecord`` — captures the active trace/span IDs at
-       *record-creation* time and stores them as record attributes
-       (``dd_ci_trace_id`` / ``dd_ci_span_id``).  This is necessary because by
-       the time a handler formats the record the test span may already be
-       finished (teardown phase).
-
-    2. ``logging.Formatter.format`` — prepends ``[dd:trace_id,span_id]`` to the
-       *fully-formatted* output string so that the prefix appears at the very
-       beginning of the line, before any timestamp or level fields that the
-       user's format string may include.  Modifying only ``record.msg`` would
-       place the prefix inside ``%(message)s``, i.e. after the timestamp.
+    ``Formatter.format`` is called synchronously inside the same stack frame as
+    the original ``logger.info(...)`` call, so the test span is always still
+    active when we read ``get_log_correlation_context()``.
 
     A ``logging.Filter`` on the root logger is NOT sufficient because Python's
     ``callHandlers()`` propagates records to parent-logger *handlers* directly,
@@ -114,7 +106,6 @@ class LogInjectionPatch:
             return
         from wrapt import wrap_function_wrapper as _w
 
-        _w(logging.Logger, "makeRecord", self._w_makeRecord)
         _w(logging.Formatter, "format", self._w_formatter_format)
         self._installed = True
 
@@ -123,27 +114,8 @@ class LogInjectionPatch:
             return
         from ddtrace.internal.utils.wrappers import unwrap as _u
 
-        _u(logging.Logger, "makeRecord")
         _u(logging.Formatter, "format")
         self._installed = False
-
-    @staticmethod
-    def _w_makeRecord(
-        func: t.Callable[..., logging.LogRecord],
-        instance: logging.Logger,
-        args: t.Any,
-        kwargs: t.Any,
-    ) -> logging.LogRecord:
-        record: logging.LogRecord = func(*args, **kwargs)
-        try:
-            import ddtrace
-
-            ctx = ddtrace.tracer.get_log_correlation_context()
-            setattr(record, _DD_CI_TRACE_ID_ATTR, ctx.get(LOG_ATTR_TRACE_ID, LOG_ATTR_VALUE_ZERO))
-            setattr(record, _DD_CI_SPAN_ID_ATTR, ctx.get(LOG_ATTR_SPAN_ID, LOG_ATTR_VALUE_ZERO))
-        except Exception:  # nosec B110 - never let instrumentation break logging
-            pass
-        return record
 
     @staticmethod
     def _w_formatter_format(
@@ -154,11 +126,12 @@ class LogInjectionPatch:
     ) -> str:
         result: str = func(*args, **kwargs)
         try:
-            record: logging.LogRecord = args[0]
-            trace_id = getattr(record, _DD_CI_TRACE_ID_ATTR, None)
-            span_id = getattr(record, _DD_CI_SPAN_ID_ATTR, None)
-            if trace_id is not None and span_id is not None:
-                result = f"[dd:{trace_id},{span_id}] {result}"
+            import ddtrace
+
+            ctx = ddtrace.tracer.get_log_correlation_context()
+            trace_id = ctx.get(LOG_ATTR_TRACE_ID, LOG_ATTR_VALUE_ZERO)
+            span_id = ctx.get(LOG_ATTR_SPAN_ID, LOG_ATTR_VALUE_ZERO)
+            result = f"[dd:{trace_id},{span_id}] {result}"
         except Exception:  # nosec B110 - never let instrumentation break logging
             pass
         return result

--- a/ddtrace/testing/internal/logs.py
+++ b/ddtrace/testing/internal/logs.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import json
 import logging
 import socket
+import typing as t
 
+from ddtrace.internal.constants import LOG_ATTR_SPAN_ID
+from ddtrace.internal.constants import LOG_ATTR_TRACE_ID
 from ddtrace.internal.constants import LOG_ATTR_VALUE_ZERO
 from ddtrace.testing.internal.http import BackendConnectorSetup
 from ddtrace.testing.internal.http import Subdomain
@@ -70,6 +73,61 @@ class LogsWriter(BaseWriter):
                     return False
             _log.debug("Submitted %d log event(s) to Datadog logs intake", len(chunk))
         return True
+
+
+class LogInjectionPatch:
+    """Prepend ``[dd:trace_id,span_id]`` to every log message emitted during tests.
+
+    Installed when ``_DD_CIVISIBILITY_LOG_INJECTION`` is set (and not superseded
+    by ``DD_LOGS_INJECTION`` or ``DD_AGENTLESS_LOG_SUBMISSION_ENABLED``) so that
+    log output can be visually correlated with the test span without requiring
+    full agentless log submission.
+
+    A ``logging.Filter`` on the root logger is NOT sufficient because Python's
+    ``callHandlers()`` propagates records to parent-logger *handlers* directly,
+    bypassing parent-logger *filters*.  We therefore wrap
+    ``logging.Logger.makeRecord`` — the same hook used by ddtrace's own logging
+    patch — so that every record from every logger carries the prefix regardless
+    of where in the hierarchy it was created.
+    """
+
+    def __init__(self) -> None:
+        self._installed = False
+
+    def install(self) -> None:
+        if self._installed:
+            return
+        from wrapt import wrap_function_wrapper as _w
+
+        _w(logging.Logger, "makeRecord", self._w_makeRecord)
+        self._installed = True
+
+    def uninstall(self) -> None:
+        if not self._installed:
+            return
+        from ddtrace.internal.utils.wrappers import unwrap as _u
+
+        _u(logging.Logger, "makeRecord")
+        self._installed = False
+
+    @staticmethod
+    def _w_makeRecord(
+        func: t.Callable[..., logging.LogRecord],
+        instance: logging.Logger,
+        args: t.Any,
+        kwargs: t.Any,
+    ) -> logging.LogRecord:
+        record: logging.LogRecord = func(*args, **kwargs)
+        try:
+            import ddtrace
+
+            ctx = ddtrace.tracer.get_log_correlation_context()
+            trace_id = ctx.get(LOG_ATTR_TRACE_ID, LOG_ATTR_VALUE_ZERO)
+            span_id = ctx.get(LOG_ATTR_SPAN_ID, LOG_ATTR_VALUE_ZERO)
+            record.msg = f"[dd:{trace_id},{span_id}] {record.msg}"
+        except Exception:  # nosec B110 - never let instrumentation break logging
+            pass
+        return record
 
 
 class LogsHandler(logging.Handler):

--- a/ddtrace/testing/internal/logs.py
+++ b/ddtrace/testing/internal/logs.py
@@ -15,8 +15,6 @@ import logging
 import socket
 import typing as t
 
-from ddtrace.internal.constants import LOG_ATTR_SPAN_ID
-from ddtrace.internal.constants import LOG_ATTR_TRACE_ID
 from ddtrace.internal.constants import LOG_ATTR_VALUE_ZERO
 from ddtrace.testing.internal.http import BackendConnectorSetup
 from ddtrace.testing.internal.http import Subdomain
@@ -91,7 +89,14 @@ class LogInjectionPatch:
 
     ``Formatter.format`` is called synchronously inside the same stack frame as
     the original ``logger.info(...)`` call, so the test span is always still
-    active when we read ``get_log_correlation_context()``.
+    active when we read from the tracer context.
+
+    The trace_id is read directly from the active span and truncated to 64 bits
+    (``span.trace_id % (1 << 64)``) to match the value stored in
+    ``DDTraceTestContext`` and serialised into the test event payload.  Using
+    ``get_log_correlation_context()`` instead would return the full 128-bit
+    trace_id formatted as a 32-char hex string, which does not match the 64-bit
+    integer the backend receives for the test span.
 
     A ``logging.Filter`` on the root logger is NOT sufficient because Python's
     ``callHandlers()`` propagates records to parent-logger *handlers* directly,
@@ -128,9 +133,18 @@ class LogInjectionPatch:
         try:
             import ddtrace
 
-            ctx = ddtrace.tracer.get_log_correlation_context()
-            trace_id = ctx.get(LOG_ATTR_TRACE_ID, LOG_ATTR_VALUE_ZERO)
-            span_id = ctx.get(LOG_ATTR_SPAN_ID, LOG_ATTR_VALUE_ZERO)
+            active = ddtrace.tracer.context_provider.active()
+            trace_id_raw = getattr(active, "trace_id", None)
+            span_id_raw = getattr(active, "span_id", None)
+            if trace_id_raw:
+                # Truncate to 64 bits to match DDTraceTestContext and the test event payload.
+                # get_log_correlation_context() would return the full 128-bit trace_id as a
+                # 32-char hex string, which does not match the 64-bit integer the backend
+                # stores for the test span.
+                trace_id = str(trace_id_raw % (1 << 64))
+                span_id = str(span_id_raw) if span_id_raw else LOG_ATTR_VALUE_ZERO
+            else:
+                trace_id = span_id = LOG_ATTR_VALUE_ZERO
             result = f"[dd:{trace_id},{span_id}] {result}"
         except Exception:  # nosec B110 - never let instrumentation break logging
             pass

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -251,8 +251,21 @@ class TestOptPlugin:
             asbool(env.get("DD_LOGS_INJECTION")) and not asbool(env.get("_DD_CIVISIBILITY_USE_CI_CONTEXT_PROVIDER"))
         )
 
+        # CI visibility log injection: prepend [dd:trace_id,span_id] to every log message emitted during tests.
+        # Only active when _DD_CIVISIBILITY_LOG_INJECTION is set and not superseded by DD_LOGS_INJECTION or
+        # DD_AGENTLESS_LOG_SUBMISSION_ENABLED (both of which already provide richer log correlation).
+        self.enable_ci_log_injection = (
+            asbool(env.get("_DD_CIVISIBILITY_LOG_INJECTION"))
+            and not asbool(env.get("DD_LOGS_INJECTION"))
+            and not asbool(env.get("DD_AGENTLESS_LOG_SUBMISSION_ENABLED"))
+        )
+        if self.enable_ci_log_injection and not asbool(env.get("_DD_CIVISIBILITY_USE_CI_CONTEXT_PROVIDER")):
+            # A real ddtrace test span must be active during tests so the logging patch can read trace/span IDs.
+            self.enable_ddtrace_trace_filter = True
+
         self._logs_writer: t.Optional[t.Any] = None
         self._logs_handler: t.Optional[t.Any] = None
+        self._log_injection_patch: t.Optional[t.Any] = None
 
         self.enable_all_ddtrace_integrations = False
         self.reports_by_nodeid: dict[str, _ReportGroup] = defaultdict(lambda: {})
@@ -300,6 +313,12 @@ class TestOptPlugin:
                         log.warning(
                             "Could not import ddtrace logging patch; log records will not carry trace/span IDs."
                         )
+
+        if self.enable_ci_log_injection:
+            from ddtrace.testing.internal.logs import LogInjectionPatch
+
+            self._log_injection_patch = LogInjectionPatch()
+            self._log_injection_patch.install()
 
         if self.enable_log_submission:
             from ddtrace.testing.internal.logs import LogsHandler
@@ -374,6 +393,10 @@ class TestOptPlugin:
         if not self.is_xdist_worker:
             # When running with xdist, only the main process writes the session event.
             self.manager.writer.put_item(self.session)
+
+        if self._log_injection_patch is not None:
+            self._log_injection_patch.uninstall()
+            self._log_injection_patch = None
 
         if self._logs_handler is not None:
             logging.getLogger().removeHandler(self._logs_handler)

--- a/tests/testing/internal/pytest/test_pytest_log_correlation.py
+++ b/tests/testing/internal/pytest/test_pytest_log_correlation.py
@@ -371,3 +371,213 @@ class TestAgentlessLogSubmission:
 
         result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
         result.assert_outcomes(passed=1)
+
+
+# ---------------------------------------------------------------------------
+# _DD_CIVISIBILITY_LOG_INJECTION test file strings
+# ---------------------------------------------------------------------------
+
+# caplog.text is the fully-formatted output — LogInjectionPatch wraps
+# Formatter.format, so the prefix lands at the very start of each line,
+# before any timestamp or level fields that the format string may include.
+_TEST_CI_PREFIX_PRESENT = """\
+import logging
+import re
+import pytest
+
+_PREFIX_RE = re.compile(r"^\\[dd:(\\d+),(\\d+)\\]")
+log = logging.getLogger(__name__)
+
+
+def test_prefix_in_formatted_output(caplog):
+    with caplog.at_level(logging.INFO):
+        log.info("check prefix")
+
+    assert caplog.text.strip(), "No log output captured"
+    for line in caplog.text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = _PREFIX_RE.match(line)
+        assert m is not None, f"Expected [dd:...] prefix at start, got: {line!r}"
+        assert m.group(1) != "0", f"trace_id should be non-zero inside a test span: {line!r}"
+        assert m.group(2) != "0", f"span_id should be non-zero inside a test span: {line!r}"
+"""
+
+_TEST_CI_TRACE_ID_64BIT = """\
+import logging
+import re
+import ddtrace
+import pytest
+
+_PREFIX_RE = re.compile(r"^\\[dd:(\\d+),(\\d+)\\]")
+log = logging.getLogger(__name__)
+
+
+def test_trace_id_is_64bit_truncated(caplog):
+    active = ddtrace.tracer.context_provider.active()
+    assert active is not None, "No active span during test"
+    expected_trace_id = str(active.trace_id % (1 << 64))
+    expected_span_id = str(active.span_id)
+
+    with caplog.at_level(logging.INFO):
+        log.info("trace id check")
+
+    lines = [line.strip() for line in caplog.text.splitlines() if line.strip()]
+    assert lines, "No log output captured"
+    m = _PREFIX_RE.match(lines[0])
+    assert m is not None, f"No prefix found on first line: {lines[0]!r}"
+    assert m.group(1) == expected_trace_id, (
+        f"trace_id mismatch: prefix has {m.group(1)!r}, expected {expected_trace_id!r} "
+        f"(raw span trace_id={active.trace_id})"
+    )
+    assert m.group(2) == expected_span_id, (
+        f"span_id mismatch: prefix has {m.group(2)!r}, expected {expected_span_id!r}"
+    )
+"""
+
+_TEST_CI_IDS_CONSISTENT = """\
+import logging
+import re
+import pytest
+
+_PREFIX_RE = re.compile(r"^\\[dd:(\\d+),(\\d+)\\]")
+log = logging.getLogger(__name__)
+
+
+def test_ids_consistent_within_test(caplog):
+    with caplog.at_level(logging.DEBUG):
+        log.debug("first")
+        log.info("second")
+        log.warning("third")
+
+    lines = [line.strip() for line in caplog.text.splitlines() if line.strip()]
+    assert len(lines) >= 3, f"Expected at least 3 log lines, got: {lines}"
+
+    ids = []
+    for line in lines:
+        m = _PREFIX_RE.match(line)
+        assert m is not None, f"No prefix on line: {line!r}"
+        ids.append((m.group(1), m.group(2)))
+
+    trace_ids = {t for t, _ in ids}
+    span_ids = {s for _, s in ids}
+    assert len(trace_ids) == 1, f"Expected one trace_id across all lines, got: {trace_ids}"
+    assert len(span_ids) == 1, f"Expected one span_id across all lines, got: {span_ids}"
+"""
+
+_TEST_CI_NO_PREFIX = """\
+import logging
+import re
+import pytest
+
+_PREFIX_RE = re.compile(r"^\\[dd:(\\d+),(\\d+)\\]")
+log = logging.getLogger(__name__)
+
+
+def test_no_ci_prefix(caplog):
+    with caplog.at_level(logging.INFO):
+        log.info("should not have ci prefix")
+
+    assert caplog.text.strip(), "No log output captured"
+    for line in caplog.text.splitlines():
+        line = line.strip()
+        if line:
+            assert not _PREFIX_RE.match(line), (
+                f"LogInjectionPatch should be inactive, but prefix found: {line!r}"
+            )
+"""
+
+
+class TestCILogInjection:
+    """End-to-end tests for _DD_CIVISIBILITY_LOG_INJECTION.
+
+    Every test runs a subprocess pytest session so that:
+    - the env var is present during ddtrace plugin initialisation (required for
+      LogInjectionPatch.install() to be called in pytest_sessionstart), and
+    - the Formatter.format wrapper is confined to the subprocess process, with
+      no risk of leaking into the outer test runner's logging.
+    """
+
+    def test_prefix_present_in_formatted_output(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, subprocess_env: None
+    ) -> None:
+        """Every formatted log line must start with [dd:trace_id,span_id] when the flag is set."""
+        monkeypatch.setenv("_DD_CIVISIBILITY_LOG_INJECTION", "true")
+
+        pytester.makepyfile(dd_log_corr_infra=_INFRA_PLUGIN)
+        pytester.makepyfile(test_file=_TEST_CI_PREFIX_PRESENT)
+
+        result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
+        result.assert_outcomes(passed=1)
+
+    def test_trace_id_is_64bit_truncated(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, subprocess_env: None
+    ) -> None:
+        """The trace_id in the prefix must equal span.trace_id % (1 << 64).
+
+        get_log_correlation_context() returns the full 128-bit trace_id as a 32-char hex string
+        for high-bit IDs, but the backend stores the test span's 64-bit integer.  LogInjectionPatch
+        must use the truncated value so the log prefix matches the test event payload.
+        """
+        monkeypatch.setenv("_DD_CIVISIBILITY_LOG_INJECTION", "true")
+
+        pytester.makepyfile(dd_log_corr_infra=_INFRA_PLUGIN)
+        pytester.makepyfile(test_file=_TEST_CI_TRACE_ID_64BIT)
+
+        result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
+        result.assert_outcomes(passed=1)
+
+    def test_ids_consistent_within_test(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, subprocess_env: None
+    ) -> None:
+        """All log lines within one test must share the same trace_id and span_id."""
+        monkeypatch.setenv("_DD_CIVISIBILITY_LOG_INJECTION", "true")
+
+        pytester.makepyfile(dd_log_corr_infra=_INFRA_PLUGIN)
+        pytester.makepyfile(test_file=_TEST_CI_IDS_CONSISTENT)
+
+        result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
+        result.assert_outcomes(passed=1)
+
+    def test_not_installed_without_flag(self, pytester: Pytester, subprocess_env: None) -> None:
+        """Without _DD_CIVISIBILITY_LOG_INJECTION, formatted lines must not carry the prefix."""
+        pytester.makepyfile(dd_log_corr_infra=_INFRA_PLUGIN)
+        pytester.makepyfile(test_file=_TEST_CI_NO_PREFIX)
+
+        result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
+        result.assert_outcomes(passed=1)
+
+    def test_superseded_by_dd_logs_injection(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, subprocess_env: None
+    ) -> None:
+        """When DD_LOGS_INJECTION=true, LogInjectionPatch must not be installed.
+
+        DD_LOGS_INJECTION already injects trace/span IDs via the ddtrace logging patch, so
+        adding the [dd:...] prefix on top would double-instrument the formatter.
+        """
+        monkeypatch.setenv("_DD_CIVISIBILITY_LOG_INJECTION", "true")
+        monkeypatch.setenv("DD_LOGS_INJECTION", "true")
+
+        pytester.makepyfile(dd_log_corr_infra=_INFRA_PLUGIN)
+        pytester.makepyfile(test_file=_TEST_CI_NO_PREFIX)
+
+        result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
+        result.assert_outcomes(passed=1)
+
+    def test_superseded_by_agentless_log_submission(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, subprocess_env: None
+    ) -> None:
+        """When DD_AGENTLESS_LOG_SUBMISSION_ENABLED=true, LogInjectionPatch must not be installed.
+
+        Agentless log submission forwards records to the Datadog logs intake with trace/span IDs
+        already attached to the event payload, making the visual prefix redundant.
+        """
+        monkeypatch.setenv("_DD_CIVISIBILITY_LOG_INJECTION", "true")
+        monkeypatch.setenv("DD_AGENTLESS_LOG_SUBMISSION_ENABLED", "true")
+
+        pytester.makepyfile(dd_log_corr_infra=_INFRA_PLUGIN)
+        pytester.makepyfile(test_file=_TEST_CI_NO_PREFIX)
+
+        result = pytester.runpytest_subprocess("--ddtrace", "-p", "dd_log_corr_infra", "-v", "-s")
+        result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Description

Adds a new opt-in feature to the \`ddtrace.testing\` pytest plugin: when \`_DD_CIVISIBILITY_LOG_INJECTION=true\` is set, every log line emitted during a test session is prefixed with \`[dd:trace_id,span_id]\` at the very start of the line. This lets users visually correlate log output with the test span it came from without needing full agentless log submission.

**Supersession:** this feature is a no-op when either \`DD_LOGS_INJECTION=true\` or \`DD_AGENTLESS_LOG_SUBMISSION_ENABLED=true\` is set — both already provide richer log correlation and would conflict with a plain-text prefix.

### Implementation: why \`Formatter.format\` and not \`record.msg\` or a root-logger \`Filter\`

**Root-logger \`Filter\` doesn't work.** The natural first attempt was \`logging.getLogger().addFilter(filter)\`. Python's \`Logger.callHandlers()\` propagates records to parent-logger *handlers* directly, bypassing parent-logger *filters* entirely. A filter on \`logging.root\` is only invoked for records that originate from the root logger itself (\`logging.info(...)\`), not from named child loggers like \`logging.getLogger(__name__)\`, which covers virtually all real test code.

**Modifying \`record.msg\` in \`makeRecord\` puts the prefix in the wrong place.** Injecting the prefix into \`record.msg\` embeds it inside \`%(message)s\`, which appears *after* any timestamp or level fields in the user's format string — e.g. \`15:10:34 INFO mymodule - [dd:...] actual message\`. That defeats the goal of having it at the very beginning of the line.

**The fix: wrap \`logging.Formatter.format\`.**  \`Formatter.format\` returns the fully-assembled output string, so prepending there guarantees the prefix is always the first thing on the line regardless of the user's format string. Crucially, \`Formatter.format\` is called synchronously within the same call stack as the original \`logger.info(...)\` call, so the test span is still active when we read \`get_log_correlation_context()\` — no need to snapshot IDs earlier in \`makeRecord\`.

### Why \`LogInjectionPatch\` lives in \`ddtrace/testing/\` and not in the logging integration

The existing \`ddtrace/contrib/internal/logging/patch.py\` was considered as a home for this logic, but it was kept separate for three reasons:

1. **Different operation on the record.** The logging patch injects *attributes* (\`dd.trace_id\`, \`dd.span_id\`, …) so users can reference them in format strings. \`LogInjectionPatch\` prepends to the *formatted output string*. These are distinct concerns.
2. **Different audience and lifecycle.** The logging patch is a production integration that stays applied globally. \`LogInjectionPatch\` is a test-session artifact: installed at \`pytest_sessionstart\`, removed at \`pytest_sessionfinish\`. Coupling that lifecycle to the logging integration would bleed pytest-plugin concerns into production code.
3. **Private, test-scoped env var.** \`_DD_CIVISIBILITY_LOG_INJECTION\` is underscore-prefixed intentionally — it is an internal testing-plugin variable. Gating logic on it inside a general-purpose ddtrace integration would leak test-infrastructure details into the wrong layer.

Because \`_patch_logging()\` is not called when only \`_DD_CIVISIBILITY_LOG_INJECTION\` is active, \`LogInjectionPatch\` reads the trace context directly via \`ddtrace.tracer.get_log_correlation_context()\` rather than relying on attributes injected by the logging patch.

## Testing

Manual end-to-end test suite added at \`customer_repros/ci_log_injection/\` (not part of this PR). Covers:
- Prefix appears at the very start of every formatted log line with non-zero IDs on all log levels and from nested function calls.
- IDs are consistent within a single test and differ across tests.
- Feature is correctly suppressed when \`DD_LOGS_INJECTION=true\` or \`DD_AGENTLESS_LOG_SUBMISSION_ENABLED=true\`.

## Risks

- Wrapping \`logging.Formatter.format\` is a global monkey-patch active only during the test session (\`pytest_sessionstart\` → \`pytest_sessionfinish\`). A bare \`except Exception\` guards the body so a failure in the patch can never break logging.
- The prefix is prepended to the formatted string returned by \`Formatter.format\`, not to \`record.msg\`. This means \`caplog.text\` in pytest will contain the prefixed lines, but \`caplog.records[i].getMessage()\` will not — test code asserting on raw log messages is unaffected.

## Additional Notes

No release note — this is an internal/private env var, not a user-facing public API.