### PR TITLE
perf(profiling): replace mem profiler untrack + track with single func

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -152,8 +152,7 @@ memalloc_realloc(void* ctx, void* ptr, size_t new_size)
     // TODO(dsn): With Python free-threading, allocators must be thread-safe even for non-RAW domains.
     // We may need to add synchronization here in the future to avoid races between realloc and untrack.
     if (ptr2) {
-        memalloc_heap_untrack_no_cpython(ptr);
-        memalloc_heap_track_invokes_cpython(memalloc_ctx->max_nframe, ptr2, new_size, memalloc_ctx->domain);
+        memalloc_heap_retrack_invokes_cpython(memalloc_ctx->max_nframe, ptr, ptr2, new_size, memalloc_ctx->domain);
     } else if (new_size == 0 && ptr != NULL) {
         // realloc(ptr, 0) is implementation-defined: some allocators (including
         // glibc) free ptr and return NULL.  In that case ptr is gone and must be
@@ -248,8 +247,7 @@ memalloc_realloc_mem(void* ctx, void* ptr, size_t new_size)
         return nullptr;
     void* ptr2 = alloc.realloc(alloc.ctx, ptr, new_size);
     if (ptr2) {
-        memalloc_heap_untrack_no_cpython(ptr);
-        memalloc_heap_track_invokes_cpython(memalloc_ctx->max_nframe, ptr2, new_size, memalloc_ctx->domain);
+        memalloc_heap_retrack_invokes_cpython(memalloc_ctx->max_nframe, ptr, ptr2, new_size, memalloc_ctx->domain);
     } else if (new_size == 0 && ptr != NULL) {
         memalloc_heap_untrack_no_cpython(ptr);
     }

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -127,6 +127,10 @@ class heap_tracker_t
     /* Reset the heap tracker state after fork in child process */
     void postfork_child();
 
+    /* Remove old_ptr from allocs_m and, if new_tb is non-null, insert it at new_ptr.
+     * Both operations occur under a single gil_guard scope. */
+    void retrack_no_cpython(void* old_ptr, void* new_ptr, std::unique_ptr<traceback_t> new_tb);
+
   private:
     uint32_t next_sample_size_no_cpython(uint32_t sample_size);
 
@@ -233,6 +237,24 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
     auto node = allocs_m.extract(ptr);
     if (!node.empty()) {
         pool_put_no_cpython(std::move(node.mapped()));
+    }
+}
+
+void
+heap_tracker_t::retrack_no_cpython(void* old_ptr, void* new_ptr, std::unique_ptr<traceback_t> new_tb)
+{
+    memalloc_gil_debug_guard_t guard(gil_guard);
+
+    // Remove old entry (if tracked) and return its traceback to the pool
+    auto node = allocs_m.extract(old_ptr);
+    if (!node.empty()) {
+        pool_put_no_cpython(std::move(node.mapped()));
+    }
+
+    // Insert new entry only when we decided to sample new_ptr
+    if (new_tb) {
+        allocs_m.insert_or_assign(new_ptr, std::move(new_tb));
+        reset_sampling_state_no_cpython();
     }
 }
 
@@ -350,6 +372,52 @@ memalloc_heap_untrack_no_cpython(void* ptr)
     if (heap_tracker_t::instance) {
         heap_tracker_t::instance->untrack_no_cpython(ptr);
     }
+}
+
+/* Retrack a reallocated pointer: remove old_ptr and, if the new allocation is sampled */
+void
+memalloc_heap_retrack_invokes_cpython(uint16_t max_nframe,
+                                      void* old_ptr,
+                                      void* new_ptr,
+                                      size_t new_size,
+                                      PyMemAllocatorDomain domain)
+{
+    (void)domain; // Parameter kept for API consistency but not currently used
+    if (!heap_tracker_t::instance)
+        return;
+
+    uint64_t allocated_memory_val = 0;
+    if (!heap_tracker_t::instance->should_sample_no_cpython(new_size, &allocated_memory_val)) {
+        heap_tracker_t::instance->untrack_no_cpython(old_ptr);
+        return;
+    }
+
+    memalloc_reentrant_guard_t guard;
+    if (!guard) {
+        // Can't capture traceback; still must remove old_ptr
+        heap_tracker_t::instance->untrack_no_cpython(old_ptr);
+        return;
+    }
+
+#if defined(_PY310_AND_LATER) && !defined(_PY312_AND_LATER)
+    pygc_temp_disable_guard_t gc_guard;
+#endif
+
+    if (!heap_tracker_t::instance) {
+        return;
+    }
+
+    auto tb =
+      heap_tracker_t::instance->pool_get_with_alloc_data_invokes_cpython(new_size, allocated_memory_val, max_nframe);
+
+    tb->sample.export_sample();
+    tb->sample.reset_alloc();
+    tb->sample.push_heap(allocated_memory_val);
+
+    if (heap_tracker_t::instance) {
+        heap_tracker_t::instance->retrack_no_cpython(old_ptr, new_ptr, std::move(tb));
+    }
+    // If instance is gone, tb's unique_ptr automatically deletes the traceback
 }
 
 /* Track a memory allocation in the heap profiler. */

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -127,10 +127,6 @@ class heap_tracker_t
     /* Reset the heap tracker state after fork in child process */
     void postfork_child();
 
