### PR TITLE
feat(llmobs): capture Bedrock Converse reasoningContent blocks

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -281,6 +281,8 @@ class BedrockIntegration(BaseLLMIntegration):
 
         text_content_blocks: dict[int, str] = {}
         tool_content_blocks: dict[int, dict[str, Any]] = {}
+        reasoning_content_blocks: dict[int, str] = {}
+        redacted_reasoning_indices: set[int] = set()
 
         current_message: Optional[dict[str, Any]] = None
 
@@ -339,9 +341,25 @@ class BedrockIntegration(BaseLLMIntegration):
                             tool_content_blocks[index].get("input", "") + delta_content["toolUse"]["input"]
                         )
 
+                    reasoning_delta = delta_content.get("reasoningContent")
+                    if isinstance(reasoning_delta, dict):
+                        # ReasoningContentBlockDelta is a union of text/signature/redactedContent.
+                        # We only surface text; signature is opaque and redacted bytes are unreadable.
+                        if isinstance(reasoning_delta.get("text"), str):
+                            reasoning_content_blocks[index] = (
+                                reasoning_content_blocks.get(index, "") + reasoning_delta["text"]
+                            )
+                        elif "redactedContent" in reasoning_delta:
+                            redacted_reasoning_indices.add(index)
+
             if "messageStop" in chunk:
