### PR TITLE
chore(celery): use polling instead of sleep in celery tests

### DIFF
--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -72,10 +72,6 @@ def test_redis_task(traced_redis_celery_app, tracer):
     ):
         t = multiply.delay(4, 4)
         assert t.get(timeout=2) == 16
-
-        # wait for spans to be received
-        time.sleep(3)
-
         assert_traces(tracer, "multiply", t, 6379)
 
 
@@ -89,15 +85,24 @@ def test_amqp_task(instrument_celery, traced_amqp_celery_app, tracer):
     ):
         t = add.delay(4, 4)
         assert t.get(timeout=30) == 8
-
-        # wait for spans to be received
-        time.sleep(3)
-
         assert_traces(tracer, "add", t, 5672)
 
 
+def _wait_for_traces(tracer, expected_traces, timeout=10.0, interval=0.1):
+    container = TracerSpanContainer(tracer)
+    deadline = time.monotonic() + timeout
+    traces = []
+    while time.monotonic() < deadline:
+        traces.extend(container.pop_traces())
+        if len(traces) >= expected_traces:
+            break
+        time.sleep(interval)
+    traces.extend(container.pop_traces())
+    return traces
+
+
 def assert_traces(tracer, task_name, task, port):
-    traces = TracerSpanContainer(tracer).pop_traces()
+    traces = _wait_for_traces(tracer, expected_traces=2)
 
     assert 2 == len(traces)
     assert 1 == len(traces[0])
@@ -158,10 +163,4 @@ def test_list_broker_urls(list_broker_celery_app, tracer):
     ):
         t = list_broker_celery_app.tasks["tests.contrib.celery.test_tagging.subtract"].delay(10, 3)
         assert t.get(timeout=2) == 7
-
-        # Allow time for the publish span to be recorded
-        time.sleep(3)
-
-        # assert_traces is assumed to be a helper function that checks that the
-        # span has the expected values (e.g. target port is 6379 for BROKER_URL)
         assert_traces(tracer, "subtract", t, 6379)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cf8c67eb-a936-4cfa-8e9b-9a1d63ad2efb","source":"chat","resourceId":"3ffc6a95-316c-498b-acb0-a8d8d2579d17","workflowId":"586fd7e0-ac47-4fe1-9468-a4020a24f184","codeChangeId":"586fd7e0-ac47-4fe1-9468-a4020a24f184","sourceType":"test-optimization"} -->
## Description

Fixing `test_amqp_task[py3.13]` • [View in Test Optimization](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdd-trace-py%22+%40test.name%3A%22test_amqp_task%5Bpy3.13%5D%22&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%229711ccbf06ee552%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D) • **Questions?** Ask in #code-gen-flaky-tests

The `test_amqp_task[py3.13]` test was failing intermittently because it relied on hard-coded `time.sleep(3)` calls to wait for spans to be recorded. This approach is inherently flaky as the actual time needed for spans to arrive can vary depending on system load and timing conditions.

The fix replaces all hard-coded sleep calls with a polling mechanism that actively waits for the expected number of traces to be available. A new `_wait_for_traces()` helper function polls the tracer with a configurable timeout and interval, ensuring we proceed as soon as spans are available rather than waiting a fixed duration.

Fixes flaky test: DD_1YA8KZ

## Testing

The changes update three test functions:
- `test_redis_task`: Removed 3-second sleep before assertion
- `test_amqp_task`: Removed 3-second sleep before assertion  
- `test_list_broker_urls`: Removed 3-second sleep before assertion

All tests now use the polling mechanism in `assert_traces()`, which waits up to 10 seconds (with 0.1-second intervals) for the expected traces to arrive, then immediately proceeds.

## Risks

Low risk. The polling approach is more robust than hard-coded sleeps and maintains backward compatibility with existing test assertions. The default timeout (10 seconds) is conservative and should handle any legitimate delays.

## Additional Notes

This addresses a 0.2% flake rate affecting CI. The polling mechanism is a standard pattern for handling timing-sensitive assertions in async/distributed systems testing.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3ffc6a95-316c-498b-acb0-a8d8d2579d17)

Comment @datadog to request changes