### PR TITLE
ci: fix update-system-tests-version.py script

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3337c67f7e807ab68229e27525a339edb4e79b40
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     secrets: inherit
     with:
       library: python_lambda
-      ref: '3337c67f7e807ab68229e27525a339edb4e79b40'
+      ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3337c67f7e807ab68229e27525a339edb4e79b40
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     secrets: inherit
     with:
       library: python
-      ref: '3337c67f7e807ab68229e27525a339edb4e79b40'
+      ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3337c67f7e807ab68229e27525a339edb4e79b40
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     with:
       library: python
-      ref: '3337c67f7e807ab68229e27525a339edb4e79b40'
+      ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3337c67f7e807ab68229e27525a339edb4e79b40
     secrets: inherit
     with:
       library: python_lambda
-      ref: 9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+      ref: '3337c67f7e807ab68229e27525a339edb4e79b40'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3337c67f7e807ab68229e27525a339edb4e79b40
     secrets: inherit
     with:
       library: python
-      ref: 9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+      ref: '3337c67f7e807ab68229e27525a339edb4e79b40'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3337c67f7e807ab68229e27525a339edb4e79b40
     with:
       library: python
-      ref: 9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
+      ref: '3337c67f7e807ab68229e27525a339edb4e79b40'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release
@@ -169,4 +169,3 @@ jobs:
           needs.tracer-release.result == 'failure' ||
           needs.tracer-release.result == 'cancelled'
         run: exit 1
-

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -99,6 +99,7 @@ jobs:
     secrets: inherit
     with:
       library: python_lambda
+      ref: 9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -129,6 +130,7 @@ jobs:
     secrets: inherit
     with:
       library: python
+      ref: 9777e7b43d6bca435236d9e231bf9bd42a6b6bb5
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "9777e7b43d6bca435236d9e231bf9bd42a6b6bb5"
+  SYSTEM_TESTS_REF: "3337c67f7e807ab68229e27525a339edb4e79b40"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "3337c67f7e807ab68229e27525a339edb4e79b40"
+  SYSTEM_TESTS_REF: "6b3152ec85b1274ebd2425a038ce2a1721313373"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/scripts/update-system-tests-version.py
+++ b/scripts/update-system-tests-version.py
@@ -21,18 +21,15 @@ def get_current_system_tests_version() -> str:
     with open(system_tests_workflows_path, "r") as file:
         content = file.read()
 
-    parse_ref = False
     lines = content.splitlines()
     for line in lines:
-        if "repository: 'DataDog/system-tests'" in line:
-            parse_ref = True
-        if parse_ref and line.strip().startswith("ref:"):
-            _, _, ref_value = line.partition(":")
+        if "uses: DataDog/system-tests/.github/workflows/system-tests.yml@" in line:
+            _, ref_value = line.split("@")
             return ref_value.strip().strip("'\r\n")
     raise ValueError(f"Could not find the current system-tests version in {system_tests_workflows_path}.")
 
 
-def update_system_tests_version(latest_version: str):
+def update_system_tests_version(latest_version: str) -> None:
     # Update GitHub workflow file
     with open(system_tests_workflows_path, "r") as file:
         content = file.read()
@@ -41,7 +38,7 @@ def update_system_tests_version(latest_version: str):
     update_ref = False
     for i in range(len(lines)):
         # Only update the ref if the repository is DataDog/system-tests
-        if "repository: 'DataDog/system-tests'" in lines[i]:
+        if "uses: DataDog/system-tests/.github/workflows/system-tests.yml" in lines[i]:
             update_ref = True
         if update_ref and lines[i].strip().startswith("ref:"):
             pre, _, _ = lines[i].partition(":")


### PR DESCRIPTION
## Description

Following: https://github.com/DataDog/dd-trace-py/pull/18160, the update-system-tests-version.py script is unable to detect the current system-tests version to perform an automatic update.
This PR fixes the script.

Additionally two other occurences of the system-tests workflow were not properly pinned (integration-framework and serverless).

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
