### PR TITLE
feat(aiokafka): add partition and offset to produce span

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -1366,8 +1366,18 @@ def _on_aiokafka_send_start(
 
 
 def _on_aiokafka_send_complete(
-    ctx: core.ExecutionContext, exc_info: tuple[Optional[type], Optional[BaseException], Optional[TracebackType]], _
+    ctx: core.ExecutionContext,
+    exc_info: tuple[Optional[type], Optional[BaseException], Optional[TracebackType]],
+    record_metadata: Optional[Any],
 ) -> None:
+    span = ctx.span
+    if span is not None and record_metadata is not None:
+        partition = getattr(record_metadata, "partition", None)
+        offset = getattr(record_metadata, "offset", None)
+        if isinstance(partition, int):
+            span._set_attribute(PARTITION, partition)
+        if isinstance(offset, int):
+            span._set_attribute(MESSAGE_OFFSET, offset)
     _finish_span(ctx, exc_info)
 
 

--- a/releasenotes/notes/aiokafka-produce-partition-offset-b890906a737d50a6.yaml
+++ b/releasenotes/notes/aiokafka-produce-partition-offset-b890906a737d50a6.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    aiokafka: Adds ``kafka.partition`` and ``kafka.message_offset`` tags to the
+    producer span once the broker acknowledges the send. The partition reflects
+    the partition the broker actually assigned to the message, which may differ
+    from the partition the caller requested. Mirrors the behavior added to the
+    Java tracer in DataDog/dd-trace-java#11107.

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570b00000000",
+      "_dd.p.tid": "6a19ef4700000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -25,8 +25,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "3964556687088658849",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "7836505328584449212",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -34,10 +34,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 14807677,
-    "start": 1779914507796498571
+    "duration": 16995950,
+    "start": 1780084551828499364
   }],
 [
   {
@@ -52,7 +52,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570800000000",
+      "_dd.p.tid": "6a19ef4400000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -64,8 +64,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "17052484314529185803",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "980526249557665312",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -73,11 +73,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1419849,
-    "start": 1779914504777313302
+    "duration": 6521944,
+    "start": 1780084548591959315
   }],
 [
   {
@@ -92,7 +93,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570800000000",
+      "_dd.p.tid": "6a19ef4400000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -104,8 +105,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "17052484314529185803",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "980526249557665312",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -113,11 +114,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 1.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 947594,
-    "start": 1779914504778968821
+    "duration": 1042377,
+    "start": 1780084548599050924
   }],
 [
   {
@@ -132,7 +134,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570800000000",
+      "_dd.p.tid": "6a19ef4400000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -144,8 +146,8 @@
       "messaging.destination.name": "getmany_multiple_messages_multiple_topics_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "15798555699390652617",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "12311909681352468218",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -153,9 +155,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1027137,
-    "start": 1779914504780076875
+    "duration": 1080335,
+    "start": 1780084548600231067
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics_with_distributed_tracing.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_multiple_messages_multiple_topics_with_distributed_tracing.json
@@ -11,8 +11,8 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17572100000000",
-      "_dd.span_links": "[{\"trace_id\": \"6a17571e00000000530364ff00ab45bc\", \"span_id\": \"00838bb53c01b97a\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a17571e00000000\", \"flags\": 1}, {\"trace_id\": \"6a17571e00000000319f0c70e4310db0\", \"span_id\": \"9b59174e6dccfa4c\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a17571e00000000\", \"flags\": 1}, {\"trace_id\": \"6a17571e000000009d8abb1de5986885\", \"span_id\": \"6ff1ff2070b98f7d\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a17571e00000000\", \"flags\": 1}]",
+      "_dd.p.tid": "6a19ef5100000000",
+      "_dd.span_links": "[{\"trace_id\": \"6a19ef4e0000000013ffe403d788d37c\", \"span_id\": \"4946278831030841\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a19ef4e00000000\", \"flags\": 1}, {\"trace_id\": \"6a19ef4e00000000ccf3429347a22528\", \"span_id\": \"ce29f130a0726f3b\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a19ef4e00000000\", \"flags\": 1}, {\"trace_id\": \"6a19ef4e00000000784669e6fe83fda1\", \"span_id\": \"26b1bbabbfdc0b0a\", \"tracestate\": \"dd=s:1;t.dm:-0;t.tid:6a19ef4e00000000\", \"flags\": 1}]",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -26,8 +26,8 @@
       "messaging.destination.name": "getmany_distributed_tracing_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "417609625933463960",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "17970675826320189982",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -35,10 +35,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 15909005,
-    "start": 1779914529782306829
+    "duration": 6798089,
+    "start": 1780084561102482780
   }],
 [
   {
@@ -53,7 +53,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571e00000000",
+      "_dd.p.tid": "6a19ef4e00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -65,8 +65,8 @@
       "messaging.destination.name": "getmany_distributed_tracing",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "18028015561035247322",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "17935234018554299732",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -74,11 +74,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1688526,
-    "start": 1779914526760723794
+    "duration": 2276292,
+    "start": 1780084558085779305
   }],
 [
   {
@@ -93,7 +94,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571e00000000",
+      "_dd.p.tid": "6a19ef4e00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -105,8 +106,8 @@
       "messaging.destination.name": "getmany_distributed_tracing",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "18028015561035247322",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "17935234018554299732",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -114,11 +115,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 1.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1360229,
-    "start": 1779914526762840577
+    "duration": 1104691,
+    "start": 1780084558088514071
   }],
 [
   {
@@ -133,7 +135,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571e00000000",
+      "_dd.p.tid": "6a19ef4e00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -145,8 +147,8 @@
       "messaging.destination.name": "getmany_distributed_tracing_2",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "6097283262106720861",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "18394097267420882967",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -154,9 +156,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1390022,
-    "start": 1779914526764464060
+    "duration": 1366234,
+    "start": 1780084558089802536
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_single_message.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_getmany_single_message.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570e00000000",
+      "_dd.p.tid": "6a19ef5400000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -24,8 +24,8 @@
       "messaging.destination.name": "getmany_single_message",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "13966335275364147180",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "7572105418330006464",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -33,10 +33,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 11602687,
-    "start": 1779914510946785465
+    "duration": 2560655,
+    "start": 1780084564089560375
   }],
 [
   {
@@ -51,7 +51,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570b00000000",
+      "_dd.p.tid": "6a19ef5100000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -63,8 +63,8 @@
       "messaging.destination.name": "getmany_single_message",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "12452068901761094219",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "9545769659554839818",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -72,9 +72,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1363683,
-    "start": 1779914507929914375
+    "duration": 1718003,
+    "start": 1780084561174318420
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_commit_with_offset.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_commit_with_offset.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571800000000",
+      "_dd.p.tid": "6a19ef5700000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -25,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_commit_with_offset",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "12508121382715048342",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "15722603865325545603",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -36,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 12320178,
-    "start": 1779914520330468519
+    "duration": 5840561,
+    "start": 1780084567158460131
   }],
 [
   {
@@ -54,7 +54,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571500000000",
+      "_dd.p.tid": "6a19ef5400000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -66,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_commit_with_offset",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "2664448950226066434",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "337520558555867571",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -75,9 +75,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1660565,
-    "start": 1779914517312415460
+    "duration": 1309086,
+    "start": 1780084564147000458
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_failure.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_failure.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570b00000000",
+      "_dd.p.tid": "6a19ef6300000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -26,8 +26,8 @@
       "messaging.destination.name": "nonexistent_topic",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "7528740217719889565",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "18288295222495489551",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -36,8 +36,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 1544144,
-    "start": 1779914507846345542
+    "duration": 104618323,
+    "start": 1780084579604610239
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[None].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[None].json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570800000000",
+      "_dd.p.tid": "6a19ef4d00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -24,8 +24,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "414625676373092143",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "4313261585553916970",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -35,10 +35,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 9912238,
-    "start": 1779914504518338356
+    "duration": 2732458,
+    "start": 1780084557984809716
   }],
 [
   {
@@ -53,7 +53,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570500000000",
+      "_dd.p.tid": "6a19ef4a00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -65,8 +65,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "508874501875563470",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "5557719227018253300",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -74,9 +74,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1652560,
-    "start": 1779914501496960385
+    "duration": 1408049,
+    "start": 1780084554970202576
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[test_key].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_key[test_key].json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571e00000000",
+      "_dd.p.tid": "6a19ef6000000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -25,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "3611963975549045488",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "18058263135650971766",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -36,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 8815178,
-    "start": 1779914526591643794
+    "duration": 4094210,
+    "start": 1780084576468218959
   }],
 [
   {
@@ -54,7 +54,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571b00000000",
+      "_dd.p.tid": "6a19ef5d00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -66,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_key",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "109338628548191948",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "15311093227726259237",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -75,9 +75,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1606274,
-    "start": 1779914523573724554
+    "duration": 1248876,
+    "start": 1780084573453920024
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[None].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[None].json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570500000000",
+      "_dd.p.tid": "6a19ef6300000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -25,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "1720210457940791299",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "6040449346044097859",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -36,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 11423165,
-    "start": 1779914501382811113
+    "duration": 3528046,
+    "start": 1780084579574300681
   }],
 [
   {
@@ -54,7 +54,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570200000000",
+      "_dd.p.tid": "6a19ef6000000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -66,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "328336203928896981",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "6501663703455823142",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -75,9 +75,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1667850,
-    "start": 1779914498359520471
+    "duration": 1306327,
+    "start": 1780084576559500957
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[hueh_hueh_hueh].json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_value[hueh_hueh_hueh].json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571500000000",
+      "_dd.p.tid": "6a19ef5d00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -25,8 +25,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "7303485111255764107",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "2336346145200220566",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -36,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 11085529,
-    "start": 1779914517198621215
+    "duration": 2561725,
+    "start": 1780084573365906242
   }],
 [
   {
@@ -54,7 +54,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571200000000",
+      "_dd.p.tid": "6a19ef5a00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -66,8 +66,8 @@
       "messaging.destination.name": "send_and_wait_value",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "8689125156372693595",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "15335609274966193700",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -75,9 +75,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1619396,
-    "start": 1779914514167226873
+    "duration": 1338406,
+    "start": 1780084570355234964
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_with_distributed_tracing.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_and_wait_with_distributed_tracing.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571800000000",
+      "_dd.p.tid": "6a19ef5700000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -23,8 +23,8 @@
       "messaging.destination.name": "send_and_wait_with_distributed_tracing",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "4494730242458558469",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "15544518814541909868",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -32,11 +32,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 2406910,
-    "start": 1779914520436754928
+    "duration": 1707213,
+    "start": 1780084567288819928
   },
      {
        "name": "kafka.consume",
@@ -50,7 +51,7 @@
        "meta": {
          "_dd.base_service": "tests.contrib.aiokafka",
          "_dd.p.dm": "-0",
-         "_dd.p.tid": "6a17571800000000",
+         "_dd.p.tid": "6a19ef5700000000",
          "_dd.svc_src": "aiokafka",
          "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
          "component": "aiokafka",
@@ -64,10 +65,10 @@
          "messaging.destination.name": "send_and_wait_with_distributed_tracing",
          "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
          "messaging.system": "kafka",
-         "pathway.hash": "8253026967498850374",
-         "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+         "pathway.hash": "9251282021490703223",
+         "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
          "span.kind": "consumer",
-         "tracestate": "dd=p:7cdc9dd8e0b15ff3;s:1;t.dm:-0;t.tid:6a17571800000000"
+         "tracestate": "dd=p:3f28edd53235ca98;s:1;t.dm:-0;t.tid:6a19ef5700000000"
        },
        "metrics": {
          "_dd.measured": 1.0,
@@ -76,8 +77,8 @@
          "_sampling_priority_v1": 1.0,
          "kafka.message_offset": -1.0,
          "kafka.partition": -1.0,
-         "process_id": 557.0
+         "process_id": 510.0
        },
-       "duration": 10317071,
-       "start": 1779914523458213324
+       "duration": 1800834,
+       "start": 1780084570302511693
      }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_commit.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_commit.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17571200000000",
+      "_dd.p.tid": "6a19ef4a00000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -25,8 +25,8 @@
       "messaging.destination.name": "send_commit",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "11254982689108233361",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "17317135141035185227",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -36,10 +36,10 @@
       "_sampling_priority_v1": 1.0,
       "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 557.0
+      "process_id": 510.0
     },
