### PR TITLE
ci(opensearch): split elasticsearch and opensearch CI

### DIFF
--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -693,9 +693,9 @@ suites:
       - rabbitmq
     snapshot: true
   elasticsearch:
+    pattern: ^elasticsearch(?!:opensearch)
     env:
       TEST_ELASTICSEARCH_HOST: elasticsearch
-      TEST_OPENSEARCH_HOST: opensearch
     venvs_per_job: 1
     paths:
       - '@bootstrap'
@@ -703,11 +703,31 @@ suites:
       - '@tracing'
       - '@contrib'
       - '@elasticsearch'
-      - tests/contrib/elasticsearch/*
-      - tests/snapshots/tests.{suite}.*
+      - tests/contrib/elasticsearch/test_elasticsearch.py
+      - tests/contrib/elasticsearch/test_elasticsearch_multi.py
+      - tests/contrib/elasticsearch/test_async.py
+      - tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch.*
+      - tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.*
+      - tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch.*
+      - tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch7.*
+    services:
+      - elasticsearch
+    snapshot: true
+  opensearch:
+    pattern: elasticsearch:opensearch
+    env:
+      TEST_OPENSEARCH_HOST: opensearch
+    venvs_per_job: 3
+    paths:
+      - '@bootstrap'
+      - '@core'
+      - '@tracing'
+      - '@contrib'
+      - '@elasticsearch'
+      - tests/contrib/elasticsearch/test_opensearch.py
+      - tests/snapshots/tests.contrib.elasticsearch.test_async.test_opensearch.*
     services:
       - opensearch
-      - elasticsearch
     snapshot: true
   falcon:
     paths:

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -703,10 +703,10 @@ suites:
       - '@tracing'
       - '@contrib'
       - '@elasticsearch'
+      - tests/contrib/elasticsearch/__init__.py
       - tests/contrib/elasticsearch/test_elasticsearch.py
       - tests/contrib/elasticsearch/test_elasticsearch_multi.py
       - tests/contrib/elasticsearch/test_async.py
-      - tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch.*
       - tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.*
       - tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch.*
       - tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch7.*
@@ -724,6 +724,7 @@ suites:
       - '@tracing'
       - '@contrib'
       - '@elasticsearch'
+      - tests/contrib/elasticsearch/__init__.py
       - tests/contrib/elasticsearch/test_opensearch.py
       - tests/snapshots/tests.contrib.elasticsearch.test_async.test_opensearch.*
     services:


### PR DESCRIPTION
## Description

There are a ton of venvs for elasticsearch. Not all of them need `opensearch` or `elasticsearch` services to run.

This PR breaks up the "elasticsearch" and "opensearch" suites in CI so we don't need to start both an elasticsearch and opensearch service for all jobs.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
