### PR TITLE
fix(aiokafka): collect kafka cluster_id for DSM

### DIFF
--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -178,24 +178,34 @@ async def traced_getone(func, instance, args, kwargs):
             parent_ctx = HTTPPropagator.extract(dd_headers)
     except Exception as e:
         err = e
-        raise err
-    finally:
-        topic = getattr(message, "topic", None)
+
+    topic = getattr(message, "topic", None)
+    # Only resolve cluster id on the success path. On error we use the cached value (or "")
+    # to avoid adding a broker round-trip — and a potential exception that would mask `err` —
+    # to the consumer's failure path.
+    if err is None:
         cluster_id = await _get_cluster_id(instance._client, topic)
-        with core.context_with_data(
-            "aiokafka.getone",
-            call_trace=False,
-            span_name=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
-            span_type=SpanTypes.WORKER,
-            service=trace_utils.ext_service(None, config.aiokafka),
-            distributed_context=parent_ctx,
-            tags=common_consume_aiokafka_tags(topic, bootstrap_servers, group_id),
-            integration_config=config.aiokafka,
-        ) as ctx:
-            core.set_item("kafka_cluster_id", cluster_id)
-            if cluster_id and ctx.span is not None:
-                ctx.span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
-            core.dispatch("aiokafka.getone.message", (instance, ctx, start_ns, message, err))
+    else:
+        client = instance._client
+        cluster_id = getattr(client, "_dd_cluster_id", "") if client is not None else ""
+
+    with core.context_with_data(
+        "aiokafka.getone",
+        call_trace=False,
+        span_name=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
+        span_type=SpanTypes.WORKER,
+        service=trace_utils.ext_service(None, config.aiokafka),
+        distributed_context=parent_ctx,
+        tags=common_consume_aiokafka_tags(topic, bootstrap_servers, group_id),
+        integration_config=config.aiokafka,
+    ) as ctx:
+        core.set_item("kafka_cluster_id", cluster_id)
+        if cluster_id and ctx.span is not None:
+            ctx.span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+        core.dispatch("aiokafka.getone.message", (instance, ctx, start_ns, message, err))
+
+    if err is not None:
+        raise err
     return message
 
 
@@ -242,12 +252,29 @@ async def traced_commit(func, instance, args, kwargs):
     return result
 
 
+async def traced_producer_start(func, instance, args, kwargs):
+    result = await func(*args, **kwargs)
+    # Eagerly resolve the cluster id once the producer is connected, so the first
+    # user send() already has it cached and DSM pathway hashes stay stable from
+    # the first message instead of flipping after the first metadata response.
+    await _get_cluster_id(instance.client, None)
+    return result
+
+
+async def traced_consumer_start(func, instance, args, kwargs):
+    result = await func(*args, **kwargs)
+    await _get_cluster_id(instance._client, None)
+    return result
+
+
 def patch():
     if getattr(aiokafka, "_datadog_patch", False):
         return
     aiokafka._datadog_patch = True
 
+    _w("aiokafka", "AIOKafkaProducer.start", traced_producer_start)
     _w("aiokafka", "AIOKafkaProducer.send", traced_send)
+    _w("aiokafka", "AIOKafkaConsumer.start", traced_consumer_start)
     _w("aiokafka", "AIOKafkaConsumer.getone", traced_getone)
     _w("aiokafka", "AIOKafkaConsumer.getmany", traced_getmany)
     _w("aiokafka.consumer.group_coordinator", "GroupCoordinator.commit_offsets", traced_commit)
@@ -259,7 +286,9 @@ def unpatch():
 
     aiokafka._datadog_patch = False
 
+    _u(aiokafka.AIOKafkaProducer, "start")
     _u(aiokafka.AIOKafkaProducer, "send")
+    _u(aiokafka.AIOKafkaConsumer, "start")
     _u(aiokafka.AIOKafkaConsumer, "getone")
     _u(aiokafka.AIOKafkaConsumer, "getmany")
     _u(aiokafka.consumer.group_coordinator.GroupCoordinator, "commit_offsets")

--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -1,6 +1,8 @@
+from time import monotonic
 from time import time_ns
 
 import aiokafka
+from aiokafka.protocol.metadata import MetadataRequest_v5
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
@@ -8,6 +10,7 @@ from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
+from ddtrace.ext import kafka as kafkax
 from ddtrace.ext.kafka import CONSUME
 from ddtrace.ext.kafka import GROUP_ID
 from ddtrace.ext.kafka import HOST_LIST