-    "duration": 5259987,
-    "start": 1779914514074805185
+    "duration": 2675113,
+    "start": 1780084554907099261
   }],
 [
   {
@@ -54,7 +54,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570f00000000",
+      "_dd.p.tid": "6a19ef4700000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -66,8 +66,8 @@
       "messaging.destination.name": "send_commit",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "10306749123033560219",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "10637579824864263587",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -75,9 +75,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1781481,
-    "start": 1779914511057955537
+    "duration": 1497173,
+    "start": 1780084551892590329
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_multiple_servers.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka.test_send_multiple_servers.json
@@ -11,7 +11,7 @@
     "meta": {
       "_dd.base_service": "tests.contrib.aiokafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17570800000000",
+      "_dd.p.tid": "6a19ef5700000000",
       "_dd.svc_src": "aiokafka",
       "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.aiokafka",
       "component": "aiokafka",
@@ -23,8 +23,8 @@
       "messaging.destination.name": "send_multiple_servers",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092', '127.0.0.1:29092', '127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "9346863313248657932",
-      "runtime-id": "729b107a3ceb47ac820b96a7acccc5d7",
+      "pathway.hash": "5112895218700696887",
+      "runtime-id": "7b808dd1021a41338f55b029feb0e93c",
       "span.kind": "producer"
     },
     "metrics": {
@@ -32,9 +32,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 557.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 510.0
     },
-    "duration": 1795270,
-    "start": 1779914504626966717
+    "duration": 1363954,
+    "start": 1780084567222408806
   }]]

