### PR TITLE
chore(profiling): clean up typos in profiler native components

### DIFF
--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options(-fPIC -fvisibility=hidden -pthread -Wall -Wextra)
 
 # Platform-specific compile definitions
 if(APPLE)
-    # Fix for newer macOS SDKs that don't define BSD-style types These are needed by Abseil on macOS
+    # Fix for newer macOS SDKs that don't define BSD-style types. These are needed by Abseil on macOS
     add_compile_definitions(_DARWIN_C_SOURCE)
 endif()
 

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -26,7 +26,7 @@ typedef struct
 } memalloc_context_t;
 
 /* We only support being started once, so we use a global context for the whole
-   module. If we ever want to be started multiple twice, we'd need a more
+   module. If we ever want to be started multiple times, we'd need a more
    object-oriented approach and allocate a context per object.
 */
 static memalloc_context_t global_memalloc_ctx;

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -326,7 +326,7 @@ heap_tracker_t* heap_tracker_t::instance = nullptr;
 bool
 memalloc_heap_tracker_init_no_cpython(uint32_t sample_size)
 {
-    // TODO(dsn): what should we do it this was already initialized?
+    // TODO(dsn): what should we do if this was already initialized?
     if (!heap_tracker_t::instance) {
         heap_tracker_t::instance = new heap_tracker_t(sample_size);
         return true;


### PR DESCRIPTION
## Description

Fixed minor typos in _memalloc.cpp, _memalloc_heap.cpp, and CMakeLists.txt comments.

## Testing

N/A

## Risks

None

## Additional Notes

N/A