### PR TITLE
fix(kafka): fix crash from `_get_cluster_id`

### DIFF
--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -355,6 +355,20 @@ def _get_cluster_id(instance, topic):
     if instance and getattr(instance, "_dd_cluster_id", None):
         return instance._dd_cluster_id
 
+    # Do not call list_topics on Consumer instances.  Calling the metadata API
+    # on a Consumer handle causes librdkafka to create internal topic handles
+    # (rd_kafka_topic_t) and background metadata-refresh tasks that persist
+    # even after partitions are revoked during a rebalance.  Those dangling
+    # internal references can be accessed concurrently with the consumer's own
+    # queue operations, producing a use-after-free inside
+    # rd_kafka_q_serve_rkmessages (librdkafka issue #4214).
+    # Producers are not affected by consumer-group rebalancing, so the call is
+    # safe for them.
+    if isinstance(instance, _Consumer) or (
+        _DeserializingConsumer is not None and isinstance(instance, _DeserializingConsumer)
+    ):
+        return ""
+
     # Check failure cache - skip for 5 minutes if we fail
     last_failure = getattr(instance, "_dd_cluster_id_failure_time", 0)
     if time() - last_failure < 300:

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -40,6 +40,11 @@ _DeserializingConsumer = (
 
 log = get_logger(__name__)
 
+# Process-wide cache: bootstrap_servers -> cluster_id.
+# Populated by producers (which safely call list_topics); read by consumers
+# (which cannot call list_topics without risking a librdkafka crash).
+_cluster_id_by_bootstrap: dict[str, str] = {}
+
 config._add(
     "kafka",
     dict(
@@ -90,6 +95,11 @@ class TracedConsumerMixin:
         super(TracedConsumerMixin, self).__init__(config, *args, **kwargs)
         self._group_id = config.get("group.id", "")
         self._auto_commit = asbool(config.get("enable.auto.commit", True))
+        self._dd_bootstrap_servers = (
+            config.get("bootstrap.servers")
+            if config.get("bootstrap.servers") is not None
+            else config.get("metadata.broker.list")
+        )
 
 
 class TracedConsumer(TracedConsumerMixin, confluent_kafka.Consumer):
@@ -364,9 +374,19 @@ def _get_cluster_id(instance, topic):
     # rd_kafka_q_serve_rkmessages (librdkafka issue #4214).
     # Producers are not affected by consumer-group rebalancing, so the call is
     # safe for them.
+    #
+    # For DSM correctness we still want a real cluster ID on consumers so that
+    # offset checkpoints are stored under the same key as producer offsets.
+    # We achieve this by reading the _cluster_id_by_bootstrap cache
+    # populated by producers on the same bootstrap address.
     if isinstance(instance, _Consumer) or (
         _DeserializingConsumer is not None and isinstance(instance, _DeserializingConsumer)
     ):
+        if bootstrap := getattr(instance, "_dd_bootstrap_servers", None):
+            if cached := _cluster_id_by_bootstrap.get(bootstrap):
+                instance._dd_cluster_id = cached
+                return cached
+
         return ""
 
     # Check failure cache - skip for 5 minutes if we fail
@@ -381,6 +401,8 @@ def _get_cluster_id(instance, topic):
         cluster_metadata = instance.list_topics(topic=topic, timeout=1.0)
         if cluster_metadata and getattr(cluster_metadata, "cluster_id", None):
             instance._dd_cluster_id = cluster_metadata.cluster_id
+            if bootstrap := getattr(instance, "_dd_bootstrap_servers", None):
+                _cluster_id_by_bootstrap[bootstrap] = cluster_metadata.cluster_id
             return cluster_metadata.cluster_id
     except Exception:
         # Cache the failure time to avoid repeated slow calls

--- a/releasenotes/notes/tracing-kafka-fix-crash-cluster-id-f15e0626ac764bd2.yaml
+++ b/releasenotes/notes/tracing-kafka-fix-crash-cluster-id-f15e0626ac764bd2.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    kafka: Fixes a crash in the ``confluent-kafka`` integration where internal ``list_topics``
+    calls triggered librdkafka background metadata-refresh tasks.

--- a/tests/contrib/kafka/test_kafka_patch.py
+++ b/tests/contrib/kafka/test_kafka_patch.py
@@ -1,3 +1,13 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch as mock_patch
+
+import confluent_kafka
+import pytest
+
+from ddtrace.contrib.internal.kafka.patch import TracedConsumer
+from ddtrace.contrib.internal.kafka.patch import TracedProducer
+from ddtrace.contrib.internal.kafka.patch import _cluster_id_by_bootstrap
+from ddtrace.contrib.internal.kafka.patch import _get_cluster_id
 from ddtrace.contrib.internal.kafka.patch import get_version
 from ddtrace.contrib.internal.kafka.patch import patch
 from ddtrace.contrib.internal.kafka.patch import unpatch
@@ -28,3 +38,65 @@ class TestKafkaPatch(PatchTestCase.Base):
         self.assert_not_double_wrapped(confluent_kafka.Consumer({"group.id": "group_id"}).poll)
         self.assert_not_double_wrapped(confluent_kafka.SerializingProducer({}).produce)
         self.assert_not_double_wrapped(confluent_kafka.DeserializingConsumer({"group.id": "group_id"}).poll)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cluster_id_cache():
+    """Reset the process-wide cluster ID cache between tests."""
+    _cluster_id_by_bootstrap.clear()
+    yield
+    _cluster_id_by_bootstrap.clear()
+
+
+class TestGetClusterId:
+    def _make_consumer(self, bootstrap_servers: str = "localhost:9092") -> TracedConsumer:
+        patch()
+        consumer = confluent_kafka.Consumer({"bootstrap.servers": bootstrap_servers, "group.id": "test_group"})
+        return consumer
+
+    def _make_producer(self, bootstrap_servers: str = "localhost:9092") -> TracedProducer:
+        patch()
+        producer = confluent_kafka.Producer({"bootstrap.servers": bootstrap_servers})
+        return producer
+
+    def teardown_method(self) -> None:
+        unpatch()
+
+    def test_consumer_returns_empty_string(self) -> None:
+        """Consumer instances must return '' without calling list_topics."""
+        consumer = self._make_consumer()
+        with mock_patch.object(type(consumer), "list_topics") as mock_list_topics:
+            result = _get_cluster_id(consumer, "test-topic")
+        assert result == ""
+        mock_list_topics.assert_not_called()
+
+    def test_consumer_never_calls_list_topics(self) -> None:
+        """list_topics must never be invoked on a Consumer regardless of cache state."""
+        consumer = self._make_consumer()
+        consumer.list_topics = MagicMock()  # type: ignore[method-assign]
+        _get_cluster_id(consumer, "test-topic")
+        consumer.list_topics.assert_not_called()
+
+    def test_consumer_uses_producer_populated_cache(self) -> None:
+        """Consumer reads cluster ID from the process-wide cache set by a producer."""
+        bootstrap = "localhost:9092"
+        producer = self._make_producer(bootstrap)
+        mock_metadata = MagicMock()
+        mock_metadata.cluster_id = "test-cluster-123"
+        with mock_patch.object(type(producer), "list_topics", return_value=mock_metadata):
+            producer_cluster_id = _get_cluster_id(producer, "test-topic")
+
+        assert producer_cluster_id == "test-cluster-123"
+        assert _cluster_id_by_bootstrap.get(bootstrap) == "test-cluster-123"
+
+        consumer = self._make_consumer(bootstrap)
+        # list_topics must NOT be called on the consumer
+        consumer.list_topics = MagicMock()  # type: ignore[method-assign]
+        consumer_cluster_id = _get_cluster_id(consumer, "test-topic")
+        consumer.list_topics.assert_not_called()
+        assert consumer_cluster_id == "test-cluster-123"
+
+    def test_consumer_returns_empty_string_when_cache_is_empty(self) -> None:
+        """Without a prior producer call the consumer still returns ''."""
+        consumer = self._make_consumer("localhost:9092")
+        assert _get_cluster_id(consumer, "test-topic") == ""


### PR DESCRIPTION
## Description

This fixes a crash that would occur when using the Kafka integration. 

**Python stacks**

```
Thread 0x00007f2e5affd6c0 (most recent call first):
  File "/usr/lib/python3.12/threading.py", line 355 in wait
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/_queue.py", line 242 in get
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/worker.py", line 120 in _target
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap

Thread 0x00007f2e797fa6c0 (most recent call first):
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/contrib/internal/kafka/patch.py", line 232 in traced_poll_or_consume
  File "/opt/app/pkgs/extensions/kafka/confluent_kafka_consumer.py", line 136 in consume
  File "/opt/app/suma/kafka/consumer/runner.py", line 158 in consume_messages
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 245 in poll_messages
  File "/opt/app/suma/kafka/consumer/runner.py", line 333 in _run
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 325 in run
  File "/opt/app/suma/kafka/consumer_cmd.py", line 156 in run_consumer_thread
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap

Thread 0x00007f2e7bfff6c0 (most recent call first):
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/contrib/internal/kafka/patch.py", line 232 in traced_poll_or_consume
  File "/opt/app/pkgs/extensions/kafka/confluent_kafka_consumer.py", line 136 in consume
  File "/opt/app/suma/kafka/consumer/runner.py", line 158 in consume_messages
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 245 in poll_messages
  File "/opt/app/suma/kafka/consumer/runner.py", line 333 in _run
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 325 in run
  File "/opt/app/suma/kafka/consumer_cmd.py", line 156 in run_consumer_thread
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap

Thread 0x00007f2ed9ffb6c0 (most recent call first):
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/contrib/internal/kafka/patch.py", line 232 in traced_poll_or_consume
  File "/opt/app/pkgs/extensions/kafka/confluent_kafka_consumer.py", line 136 in consume
  File "/opt/app/suma/kafka/consumer/runner.py", line 158 in consume_messages
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 245 in poll_messages
  File "/opt/app/suma/kafka/consumer/runner.py", line 333 in _run
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 325 in run
  File "/opt/app/suma/kafka/consumer_cmd.py", line 156 in run_consumer_thread
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap

Thread 0x00007f2ef0d016c0 (most recent call first):
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/contrib/internal/kafka/patch.py", line 232 in traced_poll_or_consume
  File "/opt/app/pkgs/extensions/kafka/confluent_kafka_consumer.py", line 136 in consume
  File "/opt/app/suma/kafka/consumer/runner.py", line 158 in consume_messages
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 245 in poll_messages
  File "/opt/app/suma/kafka/consumer/runner.py", line 333 in _run
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 325 in run
  File "/opt/app/suma/kafka/consumer_cmd.py", line 156 in run_consumer_thread
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap

Thread 0x00007f2ed97fa6c0 (most recent call first):
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/contrib/internal/kafka/patch.py", line 232 in traced_poll_or_consume
  File "/opt/app/pkgs/extensions/kafka/confluent_kafka_consumer.py", line 136 in consume
  File "/opt/app/suma/kafka/consumer/runner.py", line 158 in consume_messages
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 245 in poll_messages
  File "/opt/app/suma/kafka/consumer/runner.py", line 333 in _run
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 325 in run
  File "/opt/app/suma/kafka/consumer_cmd.py", line 156 in run_consumer_thread
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap

Thread 0x00007f2edbfff6c0 (most recent call first):
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/contrib/internal/kafka/patch.py", line 232 in traced_poll_or_consume
  File "/opt/app/pkgs/extensions/kafka/confluent_kafka_consumer.py", line 136 in consume
  File "/opt/app/suma/kafka/consumer/runner.py", line 158 in consume_messages
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 245 in poll_messages
  File "/opt/app/suma/kafka/consumer/runner.py", line 333 in _run
  File "/opt/venv/lib/python3.12/site-packages/ddtrace/_trace/tracer.py", line 860 in func_wrapper
  File "/opt/app/suma/kafka/consumer/runner.py", line 325 in run
  File "/opt/app/suma/kafka/consumer_cmd.py", line 156 in run_consumer_thread
  File "/usr/lib/python3.12/threading.py", line 1012 in run
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 133 in _run_old_run_func
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 140 in run
  File "/usr/lib/python3.12/threading.py", line 1075 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap
```

**Native stack**

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x00007f3058686017 rd_kafka_q_serve_rkmessages
#1   0x00007f30586480bc rd_kafka_consume_batch_queue
#2   0x00007f306d783cda cfunction_call
#3   0x00007f306d796f02 _PyObject_Call.localalias
#4   0x00007f306d76804a _PyEval_EvalFrameDefault.localalias
#5   0x00007f306d783a43 object_vacall
#6   0x00007f306d827040 PyObject_CallFunctionObjArgs
#7   0x00007f306d757ccc _PyObject_MakeTpCall.localalias
#8   0x00007f306d762ec4 _PyEval_EvalFrameDefault.localalias
#9   0x00007f306d7b220e _PyObject_VectorcallTstate.lto_priv.14
#10  0x00007f306d7b1d6f method_vectorcall
#11  0x00007f306d8a3afd thread_run
#12  0x00007f306d89018c pythread_wrapper
#13  0x00007f306d3e73c6 start_thread
#14  0x00007f306d46c1cc __clone3
```