### PR TITLE
fix(llmobs): eagerly finalize stream to prevent nested agent spans

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -95,7 +95,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         if chunk_type == "ResultMessage":
             if self.instance and self.context is None:
                 self.context = await _retrieve_context(self.instance)
-            # eagerly finish when the result message is received since 
+            # eagerly finish when the result message is received since
             # the generator may be left open indefinitely
             self.finalize_stream()
 

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -85,14 +85,19 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         self._step_response_chunk: Any = None  # deferred AssistantMessage for steps with tool calls
         self._step_input_snapshot: Optional[list[Message]] = None  # input captured before llm extension
         self._accumulated_input_messages: Optional[list[Message]] = None
+        self._is_finalized = False
         self._create_step_span()
 
     async def process_chunk(self, chunk, iterator=None):
         self.chunks.append(chunk)
         chunk_type = type(chunk).__name__
 
-        if chunk_type == "ResultMessage" and self.instance and self.context is None:
-            self.context = await _retrieve_context(self.instance)
+        if chunk_type == "ResultMessage":
+            if self.instance and self.context is None:
+                self.context = await _retrieve_context(self.instance)
+            # eagerly finish when the result message is received since 
+            # receive_response() may leave the generator open indefinitely
+            self.finalize_stream()
 
         content = getattr(chunk, "content", []) or []
 
@@ -104,6 +109,9 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
             self._handle_user_message(chunk, content)
 
     def finalize_stream(self, exception=None):
+        if self._is_finalized:
+            return
+        self._is_finalized = True
         try:
             # Finalize any open llm span first.
             if self.current_llm_span is not None:

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -96,7 +96,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
             if self.instance and self.context is None:
                 self.context = await _retrieve_context(self.instance)
             # eagerly finish when the result message is received since 
-            # receive_response() may leave the generator open indefinitely
+            # the generator may be left open indefinitely
             self.finalize_stream()
 
         content = getattr(chunk, "content", []) or []

--- a/releasenotes/notes/fix-claude-finalize-stream-f9837e6baceccfae.yaml
+++ b/releasenotes/notes/fix-claude-finalize-stream-f9837e6baceccfae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where sequential ``ClaudeSDKClient.query()`` calls produced nested agent spans instead of separate root traces. Agent spans are now finalized eagerly when a ``ResultMessage`` is observed, rather than relying on the wrapping async generator's ``finally`` block, which is skipped when the consumer exits iteration early (as ``receive_response()`` does internally on ``ResultMessage``).

--- a/releasenotes/notes/fix-claude-finalize-stream-f9837e6baceccfae.yaml
+++ b/releasenotes/notes/fix-claude-finalize-stream-f9837e6baceccfae.yaml
@@ -1,4 +1,7 @@
 ---
 fixes:
   - |
-    LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where sequential ``ClaudeSDKClient.query()`` calls produced nested agent spans instead of separate root traces. Agent spans are now finalized eagerly when a ``ResultMessage`` is observed, rather than relying on the wrapping async generator's ``finally`` block, which is skipped when the consumer exits iteration early (as ``receive_response()`` does internally on ``ResultMessage``).
+    LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where sequential 
+    ``ClaudeSDKClient.query()`` calls produced nested agent spans instead of separate root traces. 
+    Agent spans are now finalized eagerly when a ``ResultMessage`` is observed, rather than relying 
+    on the wrapping async generator's ``finally`` block to execute.

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -865,7 +865,7 @@ class TestLLMObsClaudeAgentSdk:
             error={"type": "ToolError", "message": MOCK_TOOL_ERROR_MESSAGE, "stack": ANY},
             tags=COMMON_TAGS,
         )
-    
+
     async def test_llmobs_client_sequential_queries(self, mock_client, claude_agent_sdk_llmobs, test_spans):
         """Two sequential ClaudeSDKClient.query() + receive_response() calls produce two
         separate root agent spans. Regression test for spans nesting under a prior
@@ -882,8 +882,6 @@ class TestLLMObsClaudeAgentSdk:
         assert all(s.name == "claude_agent_sdk.ClaudeSDKClient.query" for s in agent_spans)
         assert all(s.parent_id is None for s in agent_spans)
         assert agent_spans[0].trace_id != agent_spans[1].trace_id
-
-    
 
 
 def test_shadow_tags_llm_with_cache_tokens(tracer):

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -865,6 +865,25 @@ class TestLLMObsClaudeAgentSdk:
             error={"type": "ToolError", "message": MOCK_TOOL_ERROR_MESSAGE, "stack": ANY},
             tags=COMMON_TAGS,
         )
+    
+    async def test_llmobs_client_sequential_queries(self, mock_client, claude_agent_sdk_llmobs, test_spans):
+        """Two sequential ClaudeSDKClient.query() + receive_response() calls produce two
+        separate root agent spans. Regression test for spans nesting under a prior
+        unfinished agent span when receive_response() early-returns after ResultMessage.
+        """
+        for prompt in ("Q1", "Q2"):
+            await mock_client.query(prompt=prompt)
+            async for _ in mock_client.receive_response():
+                pass
+
+        traces = test_spans.pop_traces()
+        assert len(traces) == 2
+        agent_spans = [trace[0] for trace in traces]
+        assert all(s.name == "claude_agent_sdk.ClaudeSDKClient.query" for s in agent_spans)
+        assert all(s.parent_id is None for s in agent_spans)
+        assert agent_spans[0].trace_id != agent_spans[1].trace_id
+
+    
 
 
 def test_shadow_tags_llm_with_cache_tokens(tracer):


### PR DESCRIPTION
## Description

The claude agent sdk closes async generators lazily which can lead to unwanted nested agent spans. This PR attempts to fix this by finishing the agent span when the `ResultMessage` chunk is received.

## Testing

Repro script:
```
import asyncio
from claude_agent_sdk import (
    ClaudeSDKClient,
    ResultMessage,
)


async def run_query(client, prompt):
    await client.query(prompt)
    async for msg in client.receive_messages():
        if isinstance(msg, ResultMessage):
            break


async def main():
    async with ClaudeSDKClient() as client:
        await run_query(client, "What is 2+2?")
        await run_query(client, "What is 3+3?")


asyncio.run(main())
```

### Before
The first agent span is left open indefinitely, leading to the second agent span being treated as its child (nested underneath it within the same trace).

<img width="877" height="346" alt="Screenshot 2026-05-22 at 3 42 31 PM" src="https://github.com/user-attachments/assets/1cd2879e-1677-4e2e-919f-fe462600c8c5" />

### After
Agent spans are eagerly closed when `ResultMessage` is received, leading to two separate traces.
<img width="882" height="182" alt="Screenshot 2026-05-22 at 3 41 11 PM" src="https://github.com/user-attachments/assets/468c8ff9-4ed5-4022-9391-802cd00e2946" />

<img width="838" height="234" alt="Screenshot 2026-05-22 at 3 41 28 PM" src="https://github.com/user-attachments/assets/4156acf5-6a6f-4325-97ce-23d1b85cb76c" />

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
