### PR TITLE
chore(pre-commit): report which CMake files were reformatted by cmake-format hook

### DIFF
--- a/hooks/pre-commit/07-run-cmake-format
+++ b/hooks/pre-commit/07-run-cmake-format
@@ -1,18 +1,28 @@
 #!/usr/bin/env sh
 LINT_CMD="${LINT_CMD:-scripts/lint}"
+
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '(\.cmake$|CMakeLists\.txt$)')
 if [ -n "$staged_files" ]; then
     # Capture files with unstaged changes before formatting; we skip re-adding these to preserve partial staging.
     unstaged_before=$(git diff --name-only)
 
-    # Format staged CMake files in-place.
-    "$LINT_CMD" cmakeformat fix $staged_files || exit $?
-
-    # Re-stage only files that had no unstaged changes before formatting (preserves partial staging).
-    echo "$staged_files" | while read -r f; do
-        [ -n "$f" ] || continue
-        echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
+    # Check first (default mode = --check) so we can report exactly which files needed reformatting.
+    needs_format=""
+    for f in $staged_files; do
+        "$LINT_CMD" cmakeformat "$f" >/dev/null 2>&1 || needs_format="$needs_format\n  $f"
     done
+
+    if [ -n "$needs_format" ]; then
+        printf "cmake-format: reformatting:%b\n" "$needs_format"
+        "$LINT_CMD" cmakeformat fix $staged_files || exit $?
+
+        # Re-stage only files that had no unstaged changes before formatting (preserves partial staging).
+        echo "$staged_files" | while read -r f; do
+            [ -n "$f" ] || continue
+            echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
+        done
+        echo "cmake-format: files reformatted and re-staged."
+    fi
 else
     echo 'Run cmake-format skipped: No CMake files were found in `git diff --staged`'
 fi


### PR DESCRIPTION
Previously the hook silently formatted and re-staged files with no output, making it impossible to tell which files were changed. This adds a pre-check pass (cmake-format --check per file) so the hook explicitly names any file that needs reformatting before applying the fix, and emits a confirmation message afterwards.

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
