### PR TITLE
chore(pre-commit): build extenstions for staged files

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_state.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_state.hpp
@@ -40,6 +40,8 @@ class ProfilerState
 
     // Query state
     bool is_initialized() const { return initialized_.load(std::memory_order_acquire); }
+    bool is_active() const { return active_.load(std::memory_order_acquire); }
+    void set_active(bool v) { active_.store(v, std::memory_order_release); }
 
     // ========================================================================
     // Profiles Dictionary state
@@ -101,6 +103,9 @@ class ProfilerState
     std::atomic<int64_t> cumulative_copy_memory_error_count{ 0 };
     std::atomic<int64_t> cumulative_sample_capture_cpu_time_us{ 0 };
 
+    // Latest gauge snapshot that survives ProfilerStats upload swaps.
+    std::atomic<int64_t> last_sampling_interval_us{ -1 };
+
     // ========================================================================
     // Upload state
     // ========================================================================
@@ -138,6 +143,7 @@ class ProfilerState
 
     // Initialization state
     std::atomic<bool> initialized_{ false };
+    std::atomic<bool> active_{ false };
     std::once_flag init_flag_;
 
     // Profiles Dictionary handle

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -387,7 +387,7 @@ bool
 ddup_get_profiler_runtime_stats(ProfilerRuntimeStats* out) // cppcheck-suppress unusedFunction
 {
     auto& state = Datadog::ProfilerState::get();
-    if (!state.is_initialized()) {
+    if (!state.is_initialized() || !state.is_active()) {
         return false;
     }
 
@@ -397,13 +397,22 @@ ddup_get_profiler_runtime_stats(ProfilerRuntimeStats* out) // cppcheck-suppress 
     out->copy_memory_error_count = state.cumulative_copy_memory_error_count.load(std::memory_order_relaxed);
     out->sample_capture_cpu_time_us = state.cumulative_sample_capture_cpu_time_us.load(std::memory_order_relaxed);
 
+    // sampling_interval_us is stored on ProfilerState so it survives ProfilerStats upload swaps.
+    auto last_interval = state.last_sampling_interval_us.load(std::memory_order_relaxed);
+    if (last_interval >= 0) {
+        out->sampling_interval_us = last_interval;
+    }
+
     // Gauge values from the live ProfilerStats (borrow acquires the profile mutex).
     // Optional gauges keep their -1 default when not yet set.
     auto borrowed = state.profile_state.borrow();
     auto& stats = borrowed.stats();
 
-    if (auto v = stats.get_sampling_interval_us())
-        out->sampling_interval_us = static_cast<int64_t>(*v);
+    if (out->sampling_interval_us < 0) {
+        if (auto v = stats.get_sampling_interval_us()) {
+            out->sampling_interval_us = static_cast<int64_t>(*v);
+        }
+    }
 
     if (auto v = stats.get_asyncio_task_count())
         out->asyncio_task_count = static_cast<int64_t>(*v);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
@@ -136,6 +136,8 @@ ProfilerState::start()
 void
 ProfilerState::cleanup()
 {
+    active_.store(false, std::memory_order_release);
+
     // Clear the profile, decreasing the refcount on the Profiles Dictionary
     profile_state.cleanup();
 
@@ -201,6 +203,8 @@ ProfilerState::postfork_child()
     cumulative_sampling_event_count.store(0, std::memory_order_relaxed);
     cumulative_copy_memory_error_count.store(0, std::memory_order_relaxed);
     cumulative_sample_capture_cpu_time_us.store(0, std::memory_order_relaxed);
+    last_sampling_interval_us.store(-1, std::memory_order_relaxed);
+    active_.store(false, std::memory_order_release);
 
     // Re-init the native call registry mutex (data is preserved so forked
     // children can still see native frames from the parent's warmup phase)

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_runtime_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/test/test_runtime_stats.cpp
@@ -25,6 +25,7 @@ void
 runtime_stats_after_init()
 {
     configure("my_service", "my_env", "0.0.1", "https://127.0.0.1:9126", "cpython", "3.10.6", "3.100", 256);
+    Datadog::ProfilerState::get().set_active(true);
 
     ProfilerRuntimeStats stats{};
     bool ok = ddup_get_profiler_runtime_stats(&stats);
@@ -47,11 +48,53 @@ TEST(RuntimeStatsDeathTest, AfterInit)
 }
 
 void
+runtime_stats_init_not_active()
+{
+    configure("my_service", "my_env", "0.0.1", "https://127.0.0.1:9126", "cpython", "3.10.6", "3.100", 256);
+
+    ProfilerRuntimeStats stats{};
+    bool ok = ddup_get_profiler_runtime_stats(&stats);
+    assert(!ok);
+
+    std::exit(0);
+}
+
+TEST(RuntimeStatsDeathTest, InitNotActive)
+{
+    EXPECT_EXIT(runtime_stats_init_not_active(), ::testing::ExitedWithCode(0), "");
+}
+
+void
+sampling_interval_survives_upload()
+{
+    configure("my_service", "my_env", "0.0.1", "https://127.0.0.1:9126", "cpython", "3.10.6", "3.100", 256);
+
+    auto& state = Datadog::ProfilerState::get();
+    state.set_active(true);
+    state.last_sampling_interval_us.store(5000, std::memory_order_relaxed);
+
+    ddup_upload();
+
+    ProfilerRuntimeStats stats{};
+    bool ok = ddup_get_profiler_runtime_stats(&stats);
+    assert(ok);
+    assert(stats.sampling_interval_us == 5000);
+
+    std::exit(0);
+}
+
+TEST(RuntimeStatsDeathTest, SamplingIntervalSurvivesUpload)
+{
+    EXPECT_EXIT(sampling_interval_survives_upload(), ::testing::ExitedWithCode(0), "");
+}
+
+void
 cumulative_counters_survive_upload()
 {
     configure("my_service", "my_env", "0.0.1", "https://127.0.0.1:9126", "cpython", "3.10.6", "3.100", 256);
 
     auto& state = Datadog::ProfilerState::get();
+    state.set_active(true);
 
     // Manually bump cumulative counters (simulating what sampler.cpp does)
     state.cumulative_sample_count.fetch_add(10, std::memory_order_relaxed);

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -184,6 +184,7 @@ Sampler::adapt_sampling_interval()
 
     sample_interval_us.store(new_interval);
     Sample::profile_borrow().stats().set_sampling_interval_us(new_interval);
+    ProfilerState::get().last_sampling_interval_us.store(static_cast<int64_t>(new_interval), std::memory_order_relaxed);
 
     // Update the counters for the next iteration
     process_count = new_process_count;
@@ -394,7 +395,8 @@ Sampler::sampling_thread(const uint64_t seq_num)
             auto& state = ProfilerState::get();
             state.cumulative_sampling_event_count.fetch_add(1, std::memory_order_relaxed);
             if (copy_errors > 0) {
-                state.cumulative_copy_memory_error_count.fetch_add(copy_errors, std::memory_order_relaxed);
+                state.cumulative_copy_memory_error_count.fetch_add(static_cast<int64_t>(copy_errors),
+                                                                   std::memory_order_relaxed);
             }
             if (cpu_diff > 0) {
                 state.cumulative_sample_capture_cpu_time_us.fetch_add(cpu_diff, std::memory_order_relaxed);
@@ -427,6 +429,8 @@ Sampler::set_interval(double new_interval_s)
     microsecond_t new_interval_us = static_cast<microsecond_t>(new_interval_s * 1e6);
     sample_interval_us.store(new_interval_us);
     Sample::profile_borrow().stats().set_sampling_interval_us(new_interval_us);
+    ProfilerState::get().last_sampling_interval_us.store(static_cast<int64_t>(new_interval_us),
+                                                         std::memory_order_relaxed);
 }
 
 Sampler::Sampler()
@@ -650,12 +654,15 @@ Sampler::start()
         return false;
     }
 #endif
+    ProfilerState::get().set_active(true);
     return true;
 }
 
 void
 Sampler::stop()
 {
+    ProfilerState::get().set_active(false);
+
     // Modifying the thread sequence number will cause the sampling thread to exit when it completes
     // a sampling loop.
     ++thread_seq_num;

--- a/ddtrace/internal/runtime/metric_collectors.py
+++ b/ddtrace/internal/runtime/metric_collectors.py
@@ -136,11 +136,13 @@ class ProfilerRuntimeMetricCollector(RuntimeMetricCollector):
         if self._get_stats is not None:
             return True
         try:
-            from ddtrace.internal.datadog.profiling.ddup._ddup import get_profiler_runtime_stats
+            from ddtrace.internal.datadog.profiling import ddup
 
-            self._get_stats = get_profiler_runtime_stats
+            if not ddup.is_available:
+                return False
+            self._get_stats = ddup.get_profiler_runtime_stats
             return True
-        except ImportError:
+        except Exception:
             return False
 
     def collect_fn(self, keys: set[str]) -> list[tuple[str, int]]:

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -32,7 +32,11 @@ Individual pre-commit hooks (run in numeric order):
 | `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) |
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
+<<<<<<< Updated upstream
+| `10-build-native-ext` | Rebuilds native extensions (`python setup.py build_ext --inplace`) when staged C/C++/Rust/Cython, CMake, or `setup.py` files change. Uses `.venv/bin/python` when present. On stale `.eggs` errors (`Directory not empty` / errno 66), removes `.eggs` and retries once. Set `DD_SKIP_NATIVE_BUILD=1` to skip. |
+=======
 | `10-build-native-ext` | Rebuilds native extensions (`python setup.py build_ext --inplace`) when staged C/C++/Rust/Cython, CMake, or `setup.py` files change. Uses `.venv/bin/python` when present. Set `DD_SKIP_NATIVE_BUILD=1` to skip. |
+>>>>>>> Stashed changes
 
 ### post-merge (non-blocking)
 Runs after `git pull` or `git merge`. Non-zero exit codes are logged but **do not block** the operation (the merge has already completed). Contains:

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -32,11 +32,7 @@ Individual pre-commit hooks (run in numeric order):
 | `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) |
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
-<<<<<<< Updated upstream
-| `10-build-native-ext` | Rebuilds native extensions (`python setup.py build_ext --inplace`) when staged C/C++/Rust/Cython, CMake, or `setup.py` files change. Uses `.venv/bin/python` when present. On stale `.eggs` errors (`Directory not empty` / errno 66), removes `.eggs` and retries once. Set `DD_SKIP_NATIVE_BUILD=1` to skip. |
-=======
-| `10-build-native-ext` | Rebuilds native extensions (`python setup.py build_ext --inplace`) when staged C/C++/Rust/Cython, CMake, or `setup.py` files change. Uses `.venv/bin/python` when present. Set `DD_SKIP_NATIVE_BUILD=1` to skip. |
->>>>>>> Stashed changes
+| `10-build-native-ext` | **Warn-only by default** when staged product native/build files change (C/C++/Rust/Cython, CMake, `setup.py`; excludes `test/`, `tests/`, `fuzz/`, `*_test.cpp`). Prints rebuild guidance and does not block the commit. Set `DD_BUILD_NATIVE_ON_COMMIT=1` to run `build_ext --inplace` and block on failure (with `.eggs` retry). Set `DD_SKIP_NATIVE_BUILD=1` to skip entirely. |
 
 ### post-merge (non-blocking)
 Runs after `git pull` or `git merge`. Non-zero exit codes are logged but **do not block** the operation (the merge has already completed). Contains:
@@ -56,8 +52,30 @@ When you checkout a branch, merge changes, or pull from main that includes modif
 - Cryptic error messages
 
 ### Solution
-- **pre-commit**: `10-build-native-ext` runs `python setup.py build_ext --inplace` when you commit staged native or build files (blocks the commit if the build fails).
-- **post-merge / post-checkout**: `check-native-changes` detects native file changes and reminds you to rebuild.
+- **pre-commit**: `10-build-native-ext` **warns** when you commit staged product native or build files (does not block by default). Opt in to a blocking rebuild with `DD_BUILD_NATIVE_ON_COMMIT=1`.
+- **post-merge / post-checkout**: `check-native-changes` detects native file changes and reminds you to rebuild after pull or branch switch.
+
+### Pre-commit native hook behavior
+
+| Mode | How to enable | Commit blocked? | What runs |
+|------|----------------|-----------------|-----------|
+| Warn only (default) | (none) | No | Lists staged product native files and rebuild commands |
+| Blocking rebuild | `export DD_BUILD_NATIVE_ON_COMMIT=1` | Yes, if `build_ext` fails | Full `python setup.py build_ext --inplace` |
+| Skip | `export DD_SKIP_NATIVE_BUILD=1` or `git commit --no-verify` | No | Nothing |
+
+**Staged paths that trigger the hook** (product code only): `*.c`, `*.h`, `*.cc`, `*.cpp`, `*.hpp`, `*.rs`, `*.pyx`, `*.pxd`, `CMakeLists.txt`, `*.cmake`, root `setup.py`.
+
+**Excluded** (hook does not run for these alone): paths under `test/`, `tests/`, `fuzz/`, `dd_wrapper/test/`, and `*_test.cpp`.
+
+**Timing when blocking rebuild is enabled** (`DD_BUILD_NATIVE_ON_COMMIT=1`):
+
+- **Cold tree** (first native build after clone): often **minutes** — setuptools, CMake, and extensions compile from scratch.
+- **Warm tree, small change**: often **tens of seconds** — `setup.py` starts; incremental logic may skip up-to-date extensions (`DD_CMAKE_INCREMENTAL_BUILD`, mtime checks).
+- **Warm tree, comment-only header**: may still invoke `build_ext`, but most extensions log `skipping … (up-to-date)`.
+
+One staged `profiler_state.hpp` comment still launches the full `build_ext` driver when blocking mode is on; incremental skips limit actual recompilation.
+
+Uses `.venv/bin/python` when present. On stale `.eggs` errors (`Directory not empty` / errno 66), removes `.eggs` and retries once.
 
 ### Monitored File Types
 - `*.c`, `*.cpp`, `*.h`, `*.hpp` - C/C++ files
@@ -98,10 +116,16 @@ Run one of the following commands:
 
 ### Rebuild Commands
 
-**On commit (automatic, when native files are staged):**
+**On commit (reminder by default):**
 ```bash
 hooks/autohook.sh install   # once per clone
-git commit                  # runs build_ext --inplace if needed
+git commit                  # prints rebuild reminder if product native files are staged
+```
+
+**On commit (blocking rebuild, opt-in):**
+```bash
+export DD_BUILD_NATIVE_ON_COMMIT=1
+git commit                  # runs build_ext --inplace; aborts commit if build fails
 ```
 
 **Quick Rebuild (Recommended):**
@@ -110,7 +134,7 @@ pip install -e .
 ```
 Rebuilds changed native extensions. Fast and usually sufficient.
 
-**Manual in-place rebuild (same as the pre-commit hook):**
+**Manual in-place rebuild (same command as blocking pre-commit mode):**
 ```bash
 python setup.py build_ext --inplace
 ```
@@ -236,6 +260,7 @@ hooks/
 ├── post-checkout/           # Post-checkout hooks
 │   └── check-native-changes # Detects native code and dependency changes
 └── scripts/                 # Shared scripts
+    ├── build-native-ext.sh  # Pre-commit native warn / optional rebuild
     └── check-native-changes # Native change and dependency detection logic
 ```
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -32,6 +32,7 @@ Individual pre-commit hooks (run in numeric order):
 | `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) |
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
+| `10-build-native-ext` | Rebuilds native extensions (`python setup.py build_ext --inplace`) when staged C/C++/Rust/Cython, CMake, or `setup.py` files change. Uses `.venv/bin/python` when present. Set `DD_SKIP_NATIVE_BUILD=1` to skip. |
 
 ### post-merge (non-blocking)
 Runs after `git pull` or `git merge`. Non-zero exit codes are logged but **do not block** the operation (the merge has already completed). Contains:
@@ -51,7 +52,8 @@ When you checkout a branch, merge changes, or pull from main that includes modif
 - Cryptic error messages
 
 ### Solution
-The `check-native-changes` hook automatically detects when native code files have changed and reminds you to rebuild.
+- **pre-commit**: `10-build-native-ext` runs `python setup.py build_ext --inplace` when you commit staged native or build files (blocks the commit if the build fails).
+- **post-merge / post-checkout**: `check-native-changes` detects native file changes and reminds you to rebuild.
 
 ### Monitored File Types
 - `*.c`, `*.cpp`, `*.h`, `*.hpp` - C/C++ files
@@ -92,11 +94,22 @@ Run one of the following commands:
 
 ### Rebuild Commands
 
+**On commit (automatic, when native files are staged):**
+```bash
+hooks/autohook.sh install   # once per clone
+git commit                  # runs build_ext --inplace if needed
+```
+
 **Quick Rebuild (Recommended):**
 ```bash
 pip install -e .
 ```
 Rebuilds changed native extensions. Fast and usually sufficient.
+
+**Manual in-place rebuild (same as the pre-commit hook):**
+```bash
+python setup.py build_ext --inplace
+```
 
 **Full Clean Rebuild:**
 ```bash

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -32,7 +32,7 @@ Individual pre-commit hooks (run in numeric order):
 | `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) |
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
-| `10-build-native-ext` | **Warn-only by default** when staged product native/build files change (C/C++/Rust/Cython, CMake, `setup.py`; excludes `test/`, `tests/`, `fuzz/`, `*_test.cpp`). Prints rebuild guidance and does not block the commit. Set `DD_BUILD_NATIVE_ON_COMMIT=1` to run `build_ext --inplace` and block on failure (with `.eggs` retry). Set `DD_SKIP_NATIVE_BUILD=1` to skip entirely. |
+| `10-build-native-ext` | When staged product native/build files change (excludes `test/`, `tests/`, `fuzz/`, `*_test.cpp`). **Warn-only by default**; first interactive commit prompts once and saves `git config --local ddtrace.nativeBuildMode` (`warn` / `block` / `off`). Env vars `DD_BUILD_NATIVE_ON_COMMIT=1` and `DD_SKIP_NATIVE_BUILD=1` override for one session. |
 
 ### post-merge (non-blocking)
 Runs after `git pull` or `git merge`. Non-zero exit codes are logged but **do not block** the operation (the merge has already completed). Contains:
@@ -52,22 +52,26 @@ When you checkout a branch, merge changes, or pull from main that includes modif
 - Cryptic error messages
 
 ### Solution
-- **pre-commit**: `10-build-native-ext` **warns** when you commit staged product native or build files (does not block by default). Opt in to a blocking rebuild with `DD_BUILD_NATIVE_ON_COMMIT=1`.
+- **pre-commit**: `10-build-native-ext` **warns** when you commit staged product native or build files (does not block by default). On the first interactive commit, it asks which mode to use for this clone and saves it in local git config.
 - **post-merge / post-checkout**: `check-native-changes` detects native file changes and reminds you to rebuild after pull or branch switch.
 
 ### Pre-commit native hook behavior
 
-| Mode | How to enable | Commit blocked? | What runs |
-|------|----------------|-----------------|-----------|
-| Warn only (default) | (none) | No | Lists staged product native files and rebuild commands |
-| Blocking rebuild | `export DD_BUILD_NATIVE_ON_COMMIT=1` | Yes, if `build_ext` fails | Full `python setup.py build_ext --inplace` |
-| Skip | `export DD_SKIP_NATIVE_BUILD=1` or `git commit --no-verify` | No | Nothing |
+| Mode | How to set (persists in this repo) | Commit blocked? | What runs |
+|------|-------------------------------------|-----------------|-----------|
+| Warn only (default) | `git config --local ddtrace.nativeBuildMode warn` | No | Lists staged product native files and rebuild commands |
+| Blocking rebuild | `git config --local ddtrace.nativeBuildMode block` | Yes, if `build_ext` fails | Full `python setup.py build_ext --inplace` |
+| Skip | `git config --local ddtrace.nativeBuildMode off` | No | Nothing |
+
+**First time** you commit product native files in an interactive terminal, the hook prompts for `warn` / `block` / `off` and runs `git config --local` for you. CI, non-TTY commits, and `DDTRACE_NATIVE_BUILD_NONINTERACTIVE=1` default to **warn** without prompting.
+
+**One-session overrides** (optional): `DD_BUILD_NATIVE_ON_COMMIT=1` forces block; `DD_SKIP_NATIVE_BUILD=1` forces off. `git commit --no-verify` skips all pre-commit hooks.
 
 **Staged paths that trigger the hook** (product code only): `*.c`, `*.h`, `*.cc`, `*.cpp`, `*.hpp`, `*.rs`, `*.pyx`, `*.pxd`, `CMakeLists.txt`, `*.cmake`, root `setup.py`.
 
 **Excluded** (hook does not run for these alone): paths under `test/`, `tests/`, `fuzz/`, `dd_wrapper/test/`, and `*_test.cpp`.
 
-**Timing when blocking rebuild is enabled** (`DD_BUILD_NATIVE_ON_COMMIT=1`):
+**Timing when blocking rebuild is enabled** (`ddtrace.nativeBuildMode=block`):
 
 - **Cold tree** (first native build after clone): often **minutes** — setuptools, CMake, and extensions compile from scratch.
 - **Warm tree, small change**: often **tens of seconds** — `setup.py` starts; incremental logic may skip up-to-date extensions (`DD_CMAKE_INCREMENTAL_BUILD`, mtime checks).
@@ -122,10 +126,17 @@ hooks/autohook.sh install   # once per clone
 git commit                  # prints rebuild reminder if product native files are staged
 ```
 
-**On commit (blocking rebuild, opt-in):**
+**On commit (blocking rebuild, per-repo):**
 ```bash
-export DD_BUILD_NATIVE_ON_COMMIT=1
+git config --local ddtrace.nativeBuildMode block
 git commit                  # runs build_ext --inplace; aborts commit if build fails
+```
+
+**Change or inspect preference:**
+```bash
+git config --local --get ddtrace.nativeBuildMode
+git config --local ddtrace.nativeBuildMode warn   # back to reminders only
+git config --local --unset ddtrace.nativeBuildMode  # prompt again on next native commit
 ```
 
 **Quick Rebuild (Recommended):**

--- a/hooks/pre-commit/10-build-native-ext
+++ b/hooks/pre-commit/10-build-native-ext
@@ -1,0 +1,1 @@
+../scripts/build-native-ext.sh

--- a/hooks/scripts/build-native-ext.sh
+++ b/hooks/scripts/build-native-ext.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env sh
 # Remind or rebuild in-tree native extensions when staged changes touch product native/build inputs.
 #
-# Default: warn only (does not block the commit).
-# Blocking rebuild:  export DD_BUILD_NATIVE_ON_COMMIT=1
-# Skip entirely:     export DD_SKIP_NATIVE_BUILD=1  or  git commit --no-verify
+# Per-repo preference (recommended):
+#   git config --local ddtrace.nativeBuildMode warn   # remind only (default)
+#   git config --local ddtrace.nativeBuildMode block  # build_ext before commit
+#   git config --local ddtrace.nativeBuildMode off    # disable hook
+#
+# First commit with native files in an interactive terminal prompts once and saves the choice.
+# Session overrides: DD_BUILD_NATIVE_ON_COMMIT=1 (block), DD_SKIP_NATIVE_BUILD=1 (off)
 
 set -eu
 
+GIT_CONFIG_KEY='ddtrace.nativeBuildMode'
 NATIVE_FILE_PATTERN='\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$'
 # Product paths only; skip test harness / fuzz trees (still covered by clang-format etc.).
 TEST_PATH_EXCLUDE='(^|/)(test|tests|fuzz)(/|$)|/dd_wrapper/test/|_test\.cpp$'
@@ -16,6 +21,12 @@ cd "$repo_root"
 
 if [ "${DD_SKIP_NATIVE_BUILD:-}" = "1" ]; then
     echo 'native build hook skipped: DD_SKIP_NATIVE_BUILD=1'
+    exit 0
+fi
+
+configured_mode=$(git config --local --get "$GIT_CONFIG_KEY" 2>/dev/null || true)
+if [ "$configured_mode" = "off" ]; then
+    echo "native build hook skipped: $GIT_CONFIG_KEY=off"
     exit 0
 fi
 
@@ -33,6 +44,60 @@ if [ -z "$product_native_files" ]; then
     echo 'native build hook skipped: no staged product native or build files'
     exit 0
 fi
+
+is_interactive() {
+    [ -t 0 ] \
+        && [ -z "${CI:-}" ] \
+        && [ -z "${GITHUB_ACTIONS:-}" ] \
+        && [ -z "${BUILDKITE:-}" ] \
+        && [ -z "${DDTRACE_NATIVE_BUILD_NONINTERACTIVE:-}" ]
+}
+
+normalize_mode() {
+    case "$1" in
+        block|warn|off) printf '%s\n' "$1" ;;
+        *) printf '%s\n' 'warn' ;;
+    esac
+}
+
+maybe_prompt_for_mode() {
+    if ! is_interactive; then
+        return 0
+    fi
+
+    echo ""
+    echo "Native build pre-commit hook: choose a default for this repository"
+    echo "  [1] warn  - print a rebuild reminder (recommended)"
+    echo "  [2] block - run build_ext --inplace before each commit"
+    echo "  [3] off   - disable this hook for this repository"
+    printf "Choice [1]: "
+    IFS= read -r choice || choice=1
+
+    case "$choice" in
+        2|block|Block|BLOCK) mode=block ;;
+        3|off|Off|OFF) mode=off ;;
+        *) mode=warn ;;
+    esac
+
+    git config --local "$GIT_CONFIG_KEY" "$mode"
+    echo "Saved for this repo: git config --local $GIT_CONFIG_KEY $mode"
+    echo ""
+}
+
+resolve_native_build_mode() {
+    if [ "${DD_BUILD_NATIVE_ON_COMMIT:-}" = "1" ]; then
+        printf '%s\n' 'block'
+        return 0
+    fi
+
+    mode=$(git config --local --get "$GIT_CONFIG_KEY" 2>/dev/null || true)
+    if [ -z "$mode" ]; then
+        maybe_prompt_for_mode
+        mode=$(git config --local --get "$GIT_CONFIG_KEY" 2>/dev/null || true)
+    fi
+
+    normalize_mode "${mode:-warn}"
+}
 
 resolve_python() {
     if [ -x .venv/bin/python ]; then
@@ -63,14 +128,12 @@ warn_staged_native() {
     echo ""
     echo "You may need to rebuild native extensions before running or pushing."
     echo ""
-    echo "  # In-place rebuild (fastest when already installed editable):"
-    echo "    python setup.py build_ext --inplace"
+    echo "  python setup.py build_ext --inplace"
+    echo "  pip install -e ."
     echo ""
-    echo "  # Or reinstall editable:"
-    echo "    pip install -e ."
-    echo ""
-    echo "  # Block commit until build succeeds (this session):"
-    echo "    export DD_BUILD_NATIVE_ON_COMMIT=1"
+    echo "Change hook behavior for this repo:"
+    echo "  git config --local $GIT_CONFIG_KEY block   # rebuild before commit"
+    echo "  git config --local $GIT_CONFIG_KEY off     # disable hook"
     echo ""
     echo "post-merge/post-checkout hooks also remind you after pull or branch switch."
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -118,10 +181,19 @@ run_blocking_build() {
     return "$build_status"
 }
 
-if [ "${DD_BUILD_NATIVE_ON_COMMIT:-}" = "1" ]; then
-    run_blocking_build
-    exit $?
-fi
+native_build_mode=$(resolve_native_build_mode)
 
-warn_staged_native
-exit 0
+case "$native_build_mode" in
+    off)
+        echo "native build hook skipped: $GIT_CONFIG_KEY=off"
+        exit 0
+        ;;
+    block)
+        run_blocking_build
+        exit $?
+        ;;
+    warn)
+        warn_staged_native
+        exit 0
+        ;;
+esac

