### PR TITLE
fix(profiling): swap on-CPU greenlet to position 0 in unwind_greenlets

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -678,7 +678,19 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
     // that sample already received push_cputime via render_cpu_time. Tasks
     // rendered after the first start a new sample and, if on_cpu is true,
     // push thread_state.cpu_time_ns again, double-counting CPU time.
-    // unwind_tasks performs the same swap on leaf_tasks above.
+    //
+    // unwind_tasks performs the analogous swap on leaf_tasks above. Note that
+    // the "on-CPU" signal differs: asyncio's is_on_cpu is derived from frame
+    // matching during unwind, while a greenlet's on_cpu is set from
+    // snap.frame == Py_None (see the loop above), which is the sentinel
+    // greenlet uses for its currently-running greenlet. If that sentinel
+    // changes, this swap silently no-ops and the over-count returns.
+    //
+    // If no greenlet is on CPU (e.g. all workers are sleeping while the Hub
+    // is running, which is filtered out as a parent), no entry triggers
+    // render_task_begin's push_cputime branch, so order does not matter and
+    // this loop falls through harmlessly. Empty current_greenlets is also
+    // safe (loop body never executes).
     for (size_t i = 0; i < current_greenlets.size(); i++) {
         if (current_greenlets[i]->on_cpu) {
             if (i > 0) {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -672,6 +672,21 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
 
         current_greenlets.push_back(std::move(stack_info));
     }
+
+    // Make sure the on-CPU greenlet is first. render_task_begin reuses the
+    // sample created by render_thread_begin for the first task it renders;
+    // that sample already received push_cputime via render_cpu_time. Tasks
+    // rendered after the first start a new sample and, if on_cpu is true,
+    // push thread_state.cpu_time_ns again, double-counting CPU time.
+    // unwind_tasks performs the same swap on leaf_tasks above.
+    for (size_t i = 0; i < current_greenlets.size(); i++) {
+        if (current_greenlets[i]->on_cpu) {
+            if (i > 0) {
+                std::swap(current_greenlets[i], current_greenlets[0]);
+            }
+            break;
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -691,11 +691,9 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
     // render_task_begin's push_cputime branch, so order does not matter and
     // this loop falls through harmlessly. Empty current_greenlets is also
     // safe (loop body never executes).
-    for (size_t i = 0; i < current_greenlets.size(); i++) {
+    for (size_t i = 1; i < current_greenlets.size(); i++) {
         if (current_greenlets[i]->on_cpu) {
-            if (i > 0) {
-                std::swap(current_greenlets[i], current_greenlets[0]);
-            }
+            std::swap(current_greenlets[i], current_greenlets[0]);
             break;
         }
     }

--- a/releasenotes/notes/profiling-fix-gevent-cpu-overcount-1d2aa67778642a97.yaml
+++ b/releasenotes/notes/profiling-fix-gevent-cpu-overcount-1d2aa67778642a97.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: fixed an issue where the stack sampler over-counted total
+    CPU time for gevent workloads.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -727,10 +727,7 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     # TEMP DATA COLLECTION: always fail with ratio in message, so each CI run
     # dumps the observed ratio via captured stderr. Revert to bounded assert
     # below before merging.
-    assert False, (
-        f"COLLECT_RATIO={ratio:.4f} profile={profile_cpu_ns / 1e9:.3f}s "
-        f"actual={actual_cpu_ns / 1e9:.3f}s"
-    )
+    assert False, f"COLLECT_RATIO={ratio:.4f} profile={profile_cpu_ns / 1e9:.3f}s actual={actual_cpu_ns / 1e9:.3f}s"
 
     # Reject the ~1.6x over-count this test exists to catch. 1.25x gives ~25pp
     # of slack above the expected 1.0x for noise.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -735,8 +735,7 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     #
     # These bounds exist to catch regressions while staying flake-safe across
     # CI runners. They are NOT a claim about the profiler's CPU attribution
-    # accuracy; see DataDog/experimental#10595 for the underlying accuracy
-    # characterization.
+    # accuracy.
     assert 0.85 <= ratio <= 1.20, (
         f"profile cpu-time total ({profile_cpu_ns / 1e9:.3f}s) does not match "
         f"actual process CPU time ({actual_cpu_ns / 1e9:.3f}s); ratio={ratio:.2f} "

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -724,6 +724,14 @@ def test_gevent_cpu_time_total_accuracy() -> None:
 
     ratio = profile_cpu_ns / actual_cpu_ns
 
+    # TEMP DATA COLLECTION: always fail with ratio in message, so each CI run
+    # dumps the observed ratio via captured stderr. Revert to bounded assert
+    # below before merging.
+    assert False, (
+        f"COLLECT_RATIO={ratio:.4f} profile={profile_cpu_ns / 1e9:.3f}s "
+        f"actual={actual_cpu_ns / 1e9:.3f}s"
+    )
+
     # Reject the ~1.6x over-count this test exists to catch. 1.25x gives ~25pp
     # of slack above the expected 1.0x for noise.
     # Lower bound guards against a regression that drops real CPU (e.g.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -699,8 +699,10 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     p = profiler.Profiler()
     p.start()
     try:
-        # Stagger workers by CPU_BURN_S so their bursts interleave instead of
-        # clumping; matches the layout used in the experimental measurement.
+        # Stagger workers by CPU_BURN_S so their CPU bursts interleave with
+        # each other's sleep, which spreads the on-CPU greenlet across the
+        # unordered_map iteration order. Without staggering, the same greenlet
+        # tends to win the on-CPU position each sample, masking the bug.
         workers = []
         cpu_start_ns = time.process_time_ns()
         for i in range(NUM_WORKERS):
@@ -725,13 +727,17 @@ def test_gevent_cpu_time_total_accuracy() -> None:
     ratio = profile_cpu_ns / actual_cpu_ns
 
     # Bounds picked from measured ratios across local Mac (n=10) and CI Linux
-    # py3.9-3.14 (n=6). Observed range with the fix applied: 0.975 - 1.058;
-    # observed range without the fix (bug): 1.61 - 1.63 (n=5 CI). 1.20 upper
-    # leaves ~13% headroom above the worst observed fixed value and rejects the
-    # ~1.6x bug with ~25% margin; 0.85 lower leaves ~13% below the worst
-    # observed fixed value and rejects a regression that drops real CPU
-    # (e.g. reintroducing the is_running() gate removed in PR #16273) which
-    # would push the ratio toward 0.
+    # py3.9-3.14 (n=6). With the fix applied: observed range was 0.975 - 1.058.
+    # Without the fix (bug): observed range was 1.61 - 1.63 (CI, n=5).
+    #
+    # Upper bound 1.20:
+    #   - ~14% above the worst observed fixed value (1.058)
+    #   - ~25% below the smallest observed bug value (1.61)
+    # Lower bound 0.85:
+    #   - ~13% below the worst observed fixed value (0.975)
+    #   - rejects a regression that drops real CPU (e.g. reintroducing the
+    #     is_running() gate removed in PR #16273) which would push the ratio
+    #     toward 0.
     #
     # These bounds exist to catch regressions while staying flake-safe across
     # CI runners. They are NOT a claim about the profiler's CPU attribution

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -724,17 +724,20 @@ def test_gevent_cpu_time_total_accuracy() -> None:
 
     ratio = profile_cpu_ns / actual_cpu_ns
 
-    # TEMP DATA COLLECTION: always fail with ratio in message, so each CI run
-    # dumps the observed ratio via captured stderr. Revert to bounded assert
-    # below before merging.
-    assert False, f"COLLECT_RATIO={ratio:.4f} profile={profile_cpu_ns / 1e9:.3f}s actual={actual_cpu_ns / 1e9:.3f}s"
-
-    # Reject the ~1.6x over-count this test exists to catch. 1.25x gives ~25pp
-    # of slack above the expected 1.0x for noise.
-    # Lower bound guards against a regression that drops real CPU (e.g.
-    # reintroducing the is_running() gate from before PR #16273) and would
-    # report ~0x.
-    assert 0.7 <= ratio <= 1.25, (
+    # Bounds picked from measured ratios across local Mac (n=10) and CI Linux
+    # py3.9-3.14 (n=6). Observed range with the fix applied: 0.975 - 1.058;
+    # observed range without the fix (bug): 1.61 - 1.63 (n=5 CI). 1.20 upper
+    # leaves ~13% headroom above the worst observed fixed value and rejects the
+    # ~1.6x bug with ~25% margin; 0.85 lower leaves ~13% below the worst
+    # observed fixed value and rejects a regression that drops real CPU
+    # (e.g. reintroducing the is_running() gate removed in PR #16273) which
+    # would push the ratio toward 0.
+    #
+    # These bounds exist to catch regressions while staying flake-safe across
+    # CI runners. They are NOT a claim about the profiler's CPU attribution
+    # accuracy; see DataDog/experimental#10595 for the underlying accuracy
+    # characterization.
+    assert 0.85 <= ratio <= 1.20, (
         f"profile cpu-time total ({profile_cpu_ns / 1e9:.3f}s) does not match "
         f"actual process CPU time ({actual_cpu_ns / 1e9:.3f}s); ratio={ratio:.2f} "
         f"(expected ~1.0, bug produces ~1.6)"

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -644,6 +644,98 @@ def test_collect_gevent_task_started_before_profiler() -> None:
     )
 
 
+@pytest.mark.skipif(
+    not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
+    reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
+)
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_gevent_cpu_time_total_accuracy",
+        _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
+    ),
+    err=None,
+)
+def test_gevent_cpu_time_total_accuracy() -> None:
+    """Verify that the sum of cpu-time across all profile samples roughly matches
+    the actual process CPU time consumed by gevent workers.
+
+    Without the on-CPU swap in unwind_greenlets, when the running greenlet is
+    not the first entry in current_greenlets, render_task_begin starts a new
+    sample for it and pushes thread_state.cpu_time_ns a second time (the first
+    push already happened on the sample inherited from render_thread_begin).
+    For M=4 workers, the over-count converges to ~1.5-1.6x of the real CPU
+    consumed by the process. With the swap in place, the on-CPU greenlet
+    always reuses the first sample and the duplicate push is avoided.
+
+    Adaptive sampling is disabled to mirror the experimental measurement cell
+    that gave the cleanest 1.6x signal; this also keeps the sample interval
+    deterministic across the timed region.
+    """
+    from gevent import monkey
+
+    monkey.patch_all()
+
+    import os
+    import time
+
+    import gevent
+
+    from ddtrace.profiling import profiler
+    from tests.profiling.collector import pprof_utils
+
+    DURATION_S = 3.0
+    CPU_BURN_S = 0.01
+    SLEEP_S = 0.05
+    NUM_WORKERS = 4
+
+    def worker() -> None:
+        deadline = time.monotonic() + DURATION_S
+        while time.monotonic() < deadline:
+            burn_until = time.process_time_ns() + int(CPU_BURN_S * 1e9)
+            while time.process_time_ns() < burn_until:
+                pass
+            gevent.sleep(SLEEP_S)
+
+    p = profiler.Profiler()
+    p.start()
+    try:
+        # Stagger workers by CPU_BURN_S so their bursts interleave instead of
+        # clumping; matches the layout used in the experimental measurement.
+        workers = []
+        cpu_start_ns = time.process_time_ns()
+        for i in range(NUM_WORKERS):
+            if i > 0:
+                gevent.sleep(CPU_BURN_S)
+            workers.append(gevent.spawn(worker))
+        gevent.joinall(workers, timeout=DURATION_S + 10)
+        cpu_end_ns = time.process_time_ns()
+    finally:
+        p.stop()
+
+    assert all(g.dead for g in workers), "gevent workers did not finish within timeout"
+
+    actual_cpu_ns = cpu_end_ns - cpu_start_ns
+    assert actual_cpu_ns > 0, "process_time_ns did not advance"
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    cpu_time_index = pprof_utils.get_sample_type_index(profile, "cpu-time")
+    profile_cpu_ns = sum(sample.value[cpu_time_index] for sample in profile.sample)
+
+    ratio = profile_cpu_ns / actual_cpu_ns
+
+    # Reject the ~1.6x over-count this test exists to catch. 1.25x gives ~25pp
+    # of slack above the expected 1.0x for noise.
+    # Lower bound guards against a regression that drops real CPU (e.g.
+    # reintroducing the is_running() gate from before PR #16273) and would
+    # report ~0x.
+    assert 0.7 <= ratio <= 1.25, (
+        f"profile cpu-time total ({profile_cpu_ns / 1e9:.3f}s) does not match "
+        f"actual process CPU time ({actual_cpu_ns / 1e9:.3f}s); ratio={ratio:.2f} "
+        f"(expected ~1.0, bug produces ~1.6)"
+    )
+
+
 def test_repr() -> None:
     test_collector._test_repr(
         stack.StackCollector,


### PR DESCRIPTION
## Description

Fixes a ~1.6× over-count of total CPU time reported by the stack v2 sampler
for gevent workloads.

`ThreadInfo::sample` calls `render_thread_begin` (creates sample `S0`), then
`render_cpu_time` (pushes the CPU delta on `S0`), then renders one greenlet
per `current_greenlets` entry via `render_task_begin`.

`render_task_begin` reuses the existing sample for the first task it sees and
starts a new sample for subsequent tasks. The new-sample path re-pushes
`thread_state.cpu_time_ns` whenever `on_cpu=true`. For asyncio this is
harmless because `unwind_tasks` already swaps the on-CPU task to
`leaf_tasks[0]`, so the duplicate push never fires.

`unwind_greenlets` had no such swap: `current_greenlets` ended up in
`std::unordered_map` iteration order, so when the on-CPU greenlet landed at
position ≥ 1, its CPU delta was attributed twice. For M=4 workers, the
over-count converges to ~1.5-1.6× of the real CPU consumed by the process.

This change mirrors the existing `unwind_tasks` swap at the end of
`unwind_greenlets`. `std::swap` on `std::unique_ptr<StackInfo>` is a noexcept
pointer swap. `on_cpu` is set from `snap.frame == Py_None`, true only for the
currently-running greenlet, so multiple-on-CPU is impossible by construction.

Out of scope here: the deeper TODO in `render_cpu_time` (\"thread-level CPU
time is task time\") that would normalize at the task level. That's the
architectural fix the findings doc recommends; this PR is the minimal
symptom-fix.

Refs: [DataDog/experimental#10595](https://github.com/DataDog/experimental/pull/10595) (Phase 1 findings, Finding 3), PROF-14213.

## Testing

Added `tests/profiling/collector/test_stack.py::test_gevent_cpu_time_total_accuracy`:

- 4 staggered worker greenlets, each cycling ~10ms of pure-Python CPU burn
  (busy-loop on \`time.process_time_ns()\`) followed by \`gevent.sleep(50ms)\`
  for 3 seconds.
- Ground truth: \`time.process_time_ns()\` delta over the timed region.
- Profile read: sum \`cpu-time\` across all samples in the resulting pprof.
- Assert: \`0.85 ≤ profile_cpu / actual_cpu ≤ 1.20\`.

Verified locally on Python 3.13 + gevent latest via
\`scripts/run-tests --venv 177daf3\`:

- Without this fix (rebuilt main): \`ratio=1.60\` → test fails (upper bound
  rejects the 1.6× bug).
- With this fix: ratio ≈ 1.0 → test passes alongside the rest of the
  profiling suite (350 tests).

A test-only companion PR demonstrates the failure on \`main\`: #18221.

## Risks

- C++ change is 7 lines, lives at the end of \`unwind_greenlets\`, and exactly
  mirrors the existing pattern in \`unwind_tasks\`. No header changes, no API
  changes.
- User-visible CPU totals for gevent workloads will decrease (closer to
  actual). Release note added under \`fixes:\`.
- Lower bound (0.85×) in the new test guards against a regression where the
  fix accidentally drops real CPU samples (e.g. reintroducing the
  \`is_running()\` gate removed in #16273).

## Additional Notes

<details>
<summary>PLAN.md</summary>

\`\`\`markdown
$(cat PLAN.md)
\`\`\`

</details>

<details>
<summary>PROMPTS.md</summary>

\`\`\`markdown
$(cat PROMPTS.md)
\`\`\`

</details>
