### PR TITLE
feat(llmobs): capture context compaction events from claude_agent_sdk

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -85,6 +85,10 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         self._step_response_chunk: Any = None  # deferred AssistantMessage for steps with tool calls
         self._step_input_snapshot: Optional[list[Message]] = None  # input captured before llm extension
         self._accumulated_input_messages: Optional[list[Message]] = None
+        # Register on the instance so the PreCompact hook can find the
+        # currently-active step span to stamp compaction events onto.
+        if self.instance is not None:
+            self.instance._dd_streaming_handler = self
         self._create_step_span()
 
     async def process_chunk(self, chunk, iterator=None):
@@ -145,6 +149,8 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         except Exception:
             log.warning("Error processing claude_agent_sdk stream response.", exc_info=True)
         finally:
+            if self.instance is not None and getattr(self.instance, "_dd_streaming_handler", None) is self:
+                self.instance._dd_streaming_handler = None
             self.primary_span.finish()
 
     def _create_step_span(self) -> None:

--- a/ddtrace/contrib/internal/claude_agent_sdk/patch.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/patch.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import replace
 
 import claude_agent_sdk
 
@@ -24,6 +25,69 @@ def get_version() -> str:
 
 def _supported_versions() -> dict[str, str]:
     return {"claude_agent_sdk": ">=0.0.23"}
+
+
+def _make_dd_precompact_hook(instance):
+    """Return an async PreCompact hook that records compaction events on the active query.
+
+    The active agent span is looked up via instance._dd_query_args, which traced_client_query
+    populates for the duration of a ClaudeSDKClient.query() call.
+    """
+    async def _hook(input_data, tool_use_id, context):
+        try:
+            query_args = getattr(instance, "_dd_query_args", None)
+            if query_args is None:
+                return {}
+
+            # Schema matches dd-apm-test-agent claude_hooks._handle_pre_compact:
+            # both fields always present, custom_instructions defaults to "".
+            event = {
+                "trigger": (input_data or {}).get("trigger") or "",
+                "custom_instructions": (input_data or {}).get("custom_instructions") or "",
+            }
+
+            # Also stamp on the currently-active step span (if any) so it shows
+            # up directly on that span as "compaction happened during this step".
+            handler = getattr(instance, "_dd_streaming_handler", None)
+            step_span = getattr(handler, "current_step_span", None) if handler else None
+            if step_span is not None:
+                step_bag = step_span._get_ctx_item("_dd_compactions") or []
+                step_bag.append(event)
+                step_span._set_ctx_item("_dd_compactions", step_bag)
+
+            query_args.setdefault("compactions", []).append(event)
+        except Exception:
+            log.warning("Error recording claude_agent_sdk PreCompact event", exc_info=True)
+        return {}
+
+    return _hook
+
+
+def traced_client_init(func, instance, args, kwargs):
+    """Inject a ddtrace-owned PreCompact hook into ClaudeSDKClient.options.hooks.
+
+    The SDK reads options.hooks during connect() (via _convert_hooks_to_internal_format),
+    so adding our hook between __init__ and connect() is the cleanest injection point.
+    To avoid mutating the user's ClaudeAgentOptions object, we build a copy of the
+    options (and the hooks dict + PreCompact matcher list) and rebind instance.options.
+    """
+    func(*args, **kwargs)
+    try:
+        HookMatcher = getattr(claude_agent_sdk, "HookMatcher", None)
+        if HookMatcher is None:
+            return
+        options = getattr(instance, "options", None)
+        if options is None:
+            return
+
+        new_hooks = dict(getattr(options, "hooks", None) or {})
+        new_matchers = list(new_hooks.get("PreCompact") or [])
+        new_matchers.append(HookMatcher(matcher=None, hooks=[_make_dd_precompact_hook(instance)]))
+        new_hooks["PreCompact"] = new_matchers
+
+        instance.options = replace(options, hooks=new_hooks)
+    except Exception:
+        log.warning("Error installing claude_agent_sdk PreCompact hook", exc_info=True)
 
 
 def traced_query_async_generator(func, _instance, args, kwargs):
@@ -78,6 +142,7 @@ async def traced_client_query(func, instance, args, kwargs):
         "args": args,
         "kwargs": kwargs,
         "before_context": before_context,
+        "compactions": [],
     }
 
     try:
@@ -102,10 +167,17 @@ def traced_receive_messages(func, instance, args, kwargs):
     query_args = query_args_dict.get("args")
     query_kwargs = query_args_dict.get("kwargs") or {}
     before_context = query_args_dict.get("before_context")
