### PR TITLE
chore(libdatadog): bump libdatadog to v34.0.0

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -927,67 +927,67 @@ experiments:
           - name: sethttpmeta-all-disabled
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-all-enabled
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-collectipvariant_exists
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-no-collectipvariant
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-no-useragentvariant
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-obfuscation-no-query
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-obfuscation-regular-case-explicit-query
             thresholds:
               - execution_time < 0.09 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-obfuscation-regular-case-implicit-query
             thresholds:
               - execution_time < 0.09 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-obfuscation-send-querystring-disabled
             thresholds:
               - execution_time < 0.17 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-obfuscation-worst-case-explicit-query
             thresholds:
               - execution_time < 0.16 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-obfuscation-worst-case-implicit-query
             thresholds:
               - execution_time < 0.17 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-useragentvariant_exists_1
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-useragentvariant_exists_2
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-useragentvariant_exists_3
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-useragentvariant_not_exists_1
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
           - name: sethttpmeta-useragentvariant_not_exists_2
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 42.00 MB
+              - max_rss_usage < 38.75 MB
 
           # span
           - name: span-add-event

--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -927,67 +927,67 @@ experiments:
           - name: sethttpmeta-all-disabled
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-all-enabled
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-collectipvariant_exists
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-no-collectipvariant
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-no-useragentvariant
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-obfuscation-no-query
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-obfuscation-regular-case-explicit-query
             thresholds:
               - execution_time < 0.09 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-obfuscation-regular-case-implicit-query
             thresholds:
               - execution_time < 0.09 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-obfuscation-send-querystring-disabled
             thresholds:
               - execution_time < 0.17 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-obfuscation-worst-case-explicit-query
             thresholds:
               - execution_time < 0.16 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-obfuscation-worst-case-implicit-query
             thresholds:
               - execution_time < 0.17 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-useragentvariant_exists_1
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-useragentvariant_exists_2
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-useragentvariant_exists_3
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-useragentvariant_not_exists_1
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
           - name: sethttpmeta-useragentvariant_not_exists_2
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.75 MB
+              - max_rss_usage < 42.00 MB
 
           # span
           - name: span-add-event

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -187,8 +187,8 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "33.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "34.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "cbindgen",
  "serde",
@@ -483,7 +483,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "chrono",
  "derive_more",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "datadog-remote-config"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "base64",
@@ -1408,7 +1408,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1417,8 +1417,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1428,20 +1428,21 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities-impl"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "bytes",
  "http",
  "http-body-util",
  "libdd-capabilities",
  "libdd-common",
+ "tokio",
 ]
 
 [[package]]
 name = "libdd-common"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "4.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1479,8 +1480,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "33.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "34.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1494,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1526,8 +1527,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1540,6 +1541,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common",
+ "libdd-ddsketch",
  "libdd-dogstatsd-client",
  "libdd-shared-runtime",
  "libdd-telemetry",
@@ -1560,15 +1562,15 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1581,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "libc",
@@ -1609,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "chrono",
  "tracing",
@@ -1620,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1659,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1680,29 +1682,32 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "async-trait",
  "futures",
+ "futures-util",
  "libdd-capabilities",
+ "libdd-capabilities-impl",
  "libdd-common",
  "tokio",
  "tokio-util",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "libdd-telemetry"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1728,8 +1733,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-tinybytes"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "1.1.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "serde",
 ]
@@ -1737,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1745,8 +1750,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1761,8 +1766,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "3.0.2"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "prost",
  "serde",
@@ -1771,10 +1776,11 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "hashbrown 0.15.5",
  "http",
@@ -1795,8 +1801,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "base64",
@@ -1827,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "libdd-tracer-flare"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v33.0.0#37d17ee71ae396782242d45e1b31af2887bbbbd3"
+source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
 dependencies = [
  "anyhow",
  "bytes",

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -22,29 +22,29 @@ libc = { version = "0.2", optional = true }
 rand = "0.9"
 rustc-hash = "1.1"
 serde = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
 serde_json = "1.0"
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true, features = [
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
 pyo3 = { version = "0.28", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", features = [
     "cbindgen",
 ] }
 


### PR DESCRIPTION
## Description

Libdatadog v34 is out. Let's bump the version to stay up to date.

Also had to modify SLOs, I used the bp-analyzer-generate-slos skill.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes