### PR TITLE
chore(ci_visibility): skip upload_git_data when sibling xdist worker already did it

### DIFF
--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -374,6 +374,9 @@ class TestOptPlugin:
         if not self.is_xdist_worker:
             # When running with xdist, only the main process writes the session event.
             self.manager.writer.put_item(self.session)
+            # All workers have finished by this point, so the upload sentinel and lock
+            # file are no longer needed. Clean them up to keep .git/ tidy.
+            self.manager.cleanup_upload_artifacts()
 
         if self._logs_handler is not None:
             logging.getLogger().removeHandler(self._logs_handler)

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -678,7 +678,13 @@ class SessionManager:
                 uploaded_files += 1
 
         TelemetryAPI.get().record_git_pack_data(uploaded_files, uploaded_bytes)
-        self._mark_upload_done()
+        # Only advertise success to peers if we actually shipped something — if
+        # `pack_objects` failed silently or every `send_git_pack_file` returned None,
+        # peers should fall through and retry instead of trusting our sentinel.
+        if uploaded_files > 0:
+            self._mark_upload_done()
+        else:
+            log.debug("No packfiles uploaded successfully; leaving sentinel unset so peers can retry")
 
     def is_skippable_test(self, test_ref: TestRef) -> bool:
         if not self.settings.skipping_enabled:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -711,6 +711,7 @@ class SessionManager:
         )
 
         uploaded_files = 0
+        failed_files = 0
         uploaded_bytes = 0
 
         for packfile in git.pack_objects(revisions_to_send):
@@ -718,12 +719,18 @@ class SessionManager:
             if nbytes is not None:
                 uploaded_bytes += nbytes
                 uploaded_files += 1
+            else:
+                failed_files += 1
 
         TelemetryAPI.get().record_git_pack_data(uploaded_files, uploaded_bytes)
-        # Only advertise success to peers if we actually shipped something — if
-        # `pack_objects` failed silently or every `send_git_pack_file` returned None,
-        # peers should fall through and retry instead of trusting our sentinel.
-        if uploaded_files > 0:
+        # Only write the sentinel when every packfile succeeded. Partial success
+        # (some packfiles sent, others failed) must not suppress peer retries —
+        # the missing packs would never be uploaded if we did.
+        if failed_files > 0:
+            log.debug(
+                "%d packfile(s) failed to upload; leaving sentinel unset so peers can retry", failed_files
+            )
+        elif uploaded_files > 0:
             self._mark_upload_done()
         else:
             log.debug("No packfiles uploaded successfully; leaving sentinel unset so peers can retry")

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -430,30 +430,45 @@ class SessionManager:
             return None
         return Path(workspace_path) / ".git" / _UPLOAD_SENTINEL_FILENAME
 
-    def _is_upload_already_done(self) -> bool:
-        """Return True if a sibling worker already completed upload_git_data for our HEAD.
+    def _read_upload_sentinel(self) -> t.Optional[dict]:
+        """Return the sentinel payload if it is fresh and matches our HEAD, else None.
 
-        Matches require the sentinel to be present, well-formed, written within the
-        last ``_UPLOAD_SENTINEL_TTL_SECONDS`` seconds, and to reference the same commit
-        SHA we are about to upload for.
+        Matches require the sentinel to be present, well-formed JSON, written within
+        the last ``_UPLOAD_SENTINEL_TTL_SECONDS`` seconds, and to reference the same
+        commit SHA we are about to upload for. Anything else is treated as no match,
+        so the worker falls through to the normal upload path.
         """
         env_tags = getattr(self, "env_tags", None) or {}
         head_sha = env_tags.get(GitTag.COMMIT_SHA)
         if not head_sha:
-            return False
+            return None
         sentinel = self._upload_sentinel_path()
         if sentinel is None:
-            return False
+            return None
         try:
             data = json.loads(sentinel.read_text())
         except (OSError, ValueError):
-            return False
+            return None
         if not isinstance(data, dict) or data.get("head_sha") != head_sha:
-            return False
+            return None
         timestamp = data.get("timestamp")
         if not isinstance(timestamp, (int, float)):
-            return False
-        return time.time() - timestamp <= _UPLOAD_SENTINEL_TTL_SECONDS
+            return None
+        if time.time() - timestamp > _UPLOAD_SENTINEL_TTL_SECONDS:
+            return None
+        return data
+
+    def _apply_upload_sentinel(self, data: dict) -> None:
+        """Recover state from a sibling worker's sentinel into our own env_tags.
+
+        Currently this carries the PR merge-base SHA: a worker that skips its own
+        ``upload_git_data`` would otherwise never call ``_update_pr_merge_base``, so
+        its events would be missing ``git.pull_request.base_branch_sha``.
+        Pre-existing values (e.g. user-supplied env vars) take precedence.
+        """
+        merge_base = data.get("merge_base_sha")
+        if isinstance(merge_base, str) and merge_base and not self.env_tags.get(GitTag.PULL_REQUEST_BASE_BRANCH_SHA):
+            self.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] = merge_base
 
     def _mark_upload_done(self) -> None:
         """Persist a sentinel so sibling xdist workers can skip upload_git_data."""
@@ -464,10 +479,13 @@ class SessionManager:
         sentinel = self._upload_sentinel_path()
         if sentinel is None:
             return
-        payload = json.dumps({"head_sha": head_sha, "timestamp": time.time()})
+        payload_data: dict[str, t.Any] = {"head_sha": head_sha, "timestamp": time.time()}
+        merge_base = env_tags.get(GitTag.PULL_REQUEST_BASE_BRANCH_SHA)
+        if merge_base:
+            payload_data["merge_base_sha"] = merge_base
         tmp = sentinel.with_suffix(sentinel.suffix + ".tmp")
         try:
-            tmp.write_text(payload)
+            tmp.write_text(json.dumps(payload_data))
             tmp.replace(sentinel)
         except OSError as e:
             log.debug("Could not write git upload sentinel %s: %s", sentinel, e)
@@ -496,9 +514,11 @@ class SessionManager:
             return
 
         # If a sibling xdist worker already uploaded for this HEAD, skip the whole flow
-        # (git probe, search_commits round trip, pack-objects, pack upload).
-        if self._is_upload_already_done():
+        # (git probe, search_commits round trip, pack-objects, pack upload) and recover
+        # whatever state the sibling left for us (e.g. PR merge-base SHA).
+        if (sentinel_data := self._read_upload_sentinel()) is not None:
             log.debug("Git data upload already completed by another worker for this HEAD, skipping")
+            self._apply_upload_sentinel(sentinel_data)
             return
 
         # Missing `git` in minimal containers should not abort pytest startup.

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -445,7 +445,7 @@ class SessionManager:
             return None
         return Path(workspace_path) / ".git" / _UPLOAD_SENTINEL_FILENAME
 
-    def _read_upload_sentinel(self) -> t.Optional[dict]:
+    def _read_upload_sentinel(self) -> t.Optional[t.Dict[str, t.Any]]:
         """Return the sentinel payload if it is fresh and matches our HEAD, else None.
 
         Matches require the sentinel to be present, well-formed JSON, written within