--- a/hooks/scripts/build-native-ext.sh
+++ b/hooks/scripts/build-native-ext.sh
@@ -40,4 +40,39 @@ printf '%s\n' "$staged_files" | grep -E \
     '\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$' || true
 echo ""
 
+<<<<<<< Updated upstream
+is_stale_eggs_error() {
+    printf '%s\n' "$1" | grep -qiE 'directory not empty|errno 66|\[errno 66\]'
+}
+
+run_build_ext() {
+    set +e
+    build_output=$("$PYTHON" setup.py build_ext --inplace 2>&1)
+    build_status=$?
+    set -e
+    return "$build_status"
+}
+
+if run_build_ext; then
+    printf '%s\n' "$build_output"
+    exit 0
+fi
+
+printf '%s\n' "$build_output" >&2
+
+if is_stale_eggs_error "$build_output" && [ -d .eggs ]; then
+    echo "" >&2
+    echo "build_ext failed with a stale .eggs cache; removing .eggs and retrying once..." >&2
+    rm -rf .eggs
+    build_output=""
+    if run_build_ext; then
+        printf '%s\n' "$build_output"
+        exit 0
+    fi
+    printf '%s\n' "$build_output" >&2
+fi
+
+exit "$build_status"
+=======
 "$PYTHON" setup.py build_ext --inplace