@@ -18,6 +21,7 @@ from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.constants import MESSAGING_DESTINATION_NAME
 from ddtrace.internal.constants import MESSAGING_SYSTEM
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
@@ -27,6 +31,9 @@ from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.propagation.http import HTTPPropagator
+
+
+log = get_logger(__name__)
 
 
 config._add(
@@ -67,6 +74,42 @@ def common_consume_aiokafka_tags(topic, bootstrap_servers, group_id):
     return tags
 
 
+async def _get_cluster_id(client, topic):
+    """Fetch and cache the Kafka cluster ID from the broker.
+
+    Uses a 5 minute failure cache to avoid repeated slow calls when the broker
+    is unreachable.
+    """
+    if client is None:
+        return ""
+    cached = getattr(client, "_dd_cluster_id", None)
+    if cached:
+        return cached
+
+    last_failure = getattr(client, "_dd_cluster_id_failure_time", 0)
+    if monotonic() - last_failure < 300:
+        return ""
+
+    try:
+        node_id = client.get_random_node()
+        if node_id is None:
+            await client.force_metadata_update()
+            node_id = client.get_random_node()
+        if node_id is None:
+            client._dd_cluster_id_failure_time = monotonic()
+            return ""
+        request = MetadataRequest_v5([topic] if topic else [], False)
+        response = await client.send(node_id, request)
+        cluster_id = getattr(response, "cluster_id", "") or ""
+        if cluster_id:
+            client._dd_cluster_id = cluster_id
+        return cluster_id
+    except Exception:
+        client._dd_cluster_id_failure_time = monotonic()
+        log.debug("Failed to get Kafka cluster ID, will retry after 5 minutes")
+        return ""
+
+
 def parse_send(instance, args, kwargs):
     topic = get_argument_value(args, kwargs, 0, "topic")
     value = get_argument_value(args, kwargs, 1, "value", True)
@@ -80,6 +123,7 @@ def parse_send(instance, args, kwargs):
 
 async def traced_send(func, instance, args, kwargs):
     topic, value, headers, partition, key, bootstrap_servers = parse_send(instance, args, kwargs)
+    cluster_id = await _get_cluster_id(instance.client, topic)
 
     with core.context_with_data(
         "aiokafka.send",
@@ -89,6 +133,9 @@ async def traced_send(func, instance, args, kwargs):
         tags=common_aiokafka_tags(topic, bootstrap_servers),
         integration_config=config.aiokafka,
     ) as ctx:
+        core.set_item("kafka_cluster_id", cluster_id)
+        if cluster_id and ctx.span is not None:
+            ctx.span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
         core.dispatch("aiokafka.send.start", (topic, value, key, headers, ctx, partition))
         args, kwargs = set_argument_value(args, kwargs, 5, "headers", headers, override_unset=True)
 
@@ -133,6 +180,8 @@ async def traced_getone(func, instance, args, kwargs):
         err = e
         raise err
     finally:
+        topic = getattr(message, "topic", None)
+        cluster_id = await _get_cluster_id(instance._client, topic)
         with core.context_with_data(
             "aiokafka.getone",
             call_trace=False,
@@ -140,9 +189,12 @@ async def traced_getone(func, instance, args, kwargs):
             span_type=SpanTypes.WORKER,
             service=trace_utils.ext_service(None, config.aiokafka),
             distributed_context=parent_ctx,
-            tags=common_consume_aiokafka_tags(getattr(message, "topic", None), bootstrap_servers, group_id),
+            tags=common_consume_aiokafka_tags(topic, bootstrap_servers, group_id),
             integration_config=config.aiokafka,
         ) as ctx:
+            core.set_item("kafka_cluster_id", cluster_id)
+            if cluster_id and ctx.span is not None:
+                ctx.span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
             core.dispatch("aiokafka.getone.message", (instance, ctx, start_ns, message, err))
     return message
 
@@ -162,6 +214,17 @@ async def traced_getmany(func, instance, args, kwargs):
     ) as ctx:
         messages = await func(*args, **kwargs)
 
+        topic = None
+        if messages:
+            for records in messages.values():
+                if records:
+                    topic = records[0].topic
+                    break
+        cluster_id = await _get_cluster_id(instance._client, topic)
+        core.set_item("kafka_cluster_id", cluster_id)
+        if cluster_id and ctx.span is not None:
+            ctx.span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+
         core.dispatch("aiokafka.getmany.message", (instance, ctx, messages))
 
         return messages
@@ -169,6 +232,8 @@ async def traced_getmany(func, instance, args, kwargs):
 
 async def traced_commit(func, instance, args, kwargs):
     result = await func(*args, **kwargs)
