### PR TITLE
fix(llmobs): propagate llmobs_parent_id in _current_trace_context

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1959,6 +1959,7 @@ class LLMObs(Service):
             context = active.context
             wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active)) or str(active.trace_id)
             context._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = wire_trace_id
+            context._meta[PROPAGATED_PARENT_ID_KEY] = str(active.span_id)
             return context
         return None
 

--- a/releasenotes/notes/llmobs-propagate-parent-id-401cc2c7a9274277.yaml
+++ b/releasenotes/notes/llmobs-propagate-parent-id-401cc2c7a9274277.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixed an issue where ``_current_trace_context`` did not propagate
+    ``_dd.p.llmobs_parent_id`` into the trace context metadata. Without this value, downstream
+    consumers (e.g. dd-trace-go) could not locate the active LLMObs parent span and would create
+    orphaned child traces instead of correctly continuing the parent trace.

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -472,6 +472,19 @@ def _make_upstream_llmobs_context(trace_id_value, parent_id="987654321"):
     return ctx
 
 
+def test_current_trace_context_includes_parent_id(llmobs):
+    """_current_trace_context must set PROPAGATED_PARENT_ID_KEY so that HTTPPropagator.inject
+    (and any other consumer that reads _meta directly) propagates _dd.p.llmobs_parent_id to
+    subprocess / HTTP consumers. Without this, dd-trace-go's contextWithPropagatedLLMSpan
+    sees an empty parent_id and falls through to newLLMObsTraceID(), orphaning the child trace.
+    """
+    with llmobs.workflow("w") as span:
+        ctx = llmobs._instance._current_trace_context()
+    assert ctx is not None
+    assert ctx._meta.get(PROPAGATED_PARENT_ID_KEY) == str(span.span_id)
+    assert ctx._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) is not None
+
+
 def test_injected_trace_id_is_decimal_on_the_wire(llmobs):
     """Wire must stay decimal so older SDKs that do int(header) keep working."""
     with llmobs.workflow("w") as span:


### PR DESCRIPTION
## Summary

`_current_trace_context()` sets `PROPAGATED_LLMOBS_TRACE_ID_KEY` (`_dd.p.llmobs_trace_id`) on the returned context but omits `PROPAGATED_PARENT_ID_KEY` (`_dd.p.llmobs_parent_id`). Any consumer that reads `context._meta` directly — including `HTTPPropagator.inject` and non-Python clients (Go, Java, etc.) receiving the propagated headers — will see the trace ID but not the parent span ID.

This breaks distributed LLMObs tracing to non-Python services. For example, dd-trace-go's `contextWithPropagatedLLMSpan` requires **both** tags to be non-empty before it attaches the propagated LLMObs context:

```go
if propagatedLLMObs.SpanID == "" || propagatedLLMObs.TraceID == "" {
    // falls through to newLLMObsTraceID() — starts a fresh, unrelated trace
}
```

Without `_dd.p.llmobs_parent_id`, a downstream Go service starts a new root LLMObs trace instead of inheriting the parent, breaking the distributed trace tree.

## Fix

One line in `_current_trace_context()`:

```python
context._meta[PROPAGATED_PARENT_ID_KEY] = str(active.span_id)
```

`PROPAGATED_PARENT_ID_KEY` is already defined in `_constants.py` and imported in `_llmobs.py` — it was just never set on this code path.

Note: `_inject_llmobs_context` (the `http.span_inject` path, used by `inject_distributed_headers`) already sets this correctly. This fix brings `_current_trace_context` to parity.

## Test

Added `test_current_trace_context_includes_parent_id` to `tests/llmobs/test_propagation.py`. Asserts that the context returned by `_current_trace_context()` has both `PROPAGATED_PARENT_ID_KEY` and `PROPAGATED_LLMOBS_TRACE_ID_KEY` set, with `parent_id == str(span.span_id)`.