+>>>>>>> Stashed changes

--- a/hooks/scripts/build-native-ext.sh
+++ b/hooks/scripts/build-native-ext.sh
@@ -1,46 +1,82 @@
 #!/usr/bin/env sh
-# Rebuild in-tree native extensions when staged changes touch native/build inputs.
+# Remind or rebuild in-tree native extensions when staged changes touch product native/build inputs.
 #
-# Opt out for a single commit:  git commit --no-verify
-# Opt out for the shell session:  export DD_SKIP_NATIVE_BUILD=1
+# Default: warn only (does not block the commit).
+# Blocking rebuild:  export DD_BUILD_NATIVE_ON_COMMIT=1
+# Skip entirely:     export DD_SKIP_NATIVE_BUILD=1  or  git commit --no-verify
 
 set -eu
 
-if [ "${DD_SKIP_NATIVE_BUILD:-}" = "1" ]; then
-    echo 'build_ext skipped: DD_SKIP_NATIVE_BUILD=1'
-    exit 0
-fi
+NATIVE_FILE_PATTERN='\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$'
+# Product paths only; skip test harness / fuzz trees (still covered by clang-format etc.).
+TEST_PATH_EXCLUDE='(^|/)(test|tests|fuzz)(/|$)|/dd_wrapper/test/|_test\.cpp$'
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
+if [ "${DD_SKIP_NATIVE_BUILD:-}" = "1" ]; then
+    echo 'native build hook skipped: DD_SKIP_NATIVE_BUILD=1'
+    exit 0
+fi
+
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR)
 if [ -z "$staged_files" ]; then
