### PR TITLE
feat(ray): bridge ray.submission_id to NCCL profiler plugin via env var

### DIFF
--- a/ddtrace/contrib/internal/ray/core/utils.py
+++ b/ddtrace/contrib/internal/ray/core/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import socket
 import sys
+import threading
 from typing import Any
 from typing import Callable
 from typing import Optional
@@ -21,6 +22,7 @@ from ddtrace.constants import _DJM_ENABLED_KEY
 from ddtrace.constants import _FILTER_KEPT_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import _SPAN_MEASURED_KEY
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings import env
 from ddtrace.propagation.http import _TraceContext
 
@@ -38,6 +40,9 @@ from ..constants import RAY_TASK_ID
 from ..constants import RAY_WORKER_ID
 from ..constants import REDACTED_PATH
 from ..constants import REDACTED_VALUE
+
+
+log = get_logger(__name__)
 
 
 # The job name regex serves to convert a submission ID in the format job:train_my_model,run:1758573287
@@ -129,6 +134,73 @@ def _set_runtime_context_attributes(span: Span, submission_id: Optional[str] = N
         actor_id = runtime_context.get_actor_id()
         if actor_id is not None:
             span._set_attribute(RAY_ACTOR_ID, actor_id)
+
+    # Publish ray.submission_id onto DD_NCCL_EXTRA_TAGS so the NCCL profiler
+    # plugin (loaded in NCCL's C++ profiler thread, no Python access) can tag
+    # nccl.collective.* metrics + spans with it. Idempotent + no-op when the
+    # NCCL plugin is not loaded in this pod.
+    _publish_ray_context_to_nccl_plugin()
+
+
+_nccl_bridge_lock = threading.Lock()
+_nccl_bridge_done = False
+
+
+def _publish_ray_context_to_nccl_plugin() -> None:
+    """Mirror ray.submission_id onto DD_NCCL_EXTRA_TAGS so the NCCL profiler
+    plugin (running in NCCL's profiler thread, C++ code, no Python access)
+    can tag nccl.collective.* metrics + spans with it.
+
+    Auto-gated on NCCL_PROFILER_PLUGIN env var (set by the admission webhook
+    when the plugin is loaded in this pod). No-op otherwise.
+
+    Idempotent: writes once per process. submission_id is actor/driver-scoped
+    and doesn't change.
+
+    Multi-source fallback because Ray exposes submission_id in different places
+    depending on Ray version and process role (driver vs actor):
+
+        1. _RAY_SUBMISSION_ID env var - set on driver by Ray Jobs CLI
+        2. RAY_SUBMISSION_ID_FROM_DRIVER env var - convention for actor
+           processes when the driver propagates via runtime_env.env_vars
+        3. RAY_JOB_CONFIG_JSON_ENV_VAR - Ray 2.49.x driver-mode env var with
+           JSON containing metadata.job_submission_id
+        4. ray.runtime_context.get_job_submission_id() - Ray >= 2.50 only
+    """
+    global _nccl_bridge_done
+    if _nccl_bridge_done:
+        return
+    with _nccl_bridge_lock:
+        if _nccl_bridge_done:
+            return
+        if not env.get("NCCL_PROFILER_PLUGIN"):
+            _nccl_bridge_done = True
+            return
+
+        sid = env.get(RAY_SUBMISSION_ID)
+        if not sid:
+            sid = env.get("RAY_SUBMISSION_ID_FROM_DRIVER")
+        if not sid:
+            raw = env.get("RAY_JOB_CONFIG_JSON_ENV_VAR") or ""
+            if raw:
+                try:
+                    payload = json.loads(raw)
+                except json.JSONDecodeError:
+                    log.debug("RAY_JOB_CONFIG_JSON_ENV_VAR is not valid JSON", exc_info=True)
+                    payload = None
+                if isinstance(payload, dict):
+                    metadata = payload.get("metadata")
+                    if isinstance(metadata, dict):
+                        sid = metadata.get("job_submission_id")
+        if not sid and ray.is_initialized():
+            try:
+                sid = get_runtime_context().get_job_submission_id()
+            except AttributeError:
+                log.debug("ray.runtime_context.get_job_submission_id is not available on this Ray version")
+
+        if sid:
+            env["DD_NCCL_EXTRA_TAGS"] = "ray.submission_id:" + sid
+            _nccl_bridge_done = True
 
 
 def set_tag_or_truncate(span: Span, tag_name: str, tag_value: Any = None) -> None:

--- a/releasenotes/notes/ray-nccl-submission-id-bridge-14312d756f4fbe71.yaml
+++ b/releasenotes/notes/ray-nccl-submission-id-bridge-14312d756f4fbe71.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Ray: Adds a runtime bridge that mirrors ``ray.submission_id`` onto the
+    ``DD_NCCL_EXTRA_TAGS`` environment variable so the NCCL profiler plugin
+    (which runs in NCCL's C++ profiler thread with no Python interpreter
+    access) can tag ``nccl.collective.*`` metrics with the user-facing Ray
+    job submission id. The bridge fires from
+    ``ddtrace.contrib.internal.ray.core.utils._set_runtime_context_attributes``,
+    is gated on ``NCCL_PROFILER_PLUGIN`` being set in the pod environment
+    (no-op otherwise), is idempotent + thread-safe, and supports a
+    four-source fallback (``_RAY_SUBMISSION_ID``,
+    ``RAY_SUBMISSION_ID_FROM_DRIVER``, the
+    ``RAY_JOB_CONFIG_JSON_ENV_VAR`` JSON blob's
+    ``metadata.job_submission_id`` field, and
+    ``ray.runtime_context.get_job_submission_id()`` on Ray >= 2.50) so it
+    works across Ray versions and driver/actor process roles.


### PR DESCRIPTION
## Description
Adds a hook in ddtrace.contrib.internal.ray.core.utils that publishes ray.submission_id (Ray's canonical user-facing job id) onto the `DD_NCCL_EXTRA_TAGS` env var, so the NCCL profiler plugin can tag nccl.collective.* metrics with it.

**Background.** The NCCL profiler plugin is loaded by NCCL via `dlopen` and runs in NCCL's C++ profiler thread. It
has no Python interpreter access, so it cannot reach Ray's `runtime_context`. The set of tags it can self-source on
  a Ray worker pod is limited to static env vars Ray sets at pod creation time — currently `ray_job_id`,
  `ray_cluster_name`, `ray_node_type_name` (see [nccl-profiler-injector#7](https://github.com/DataDog/nccl-profiler-injector/pull/7)). `ray.submission_id` is **not** a static env on the worker pod — it only exists in the driver process (via `RAY_JOB_CONFIG_JSON_ENV_VAR`'s JSON `metadata.job_submission_id`) and has to be propagated to actors at runtime. That propagation is what this PR
  adds.

**Why dd-trace-py is the right place.** Ray is Python, and dd-trace-py's Ray integration already wraps Ray's actor/driver lifecycle and runtime context. Adding the hook to the existing `_set_runtime_context_attributes` function means it fires automatically the first time Ray's runtime context is consulted on either side, with no extra opt-in surface area.

Note: The NCCL plugin reads DD_NCCL_EXTRA_TAGS per collective event rather than at dlopen, so even if dd-trace-py writes the env after NCCL is already loaded, the next collective picks up the tag.
  
  ### What changes

  One file: `ddtrace/contrib/internal/ray/core/utils.py`.

  - Adds `_publish_ray_context_to_nccl_plugin()` — gated on `NCCL_PROFILER_PLUGIN` env (the marker the NCCL profiler
  admission webhook sets on the pod). When the plugin is not loaded, the function returns immediately and writes
  nothing. Idempotent via a module-level lock + a "done" flag — runs at most once per process.
  - Hooks a single call to that function at the tail of `_set_runtime_context_attributes`.
  - Adds a release note.

  Multi-source fallback for the submission id, tried in order until one hits:

  1. `_RAY_SUBMISSION_ID` env (driver process, set by Ray Jobs CLI)
  2. `RAY_SUBMISSION_ID_FROM_DRIVER` env (driver→actor propagation convention)
  3. `RAY_JOB_CONFIG_JSON_ENV_VAR` JSON blob, field `metadata.job_submission_id` (Ray 2.49.x driver-mode)
  4. `ray.runtime_context.get_job_submission_id()` (Ray ≥ 2.50 only)

  When found, writes `DD_NCCL_EXTRA_TAGS=ray.submission_id:<sid>` via `ddtrace.internal.settings.env`. The NCCL plugin reads this env on each collective event and appends it to every emitted metric/span.

<!-- Any other information that would be helpful for reviewers -->
