### PR TITLE
fix(deps): exclude wrapt 2.2.0 to avoid descriptor regression [backport 4.9]

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
+          ref: '3f0804cb244c7fa93a4513c7d66c0cb345d9ff45'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
+          ref: '3f0804cb244c7fa93a4513c7d66c0cb345d9ff45'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -392,7 +392,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3f0804cb244c7fa93a4513c7d66c0cb345d9ff45
     secrets: inherit
     with:
       library: python_lambda
@@ -422,7 +422,7 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@3f0804cb244c7fa93a4513c7d66c0cb345d9ff45
     secrets: inherit
     with:
       library: python

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7'
+          ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7'
+          ref: '6b3152ec85b1274ebd2425a038ce2a1721313373'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -392,7 +392,7 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     secrets: inherit
     with:
       library: python_lambda
@@ -422,7 +422,7 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6b3152ec85b1274ebd2425a038ce2a1721313373
     secrets: inherit
     with:
       library: python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "0c5de1b1354fa47fb24b88695e9fdafdfb69b6f7"
+  SYSTEM_TESTS_REF: "6b3152ec85b1274ebd2425a038ce2a1721313373"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "6b3152ec85b1274ebd2425a038ce2a1721313373"
+  SYSTEM_TESTS_REF: "3f0804cb244c7fa93a4513c7d66c0cb345d9ff45"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/lib-injection/sources/requirements.csv
+++ b/lib-injection/sources/requirements.csv
@@ -6,6 +6,6 @@ bytecode,">=0.14.0,<1",python_version~='3.11.0'
 bytecode,">=0.13.0,<1",python_version<'3.11'
 envier,~=0.6.1,
 opentelemetry-api,">=1,<2",
-wrapt,">=1,<3",
+wrapt,">=1,!=2.2.0,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,14 @@ dependencies = [
     "bytecode>=0.13.0,<1; python_version<'3.11'",
     "envier~=0.6.1",
     "opentelemetry-api>=1,<2",
-    "wrapt>=1,<3",
+    # TODO: lift the `!=2.2.0` exclusion once wrapt ships a release that
+    # reverts/fixes the descriptor regression introduced in
+    # https://github.com/GrahamDumpleton/wrapt/commit/ae93dd71c378161ff3643c9a1f708f66f97f3b5d
+    # wrapt 2.2.0's `FunctionWrapper.__get__(None, owner)` calls `tp_descr_get`
+    # with `Py_None` instead of `NULL`, which breaks class-level access to any
+    # C method_descriptor we wrap (e.g. `_pickle.Unpickler.load`,
+    # `asyncpg.protocol.protocol.BaseProtocol.execute`). See incident 53643.
+    "wrapt>=1,!=2.2.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/dependencies-exclude-wrapt-2-2-0-68425d65e72af874.yaml
+++ b/releasenotes/notes/dependencies-exclude-wrapt-2-2-0-68425d65e72af874.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Exclude ``wrapt==2.2.0`` from the supported dependency range to avoid a regression that breaks wrapped C descriptors.

--- a/requirements.csv
+++ b/requirements.csv
@@ -6,6 +6,6 @@ bytecode,">=0.14.0,<1",python_version~='3.11.0'
 bytecode,">=0.13.0,<1",python_version<'3.11'
 envier,~=0.6.1,
 opentelemetry-api,">=1,<2",
-wrapt,">=1,<3",
+wrapt,">=1,!=2.2.0,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",


### PR DESCRIPTION
## Description

Backport of #18229 to 4.9

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
