### PR TITLE
ci(stdlib): skip asyncio test_lazyimport tests

### DIFF
--- a/tests/contrib/asyncio/test_lazyimport.py
+++ b/tests/contrib/asyncio/test_lazyimport.py
@@ -1,7 +1,7 @@
 import pytest  # noqa: I001
 
 
-pytest.skip("PGB-123")
+pytest.skip(reason="PGB-123", allow_module_level=True)
 
 
 @pytest.mark.subprocess()

--- a/tests/contrib/asyncio/test_lazyimport.py
+++ b/tests/contrib/asyncio/test_lazyimport.py
@@ -1,7 +1,7 @@
 import pytest  # noqa: I001
 
 
-pytest.mark.skip("PGB-123")
+pytest.skip("PGB-123")
 
 
 @pytest.mark.subprocess()

--- a/tests/contrib/asyncio/test_lazyimport.py
+++ b/tests/contrib/asyncio/test_lazyimport.py
@@ -1,6 +1,9 @@
 import pytest  # noqa: I001
 
 
+pytest.mark.skip("PGB-123")
+
+
 @pytest.mark.subprocess()
 def test_lazy_import():
     import ddtrace.auto  # noqa: F401,I001


### PR DESCRIPTION
## Description

This test is quarantined on `main`, but is not getting skipped on this branch.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
