### PR TITLE
test(ai_guard): add regression tests for strands plugin dispatch

### DIFF
--- a/tests/appsec/ai_guard/strands_hooks/test_strands.py
+++ b/tests/appsec/ai_guard/strands_hooks/test_strands.py
@@ -808,6 +808,87 @@ class TestPluginHookDiscovery:
 
 
 # ---------------------------------------------------------------------------
+# APMSP-3088 regression: end-to-end @hook dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestPluginEndToEndDispatch:
+    """APMSP-3088 regression: drive ``HookRegistry.invoke_callbacks`` to catch class-identity drift."""
+
+    HOOKS_TO_EVENTS = (
+        ("on_before_invocation", BeforeInvocationEvent),
+        ("on_after_invocation", AfterInvocationEvent),
+        ("on_before_model_call", BeforeModelCallEvent),
+        ("on_after_model_call", AfterModelCallEvent),
+        ("on_before_tool_call", BeforeToolCallEvent),
+        ("on_after_tool_call", AfterToolCallEvent),
+    )
+
+    @staticmethod
+    def _register_plugin_hooks(plugin):
+        registry = HookRegistry()
+        for callback in plugin.hooks:
+            for event_type in callback._hook_event_types:
+                registry.add_callback(event_type, callback)
+        return registry
+
+    def test_hook_event_types_match_public_strands_classes(self, ai_guard_strands_plugin):
+        for method_name, public_event_cls in self.HOOKS_TO_EVENTS:
+            method = getattr(ai_guard_strands_plugin, method_name)
+            event_types = getattr(method, "_hook_event_types", None)
+            assert event_types, f"{method_name} missing _hook_event_types"
+            # Identity (`is`), not equality: Strands keys the registry by class identity, so a
+            # stale duplicate of the event dataclass silently bypasses AI Guard (APMSP-3088).
+            assert event_types[0] is public_event_cls, (
+                f"{method_name} bound to {event_types[0]!r}, agent dispatches {public_event_cls!r}"
+            )
+
+    def test_plugin_discovers_hook_for_every_event(self, ai_guard_strands_plugin):
+        registry = self._register_plugin_hooks(ai_guard_strands_plugin)
+        for _, public_event_cls in self.HOOKS_TO_EVENTS:
+            assert registry._registered_callbacks.get(public_event_cls), (
+                f"No callback registered for {public_event_cls.__name__}"
+            )
+
+    @pytest.mark.parametrize(
+        "event_factory",
+        [
+            lambda: before_model_event(messages=[{"role": "user", "content": [{"text": "Hi"}]}]),
+            lambda: after_model_event(
+                response_message={"role": "assistant", "content": [{"text": "Answer"}]},
+            ),
+            lambda: before_tool_event(
+                tool_use={"toolUseId": "tc1", "name": "calc", "input": {}},
+                messages=[],
+            ),
+            lambda: after_tool_event(
+                tool_use={"toolUseId": "tc1", "name": "calc", "input": {}},
+                tool_result={"toolUseId": "tc1", "content": [{"text": "4"}], "status": "success"},
+                messages=[],
+            ),
+        ],
+        ids=["before_model", "after_model", "before_tool", "after_tool"],
+    )
+    @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+    def test_hook_fires_via_registry_dispatch(self, mock_execute_request, ai_guard_strands_plugin, event_factory):
+        mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+        registry = self._register_plugin_hooks(ai_guard_strands_plugin)
+
+        registry.invoke_callbacks(event_factory())
+
+        mock_execute_request.assert_called_once()
+
+    @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+    def test_before_model_call_blocks_via_registry_dispatch(self, mock_execute_request, ai_guard_strands_plugin):
+        mock_execute_request.return_value = mock_evaluate_response("DENY")
+        registry = self._register_plugin_hooks(ai_guard_strands_plugin)
+        event = before_model_event(messages=[{"role": "user", "content": [{"text": "bad"}]}])
+
+        with pytest.raises(AIGuardAbortError):
+            registry.invoke_callbacks(event)
+
+
+# ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

[APMSP-3088](https://datadoghq.atlassian.net/browse/APMSP-3088) (Codex scan finding) flagged a hypothetical bypass in `AIGuardStrandsPlugin`: bare `@hook` decorators combined with `from __future__ import annotations` could leave the plugin's `@hook` callbacks registered against the wrong event class — agent dispatches one class, registry holds callbacks against another, AI Guard silently fails to fire.

Investigation showed the **finding's specific premise is wrong** today: Strands resolves PEP 563 string annotations via `typing.get_type_hints()` (`strands/hooks/_type_inference.py:33`), so identity is preserved at decoration time. The closely-related stale-class import-ordering case was already fixed by #17880.

However, the prior tests in this suite only invoked the hook methods **directly** (e.g. `plugin.on_before_model_call(event)`), which never exercises the registry's class-identity lookup. So if that identity ever drifted again — via a Strands resolver change, a regression of #17880, or any other path — the test suite wouldn't notice.

This PR closes that gap with a `TestPluginEndToEndDispatch` class that drives `HookRegistry.invoke_callbacks` exactly the way the Strands agent runtime does. The decisive identity check (`_hook_event_types[0] is <PublicEventClass>`) plus a parametrized dispatch test across the four model/tool hooks will fail loudly if the bypass ever reappears.

## Testing

`tests/appsec/ai_guard/strands_hooks/test_strands.py` — new class `TestPluginEndToEndDispatch` (7 test items):

- `test_hook_event_types_match_public_strands_classes` — asserts `is`-identity between each `@hook` method's resolved event type and the public class the agent dispatches.
- `test_plugin_discovers_hook_for_every_event` — confirms `Plugin.__init__` populates `plugin.hooks` for all six events.
- `test_hook_fires_via_registry_dispatch[before_model|after_model|before_tool|after_tool]` — drives the registry's actual `invoke_callbacks` path and asserts AI Guard fires.
- `test_before_model_call_blocks_via_registry_dispatch` — DENY decision → `AIGuardAbortError` propagates out of `invoke_callbacks`.

Verified on Python 3.13 (`appsec::ai_guard_strands` suite): 116 passed.

## Risks

None. Test-only addition; no production code paths touched. The new tests use the existing `_execute_request` mock pattern, so no network or service dependencies are introduced.

## Additional Notes

If these tests pass green on CI, recommendation is to close APMSP-3088 as **Not Reproducible / False Positive**, pointing at this regression coverage and at #17880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APMSP-3088]: https://datadoghq.atlassian.net/browse/APMSP-3088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