--- a/tests/snapshots/tests.contrib.aiokafka.test_aiokafka_dsm.test_data_streams_aiokafka_enabled.json
+++ b/tests/snapshots/tests.contrib.aiokafka.test_aiokafka_dsm.test_data_streams_aiokafka_enabled.json
@@ -11,9 +11,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17573b00000000",
+      "_dd.p.tid": "6a19ef6700000000",
       "_dd.svc_src": "aiokafka",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpibma4voa,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmp7yumv_d2,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiokafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "None",
@@ -23,8 +23,8 @@
       "messaging.destination.name": "test_data_streams_aiokafka_enabled",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "8642095245803236792",
-      "runtime-id": "5b20a5981ce341ebb61cb591dd7167a1",
+      "pathway.hash": "5920449047138131985",
+      "runtime-id": "314f24f751d9495bb44a5978ed469431",
       "span.kind": "producer"
     },
     "metrics": {
@@ -32,11 +32,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.partition": -1.0,
-      "process_id": 613.0
+      "kafka.message_offset": 0.0,
+      "kafka.partition": 0.0,
+      "process_id": 648.0
     },
-    "duration": 3917622,
-    "start": 1779914555201332602
+    "duration": 4244398,
+    "start": 1780084583293182419
   }],
 [
   {
@@ -51,9 +52,9 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "6a17573b00000000",
+      "_dd.p.tid": "6a19ef6700000000",
       "_dd.svc_src": "aiokafka",
-      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpibma4voa,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmp7yumv_d2,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "aiokafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.group_id": "test_group",
@@ -64,8 +65,8 @@
       "messaging.destination.name": "test_data_streams_aiokafka_enabled",
       "messaging.kafka.bootstrap.servers": "['127.0.0.1:29092']",
       "messaging.system": "kafka",
-      "pathway.hash": "1465279382551306564",
-      "runtime-id": "5b20a5981ce341ebb61cb591dd7167a1",
+      "pathway.hash": "12242356098827355803",
+      "runtime-id": "314f24f751d9495bb44a5978ed469431",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -73,10 +74,10 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.message_offset": 1.0,
+      "kafka.message_offset": -1.0,
       "kafka.partition": -1.0,
-      "process_id": 613.0
+      "process_id": 648.0
     },
-    "duration": 6631969,
-    "start": 1779914555709621844
+    "duration": 499024,
+    "start": 1780084583798318465
   }]]


### PR DESCRIPTION
## Summary
- After the broker acknowledges a send, populate `kafka.partition` and `kafka.message_offset` on the producer span from the resulting `RecordMetadata`.
- The partition tag now reflects the partition the broker actually assigned, which may differ from any hint the caller passed via `send(..., partition=...)`.
- Mirrors the equivalent feature added to the Java tracer in DataDog/dd-trace-java#11107.

## Test plan
- [x] Verified locally: aiokafka produce snapshots now carry `kafka.partition: 0` / `kafka.message_offset: 0` instead of `-1` for first-message produces.
- [ ] CI: aiokafka contrib suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)