-    /* Remove old_ptr from allocs_m and, if new_tb is non-null, insert it at new_ptr.
-     * Both operations occur under a single gil_guard scope. */
-    void retrack_no_cpython(void* old_ptr, void* new_ptr, std::unique_ptr<traceback_t> new_tb);
-
   private:
     uint32_t next_sample_size_no_cpython(uint32_t sample_size);
 
@@ -237,24 +233,6 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
     auto node = allocs_m.extract(ptr);
     if (!node.empty()) {
         pool_put_no_cpython(std::move(node.mapped()));
-    }
-}
-
-void
-heap_tracker_t::retrack_no_cpython(void* old_ptr, void* new_ptr, std::unique_ptr<traceback_t> new_tb)
-{
-    memalloc_gil_debug_guard_t guard(gil_guard);
-
-    // Remove old entry (if tracked) and return its traceback to the pool
-    auto node = allocs_m.extract(old_ptr);
-    if (!node.empty()) {
-        pool_put_no_cpython(std::move(node.mapped()));
-    }
-
-    // Insert new entry only when we decided to sample new_ptr
-    if (new_tb) {
-        allocs_m.insert_or_assign(new_ptr, std::move(new_tb));
-        reset_sampling_state_no_cpython();
     }
 }
 
@@ -386,16 +364,15 @@ memalloc_heap_retrack_invokes_cpython(uint16_t max_nframe,
     if (!heap_tracker_t::instance)
         return;
 
+    heap_tracker_t::instance->untrack_no_cpython(old_ptr);
+
     uint64_t allocated_memory_val = 0;
     if (!heap_tracker_t::instance->should_sample_no_cpython(new_size, &allocated_memory_val)) {
-        heap_tracker_t::instance->untrack_no_cpython(old_ptr);
         return;
     }
 
     memalloc_reentrant_guard_t guard;
     if (!guard) {
-        // Can't capture traceback; still must remove old_ptr
-        heap_tracker_t::instance->untrack_no_cpython(old_ptr);
         return;
     }
 
@@ -415,7 +392,7 @@ memalloc_heap_retrack_invokes_cpython(uint16_t max_nframe,
     tb->sample.push_heap(allocated_memory_val);
 
     if (heap_tracker_t::instance) {
-        heap_tracker_t::instance->retrack_no_cpython(old_ptr, new_ptr, std::move(tb));
+        heap_tracker_t::instance->add_sample_no_cpython(new_ptr, std::move(tb));
     }
     // If instance is gone, tb's unique_ptr automatically deletes the traceback
 }

--- a/ddtrace/profiling/collector/_memalloc_heap.h
+++ b/ddtrace/profiling/collector/_memalloc_heap.h
@@ -21,6 +21,12 @@ void
 memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain);
 void
 memalloc_heap_untrack_no_cpython(void* ptr);
+void
+memalloc_heap_retrack_invokes_cpython(uint16_t max_nframe,
+                                      void* old_ptr,
+                                      void* new_ptr,
+                                      size_t new_size,
+                                      PyMemAllocatorDomain domain);
 
 void
 memalloc_heap_postfork_child(void);


### PR DESCRIPTION
## Description

[PROF-14719](https://datadoghq.atlassian.net/browse/PROF-14719)

The change replaces two separate heap-tracker operations on a successful realloc, untracking the old pointer, then independently tracking the new one, with a single function. The practical effect is that the allocation is never absent from the tracking map between the two operations, closing a window where a concurrent heap export could have missed it. 


There is no measurable throughput difference when I time benchmarked the profiler with constant reallocation; the value is correctness.

Note (6/8/2025): Benchmarking with smoke test app shows 20% regression on `memalloc_realloc`
## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[PROF-14719]: https://datadoghq.atlassian.net/browse/PROF-14719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