### PR TITLE
fix(asm): multipart body parts with `Content-Type` parameters

### DIFF
--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -380,15 +380,17 @@ def parse_form_params(body: str) -> dict[str, Union[str, list[str]]]:
     return req_body
 
 
-def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None) -> dict[str, Any]:
+def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None) -> Union[str, dict[str, Any]]:
     """Return a dict of form data after HTTP form parsing"""
     import email
     import json
     from urllib.parse import parse_qs
 
-    def parse_message(msg):
+    def parse_message(msg) -> Union[str, dict[str, Any]]:
+        res: Union[str, dict[str, Any]] = ""
+
         if msg.is_multipart():
-            res: dict[str, list] = {}
+            res = {}
             for part in msg.get_payload():
                 key = part.get_param("name", failobj=part.get_filename(), header="content-disposition")
                 value = parse_message(part)
@@ -396,15 +398,16 @@ def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None)
             res = {k: v[0] if len(v) == 1 else v for k, v in res.items()}
         else:
             content_type = msg.get("Content-Type")
-            if content_type in ("application/json", "text/json"):
+            base_content_type = content_type.split(";", 1)[0].strip() if content_type else content_type
+            if base_content_type in ("application/json", "text/json"):
                 res = json.loads(msg.get_payload())
-            elif content_type in ("application/xml", "text/xml"):
+            elif base_content_type in ("application/xml", "text/xml"):
                 import ddtrace.vendor.xmltodict as xmltodict
 
                 res = xmltodict.parse(msg.get_payload())
-            elif content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
+            elif base_content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
                 res = parse_qs(msg.get_payload())
-            elif content_type in ("text/plain", None):
+            elif base_content_type in ("text/plain", None):
                 res = msg.get_payload()
             else:
                 res = ""
@@ -415,6 +418,7 @@ def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None)
         content_type = headers.get("Content-Type") or headers.get("content-type")
         msg = email.message_from_string("MIME-Version: 1.0\nContent-Type: %s\n%s" % (content_type, body))
         return parse_message(msg)
+
     return {}
 
 

--- a/releasenotes/notes/fix-parse-form-multipart-charset-b1a8c64d8627d47d.yaml
+++ b/releasenotes/notes/fix-parse-form-multipart-charset-b1a8c64d8627d47d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: Fixes multipart body parts whose ``Content-Type`` header carried parameters being dropped.

--- a/tests/internal/test_utils_http.py
+++ b/tests/internal/test_utils_http.py
@@ -3,6 +3,7 @@ import pytest
 
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
 from ddtrace.internal.utils.http import connector
+from ddtrace.internal.utils.http import parse_form_multipart
 
 
 parameters = ["http"]
@@ -22,3 +23,26 @@ def test_connector(scheme):
             response = conn.getresponse()
             assert response.status == 200
             assert response.read() == b'{"hello": "world"}'
+
+
+def test_parse_form_multipart_handles_charset_suffix() -> None:
+    body = (
+        "--BOUNDARY\r\n"
+        'Content-Disposition: form-data; name="meta"\r\n'
+        "Content-Type: application/json; charset=utf-8\r\n"
+        "\r\n"
+        '{"id": 42}\r\n'
+        "--BOUNDARY\r\n"
+        'Content-Disposition: form-data; name="raw"\r\n'
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"id": 99}\r\n'
+        "--BOUNDARY--\r\n"
+    )
+    headers = {"Content-Type": "multipart/form-data; boundary=BOUNDARY"}
+    parsed = parse_form_multipart(body, headers)
+
+    # Both parts (with and without the charset suffix) must be JSON-parsed,
+    # not collapsed to empty strings.
+    assert parsed["meta"] == {"id": 42}
+    assert parsed["raw"] == {"id": 99}


### PR DESCRIPTION
## Description


Similar to another recent PR of mine -- we shouldn't ignore `Content-Type` header values that have parameters.