### PR TITLE
ci(benchmarks): add pip cache to microbenchmarks

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -71,6 +71,18 @@ variables:
       - reports/
       - artifacts/
     expire_in: 3 months
+  cache:
+    - key:
+        # Per-scenario requirements_scenario.txt files are intentionally excluded
+        # from the cache key. This gives a best-effort incremental cache shared
+        # across all parallel jobs, keyed only on the base requirements which
+        # rarely change.
+        files:
+          - benchmarks/base/requirements.txt
+          - benchmarks/base/requirements_scenario.txt
+      paths:
+        - .cache/pip
+      policy: pull-push
   variables:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID # The ID of the current project. This ID is unique across all projects on the GitLab instance.
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME # "dd-trace-py"
@@ -79,6 +91,7 @@ variables:
     CARGO_NET_GIT_FETCH_WITH_CLI: "true" # use system git binary to pull git dependencies
     CMAKE_BUILD_PARALLEL_LEVEL: 12
     CARGO_BUILD_JOBS: 12
+    PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.cache/pip"
 
 baseline:detect:
   image: $GITHUB_CLI_IMAGE


### PR DESCRIPTION
## Description

These dependencies rarely if ever change, might as well cache them

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