@@ -473,7 +473,7 @@ class SessionManager:
             return None
         return data
 
-    def _apply_upload_sentinel(self, data: dict) -> None:
+    def _apply_upload_sentinel(self, data: t.Dict[str, t.Any]) -> None:
         """Recover state from a sibling worker's sentinel into our own env_tags.
 
         Currently this carries the PR merge-base SHA: a worker that skips its own
@@ -516,33 +516,37 @@ class SessionManager:
     def _upload_lock(self) -> t.Iterator[bool]:
         """Acquire a cross-process exclusive lock around upload_git_data.
 
-        Yields ``True`` if the lock was acquired (this process is the elected
-        uploader), or ``False`` if locking is unavailable (no fcntl, no writable
-        ``.git/`` directory, or the holder exceeded the timeout). When ``False``,
-        callers should proceed without coordination — the backend dedupes
-        commits, so duplicate uploads are wasteful but not incorrect.
+        Yields ``True`` if this process is the elected uploader. This covers
+        two cases: the lock was acquired successfully, or lock infrastructure
+        is unavailable (no fcntl, no writable ``.git/`` directory, flock error)
+        — in those cases no coordination is possible so we proceed as sole uploader.
+
+        Yields ``False`` only when the lock timeout is exceeded, meaning a peer
+        process is alive and actively holding the lock. Crashed processes release
+        flock locks immediately on fd close, so timeout == live peer uploading.
+        The caller should skip the upload in that case.
         """
         if not _FCNTL_AVAILABLE:
-            yield False
+            yield True
             return
 
         lock_path = self._upload_lock_path()
         if lock_path is None:
-            yield False
+            yield True
             return
 
         try:
             lock_path.parent.mkdir(parents=True, exist_ok=True)
         except OSError as e:
             log.debug("Could not create directory for upload lock %s: %s", lock_path, e)
-            yield False
+            yield True
             return
 
         try:
             lock_file = open(lock_path, "w")
         except OSError as e:
             log.debug("Could not open upload lock %s: %s", lock_path, e)
-            yield False
+            yield True
             return
 
         try:
@@ -554,7 +558,7 @@ class SessionManager:
                 except BlockingIOError:
                     if time.monotonic() >= deadline:
                         log.debug(
-                            "Upload lock timeout after %ss, proceeding without coordination",
+                            "Upload lock timeout after %ss, skipping upload (peer is uploading)",
                             _UPLOAD_LOCK_TIMEOUT_SECONDS,
                         )
                         yield False
@@ -562,7 +566,7 @@ class SessionManager:
                     time.sleep(_UPLOAD_LOCK_RETRY_INTERVAL_SECONDS)
                 except OSError as e:
                     log.debug("flock on %s failed: %s", lock_path, e)
-                    yield False
+                    yield True
                     return
             try:
                 yield True
@@ -604,11 +608,15 @@ class SessionManager:
             return
 
         # Cross-process lock: only one xdist worker per workspace runs the upload at a time.
-        # If the lock is unavailable (no fcntl, no .git/, etc.) we fall through and run
-        # without coordination — duplicate uploads are wasteful but the backend dedupes
-        # commits, so they remain correct.
-        with self._upload_lock():
-            # Re-check the sentinel: a peer may have finished while we waited.
+        with self._upload_lock() as lock_acquired:
+            if not lock_acquired:
+                # Timed out or lock unavailable — a peer is alive and uploading (crashed
+                # processes release flock locks immediately). Re-check the sentinel for
+                # the merge-base side effect, then bail; the peer will write it on success.
+                if (sentinel_data := self._read_upload_sentinel()) is not None:
+                    self._apply_upload_sentinel(sentinel_data)
+                return
+            # Re-check the sentinel: a peer may have finished while we waited for the lock.
             if (sentinel_data := self._read_upload_sentinel()) is not None:
                 log.debug("Git data upload completed by peer while waiting for lock, skipping")
                 self._apply_upload_sentinel(sentinel_data)

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -635,11 +635,20 @@ class SessionManager:
         # Cross-process lock: only one xdist worker per workspace runs the upload at a time.
         with self._upload_lock() as lock_acquired:
             if not lock_acquired:
-                # Timed out or lock unavailable — a peer is alive and uploading (crashed
-                # processes release flock locks immediately). Re-check the sentinel for
-                # the merge-base side effect, then bail; the peer will write it on success.
+                # Timed out — a peer is alive and still uploading (crashed processes
+                # release flock locks immediately on fd close).
                 if (sentinel_data := self._read_upload_sentinel()) is not None:
+                    # Peer finished just before our timeout fired — recover merge-base.
                     self._apply_upload_sentinel(sentinel_data)
+                else:
+                    # Peer is still uploading; sentinel not yet written. Compute the
+                    # merge-base directly so this worker's events aren't missing
+                    # git.pull_request.base_branch_sha. This is a single git command
+                    # (no upload, no lock needed).
+                    try:
+                        self._update_pr_merge_base(Git())
+                    except RuntimeError:
+                        log.debug("git binary unavailable, skipping merge-base computation on lock timeout")
                 return
             # Re-check the sentinel: a peer may have finished while we waited for the lock.
             if (sentinel_data := self._read_upload_sentinel()) is not None:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -1,10 +1,19 @@
 import atexit
+import contextlib
 import json
 import logging
 from pathlib import Path
 import re
 import time
 import typing as t
+
+
+try:
+    import fcntl
+
+    _FCNTL_AVAILABLE = True
+except ImportError:  # pragma: no cover — Windows / restricted environments
+    _FCNTL_AVAILABLE = False
 
 from ddtrace.internal.settings import env
 from ddtrace.testing.internal.api_client import APIClient
@@ -49,6 +58,12 @@ log = logging.getLogger(__name__)
 # can skip re-running the same git probe + pack-objects + upload work.
 _UPLOAD_SENTINEL_FILENAME = "dd-trace-py.upload-done"
 _UPLOAD_SENTINEL_TTL_SECONDS = 300
+
+# Cross-process lock so concurrent xdist workers don't all race into the same
+# upload work; the holder writes the sentinel, peers see it on lock release.
+_UPLOAD_LOCK_FILENAME = "dd-trace-py.upload.lock"
+_UPLOAD_LOCK_TIMEOUT_SECONDS = 60.0
+_UPLOAD_LOCK_RETRY_INTERVAL_SECONDS = 0.5
 
 
 def _parse_line_number(value: str) -> t.Optional[int]:
@@ -490,6 +505,75 @@ class SessionManager:
         except OSError as e:
             log.debug("Could not write git upload sentinel %s: %s", sentinel, e)
 
+    def _upload_lock_path(self) -> t.Optional[Path]:
+        """Return the path to the cross-process upload lock, or None if unavailable."""
+        workspace_path = getattr(self, "workspace_path", None)
+        if workspace_path is None:
+            return None
+        return Path(workspace_path) / ".git" / _UPLOAD_LOCK_FILENAME
+
+    @contextlib.contextmanager
+    def _upload_lock(self) -> t.Iterator[bool]:
+        """Acquire a cross-process exclusive lock around upload_git_data.
+
+        Yields ``True`` if the lock was acquired (this process is the elected
+        uploader), or ``False`` if locking is unavailable (no fcntl, no writable
+        ``.git/`` directory, or the holder exceeded the timeout). When ``False``,
+        callers should proceed without coordination — the backend dedupes
+        commits, so duplicate uploads are wasteful but not incorrect.
+        """
+        if not _FCNTL_AVAILABLE:
+            yield False
+            return
+
+        lock_path = self._upload_lock_path()
+        if lock_path is None:
+            yield False
+            return
+
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            log.debug("Could not create directory for upload lock %s: %s", lock_path, e)
+            yield False
+            return
+
+        try:
+            lock_file = open(lock_path, "w")
+        except OSError as e:
+            log.debug("Could not open upload lock %s: %s", lock_path, e)
+            yield False
+            return
+
+        try:
+            deadline = time.monotonic() + _UPLOAD_LOCK_TIMEOUT_SECONDS
+            while True:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        log.debug(
+                            "Upload lock timeout after %ss, proceeding without coordination",
+                            _UPLOAD_LOCK_TIMEOUT_SECONDS,
+                        )
+                        yield False
+                        return
+                    time.sleep(_UPLOAD_LOCK_RETRY_INTERVAL_SECONDS)
+                except OSError as e:
+                    log.debug("flock on %s failed: %s", lock_path, e)
+                    yield False
+                    return
+            try:
+                yield True
+            finally:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+        finally:
+            lock_file.close()
+
     def _update_pr_merge_base(self, git: Git) -> None:
         """Compute PULL_REQUEST_BASE_BRANCH_SHA via git merge-base if not already set.
 
