### PR TITLE
refactor(google_adk): properly early-return in edge case

### DIFF
--- a/ddtrace/contrib/internal/google_adk/patch.py
+++ b/ddtrace/contrib/internal/google_adk/patch.py
@@ -105,13 +105,16 @@ async def _traced_functions_call_tool_async(wrapped, instance, args, kwargs):
 
 
 async def _traced_functions_call_tool_live(wrapped, instance, args, kwargs):
-    integration: GoogleAdkIntegration = adk._datadog_integration
     agent = extract_agent_from_tool_context(args, kwargs)
     if agent is None:
         logger.warning("Unable to trace google adk live tool call, could not extract agent from tool context.")
         agen = wrapped(*args, **kwargs)
         async for item in agen:
             yield item
+
+        return
+
+    integration: GoogleAdkIntegration = adk._datadog_integration
 
     provider_name, model_name = extract_provider_and_model_name(
         instance=getattr(agent, "model", {}), model_name_attr="model"

--- a/tests/contrib/google_adk/test_google_adk.py
+++ b/tests/contrib/google_adk/test_google_adk.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 from google.adk.code_executors.code_execution_utils import CodeExecutionInput
 from google.adk.code_executors.unsafe_local_code_executor import UnsafeLocalCodeExecutor
 import pytest
 
+from ddtrace.contrib.internal.google_adk.patch import _traced_functions_call_tool_live
 from tests.contrib.google_adk.conftest import create_test_message
 
 
@@ -243,3 +246,28 @@ async def test_error_handling_e2e(test_runner, test_spans, request_vcr):
     assert runner_span.get_tag("component") == "google_adk"
     assert runner_span.get_tag("google_adk.request.provider") == "google"
     assert runner_span.get_tag("google_adk.request.model") == "gemini-2.5-pro"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_live_fallback_does_not_double_invoke_wrapped() -> None:
+    call_count = 0
+
+    async def fake_wrapped(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        for item in ("a", "b", "c"):
+            yield item
+
+    class _ToolContextWithoutInvocation:
+        pass
+
+    instance = object()
+    args = (object(), object(), _ToolContextWithoutInvocation())
+    kwargs: dict[str, Any] = {}
+
+    yielded: list[str] = []
+    async for item in _traced_functions_call_tool_live(fake_wrapped, instance, args, kwargs):
+        yielded.append(item)
+
+    assert yielded == ["a", "b", "c"]
+    assert call_count == 1, f"wrapped should be invoked exactly once, was invoked {call_count} times"


### PR DESCRIPTION
## Description

As title says. Without this `return`,  we would call/execute the wrapped function twice. 

**Note** not including a changelog entry because it's an edge case. Can add if you think it's worth it. 