-    echo 'build_ext skipped: no staged files'
+    echo 'native build hook skipped: no staged files'
     exit 0
 fi
 
-if ! printf '%s\n' "$staged_files" | grep -qE \
-    '\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$'; then
-    echo 'build_ext skipped: no staged native or build files'
+product_native_files=$(printf '%s\n' "$staged_files" \
+    | grep -E "$NATIVE_FILE_PATTERN" \
+    | grep -vE "$TEST_PATH_EXCLUDE" || true)
+
+if [ -z "$product_native_files" ]; then
+    echo 'native build hook skipped: no staged product native or build files'
     exit 0
 fi
 
-if [ -x .venv/bin/python ]; then
-    PYTHON=.venv/bin/python
-elif [ -n "${PYTHON:-}" ]; then
-    PYTHON=$PYTHON
-else
-    PYTHON=python3
-fi
+resolve_python() {
+    if [ -x .venv/bin/python ]; then
+        PYTHON=.venv/bin/python
+    elif [ -n "${PYTHON:-}" ]; then
+        PYTHON=$PYTHON
+    else
+        PYTHON=python3
+    fi
+}
 
-echo "Rebuilding native extensions ($PYTHON setup.py build_ext --inplace)..."
-echo "Staged native/build files:"
-printf '%s\n' "$staged_files" | grep -E \
-    '\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$' || true
-echo ""
+warn_staged_native() {
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "⚠️  STAGED NATIVE/BUILD FILES (rebuild recommended)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "The following staged files may require rebuilt native extensions:"
+    echo ""
 
-<<<<<<< Updated upstream
+    printf '%s\n' "$product_native_files" | head -n 10 | sed 's/^/  • /'
+
+    total=$(printf '%s\n' "$product_native_files" | wc -l | tr -d ' ')
+    if [ "$total" -gt 10 ]; then
+        echo "  ... and $((total - 10)) more file(s)"
+    fi
+
+    echo ""
+    echo "You may need to rebuild native extensions before running or pushing."
+    echo ""
+    echo "  # In-place rebuild (fastest when already installed editable):"
+    echo "    python setup.py build_ext --inplace"
+    echo ""
+    echo "  # Or reinstall editable:"
+    echo "    pip install -e ."
+    echo ""
+    echo "  # Block commit until build succeeds (this session):"
+    echo "    export DD_BUILD_NATIVE_ON_COMMIT=1"
+    echo ""
+    echo "post-merge/post-checkout hooks also remind you after pull or branch switch."
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+}
+
 is_stale_eggs_error() {
     printf '%s\n' "$1" | grep -qiE 'directory not empty|errno 66|\[errno 66\]'
 }