@@ -513,14 +597,26 @@ class SessionManager:
             log.debug("Skipping git data upload in offline/payload-files mode")
             return
 
-        # If a sibling xdist worker already uploaded for this HEAD, skip the whole flow
-        # (git probe, search_commits round trip, pack-objects, pack upload) and recover
-        # whatever state the sibling left for us (e.g. PR merge-base SHA).
+        # Fast path: a sibling worker already uploaded for this HEAD.
         if (sentinel_data := self._read_upload_sentinel()) is not None:
             log.debug("Git data upload already completed by another worker for this HEAD, skipping")
             self._apply_upload_sentinel(sentinel_data)
             return
 
+        # Cross-process lock: only one xdist worker per workspace runs the upload at a time.
+        # If the lock is unavailable (no fcntl, no .git/, etc.) we fall through and run
+        # without coordination — duplicate uploads are wasteful but the backend dedupes
+        # commits, so they remain correct.
+        with self._upload_lock():
+            # Re-check the sentinel: a peer may have finished while we waited.
+            if (sentinel_data := self._read_upload_sentinel()) is not None:
+                log.debug("Git data upload completed by peer while waiting for lock, skipping")
+                self._apply_upload_sentinel(sentinel_data)
+                return
+            self._do_upload_git_data()
+
+    def _do_upload_git_data(self) -> None:
+        """Run the actual upload flow; the caller should already hold the upload lock."""
         # Missing `git` in minimal containers should not abort pytest startup.
         try:
             git = Git()

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -525,6 +525,15 @@ class SessionManager:
         process is alive and actively holding the lock. Crashed processes release
         flock locks immediately on fd close, so timeout == live peer uploading.
         The caller should skip the upload in that case.
+
+        **Windows note**: ``fcntl`` is not available on Windows, so this lock is
+        a no-op there (always yields ``True``). Cross-worker coordination on
+        Windows relies solely on the upload sentinel file: workers that arrive
+        after the first successful upload see the sentinel and skip. Workers that
+        all start simultaneously may each attempt an upload, but the backend
+        deduplicates commits so duplicate uploads are wasteful but not incorrect.
+        If full coordination on Windows becomes necessary, replacing this with a
+        ``filelock``-based implementation would be the cleanest path.
         """
         if not _FCNTL_AVAILABLE:
             yield True

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -445,7 +445,7 @@ class SessionManager:
             return None
         return Path(workspace_path) / ".git" / _UPLOAD_SENTINEL_FILENAME
 
-    def _read_upload_sentinel(self) -> t.Optional[t.Dict[str, t.Any]]:
+    def _read_upload_sentinel(self) -> t.Optional[dict[str, t.Any]]:
         """Return the sentinel payload if it is fresh and matches our HEAD, else None.
 
         Matches require the sentinel to be present, well-formed JSON, written within
@@ -473,7 +473,7 @@ class SessionManager:
             return None
         return data
 