+    cluster_id = await _get_cluster_id(getattr(instance, "_client", None), None)
+    core.set_item("kafka_cluster_id", cluster_id)
     core.dispatch("aiokafka.commit.end", (instance, args, kwargs))
     return result
 

--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -232,7 +232,11 @@ async def traced_getmany(func, instance, args, kwargs):
 
 async def traced_commit(func, instance, args, kwargs):
     result = await func(*args, **kwargs)
-    cluster_id = await _get_cluster_id(getattr(instance, "_client", None), None)
+    # Use only the cached cluster id on the commit path — avoid a metadata
+    # round-trip in this hot path. The id is normally populated by a prior
+    # produce/consume; if it isn't yet, we just skip the tag for this commit.
+    client = getattr(instance, "_client", None)
+    cluster_id = getattr(client, "_dd_cluster_id", "") if client is not None else ""
     core.set_item("kafka_cluster_id", cluster_id)
     core.dispatch("aiokafka.commit.end", (instance, args, kwargs))
     return result

--- a/ddtrace/internal/datastreams/aiokafka.py
+++ b/ddtrace/internal/datastreams/aiokafka.py
@@ -48,7 +48,10 @@ def dsm_aiokafka_send_start(
         header_dict = {}
     payload_size += _calculate_byte_size(header_dict)
 
+    cluster_id = core.find_item("kafka_cluster_id")
     edge_tags = ["direction:out", f"topic:{topic}", "type:kafka"]
+    if cluster_id:
+        edge_tags.append(f"kafka_cluster_id:{cluster_id}")
     ctx = dsm_processor.set_checkpoint(edge_tags, payload_size=payload_size, span=span)
 
     dsm_headers: dict[str, str] = {}
@@ -70,8 +73,13 @@ def dsm_aiokafka_send_completed(
 
     if record_metadata is not None:
         reported_offset = record_metadata.offset if isinstance(record_metadata.offset, int) else -1
+        cluster_id = core.find_item("kafka_cluster_id")
         dsm_processor.track_kafka_produce(
-            record_metadata.topic, record_metadata.partition, reported_offset, time.time()
+            record_metadata.topic,
+            record_metadata.partition,
+            reported_offset,
+            time.time(),
+            cluster_id=cluster_id,
         )
 
 
@@ -96,6 +104,7 @@ def dsm_aiokafka_message_consume(
         if val is not None
     }
     group = instance._group_id
+    cluster_id = core.find_item("kafka_cluster_id")
 
     payload_size = 0
     payload_size += _calculate_byte_size(message.value)
@@ -103,16 +112,22 @@ def dsm_aiokafka_message_consume(
     payload_size += _calculate_byte_size(headers)
 
     ctx = DsmPathwayCodec.decode(headers, dsm_processor)
-    ctx.set_checkpoint(
-        ["direction:in", f"group:{group}", f"topic:{message.topic}", "type:kafka"], payload_size=payload_size, span=span
-    )
+    edge_tags = ["direction:in", f"group:{group}", f"topic:{message.topic}", "type:kafka"]
+    if cluster_id:
+        edge_tags.append(f"kafka_cluster_id:{cluster_id}")
+    ctx.set_checkpoint(edge_tags, payload_size=payload_size, span=span)
 
     if instance._enable_auto_commit:
         # it's not exactly true, but if auto commit is enabled, we consider that a message is acknowledged
         # when it's read. We add one because the commit offset is the next message to read.
         reported_offset = (message.offset + 1) if isinstance(message.offset, int) else -1
         dsm_processor.track_kafka_commit(
-            instance._group_id, message.topic, message.partition, reported_offset, time.time()
+            instance._group_id,
+            message.topic,
+            message.partition,
+            reported_offset,
+            time.time(),
+            cluster_id=cluster_id,
         )
 
 
@@ -136,6 +151,7 @@ def dsm_aiokafka_message_commit(instance: "GroupCoordinator", args: Any, kwargs:
 
     offsets = get_argument_value(args, kwargs, 1, "offsets", optional=True)
     if offsets:
+        cluster_id = core.find_item("kafka_cluster_id")
         for tp, offset in offsets.items():
             # offset can be either an int or a tuple of (offset, metadata)
             if isinstance(offset, int):
@@ -144,7 +160,14 @@ def dsm_aiokafka_message_commit(instance: "GroupCoordinator", args: Any, kwargs:
                 reported_offset = offset[0]
             else:
                 reported_offset = -1
-            dsm_processor.track_kafka_commit(instance.group_id, tp.topic, tp.partition, reported_offset, time.time())
+            dsm_processor.track_kafka_commit(
+                instance.group_id,
+                tp.topic,
+                tp.partition,
+                reported_offset,
+                time.time(),
+                cluster_id=cluster_id,
+            )
 
 
 if config._data_streams_enabled:

--- a/releasenotes/notes/aiokafka-dsm-cluster-id-14b0133ab94b1f5c.yaml
+++ b/releasenotes/notes/aiokafka-dsm-cluster-id-14b0133ab94b1f5c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    aiokafka: Collects the Kafka cluster ID when tracing aiokafka producers and
+    consumers and forwards it to Data Streams Monitoring, matching the behavior
+    of the ``confluent_kafka`` integration.

--- a/tests/contrib/aiokafka/test_aiokafka_dsm.py
+++ b/tests/contrib/aiokafka/test_aiokafka_dsm.py
@@ -60,6 +60,7 @@ async def test_data_streams_pathway_stats(dsm_processor):
 
     async with producer_ctx([BOOTSTRAP_SERVERS]) as producer:
         await producer.send_and_wait(topic, value=PAYLOAD, key=KEY)
+        cluster_id = getattr(producer.client, "_dd_cluster_id", "") or ""
 
     async with consumer_ctx([topic]) as consumer:
         await consumer.getone()
@@ -67,24 +68,24 @@ async def test_data_streams_pathway_stats(dsm_processor):
 
     pathway_stats = pathway_stats_merged(dsm_processor)
 
+    producer_tags = ["direction:out", f"topic:{topic}", "type:kafka"]
+    consumer_tags = ["direction:in", f"group:{GROUP_ID}", f"topic:{topic}", "type:kafka"]
+    if cluster_id:
+        producer_tags.append(f"kafka_cluster_id:{cluster_id}")
+        consumer_tags.append(f"kafka_cluster_id:{cluster_id}")
+
     # Compute expected hashes based on edge tags to verify pathway continuity
     ctx = DataStreamsCtx(dsm_processor, 0, 0, 0)
-    expected_producer_hash = ctx._compute_hash(
-        sorted(["direction:out", f"topic:{topic}", "type:kafka"]),
-        0,
-    )
-    expected_consumer_hash = ctx._compute_hash(
-        sorted(["direction:in", f"group:{GROUP_ID}", f"topic:{topic}", "type:kafka"]),
-        expected_producer_hash,
-    )
+    expected_producer_hash = ctx._compute_hash(sorted(producer_tags), 0)
+    expected_consumer_hash = ctx._compute_hash(sorted(consumer_tags), expected_producer_hash)
 
     expected_producer_key = (
-        f"direction:out,topic:{topic},type:kafka",
+        ",".join(sorted(producer_tags)),
         expected_producer_hash,
         0,
     )
     expected_consumer_key = (
-        f"direction:in,group:{GROUP_ID},topic:{topic},type:kafka",
+        ",".join(sorted(consumer_tags)),
         expected_consumer_hash,
         expected_producer_hash,
     )
@@ -106,12 +107,13 @@ async def test_data_streams_offset_monitoring_auto_commit(dsm_processor):
     async with producer_ctx([BOOTSTRAP_SERVERS]) as producer:
         await producer.send_and_wait(topic, value=PAYLOAD, key=KEY)
         await producer.send_and_wait(topic, value=PAYLOAD, key=KEY)
+        cluster_id = getattr(producer.client, "_dd_cluster_id", "") or ""
 
     async with consumer_ctx([topic], enable_auto_commit=True) as consumer:
         msg = await consumer.getone()
 
-    assert max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
-    assert max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
+    assert max_produce_offset(dsm_processor, PartitionKey(topic, 0, cluster_id)) == 1
+    assert max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, cluster_id)) == msg.offset + 1
 
 
 @pytest.mark.asyncio
@@ -129,14 +131,15 @@ async def test_data_streams_offset_monitoring_commit(dsm_processor, offsets):
     async with producer_ctx([BOOTSTRAP_SERVERS]) as producer:
         await producer.send_and_wait(topic, value=PAYLOAD, key=KEY)
         await producer.send_and_wait(topic, value=PAYLOAD, key=KEY)
+        cluster_id = getattr(producer.client, "_dd_cluster_id", "") or ""
 
     async with consumer_ctx([topic], enable_auto_commit=False) as consumer:
         await consumer.getone()
         msg = await consumer.getone()
         await consumer.commit(offsets)
 
-    assert max_produce_offset(dsm_processor, PartitionKey(topic, 0, "")) == 1
-    assert max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, "")) == msg.offset + 1
+    assert max_produce_offset(dsm_processor, PartitionKey(topic, 0, cluster_id)) == 1
+    assert max_commit_offset(dsm_processor, ConsumerPartitionKey(GROUP_ID, topic, 0, cluster_id)) == msg.offset + 1
 
 
 @pytest.mark.asyncio

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9f00000000",
+      "_dd.p.tid": "6a17570b00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.partitions.getmany_multiple_messages_multiple_topics": "0",
       "kafka.partitions.getmany_multiple_messages_multiple_topics_2": "0",
@@ -23,8 +25,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "18265438875833290531",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "3964556687088658849",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -32,10 +34,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 10369125,
-    "start": 1771924895527537638
+    "duration": 14807677,
+    "start": 1779914507796498571
   }],
 [
   {
@@ -50,9 +52,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9c00000000",
+      "_dd.p.tid": "6a17570800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_multiple_messages_multiple_topics",
@@ -60,8 +64,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "2482551911420487554",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "17052484314529185803",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -70,10 +74,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 4255625,
-    "start": 1771924892490358719
+    "duration": 1419849,
+    "start": 1779914504777313302
   }],
 [
   {
@@ -88,9 +92,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9c00000000",
+      "_dd.p.tid": "6a17570800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_multiple_messages_multiple_topics",
@@ -98,8 +104,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "2482551911420487554",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "17052484314529185803",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -108,10 +114,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 1668292,
-    "start": 1771924892495042511
+    "duration": 947594,
+    "start": 1779914504778968821
   }],
 [
   {
@@ -126,9 +132,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9c00000000",
+      "_dd.p.tid": "6a17570800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_multiple_messages_multiple_topics_2",
@@ -136,8 +144,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "1005662364923142093",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "15798555699390652617",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -146,8 +154,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 2246333,
-    "start": 1771924892497097678
+    "duration": 1027137,
+    "start": 1779914504780076875
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics_with_distributed_tracing.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics_with_distributed_tracing.json
@@ -11,10 +11,12 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da200000000",
-      "_dd.span_links": "[{\"trace_id\": \"699d6d9f000000007374eb43e9a2605a\", \"span_id\": \"a58978e6c88e0812\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:699d6d9f00000000\", \"flags\": 1}, {\"trace_id\": \"699d6d9f00000000ffe03c556252abdf\", \"span_id\": \"7c9d1869a6ad89fc\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:699d6d9f00000000\", \"flags\": 1}, {\"trace_id\": \"699d6d9f000000005469c3fca04bbad4\", \"span_id\": \"232a4d4adf2d63b3\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:699d6d9f00000000\", \"flags\": 1}]",
+      "_dd.p.tid": "6a17572100000000",
+      "_dd.span_links": "[{\"trace_id\": \"6a17571e00000000530364ff00ab45bc\", \"span_id\": \"00838bb53c01b97a\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a17571e00000000\", \"flags\": 1}, {\"trace_id\": \"6a17571e00000000319f0c70e4310db0\", \"span_id\": \"9b59174e6dccfa4c\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a17571e00000000\", \"flags\": 1}, {\"trace_id\": \"6a17571e000000009d8abb1de5986885\", \"span_id\": \"6ff1ff2070b98f7d\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a17571e00000000\", \"flags\": 1}]",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.partitions.getmany_distributed_tracing": "0",
       "kafka.partitions.getmany_distributed_tracing_2": "0",
@@ -24,8 +26,8 @@
       "messaging.destination.name": "getmany_distributed_tracing_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "15235054833820270583",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "417609625933463960",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -33,10 +35,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 13445958,
-    "start": 1771924898709862958
+    "duration": 15909005,
+    "start": 1779914529782306829
   }],
 [
   {
@@ -51,9 +53,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9f00000000",
+      "_dd.p.tid": "6a17571e00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_distributed_tracing",
@@ -61,8 +65,8 @@
       "messaging.destination.name": "getmany_distributed_tracing",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "14096320603504469884",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "18028015561035247322",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -71,10 +75,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3503042,
-    "start": 1771924895660126554
+    "duration": 1688526,
+    "start": 1779914526760723794
   }],
 [
   {
@@ -89,9 +93,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9f00000000",
+      "_dd.p.tid": "6a17571e00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_distributed_tracing",
@@ -99,8 +105,8 @@
       "messaging.destination.name": "getmany_distributed_tracing",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "14096320603504469884",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "18028015561035247322",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -109,10 +115,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 1713417,
-    "start": 1771924895665811179
+    "duration": 1360229,
+    "start": 1779914526762840577
   }],
 [
   {
@@ -127,9 +133,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9f00000000",
+      "_dd.p.tid": "6a17571e00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_distributed_tracing_2",
@@ -137,8 +145,8 @@
       "messaging.destination.name": "getmany_distributed_tracing_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "17088217485376547206",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "6097283262106720861",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -147,8 +155,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 1639542,
-    "start": 1771924895667858346
+    "duration": 1390022,
+    "start": 1779914526764464060
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_single_message.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_single_message.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6dac00000000",
+      "_dd.p.tid": "6a17570e00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.partitions.getmany_single_message": "0",
       "kafka.received_message": "True",
@@ -22,8 +24,8 @@
       "messaging.destination.name": "getmany_single_message",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "11371839732645763575",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "13966335275364147180",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -31,10 +33,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3402917,
-    "start": 1771924908132139796
+    "duration": 11602687,
+    "start": 1779914510946785465
   }],
 [
   {
@@ -49,9 +51,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da900000000",
+      "_dd.p.tid": "6a17570b00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "getmany_single_message",
@@ -59,8 +63,8 @@
       "messaging.destination.name": "getmany_single_message",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "7426769034398744371",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "12452068901761094219",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -69,8 +73,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3541000,
-    "start": 1771924905111949628
+    "duration": 1363683,
+    "start": 1779914507929914375
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_commit_with_offset.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_commit_with_offset.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9600000000",
+      "_dd.p.tid": "6a17571800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
@@ -23,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_commit_with_offset",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "4966328156231369102",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "12508121382715048342",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -34,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 4697958,
-    "start": 1771924886135472133
+    "duration": 12320178,
+    "start": 1779914520330468519
   }],
 [
   {
@@ -52,9 +54,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9300000000",
+      "_dd.p.tid": "6a17571500000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "send_and_wait_commit_with_offset",
@@ -62,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_commit_with_offset",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "14472152689926797616",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "2664448950226066434",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -72,8 +76,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3715708,
-    "start": 1771924883112695507
+    "duration": 1660565,
+    "start": 1779914517312415460
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_failure.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_failure.json
@@ -11,12 +11,14 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6daf00000000",
+      "_dd.p.tid": "6a17570b00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
       "error.message": "[Error 10] MessageSizeTooLargeError: The message is 10485790 bytes when serialized which is larger than the maximum request size you have configured with the max_request_size configuration",
-      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/internal/aiokafka/patch.py\", line 96, in traced_send\n    result = await func(*args, **kwargs)\n  File \"/home/bits/project/.riot/venv_py31018_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_pytest-randomly_aiokafka~090/lib/python3.10/site-packages/aiokafka/producer/producer.py\", line 458, in send\n    key_bytes, value_bytes = self._serialize(topic, key, value)\n  File \"/home/bits/project/.riot/venv_py31018_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_pytest-randomly_aiokafka~090/lib/python3.10/site-packages/aiokafka/producer/producer.py\", line 367, in _serialize\n    raise MessageSizeTooLargeError(\naiokafka.errors.MessageSizeTooLargeError: [Error 10] MessageSizeTooLargeError: The message is 10485790 bytes when serialized which is larger than the maximum request size you have configured with the max_request_size configuration\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/home/bits/project/ddtrace/contrib/internal/aiokafka/patch.py\", line 143, in traced_send\n    result = await func(*args, **kwargs)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_pytest-randomly_aiokafka~090/lib/python3.9/site-packages/aiokafka/producer/producer.py\", line 458, in send\n    key_bytes, value_bytes = self._serialize(topic, key, value)\n  File \"/home/bits/project/.riot/venv_py3925_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_pytest-randomly_aiokafka~090/lib/python3.9/site-packages/aiokafka/producer/producer.py\", line 367, in _serialize\n    raise MessageSizeTooLargeError(\naiokafka.errors.MessageSizeTooLargeError: [Error 10] MessageSizeTooLargeError: The message is 10485790 bytes when serialized which is larger than the maximum request size you have configured with the max_request_size configuration\n",
       "error.type": "aiokafka.errors.MessageSizeTooLargeError",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "nonexistent_topic",
@@ -24,8 +26,8 @@
       "messaging.destination.name": "nonexistent_topic",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "12340253750658364713",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "7528740217719889565",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -34,8 +36,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 113633125,
-    "start": 1771924911308646256
+    "duration": 1544144,
+    "start": 1779914507846345542
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[None].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[None].json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da500000000",
+      "_dd.p.tid": "6a17570800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.received_message": "True",
       "kafka.tombstone": "False",
@@ -22,8 +24,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "597005817339765710",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "414625676373092143",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -33,10 +35,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 6946333,
-    "start": 1771924901844851460
+    "duration": 9912238,
+    "start": 1779914504518338356
   }],
 [
   {
@@ -51,9 +53,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da200000000",
+      "_dd.p.tid": "6a17570500000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "send_and_wait_key",
@@ -61,8 +65,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "17420446172232493439",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "508874501875563470",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -71,8 +75,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3427000,
-    "start": 1771924898818751083
+    "duration": 1652560,
+    "start": 1779914501496960385
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[test_key].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[test_key].json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6db200000000",
+      "_dd.p.tid": "6a17571e00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
@@ -23,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "18396602311830451076",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "3611963975549045488",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -34,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 7569834,
-    "start": 1771924914552303382
+    "duration": 8815178,
+    "start": 1779914526591643794
   }],
 [
   {
@@ -52,9 +54,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6daf00000000",
+      "_dd.p.tid": "6a17571b00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "send_and_wait_key",
@@ -62,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "7655882662271455509",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "109338628548191948",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -72,8 +76,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3711209,
-    "start": 1771924911521290339
+    "duration": 1606274,
+    "start": 1779914523573724554
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[None].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[None].json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da900000000",
+      "_dd.p.tid": "6a17570500000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
@@ -23,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "8296255993999953152",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "1720210457940791299",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -34,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 7726875,
-    "start": 1771924905021974753
+    "duration": 11423165,
+    "start": 1779914501382811113
   }],
 [
   {
@@ -52,9 +54,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da500000000",
+      "_dd.p.tid": "6a17570200000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "True",
       "kafka.topic": "send_and_wait_value",
@@ -62,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "6704289409960080034",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "328336203928896981",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -72,8 +76,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3621208,
-    "start": 1771924901995366460
+    "duration": 1667850,
+    "start": 1779914498359520471
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[hueh_hueh_hueh].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[hueh_hueh_hueh].json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6daf00000000",
+      "_dd.p.tid": "6a17571500000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
@@ -23,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "4854921899776666866",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "7303485111255764107",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -34,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 6997208,
-    "start": 1771924911265996881
+    "duration": 11085529,
+    "start": 1779914517198621215
   }],
 [
   {
@@ -52,9 +54,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6dac00000000",
+      "_dd.p.tid": "6a17571200000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "send_and_wait_value",
@@ -62,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "9308188236601385926",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "8689125156372693595",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -72,8 +76,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 4239166,
-    "start": 1771924908235623838
+    "duration": 1619396,
+    "start": 1779914514167226873
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_with_distributed_tracing.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_with_distributed_tracing.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9600000000",
+      "_dd.p.tid": "6a17571800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "send_and_wait_with_distributed_tracing",
@@ -21,8 +23,8 @@
       "messaging.destination.name": "send_and_wait_with_distributed_tracing",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "12322533369065483523",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "4494730242458558469",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -31,10 +33,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 5714084,
-    "start": 1771924886205423841
+    "duration": 2406910,
+    "start": 1779914520436754928
   },
      {
        "name": "kafka.consume",
@@ -48,9 +50,11 @@
        "meta": {
          "_dd.base_service": "tests.contrib.aiokafka",
          "_dd.p.dm": "-0",
-         "_dd.p.tid": "699d6d9600000000",
+         "_dd.p.tid": "6a17571800000000",
          "_dd.svc_src": "aiokafka",
+         "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
          "component": "aiokafka",
+         "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
          "kafka.group_id": "test_group",
          "kafka.message_key": "test_key",
          "kafka.received_message": "True",
@@ -60,10 +64,10 @@
          "messaging.destination.name": "send_and_wait_with_distributed_tracing",
          "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
          "messaging.system": "kafka",
-         "pathway.hash": "11192878731509695251",
-         "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+         "pathway.hash": "8253026967498850374",
+         "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
          "span.kind": "consumer",
-         "tracestate": "dd=p:59a8bc7396fc48b2;s:1;t.dm:-0;t.tid:699d6d9600000000"
+         "tracestate": "dd=p:7cdc9dd8e0b15ff3;s:1;t.dm:-0;t.tid:6a17571800000000"
        },
        "metrics": {
          "_dd.measured": 1.0,
@@ -72,8 +76,8 @@
          "_sampling_priority_v1": 1.0,
          "kafka.message_offset": -1.0,
          "kafka.partition": -1.0,
-         "process_id": 40033.0
+         "process_id": 557.0
        },
-       "duration": 10248292,
-       "start": 1771924889234504551
+       "duration": 10317071,
+       "start": 1779914523458213324
      }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_commit.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_commit.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9c00000000",
+      "_dd.p.tid": "6a17571200000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
@@ -23,8 +25,8 @@
       "messaging.destination.name": "send_commit",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "7256095497002109613",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "11254982689108233361",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -34,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 8632042,
-    "start": 1771924892362769511
+    "duration": 5259987,
+    "start": 1779914514074805185
   }],
 [
   {
@@ -52,9 +54,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d9900000000",
+      "_dd.p.tid": "6a17570f00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "send_commit",
@@ -62,8 +66,8 @@
       "messaging.destination.name": "send_commit",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "7336897876728919401",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "10306749123033560219",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -72,8 +76,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 10517333,
-    "start": 1771924889325380760
+    "duration": 1781481,
+    "start": 1779914511057955537
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_multiple_servers.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_multiple_servers.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6da500000000",
+      "_dd.p.tid": "6a17570800000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
       "kafka.tombstone": "False",
       "kafka.topic": "send_multiple_servers",
@@ -21,8 +23,8 @@
       "messaging.destination.name": "send_multiple_servers",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "8622753506491558682",
-      "runtime-id": "f649d700c1784c9d8deb91e3c20fa07e",
+      "pathway.hash": "9346863313248657932",
+      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
       "span.kind": "producer"
     },
     "metrics": {
@@ -31,8 +33,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40033.0
+      "process_id": 557.0
     },
-    "duration": 3309458,
-    "start": 1771924901930948835
+    "duration": 1795270,
+    "start": 1779914504626966717
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka_dsm.test_data_streams_aiokafka_enabled.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka_dsm.test_data_streams_aiokafka_enabled.json
@@ -11,9 +11,11 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d8f00000000",
+      "_dd.p.tid": "6a17573b00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpibma4voa,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
       "kafka.tombstone": "False",
       "kafka.topic": "test_data_streams_aiokafka_enabled",
@@ -21,8 +23,8 @@
       "messaging.destination.name": "test_data_streams_aiokafka_enabled",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "15940366017932999317",
-      "runtime-id": "cb7ceb5215b049fcbb02584551f2bbd9",
+      "pathway.hash": "8642095245803236792",
+      "runtime-id": "5b20a5981ce341ebb61cb591dd7167a1",
       "span.kind": "producer"
     },
     "metrics": {
@@ -31,10 +33,10 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40174.0
+      "process_id": 613.0
     },