@@ -53,26 +89,39 @@ run_build_ext() {
     return "$build_status"
 }
 
-if run_build_ext; then
-    printf '%s\n' "$build_output"
-    exit 0
-fi
+run_blocking_build() {
+    resolve_python
+    echo "Rebuilding native extensions ($PYTHON setup.py build_ext --inplace)..."
+    echo "Triggered by staged product native/build files:"
+    printf '%s\n' "$product_native_files" | sed 's/^/  /'
+    echo ""
 
-printf '%s\n' "$build_output" >&2
-
-if is_stale_eggs_error "$build_output" && [ -d .eggs ]; then
-    echo "" >&2
-    echo "build_ext failed with a stale .eggs cache; removing .eggs and retrying once..." >&2
-    rm -rf .eggs
-    build_output=""
     if run_build_ext; then
         printf '%s\n' "$build_output"
-        exit 0
+        return 0
     fi
+
     printf '%s\n' "$build_output" >&2
+
+    if is_stale_eggs_error "$build_output" && [ -d .eggs ]; then
+        echo "" >&2
+        echo "build_ext failed with a stale .eggs cache; removing .eggs and retrying once..." >&2
+        rm -rf .eggs
+        build_output=""
+        if run_build_ext; then
+            printf '%s\n' "$build_output"
+            return 0
+        fi
+        printf '%s\n' "$build_output" >&2
+    fi
+
+    return "$build_status"
+}
+
+if [ "${DD_BUILD_NATIVE_ON_COMMIT:-}" = "1" ]; then
+    run_blocking_build
+    exit $?
 fi
 
