### PR TITLE
refactor(profiling): fix UB in `Frame::read`

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc
@@ -8,6 +8,7 @@
 
 #if PY_VERSION_HEX >= 0x030b0000
 #include <cstddef>
+#include <limits>
 #endif // PY_VERSION_HEX >= 0x030b0000
 
 // ------------------------------------------------------------------------
@@ -129,6 +130,36 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
     }
 #endif // PY_VERSION_HEX >= 0x030c0000
 
+    auto compute_lasti = [](uintptr_t instr_addr, uintptr_t code_obj_addr) -> Result<int> {
+        constexpr uintptr_t code_unit_size = sizeof(_Py_CODEUNIT);
+        constexpr uintptr_t code_unit_alignment = alignof(_Py_CODEUNIT);
+
+        if ((instr_addr % code_unit_alignment) != 0 || (code_obj_addr % code_unit_alignment) != 0) {
+            return ErrorKind::FrameError;
+        }
+
+        const uintptr_t code_start_addr = code_obj_addr + offsetof(PyCodeObject, co_code_adaptive);
+        if ((code_start_addr % code_unit_alignment) != 0) {
+            return ErrorKind::FrameError;
+        }
+
+        if (instr_addr < code_start_addr) {
+            return ErrorKind::FrameError;
+        }
+
+        const uintptr_t delta = instr_addr - code_start_addr;
+        if ((delta % code_unit_size) != 0) {
+            return ErrorKind::FrameError;
+        }
+
+        const uintptr_t lasti_index = delta / code_unit_size;
+        if (lasti_index > static_cast<uintptr_t>(std::numeric_limits<int>::max())) {
+            return ErrorKind::FrameError;
+        }
+
+        return static_cast<int>(lasti_index);
+    };
+
     // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
     // from the code object, which is a remote address here.  Use offsetof
     // arithmetic instead to avoid dereferencing it.
@@ -140,12 +171,15 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
         return ErrorKind::FrameError;
     }
 
-    // In Python 3.13+, instr_ptr points to the current instruction (not past it),
-    // so _PyInterpreterFrame_LASTI = instr_ptr - _PyCode_CODE(code) with no -1.
-    _Py_CODEUNIT* code_units = reinterpret_cast<_Py_CODEUNIT*>(code_obj);
-    const int lasti =
-      static_cast<int>((frame_addr->instr_ptr - code_units) -
-                       static_cast<ptrdiff_t>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT)));
+    // In Python 3.13+, instr_ptr points to the current instruction.
+    // Compute lasti with raw addresses to avoid UB on misaligned fuzzed pointers.
+    auto maybe_lasti =
+      compute_lasti(reinterpret_cast<uintptr_t>(frame_addr->instr_ptr), reinterpret_cast<uintptr_t>(code_obj));
+    if (!maybe_lasti) {
+        return ErrorKind::FrameError;
+    }
+    const int lasti = *maybe_lasti;
+
     auto maybe_frame = Frame::get(echion, code_obj, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;
@@ -157,9 +191,13 @@ Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
         return ErrorKind::FrameError;
     }
 
-    const int lasti =
-      static_cast<int>((frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>(frame_addr->f_code)) -
-                       static_cast<ptrdiff_t>(offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT)));
+    auto maybe_lasti = compute_lasti(reinterpret_cast<uintptr_t>(frame_addr->prev_instr),
+                                     reinterpret_cast<uintptr_t>(frame_addr->f_code));
+    if (!maybe_lasti) {
+        return ErrorKind::FrameError;
+    }
+    const int lasti = *maybe_lasti;
+
     auto maybe_frame = Frame::get(echion, frame_addr->f_code, lasti);
     if (!maybe_frame) {
         return ErrorKind::FrameError;


### PR DESCRIPTION
## Description

This fixes an UB detected by the fuzzer in `Frame::read` that occurred at different locations based on the Python version.

```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
  /src/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc:116:67:
    runtime error: load of misaligned address 0x60f00000227b for type 'char', which requires 2 byte alignment

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
  /src/ddtrace/internal/datadog/profiling/stack/src/echion/frame.cc:109:21:
    runtime error: load of misaligned address 0x60f00000227b for type 'char', which requires 2 byte alignment
```