-    def _apply_upload_sentinel(self, data: t.Dict[str, t.Any]) -> None:
+    def _apply_upload_sentinel(self, data: dict[str, t.Any]) -> None:
         """Recover state from a sibling worker's sentinel into our own env_tags.
 
         Currently this carries the PR merge-base SHA: a worker that skips its own

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -452,7 +452,7 @@ class SessionManager:
 
         commits_not_in_backend = list(set(latest_commits) - set(backend_commits))
 
-        if git.is_shallow_repository() and git.get_git_version() >= (2, 27, 0):
+        if len(commits_not_in_backend) > 0 and git.is_shallow_repository() and git.get_git_version() >= (2, 27, 0):
             log.debug("Shallow repository detected on git > 2.27 detected, unshallowing")
             unshallow_successful = git.try_all_unshallow_repository_methods()
             if unshallow_successful:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -452,7 +452,7 @@ class SessionManager:
 
         commits_not_in_backend = list(set(latest_commits) - set(backend_commits))
 
-        if len(commits_not_in_backend) > 0 and git.is_shallow_repository() and git.get_git_version() >= (2, 27, 0):
+        if git.is_shallow_repository() and git.get_git_version() >= (2, 27, 0):
             log.debug("Shallow repository detected on git > 2.27 detected, unshallowing")
             unshallow_successful = git.try_all_unshallow_repository_methods()
             if unshallow_successful:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -1,7 +1,9 @@
 import atexit
+import json
 import logging
 from pathlib import Path
 import re
+import time
 import typing as t
 
 from ddtrace.internal.settings import env
@@ -41,6 +43,12 @@ from ddtrace.testing.internal.writer import TestOptWriter
 
 
 log = logging.getLogger(__name__)
+
+
+# Sentinel written after a successful upload_git_data() so sibling xdist workers
+# can skip re-running the same git probe + pack-objects + upload work.
+_UPLOAD_SENTINEL_FILENAME = "dd-trace-py.upload-done"
+_UPLOAD_SENTINEL_TTL_SECONDS = 300
 
 
 def _parse_line_number(value: str) -> t.Optional[int]:
@@ -411,6 +419,59 @@ class SessionManager:
 
         return self.session.test_command
 
+    def _upload_sentinel_path(self) -> t.Optional[Path]:
+        """Return the path to the upload-completion sentinel, or None if unavailable.
+
+        The sentinel lives inside ``.git/`` so it is naturally scoped to one repo
+        checkout and shared between xdist workers running against the same workspace.
+        """
+        workspace_path = getattr(self, "workspace_path", None)
+        if workspace_path is None:
+            return None
+        return Path(workspace_path) / ".git" / _UPLOAD_SENTINEL_FILENAME
+
+    def _is_upload_already_done(self) -> bool:
+        """Return True if a sibling worker already completed upload_git_data for our HEAD.
+
+        Matches require the sentinel to be present, well-formed, written within the
+        last ``_UPLOAD_SENTINEL_TTL_SECONDS`` seconds, and to reference the same commit
+        SHA we are about to upload for.
+        """
+        env_tags = getattr(self, "env_tags", None) or {}
+        head_sha = env_tags.get(GitTag.COMMIT_SHA)
+        if not head_sha:
+            return False
+        sentinel = self._upload_sentinel_path()
+        if sentinel is None:
+            return False
+        try:
+            data = json.loads(sentinel.read_text())
+        except (OSError, ValueError):
+            return False
+        if not isinstance(data, dict) or data.get("head_sha") != head_sha:
+            return False
+        timestamp = data.get("timestamp")
+        if not isinstance(timestamp, (int, float)):
+            return False
+        return time.time() - timestamp <= _UPLOAD_SENTINEL_TTL_SECONDS
+
+    def _mark_upload_done(self) -> None:
+        """Persist a sentinel so sibling xdist workers can skip upload_git_data."""
+        env_tags = getattr(self, "env_tags", None) or {}
+        head_sha = env_tags.get(GitTag.COMMIT_SHA)
+        if not head_sha:
+            return
+        sentinel = self._upload_sentinel_path()
+        if sentinel is None:
+            return
+        payload = json.dumps({"head_sha": head_sha, "timestamp": time.time()})
+        tmp = sentinel.with_suffix(sentinel.suffix + ".tmp")
+        try:
+            tmp.write_text(payload)
+            tmp.replace(sentinel)
+        except OSError as e:
+            log.debug("Could not write git upload sentinel %s: %s", sentinel, e)
+
     def _update_pr_merge_base(self, git: Git) -> None:
         """Compute PULL_REQUEST_BASE_BRANCH_SHA via git merge-base if not already set.
 
@@ -432,6 +493,12 @@ class SessionManager:
         offline = get_offline_mode()
         if offline.manifest_enabled or offline.payload_files_enabled:
             log.debug("Skipping git data upload in offline/payload-files mode")
+            return
+
+        # If a sibling xdist worker already uploaded for this HEAD, skip the whole flow
+        # (git probe, search_commits round trip, pack-objects, pack upload).
+        if self._is_upload_already_done():
+            log.debug("Git data upload already completed by another worker for this HEAD, skipping")
             return
 
         # Missing `git` in minimal containers should not abort pytest startup.
@@ -478,6 +545,7 @@ class SessionManager:
 
         if len(commits_not_in_backend) == 0:
             log.debug("All latest commits found in backend, skipping metadata upload")
