### PR TITLE
[do not merge]: python profiler memory tests

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -4,9 +4,11 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include <echion/cache.h>
 #include <echion/frame.h>
+#include <echion/greenlets.h>
 #include <echion/strings.h>
 #include <echion/threads.h>
 
@@ -40,6 +42,15 @@ class EchionSampler
     std::optional<Frame::Key> asyncio_frame_cache_key_;
     std::optional<Frame::Key> uvloop_frame_cache_key_;
     std::unordered_set<PyObject*> previous_task_objects_;
+
+    // Sampling-thread scratch buffers. Only the single sampling thread
+    // (Sampler::sampling_thread) touches these. Functions clear/reset them
+    // between uses to amortize allocator churn that would otherwise dominate
+    // native heap-live-size (see unwind_greenlets in particular).
+    std::vector<GreenletSnapshot> greenlet_snapshots_scratch_;
+    std::unordered_set<GreenletInfo::ID> greenlet_parents_scratch_;
+    std::unordered_set<GreenletInfo::ID> greenlet_visited_scratch_;
+    std::unordered_set<PyObject*> seen_frames_scratch_;
 
     // Accumulated asyncio task count across sampled threads in the current sampling cycle.
     // When thread subsampling is enabled (_DD_PROFILING_STACK_MAX_THREADS), this only
@@ -88,6 +99,11 @@ class EchionSampler
     std::optional<Frame::Key>& uvloop_frame_cache_key() { return uvloop_frame_cache_key_; }
     std::unordered_set<PyObject*>& previous_task_objects() { return previous_task_objects_; }
 
+    std::vector<GreenletSnapshot>& greenlet_snapshots_scratch() { return greenlet_snapshots_scratch_; }
+    std::unordered_set<GreenletInfo::ID>& greenlet_parents_scratch() { return greenlet_parents_scratch_; }
+    std::unordered_set<GreenletInfo::ID>& greenlet_visited_scratch() { return greenlet_visited_scratch_; }
+    std::unordered_set<PyObject*>& seen_frames_scratch() { return seen_frames_scratch_; }
+
     void reset_asyncio_task_count() { asyncio_task_count_ = 0; }
     void add_asyncio_task_count(size_t count) { asyncio_task_count_ += count; }
     size_t asyncio_task_count() const { return asyncio_task_count_; }
@@ -121,6 +137,11 @@ class EchionSampler
         greenlet_info_map_.clear();
         greenlet_parent_map_.clear();
         greenlet_thread_map_.clear();
+
+        greenlet_snapshots_scratch_.clear();
+        greenlet_parents_scratch_.clear();
+        greenlet_visited_scratch_.clear();
+        seen_frames_scratch_.clear();
 
         // Clear renderer caches to avoid using stale interned IDs from the
         // parent's Profiles Dictionary

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
@@ -7,7 +7,8 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <deque>
+#include <unordered_set>
+#include <vector>
 
 #include <echion/config.h>
 #include <echion/frame.h>
@@ -22,10 +23,18 @@ class EchionSampler;
 // FrameStack owns the Frames so that they stay valid across cache evictions
 // (asyncio unwind_tasks precomputes per-task stacks via Frame::get, which can
 // evict entries still referenced from an earlier thread-stack capture).
-class FrameStack : public std::deque<Frame>
+//
+// Backed by std::vector<Frame> rather than std::deque<Frame>: every call site
+// uses only push_back, forward iteration, size(), clear(), and integer
+// indexing, and none retains references across mutations. Vector avoids the
+// per-instance chunk-map allocation that previously dominated native
+// heap-live-size for the gevent sampling path.
+class FrameStack : public std::vector<Frame>
 {
   public:
     using Key = Frame::Key;
+
+    FrameStack() { reserve(max_frames); }
 
     void render(EchionSampler& echion);
 };
@@ -34,6 +43,18 @@ class FrameStack : public std::deque<Frame>
 class EchionSampler;
 
 // ----------------------------------------------------------------------------
+// Scratch-buffer-reusing variant. Callers on the sampling thread should pass
+// EchionSampler::seen_frames_scratch() to avoid per-call hash-table allocation.
+// `seen_frames` is cleared on entry.
+size_t
+unwind_frame(EchionSampler& echion,
+             PyObject* frame_addr,
+             FrameStack& stack,
+             std::unordered_set<PyObject*>& seen_frames,
+             size_t max_depth = max_frames);
+
+// Convenience wrapper that owns a local scratch set (used by fuzz harnesses
+// and other callers outside the sampling thread).
 size_t
 unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -43,7 +43,13 @@ class ThreadInfo
     unsigned long native_id;
     FrameStack python_stack;
     std::vector<std::unique_ptr<StackInfo>> current_tasks;
-    std::vector<std::unique_ptr<StackInfo>> current_greenlets;
+
+    // current_greenlets and greenlet_count_ together form a reusable buffer:
+    // entries are kept alive between samples so the inner FrameStack capacity
+    // amortizes. The valid range each sample is [0, greenlet_count_); the
+    // outer vector grows on demand only when a sample exceeds prior peak.
+    std::vector<StackInfo> current_greenlets;
+    size_t greenlet_count_ = 0;
 
     std::string name;
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc
@@ -40,7 +40,7 @@ GreenletInfo::unwind(EchionSampler& echion, PyObject* cur_frame, PyThreadState* 
 #else // Python < 3.11
     frame_addr = cur_frame == Py_None ? reinterpret_cast<PyObject*>(tstate->frame) : cur_frame;
 #endif
-    unwind_frame(echion, frame_addr, stack);
+    unwind_frame(echion, frame_addr, stack, echion.seen_frames_scratch());
 
     stack.push_back(Frame::get(echion, name));
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc
@@ -31,12 +31,18 @@ FrameStack::render(EchionSampler& echion)
 }
 
 // Unwind Python frames starting from frame_addr and push them onto stack.
+// @param seen_frames: Cycle-detection set. Cleared on entry; capacity is reused
+//                     by callers (typically EchionSampler::seen_frames_scratch).
 // @param max_depth: Maximum number of frames to unwind. Defaults to max_frames.
 // @return: Number of frames added to the stack.
 size_t
-unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth)
+unwind_frame(EchionSampler& echion,
+             PyObject* frame_addr,
+             FrameStack& stack,
+             std::unordered_set<PyObject*>& seen_frames,
+             size_t max_depth)
 {
-    std::unordered_set<PyObject*> seen_frames; // Used to detect cycles in the stack
+    seen_frames.clear();
     size_t count = 0;
 
     PyObject* current_frame_addr = frame_addr;
@@ -72,6 +78,14 @@ unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, siz
     return count;
 }
 
+// Convenience wrapper that owns its own scratch set.
+size_t
+unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth)
+{
+    std::unordered_set<PyObject*> local_seen_frames;
+    return unwind_frame(echion, frame_addr, stack, local_seen_frames, max_depth);
+}
+
 void
 unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack)
 {
@@ -99,5 +113,5 @@ unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& st
 #else // Python < 3.11
     PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->frame);
 #endif
