### PR TITLE
fix(profiling): fix for possible memory leak in sample pool

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -25,6 +25,15 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
     if (failed) {
         return;
     }
+    // A previous sampling cycle may have left a sample checked out if it returned early (e.g. one of echion's
+    // ThreadInfo::sample() error paths) without reaching render_stack_end(). Return that orphan to the pool before
+    // checking out a new one; otherwise the checked-out pointer is overwritten here and lost, permanently draining a
+    // slot from the (fixed-capacity) StaticSamplePool. Once the pool is drained every sample is heap-allocated and
+    // leaked. This keeps the renderer's in-flight sample bounded to exactly one regardless of upstream error paths.
+    if (sample != nullptr) {
+        SampleManager::drop_sample(sample);
+        sample = nullptr;
+    }
     sample = SampleManager::start_sample();
     if (sample == nullptr) {
         std::cerr << "Failed to create a sample.  Stack v2 sampler will be disabled." << std::endl;
@@ -280,4 +289,11 @@ Datadog::StackRenderer::postfork_child()
     // from the parent process's dictionary
     string_id_cache.clear();
     function_id_cache.clear();
+
+    // If the fork interrupted a sampling cycle, a sample may still be checked out from the pool. Return it so the
+    // child starts with the pool at full capacity rather than permanently down a slot.
+    if (sample != nullptr) {
+        SampleManager::drop_sample(sample);
+        sample = nullptr;
+    }
 }

--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -37,7 +37,13 @@ endif()
 
 function(dd_wrapper_add_test name)
     add_executable(${name} ${ARGN})
-    target_include_directories(${name} PRIVATE ../include)
+    # Mirror the _stack extension's include layout so tests can include stack/echion/dd_wrapper headers transitively
+    # (e.g. stack_renderer.hpp -> "dd_wrapper/include/sample.hpp", "python_headers.hpp", "echion/frame.h"). ../.. is the
+    # profiling root (makes the dd_wrapper/include/... paths resolve); ../include is stack/include.
+    target_include_directories(${name} PRIVATE ../include ../..)
+    # Python and echion are marked SYSTEM to suppress warnings (e.g. -Wold-style-cast) coming from CPython and echion
+    # headers, which are otherwise fatal under -Werror. This matches stack/CMakeLists.txt.
+    target_include_directories(${name} SYSTEM PRIVATE ${Python3_INCLUDE_DIRS} ../echion ../include/util)
     # this has to refer to the stack extension name to properly link against
     target_link_libraries(${name} PRIVATE gmock gtest_main ${EXTENSION_NAME})
 
@@ -78,3 +84,4 @@ endfunction()
 
 # Add the tests
 dd_wrapper_add_test(test_thread_span_links test_thread_span_links.cpp)
+dd_wrapper_add_test(test_sample_pool_leak test_sample_pool_leak.cpp)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_sample_pool_leak.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_sample_pool_leak.cpp
@@ -1,0 +1,70 @@
+#include "stack_renderer.hpp"
+
+#include "dd_wrapper/include/ddup_interface.hpp"
+#include "dd_wrapper/include/sample_manager.hpp"
+#include "dd_wrapper/include/static_sample_pool.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+using namespace Datadog;
+
+namespace {
+
+// Drain every sample the pool will currently hand out, count them, then return them all.
+// Leaves the pool in its original state and reports how many samples were available.
+size_t
+count_available_pool_samples()
+{
+    std::vector<Sample*> taken;
+    while (auto s = StaticSamplePool::take_sample()) {
+        taken.push_back(*s);
+    }
+    const size_t available = taken.size();
+    for (auto* s : taken) {
+        if (auto leftover = StaticSamplePool::return_sample(s)) {
+            // Pool full -- should not happen here since we just drained it.
+            delete *leftover; // NOLINT(cppcoreguidelines-owning-memory)
+        }
+    }
+    return available;
+}
+
+} // namespace
+
+// Regression test for the sample-pool leak.
+//
+// render_thread_begin() checks a Sample out of the fixed-capacity StaticSamplePool. Prior to the fix it overwrote the
+// in-flight pointer without returning it whenever a sampling cycle ended early -- e.g. one of echion's
+// ThreadInfo::sample() error paths (CpuTimeError, ThreadInfoError) returned after render_thread_begin() but before
+// render_stack_end(). Each such cycle permanently drained one pool slot; once the pool was drained every subsequent
+// sample was heap-allocated via `new` and leaked. The fix returns any in-flight sample before checking out a new one.
+TEST(StackRendererSamplePool, ThreadBeginWithoutEndDoesNotDrainPool)
+{
+    // Initialize profiler state so SampleManager::start_sample() can build valid samples.
+    ddup_config_service("test_service");
+    ddup_config_env("test_env");
+    ddup_config_version("0.0.1");
+    ddup_config_url("http://localhost:8126");
+    ddup_config_max_nframes(256);
+    ddup_start();
+
+    ASSERT_EQ(count_available_pool_samples(), StaticSamplePool::CAPACITY);
+
+    StackRenderer renderer;
+
+    // Simulate many sampling cycles that begin a thread render but never reach render_stack_end() -- the production
+    // trigger. Run well past CAPACITY so that a leak would fully drain the pool.
+    for (size_t i = 0; i < StaticSamplePool::CAPACITY * 4 + 4; ++i) {
+        renderer.render_thread_begin(nullptr, "test_thread", 0, /*thread_id=*/i + 1, /*native_id=*/i + 1);
+    }
+    // Close the final, legitimately in-flight sample.
+    renderer.render_stack_end();
+
+    // With the fix, every render_thread_begin() returns the prior orphan before taking a new sample, so the pool is
+    // fully restored. Without the fix only the single sample recovered by the final render_stack_end() is available.
+    EXPECT_EQ(count_available_pool_samples(), StaticSamplePool::CAPACITY)
+      << "render_thread_begin() leaked sample-pool slots when a sampling cycle ended without render_stack_end()";
+}

--- a/releasenotes/notes/profiling-fix-sample-pool-leak-434a136c2cc9939b.yaml
+++ b/releasenotes/notes/profiling-fix-sample-pool-leak-434a136c2cc9939b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: fixed a memory leak in the stack profiler that could slowly grow process memory while profiling is enabled.


### PR DESCRIPTION
## Description

The stack profiler's `StackRenderer` checks a `Sample` out of a fixed-capacity pool (`StaticSamplePool`) in `render_thread_begin()` and returns it in `render_stack_end()`. When a sampling cycle ended early — e.g. an echion `ThreadInfo::sample()` error path (`CpuTimeError`, `ThreadInfoError`) returned after `render_thread_begin()` but before `render_stack_end()` — the checked-out sample was never returned. The next `render_thread_begin()` overwrote the pointer, orphaning it.

Each occurrence permanently drained one pool slot; once the pool was empty every subsequent sample was heap-allocated via `new` and leaked. This grows process memory over time and is most likely under thread/task churn (threads exiting mid-sample, asyncio/greenlet workloads).

### Fix

`StackRenderer` now returns any in-flight sample to the pool before checking out a new one in `render_thread_begin()`, and also on fork (`postfork_child()`). This bounds the renderer to a single in-flight sample regardless of which error path echion takes, so the pool can no longer be drained or leaked.

## Testing

Adds a gtest (`stack/test/test_sample_pool_leak.cpp`) that drives `render_thread_begin()` past the pool capacity without `render_stack_end()` and asserts the pool is fully restored — fails before the fix (only 1 slot recovered), passes after (full capacity).