+            self._mark_upload_done()
             return
 
         revisions_to_send = git.get_filtered_revisions(
@@ -494,6 +562,7 @@ class SessionManager:
                 uploaded_files += 1
 
         TelemetryAPI.get().record_git_pack_data(uploaded_files, uploaded_bytes)
+        self._mark_upload_done()
 
     def is_skippable_test(self, test_ref: TestRef) -> bool:
         if not self.settings.skipping_enabled:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -727,9 +727,7 @@ class SessionManager:
         # (some packfiles sent, others failed) must not suppress peer retries —
         # the missing packs would never be uploaded if we did.
         if failed_files > 0:
-            log.debug(
-                "%d packfile(s) failed to upload; leaving sentinel unset so peers can retry", failed_files
-            )
+            log.debug("%d packfile(s) failed to upload; leaving sentinel unset so peers can retry", failed_files)
         elif uploaded_files > 0:
             self._mark_upload_done()
         else:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -512,6 +512,22 @@ class SessionManager:
             return None
         return Path(workspace_path) / ".git" / _UPLOAD_LOCK_FILENAME
 
+    def cleanup_upload_artifacts(self) -> None:
+        """Delete the upload sentinel and lock files left in .git/.
+
+        Safe to call once the session is finishing — by that point all workers
+        have already run upload_git_data() during their __init__, so neither
+        file is needed any more. Should be called only from the controller
+        process (not xdist workers) so we don't race with a slow-starting peer.
+        """
+        for path in (self._upload_sentinel_path(), self._upload_lock_path()):
+            if path is None:
+                continue
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as e:
+                log.debug("Could not remove upload artifact %s: %s", path, e)
+
     @contextlib.contextmanager
     def _upload_lock(self) -> t.Iterator[bool]:
         """Acquire a cross-process exclusive lock around upload_git_data.

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -770,6 +770,30 @@ class TestUploadSentinel:
 
         assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()
 
+    def test_upload_git_data_does_not_write_sentinel_on_partial_upload_failure(self, tmp_path) -> None:
+        """Partial success (some packfiles sent, some failed) must not suppress peer retries."""
+        from pathlib import Path as _Path
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        (tmp_path / ".git").mkdir()
+        sm.api_client.get_known_commits.return_value = []
+        # First packfile succeeds, second fails.
+        sm.api_client.send_git_pack_file.side_effect = [123, None]
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1"]
+        mock_git.is_shallow_repository.return_value = False
+        mock_git.get_filtered_revisions.return_value = ["commit-1"]
+        mock_git.pack_objects.return_value = iter([_Path("/tmp/fake1.pack"), _Path("/tmp/fake2.pack")])
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()
+
     def test_upload_git_data_does_not_write_sentinel_on_search_commits_failure(self, tmp_path) -> None:
         """If search_commits fails, no sentinel is written so peers can retry."""
         sm = self._make_sm(tmp_path, head_sha="head-sha")

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -578,3 +578,168 @@ class TestUpdatePrMergeBase:
         mock_git.get_merge_base.assert_called_once_with(base_sha, head_sha)
         assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == expected_merge_base
         mock_git.pack_objects.assert_not_called()
+
+
+class TestUploadSentinel:
+    """Tests for the upload-completion sentinel used to deduplicate work across xdist workers."""
+
+    def _make_sm(self, workspace_path, head_sha: t.Optional[str] = None) -> SessionManager:
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = SessionManager.__new__(SessionManager)
+        sm.workspace_path = workspace_path
+        sm.env_tags = {GitTag.COMMIT_SHA: head_sha} if head_sha else {}
+        sm.api_client = Mock()
+        return sm
+
+    def _write_sentinel(self, workspace_path, data) -> None:
+        import json as _json
+
+        sentinel_dir = workspace_path / ".git"
+        sentinel_dir.mkdir(exist_ok=True)
+        (sentinel_dir / "dd-trace-py.upload-done").write_text(_json.dumps(data))
+
+    def test_no_sentinel_returns_false(self, tmp_path) -> None:
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        assert not sm._is_upload_already_done()
+
+    def test_fresh_matching_sentinel_returns_true(self, tmp_path) -> None:
+        import time as _time
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time()})
+        assert sm._is_upload_already_done()
+
+    def test_stale_sentinel_returns_false(self, tmp_path) -> None:
+        import time as _time
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        # 1 hour in the past — well beyond the 5-minute TTL.
+        self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time() - 3600})
+        assert not sm._is_upload_already_done()
+
+    def test_different_head_sentinel_returns_false(self, tmp_path) -> None:
+        import time as _time
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        self._write_sentinel(tmp_path, {"head_sha": "other-sha", "timestamp": _time.time()})
+        assert not sm._is_upload_already_done()
+
+    def test_malformed_sentinel_returns_false(self, tmp_path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "dd-trace-py.upload-done").write_text("not json{{")
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        assert not sm._is_upload_already_done()
+
+    def test_missing_head_sha_skips_check(self, tmp_path) -> None:
+        import time as _time
+
+        # No COMMIT_SHA in env_tags: even a matching sentinel must not be honored,
+        # because we don't know what HEAD to validate against.
+        sm = self._make_sm(tmp_path, head_sha=None)
+        self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time()})
+        assert not sm._is_upload_already_done()
+
+    def test_missing_workspace_path_attribute_returns_false(self) -> None:
+        from ddtrace.testing.internal.git import GitTag
+
+        # Some tests build SessionManager via __new__ without setting workspace_path.
+        sm = SessionManager.__new__(SessionManager)
+        sm.env_tags = {GitTag.COMMIT_SHA: "head-sha"}
+        assert not sm._is_upload_already_done()
+
+    def test_mark_writes_expected_payload(self, tmp_path) -> None:
+        import json as _json
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm._mark_upload_done()
+        data = _json.loads((tmp_path / ".git" / "dd-trace-py.upload-done").read_text())
+        assert data["head_sha"] == "head-sha"
+        assert isinstance(data["timestamp"], (int, float))
+
+    def test_mark_noop_without_head_sha(self, tmp_path) -> None:
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha=None)
+        sm._mark_upload_done()
+        assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()
+
+    def test_upload_git_data_skips_when_sentinel_fresh(self, tmp_path) -> None:
+        """When the sentinel matches, upload_git_data skips git entirely."""
+        import time as _time
+
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time()})
+        assert sm.env_tags[GitTag.COMMIT_SHA] == "head-sha"
+
+        with patch("ddtrace.testing.internal.session_manager.Git") as mock_git_cls:
+            sm.upload_git_data()
+
+        mock_git_cls.assert_not_called()
+        sm.api_client.get_known_commits.assert_not_called()
+
+    def test_upload_git_data_writes_sentinel_on_all_commits_known(self, tmp_path) -> None:
+        """The sentinel is written when the early-return on all-commits-known path is taken."""
+        import json as _json
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        (tmp_path / ".git").mkdir()
+        sm.api_client.get_known_commits.return_value = ["commit-1", "commit-2"]
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1", "commit-2"]
+        mock_git.is_shallow_repository.return_value = False
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        data = _json.loads((tmp_path / ".git" / "dd-trace-py.upload-done").read_text())
+        assert data["head_sha"] == "head-sha"
+
+    def test_upload_git_data_writes_sentinel_after_pack_upload(self, tmp_path) -> None:
+        """The sentinel is written after the pack-upload path completes."""
+        import json as _json
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        (tmp_path / ".git").mkdir()
+        sm.api_client.get_known_commits.return_value = []
+        sm.api_client.send_git_pack_file.return_value = 0
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1"]
+        mock_git.is_shallow_repository.return_value = False
+        mock_git.get_filtered_revisions.return_value = ["commit-1"]
+        mock_git.pack_objects.return_value = iter([])
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        data = _json.loads((tmp_path / ".git" / "dd-trace-py.upload-done").read_text())
+        assert data["head_sha"] == "head-sha"
+
+    def test_upload_git_data_does_not_write_sentinel_on_search_commits_failure(self, tmp_path) -> None:
+        """If search_commits fails, no sentinel is written so peers can retry."""
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        (tmp_path / ".git").mkdir()
+        # API returning None signals a failure that aborts the upload.
+        sm.api_client.get_known_commits.return_value = None
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1"]
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -876,22 +876,22 @@ class TestUploadLock:
         with sm._upload_lock() as acquired:
             assert acquired is True
 
-    def test_lock_yields_false_when_path_unavailable(self) -> None:
-        """Without workspace_path, the lock can't be acquired and yields False."""
+    def test_lock_yields_true_when_path_unavailable(self) -> None:
+        """Without workspace_path there is no peer coordination possible; yield True (proceed as sole uploader)."""
         sm = SessionManager.__new__(SessionManager)
         sm.env_tags = {}
 
         with sm._upload_lock() as acquired:
-            assert acquired is False
+            assert acquired is True
 
-    def test_lock_yields_false_when_fcntl_unavailable(self, tmp_path) -> None:
-        """If fcntl is unavailable (e.g. Windows), the lock is a no-op yielding False."""
+    def test_lock_yields_true_when_fcntl_unavailable(self, tmp_path) -> None:
+        """If fcntl is unavailable (e.g. Windows), no coordination is possible; yield True (proceed as sole uploader)."""
         (tmp_path / ".git").mkdir()
         sm = self._make_sm(tmp_path, head_sha="head-sha")
 
         with patch("ddtrace.testing.internal.session_manager._FCNTL_AVAILABLE", False):
             with sm._upload_lock() as acquired:
-                assert acquired is False
+                assert acquired is True
 
     def test_lock_yields_false_on_timeout(self, tmp_path) -> None:
         """If flock keeps raising BlockingIOError past the deadline, yield False."""
@@ -959,25 +959,50 @@ class TestUploadLock:
         mock_git_cls.assert_not_called()
         assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-mb"
 
-    def test_upload_git_data_proceeds_when_lock_unavailable(self, tmp_path) -> None:
-        """If the lock can't be acquired (timeout / no fcntl), the upload runs unlocked."""
+    def test_upload_git_data_skips_when_lock_times_out(self, tmp_path) -> None:
+        """If the lock times out (peer is alive and uploading), the upload is skipped.
+
+        A timeout means a peer is alive and uploading; a crashed peer would have
+        released the flock lock immediately. We bail rather than duplicate the work.
+        """
         (tmp_path / ".git").mkdir()
         sm = self._make_sm(tmp_path, head_sha="head-sha")
-        sm.api_client.get_known_commits.return_value = ["c1"]
-
-        mock_git = Mock()
-        mock_git.get_latest_commits.return_value = ["c1"]
-        mock_git.is_shallow_repository.return_value = False
 
         @contextmanager
         def no_lock():
-            yield False  # timeout / fcntl unavailable
+            yield False  # timeout: live peer holds the lock
 
         with (
             patch.object(sm, "_upload_lock", no_lock),
-            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git) as mock_git_cls,
-            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+            patch("ddtrace.testing.internal.session_manager.Git") as mock_git_cls,
         ):
             sm.upload_git_data()
 