-    unwind_frame(echion, frame_addr, stack);
+    unwind_frame(echion, frame_addr, stack, echion.seen_frames_scratch());
 }

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
@@ -235,7 +235,7 @@ TaskInfo::unwind(EchionSampler& echion, FrameStack& stack, bool using_uvloop)
         // For a running Task, unwind_frame would also yield the asyncio runtime frames "on top"
         // of the Task frame, but we would discard those anyway. Limiting to 1 frame avoids walking
         // the Frame chain unnecessarily.
-        auto new_frames = unwind_frame(echion, frame, stack, 1);
+        auto new_frames = unwind_frame(echion, frame, stack, echion.seen_frames_scratch(), 1);
         assert(new_frames <= 1 && "expected exactly 1 frame to be unwound (or 0 in case of an error)");
 
         // If we failed to unwind the Frame, stop unwinding the coroutine chain; otherwise we could

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -277,7 +277,10 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
                     if (is_uvloop_wrapper_frame(echion, using_uvloop, python_frame)) {
                         continue;
                     }
-                    stack.push_front(python_frame);
+                    // FrameStack is std::vector<Frame>; emulate push_front via
+                    // insert at begin(). The loop runs at most ~max_frames times
+                    // and each insert is O(n), but n is small in practice.
+                    stack.insert(stack.begin(), python_frame);
                 }
             }
 
@@ -575,7 +578,8 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState*)
 void
 ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsigned long cur_native_id)
 {
-    std::vector<GreenletSnapshot> snapshots;
+    auto& snapshots = echion.greenlet_snapshots_scratch();
+    size_t snap_count = 0;
 
     // Phase 1: Snapshot greenlet data under the lock.
     // This minimises the time we hold greenlet_info_map_lock, which is also
@@ -589,10 +593,13 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
         auto& greenlet_parent_map = echion.greenlet_parent_map();
         auto& greenlet_thread_map = echion.greenlet_thread_map();
 
-        if (greenlet_thread_map.find(cur_native_id) == greenlet_thread_map.end())
+        if (greenlet_thread_map.find(cur_native_id) == greenlet_thread_map.end()) {
+            greenlet_count_ = 0;
             return;
+        }
 
-        std::unordered_set<GreenletInfo::ID> parent_greenlets;
+        auto& parent_greenlets = echion.greenlet_parents_scratch();
+        parent_greenlets.clear();
 
         // Collect all parent greenlets
         std::transform(greenlet_parent_map.cbegin(),
@@ -600,7 +607,13 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
                        std::inserter(parent_greenlets, parent_greenlets.begin()),
                        [](const std::pair<GreenletInfo::ID, GreenletInfo::ID>& kv) { return kv.second; });
 
-        // Snapshot the leaf greenlets and precompute their parent chains
+        auto& visited = echion.greenlet_visited_scratch();
+
+        // Snapshot the leaf greenlets and precompute their parent chains.
+        // snap_count tracks the active range of the reusable snapshots scratch;
+        // beyond that range we emplace_back to grow on demand. Keeping the
+        // snapshots vector alive between samples preserves the inner
+        // parent_chain capacities.
         for (auto& [gid, greenlet] : greenlet_info_map) {
             if (parent_greenlets.contains(gid))
                 continue;
@@ -611,14 +624,23 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
                 continue;
             }
 
-            GreenletSnapshot snap;
+            GreenletSnapshot* snap_ptr;
+            if (snap_count < snapshots.size()) {
+                snap_ptr = &snapshots[snap_count];
+                // Reset the slot but keep parent_chain capacity.
+                snap_ptr->parent_chain.clear();
+            } else {
+                snapshots.emplace_back();
+                snap_ptr = &snapshots.back();
+            }
+            auto& snap = *snap_ptr;
             snap.greenlet_id = gid;
             snap.name = greenlet->name;
             snap.frame = frame;
 
             // Precompute parent chain while we still hold the lock
             auto current_id = gid;
-            std::unordered_set<GreenletInfo::ID> visited;
+            visited.clear();
             // The limit here is arbitrary, but it should be more than enough for
             // most use cases.
             const size_t MAX_GREENLET_DEPTH = 512;
@@ -648,19 +670,31 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
                 current_id = parent_id;
             }
 
-            snapshots.push_back(std::move(snap));
+            ++snap_count;
         }
     } // Lock released here
 
-    // Phase 2: Unwind outside the lock.
+    // Phase 2: Unwind outside the lock, reusing current_greenlets entries.
     // The expensive process_vm_readv / copy_type calls happen here, without
     // blocking greenlet switches.  Snapshotted frame pointers may have become
     // stale, but unwind_frame() handles invalid pointers gracefully via
     // copy_type() which returns non-zero on failure.
-    for (auto& snap : snapshots) {
+    greenlet_count_ = 0;
+    for (size_t s = 0; s < snap_count; ++s) {
+        auto& snap = snapshots[s];
         bool on_cpu = snap.frame == Py_None;
-        auto stack_info = std::make_unique<StackInfo>(snap.name, on_cpu);
-        auto& stack = stack_info->stack;
+
+        // Reuse an existing StackInfo slot if available, otherwise grow.
+        if (greenlet_count_ < current_greenlets.size()) {
+            auto& slot = current_greenlets[greenlet_count_];
+            slot.task_name = snap.name;
+            slot.on_cpu = on_cpu;
+            slot.stack.clear();
+        } else {
+            current_greenlets.emplace_back(snap.name, on_cpu);
+        }
+        auto& stack_info = current_greenlets[greenlet_count_];
+        auto& stack = stack_info.stack;
 
         GreenletInfo temp(snap.greenlet_id, snap.frame, snap.name);
         temp.unwind(echion, snap.frame, tstate, stack);
@@ -670,7 +704,7 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
             parent_temp.unwind(echion, parent_frame, tstate, stack);
         }
 
-        current_greenlets.push_back(std::move(stack_info));
+        ++greenlet_count_;
     }
 
     // Make sure the on-CPU greenlet is first. render_task_begin reuses the
@@ -689,10 +723,10 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsig
     // If no greenlet is on CPU (e.g. all workers are sleeping while the Hub
     // is running, which is filtered out as a parent), no entry triggers
     // render_task_begin's push_cputime branch, so order does not matter and
