### PR TITLE
feat(profiling): make fast copy the default

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -189,7 +189,28 @@ def start(additional_tags: Optional[dict[str, str]] = None) -> bool:
             log.error("Failed to start crashtracker: failed to construct crashtracker configuration")
             return False
 
+        # If the stack profiler's SIGSEGV/SIGBUS recovery handler is already
+        # installed (i.e. the profiler started before crashtracking), momentarily
+        # uninstall it so the crashtracker records the real underlying handler as
+        # its "previous" rather than the profiler's handler. We reinstall the
+        # profiler's handler on top afterwards, yielding a linear handler chain
+        # (profiler -> crashtracker -> default) with no cycle. We only touch the
+        # stack module if it is already imported: importing it here would load the
+        # native extension and install signal handlers even when profiling is off.
+        stack_mod = sys.modules.get("ddtrace.internal.datadog.profiling.stack")
+        if stack_mod is not None:
+            try:
+                stack_mod.uninstall_segv_handler()
+            except Exception:  # nosec: B110
+                pass
+
         crashtracker_init(config, receiver_config, metadata)
+
+        if stack_mod is not None:
+            try:
+                stack_mod.reinstall_segv_handler()
+            except Exception:  # nosec: B110
+                pass
 
         def crashtracker_fork_handler():
             # We recreate the args here mainly to pass updated runtime_id after

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -39,6 +39,13 @@ thread_local ThreadAltStack t_altstack;
 thread_local sigjmp_buf t_jmpenv;
 thread_local volatile sig_atomic_t t_handler_armed = 0;
 
+// Guards against a signal-handler chaining cycle. The unarmed path below chains
+// to the previously installed handler and re-raises; if that handler chains back
+// to us (e.g. profiler <-> crashtracker pointing at each other), we would loop
+// forever and hang the process. If we re-enter the unarmed path while already
+// chaining, fall through to the default disposition so termination is guaranteed.
+thread_local volatile sig_atomic_t t_in_unarmed_chain = 0;
+
 static inline void
 arm_fault_handler()
 {
@@ -57,6 +64,22 @@ static void
 segv_handler(int signo, siginfo_t*, void*)
 {
     if (!t_handler_armed) {
+        if (t_in_unarmed_chain) {
+            // We are being re-entered while already chaining to a previous
+            // handler: the handler chain has cycled back to us. Restore the
+            // default disposition and re-raise to guarantee the process
+            // terminates instead of looping forever.
+            struct sigaction dfl
+            {};
+            dfl.sa_handler = SIG_DFL;
+            sigemptyset(&dfl.sa_mask);
+            dfl.sa_flags = 0;
+            sigaction(signo, &dfl, nullptr);
+            pthread_kill(pthread_self(), signo);
+            return;
+        }
+        t_in_unarmed_chain = 1;
+
         struct sigaction* old = (signo == SIGSEGV) ? &g_old_segv : &g_old_bus;
         // Restore the previous handler and re-raise so default/old handling occurs.
         // Use pthread_kill(pthread_self(), signo): thread-directed (targets the

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -342,7 +342,7 @@ class ProfilingConfigStack(DDConfig):
     fast_copy = DDConfig.v(
         bool,
         "fast_copy",
-        default=False,
+        default=True,
         help_type="Boolean",
         help="Whether to use fast memory copying (safe_memcpy) instead of process_vm_readv for stack sampling.",
         private=True,

--- a/releasenotes/notes/profiling-enable-fast-copy-memory-by-default-402b1f3e37db479f.yaml
+++ b/releasenotes/notes/profiling-enable-fast-copy-memory-by-default-402b1f3e37db479f.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    profiling: The fast stack profiler optimisation is now enabled by default.

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -5808,7 +5808,7 @@
     ],
     "_DD_PROFILING_STACK_FAST_COPY": [
       {
-        "implementation": "A",
+        "implementation": "B",
         "type": "boolean",
         "default": "true",
         "internal": true

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -5810,7 +5810,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "false",
+        "default": "true",
         "internal": true
       }
     ],

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -153,6 +153,7 @@ suites:
     paths:
       - '@crashtracker'
       - '@core'
+      - '@profiling'
     snapshot: true
   conftest:
     parallelism: 1


### PR DESCRIPTION
## Description

Previous | Next https://github.com/DataDog/dd-trace-py/pull/18332

This PR updates the Profiling codebase to make "fast copy" (using guarded `memcpy` instead of `process_vm_readv`) the default in the Stack Sampler.