### PR TITLE
fix(aap): asgi websocket connections broken by appsec body-parsing hook

### DIFF
--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -316,6 +316,7 @@ class TraceMiddleware:
                 if result:
                     receive, body = await result.value
 
+            if not is_subapp:
                 client = scope.get("client")
                 # Both list and tuple must be supported for scope["client"].
                 # In Startlette's ASGI implementation, it is a 2-item tuple (host, port). Other implementations

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -305,12 +305,11 @@ class TraceMiddleware:
                     raw_url = f"{raw_url}?{query_string}"
             if not self.integration_config.trace_query_string:
                 query_string = None
-            # Sub-app middlewares skip body parsing since it's already handled
-            # by the parent app's middleware. HTTP meta and version tags are still
-            # set on the child span for visibility.
+            # Body parsing is HTTP-only: sub-apps skip it (parent already handled it),
+            # and websocket scopes must not have their receive() consumed here.
             body = None
             peer_ip = None
-            if not is_subapp:
+            if not is_subapp and scope["type"] == "http":
                 result = core.dispatch_with_results(  # ast-grep-ignore: core-dispatch-with-results
                     "asgi.request.parse.body", (receive, headers)
                 ).await_receive_and_body

--- a/releasenotes/notes/aap-fix-asgi-websocket-appsec-a392040e2bc9dbb5.yaml
+++ b/releasenotes/notes/aap-fix-asgi-websocket-appsec-a392040e2bc9dbb5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    AAP: This fix resolves an issue where the AppSec body-parsing hook consumed the
+    ``websocket.connect`` ASGI message, causing ASGI/FastAPI WebSocket connections
+    to fail with HTTP 500 when AppSec was enabled.

--- a/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec.py
+++ b/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec.py
@@ -1,4 +1,5 @@
 from fastapi import Request
+from fastapi import WebSocket
 from fastapi.responses import PlainTextResponse
 import pytest
 
@@ -51,3 +52,21 @@ def test_core_callback_request_body(fastapi_application, client, tracer, test_sp
         )
         assert resp.status_code == 200
         assert get_response_body(resp) == '{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}'
+
+
+def test_websocket_not_broken_by_appsec(fastapi_application, client, tracer, test_spans):
+    """Regression test for https://github.com/DataDog/dd-trace-py/issues/18279.
+
+    AppSec's body-parsing hook must not consume the websocket.connect message.
+    """
+
+    @fastapi_application.websocket("/ws")
+    async def ws_endpoint(ws: WebSocket):
+        await ws.accept()
+        await ws.send_text("hello")
+        await ws.close()
+
+    with override_global_config(dict(_asm_enabled=True)):
+        with client.websocket_connect("/ws") as ws:
+            data = ws.receive_text()
+        assert data == "hello"


### PR DESCRIPTION
APPSEC-67734

## Summary

- Fixes #18279: FastAPI/ASGI WebSocket connections fail with HTTP 500 when `DD_APPSEC_ENABLED=true`
- Root cause: AppSec's `asgi.request.parse.body` hook was dispatched for all ASGI scope types, consuming the `websocket.connect` handshake message and replacing `receive()` with one returning `http.request`, causing Starlette to raise `RuntimeError: Expected ASGI message "websocket.connect", but got 'http.request'`
- Fix: guard the dispatch to `scope["type"] == "http"` only

## Test plan

- [x] `test_websocket_not_broken_by_appsec` regression test added in `tests/appsec/integrations/fastapi_tests/test_fastapi_appsec.py`
- [x] Existing AppSec FastAPI tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)