### PR TITLE
chore(profiling): include build sha in profiler version

### DIFF
--- a/ddtrace/_build_metadata.py
+++ b/ddtrace/_build_metadata.py
@@ -1,0 +1,3 @@
+"""Build metadata for the installed ddtrace package."""
+
+GIT_COMMIT_SHA = ""

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -22,6 +22,7 @@ from ddtrace.internal.datadog.profiling.util import sanitize_string
 from ddtrace.internal.runtime import get_process_role
 from ddtrace.internal.runtime import get_runtime_id
 from ddtrace.internal.settings._agent import config as agent_config
+from ddtrace.profiling._metadata import get_profiler_version
 
 
 ctypedef void (*func_ptr_t)(string_view)
@@ -379,7 +380,7 @@ def config(
     # Inherited
     call_func_with_str(ddup_config_runtime, platform.python_implementation())
     call_func_with_str(ddup_config_runtime_version, platform.python_version())
-    call_func_with_str(ddup_config_profiler_version, ddtrace.__version__)
+    call_func_with_str(ddup_config_profiler_version, get_profiler_version())
 
     if max_nframes is not None:
         ddup_config_max_nframes(clamp_to_int64_unsigned(max_nframes))

--- a/ddtrace/profiling/_metadata.py
+++ b/ddtrace/profiling/_metadata.py
@@ -1,0 +1,40 @@
+"""Helpers for profiler package metadata."""
+
+import functools
+import re
+from typing import Any
+from typing import Optional
+
+from ddtrace import _build_metadata
+from ddtrace.version import __version__
+
+
+_FINAL_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _normalize_git_sha(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip().lower()
+    if 7 <= len(value) <= 64 and all(c in "0123456789abcdef" for c in value):
+        return value
+
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def get_profiler_git_commit_sha() -> Optional[str]:
+    """Return the git commit SHA stamped into the installed ddtrace build, if available."""
+    return _normalize_git_sha(getattr(_build_metadata, "GIT_COMMIT_SHA", None))
+
+
+@functools.lru_cache(maxsize=1)
+def get_profiler_version() -> str:
+    """Return the profiler version string sent to the backend."""
+    commit_sha = get_profiler_git_commit_sha()
+    if not commit_sha or _FINAL_RELEASE_VERSION_RE.fullmatch(__version__):
+        return __version__
+
+    local_version_separator = "." if "+" in __version__ else "+"
+    return f"{__version__}{local_version_separator}g{commit_sha}"

--- a/setup.py
+++ b/setup.py
@@ -119,10 +119,14 @@ IAST_DIR = DDTRACE_DIR / "appsec" / "_iast" / "_taint_tracking"
 DDUP_DIR = DDTRACE_DIR / "internal" / "datadog" / "profiling" / "ddup"
 STACK_DIR = DDTRACE_DIR / "internal" / "datadog" / "profiling" / "stack"
 VENDOR_DIR = DDTRACE_DIR / "vendor"
+BUILD_METADATA_FILE = DDTRACE_DIR / "_build_metadata.py"
 CARGO_TARGET_DIR = NATIVE_CRATE.absolute() / f"target{sys.version_info.major}.{sys.version_info.minor}"
 DD_CARGO_ARGS = shlex.split(os.getenv("DD_CARGO_ARGS", ""))
 
 BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower() in ("1", "yes", "on", "true")
+
+GIT_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
 
 CURRENT_OS = platform.system()
 SERVERLESS_BUILD = os.getenv("DD_SERVERLESS_BUILD", "0").lower() in ("1", "yes", "on", "true")
@@ -133,6 +137,26 @@ LIBDDWAF_VERSION = "1.30.1"
 # DEV: update this accordingly when src/native upgrades libdatadog dependency.
 # libdatadog v15.0.0 requires rust 1.78.
 RUST_MINIMUM_VERSION = "1.78"
+
+
+def get_build_git_commit_sha() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=HERE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=True,
+        )
+    except Exception:
+        return ""
+
+    commit_sha = result.stdout.strip()
+    if GIT_COMMIT_SHA_RE.fullmatch(commit_sha):
+        return commit_sha.lower()
+
+    return ""
 
 
 def interpose_sccache():
@@ -669,7 +693,20 @@ class LibraryDownloader(BuildPyCommand):
             CleanLibraries.remove_artifacts()
         LibDDWafDownload.run()
         BuildPyCommand.run(self)
+        self._write_build_metadata()
         self._strip_build_artifacts()
+
+    def _write_build_metadata(self) -> None:
+        if not self.build_lib:
+            return
+
+        build_metadata_file = Path(self.build_lib) / BUILD_METADATA_FILE.relative_to(HERE)
+        build_metadata_file.parent.mkdir(parents=True, exist_ok=True)
+        build_metadata_file.write_text(
+            '"""Build metadata for the installed ddtrace package."""\n\n'
+            f'GIT_COMMIT_SHA = "{get_build_git_commit_sha()}"\n',
+            encoding="utf-8",
+        )
 
     def find_data_files(self, package, src_dir):
         """Strip build/source artifacts from wheel data files."""

--- a/tests/profiling/test_metadata.py
+++ b/tests/profiling/test_metadata.py
@@ -1,0 +1,55 @@
+from ddtrace.profiling import _metadata
+
+
+def _clear_caches():
+    _metadata.get_profiler_git_commit_sha.cache_clear()
+    _metadata.get_profiler_version.cache_clear()
+
+
+def test_get_profiler_git_commit_sha_uses_build_metadata(monkeypatch):
+    commit_sha = "ABCDEF1234567890abcdef1234567890abcdef12"
+
+    _clear_caches()
+    monkeypatch.setattr(_metadata._build_metadata, "GIT_COMMIT_SHA", commit_sha)
+
+    assert _metadata.get_profiler_git_commit_sha() == commit_sha.lower()
+
+
+def test_get_profiler_git_commit_sha_returns_none_for_missing_build_metadata(monkeypatch):
+    _clear_caches()
+    monkeypatch.setattr(_metadata._build_metadata, "GIT_COMMIT_SHA", "")
+
+    assert _metadata.get_profiler_git_commit_sha() is None
+
+
+def test_get_profiler_git_commit_sha_returns_none_for_invalid_build_metadata(monkeypatch):
+    _clear_caches()
+    monkeypatch.setattr(_metadata._build_metadata, "GIT_COMMIT_SHA", "not a sha")
+
+    assert _metadata.get_profiler_git_commit_sha() is None
+
+
+def test_get_profiler_version_includes_build_metadata_commit_sha(monkeypatch):
+    commit_sha = "a" * 40
+
+    _clear_caches()
+    monkeypatch.setattr(_metadata._build_metadata, "GIT_COMMIT_SHA", commit_sha)
+    monkeypatch.setattr(_metadata, "__version__", "4.10.0rc1")
+
+    assert _metadata.get_profiler_version() == f"4.10.0rc1+g{commit_sha}"
+
+
+def test_get_profiler_version_preserves_final_release_version(monkeypatch):
+    _clear_caches()
+    monkeypatch.setattr(_metadata._build_metadata, "GIT_COMMIT_SHA", "a" * 40)
+    monkeypatch.setattr(_metadata, "__version__", "4.10.0")
+
+    assert _metadata.get_profiler_version() == "4.10.0"
+
+
+def test_get_profiler_version_preserves_version_without_build_metadata(monkeypatch):
+    _clear_caches()
+    monkeypatch.setattr(_metadata._build_metadata, "GIT_COMMIT_SHA", "")
+    monkeypatch.setattr(_metadata, "__version__", "4.10.0rc1")
+
+    assert _metadata.get_profiler_version() == "4.10.0rc1"


### PR DESCRIPTION
## Description

Stacked on #18290.

Use the build-stamped git commit SHA from `ddtrace._build_metadata` to suffix the profiler version sent to libdatadog for non-final ddtrace versions, for example:

`4.10.0rc1+g<commit-sha>`

Final released versions matching `x.y.z` are left unchanged, so a release like `4.10.0` continues to send `profiler_version:4.10.0`.

This keeps using the existing `profiler_version` profile tag instead of adding a separate profiler commit tag.

## Testing

- `scripts/lint fmt ddtrace/profiling/_metadata.py tests/profiling/test_metadata.py`
- `scripts/lint style ddtrace/profiling/_metadata.py tests/profiling/test_metadata.py`
- `scripts/lint cython-lint ddtrace/internal/datadog/profiling/ddup/_ddup.pyx`
- `git diff --check`

## Risks

Low. If no build commit SHA is available, or if the ddtrace version is a final `x.y.z` release, the profiler version remains unchanged.

## Additional Notes

No release note; internal profiling metadata/tagging improvement for test/debug visibility.