-                messages.append(
-                    get_final_message_converse_stream_message(current_message, text_content_blocks, tool_content_blocks)
+                for idx in redacted_reasoning_indices:
+                    if idx not in reasoning_content_blocks:
+                        reasoning_content_blocks[idx] = "[REDACTED REASONING]"
+                messages.extend(
+                    get_final_message_converse_stream_message(
+                        current_message, text_content_blocks, tool_content_blocks, reasoning_content_blocks
+                    )
                 )
                 current_message = None
 
@@ -349,8 +367,13 @@ class BedrockIntegration(BaseLLMIntegration):
 
         # Handle the case where we didn't receive an explicit message stop event
         if current_message is not None and current_message.get("content_block_indicies"):
-            messages.append(
-                get_final_message_converse_stream_message(current_message, text_content_blocks, tool_content_blocks)
+            for idx in redacted_reasoning_indices:
+                if idx not in reasoning_content_blocks:
+                    reasoning_content_blocks[idx] = "[REDACTED REASONING]"
+            messages.extend(
+                get_final_message_converse_stream_message(
+                    current_message, text_content_blocks, tool_content_blocks, reasoning_content_blocks
+                )
             )
 
         if not messages:

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -236,12 +236,20 @@ def get_messages_from_converse_content(role: str, content: list[dict[str, Any]])
         return []
     messages: list[Message] = []
     content_blocks = []
+    reasoning_blocks: list[str] = []
     tool_calls_info = []
     tool_messages: list[Message] = []
     unsupported_content_messages: list[Message] = []
     for content_block in content:
         if content_block.get("text") and isinstance(content_block.get("text"), str):
             content_blocks.append(content_block.get("text", ""))
+        elif isinstance(content_block.get("reasoningContent"), dict):
+            reasoning_content = content_block["reasoningContent"]
+            reasoning_text = reasoning_content.get("reasoningText")
+            if isinstance(reasoning_text, dict) and isinstance(reasoning_text.get("text"), str):
+                reasoning_blocks.append(reasoning_text["text"])
+            elif "redactedContent" in reasoning_content:
+                reasoning_blocks.append("[REDACTED REASONING]")
         elif content_block.get("toolUse") and isinstance(content_block.get("toolUse"), dict):
             toolUse = content_block.get("toolUse", {})
             tool_call_info = ToolCall(
@@ -285,6 +293,8 @@ def get_messages_from_converse_content(role: str, content: list[dict[str, Any]])
             unsupported_content_messages.append(
                 Message(content="[Unsupported content type: {}]".format(content_type), role=role)
             )
+    if reasoning_blocks:
+        messages.append(Message(content="".join(reasoning_blocks), role="reasoning"))
     message: Message = Message()
     if tool_calls_info:
         message["tool_calls"] = tool_calls_info
@@ -1510,21 +1520,32 @@ class LLMObsTraceInfo:
 
 
 def get_final_message_converse_stream_message(
-    message: dict[str, Any], text_blocks: dict[int, str], tool_blocks: dict[int, dict[str, Any]]
-) -> Message:
+    message: dict[str, Any],
+    text_blocks: dict[int, str],
+    tool_blocks: dict[int, dict[str, Any]],
+    reasoning_blocks: Optional[dict[int, str]] = None,
+) -> list[Message]:
     """Process a message and its content blocks into LLM Obs message format.
 
     Args:
         message: A message to be processed containing role and content block indices
         text_blocks: Mapping of content block indices to their text content
         tool_blocks: Mapping of content block indices to their tool usage data
+        reasoning_blocks: Mapping of content block indices to their accumulated reasoning text
 
     Returns:
-        dict containing the processed message with content and optional tool calls
+        A list of messages. When the assistant produced reasoning content, a separate
+        ``role="reasoning"`` message is emitted before the main message.
     """
     indices = sorted(message.get("content_block_indicies", []))
-    message_output = Message(role=message["role"])
+    outputs: list[Message] = []
 
+    if reasoning_blocks:
+        reasoning_text = "".join(reasoning_blocks[idx] for idx in indices if idx in reasoning_blocks)
+        if reasoning_text:
+            outputs.append(Message(content=reasoning_text, role="reasoning"))
+
+    message_output = Message(role=message["role"])
     text_contents = [text_blocks[idx] for idx in indices if idx in text_blocks]
     message_output.update({"content": "".join(text_contents)} if text_contents else {})
 
@@ -1551,7 +1572,8 @@ def get_final_message_converse_stream_message(
     if tool_calls:
         message_output["tool_calls"] = tool_calls
 
-    return message_output
+    outputs.append(message_output)
+    return outputs
 
 
 _punc_regex = re.compile(r"[\w']+|[.,!?;~@#$%^&*()+/-]")

--- a/releasenotes/notes/bedrock-converse-reasoning-content-1471317913cbf9cc.yaml
+++ b/releasenotes/notes/bedrock-converse-reasoning-content-1471317913cbf9cc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: Bedrock Converse and ConverseStream ``reasoningContent`` content blocks are now captured as a separate ``role="reasoning"`` message on LLM Observability ``llm`` spans. Encrypted ``redactedContent`` reasoning blocks are surfaced as ``[REDACTED REASONING]`` placeholders.


### PR DESCRIPTION
## Summary
- Bedrock Converse/ConverseStream ``reasoningContent`` blocks (Chain-of-Thought) are now surfaced as a separate ``role=\"reasoning\"`` message on LLM Observability ``llm`` spans, mirroring how the OpenAI integration handles reasoning.
- Encrypted ``reasoningContent.redactedContent`` blocks are surfaced as a ``[REDACTED REASONING]`` placeholder rather than dropped or stringified into gibberish.
- Stream handling: ``ContentBlockDelta.reasoningContent.text`` deltas are accumulated per ``contentBlockIndex``; a redacted-delta on an index is tracked and replaced with the placeholder at ``messageStop``. Signature deltas are intentionally ignored (opaque to the user).
- Internal API change: ``get_final_message_converse_stream_message`` now returns ``list[Message]`` and accepts an optional ``reasoning_blocks`` mapping. Only callers are inside ``bedrock.py``.

## Schema reference (AWS docs)
- [ContentBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html) — ``reasoningContent`` member of type [ReasoningContentBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html), a union of [ReasoningTextBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningTextBlock.html) (``text`` required, ``signature`` optional) and ``redactedContent`` (base64 binary).
- [ContentBlockDelta](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlockDelta.html) — ``reasoningContent`` member of type [ReasoningContentBlockDelta](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html), a flat union of ``text`` / ``signature`` / ``redactedContent``.

## Out of scope (follow-ups)
- VCR cassettes + assertions for a reasoning-enabled Converse call (e.g. Claude 3.7 Sonnet with ``additionalModelRequestFields={\"thinking\": {\"type\": \"enabled\", \"budget_tokens\": 1024}}``). Existing cassettes don't exercise reasoning, so current tests are unaffected.
- InvokeModel path still drops Anthropic-native ``thinking`` / ``tool_use`` content blocks (different code path, different schema — separate PR).

## Test plan
- [ ] Existing Converse/ConverseStream tests pass (no current cassettes contain ``reasoningContent``, so behavior is unchanged for them).
- [ ] Add a Converse cassette with ``reasoningContent`` and assert ``role=\"reasoning\"`` output message.
- [ ] Add a ConverseStream cassette with interleaved ``reasoningContent`` and ``text`` deltas; verify the reasoning message precedes the assistant message in ``output_messages``.
- [ ] Add a case for ``redactedContent`` and assert ``[REDACTED REASONING]`` placeholder.

Claude session: \`70e57399-69e6-4e00-ad85-70bf5da5a164\`
Resume: \`claude --resume 70e57399-69e6-4e00-ad85-70bf5da5a164\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)