### PR TITLE
ci: always save package artifacts

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -45,6 +45,7 @@ variables:
     KUBERNETES_MEMORY_LIMIT: "10Gi"
     DD_DISABLE_VPA: true
   artifacts:
+    when: always
     paths:
       - "pywheels/*.whl"
       - "pywheels/*.tar.gz"
@@ -288,6 +289,7 @@ variables:
   script:
     - bash .gitlab/scripts/build-wheel-windows.sh
   artifacts:
+    when: always
     paths:
       - "pywheels/*.whl"
       - "debugwheelhouse/*.log"
@@ -314,6 +316,7 @@ variables:
     git config --global --add safe.directory "${CI_PROJECT_DIR}"
     .gitlab/download-wheels-from-gh-actions.sh
   artifacts:
+    when: always
     paths:
       - "pywheels/*.whl"
       - "pywheels/*.tar.gz"
@@ -348,6 +351,7 @@ download_dependency_wheels:
       paths:
         - ${CI_PROJECT_DIR}/.cache/
   artifacts:
+    when: always
     paths:
       - "pywheels-dep/"
 
@@ -417,6 +421,7 @@ download_dependency_wheels:
   script:
     - echo "Collected $(ls pywheels/*.whl 2>/dev/null | wc -l) Windows wheels"
   artifacts:
+    when: always
     paths:
       - "pywheels/*.whl"
 
@@ -428,6 +433,7 @@ download_dependency_wheels:
   before_script:
     - pip install 'packaging>=24.0,<26'  # ci-deps: allow
   artifacts:
+    when: always
     paths:
       - "pywheels/*.whl"
       - "pywheels/*.tar.gz"


### PR DESCRIPTION
## Description

I am trying to debug a build problem in CI where the smoke tests are failing, but we don't get the artifacts saved to the job in the case of failures. This PR changes that.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
