### PR TITLE
fix(claude_agent_sdk): always finish llm/step spans even when set_tags raises

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -177,21 +177,25 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         span = self.current_llm_span
         self.current_llm_span = None
 
-        if self._accumulated_input_messages is None:
-            self._accumulated_input_messages = self.integration.extract_llm_input_messages(
-                self.request_args, self.request_kwargs, self.primary_span
-            )
+        try:
+            if self._accumulated_input_messages is None:
+                self._accumulated_input_messages = self.integration.extract_llm_input_messages(
+                    self.request_args, self.request_kwargs, self.primary_span
+                )
 
-        self.integration.llmobs_set_tags(
-            span,
-            args=[],
-            kwargs={"input_messages": list(self._accumulated_input_messages)},
-            response=chunk,
-            operation="llm",
-        )
-        if exception is not None:
-            span.set_exc_info(type(exception), exception, exception.__traceback__)
-        span.finish()
+            self.integration.llmobs_set_tags(
+                span,
+                args=[],
+                kwargs={"input_messages": list(self._accumulated_input_messages)},
+                response=chunk,
+                operation="llm",
+            )
+            if exception is not None:
+                span.set_exc_info(type(exception), exception, exception.__traceback__)
+        except Exception:
+            log.debug("Failed to set tags on llm span", exc_info=True)
+        finally:
+            span.finish()
 
         # Extend accumulated context with the assistant's response for the next step.
         if chunk is not None:
@@ -206,25 +210,29 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         span = self.current_step_span
         self.current_step_span = None
 
-        input_msgs = self._step_input_snapshot
-        if input_msgs is None:
-            if self._accumulated_input_messages is None:
-                self._accumulated_input_messages = self.integration.extract_llm_input_messages(
-                    self.request_args, self.request_kwargs, self.primary_span
-                )
-            input_msgs = self._accumulated_input_messages
-        self._step_input_snapshot = None
+        try:
+            input_msgs = self._step_input_snapshot
+            if input_msgs is None:
+                if self._accumulated_input_messages is None:
+                    self._accumulated_input_messages = self.integration.extract_llm_input_messages(
+                        self.request_args, self.request_kwargs, self.primary_span
+                    )
+                input_msgs = self._accumulated_input_messages
+            self._step_input_snapshot = None
 
-        self.integration.llmobs_set_tags(
-            span,
-            args=[],
-            kwargs={"input_messages": list(input_msgs)},
-            response=chunk,
-            operation="step",
-        )
-        if exception is not None:
-            span.set_exc_info(type(exception), exception, exception.__traceback__)
-        span.finish()
+            self.integration.llmobs_set_tags(
+                span,
+                args=[],
+                kwargs={"input_messages": list(input_msgs)},
+                response=chunk,
+                operation="step",
+            )
+            if exception is not None:
+                span.set_exc_info(type(exception), exception, exception.__traceback__)
+        except Exception:
+            log.debug("Failed to set tags on step span", exc_info=True)
+        finally:
+            span.finish()
 
     def _finalize_tool_span(self, tool_data: dict[str, Any], tool_output: str, is_error: bool = False) -> None:
         tool_span = tool_data["tool_span"]

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -884,6 +884,97 @@ class TestLLMObsClaudeAgentSdk:
         assert agent_spans[0].trace_id != agent_spans[1].trace_id
 
 