-        mock_git_cls.assert_called_once()
+        mock_git_cls.assert_not_called()
+
+    def test_upload_git_data_applies_sentinel_on_lock_timeout(self, tmp_path) -> None:
+        """When the lock times out but the peer wrote the sentinel while we waited, apply it."""
+        import json as _json
+        import time as _time
+
+        from ddtrace.testing.internal.git import GitTag
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+
+        @contextmanager
+        def no_lock():
+            # Simulate: peer finished and wrote the sentinel just before our timeout fired.
+            (tmp_path / ".git" / "dd-trace-py.upload-done").write_text(
+                _json.dumps({"head_sha": "head-sha", "timestamp": _time.time(), "merge_base_sha": "peer-mb"})
+            )
+            yield False  # timeout: live peer holds the lock
+
+        with (
+            patch.object(sm, "_upload_lock", no_lock),
+            patch("ddtrace.testing.internal.session_manager.Git") as mock_git_cls,
+        ):
+            sm.upload_git_data()
+
+        mock_git_cls.assert_not_called()
+        assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-mb"

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -703,19 +703,20 @@ class TestUploadSentinel:
         assert data["head_sha"] == "head-sha"
 
     def test_upload_git_data_writes_sentinel_after_pack_upload(self, tmp_path) -> None:
-        """The sentinel is written after the pack-upload path completes."""
+        """The sentinel is written after the pack-upload path completes successfully."""
         import json as _json
+        from pathlib import Path as _Path
 
         sm = self._make_sm(tmp_path, head_sha="head-sha")
         (tmp_path / ".git").mkdir()
         sm.api_client.get_known_commits.return_value = []
-        sm.api_client.send_git_pack_file.return_value = 0
+        sm.api_client.send_git_pack_file.return_value = 123  # bytes uploaded
 
         mock_git = Mock()
         mock_git.get_latest_commits.return_value = ["commit-1"]
         mock_git.is_shallow_repository.return_value = False
         mock_git.get_filtered_revisions.return_value = ["commit-1"]
-        mock_git.pack_objects.return_value = iter([])
+        mock_git.pack_objects.return_value = iter([_Path("/tmp/fake.pack")])
 
         with (
             patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
@@ -725,6 +726,49 @@ class TestUploadSentinel:
 
         data = _json.loads((tmp_path / ".git" / "dd-trace-py.upload-done").read_text())
         assert data["head_sha"] == "head-sha"
+
+    def test_upload_git_data_does_not_write_sentinel_when_pack_objects_yields_nothing(self, tmp_path) -> None:
+        """If pack_objects fails silently (yields no files), don't trust peers with our sentinel."""
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        (tmp_path / ".git").mkdir()
+        sm.api_client.get_known_commits.return_value = []
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1"]
+        mock_git.is_shallow_repository.return_value = False
+        mock_git.get_filtered_revisions.return_value = ["commit-1"]
+        mock_git.pack_objects.return_value = iter([])  # nothing yielded
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()
+
+    def test_upload_git_data_does_not_write_sentinel_when_all_uploads_fail(self, tmp_path) -> None:
+        """If every send_git_pack_file returns None, peers should retry rather than skip."""
+        from pathlib import Path as _Path
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        (tmp_path / ".git").mkdir()
+        sm.api_client.get_known_commits.return_value = []
+        sm.api_client.send_git_pack_file.return_value = None  # upload failure
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["commit-1"]
+        mock_git.is_shallow_repository.return_value = False
+        mock_git.get_filtered_revisions.return_value = ["commit-1"]
+        mock_git.pack_objects.return_value = iter([_Path("/tmp/fake.pack")])
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()
 
     def test_upload_git_data_does_not_write_sentinel_on_search_commits_failure(self, tmp_path) -> None:
         """If search_commits fails, no sentinel is written so peers can retry."""

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -602,14 +602,14 @@ class TestUploadSentinel:
     def test_no_sentinel_returns_false(self, tmp_path) -> None:
         (tmp_path / ".git").mkdir()
         sm = self._make_sm(tmp_path, head_sha="head-sha")
-        assert not sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is None
 
     def test_fresh_matching_sentinel_returns_true(self, tmp_path) -> None:
         import time as _time
 
         sm = self._make_sm(tmp_path, head_sha="head-sha")
         self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time()})
-        assert sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is not None
 
     def test_stale_sentinel_returns_false(self, tmp_path) -> None:
         import time as _time
@@ -617,20 +617,20 @@ class TestUploadSentinel:
         sm = self._make_sm(tmp_path, head_sha="head-sha")
         # 1 hour in the past — well beyond the 5-minute TTL.
         self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time() - 3600})
-        assert not sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is None
 
     def test_different_head_sentinel_returns_false(self, tmp_path) -> None:
         import time as _time
 
         sm = self._make_sm(tmp_path, head_sha="head-sha")
         self._write_sentinel(tmp_path, {"head_sha": "other-sha", "timestamp": _time.time()})
-        assert not sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is None
 
     def test_malformed_sentinel_returns_false(self, tmp_path) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "dd-trace-py.upload-done").write_text("not json{{")
         sm = self._make_sm(tmp_path, head_sha="head-sha")