-    // this loop falls through harmlessly. Empty current_greenlets is also
-    // safe (loop body never executes).
-    for (size_t i = 1; i < current_greenlets.size(); i++) {
-        if (current_greenlets[i]->on_cpu) {
+    // this loop falls through harmlessly. greenlet_count_ == 0 is also safe
+    // (loop body never executes).
+    for (size_t i = 1; i < greenlet_count_; i++) {
+        if (current_greenlets[i].on_cpu) {
             std::swap(current_greenlets[i], current_greenlets[0]);
             break;
         }
@@ -736,23 +770,26 @@ ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t d
         }
 
         current_tasks.clear();
-    } else if (!current_greenlets.empty()) {
-        for (auto& greenlet_stack : current_greenlets) {
-            auto maybe_task_name = echion.string_table().lookup(greenlet_stack->task_name);
+    } else if (greenlet_count_ > 0) {
+        for (size_t i = 0; i < greenlet_count_; i++) {
+            auto& greenlet_stack = current_greenlets[i];
+            auto maybe_task_name = echion.string_table().lookup(greenlet_stack.task_name);
             if (!maybe_task_name) {
+                // Reset the cursor before bailing so stale entries are not
+                // re-rendered next sample. The stack capacities are preserved.
+                greenlet_count_ = 0;
                 return ErrorKind::ThreadInfoError;
             }
 
             const auto& task_name = maybe_task_name->get();
-            renderer.render_task_begin(task_name, greenlet_stack->on_cpu);
+            renderer.render_task_begin(task_name, greenlet_stack.on_cpu);
 
-            auto& stack = greenlet_stack->stack;
-            stack.render(echion);
+            greenlet_stack.stack.render(echion);
 
             renderer.render_stack_end();
         }
 
-        current_greenlets.clear();
+        greenlet_count_ = 0;
     } else {
         python_stack.render(echion);
         renderer.render_stack_end();

--- a/releasenotes/notes/fix-profiling-unwind-greenlets-heap-memory-f2b02ca10329da31.yaml
+++ b/releasenotes/notes/fix-profiling-unwind-greenlets-heap-memory-f2b02ca10329da31.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    profiling: Reduced native heap memory used by the stack collector during
+    gevent workloads. Previously each sampling iteration allocated a fresh
+    ``StackInfo`` (with an internal ``std::deque<Frame>``) per tracked
+    greenlet and a fresh cycle-detection set per frame walk, which dominated
+    native heap live size in long-running services. Per-sample buffers are
+    now reused across samples, dropping the steady-state allocation rate for
+    this code path to near zero.

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1099,6 +1099,93 @@ def test_gevent_greenlet_switch_not_blocked_by_profiler() -> None:
     )
 
 
+@pytest.mark.skipif(
+    not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
+    reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
+)
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_gevent_unwind_greenlets_rss_stable",
+    ),
+    out=None,
+    err=None,
+)
+def test_gevent_unwind_greenlets_rss_stable() -> None:
+    """Verify that sustained unwind_greenlets sampling does not grow RSS
+    unboundedly.
+
+    Before the fix, every sample iteration allocated a fresh StackInfo (with
+    an internal std::deque<Frame>) per tracked greenlet, contributing ~half of
+    the native heap-live-size in long-running gevent services. After the fix
+    the per-thread buffers are reused across samples, so RSS should plateau
+    quickly after a warmup window.
+    """
+    from gevent import monkey
+
+    monkey.patch_all()
+
+    import time
+
+    import gevent
+
+    from ddtrace.internal.datadog.profiling import stack
+    from ddtrace.profiling import profiler
+    from ddtrace.vendor import psutil
+
+    N_IDLE = 1000
+    STACK_DEPTH = 30
+    WARMUP_S = 3.0
+    MEASURE_S = 10.0
+    SAMPLE_PERIOD_S = 1.0
+    MAX_GROWTH_MB = 20  # generous; regressions typically show hundreds of MB
+
+    def _idle_deep(depth: int) -> None:
+        if depth > 0:
+            _idle_deep(depth - 1)
+        else:
+            gevent.sleep(1000)
+
+    def idle_greenlet() -> None:
+        _idle_deep(STACK_DEPTH)
+
+    p = profiler.Profiler()
+    p.start()
+    stack.set_interval(0.005)  # 5ms (minimum allowed) for aggressive sampling
+    stack.set_adaptive_sampling(False)
+    try:
+        idles = [gevent.spawn(idle_greenlet) for _ in range(N_IDLE)]
+        gevent.sleep(0.1)  # let them register
+
+        proc = psutil.Process()
+        t_end = time.monotonic() + WARMUP_S
+        while time.monotonic() < t_end:
+            gevent.sleep(SAMPLE_PERIOD_S)
+
+        rss_after_warmup = proc.memory_info().rss
+
+        samples = []
+        t_end = time.monotonic() + MEASURE_S
+        while time.monotonic() < t_end:
+            gevent.sleep(SAMPLE_PERIOD_S)
+            samples.append(proc.memory_info().rss)
+
+        gevent.killall(idles, timeout=5)
+    finally:
+        p.stop()
+
+    peak_rss = max(samples)
+    growth_bytes = peak_rss - rss_after_warmup
+    growth_mb = growth_bytes / (1024 * 1024)
+
+    assert growth_mb < MAX_GROWTH_MB, (
+        f"RSS grew {growth_mb:.1f} MB during {MEASURE_S:.0f}s of sustained "
+        f"unwind_greenlets sampling (after {WARMUP_S:.0f}s warmup, "
+        f"baseline {rss_after_warmup / (1024 * 1024):.1f} MB, peak "
+        f"{peak_rss / (1024 * 1024):.1f} MB). Per-sample stack-collector "
+        f"buffers may no longer be reused."
+    )
+
+
 def test_greenlet_string_table_cleanup_after_ephemeral_clear(tmp_path: Path) -> None:
     """Verify that tracking/untracking greenlets across 25+ uploads (which triggers
     ephemeral string table clearing) does not crash or lose greenlet names.


### PR DESCRIPTION
## Description

`ThreadInfo::unwind_greenlets` previously allocated per leaf greenlet on every sample iteration: a new `StackInfo` (via `make_unique`) plus a fresh `std::deque<Frame>` with its own chunk map, plus per-call hash sets for cycle detection and parent tracking. In a [DOE gevent benchmark](https://benchmarks.datadoghq.com/profiling/explorer?query=service%3Adoe%2Fpython%20language%3Anative%20doe.hash%3A1d8ac90d1735928664c8b66d3e0909dd&agg_m=%40prof_native_cpu_cores&agg_m_source=base&agg_t=sum&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=enabled&profile_type=heap-live-size&refresh_mode=paused&viz=flame_graph&from_ts=1779904837285&to_ts=1779908437285&live=false) this contributed **283 MB (47.7%) of native heap-live-size**, dominated by deque chunk allocations (~138 MB initialization + ~114 MB push_back chunks) and `make_unique<StackInfo>` overhead.

### Changes

- **`FrameStack`**: `std::deque<Frame>` -> `std::vector<Frame>` with `reserve(max_frames)` in the default ctor. All call sites already use `push_back`, forward iteration, `size()`, `clear()`, and integer indexing; the one `push_front` call in the asyncio task path becomes `insert(begin(), ...)`.
- **`EchionSampler` scratch buffers**: new members hold greenlet snapshots, parent set, visited set, and `seen_frames` set. Only the single sampling thread touches these so no locks are needed. `unwind_frame` gains an overload taking the scratch `seen_frames` by reference; callers on the sampling thread pass `echion.seen_frames_scratch()` while a 3-arg convenience wrapper keeps fuzz harnesses and other callers unchanged.
- **`ThreadInfo::current_greenlets`**: `std::vector<std::unique_ptr<StackInfo>>` -> `std::vector<StackInfo>` (by value) with a `greenlet_count_` cursor. Entries are kept alive between samples so the inner `FrameStack` capacity amortizes. `unwind_greenlets` uses a parallel `snap_count` cursor on the snapshots scratch so `parent_chain` vectors retain capacity too.
- **`ThreadInfo::sample`**: iterates `current_greenlets` via the cursor and resets `greenlet_count_` on the early-return error path so stale entries do not leak into the next sample.

## Testing

- New test `test_gevent_unwind_greenlets_rss_stable` runs 1000 idle greenlets with 30-frame stacks under aggressive (5ms) sampling for ~13 seconds and asserts post-warmup RSS grows by < 20 MB. Passes locally on Python 3.14 / gevent venv.
- Existing `tests/profiling/collector/test_stack.py` full suite passes: 350 passed, 11 skipped, 2 xfailed.
- Existing greenlet-specific tests including `test_gevent_greenlet_switch_not_blocked_by_profiler` still pass, confirming the SCP-1141 latency guard is not regressed.
- Manual DOE benchmark re-run is the operator-driven validation step that confirms the heap-live-size attribution drops.

## Risks

- `FrameStack` switching from `deque` to `vector` changes growth semantics: `push_back` past capacity reallocates and invalidates iterators/references. Code review confirmed no call site retains a reference or iterator across mutations; the `reserve(max_frames)` in the default ctor makes regrowth practically unreachable. The one `push_front` call site (asyncio task path) is now `insert(begin(), ...)` which is O(n) per insert; loop runs at most ~max_frames times so worst case is O(max_frames^2) for small max_frames.
- `current_greenlets` becoming a `vector<StackInfo>` (by value) means `emplace_back` may move existing entries. `StackInfo` is move-safe (its `FrameStack` is just a vector). Reused entries are written via `slot.task_name = ...; slot.on_cpu = ...; slot.stack.clear();` which preserves capacity correctly.
- The error early-return in `ThreadInfo::sample()` now resets `greenlet_count_` to 0. Previously a string-table lookup miss left entries un-cleared until the next greenlet sample iterated and overwrote them; with the cursor pattern that would have leaked indefinitely. The new behavior drops the un-rendered entries on miss, which is the same conceptual outcome (loss of one sample) but no longer accumulates.

## Additional Notes

Out of scope (followups for separate PRs):

- Apply the same `unique_ptr` -> value + buffer-reuse pattern to `current_tasks` and `task_coro_stacks`. The asyncio task path has the same shape but smaller live-size impact in the DOE profile.
- Consider replacing `unordered_set<PyObject*> seen_frames` and `unordered_set<GreenletInfo::ID> visited` with small linear-scan vectors since stack depth is bounded and small.

<details>
<summary>Session prompts</summary>

# Prompts log

## 2026-05-27

### Initial ask

> I'd like to understand why we'd see [DOE benchmarks URL for service:doe/python, language:native, doe.hash:1d8ac90d1735928664c8b66d3e0909dd, profile_type=heap-live-size] a lot of heap live size from unwind_greenlets function, and would like to come up with a fix

### Profile attached

> There's also a downloaded profile ~/Downloads/20260527-185707_doe_python_AZ5qzRirAACZcns14qKcgAAA.zip

### Design choices (AskUserQuestion answers)

- Scope of fix in one PR: **All four changes together**
- Where do scratch buffers live: **Hybrid: per-ThreadInfo for `current_greenlets`, EchionSampler for scratch (snapshots/visited/parent_greenlets/seen_frames)**

</details>

<details>
<summary>Implementation plan</summary>

# unwind_greenlets heap live size reduction Implementation Plan

> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

**Goal:** Eliminate the per-sample heap-allocation churn in `ThreadInfo::unwind_greenlets` so it stops dominating native heap-live-size in gevent workloads (currently 283 MB / 47.7% of inuse-space in the DOE benchmark).

**Architecture:** Convert per-call heap allocations into reusable buffers. The C++ sampling thread is single-threaded, so non-output scratch buffers move to `EchionSampler`; the per-thread output buffer `current_greenlets` stays on `ThreadInfo` but reuses entries in place. `FrameStack` becomes `vector<Frame>` with reserved capacity to eliminate `std::deque<Frame>` chunk allocations (the largest contributor at 138 MB live + 114 MB push_back live).

**Tech Stack:** C++17 (libstdc++), Python 3.13, gevent, pytest, native heap profiling via libdatadog.

---

## Evidence summary

From `~/Downloads/20260527-185707_doe_python_AZ5qzRirAACZcns14qKcgAAA.zip` (DOE benchmark, 59s, total inuse-space 593 MB):

| Site | inuse-space | % of profile |
|---|---|---|
| `ThreadInfo::unwind_greenlets` total | 283 MB | 47.68% |
| `make_unique<StackInfo>` | 164 MB | 27.6% |
| ↳ `deque::_M_initialize_map` (inside StackInfo's FrameStack) | 138 MB | 23.3% |
| ↳ StackInfo struct itself | 26 MB | 4.4% |
| `deque::push_back` via `unwind_frame` | 114.5 MB | 19.3% |
| `current_greenlets` `emplace_back` | 4.5 MB | 0.8% |

Allocation ratio (alloc-space 503 MB / inuse-space 283 MB = 56% retention) confirms allocations live the full unwind → render → clear cycle, so reducing per-call allocations directly reduces inuse-space.

## File structure

Files to modify (worktree-relative):

- `ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h` — `FrameStack` base type and reserve helper
- `ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc` — `unwind_frame` accepts scratch `seen_frames`
- `ddtrace/internal/datadog/profiling/stack/echion/echion/greenlets.h` — `GreenletSnapshot` is fine as-is; no signature change to `GreenletInfo::unwind`
- `ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc` — pass-through unchanged
- `ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h` — `current_greenlets` type and `in_use_count_` cursor
- `ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc` — `unwind_greenlets` reuses scratch, `sample()` resets cursor and fixes early-return leak
- `ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h` — new scratch members + accessors
- `ddtrace/internal/datadog/profiling/stack/echion/echion/tasks.h` — `TaskInfo::unwind` signature stays; updated `unwind_frame` call site in tasks.cc gets scratch
- `ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc` — pass scratch to `unwind_frame`
- `ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_stacks.cpp` and `fuzz_echion_greenlet.cpp` — update local `unwind_frame` calls to supply a stack-local scratch set
- `tests/profiling/collector/test_stack.py` — add RSS regression test

## Test strategy

There is no easy C++ unit test scaffold for this collector. Validation uses three layers:

1. **Existing pytest suite** under `tests/profiling/collector/test_stack.py` — all greenlet tests (`test_gevent_*`) must keep passing semantically.
2. **New RSS regression test** — runs a gevent workload similar to `test_gevent_greenlet_switch_not_blocked_by_profiler`, samples RSS every second, asserts post-warmup RSS plateau does not grow more than `MAX_RSS_GROWTH_MB`.
3. **Manual DOE benchmark re-run** — re-run the DOE benchmark and verify `unwind_greenlets` heap-live-size attribution drops from ~283 MB to a small fraction. This is operator-driven (not automated in CI).

The user's AGENTS.md mandates: use the `run-tests` skill for running tests (never raw pytest), use the `lint` skill for formatting. Each task that touches code runs `run-tests` + `lint` before committing.

---

## Task 1: Add scratch buffers to EchionSampler

**Files:**
- Modify: `ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h`

The sampling thread is single-threaded (`Sampler::sampling_thread` is one `pthread_create`), so these buffers can be shared across `ThreadInfo` iterations without locks.

- [ ] **Step 1: Add private scratch members and accessors to `EchionSampler`**

Edit `echion_sampler.h`. After the existing `previous_task_objects_` member, add:

```cpp
    // ---- Sampling-thread scratch buffers ------------------------------------
    // Only the single sampling thread (Sampler::sampling_thread) touches these.
    // Functions store/clear them between uses to amortize allocator churn.
    std::vector<GreenletSnapshot> greenlet_snapshots_scratch_;
    std::unordered_set<GreenletInfo::ID> greenlet_parents_scratch_;
    std::unordered_set<GreenletInfo::ID> greenlet_visited_scratch_;
    std::unordered_set<PyObject*> seen_frames_scratch_;
```

In the public accessor section (next to `previous_task_objects()`):

```cpp
    std::vector<GreenletSnapshot>& greenlet_snapshots_scratch() { return greenlet_snapshots_scratch_; }
    std::unordered_set<GreenletInfo::ID>& greenlet_parents_scratch() { return greenlet_parents_scratch_; }
    std::unordered_set<GreenletInfo::ID>& greenlet_visited_scratch() { return greenlet_visited_scratch_; }
    std::unordered_set<PyObject*>& seen_frames_scratch() { return seen_frames_scratch_; }
```

Also add `#include <echion/greenlets.h>` if `GreenletSnapshot` isn't visible yet (check existing includes; `GreenletInfo::ID` is already used via `greenlet_info_map_`).

In `postfork_child()`, after the existing `task_link_map_.clear();` calls, add:

```cpp
        greenlet_snapshots_scratch_.clear();
        greenlet_parents_scratch_.clear();
        greenlet_visited_scratch_.clear();
        seen_frames_scratch_.clear();
```

- [ ] **Step 2: Compile-check**

Run: `scripts/lint cpp ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h`
Expected: clean (no formatter changes after first iteration).

Build the C extension to verify the header compiles. The user's preferred test command is via the `run-tests` skill. For just a compile check, run:

`scripts/build-ext-only stack` (or the equivalent native-only build target if it exists; otherwise rely on Task 8's full build).

If `scripts/build-ext-only` does not exist, skip this isolated compile and verify in a later task that does a full build.

- [ ] **Step 3: Commit**

```bash
git add ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
git commit -m "chore(profiling): add scratch buffers to EchionSampler"
```

---

## Task 2: Convert FrameStack from std::deque<Frame> to std::vector<Frame>

**Files:**
- Modify: `ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h`

Switching base class from deque to vector eliminates the ~138 MB of `_M_initialize_map` allocations and the ~114 MB of per-chunk `push_back` allocations. All existing callers use only `push_back`, iteration via `begin()/end()`, `size()`, `clear()`, and integer indexing — all available on `vector`. No code holds references across mutations, so vector's reallocation-on-grow is safe.

- [ ] **Step 1: Read the current FrameStack to confirm interface**

Read: `ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h:21-31`

Confirm only `push_back`, iteration, `size`, `clear`, indexing are used (grep already done; see plan top).

- [ ] **Step 2: Change FrameStack base class**

Edit `stacks.h`. Replace:

```cpp
#include <deque>

#include <echion/config.h>
#include <echion/frame.h>
#if PY_VERSION_HEX >= 0x030b0000
#include "echion/stack_chunk.h"
#endif // PY_VERSION_HEX >= 0x030b0000
#include <echion/errors.h>

class EchionSampler;

// ----------------------------------------------------------------------------
// FrameStack owns the Frames so that they stay valid across cache evictions
// (asyncio unwind_tasks precomputes per-task stacks via Frame::get, which can
// evict entries still referenced from an earlier thread-stack capture).
class FrameStack : public std::deque<Frame>
{
  public:
    using Key = Frame::Key;

    void render(EchionSampler& echion);
};
```

with:

```cpp
#include <vector>

#include <echion/config.h>
#include <echion/frame.h>
#if PY_VERSION_HEX >= 0x030b0000
#include "echion/stack_chunk.h"
#endif // PY_VERSION_HEX >= 0x030b0000
#include <echion/errors.h>

class EchionSampler;

// ----------------------------------------------------------------------------
// FrameStack owns the Frames so that they stay valid across cache evictions
// (asyncio unwind_tasks precomputes per-task stacks via Frame::get, which can
// evict entries still referenced from an earlier thread-stack capture).
//
// Backed by std::vector<Frame> rather than std::deque<Frame> to eliminate the
// per-instance chunk-map allocation that previously dominated heap live size
// (see commit message and PR for measurements). All call sites use push_back,
// forward iteration, size(), clear(), and integer indexing only; none retain
// references across mutations, so vector reallocation-on-grow is safe.
class FrameStack : public std::vector<Frame>
{
  public:
    using Key = Frame::Key;

    FrameStack() { reserve(max_frames); }

    void render(EchionSampler& echion);
};
```

The `reserve(max_frames)` in the default constructor preallocates the maximum stack depth so steady-state `push_back` never reallocates. `max_frames` is defined in `echion/config.h` (already included).

- [ ] **Step 3: Run existing collector tests via the run-tests skill**

Use the `run-tests` skill to run profiling stack tests:
- Test selectors: `tests/profiling/collector/test_stack.py`

Expected: all greenlet and asyncio tests pass with the new vector backing.

- [ ] **Step 4: Run lint**

Use the `lint` skill:
- Target file: `ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h`

Expected: no changes (or only formatter cleanup).

- [ ] **Step 5: Commit**

```bash
git add ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h
git commit -m "perf(profiling): back FrameStack with std::vector to drop deque chunk allocs"
```

---

## Task 3: unwind_frame accepts a reusable seen_frames buffer

**Files:**
- Modify: `ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h`
- Modify: `ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc`
- Modify: `ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc` (call site in tasks unwind)
- Modify: `ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc` (call site)
- Modify: `ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc` (call site)
- Modify: `ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_echion_stacks.cpp`, `fuzz_echion_greenlet.cpp`, `fuzz_echion_task_unwind.cpp`, `fuzz_echion_frame_read.cpp` (call sites in fuzz harnesses)

`unwind_frame` currently allocates a fresh `std::unordered_set<PyObject*> seen_frames` on every call. This shows up as 152 MB of allocation churn from `unwind_greenlets`. We pass the set in by reference and let callers reuse `EchionSampler::seen_frames_scratch()`.

- [ ] **Step 1: Add overload declaration to stacks.h**

Edit `stacks.h`. Replace the existing `unwind_frame` declaration with two overloads — one that takes a scratch set, one back-compatible wrapper:

```cpp
// Scratch-buffer-reusing variant. Callers in the sampling thread should pass
// EchionSampler::seen_frames_scratch() to avoid per-call hash-table allocation.
// `seen_frames` is cleared on entry.
size_t
unwind_frame(EchionSampler& echion,
             PyObject* frame_addr,
             FrameStack& stack,
             std::unordered_set<PyObject*>& seen_frames,
             size_t max_depth = max_frames);

// Convenience wrapper that owns a local scratch set (used by fuzz harnesses
// and any caller outside the sampling thread).
size_t
unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
```

- [ ] **Step 2: Implement the scratch-taking variant in stacks.cc**

Edit `stacks.cc`. Replace the existing `unwind_frame` definition with:

```cpp
size_t
unwind_frame(EchionSampler& echion,
             PyObject* frame_addr,
             FrameStack& stack,
             std::unordered_set<PyObject*>& seen_frames,
             size_t max_depth)
{
    seen_frames.clear();
    size_t count = 0;

    PyObject* current_frame_addr = frame_addr;
    while (current_frame_addr != NULL && stack.size() < max_frames) {
        if (seen_frames.contains(current_frame_addr))
            break;

        seen_frames.insert(current_frame_addr);

#if PY_VERSION_HEX >= 0x030b0000
        auto maybe_frame = Frame::read(echion,
                                       reinterpret_cast<_PyInterpreterFrame*>(current_frame_addr),
                                       reinterpret_cast<_PyInterpreterFrame**>(&current_frame_addr));
#else
        auto maybe_frame = Frame::read(echion, current_frame_addr, &current_frame_addr);
#endif
        if (!maybe_frame) {
            break;
        }

        if (maybe_frame->get().name == StringTable::C_FRAME) {
            continue;
        }

        stack.push_back(maybe_frame->get());
        count++;

        if (count >= max_depth) {
            break;
        }
    }

    return count;
}

size_t
unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth)
{
    std::unordered_set<PyObject*> local_seen_frames;
    return unwind_frame(echion, frame_addr, stack, local_seen_frames, max_depth);
}
```

Also update `unwind_python_stack` in the same file (lines 76-103) to use the scratch buffer:

```cpp
void
unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack)
{
    stack.clear();
#if PY_VERSION_HEX >= 0x030b0000
    if (stack_chunk == nullptr) {
        stack_chunk = std::make_unique<StackChunk>();
    }

    if (!stack_chunk->update(reinterpret_cast<_PyStackChunk*>(tstate->datastack_chunk))) {
        stack_chunk = nullptr;
    }
#endif

#if PY_VERSION_HEX >= 0x030d0000
    PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->current_frame);
#elif PY_VERSION_HEX >= 0x030b0000
    _PyCFrame cframe;
    _PyCFrame* cframe_addr = tstate->cframe;
    if (copy_type(cframe_addr, cframe))
        return;

    PyObject* frame_addr = reinterpret_cast<PyObject*>(cframe.current_frame);
#else
    PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->frame);
#endif
    unwind_frame(echion, frame_addr, stack, echion.seen_frames_scratch());
}
```

- [ ] **Step 3: Update GreenletInfo::unwind to pass scratch**

Edit `ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc:43`. Replace:

```cpp
    unwind_frame(echion, frame_addr, stack);
```

with:

```cpp
    unwind_frame(echion, frame_addr, stack, echion.seen_frames_scratch());
```

- [ ] **Step 4: Update tasks.cc unwind_frame call sites**

Edit `ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc:238`. Replace:

```cpp
        auto new_frames = unwind_frame(echion, frame, stack, 1);
```

with:

```cpp
        auto new_frames = unwind_frame(echion, frame, stack, echion.seen_frames_scratch(), 1);
```

- [ ] **Step 5: Confirm fuzz harnesses still compile**

Read each fuzz file referenced in this task. Each currently calls the 3-arg `unwind_frame` overload, which still exists as the back-compat wrapper. No edits needed unless the file uses a 4-arg call (search and verify).

Run: `grep -n "unwind_frame" ddtrace/internal/datadog/profiling/stack/fuzz/*.cpp`

Expected: All calls match either the 3-arg (frame, stack) or the 4-arg-with-max-depth signature. No edits needed.

If any fuzz file fails to compile, switch its call to pass a local scratch:

```cpp
std::unordered_set<PyObject*> scratch;
unwind_frame(echion_sampler, p0, fuzz_stack, scratch);
```

- [ ] **Step 6: Run tests via run-tests skill**

Use the `run-tests` skill:
- Test selectors: `tests/profiling/collector/test_stack.py`

Expected: all tests pass.

- [ ] **Step 7: Lint**

Use the `lint` skill:
- Files: the four modified `.h`/`.cc` files in this task.

- [ ] **Step 8: Commit**

```bash
git add ddtrace/internal/datadog/profiling/stack/echion/echion/stacks.h \
        ddtrace/internal/datadog/profiling/stack/src/echion/stacks.cc \
        ddtrace/internal/datadog/profiling/stack/src/echion/greenlets.cc \
        ddtrace/internal/datadog/profiling/stack/src/echion/tasks.cc
git commit -m "perf(profiling): reuse seen_frames scratch across unwind_frame calls"
```

---

## Task 4: Change current_greenlets to std::vector<StackInfo> with reuse cursor

**Files:**
- Modify: `ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h`
- Modify: `ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc`

Switching from `vector<unique_ptr<StackInfo>>` to `vector<StackInfo>` (by value) lets us reuse the inner `FrameStack` capacity across samples. Instead of clearing the outer vector (which destroys every StackInfo and its FrameStack), we keep entries alive and reset them in place.

Use an integer cursor `greenlet_count_` so the rendering loop iterates `[0, greenlet_count_)` and the unwind loop reuses entries up to `current_greenlets.size()` then `emplace_back` for any new ones.

- [ ] **Step 1: Update threads.h**

Edit `threads.h`. Replace the field declarations (around lines 45-46):

```cpp
    std::vector<std::unique_ptr<StackInfo>> current_tasks;
    std::vector<std::unique_ptr<StackInfo>> current_greenlets;
```

with:

```cpp
    std::vector<std::unique_ptr<StackInfo>> current_tasks;

    // current_greenlets and greenlet_count_ together form a reusable buffer:
    // entries are kept alive between samples so the inner FrameStack capacity
    // amortizes. The valid range each sample is [0, greenlet_count_), and the
    // outer vector grows on demand only when a sample exceeds prior peak.
    std::vector<StackInfo> current_greenlets;
    size_t greenlet_count_ = 0;
```

(We keep `current_tasks` as-is for now since this PR scopes to greenlets; tasks is a separate, smaller item.)

- [ ] **Step 2: Update threads.cc unwind_greenlets to use cursors and scratch buffers**

Edit `threads.cc:576-700`. Replace the full body of `ThreadInfo::unwind_greenlets` with the version below. Note the use of a `snap_count` cursor on the snapshots scratch (mirrors the `greenlet_count_` cursor on `current_greenlets`), so the inner `parent_chain` vectors keep their capacity across samples instead of being destroyed by `clear()`:

```cpp
void
ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsigned long cur_native_id)
{
    auto& snapshots = echion.greenlet_snapshots_scratch();
    size_t snap_count = 0;

    // Phase 1: Snapshot greenlet data under the lock.
    // This minimises the time we hold greenlet_info_map_lock, which is also
    // acquired by update_greenlet_frame() on every greenlet switch.  Holding
    // the lock during the expensive unwind (Phase 2) would block ALL greenlet
    // switches and lead to resource exhaustion (e.g. DB connection pools).
    {
        const std::lock_guard<std::mutex> guard(echion.greenlet_info_map_lock());

        auto& greenlet_info_map = echion.greenlet_info_map();
        auto& greenlet_parent_map = echion.greenlet_parent_map();
        auto& greenlet_thread_map = echion.greenlet_thread_map();

        if (greenlet_thread_map.find(cur_native_id) == greenlet_thread_map.end()) {
            greenlet_count_ = 0;
            return;
        }

        auto& parent_greenlets = echion.greenlet_parents_scratch();
        parent_greenlets.clear();

        // Collect all parent greenlets
        std::transform(greenlet_parent_map.cbegin(),
                       greenlet_parent_map.cend(),
                       std::inserter(parent_greenlets, parent_greenlets.begin()),
                       [](const std::pair<GreenletInfo::ID, GreenletInfo::ID>& kv) { return kv.second; });

        auto& visited = echion.greenlet_visited_scratch();

        // Snapshot the leaf greenlets and precompute their parent chains.
        // snap_count tracks the active range in the reusable snapshots vector;
        // beyond that range we emplace_back to grow on demand.
        for (auto& [gid, greenlet] : greenlet_info_map) {
            if (parent_greenlets.contains(gid))
                continue;

            auto frame = greenlet->frame;
            if (frame == FRAME_NOT_SET) {
                // The greenlet has not been started yet or has finished
                continue;
            }

            GreenletSnapshot* snap_ptr;
            if (snap_count < snapshots.size()) {
                snap_ptr = &snapshots[snap_count];
                // Reset the slot but keep parent_chain capacity.
                snap_ptr->parent_chain.clear();
            } else {
                snapshots.emplace_back();
                snap_ptr = &snapshots.back();
            }
            auto& snap = *snap_ptr;
            snap.greenlet_id = gid;
            snap.name = greenlet->name;
            snap.frame = frame;

            // Precompute parent chain while we still hold the lock
            auto current_id = gid;
            visited.clear();
            // The limit here is arbitrary, but it should be more than enough for
            // most use cases.
            const size_t MAX_GREENLET_DEPTH = 512;
            // Safety: prevent infinite loops from cycles or corrupted parent maps
            for (size_t iteration_count = 0; iteration_count < MAX_GREENLET_DEPTH; ++iteration_count) {
                if (visited.contains(current_id))
                    break;
                visited.insert(current_id);

                auto pit = greenlet_parent_map.find(current_id);
                if (pit == greenlet_parent_map.end())
                    break;

                auto parent_id = pit->second;
                auto git = greenlet_info_map.find(parent_id);
                if (git == greenlet_info_map.end())
                    break;

                auto parent_frame = git->second->frame;
                if (parent_frame == FRAME_NOT_SET || parent_frame == Py_None)
                    break;

                snap.parent_chain.emplace_back(git->second->name, parent_frame);

                current_id = parent_id;
            }

            ++snap_count;
        }
    } // Lock released here

    // Phase 2: Unwind outside the lock, reusing current_greenlets entries.
    greenlet_count_ = 0;
    for (size_t s = 0; s < snap_count; ++s) {
        auto& snap = snapshots[s];
        bool on_cpu = snap.frame == Py_None;

        // Reuse an existing StackInfo slot if available, otherwise grow.
        if (greenlet_count_ < current_greenlets.size()) {
            auto& slot = current_greenlets[greenlet_count_];
            slot.task_name = snap.name;
            slot.on_cpu = on_cpu;
            slot.stack.clear();
        } else {
            current_greenlets.emplace_back(snap.name, on_cpu);
        }
        auto& stack_info = current_greenlets[greenlet_count_];
        auto& stack = stack_info.stack;

        GreenletInfo temp(snap.greenlet_id, snap.frame, snap.name);
        temp.unwind(echion, snap.frame, tstate, stack);

        for (auto& [parent_name, parent_frame] : snap.parent_chain) {
            GreenletInfo parent_temp(0, parent_frame, parent_name);
            parent_temp.unwind(echion, parent_frame, tstate, stack);
        }

        ++greenlet_count_;
    }

    // Make sure the on-CPU greenlet is first. render_task_begin reuses the
    // sample created by render_thread_begin for the first task it renders;
    // that sample already received push_cputime via render_cpu_time. Tasks
    // rendered after the first start a new sample and, if on_cpu is true,
    // push thread_state.cpu_time_ns again, double-counting CPU time.
    //
    // unwind_tasks performs the analogous swap on leaf_tasks above. Note that
    // the "on-CPU" signal differs: asyncio's is_on_cpu is derived from frame
    // matching during unwind, while a greenlet's on_cpu is set from
    // snap.frame == Py_None (see the loop above), which is the sentinel
    // greenlet uses for its currently-running greenlet. If that sentinel
    // changes, this swap silently no-ops and the over-count returns.
    //
    // If no greenlet is on CPU (e.g. all workers are sleeping while the Hub
    // is running, which is filtered out as a parent), no entry triggers
    // render_task_begin's push_cputime branch, so order does not matter and
    // this loop falls through harmlessly. greenlet_count_ == 0 is also safe
    // (loop body never executes).
    for (size_t i = 1; i < greenlet_count_; i++) {
        if (current_greenlets[i].on_cpu) {
            std::swap(current_greenlets[i], current_greenlets[0]);
            break;
        }
    }
}
```

- [ ] **Step 3: Update sample() to use greenlet_count_ and remove the latent leak on early-return**

Edit `threads.cc:703-760` (the `ThreadInfo::sample` body). The current greenlet rendering branch reads:

```cpp
    } else if (!current_greenlets.empty()) {
        for (auto& greenlet_stack : current_greenlets) {
            auto maybe_task_name = echion.string_table().lookup(greenlet_stack->task_name);
            if (!maybe_task_name) {
                return ErrorKind::ThreadInfoError;
            }

            const auto& task_name = maybe_task_name->get();
            renderer.render_task_begin(task_name, greenlet_stack->on_cpu);

            auto& stack = greenlet_stack->stack;
            stack.render(echion);

            renderer.render_stack_end();
        }

        current_greenlets.clear();
    } else {
```

Replace with (note: cursor-based iteration, reset cursor on every exit path including the error early-return so reused entries don't leak across samples):

```cpp
    } else if (greenlet_count_ > 0) {
        for (size_t i = 0; i < greenlet_count_; i++) {
            auto& greenlet_stack = current_greenlets[i];
            auto maybe_task_name = echion.string_table().lookup(greenlet_stack.task_name);
            if (!maybe_task_name) {
                // Reset the cursor before bailing so the stale entries are not
                // re-rendered next sample. The stack capacities are preserved.
                greenlet_count_ = 0;
                return ErrorKind::ThreadInfoError;
            }

            const auto& task_name = maybe_task_name->get();
            renderer.render_task_begin(task_name, greenlet_stack.on_cpu);

            greenlet_stack.stack.render(echion);

            renderer.render_stack_end();
        }

        greenlet_count_ = 0;
    } else {
```

- [ ] **Step 4: Run tests via run-tests skill**

Test selectors:
- `tests/profiling/collector/test_stack.py`

Expected: all greenlet tests pass. If `test_gevent_greenlet_switch_not_blocked_by_profiler` fails, inspect the failure — the scaling-ratio threshold (MAX_SCALING_RATIO=3.0) should still hold since we didn't change locking behavior.

- [ ] **Step 5: Lint**

Use the `lint` skill on the modified files.

- [ ] **Step 6: Commit**

```bash
git add ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h \
        ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
git commit -m "perf(profiling): reuse current_greenlets entries and scratch buffers between samples"
```

---

## Task 5: Add RSS regression test

**Files:**
- Modify: `tests/profiling/collector/test_stack.py`

The new test stresses `unwind_greenlets` in a gevent workload similar to the existing latency test, then asserts that resident set size (RSS) stops growing after a warmup window. This catches future regressions that re-introduce per-call heap churn.

- [ ] **Step 1: Add the test function after `test_gevent_greenlet_switch_not_blocked_by_profiler`**

Insert this new test in `tests/profiling/collector/test_stack.py` immediately after the existing `test_gevent_greenlet_switch_not_blocked_by_profiler`:

```python
@pytest.mark.skipif(
    sys.platform == "win32",
    reason="gevent is not supported on Windows",
)
@pytest.mark.subprocess(
    env=dict(
        DD_PROFILING_OUTPUT_PPROF="/tmp/test_gevent_unwind_greenlets_no_rss_growth",
    ),
    out=None,
    err=None,
)
def test_gevent_unwind_greenlets_rss_stable() -> None:
    """Verify that long-running gevent workloads do not see unbounded RSS growth
    attributable to per-sample heap churn in unwind_greenlets.

    Before the fix, each unwind_greenlets call allocated a new StackInfo with
    a fresh std::deque<Frame> per leaf greenlet. With many greenlets and high
    sample rates this manifested as ~half of the native heap-live-size in
    long-running gevent services. After the fix the buffers are reused across
    samples, so RSS should plateau after a brief warmup.
    """
    from gevent import monkey

    monkey.patch_all()

    import time

    import gevent
    import psutil

    from ddtrace.internal.datadog.profiling import stack
    from ddtrace.profiling import profiler

    N_IDLE = 1000
    STACK_DEPTH = 30
    WARMUP_S = 3.0
    MEASURE_S = 10.0
    SAMPLE_PERIOD_S = 1.0
    MAX_GROWTH_MB = 20  # generous; regression typically shows hundreds of MB

    def _idle_deep(depth: int) -> None:
        if depth > 0:
            _idle_deep(depth - 1)
        else:
            gevent.sleep(1000)

    def idle_greenlet() -> None:
        _idle_deep(STACK_DEPTH)

    p = profiler.Profiler()
    p.start()
    stack.set_interval(0.005)  # 5ms (minimum allowed) for aggressive sampling
    stack.set_adaptive_sampling(False)
    try:
        idles = [gevent.spawn(idle_greenlet) for _ in range(N_IDLE)]
        gevent.sleep(0.1)  # let them register

        proc = psutil.Process()
        t_end = time.monotonic() + WARMUP_S
        while time.monotonic() < t_end:
            gevent.sleep(SAMPLE_PERIOD_S)

        rss_after_warmup = proc.memory_info().rss

        samples = []
        t_end = time.monotonic() + MEASURE_S
        while time.monotonic() < t_end:
            gevent.sleep(SAMPLE_PERIOD_S)
            samples.append(proc.memory_info().rss)

        gevent.killall(idles, timeout=5)
    finally:
        p.stop()

    growth_bytes = max(samples) - rss_after_warmup
    growth_mb = growth_bytes / (1024 * 1024)

    assert growth_mb < MAX_GROWTH_MB, (
        f"RSS grew {growth_mb:.1f} MB during {MEASURE_S:.0f}s of sustained "
        f"unwind_greenlets sampling (after {WARMUP_S:.0f}s warmup, "
        f"baseline {rss_after_warmup / (1024 * 1024):.1f} MB). "
        f"Per-sample heap allocations may have regressed."
    )
```

- [ ] **Step 2: Run the new test via run-tests skill**

Test selectors:
- `tests/profiling/collector/test_stack.py::test_gevent_unwind_greenlets_rss_stable`

Expected: passes. If it fails with growth > 20 MB, the per-call allocation fix is incomplete; revisit Task 4.

- [ ] **Step 3: Run the full stack test suite to verify no regression**

Test selectors:
- `tests/profiling/collector/test_stack.py`

Expected: all tests pass.

- [ ] **Step 4: Lint**

Use the `lint` skill on `tests/profiling/collector/test_stack.py`.

- [ ] **Step 5: Commit**

```bash
git add tests/profiling/collector/test_stack.py
git commit -m "test(profiling): add RSS regression test for unwind_greenlets buffer reuse"
```

---

## Task 6: Add release notes

**Files:**
- Create: `releasenotes/notes/profiler-unwind-greenlets-memory-XXXXXX.yaml` (filename auto-generated by reno)

- [ ] **Step 1: Use the releasenote skill**

Invoke the `releasenote` skill (`Skill releasenote`). It will draft a YAML file under `releasenotes/notes/` summarizing the user-impacting change. Suggested category: `fixes` (since this resolves elevated native heap usage in gevent workloads).

Suggested wording for the agent to draft:

```yaml
---
fixes:
  - |
    profiling: reduce native heap memory used by the stack collector during
    gevent workloads. Previously each sampling iteration allocated a fresh
    ``StackInfo`` (with an internal ``std::deque<Frame>``) per tracked
    greenlet, dominating native heap live size in long-running services.
    Per-sample buffers are now reused, dropping the steady-state allocation
    rate to near-zero for this code path.
```

- [ ] **Step 2: Commit the generated YAML**

```bash
git add releasenotes/notes/<generated-filename>.yaml
git commit -m "docs(profiling): add release note for unwind_greenlets memory fix"
```

---

## Task 7: Final validation

- [ ] **Step 1: Run the full profiling test directory via run-tests skill**

Test selectors:
- `tests/profiling/collector/test_stack.py`
- `tests/profiling/test_main.py` (if available)

Expected: all tests pass.

- [ ] **Step 2: Run lint over the full changeset**

Use the `lint` skill targeting all modified files.

- [ ] **Step 3: Manual benchmark re-run (operator action)**

This step is operator-driven and not automated:

1. Rebuild dd-trace-py with the changes installed in the DOE benchmark image.
2. Re-run the DOE benchmark with the same configuration (`doe.hash:1d8ac90d1735928664c8b66d3e0909dd`).
3. Open the heap-live-size flame graph in benchmarks.datadoghq.com.
4. Confirm `unwind_greenlets` attribution dropped from ~283 MB to a small fraction of total.
5. Confirm `test_gevent_greenlet_switch_not_blocked_by_profiler` ratio stays under 3.0 (no latency regression from the refactor).

- [ ] **Step 4: Open draft PR**

Per the user's preference, open the PR in draft mode. Title (commitlint conventional commits):

```
perf(profiling): reuse stack-collector buffers across samples to cut native heap live size
```

Body should follow `.github/PULL_REQUEST_TEMPLATE.md`. Include the PROMPTS.md and PLAN.md contents in two collapsible sections at the end of the description, per the user's standing instructions.

---

## Out of scope (followups for separate PRs)

- Apply the same `unique_ptr → value` + buffer-reuse pattern to `current_tasks` and `task_coro_stacks`. The asyncio task path has the same shape but smaller live-size impact in the DOE profile; this should be a separate PR with its own benchmark validation.
- Consider replacing the `unordered_set<PyObject*> seen_frames` with a small linear-scan `vector` since stack depth is bounded and small. Worth measuring before changing.
- Consider replacing `unordered_set<GreenletInfo::ID> visited` similarly.

</details>