-exit "$build_status"
-=======
-"$PYTHON" setup.py build_ext --inplace
->>>>>>> Stashed changes
+warn_staged_native
+exit 0

--- a/hooks/scripts/build-native-ext.sh
+++ b/hooks/scripts/build-native-ext.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# Rebuild in-tree native extensions when staged changes touch native/build inputs.
+#
+# Opt out for a single commit:  git commit --no-verify
+# Opt out for the shell session:  export DD_SKIP_NATIVE_BUILD=1
+
+set -eu
+
+if [ "${DD_SKIP_NATIVE_BUILD:-}" = "1" ]; then
+    echo 'build_ext skipped: DD_SKIP_NATIVE_BUILD=1'
+    exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR)
+if [ -z "$staged_files" ]; then
+    echo 'build_ext skipped: no staged files'
+    exit 0
+fi
+
+if ! printf '%s\n' "$staged_files" | grep -qE \
+    '\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$'; then
+    echo 'build_ext skipped: no staged native or build files'
+    exit 0
+fi
+
+if [ -x .venv/bin/python ]; then
+    PYTHON=.venv/bin/python
+elif [ -n "${PYTHON:-}" ]; then
+    PYTHON=$PYTHON
+else
+    PYTHON=python3
+fi
+
+echo "Rebuilding native extensions ($PYTHON setup.py build_ext --inplace)..."
+echo "Staged native/build files:"
+printf '%s\n' "$staged_files" | grep -E \
+    '\.(c|h|cc|cpp|hpp|rs|pyx|pxd)$|CMakeLists\.txt|\.cmake$|^setup\.py$' || true
+echo ""
+
+"$PYTHON" setup.py build_ext --inplace

