### PR TITLE
fix(iast): do not wrap _pickle.Unpickler.load to prevent dill import crash

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/untrusted_serialization.py
+++ b/ddtrace/appsec/_iast/taint_sinks/untrusted_serialization.py
@@ -29,6 +29,16 @@ def get_version() -> Text:
 
 _IS_PATCHED = False
 
+# NOTE: Do NOT add ("_pickle", "Unpickler.load") here. _pickle.Unpickler is an
+# immutable C type; wrapping its load method_descriptor via the forbiddenfruit
+# fallback in apply_patch poisons class-level attribute access because
+# wrapt.FunctionWrapper.__get__(None, owner) ends up invoking
+# method_descriptor.__get__(descr, Py_None, owner), which CPython rejects with the
+# "descriptor 'load' for '_pickle.Unpickler' objects doesn't apply to a
+# 'NoneType' object" error message. That breaks dill's class body (dill/_dill.py:
+# `load.__doc__ = StockUnpickler.load.__doc__`) and any other code that accesses the load
+# attribute on the class. Top-level _pickle.load/loads and dill.load/loads
+# already provide the necessary instrumentation entry points.
 _MODULES = {
     ("pickle", "load"),  # maps to pickle._load/_pickle.load
     ("pickle", "loads"),  # maps to pickle.loads/_pickle.loads
@@ -37,7 +47,6 @@ _MODULES = {
     ("pickle", "_Unpickler.load"),
     ("_pickle", "load"),
     ("_pickle", "loads"),
-    ("_pickle", "Unpickler.load"),
     ("dill", "load"),
     ("dill", "loads"),
     ("yaml", "load"),

--- a/releasenotes/notes/iast-fix-untrusted-serialization-pickle-unpickler-load-1f7c4b8e6a2d5c39.yaml
+++ b/releasenotes/notes/iast-fix-untrusted-serialization-pickle-unpickler-load-1f7c4b8e6a2d5c39.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Code Security: This fix resolves an ``ImportError`` when ``dill`` is imported after IAST patches are applied (e.g. inside a request handler).
+    This issue surfaced with ``TypeError: descriptor 'load' for '_pickle.Unpickler' objects doesn't apply to a 'NoneType' object`` error message.

--- a/tests/appsec/iast/taint_sinks/test_untrusted_serialization.py
+++ b/tests/appsec/iast/taint_sinks/test_untrusted_serialization.py
@@ -147,7 +147,7 @@ def test_untrusted_serialization__pickle_unpickler_load(iast_context_defaults):
     _assert_no_untrusted_vuln()
 
 
-def test_pickle_unpickler_load_class_access_does_not_raise():
+def test_pickle_unpickler_load_class_access_does_not_raise(iast_context_defaults):
     """Regression for the 4.9 CI failure of
     test_django_untrusted_serialization_dill_smoke[py3.9].
 

--- a/tests/appsec/iast/taint_sinks/test_untrusted_serialization.py
+++ b/tests/appsec/iast/taint_sinks/test_untrusted_serialization.py
@@ -147,6 +147,33 @@ def test_untrusted_serialization__pickle_unpickler_load(iast_context_defaults):
     _assert_no_untrusted_vuln()
 
 
+def test_pickle_unpickler_load_class_access_does_not_raise():
+    """Regression for the 4.9 CI failure of
+    test_django_untrusted_serialization_dill_smoke[py3.9].
+
+    Wrapping ``_pickle.Unpickler.load`` (a C method_descriptor on an immutable
+    type) via the forbiddenfruit fallback in ``apply_patch`` causes
+    ``_pickle.Unpickler.load`` class-level attribute access to raise
+    ``TypeError: descriptor 'load' for '_pickle.Unpickler' objects doesn't
+    apply to a 'NoneType' object``. That in turn breaks ``import dill``,
+    because dill's class body executes
+    ``load.__doc__ = StockUnpickler.load.__doc__`` at module import time.
+    """
+    import _pickle
+
+    # Class-level attribute access must not raise.
+    assert _pickle.Unpickler.load is not None
+    _ = _pickle.Unpickler.load.__doc__
+
+    # Subclassing _pickle.Unpickler the same way dill does must not raise
+    # at class-definition time.
+    class _DillLike(_pickle.Unpickler):
+        def load(self):  # noqa: D401
+            return _pickle.Unpickler.load(self)
+
+        load.__doc__ = _pickle.Unpickler.load.__doc__
+
+
 def test_untrusted_serialization_dill_load(iast_context_defaults):
     dill = pytest.importorskip("dill")
     import pickle


### PR DESCRIPTION
## Summary

Clean cherry-pick of Vlad's fix from #18219 onto the `4.9` branch, without the merge-from-main commits that bloat the original PR.

- Drops `("_pickle", "Unpickler.load")` from the IAST untrusted-serialization sink registration in `ddtrace/appsec/_iast/taint_sinks/untrusted_serialization.py`.
- Adds a regression test `test_pickle_unpickler_load_class_access_does_not_raise` covering the class-level attribute access pattern that `dill` uses at import time.
- Preserves Vlad's release note.

## Why

On the `4.9` branch, CI is failing with:

```
TypeError: descriptor 'load' for '_pickle.Unpickler' objects doesn't apply to a 'NoneType' object
```

This is a regression introduced by upstream wrapt commit [`ae93dd71`](https://github.com/GrahamDumpleton/wrapt/commit/ae93dd71c378161ff3643c9a1f708f66f97f3b5d) (shipped in wrapt 2.2.0): `wrapt.FunctionWrapper.__get__(None, owner)` now calls `tp_descr_get` with `Py_None` instead of `NULL`, which CPython's descriptor checks reject. Wrapping `_pickle.Unpickler.load` (an immutable C method-descriptor) via the forbiddenfruit fallback in `apply_patch` is what trips this, and any code that touches the class attribute (notably `dill/_dill.py`'s `load.__doc__ = StockUnpickler.load.__doc__`) blows up at import time.

Top-level `_pickle.load`/`loads` and `dill.load`/`loads` already give us the instrumentation entry points, so dropping the `Unpickler.load` registration costs nothing in coverage.

A complementary, broader mitigation (pinning `wrapt != 2.2.0` in `pyproject.toml`) is coming in a separate PR against `main` with backports to `4.9` and `4.8`.

## Related

- Original PR: #18219 (this is a cleaner cherry-pick of just the fix + release note commits)
- Incident: [#incident-53643](https://app.datadoghq.com/incidents/53643) — dd-trace-py upgrade to v4.9
- Upstream wrapt regression: GrahamDumpleton/wrapt@ae93dd71

## Test plan

- [x] Cherry-pick applies cleanly against `4.9`
- [x] `scripts/lint style` passes on changed files
- [ ] CI green on `4.9` (the failing `test_django_untrusted_serialization_dill_smoke[py3.9]` job specifically)