### PR TITLE
feat(llmobs): expose summary error source metadata

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -210,6 +210,10 @@ class SummaryEvaluatorContext:
     :param evaluation_results: Dictionary mapping evaluator names to their results (read-only).
     :param metadata: list of metadata for each dataset record, each combined with experiment configuration (read-only).
                      Each element contains the record's metadata merged with {"experiment_config": ...}.
+    :param task_errors: list of task error objects for each record (read-only).
+                        Each element contains `message`, `type`, and `stack` fields from the task row.
+    :param evaluation_details: Dictionary mapping evaluator names to per-record detail payloads (read-only).
+                               Each payload contains `value`, `error`, `status`, and `source`.
     """
 
     inputs: list[JSONType]
@@ -217,6 +221,8 @@ class SummaryEvaluatorContext:
     expected_outputs: list[JSONType]
     evaluation_results: dict[str, list[JSONType]]
     metadata: list[dict[str, Any]] = field(default_factory=list)
+    task_errors: list[dict[str, Optional[str]]] = field(default_factory=list)
+    evaluation_details: dict[str, list[dict[str, JSONType]]] = field(default_factory=dict)
 
 
 class BaseEvaluator(ABC):
@@ -1995,12 +2001,16 @@ class Experiment:
         list[JSONType],
         list[dict[str, Any]],
         dict[str, list[JSONType]],
+        list[dict[str, Optional[str]]],
+        dict[str, list[dict[str, JSONType]]],
     ]:
         inputs: list[JSONType] = []
         outputs: list[JSONType] = []
         expected_outputs: list[JSONType] = []
         metadata_list: list[dict[str, Any]] = []
         eval_results_by_name: dict[str, list[JSONType]] = {}
+        task_errors: list[dict[str, Optional[str]]] = []
+        eval_details_by_name: dict[str, list[dict[str, JSONType]]] = {}
 
         for idx, task_result in enumerate(task_results):
             outputs.append(task_result["output"])
@@ -2009,14 +2019,42 @@ class Experiment:
             expected_outputs.append(record["expected_output"])
             record_metadata = record.get("metadata") or {}
             metadata_list.append({**record_metadata, "experiment_config": self._config})
+            task_errors.append(task_result.get("error") or {})
 
             eval_result_at_idx_by_name = eval_results[idx]["evaluations"]
             for name, eval_value in eval_result_at_idx_by_name.items():
                 if name not in eval_results_by_name:
                     eval_results_by_name[name] = []
                 eval_results_by_name[name].append(eval_value.get("value"))
+                if name not in eval_details_by_name:
+                    eval_details_by_name[name] = []
+                eval_error = eval_value.get("error")
+                eval_status = eval_value.get("status")
+                if isinstance(eval_status, str):
+                    status = eval_status
+                elif eval_error:
+                    status = "ERROR"
+                else:
+                    status = "OK"
+                source = "datadog_managed_evaluator" if name in self._remote_evaluator_names else "customer_evaluator"
+                eval_details_by_name[name].append(
+                    {
+                        "value": eval_value.get("value"),
+                        "error": eval_error,
+                        "status": status,
+                        "source": source,
+                    }
+                )
 
-        return inputs, outputs, expected_outputs, metadata_list, eval_results_by_name
+        return (
+            inputs,
+            outputs,
+            expected_outputs,
+            metadata_list,
+            eval_results_by_name,
+            task_errors,
+            eval_details_by_name,
+        )
 
     def _update_status(self, status: str, error: Optional[str] = None) -> None:
         if not self._llmobs_instance or not self._id:
@@ -2398,7 +2436,11 @@ class Experiment:
                             eval_result = await evaluator.evaluate(context)
                         elif asyncio.iscoroutinefunction(evaluator):
                             evaluator_name = evaluator.__name__  # type: ignore[union-attr]
-                            eval_result = await evaluator(input_data, output_data, expected_output)  # type: ignore[misc, operator]
+                            eval_result = await evaluator(  # type: ignore[misc, operator]
+                                input_data,
+                                output_data,
+                                expected_output,
+                            )
                         elif _is_class_evaluator(evaluator):
                             evaluator_name = evaluator.name  # type: ignore[union-attr]
                             combined_metadata = {
@@ -2589,9 +2631,31 @@ class Experiment:
             expected_outputs,
             metadata_list,
             eval_results_by_name,
+            task_errors,
+            eval_details_by_name,
         ) = self._prepare_summary_evaluator_data(task_results, eval_results)
         asyncio = get_asyncio()
         semaphore = asyncio.Semaphore(jobs)
+        summary_context = SummaryEvaluatorContext(
+            inputs=inputs,
+            outputs=outputs,
+            expected_outputs=expected_outputs,
+            evaluation_results=eval_results_by_name,
+            metadata=metadata_list,
+            task_errors=task_errors,
+            evaluation_details=eval_details_by_name,
+        )
+
+        def _build_optional_summary_evaluator_kwargs(signature: inspect.Signature) -> dict[str, Any]:
+            params = signature.parameters
+            supports_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+            extra_kwargs = {}
+            # AIDEV-NOTE: keep these kwargs opt-in so existing 4-arg summary evaluators stay backward-compatible.
+            if supports_kwargs or "task_errors" in params:
+                extra_kwargs["task_errors"] = task_errors
+            if supports_kwargs or "evaluation_details" in params:
+                extra_kwargs["evaluation_details"] = eval_details_by_name
+            return extra_kwargs
 
         async def _evaluate_summary_single(
             summary_evaluator: Any,
@@ -2604,59 +2668,38 @@ class Experiment:
                 try:
                     if isinstance(summary_evaluator, BaseAsyncSummaryEvaluator):
                         evaluator_name = summary_evaluator.name
-                        context = SummaryEvaluatorContext(
-                            inputs=inputs,
-                            outputs=outputs,
-                            expected_outputs=expected_outputs,
-                            evaluation_results=eval_results_by_name,
-                            metadata=metadata_list,
-                        )
-                        eval_result = await summary_evaluator.evaluate(context)
+                        eval_result = await summary_evaluator.evaluate(summary_context)
                     elif asyncio.iscoroutinefunction(summary_evaluator):
                         evaluator_name = summary_evaluator.__name__
                         signature = inspect.signature(summary_evaluator)
                         if len(signature.parameters) == 1:
-                            context = SummaryEvaluatorContext(
-                                inputs=inputs,
-                                outputs=outputs,
-                                expected_outputs=expected_outputs,
-                                evaluation_results=eval_results_by_name,
-                                metadata=metadata_list,
-                            )
-                            eval_result = await summary_evaluator(context)
+                            eval_result = await summary_evaluator(summary_context)
                         else:
+                            extra_kwargs = _build_optional_summary_evaluator_kwargs(signature)
                             eval_result = await summary_evaluator(
-                                inputs, outputs, expected_outputs, eval_results_by_name
+                                inputs,
+                                outputs,
+                                expected_outputs,
+                                eval_results_by_name,
+                                **extra_kwargs,
                             )
                     elif _is_class_summary_evaluator(summary_evaluator):
                         evaluator_name = summary_evaluator.name
-                        context = SummaryEvaluatorContext(
-                            inputs=inputs,
-                            outputs=outputs,
-                            expected_outputs=expected_outputs,
-                            evaluation_results=eval_results_by_name,
-                            metadata=metadata_list,
-                        )
-                        eval_result = await asyncio.to_thread(summary_evaluator.evaluate, context)
+                        eval_result = await asyncio.to_thread(summary_evaluator.evaluate, summary_context)
                     else:
                         evaluator_name = summary_evaluator.__name__
                         signature = inspect.signature(summary_evaluator)
                         if len(signature.parameters) == 1:
-                            context = SummaryEvaluatorContext(
-                                inputs=inputs,
-                                outputs=outputs,
-                                expected_outputs=expected_outputs,
-                                evaluation_results=eval_results_by_name,
-                                metadata=metadata_list,
-                            )
-                            eval_result = summary_evaluator(context)
+                            eval_result = summary_evaluator(summary_context)
                         else:
+                            extra_kwargs = _build_optional_summary_evaluator_kwargs(signature)
                             eval_result = await asyncio.to_thread(
                                 summary_evaluator,
                                 inputs,
                                 outputs,
                                 expected_outputs,
                                 eval_results_by_name,
+                                **extra_kwargs,
                             )
                     eval_result_value = eval_result
                 except Exception as e:

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -2651,9 +2651,15 @@ class Experiment:
             supports_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
             extra_kwargs = {}
             # AIDEV-NOTE: keep these kwargs opt-in so existing 4-arg summary evaluators stay backward-compatible.
-            if supports_kwargs or "task_errors" in params:
+            # Skip positional-only params — they cannot be passed by keyword.
+            if supports_kwargs or (
+                "task_errors" in params and params["task_errors"].kind != inspect.Parameter.POSITIONAL_ONLY
+            ):
                 extra_kwargs["task_errors"] = task_errors
-            if supports_kwargs or "evaluation_details" in params:
+            if supports_kwargs or (
+                "evaluation_details" in params
+                and params["evaluation_details"].kind != inspect.Parameter.POSITIONAL_ONLY
+            ):
                 extra_kwargs["evaluation_details"] = eval_details_by_name
             return extra_kwargs
 

--- a/releasenotes/notes/llmobs-summary-evaluator-error-source-6f1a2c9b4d8e7a13.yaml
+++ b/releasenotes/notes/llmobs-summary-evaluator-error-source-6f1a2c9b4d8e7a13.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    LLM Observability: Summary evaluators can now distinguish row-level task
+    failures from evaluator failures and identify whether evaluator errors come
+    from customer-defined evaluators or Datadog-managed evaluators. The summary
+    evaluation context now includes ``task_errors`` and ``evaluation_details``
+    metadata for richer error handling in multi-run experiment summaries.

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -4825,8 +4825,112 @@ def test_prepare_summary_evaluator_data_handles_none_metadata():
         }
     ]
     eval_results = [{"idx": 0, "evaluations": {"dummy_evaluator": {"value": True, "error": None}}}]
-    _, _, _, metadata_list, _ = exp._prepare_summary_evaluator_data(task_results, eval_results)
+    _, _, _, metadata_list, _, task_errors, eval_details = exp._prepare_summary_evaluator_data(
+        task_results, eval_results
+    )
     assert metadata_list == [{"experiment_config": {}}]
+    assert task_errors == [{"message": None, "type": None, "stack": None}]
+    assert eval_details["dummy_evaluator"] == [
+        {
+            "value": True,
+            "error": None,
+            "status": "OK",
+            "source": "customer_evaluator",
+        }
+    ]
+
+
+def test_prepare_summary_evaluator_data_includes_remote_error_details():
+    dataset = _make_dataset_with_records(
+        [
+            {"input_data": {"prompt": "hi"}, "expected_output": "hello", "metadata": {}},
+        ]
+    )
+    exp = Experiment(
+        name="test",
+        task=dummy_task,
+        dataset=dataset,
+        evaluators=[dummy_evaluator],
+        project_name="test-project",
+        summary_evaluators=[dummy_summary_evaluator],
+    )
+    exp._remote_evaluator_names = {"remote_eval"}
+
+    task_results = [
+        {
+            "idx": 0,
+            "span_id": "1",
+            "trace_id": "1",
+            "timestamp": 0,
+            "output": "hello",
+            "metadata": {},
+            "error": {"message": "task failed", "type": "ValueError", "stack": "trace"},
+        }
+    ]
+    eval_results = [
+        {
+            "idx": 0,
+            "evaluations": {
+                "remote_eval": {
+                    "value": None,
+                    "error": {
+                        "type": "RATE_LIMIT_EXCEEDED",
+                        "message": "Rate limit exceeded for OpenAI API",
+                        "recommended_resolution": "Wait before retrying",
+                    },
+                    "status": "WARN",
+                }
+            },
+        }
+    ]
+
+    _, _, _, _, _, task_errors, eval_details = exp._prepare_summary_evaluator_data(task_results, eval_results)
+    assert task_errors == [{"message": "task failed", "type": "ValueError", "stack": "trace"}]
+    assert eval_details["remote_eval"] == [
+        {
+            "value": None,
+            "error": {
+                "type": "RATE_LIMIT_EXCEEDED",
+                "message": "Rate limit exceeded for OpenAI API",
+                "recommended_resolution": "Wait before retrying",
+            },
+            "status": "WARN",
+            "source": "datadog_managed_evaluator",
+        }
+    ]
+
+
+def test_summary_evaluator_receives_optional_error_details(llmobs, test_dataset_one_record):
+    captured = {}
+
+    def summary_with_optional_details(
+        inputs,
+        outputs,
+        expected_outputs,
+        evaluators_results,
+        task_errors,
+        evaluation_details,
+    ):
+        captured["task_errors"] = task_errors
+        captured["evaluation_details"] = evaluation_details
+        return len(inputs)
+
+    exp = llmobs.experiment(
+        "test_experiment",
+        faulty_task,
+        test_dataset_one_record,
+        [dummy_evaluator],
+        summary_evaluators=[summary_with_optional_details],
+    )
+
+    task_results = asyncio.run(exp._experiment._run_task(1, run=run_info_with_stable_id(0), raise_errors=False))
+    eval_results = asyncio.run(exp._experiment._run_evaluators(task_results, raise_errors=False))
+    summary_eval_results = asyncio.run(exp._experiment._run_summary_evaluators(task_results, eval_results))
+
+    assert summary_eval_results[0]["evaluations"]["summary_with_optional_details"]["value"] == 1
+    assert captured["task_errors"][0]["message"] == "This is a test error"
+    assert captured["evaluation_details"]["dummy_evaluator"][0]["status"] == "OK"
+    assert captured["evaluation_details"]["dummy_evaluator"][0]["source"] == "customer_evaluator"
 
 
 @pytest.mark.parametrize(

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -2399,6 +2399,109 @@ def test_summary_evaluators_with_errors_concurrent(llmobs, test_dataset_one_reco
     assert summary_evals_dict["successful_summary_evaluator"]["error"] is None
 
 
+def test_summary_evaluator_receives_task_errors_when_declared(llmobs, test_dataset_one_record):
+    """Summary evaluator with task_errors param receives it; 4-arg evaluator does not."""
+    received = {}
+
+    def eval_with_task_errors(inputs, outputs, expected_outputs, evaluators_results, task_errors):
+        received["task_errors"] = task_errors
+        return 1
+
+    def eval_without_task_errors(inputs, outputs, expected_outputs, evaluators_results):
+        received["no_extra_kwargs"] = True
+        return 2
+
+    def simple_evaluator(input_data, output_data, expected_output):
+        return 1
+
+    exp = llmobs.experiment(
+        "test_experiment",
+        dummy_task,
+        test_dataset_one_record,
+        [simple_evaluator],
+        summary_evaluators=[eval_with_task_errors, eval_without_task_errors],
+    )
+    task_results = asyncio.run(exp._experiment._run_task(1, run=run_info_with_stable_id(0), raise_errors=False))
+    eval_results = asyncio.run(exp._experiment._run_evaluators(task_results, raise_errors=False))
+    summary_eval_results = asyncio.run(
+        exp._experiment._run_summary_evaluators(task_results, eval_results, raise_errors=False)
+    )
+
+    assert "task_errors" in received
+    assert isinstance(received["task_errors"], list)
+    assert "no_extra_kwargs" in received
+
+    summary_evals_dict = {}
+    for r in summary_eval_results:
+        summary_evals_dict.update(r["evaluations"])
+    assert summary_evals_dict["eval_with_task_errors"]["error"] is None
+    assert summary_evals_dict["eval_without_task_errors"]["error"] is None
+
+
+def test_summary_evaluator_receives_evaluation_details_when_declared(llmobs, test_dataset_one_record):
+    """Summary evaluator with evaluation_details param receives it."""
+    received = {}
+
+    def eval_with_details(inputs, outputs, expected_outputs, evaluators_results, evaluation_details):
+        received["evaluation_details"] = evaluation_details
+        return 1
+
+    def simple_evaluator(input_data, output_data, expected_output):
+        return 1
+
+    exp = llmobs.experiment(
+        "test_experiment",
+        dummy_task,
+        test_dataset_one_record,
+        [simple_evaluator],
+        summary_evaluators=[eval_with_details],
+    )
+    task_results = asyncio.run(exp._experiment._run_task(1, run=run_info_with_stable_id(0), raise_errors=False))
+    eval_results = asyncio.run(exp._experiment._run_evaluators(task_results, raise_errors=False))
+    asyncio.run(exp._experiment._run_summary_evaluators(task_results, eval_results, raise_errors=False))
+
+    assert "evaluation_details" in received
+    assert isinstance(received["evaluation_details"], dict)
+
+
+def test_summary_evaluator_positional_only_params_not_injected(llmobs, test_dataset_one_record):
+    """task_errors/evaluation_details declared positional-only must not be injected as kwargs."""
+    received = {}
+
+    # Use exec to create a function with positional-only syntax (Python 3.8+)
+    ns = {}
+    exec(
+        "def eval_pos_only(inputs, outputs, expected_outputs, evaluators_results, task_errors, /):\n"
+        "    received['called'] = True\n"
+        "    return 99\n",
+        {"received": received},
+        ns,
+    )
+    eval_pos_only = ns["eval_pos_only"]
+
+    def simple_evaluator(input_data, output_data, expected_output):
+        return 1
+
+    exp = llmobs.experiment(
+        "test_experiment",
+        dummy_task,
+        test_dataset_one_record,
+        [simple_evaluator],
+        summary_evaluators=[eval_pos_only],
+    )
+    task_results = asyncio.run(exp._experiment._run_task(1, run=run_info_with_stable_id(0), raise_errors=False))
+    eval_results = asyncio.run(exp._experiment._run_evaluators(task_results, raise_errors=False))
+    # Should not raise TypeError (positional-only param not injected as kwarg)
+    summary_eval_results = asyncio.run(
+        exp._experiment._run_summary_evaluators(task_results, eval_results, raise_errors=True)
+    )
+
+    summary_evals_dict = {}
+    for r in summary_eval_results:
+        summary_evals_dict.update(r["evaluations"])
+    assert summary_evals_dict["eval_pos_only"]["error"] is None
+
+
 def test_experiment_with_remote_evaluator(llmobs, test_dataset_one_record):
     """Test that RemoteEvaluator integrates with experiment framework."""
     mock_response = {


### PR DESCRIPTION
## Description

LLM Observability experiment summaries now preserve enough per-row error context to distinguish:
- task failures from evaluator failures
- customer evaluator failures from Datadog-managed evaluator failures

This change adds `task_errors` and `evaluation_details` to `SummaryEvaluatorContext` and keeps backward compatibility for existing summary evaluators:
- 1-arg context evaluators continue to work
- 4-arg function evaluators continue to work
- optional `task_errors` / `evaluation_details` kwargs are injected only when supported

## Testing

- `scripts/lint pre-commit-python ddtrace/llmobs/_experiment.py tests/llmobs/test_experiments.py`
- `scripts/run-tests --venv f6f0f28 tests/llmobs/test_experiments.py -- -- -k "prepare_summary_evaluator_data or summary_evaluator_receives_optional_error_details"`

## Risks

Low. The change is additive and keeps existing summary evaluator call patterns intact.

## Additional Notes

- Added release note: `releasenotes/notes/llmobs-summary-evaluator-error-source-6f1a2c9b4d8e7a13.yaml`
