### PR TITLE
fix(iast): do not wrap `_pickle.Unpickler.load` to prevent dill import crash

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/untrusted_serialization.py
+++ b/ddtrace/appsec/_iast/taint_sinks/untrusted_serialization.py
@@ -29,6 +29,16 @@ def get_version() -> Text:
 
 _IS_PATCHED = False
 
+# NOTE: Do NOT add ("_pickle", "Unpickler.load") here. _pickle.Unpickler is an
+# immutable C type; wrapping its load method_descriptor via the forbiddenfruit
+# fallback in apply_patch poisons class-level attribute access because
+# wrapt.FunctionWrapper.__get__(None, owner) ends up invoking
+# method_descriptor.__get__(descr, Py_None, owner), which CPython rejects with the
+# "descriptor 'load' for '_pickle.Unpickler' objects doesn't apply to a
+# 'NoneType' object" error message. That breaks dill's class body (dill/_dill.py:
+# `load.__doc__ = StockUnpickler.load.__doc__`) and any other code that accesses the load
+# attribute on the class. Top-level _pickle.load/loads and dill.load/loads
+# already provide the necessary instrumentation entry points.
 _MODULES = {
     ("pickle", "load"),  # maps to pickle._load/_pickle.load
     ("pickle", "loads"),  # maps to pickle.loads/_pickle.loads
@@ -37,7 +47,6 @@ _MODULES = {
     ("pickle", "_Unpickler.load"),
     ("_pickle", "load"),
     ("_pickle", "loads"),
-    ("_pickle", "Unpickler.load"),
     ("dill", "load"),
     ("dill", "loads"),
     ("yaml", "load"),

--- a/releasenotes/notes/iast-fix-untrusted-serialization-pickle-unpickler-load-1f7c4b8e6a2d5c39.yaml
+++ b/releasenotes/notes/iast-fix-untrusted-serialization-pickle-unpickler-load-1f7c4b8e6a2d5c39.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Code Security: This fix resolves an ``ImportError`` when ``dill`` is imported after IAST patches are applied (e.g. inside a request handler).
+    This issue surfaced with ``TypeError: descriptor 'load' for '_pickle.Unpickler' objects doesn't apply to a 'NoneType' object`` error message.

--- a/tests/appsec/iast/taint_sinks/test_untrusted_serialization.py
+++ b/tests/appsec/iast/taint_sinks/test_untrusted_serialization.py
@@ -147,6 +147,33 @@ def test_untrusted_serialization__pickle_unpickler_load(iast_context_defaults):
     _assert_no_untrusted_vuln()
 
 
+def test_pickle_unpickler_load_class_access_does_not_raise():
+    """Regression for the 4.9 CI failure of
+    test_django_untrusted_serialization_dill_smoke[py3.9].
+
+    Wrapping ``_pickle.Unpickler.load`` (a C method_descriptor on an immutable
+    type) via the forbiddenfruit fallback in ``apply_patch`` causes
+    ``_pickle.Unpickler.load`` class-level attribute access to raise
+    ``TypeError: descriptor 'load' for '_pickle.Unpickler' objects doesn't
+    apply to a 'NoneType' object``. That in turn breaks ``import dill``,
+    because dill's class body executes
+    ``load.__doc__ = StockUnpickler.load.__doc__`` at module import time.
+    """
+    import _pickle
+
+    # Class-level attribute access must not raise.
+    assert _pickle.Unpickler.load is not None
+    _ = _pickle.Unpickler.load.__doc__
+
+    # Subclassing _pickle.Unpickler the same way dill does must not raise
+    # at class-definition time.
+    class _DillLike(_pickle.Unpickler):
+        def load(self):  # noqa: D401
+            return _pickle.Unpickler.load(self)
+
+        load.__doc__ = _pickle.Unpickler.load.__doc__
+
+
 def test_untrusted_serialization_dill_load(iast_context_defaults):
     dill = pytest.importorskip("dill")
     import pickle


### PR DESCRIPTION
## Description

Fixes the `test_django_untrusted_serialization_dill_smoke[py3.9]` failure on the 4.9 branch ([job 1704243154](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1704243154)):

```
TypeError: descriptor 'load' for '_pickle.Unpickler' objects doesn't apply to a 'NoneType' object
```

### Root cause

The IAST untrusted-serialization sink registered `("_pickle", "Unpickler.load")` in `_MODULES`. `_pickle.Unpickler` is an immutable C type, so `setattr` fails and `apply_patch` falls back to `patch_builtins` (forbiddenfruit-style mutation of `_pickle.Unpickler.__dict__` via `gc.get_referents`). On the Linux glibc CPython 3.9 build used in CI, that fallback **succeeds** and replaces `_pickle.Unpickler.__dict__["load"]` with a `wrapt.FunctionWrapper`.

Once installed, any class-level access to `_pickle.Unpickler.load` invokes `FunctionWrapper.__get__(None, owner)`, which calls `method_descriptor.__class__.__get__(descr, Py_None, owner)`. CPython's `descr_check` (`Objects/descrobject.c`) only short-circuits when `obj == NULL`; here it receives `Py_None`, runs the type check (`isinstance(None, _pickle.Unpickler) → False`) and raises the exact descriptor `TypeError`.

The dill module hits this at **import time**, inside the `Unpickler(StockUnpickler)` class body:

```python
# dill/_dill.py:460
load.__doc__ = StockUnpickler.load.__doc__  # StockUnpickler is _pickle.Unpickler
```

Because the smoke test does `import dill` inside the view (after Django+IAST have initialized and applied patches), dill's import is the trigger.

### Why the bug surfaced now

`("_pickle", "Unpickler.load")` has been in `_MODULES` since the feature landed in #14637 but has always been a no-op on macOS (`gc.get_referents` returns a read-only `mappingproxy` for immutable C types there). The Linux glibc 3.9 build silently took the patch, so CI was the first environment to observe the resulting descriptor error once the test imported dill after patches were applied.

### Fix

Remove `("_pickle", "Unpickler.load")` from `_MODULES` and document why it must not be re-added. Coverage is preserved by the remaining entry points:

- `("_pickle", "load")` and `("_pickle", "loads")` — top-level C functions
- `("pickle", "load")`, `("pickle", "loads")`, `("pickle", "_load")`, `("pickle", "_loads")` — Python-level wrappers
- `("pickle", "_Unpickler.load")` — pure-Python `Unpickler.load` (mutable, safe to wrap)
- `("dill", "load")`, `("dill", "loads")` — dill module functions

## Testing

- Added `test_pickle_unpickler_load_class_access_does_not_raise` in `tests/appsec/iast/taint_sinks/test_untrusted_serialization.py`. It exercises class-level `_pickle.Unpickler.load` attribute access, `.__doc__` access, and dill-style subclassing with `load.__doc__ = _pickle.Unpickler.load.__doc__` in the class body. On Linux py3.9 (where forbiddenfruit takes effect) this would have failed with the bug present.
- The originally failing `tests/appsec/integrations/django_tests/test_iast_django.py::test_django_untrusted_serialization_dill_smoke[py3.9]` integration test now passes (CI confirmation).
- Reproduced the exact failure mode locally with a minimal harness:

```python
class FakeUnpickler(_pickle.Unpickler): pass
FakeUnpickler.load = wrapt.FunctionWrapper(_pickle.Unpickler.load, hook)
FakeUnpickler.load  # → TypeError: descriptor 'load' for '_pickle.Unpickler' objects
                    #   doesn't apply to a 'NoneType' object
```

## Risks

Low. The removed `("_pickle", "Unpickler.load")` patch was a no-op on macOS and corrupted attribute access on Linux py3.9 — both behaviours are net improvements. Direct calls like `_pickle.Unpickler(bio).load()` will no longer be intercepted at the method level, but they were never reliably intercepted before, and the higher-level `_pickle.load`/`_pickle.loads` and `pickle.*` entry points already cover taint detection. No existing test that asserts vulnerability detection relies on the removed entry.

## Additional Notes

- Release note: `releasenotes/notes/iast-fix-untrusted-serialization-pickle-unpickler-load-1f7c4b8e6a2d5c39.yaml`
- The pre-commit `mypy` errors in `tests/appsec/iast/iast_utils.py` (`oce` and `iastpatch` attr-defined) are **pre-existing** — they appeared after `ci: enable mypy strict mode by default` (#18077) flipped `no_implicit_reexport` to `true`. They are not introduced by this change and exist on `main` and `4.9` already.