-    instance._dd_query_args = None
+    # Keep _dd_query_args alive (don't reset to None here) so the PreCompact
+    # hook can still append to the compactions list during streaming, which is
+    # when compactions actually fire. The next traced_client_query call will
+    # overwrite it with fresh per-query state.
+    compactions = query_args_dict.setdefault("compactions", [])
 
     if before_context is not None:
         query_kwargs["_dd_before_context"] = before_context
+    # Pass the list reference (not a snapshot) so finalize sees any events
+    # appended by the hook during the stream that follows.
+    query_kwargs["_dd_compactions"] = compactions
 
     if span is None:
         return func(*args, **kwargs)
@@ -132,6 +204,7 @@ def patch():
     claude_agent_sdk._datadog_integration = integration
 
     wrap("claude_agent_sdk", "query", traced_query_async_generator)
+    wrap("claude_agent_sdk", "ClaudeSDKClient.__init__", traced_client_init)
     wrap("claude_agent_sdk", "ClaudeSDKClient.query", traced_client_query)
     wrap("claude_agent_sdk", "ClaudeSDKClient.receive_messages", traced_receive_messages)
 
@@ -143,6 +216,7 @@ def unpatch():
     claude_agent_sdk._datadog_patch = False
 
     unwrap(claude_agent_sdk, "query")
+    unwrap(claude_agent_sdk.ClaudeSDKClient, "__init__")
     unwrap(claude_agent_sdk.ClaudeSDKClient, "query")
     unwrap(claude_agent_sdk.ClaudeSDKClient, "receive_messages")
 

--- a/ddtrace/contrib/internal/claude_agent_sdk/patch.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/patch.py
@@ -28,34 +28,24 @@ def _supported_versions() -> dict[str, str]:
 
 
 def _make_dd_precompact_hook(instance):
-    """Return an async PreCompact hook that records compaction events on the active query.
-
-    The active agent span is looked up via instance._dd_query_args, which traced_client_query
-    populates for the duration of a ClaudeSDKClient.query() call.
-    """
     async def _hook(input_data, tool_use_id, context):
         try:
-            query_args = getattr(instance, "_dd_query_args", None)
-            if query_args is None:
+            handler = getattr(instance, "_dd_streaming_handler", None)
+            if handler is None:
                 return {}
 
-            # Schema matches dd-apm-test-agent claude_hooks._handle_pre_compact:
-            # both fields always present, custom_instructions defaults to "".
             event = {
                 "trigger": (input_data or {}).get("trigger") or "",
                 "custom_instructions": (input_data or {}).get("custom_instructions") or "",
             }
 
-            # Also stamp on the currently-active step span (if any) so it shows
-            # up directly on that span as "compaction happened during this step".
-            handler = getattr(instance, "_dd_streaming_handler", None)
-            step_span = getattr(handler, "current_step_span", None) if handler else None
-            if step_span is not None:
-                step_bag = step_span._get_ctx_item("_dd_compactions") or []
-                step_bag.append(event)
-                step_span._set_ctx_item("_dd_compactions", step_bag)
-
-            query_args.setdefault("compactions", []).append(event)
+            # stamp compaction events on both the agent span and the active step span
+            for span in (handler.primary_span, handler.current_step_span):
+                if span is None:
+                    continue
+                bag = span._get_ctx_item("_dd_compactions") or []
+                bag.append(event)
+                span._set_ctx_item("_dd_compactions", bag)
         except Exception:
             log.warning("Error recording claude_agent_sdk PreCompact event", exc_info=True)
         return {}
@@ -142,7 +132,6 @@ async def traced_client_query(func, instance, args, kwargs):
         "args": args,
         "kwargs": kwargs,
         "before_context": before_context,
-        "compactions": [],
     }
 
     try:
@@ -167,17 +156,10 @@ def traced_receive_messages(func, instance, args, kwargs):
     query_args = query_args_dict.get("args")
     query_kwargs = query_args_dict.get("kwargs") or {}
     before_context = query_args_dict.get("before_context")
-    # Keep _dd_query_args alive (don't reset to None here) so the PreCompact
-    # hook can still append to the compactions list during streaming, which is
-    # when compactions actually fire. The next traced_client_query call will
-    # overwrite it with fresh per-query state.
-    compactions = query_args_dict.setdefault("compactions", [])
+    instance._dd_query_args = None
 
     if before_context is not None:
         query_kwargs["_dd_before_context"] = before_context
-    # Pass the list reference (not a snapshot) so finalize sees any events
-    # appended by the hook during the stream that follows.
-    query_kwargs["_dd_compactions"] = compactions
 
     if span is None:
         return func(*args, **kwargs)

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -88,6 +88,14 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
                 span.set_tag(ERROR_TYPE, error)
                 span.set_tag(ERROR_MSG, error)
         input_messages: list[Message] = (kwargs or {}).get("input_messages") or []