-        assert not sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is None
 
     def test_missing_head_sha_skips_check(self, tmp_path) -> None:
         import time as _time
@@ -639,7 +639,7 @@ class TestUploadSentinel:
         # because we don't know what HEAD to validate against.
         sm = self._make_sm(tmp_path, head_sha=None)
         self._write_sentinel(tmp_path, {"head_sha": "head-sha", "timestamp": _time.time()})
-        assert not sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is None
 
     def test_missing_workspace_path_attribute_returns_false(self) -> None:
         from ddtrace.testing.internal.git import GitTag
@@ -647,7 +647,7 @@ class TestUploadSentinel:
         # Some tests build SessionManager via __new__ without setting workspace_path.
         sm = SessionManager.__new__(SessionManager)
         sm.env_tags = {GitTag.COMMIT_SHA: "head-sha"}
-        assert not sm._is_upload_already_done()
+        assert sm._read_upload_sentinel() is None
 
     def test_mark_writes_expected_payload(self, tmp_path) -> None:
         import json as _json
@@ -743,3 +743,69 @@ class TestUploadSentinel:
             sm.upload_git_data()
 
         assert not (tmp_path / ".git" / "dd-trace-py.upload-done").exists()
+
+    def test_mark_includes_merge_base_when_set(self, tmp_path) -> None:
+        """The sentinel encodes merge_base_sha so peers can recover it on skip."""
+        import json as _json
+
+        from ddtrace.testing.internal.git import GitTag
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] = "merge-base-sha"
+        sm._mark_upload_done()
+        data = _json.loads((tmp_path / ".git" / "dd-trace-py.upload-done").read_text())
+        assert data["merge_base_sha"] == "merge-base-sha"
+
+    def test_mark_omits_merge_base_when_unset(self, tmp_path) -> None:
+        """If env_tags has no merge-base, the sentinel doesn't include the key."""
+        import json as _json
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm._mark_upload_done()
+        data = _json.loads((tmp_path / ".git" / "dd-trace-py.upload-done").read_text())
+        assert "merge_base_sha" not in data
+
+    def test_apply_sentinel_populates_merge_base(self, tmp_path) -> None:
+        """A peer that skips uploads recovers the merge-base SHA from the sentinel."""
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm._apply_upload_sentinel({"head_sha": "head-sha", "merge_base_sha": "recovered-sha"})
+        assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "recovered-sha"
+
+    def test_apply_sentinel_does_not_overwrite_existing_merge_base(self, tmp_path) -> None:
+        """User-supplied PR base SHA takes precedence over the sentinel's value."""
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] = "existing-sha"
+        sm._apply_upload_sentinel({"head_sha": "head-sha", "merge_base_sha": "sentinel-sha"})
+        assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "existing-sha"
+
+    def test_apply_sentinel_skips_when_merge_base_absent(self, tmp_path) -> None:
+        """Sentinel without merge_base_sha leaves env_tags untouched."""
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm._apply_upload_sentinel({"head_sha": "head-sha"})
+        assert GitTag.PULL_REQUEST_BASE_BRANCH_SHA not in sm.env_tags
+
+    def test_upload_git_data_skip_applies_sentinel_merge_base(self, tmp_path) -> None:
+        """End-to-end: a peer skipping upload recovers the merge-base from the sentinel."""
+        import time as _time
+
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        self._write_sentinel(
+            tmp_path,
+            {"head_sha": "head-sha", "timestamp": _time.time(), "merge_base_sha": "peer-merge-base"},
+        )
+
+        with patch("ddtrace.testing.internal.session_manager.Git") as mock_git_cls:
+            sm.upload_git_data()
+
+        mock_git_cls.assert_not_called()
+        assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-merge-base"

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -978,7 +978,34 @@ class TestUploadLock:
         ):
             sm.upload_git_data()
 
-        mock_git_cls.assert_not_called()
+        # Full upload skipped, but Git() was still instantiated to compute merge-base.
+        mock_git_cls.assert_called_once()
+
+    def test_upload_git_data_computes_merge_base_on_lock_timeout(self, tmp_path) -> None:
+        """On lock timeout with no sentinel, merge-base is computed directly (no upload)."""
+        from ddtrace.testing.internal.git import GitTag
+        from tests.testing.mocks import get_mock_git_instance
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_HEAD_SHA] = "base"
+        sm.env_tags[GitTag.COMMIT_HEAD_SHA] = "head"
+
+        mock_git = get_mock_git_instance()
+        mock_git.get_merge_base.return_value = "merge-base-sha"
+
+        @contextmanager
+        def no_lock():
+            yield False
+
+        with (
+            patch.object(sm, "_upload_lock", no_lock),
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git),
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "merge-base-sha"
 
     def test_upload_git_data_applies_sentinel_on_lock_timeout(self, tmp_path) -> None:
         """When the lock times out but the peer wrote the sentinel while we waited, apply it."""

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -885,7 +885,7 @@ class TestUploadLock:
             assert acquired is True
 
     def test_lock_yields_true_when_fcntl_unavailable(self, tmp_path) -> None:
-        """If fcntl is unavailable (e.g. Windows), no coordination is possible; yield True (proceed as sole uploader)."""
+        """If fcntl is unavailable (e.g. Windows), no coordination is possible; yield True (sole uploader)."""
         (tmp_path / ".git").mkdir()
         sm = self._make_sm(tmp_path, head_sha="head-sha")
 

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -809,3 +809,131 @@ class TestUploadSentinel:
 
         mock_git_cls.assert_not_called()
         assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-merge-base"
