### PR TITLE
test(profiling): add gevent CPU over-count regression test (demonstrates PROF-14213)

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -724,12 +724,20 @@ def test_gevent_cpu_time_total_accuracy() -> None:
 
     ratio = profile_cpu_ns / actual_cpu_ns
 
-    # Reject the ~1.6x over-count this test exists to catch. 1.25x gives ~25pp
-    # of slack above the expected 1.0x for noise.
-    # Lower bound guards against a regression that drops real CPU (e.g.
-    # reintroducing the is_running() gate from before PR #16273) and would
-    # report ~0x.
-    assert 0.7 <= ratio <= 1.25, (
+    # Bounds picked from measured ratios across local Mac (n=10) and CI Linux
+    # py3.9-3.14 (n=6). Observed range with the fix applied: 0.975 - 1.058;
+    # observed range without the fix (bug): 1.61 - 1.63 (n=5 CI). 1.20 upper
+    # leaves ~13% headroom above the worst observed fixed value and rejects the
+    # ~1.6x bug with ~25% margin; 0.85 lower leaves ~13% below the worst
+    # observed fixed value and rejects a regression that drops real CPU
+    # (e.g. reintroducing the is_running() gate removed in PR #16273) which
+    # would push the ratio toward 0.
+    #
+    # These bounds exist to catch regressions while staying flake-safe across
+    # CI runners. They are NOT a claim about the profiler's CPU attribution
+    # accuracy; see DataDog/experimental#10595 for the underlying accuracy
+    # characterization.
+    assert 0.85 <= ratio <= 1.20, (
         f"profile cpu-time total ({profile_cpu_ns / 1e9:.3f}s) does not match "
         f"actual process CPU time ({actual_cpu_ns / 1e9:.3f}s); ratio={ratio:.2f} "
         f"(expected ~1.0, bug produces ~1.6)"

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -735,8 +735,7 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     #
     # These bounds exist to catch regressions while staying flake-safe across
     # CI runners. They are NOT a claim about the profiler's CPU attribution
-    # accuracy; see DataDog/experimental#10595 for the underlying accuracy
-    # characterization.
+    # accuracy.
     assert 0.85 <= ratio <= 1.20, (
         f"profile cpu-time total ({profile_cpu_ns / 1e9:.3f}s) does not match "
         f"actual process CPU time ({actual_cpu_ns / 1e9:.3f}s); ratio={ratio:.2f} "

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -699,8 +699,10 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     p = profiler.Profiler()
     p.start()
     try:
-        # Stagger workers by CPU_BURN_S so their bursts interleave instead of
-        # clumping; matches the layout used in the experimental measurement.
+        # Stagger workers by CPU_BURN_S so their CPU bursts interleave with
+        # each other's sleep, which spreads the on-CPU greenlet across the
+        # unordered_map iteration order. Without staggering, the same greenlet
+        # tends to win the on-CPU position each sample, masking the bug.
         workers = []
         cpu_start_ns = time.process_time_ns()
         for i in range(NUM_WORKERS):
@@ -725,13 +727,17 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     ratio = profile_cpu_ns / actual_cpu_ns
 
     # Bounds picked from measured ratios across local Mac (n=10) and CI Linux
-    # py3.9-3.14 (n=6). Observed range with the fix applied: 0.975 - 1.058;
-    # observed range without the fix (bug): 1.61 - 1.63 (n=5 CI). 1.20 upper
-    # leaves ~13% headroom above the worst observed fixed value and rejects the
-    # ~1.6x bug with ~25% margin; 0.85 lower leaves ~13% below the worst
-    # observed fixed value and rejects a regression that drops real CPU
-    # (e.g. reintroducing the is_running() gate removed in PR #16273) which
-    # would push the ratio toward 0.
+    # py3.9-3.14 (n=6). With the fix applied: observed range was 0.975 - 1.058.
+    # Without the fix (bug): observed range was 1.61 - 1.63 (CI, n=5).
+    #
+    # Upper bound 1.20:
+    #   - ~14% above the worst observed fixed value (1.058)
+    #   - ~25% below the smallest observed bug value (1.61)
+    # Lower bound 0.85:
+    #   - ~13% below the worst observed fixed value (0.975)
+    #   - rejects a regression that drops real CPU (e.g. reintroducing the
+    #     is_running() gate removed in PR #16273) which would push the ratio
+    #     toward 0.
     #
     # These bounds exist to catch regressions while staying flake-safe across
     # CI runners. They are NOT a claim about the profiler's CPU attribution

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -644,6 +644,98 @@ def test_collect_gevent_task_started_before_profiler() -> None:
     )
 
 
+@pytest.mark.skipif(
+    not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
+    reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
+)
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_gevent_cpu_time_total_accuracy",
+        _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
+    ),
+    err=None,
+)
+def test_gevent_cpu_time_total_accuracy() -> None:
+    """Verify that the sum of cpu-time across all profile samples roughly matches
+    the actual process CPU time consumed by gevent workers.
+
+    Without the on-CPU swap in unwind_greenlets, when the running greenlet is
+    not the first entry in current_greenlets, render_task_begin starts a new
+    sample for it and pushes thread_state.cpu_time_ns a second time (the first
+    push already happened on the sample inherited from render_thread_begin).
+    For M=4 workers, the over-count converges to ~1.5-1.6x of the real CPU
+    consumed by the process. With the swap in place, the on-CPU greenlet
+    always reuses the first sample and the duplicate push is avoided.
+
+    Adaptive sampling is disabled to mirror the experimental measurement cell
+    that gave the cleanest 1.6x signal; this also keeps the sample interval
+    deterministic across the timed region.
+    """
+    from gevent import monkey
+
+    monkey.patch_all()
+
+    import os
+    import time
+
+    import gevent
+
+    from ddtrace.profiling import profiler
+    from tests.profiling.collector import pprof_utils
+
+    DURATION_S = 3.0
+    CPU_BURN_S = 0.01
+    SLEEP_S = 0.05
+    NUM_WORKERS = 4
+
+    def worker() -> None:
+        deadline = time.monotonic() + DURATION_S
+        while time.monotonic() < deadline:
+            burn_until = time.process_time_ns() + int(CPU_BURN_S * 1e9)
+            while time.process_time_ns() < burn_until:
+                pass
+            gevent.sleep(SLEEP_S)
+
+    p = profiler.Profiler()
+    p.start()
+    try:
+        # Stagger workers by CPU_BURN_S so their bursts interleave instead of
+        # clumping; matches the layout used in the experimental measurement.
+        workers = []
+        cpu_start_ns = time.process_time_ns()
+        for i in range(NUM_WORKERS):
+            if i > 0:
+                gevent.sleep(CPU_BURN_S)
+            workers.append(gevent.spawn(worker))
+        gevent.joinall(workers, timeout=DURATION_S + 10)
+        cpu_end_ns = time.process_time_ns()
+    finally:
+        p.stop()
+
+    assert all(g.dead for g in workers), "gevent workers did not finish within timeout"
+
+    actual_cpu_ns = cpu_end_ns - cpu_start_ns
+    assert actual_cpu_ns > 0, "process_time_ns did not advance"
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    cpu_time_index = pprof_utils.get_sample_type_index(profile, "cpu-time")
+    profile_cpu_ns = sum(sample.value[cpu_time_index] for sample in profile.sample)
+
+    ratio = profile_cpu_ns / actual_cpu_ns
+
+    # Reject the ~1.6x over-count this test exists to catch. 1.25x gives ~25pp
+    # of slack above the expected 1.0x for noise.
+    # Lower bound guards against a regression that drops real CPU (e.g.
+    # reintroducing the is_running() gate from before PR #16273) and would
+    # report ~0x.
+    assert 0.7 <= ratio <= 1.25, (
+        f"profile cpu-time total ({profile_cpu_ns / 1e9:.3f}s) does not match "
+        f"actual process CPU time ({actual_cpu_ns / 1e9:.3f}s); ratio={ratio:.2f} "
+        f"(expected ~1.0, bug produces ~1.6)"
+    )
+
+
 def test_repr() -> None:
     test_collector._test_repr(
         stack.StackCollector,


### PR DESCRIPTION
## Description

This PR adds **only the test** for the gevent CPU over-count bug described in
[experimental#10595 Phase 1 findings, Finding 3](https://github.com/DataDog/experimental/pull/10595).

**This PR is expected to fail CI** — that is its purpose. It demonstrates that
the bug exists on `main` without the fix. The companion PR contains the fix
that makes this test pass.

## What the test does

`tests/profiling/collector/test_stack.py::test_gevent_cpu_time_total_accuracy`
runs 4 staggered gevent worker greenlets, each cycling ~10ms of pure-Python
CPU burn followed by `gevent.sleep(50ms)` for 3 seconds. It then compares the
sum of `cpu-time` across all profile samples against `time.process_time_ns()`
delta over the same region.

With current `main`, the ratio is ~1.6× and the test fails. With the fix
applied, the ratio is ~1.0× and the test passes.

## Underlying bug (for reviewers)

`render_task_begin` in `stack_renderer.cpp` re-pushes `thread_state.cpu_time_ns`
whenever it starts a new sample for a task with `on_cpu=true`. `unwind_greenlets`
populates `current_greenlets` in `std::unordered_map` iteration order, so if
the on-CPU greenlet lands at position ≥ 1, the duplicate push inflates the
total CPU by ~1.5-1.6×. `unwind_tasks` already mirrors the on-CPU task to
position 0, so asyncio totals are correct; `unwind_greenlets` does not.

## Testing

Locally:

* Without fix (this PR): `ratio=1.60` → test fails as designed.
* With fix (companion PR): `ratio≈1.0` → test passes.

Verified on Python 3.13 + gevent latest via
`scripts/run-tests --venv 177daf3`.

## Risks

None on its own — adds a test, no production code changes. The PR is filed as
draft and is not meant to merge. It will be closed (or rebased away) once the
companion fix PR lands.

## Additional Notes

Refs: DataDog/experimental#10595, PROF-14213.