--- a/hooks/tests/test-build-native-ext.sh
+++ b/hooks/tests/test-build-native-ext.sh
@@ -27,6 +27,17 @@ assert_contains() {
 output=$(DD_SKIP_NATIVE_BUILD=1 sh "$SCRIPT" 2>&1 || true)
 assert_contains "$output" "DD_SKIP_NATIVE_BUILD" "respects DD_SKIP_NATIVE_BUILD"
 
+<<<<<<< Updated upstream
+# stale .eggs detection helper (sourced logic via grep pattern)
+if printf '%s\n' 'OSError: [Errno 66] Directory not empty: .eggs/foo' | grep -qiE 'directory not empty|errno 66|\[errno 66\]'; then
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: stale .eggs error pattern"
+    FAIL=$((FAIL + 1))
+fi
+
+=======
+>>>>>>> Stashed changes
 # skip when no native staged files (requires git repo)
 if git rev-parse --git-dir >/dev/null 2>&1; then
     output=$(sh "$SCRIPT" 2>&1 || true)

--- a/hooks/tests/test-build-native-ext.sh
+++ b/hooks/tests/test-build-native-ext.sh
@@ -4,6 +4,8 @@
 
 set -eu
 
+export DDTRACE_NATIVE_BUILD_NONINTERACTIVE=1
+
 SCRIPT="$(cd "$(dirname "$0")/../scripts" && pwd)/build-native-ext.sh"
 PASS=0
 FAIL=0
@@ -25,7 +27,7 @@ assert_contains() {
 
 # skip when env set
 output=$(DD_SKIP_NATIVE_BUILD=1 sh "$SCRIPT" 2>&1 || true)
-assert_contains "$output" "DD_SKIP_NATIVE_BUILD" "respects DD_SKIP_NATIVE_BUILD"
+assert_contains "$output" "DD_SKIP_NATIVE_BUILD" "respects DD_SKIP_NATIVE_BUILD via off mode"
 
 # stale .eggs detection helper (same pattern as build-native-ext.sh)
 if printf '%s\n' 'OSError: [Errno 66] Directory not empty: .eggs/foo' | grep -qiE 'directory not empty|errno 66|\[errno 66\]'; then
@@ -57,21 +59,31 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# skip when no native staged files (requires git repo)
+# git config off mode (requires git repo)
 if git rev-parse --git-dir >/dev/null 2>&1; then
+    saved_mode=$(git config --local --get ddtrace.nativeBuildMode 2>/dev/null || true)
+    git config --local ddtrace.nativeBuildMode off
+    output=$(sh "$SCRIPT" 2>&1 || true)
+    assert_contains "$output" "ddtrace.nativeBuildMode=off" "respects git config off"
+    git config --local ddtrace.nativeBuildMode warn
     output=$(sh "$SCRIPT" 2>&1 || true)
     case "$output" in
         *"native build hook skipped"*) PASS=$((PASS + 1)) ;;
         *"STAGED NATIVE/BUILD FILES"*)
-            assert_contains "$output" "DD_BUILD_NATIVE_ON_COMMIT" "warn-only default mentions opt-in rebuild"
+            assert_contains "$output" "git config --local ddtrace.nativeBuildMode" "warn mode mentions git config"
             ;;
         *"Rebuilding native extensions"*)
             if [ "${DD_BUILD_NATIVE_ON_COMMIT:-}" = "1" ]; then
                 PASS=$((PASS + 1))
             else
-                echo "FAIL: rebuild ran without DD_BUILD_NATIVE_ON_COMMIT=1"
-                echo "$output"
-                FAIL=$((FAIL + 1))
+                saved=$(git config --local --get ddtrace.nativeBuildMode 2>/dev/null || true)
+                if [ "$saved" = "block" ]; then
+                    PASS=$((PASS + 1))
+                else
+                    echo "FAIL: rebuild ran without block mode"
+                    echo "$output"
+                    FAIL=$((FAIL + 1))
+                fi
             fi
             ;;
         *)
@@ -80,6 +92,12 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
             FAIL=$((FAIL + 1))
             ;;
     esac
+
+    if [ -n "$saved_mode" ]; then
+        git config --local ddtrace.nativeBuildMode "$saved_mode"
+    else
+        git config --local --unset ddtrace.nativeBuildMode 2>/dev/null || true
+    fi
 else
     echo "SKIP: not in a git repo"
 fi

--- a/hooks/tests/test-build-native-ext.sh
+++ b/hooks/tests/test-build-native-ext.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# Tests for hooks/scripts/build-native-ext.sh
+# Run with: sh hooks/tests/test-build-native-ext.sh
+
+set -eu
+
+SCRIPT="$(cd "$(dirname "$0")/../scripts" && pwd)/build-native-ext.sh"
+PASS=0
+FAIL=0
+
+assert_contains() {
+    output=$1
+    needle=$2
+    label=$3
+    case "$output" in
+        *"$needle"*) PASS=$((PASS + 1)) ;;
+        *)
+            echo "FAIL: $label"
+            echo "  expected output to contain: $needle"
+            echo "  got: $output"
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+}
+
+# skip when env set
+output=$(DD_SKIP_NATIVE_BUILD=1 sh "$SCRIPT" 2>&1 || true)
+assert_contains "$output" "DD_SKIP_NATIVE_BUILD" "respects DD_SKIP_NATIVE_BUILD"
+
+# skip when no native staged files (requires git repo)
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    output=$(sh "$SCRIPT" 2>&1 || true)
+    case "$output" in
+        *"build_ext skipped"*) PASS=$((PASS + 1)) ;;
+        *"Rebuilding native extensions"*)
+            echo "NOTE: native rebuild ran (staged native files present); skip test counted as pass"
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            echo "FAIL: unexpected output from build-native-ext"
+            echo "$output"
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+else
+    echo "SKIP: not in a git repo"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/hooks/tests/test-build-native-ext.sh
+++ b/hooks/tests/test-build-native-ext.sh
@@ -27,8 +27,7 @@ assert_contains() {
 output=$(DD_SKIP_NATIVE_BUILD=1 sh "$SCRIPT" 2>&1 || true)
 assert_contains "$output" "DD_SKIP_NATIVE_BUILD" "respects DD_SKIP_NATIVE_BUILD"
 
-<<<<<<< Updated upstream
-# stale .eggs detection helper (sourced logic via grep pattern)
+# stale .eggs detection helper (same pattern as build-native-ext.sh)
 if printf '%s\n' 'OSError: [Errno 66] Directory not empty: .eggs/foo' | grep -qiE 'directory not empty|errno 66|\[errno 66\]'; then
     PASS=$((PASS + 1))
 else
@@ -36,16 +35,44 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-=======
->>>>>>> Stashed changes
+# test-only paths excluded from product native filter
+if printf '%s\n' 'ddtrace/internal/foo_test.cpp' | grep -vE '(^|/)(test|tests|fuzz)(/|$)|/dd_wrapper/test/|_test\.cpp$' | grep -q .; then
+    echo "FAIL: _test.cpp should be excluded"
+    FAIL=$((FAIL + 1))
+else
+    PASS=$((PASS + 1))
+fi
+
+if printf '%s\n' 'dd_wrapper/test/test_foo.cpp' | grep -vE '(^|/)(test|tests|fuzz)(/|$)|/dd_wrapper/test/|_test\.cpp$' | grep -q .; then
+    echo "FAIL: dd_wrapper/test paths should be excluded"
+    FAIL=$((FAIL + 1))
+else
+    PASS=$((PASS + 1))
+fi
+
+if printf '%s\n' 'ddtrace/profiling/collector/stack.cpp' | grep -vE '(^|/)(test|tests|fuzz)(/|$)|/dd_wrapper/test/|_test\.cpp$' | grep -q .; then
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: product .cpp should not be excluded"
+    FAIL=$((FAIL + 1))
+fi
+
 # skip when no native staged files (requires git repo)
 if git rev-parse --git-dir >/dev/null 2>&1; then
     output=$(sh "$SCRIPT" 2>&1 || true)
     case "$output" in
-        *"build_ext skipped"*) PASS=$((PASS + 1)) ;;
+        *"native build hook skipped"*) PASS=$((PASS + 1)) ;;
+        *"STAGED NATIVE/BUILD FILES"*)
+            assert_contains "$output" "DD_BUILD_NATIVE_ON_COMMIT" "warn-only default mentions opt-in rebuild"
+            ;;
         *"Rebuilding native extensions"*)
