### PR TITLE
fix(symbol_db): skip empty payload uploads

### DIFF
--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -555,6 +555,13 @@ class ScopeContext:
             }
 
     def upload(self) -> None:
+        with self._scopes_lock:
+            if not self._scopes:
+                return
+            payload = self.to_json()
+            n = len(self._scopes)
+            self._scopes.clear()
+
         body, headers = multipart(
             parts=[
                 FormData(
@@ -571,11 +578,6 @@ class ScopeContext:
                 ),
             ]
         )
-
-        with self._scopes_lock:
-            payload = self.to_json()
-            n = len(self._scopes)
-            self._scopes.clear()
 
         # DEV: The as_bytes method ends up writing the data line by line, which
         # breaks the final payload. We add a placeholder instead and manually

--- a/releasenotes/notes/fix-symdb-skip-empty-uploads-5b74859b81cecc62.yaml
+++ b/releasenotes/notes/fix-symdb-skip-empty-uploads-5b74859b81cecc62.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixes an issue where the Symbol Database uploader
+    sends empty payloads on a recurring timer.

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import tempfile
 from types import ModuleType
 import typing as t
+from unittest import mock
 
 import pytest
 
 from ddtrace.internal.symbol_db.symbols import Scope
+from ddtrace.internal.symbol_db.symbols import ScopeContext
 from ddtrace.internal.symbol_db.symbols import ScopeData
 from ddtrace.internal.symbol_db.symbols import ScopeType
 from ddtrace.internal.symbol_db.symbols import Symbol
@@ -285,6 +287,16 @@ def test_benchmark_module_get_from(benchmark, file_size, num_attributes):
 )
 def test_symbols_injectible_line_ranges(lines, expected):
     assert _line_ranges(lines) == expected
+
+
+def test_scope_context_upload_skips_empty_batch():
+    """Empty scope batches must not produce a SymDB upload request."""
+    context = ScopeContext()
+
+    with mock.patch("ddtrace.internal.symbol_db.symbols.connector") as mock_connector:
+        context.upload()
+
+    mock_connector.assert_not_called()
 
 
 @pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_SYMBOL_DATABASE_UPLOAD_ENABLED="1"))


### PR DESCRIPTION
## Description

Symbol DB uploads were firing on a recurring 1-second timer regardless of whether any new module scopes had been accumulated. On affected services this generated millions of empty-payload POSTs to `/symdb/v1/input` (>30% of all Symbol DB attachments in staging during the investigation window).

This change adds an early return in `ScopeContext.upload()` when `_scopes` is empty, before any multipart body, JSON serialization, or HTTP work is performed.

Investigation: [DEBUG-5712](https://datadoghq.atlassian.net/browse/DEBUG-5712). 

## Testing

- Added `test_scope_context_upload_skips_empty_batch` which patches `connector` and asserts it is not invoked when `_scopes` is empty.
- The existing `test_symbols_force_upload` / `test_symbols_timeout_upload` continue to cover the populated-batch path.

## Risks

Low. The fix is a single early return inside an existing lock-protected block; behavior is unchanged when scopes are present.

## Additional Notes

None.