+
+
+class TestUploadLock:
+    """Tests for the cross-process lock around upload_git_data."""
+
+    def _make_sm(self, workspace_path, head_sha: t.Optional[str] = None) -> SessionManager:
+        from ddtrace.testing.internal.git import GitTag
+
+        sm = SessionManager.__new__(SessionManager)
+        sm.workspace_path = workspace_path
+        sm.env_tags = {GitTag.COMMIT_SHA: head_sha} if head_sha else {}
+        sm.api_client = Mock()
+        sm.api_client.get_known_commits.return_value = []
+        return sm
+
+    def test_lock_acquired_when_no_contention(self, tmp_path) -> None:
+        """Single process: lock yields True and runs the upload body."""
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+
+        with sm._upload_lock() as acquired:
+            assert acquired is True
+
+    def test_lock_yields_false_when_path_unavailable(self) -> None:
+        """Without workspace_path, the lock can't be acquired and yields False."""
+        sm = SessionManager.__new__(SessionManager)
+        sm.env_tags = {}
+
+        with sm._upload_lock() as acquired:
+            assert acquired is False
+
+    def test_lock_yields_false_when_fcntl_unavailable(self, tmp_path) -> None:
+        """If fcntl is unavailable (e.g. Windows), the lock is a no-op yielding False."""
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+
+        with patch("ddtrace.testing.internal.session_manager._FCNTL_AVAILABLE", False):
+            with sm._upload_lock() as acquired:
+                assert acquired is False
+
+    def test_lock_yields_false_on_timeout(self, tmp_path) -> None:
+        """If flock keeps raising BlockingIOError past the deadline, yield False."""
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+
+        # Force flock to always say "would block" and drive time forward past the deadline.
+        with (
+            patch("ddtrace.testing.internal.session_manager.fcntl.flock", side_effect=BlockingIOError()),
+            patch("ddtrace.testing.internal.session_manager.time.monotonic", side_effect=[0.0, 9999.0]),
+            patch("ddtrace.testing.internal.session_manager.time.sleep"),
+        ):
+            with sm._upload_lock() as acquired:
+                assert acquired is False
+
+    def test_upload_git_data_runs_under_lock(self, tmp_path) -> None:
+        """upload_git_data acquires the lock and proceeds to the upload work."""
+        from ddtrace.testing.internal.git import GitTag
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm.api_client.get_known_commits.return_value = ["c1"]
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["c1"]
+        mock_git.is_shallow_repository.return_value = False
+
+        with (
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git) as mock_git_cls,
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        mock_git_cls.assert_called_once()
+        # Sentinel should be there now — a second call should short-circuit.
+        sentinel_path = tmp_path / ".git" / "dd-trace-py.upload-done"
+        assert sentinel_path.exists()
+        assert sm.env_tags.get(GitTag.COMMIT_SHA) == "head-sha"
+
+    def test_upload_git_data_rechecks_sentinel_after_lock(self, tmp_path) -> None:
+        """If a peer writes the sentinel while we wait for the lock, we skip on re-check."""
+        import time as _time
+
+        from ddtrace.testing.internal.git import GitTag
+
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+
+        @contextmanager
+        def fake_lock_with_peer_completion():
+            # Simulate: while we waited for the lock, a peer finished and wrote the sentinel.
+            (tmp_path / ".git" / "dd-trace-py.upload-done").write_text(
+                _json.dumps({"head_sha": "head-sha", "timestamp": _time.time(), "merge_base_sha": "peer-mb"})
+            )
+            yield True
+
+        import json as _json
+
+        with (
+            patch.object(sm, "_upload_lock", fake_lock_with_peer_completion),
+            patch("ddtrace.testing.internal.session_manager.Git") as mock_git_cls,
+        ):
+            sm.upload_git_data()
+
+        mock_git_cls.assert_not_called()
+        assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-mb"
+
+    def test_upload_git_data_proceeds_when_lock_unavailable(self, tmp_path) -> None:
+        """If the lock can't be acquired (timeout / no fcntl), the upload runs unlocked."""
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm.api_client.get_known_commits.return_value = ["c1"]
+
+        mock_git = Mock()
+        mock_git.get_latest_commits.return_value = ["c1"]
+        mock_git.is_shallow_repository.return_value = False
+
+        @contextmanager
+        def no_lock():
+            yield False  # timeout / fcntl unavailable
+
+        with (
+            patch.object(sm, "_upload_lock", no_lock),
+            patch("ddtrace.testing.internal.session_manager.Git", return_value=mock_git) as mock_git_cls,
+            patch("ddtrace.testing.internal.session_manager.TelemetryAPI"),
+        ):
+            sm.upload_git_data()
+
+        mock_git_cls.assert_called_once()

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -1006,3 +1006,29 @@ class TestUploadLock:
 
         mock_git_cls.assert_not_called()
         assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-mb"
+
+    def test_cleanup_removes_sentinel_and_lock(self, tmp_path) -> None:
+        """cleanup_upload_artifacts() deletes both files when present."""
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sentinel = tmp_path / ".git" / "dd-trace-py.upload-done"
+        lock = tmp_path / ".git" / "dd-trace-py.upload.lock"
+        sentinel.write_text("{}")
+        lock.write_text("")
+
+        sm.cleanup_upload_artifacts()
+
+        assert not sentinel.exists()
+        assert not lock.exists()
+
+    def test_cleanup_is_noop_when_files_absent(self, tmp_path) -> None:
+        """cleanup_upload_artifacts() does not raise when files are already gone."""
+        (tmp_path / ".git").mkdir()
+        sm = self._make_sm(tmp_path, head_sha="head-sha")
+        sm.cleanup_upload_artifacts()  # no files present — must not raise
+
+    def test_cleanup_is_noop_without_workspace_path(self) -> None:
+        """cleanup_upload_artifacts() does not raise when workspace_path is unset."""
+        sm = SessionManager.__new__(SessionManager)
+        sm.env_tags = {}
+        sm.cleanup_upload_artifacts()  # no workspace_path — must not raise


### PR DESCRIPTION
## Description

When running pytest with xdist, all workers start up at the same time and each one tries to upload the same git history to Datadog's backend. This PR makes them coordinate so only one worker does the work.

**How it works:**

1. After a successful upload, write a small JSON file to \`.git/dd-trace-py.upload-done\`. Any worker that sees this file skips the upload entirely and reads the merge-base SHA from it so nothing is missing from span metadata.

2. Before uploading, acquire an exclusive file lock (\`fcntl\`). Only one worker runs the upload; the others wait, then see the sentinel and skip. If the lock times out (60 s), it means a live peer is still uploading — skip rather than duplicate. If \`fcntl\` is unavailable (Windows) or the lock can't be created, fall back to the pre-PR behaviour and proceed without coordination.

3. Only write the sentinel if the upload actually succeeded. A silent failure leaves the sentinel absent so the next worker retries.

**Windows**: no \`fcntl\`, so the lock is a no-op. The sentinel still prevents duplicates for workers that arrive after the first success, but workers that all start at the same moment may each upload. Duplicate uploads are harmless — the backend deduplicates commits. Documented as a known limitation; \`filelock\` would be the path to full parity if this ever matters.

## Testing

- 16 sentinel tests: present/missing/stale/wrong-HEAD/malformed, merge-base round-trip, no sentinel on upload failure.
- 9 lock tests: acquired, unavailable (no fcntl / no path), timeout, peer-wrote-sentinel-while-waiting, skip-on-timeout.
- Full test suite passes on py3.13 (1033 passed, 1 skipped).

## Risks

- **Lock timeout**: peer re-checks the sentinel and bails. If the holder crashed without writing the sentinel, that session's upload is skipped — the next CI run catches it.
- **Windows / unwritable \`.git/\`**: falls back to today's behaviour (every worker uploads). Harmless.
- **Stale sentinel from a prior run**: HEAD-SHA check + 5-min TTL prevent false hits.