+def test_finalize_llm_span_always_finishes_span_even_when_set_tags_raises(tracer):
+    """span.finish() must be called even when llmobs_set_tags raises.
+
+    When a stream is interrupted mid-turn (e.g. UserAbortError after tool results arrive
+    but before the next AssistantMessage), _finalize_llm_span is called with chunk=None.
+    If llmobs_set_tags raises (e.g. due to malformed input data), the span must still be
+    finished so it doesn't leak and later get submitted without a span kind, which causes
+    'Span kind not found in span context' warnings in ddtrace.
+    """
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+
+    from ddtrace.contrib.internal.claude_agent_sdk._streaming import ClaudeAgentSdkAsyncStreamHandler
+    from ddtrace.llmobs._integrations.claude_agent_sdk import ClaudeAgentSdkIntegration
+
+    integration = MagicMock(spec=ClaudeAgentSdkIntegration)
+    integration.llmobs_enabled = True
+
+    primary_span = tracer.trace("claude_agent_sdk.ClaudeSDKClient.query")
+
+    handler = ClaudeAgentSdkAsyncStreamHandler.__new__(ClaudeAgentSdkAsyncStreamHandler)
+    handler.integration = integration
+    handler.primary_span = primary_span
+    handler.request_args = []
+    handler.request_kwargs = {}
+    handler.chunks = []
+    handler.operation = "request"
+    handler.instance = None
+    handler.context = None
+    handler._active_tool_spans = {}
+    handler.current_step_span = None
+    handler._step_response_chunk = None
+    handler._step_input_snapshot = None
+    handler._accumulated_input_messages = None
+    handler._is_finalized = False
+
+    # Open an llm span (simulates _create_step_span creating the child)
+    with tracer.trace("claude_agent_sdk.llm") as llm_span:
+        handler.current_llm_span = llm_span
+
+        # Make llmobs_set_tags raise to simulate the failure path
+        integration.llmobs_set_tags.side_effect = RuntimeError("simulated tag failure")
+        integration.extract_llm_input_messages.return_value = []
+
+        handler._finalize_llm_span(None)
+
+    # The span must be finished regardless of the llmobs_set_tags failure
+    assert llm_span.finished, "llm span must be finished even when llmobs_set_tags raises"
+    assert handler.current_llm_span is None
+
+
+def test_finalize_step_span_always_finishes_span_even_when_set_tags_raises(tracer):
+    """span.finish() must be called even when llmobs_set_tags raises in _finalize_step_span."""
+    from unittest.mock import MagicMock
+
+    from ddtrace.contrib.internal.claude_agent_sdk._streaming import ClaudeAgentSdkAsyncStreamHandler
+    from ddtrace.llmobs._integrations.claude_agent_sdk import ClaudeAgentSdkIntegration
+
+    integration = MagicMock(spec=ClaudeAgentSdkIntegration)
+    integration.llmobs_enabled = True
+
+    primary_span = tracer.trace("claude_agent_sdk.ClaudeSDKClient.query")
+
+    handler = ClaudeAgentSdkAsyncStreamHandler.__new__(ClaudeAgentSdkAsyncStreamHandler)
+    handler.integration = integration
+    handler.primary_span = primary_span
+    handler.request_args = []
+    handler.request_kwargs = {}
+    handler.chunks = []
+    handler.operation = "request"
+    handler.instance = None
+    handler.context = None
+    handler._active_tool_spans = {}
+    handler.current_llm_span = None
+    handler._step_response_chunk = None
+    handler._step_input_snapshot = None
+    handler._accumulated_input_messages = None
+    handler._is_finalized = False
+
+    with tracer.trace("claude_agent_sdk.step") as step_span:
+        handler.current_step_span = step_span
+
+        integration.llmobs_set_tags.side_effect = RuntimeError("simulated tag failure")
+        integration.extract_llm_input_messages.return_value = []
+
+        handler._finalize_step_span(None)
+
+    assert step_span.finished, "step span must be finished even when llmobs_set_tags raises"
+    assert handler.current_step_span is None
+
+
 def test_shadow_tags_llm_with_cache_tokens(tracer):
     """Verify cache-token shadow metrics propagate from claude_agent_sdk usage to APM span."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## What does this PR do?

In `_finalize_llm_span` and `_finalize_step_span`, `span.finish()` was placed after `llmobs_set_tags(...)`, so if tagging raised an exception the span would leak: it was never finished, and when Python GC eventually called `finish()` on the abandoned object, ddtrace would try to submit it to LLMObs and fail with:

```
Error generating LLMObs span event for span <Span(name=claude_agent_sdk.llm)>,
likely due to malformed span
KeyError: 'Span kind not found in span context'
```

because `_annotate_llmobs_span_data` (which sets the span kind) had never been called.

## How is it triggered?

When a stream is interrupted mid-turn — for example, a `UserAbortError` is raised after tool results arrive but before the next `AssistantMessage` — `finalize_stream` calls `_finalize_llm_span(chunk=None)`. If `llmobs_set_tags` raises (or `extract_llm_input_messages` raises before it), the span leaks. The `except Exception` in `finalize_stream` swallows the error and the primary span finishes normally, but the orphaned llm/step span is left open.

The `finalize_stream` method itself already uses this pattern (`finally: self.primary_span.finish()`), so this fix applies the same pattern consistently to `_finalize_llm_span` and `_finalize_step_span`.

## Changes

- Wrap the tagging logic in `_finalize_llm_span` and `_finalize_step_span` in `try/except/finally` so `span.finish()` is always called.
- Add two regression tests that inject a `RuntimeError` from `llmobs_set_tags` and assert the span is still finished.

## Test plan

- [ ] `tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py::test_finalize_llm_span_always_finishes_span_even_when_set_tags_raises`
- [ ] `tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py::test_finalize_step_span_always_finishes_span_even_when_set_tags_raises`
- [ ] Existing `TestLLMObsClaudeAgentSdk` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)