-    "duration": 16392250,
-    "start": 1771924879266062088
+    "duration": 3917622,
+    "start": 1779914555201332602
   }],
 [
   {
@@ -49,9 +51,11 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "699d6d8f00000000",
+      "_dd.p.tid": "6a17573b00000000",
       "_dd.svc_src": "aiokafka",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpibma4voa,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiokafka",
+      "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
       "kafka.received_message": "True",
       "kafka.tombstone": "False",
@@ -60,8 +64,8 @@
       "messaging.destination.name": "test_data_streams_aiokafka_enabled",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "3652005990883303490",
-      "runtime-id": "cb7ceb5215b049fcbb02584551f2bbd9",
+      "pathway.hash": "1465279382551306564",
+      "runtime-id": "5b20a5981ce341ebb61cb591dd7167a1",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -69,10 +73,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.message_offset": -1.0,
+      "kafka.message_offset": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 40174.0
+      "process_id": 613.0
     },
-    "duration": 4898125,
-    "start": 1771924879789737047
+    "duration": 6631969,
+    "start": 1779914555709621844
   }]]


### PR DESCRIPTION
## Summary
- The `aiokafka` integration was missing `kafka_cluster_id` collection while `confluent_kafka` already collects it. As a result, DSM edges and produce/commit tracking from aiokafka producers/consumers were missing the `kafka_cluster_id` tag, breaking cluster-level aggregation in Data Streams Monitoring.
- Added an async `_get_cluster_id` helper that sends a `MetadataRequest_v5` to a connected broker and caches the result on the `AIOKafkaClient` (success + 5 min failure cache, mirroring the confluent_kafka helper).
- Set the id as the `kafka.cluster_id` span tag and propagate it to the DSM hooks via `core.set_item("kafka_cluster_id", ...)`, so consume/produce edge tags and `track_kafka_produce` / `track_kafka_commit` calls include it.

## Test plan
- [x] Locally verified end-to-end with the DSM kafka-demo docker-compose, swapping the producer/consumer for `aiokafka` apps against `confluentinc/cp-kafka:7.5.0`. `_get_cluster_id(p.client, "demo-orders")` returned the broker's `CLUSTER_ID` (`Mka3OEVBNTcwNTJENDM2Qg`), and the Datadog agent successfully forwarded traces and data_streams_messages to `datad0g.com`.
- [ ] CI: existing aiokafka + DSM test suites should still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)