-            echo "NOTE: native rebuild ran (staged native files present); skip test counted as pass"
-            PASS=$((PASS + 1))
+            if [ "${DD_BUILD_NATIVE_ON_COMMIT:-}" = "1" ]; then
+                PASS=$((PASS + 1))
+            else
+                echo "FAIL: rebuild ran without DD_BUILD_NATIVE_ON_COMMIT=1"
+                echo "$output"
+                FAIL=$((FAIL + 1))
+            fi
             ;;
         *)
             echo "FAIL: unexpected output from build-native-ext"

--- a/tests/profiling/collector/test_profiler_runtime_stats.py
+++ b/tests/profiling/collector/test_profiler_runtime_stats.py
@@ -39,6 +39,8 @@ def test_get_profiler_runtime_stats_returns_counters():
 
     p.stop()
 
+    assert get_profiler_runtime_stats() is None
+
 
 @pytest.mark.subprocess(
     env=dict(

--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -134,10 +134,9 @@ class TestProfilerRuntimeMetricCollector(BaseTestCase):
         self.assertEqual(metrics, [])
 
     def test_import_failure(self):
-        """When ddup cannot be imported, the collector returns no metrics."""
+        """When ddup is unavailable, the collector returns no metrics."""
         collector = ProfilerRuntimeMetricCollector()
-        with mock.patch.dict("sys.modules", {"ddtrace.internal.datadog.profiling.ddup._ddup": None}):
-            collector._get_stats = None
+        with mock.patch("ddtrace.internal.datadog.profiling.ddup.is_available", False):
             metrics = collector.collect(PROFILER_RUNTIME_METRICS)
         self.assertEqual(metrics, [])
 

--- a/tests/tracer/runtime/test_runtime_metrics.py
+++ b/tests/tracer/runtime/test_runtime_metrics.py
@@ -1,14 +1,16 @@
 import contextlib
 import os
 import time
+from unittest import mock
 
-import mock
 import pytest
 
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.runtime.constants import DEFAULT_RUNTIME_METRICS
 from ddtrace.internal.runtime.constants import ENV
 from ddtrace.internal.runtime.constants import GC_COUNT_GEN0
+from ddtrace.internal.runtime.constants import GC_RUNTIME_METRICS
+from ddtrace.internal.runtime.constants import PSUTIL_RUNTIME_METRICS
 from ddtrace.internal.runtime.constants import SERVICE
 from ddtrace.internal.runtime.runtime_metrics import RuntimeMetrics
 from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
@@ -139,7 +141,9 @@ def test_runtime_tags_manual_tracer_tags():
 class TestRuntimeMetrics(BaseTestCase):
     def test_all_metrics(self):
         metrics = set([k for (k, v) in RuntimeMetrics()])
-        self.assertSetEqual(metrics, DEFAULT_RUNTIME_METRICS)
+        always_available = GC_RUNTIME_METRICS | PSUTIL_RUNTIME_METRICS
+        self.assertTrue(always_available.issubset(metrics))
+        self.assertTrue(metrics.issubset(DEFAULT_RUNTIME_METRICS))
 
     def test_one_metric(self):
         metrics = [k for (k, v) in RuntimeMetrics(enabled=[GC_COUNT_GEN0])]


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

```
$ ga ddtrace/ tests/ && gcm -m "addressed bot comments"

...
OSError: [Errno 66] Directory not empty: '/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py-2/.eggs/cmake-3.27.9-py3.10-macosx-15.6-arm64.egg/cmake-3.27.9.dist-info' -> '/Users/vlad.scherbich/go/src/github.com/DataDog/dd-trace-py-2/.eggs/cmake-3.27.9-py3.10-macosx-15.6-arm64.egg/EGG-INFO'

build_ext failed with a stale .eggs cache; removing .eggs and retrying once...
...
[Autohook] FINISH 10-build-native-ext
[vlad/observability-surface-py-ops-metrics da70d8177f] addressed bot comments
 13 files changed, 197 insertions(+), 13 deletions(-)
 create mode 120000 hooks/pre-commit/10-build-native-ext
 create mode 100755 hooks/scripts/build-native-ext.sh
 create mode 100644 hooks/tests/test-build-native-ext.sh
```
