### PR TITLE
fix(deps): exclude wrapt 2.2.0 to avoid descriptor regression

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     secrets: inherit
     with:
       library: python_lambda
@@ -125,7 +125,7 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     secrets: inherit
     with:
       library: python
@@ -136,10 +136,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     with:
       library: python
-      ref: 9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+      ref: 6b3152ec85b1274ebd2425a038ce2a1721313373
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "9777e7b43d6bca435236d9e231bf9bd42a6b6bb5"
+  SYSTEM_TESTS_REF: "6b3152ec85b1274ebd2425a038ce2a1721313373"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/lib-injection/sources/requirements.csv
+++ b/lib-injection/sources/requirements.csv
@@ -6,6 +6,6 @@ bytecode,">=0.14.0,<1",python_version~='3.11.0'
 bytecode,">=0.13.0,<1",python_version<'3.11'
 envier,~=0.6.1,
 opentelemetry-api,">=1,<2",
-wrapt,">=1,<3",
+wrapt,">=1,!=2.2.0,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "bytecode>=0.13.0,<1; python_version<'3.11'",
     "envier~=0.6.1",
     "opentelemetry-api>=1,<2",
-    # AIDEV-TODO: lift the `!=2.2.0` exclusion once wrapt ships a release that
+    # TODO: lift the `!=2.2.0` exclusion once wrapt ships a release that
     # reverts/fixes the descriptor regression introduced in
     # https://github.com/GrahamDumpleton/wrapt/commit/ae93dd71c378161ff3643c9a1f708f66f97f3b5d
     # wrapt 2.2.0's `FunctionWrapper.__get__(None, owner)` calls `tp_descr_get`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,14 @@ dependencies = [
     "bytecode>=0.13.0,<1; python_version<'3.11'",
     "envier~=0.6.1",
     "opentelemetry-api>=1,<2",
-    "wrapt>=1,<3",
+    # AIDEV-TODO: lift the `!=2.2.0` exclusion once wrapt ships a release that
+    # reverts/fixes the descriptor regression introduced in
+    # https://github.com/GrahamDumpleton/wrapt/commit/ae93dd71c378161ff3643c9a1f708f66f97f3b5d
+    # wrapt 2.2.0's `FunctionWrapper.__get__(None, owner)` calls `tp_descr_get`
+    # with `Py_None` instead of `NULL`, which breaks class-level access to any
+    # C method_descriptor we wrap (e.g. `_pickle.Unpickler.load`,
+    # `asyncpg.protocol.protocol.BaseProtocol.execute`). See incident 53643.
+    "wrapt>=1,!=2.2.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/dependencies-exclude-wrapt-2-2-0-68425d65e72af874.yaml
+++ b/releasenotes/notes/dependencies-exclude-wrapt-2-2-0-68425d65e72af874.yaml
@@ -1,8 +1,4 @@
 ---
 fixes:
   - |
-    tracing: Exclude ``wrapt==2.2.0`` from the supported dependency range. ``wrapt`` 2.2.0 introduced a regression in
-    ``FunctionWrapper.__get__`` that breaks class-level access to wrapped C ``method_descriptor`` objects (for example
-    ``_pickle.Unpickler.load`` and ``asyncpg.protocol.protocol.BaseProtocol.execute``) with
-    ``TypeError: descriptor '<name>' for '<type>' objects doesn't apply to a 'NoneType' object``. The pin can be relaxed
-    once an upstream fix is released.
+    tracing: Exclude ``wrapt==2.2.0`` from the supported dependency range to avoid a regression that breaks wrapped C descriptors.

--- a/releasenotes/notes/dependencies-exclude-wrapt-2-2-0-68425d65e72af874.yaml
+++ b/releasenotes/notes/dependencies-exclude-wrapt-2-2-0-68425d65e72af874.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    tracing: Exclude ``wrapt==2.2.0`` from the supported dependency range. ``wrapt`` 2.2.0 introduced a regression in
+    ``FunctionWrapper.__get__`` that breaks class-level access to wrapped C ``method_descriptor`` objects (for example
+    ``_pickle.Unpickler.load`` and ``asyncpg.protocol.protocol.BaseProtocol.execute``) with
+    ``TypeError: descriptor '<name>' for '<type>' objects doesn't apply to a 'NoneType' object``. The pin can be relaxed
+    once an upstream fix is released.

--- a/requirements.csv
+++ b/requirements.csv
@@ -6,6 +6,6 @@ bytecode,">=0.14.0,<1",python_version~='3.11.0'
 bytecode,">=0.13.0,<1",python_version<'3.11'
 envier,~=0.6.1,
 opentelemetry-api,">=1,<2",
-wrapt,">=1,<3",
+wrapt,">=1,!=2.2.0,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",


### PR DESCRIPTION
## Summary

Exclude `wrapt==2.2.0` from `pyproject.toml`: `wrapt>=1,<3` → `wrapt>=1,!=2.2.0,<3`.

## Why

`wrapt` 2.2.0 introduced a regression in `FunctionWrapper.__get__`: when called as `__get__(None, owner)` it now invokes `tp_descr_get` with `Py_None` instead of `NULL`, which CPython's descriptor checks reject. Class-level access to any C `method_descriptor` we wrap then raises:

```
TypeError: descriptor '<name>' for '<type>' objects doesn't apply to a 'NoneType' object
```

This caused two distinct CI failures on `4.9`:

- `test_django_untrusted_serialization_dill_smoke[py3.9]` — `_pickle.Unpickler.load` (`dill` imports `load.__doc__ = StockUnpickler.load.__doc__` at module scope).
- `asyncpg.protocol.protocol.BaseProtocol.execute` failures from the asyncpg integration.

It will also affect customers once their resolvers pick up `wrapt 2.2.0`, because we declare `wrapt>=1,<3`.

Upstream regression: GrahamDumpleton/wrapt@[ae93dd71](https://github.com/GrahamDumpleton/wrapt/commit/ae93dd71c378161ff3643c9a1f708f66f97f3b5d).

## Backports

Labeled for backport to `4.9` and `4.8`. Both branches declare the same `wrapt>=1,<3` constraint, so the exclusion needs to land there too.

## Test plan

- [x] `pyproject.toml` still parses (`python -c "import tomllib; ..."`)
- [x] `scripts/lint spelling` passes on the release note
- [ ] CI green on `main`
- [ ] Backport PRs created for `4.9` and `4.8` (via labels)

## Related
https://datadoghq.atlassian.net/browse/APPSEC-65691