### PR TITLE
fix(di): fix `args`/`kwargs` being dropped

### DIFF
--- a/ddtrace/debugging/_safety.py
+++ b/ddtrace/debugging/_safety.py
@@ -15,7 +15,18 @@ GetSetDescriptor = type(type.__dict__["__dict__"])  # type: ignore[index]  # noq
 def get_args(frame: FrameType) -> Iterator[tuple[str, Any]]:
     code = frame.f_code
     _locals = frame.f_locals
-    nargs = code.co_argcount + bool(code.co_flags & CO_VARARGS) + bool(code.co_flags & CO_VARKEYWORDS)
+    # co_varnames lays out arguments as: positional, then keyword-only,
+    # then *args (if CO_VARARGS), then **kwargs (if CO_VARKEYWORDS).
+    # Without co_kwonlyargcount in the offset, keyword-only args were
+    # captured as positional and *args / **kwargs were missed entirely
+    # (and then leaked into get_locals as if they were function-local
+    # variables).
+    nargs = (
+        code.co_argcount
+        + code.co_kwonlyargcount
+        + bool(code.co_flags & CO_VARARGS)
+        + bool(code.co_flags & CO_VARKEYWORDS)
+    )
     arg_names = code.co_varnames[:nargs]
     return ((name, _locals.get(name)) for name in arg_names)
 
@@ -23,7 +34,12 @@ def get_args(frame: FrameType) -> Iterator[tuple[str, Any]]:
 def get_locals(frame: FrameType) -> Iterator[tuple[str, Any]]:
     code = frame.f_code
     _locals = frame.f_locals
-    nargs = code.co_argcount + bool(code.co_flags & CO_VARARGS) + bool(code.co_flags & CO_VARKEYWORDS)
+    nargs = (
+        code.co_argcount
+        + code.co_kwonlyargcount
+        + bool(code.co_flags & CO_VARARGS)
+        + bool(code.co_flags & CO_VARKEYWORDS)
+    )
     return (
         (name, _locals.get(name)) for name in chain(code.co_varnames[nargs:], code.co_freevars, code.co_cellvars)
     )  # include freevars and cellvars

--- a/releasenotes/notes/fix-debugger-args-kwonly-2494eefa0a87acbc.yaml
+++ b/releasenotes/notes/fix-debugger-args-kwonly-2494eefa0a87acbc.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: Fixes debugger argument/local captures
+    misclassifying keyword-only arguments and dropping ``*args`` /
+    ``**kwargs`` for any function that declares keyword-only parameters
+    alongside variadic arguments.

--- a/tests/debugging/test_safety.py
+++ b/tests/debugging/test_safety.py
@@ -39,6 +39,23 @@ def test_get_args():
         assert_args({"ars"})
         assert_locals(set())
 
+    # `co_varnames` lays out keyword-only arguments BEFORE
+    # `*args` / `**kwargs`. The previous nargs offset
+    # `co_argcount + VARARGS + VARKEYWORDS` omitted `co_kwonlyargcount`,
+    # so for `def f(a, *args, c, **kwargs)` keyword-only `c` was
+    # mis-classified as positional and the actual `args` / `kwargs`
+    # objects fell out of `get_args` entirely (and got reported by
+    # `get_locals` instead).
+    def kwonly_and_args_and_kwargs(a, *ars, c, **kwars):
+        local = 1  # noqa
+        assert_args({"a", "ars", "c", "kwars"})
+        assert_locals({"local"})
+
+    def kwonly_only(a, *, c, d):
+        local = 1  # noqa
+        assert_args({"a", "c", "d"})
+        assert_locals({"local"})
+
     def referenced_globals():
         global GLOBAL_VALUE
         a = GLOBAL_VALUE >> 1  # noqa
@@ -49,6 +66,8 @@ def test_get_args():
     arg_and_args_and_kwargs(1, 42, b=2)
     args_and_kwargs()
     args()
+    kwonly_and_args_and_kwargs(1, 42, c=3, extra=9)
+    kwonly_only(1, c=3, d=4)
     referenced_globals()
 
 


### PR DESCRIPTION
## Description

This fixes an issue reported by a Claude Code analysis of the codebase. The test changes make sense to me so I think it's worth merging.