+
+        # Per-span compactions (stamped by the PreCompact hook when this span
+        # was the currently-active step). Read off the span's context bag.
+        metadata: dict[str, Any] = {}
+        span_compactions = span._get_ctx_item("_dd_compactions") if span else None
+        if span_compactions:
+            metadata.setdefault("_dd", {})["compactions"] = span_compactions
+
         _annotate_llmobs_span_data(
             span,
             kind=kind,
@@ -96,6 +104,7 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             input_messages=input_messages or None,
             output_messages=output_messages or [Message(content="")],
             metrics=metrics or None,
+            metadata=metadata or None,
         )
 
     def _llmobs_set_tool_tags(self, span: Span, kwargs: dict[str, Any]) -> None:
@@ -308,7 +317,14 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             if hasattr(options, key) and getattr(options, key):
                 metadata[key] = getattr(options, key)
         self._format_context(metadata, kwargs)
+        self._format_compactions(metadata, kwargs)
         return metadata
+
+    def _format_compactions(self, metadata: dict[str, Any], kwargs: dict[str, Any]) -> None:
+        compactions = kwargs.get("_dd_compactions")
+        if not compactions:
+            return
+        metadata.setdefault("_dd", {})["compactions"] = compactions
 
     def _format_context(self, metadata: dict[str, Any], kwargs: dict[str, Any]) -> None:
         after_context = kwargs.get("_dd_context")

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -89,8 +89,6 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
                 span.set_tag(ERROR_MSG, error)
         input_messages: list[Message] = (kwargs or {}).get("input_messages") or []
 
-        # Per-span compactions (stamped by the PreCompact hook when this span
-        # was the currently-active step). Read off the span's context bag.
         metadata: dict[str, Any] = {}
         span_compactions = span._get_ctx_item("_dd_compactions") if span else None
         if span_compactions:
@@ -127,6 +125,9 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
         model = span.get_tag("claude_agent_sdk.request.model") or ""
 
         metadata = self._extract_metadata(kwargs)
+        span_compactions = span._get_ctx_item("_dd_compactions") if span else None
+        if span_compactions:
+            metadata.setdefault("_dd", {})["compactions"] = span_compactions
 
         input_messages = self._extract_input_messages(prompt, span)
 
@@ -317,14 +318,7 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             if hasattr(options, key) and getattr(options, key):
                 metadata[key] = getattr(options, key)
         self._format_context(metadata, kwargs)
-        self._format_compactions(metadata, kwargs)
         return metadata
-
-    def _format_compactions(self, metadata: dict[str, Any], kwargs: dict[str, Any]) -> None:
-        compactions = kwargs.get("_dd_compactions")
-        if not compactions:
-            return
-        metadata.setdefault("_dd", {})["compactions"] = compactions
 
     def _format_context(self, metadata: dict[str, Any], kwargs: dict[str, Any]) -> None:
         after_context = kwargs.get("_dd_context")

--- a/releasenotes/notes/claude-agent-sdk-compactions-eb33d734ddd8d1d0.yaml
+++ b/releasenotes/notes/claude-agent-sdk-compactions-eb33d734ddd8d1d0.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    LLM Observability: This introduces capture of context compaction events from the Claude Agent SDK integration. ``ClaudeSDKClient`` queries now record each ``PreCompact`` hook invocation (with ``trigger`` of ``"auto"`` or ``"manual"``, and ``custom_instructions`` when present) on the agent span under ``metadata._dd.compactions``.
+    LLM Observability: This introduces capture of context compaction events from the Claude Agent SDK integration for 
+    ``ClaudeSDKClient`` queries. Compactions are inferred from the ``PreCompact`` hook invocation.

--- a/releasenotes/notes/claude-agent-sdk-compactions-eb33d734ddd8d1d0.yaml
+++ b/releasenotes/notes/claude-agent-sdk-compactions-eb33d734ddd8d1d0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: This introduces capture of context compaction events from the Claude Agent SDK integration. ``ClaudeSDKClient`` queries now record each ``PreCompact`` hook invocation (with ``trigger`` of ``"auto"`` or ``"manual"``, and ``custom_instructions`` when present) on the agent span under ``metadata._dd.compactions``.


### PR DESCRIPTION
## Description

Currently, the Claude Agent SDK does not capture compaction events in contrast to lapdog which does. This PR uses the `PreCompact` hook to record compaction events on the active agent span as well as the current active step span. 

<img width="1510" height="371" alt="Screenshot 2026-05-22 at 4 16 42 PM" src="https://github.com/user-attachments/assets/e1116340-4e95-40d8-a4a3-c44ca3d7529c" />

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
