### PR TITLE
feat(code_origin): add DD_CODE_ORIGIN_FILE_PATH_REWRITE for container-to-repo path mapping

### DIFF
--- a/ddtrace/debugging/_origin/__init__.py
+++ b/ddtrace/debugging/_origin/__init__.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import typing as t
+
+from ddtrace.internal.settings.code_origin import config as co_config
+
+
+# Parse file path rewrite rules once at module load time.
+# Format: "old_prefix=new_prefix" pipe-delimited for multiple rules.
+# Uses '=' as the delimiter to avoid conflicts with Windows drive letters (C:\).
+_rewrite_rules: list[tuple[str, str]] = []
+_raw_rewrite = co_config.file_path_rewrite
+if _raw_rewrite:
+    _rewrite_rules = [tuple(r.split("=", 1)) for r in _raw_rewrite.split("|") if "=" in r]  # type: ignore[misc]
+
+
+def apply_path_rewrite(filename: str) -> str:
+    """Apply the first matching file path rewrite rule to a resolved filename.
+
+    Used by code origin instrumentation to map container-absolute paths to
+    repo-relative paths for Datadog Source Code Integration.
+    """
+    for old, new in _rewrite_rules:
+        if filename.startswith(old):
+            return new + filename[len(old):]
+    return filename
+
+
+def resolve_code_origin_filename(code_filename: str) -> str:
+    """Resolve a code object filename and apply any configured path rewrites."""
+    return apply_path_rewrite(str(Path(code_filename).resolve()))

--- a/ddtrace/debugging/_origin/span.py
+++ b/ddtrace/debugging/_origin/span.py
@@ -28,16 +28,16 @@ from ddtrace.internal.wrapping.context import LazyWrappingContext
 
 log = get_logger(__name__)
 
-# Parse file path rewrite rules once at module level for performance.
-# Format: "old_prefix:new_prefix|old_prefix2:new_prefix2"
+# Parse file path rewrite rules once at module load time.
+# Format: "old_prefix:new_prefix" pipe-delimited for multiple rules.
 _rewrite_rules: list[tuple[str, str]] = []
-_raw = co_config.file_path_rewrite
-if _raw:
-    _rewrite_rules = [tuple(r.split(":", 1)) for r in _raw.split("|") if ":" in r]  # type: ignore[misc]
+_raw_rewrite = co_config.file_path_rewrite
+if _raw_rewrite:
+    _rewrite_rules = [tuple(r.split(":", 1)) for r in _raw_rewrite.split("|") if ":" in r]  # type: ignore[misc]
 
 
-def _rewrite_filename(filename: str) -> str:
-    """Apply file path rewrite rules to a resolved filename."""
+def _apply_path_rewrite(filename: str) -> str:
+    """Apply the first matching file path rewrite rule to the given filename."""
     for old, new in _rewrite_rules:
         if filename.startswith(old):
             return new + filename[len(old):]
@@ -102,7 +102,8 @@ class EntrySpanWrappingContext(LazyWrappingContext):
 
         self.uploader = uploader
 
-        filename = _rewrite_filename(str(Path(f.__code__.co_filename).resolve()))
+        filename = str(Path(f.__code__.co_filename).resolve())
+        filename = _apply_path_rewrite(filename)
         name = f.__qualname__
         module = f.__module__
         self.location = EntrySpanLocation(

--- a/ddtrace/debugging/_origin/span.py
+++ b/ddtrace/debugging/_origin/span.py
@@ -21,11 +21,27 @@ from ddtrace.internal.compat import NO_EXCEPTION
 from ddtrace.internal.compat import ExcInfoType
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.safety import _isinstance
+from ddtrace.internal.settings.code_origin import config as co_config
 from ddtrace.internal.threads import RLock
 from ddtrace.internal.wrapping.context import LazyWrappingContext
 
 
 log = get_logger(__name__)
+
+# Parse file path rewrite rules once at module level for performance.
+# Format: "old_prefix:new_prefix|old_prefix2:new_prefix2"
+_rewrite_rules: list[tuple[str, str]] = []
+_raw = co_config.file_path_rewrite
+if _raw:
+    _rewrite_rules = [tuple(r.split(":", 1)) for r in _raw.split("|") if ":" in r]  # type: ignore[misc]
+
+
+def _rewrite_filename(filename: str) -> str:
+    """Apply file path rewrite rules to a resolved filename."""
+    for old, new in _rewrite_rules:
+        if filename.startswith(old):
+            return new + filename[len(old):]
+    return filename
 
 
 def frame_stack(frame: FrameType) -> t.Iterator[FrameType]:
@@ -86,7 +102,7 @@ class EntrySpanWrappingContext(LazyWrappingContext):
 
         self.uploader = uploader
 
-        filename = str(Path(f.__code__.co_filename).resolve())
+        filename = _rewrite_filename(str(Path(f.__code__.co_filename).resolve()))
         name = f.__qualname__
         module = f.__module__
         self.location = EntrySpanLocation(

--- a/ddtrace/debugging/_origin/span.py
+++ b/ddtrace/debugging/_origin/span.py
@@ -9,6 +9,7 @@ import typing as t
 import uuid
 
 import ddtrace
+from ddtrace.debugging._origin import resolve_code_origin_filename
 from ddtrace.debugging._probe.model import DEFAULT_CAPTURE_LIMITS
 from ddtrace.debugging._probe.model import LiteralTemplateSegment
 from ddtrace.debugging._probe.model import LogFunctionProbe
@@ -21,27 +22,11 @@ from ddtrace.internal.compat import NO_EXCEPTION
 from ddtrace.internal.compat import ExcInfoType
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.safety import _isinstance
-from ddtrace.internal.settings.code_origin import config as co_config
 from ddtrace.internal.threads import RLock
 from ddtrace.internal.wrapping.context import LazyWrappingContext
 
 
 log = get_logger(__name__)
-
-# Parse file path rewrite rules once at module load time.
-# Format: "old_prefix:new_prefix" pipe-delimited for multiple rules.
-_rewrite_rules: list[tuple[str, str]] = []
-_raw_rewrite = co_config.file_path_rewrite
-if _raw_rewrite:
-    _rewrite_rules = [tuple(r.split(":", 1)) for r in _raw_rewrite.split("|") if ":" in r]  # type: ignore[misc]
-
-
-def _apply_path_rewrite(filename: str) -> str:
-    """Apply the first matching file path rewrite rule to the given filename."""
-    for old, new in _rewrite_rules:
-        if filename.startswith(old):
-            return new + filename[len(old):]
-    return filename
 
 
 def frame_stack(frame: FrameType) -> t.Iterator[FrameType]:
@@ -102,8 +87,7 @@ class EntrySpanWrappingContext(LazyWrappingContext):
 
         self.uploader = uploader
 
-        filename = str(Path(f.__code__.co_filename).resolve())
-        filename = _apply_path_rewrite(filename)
+        filename = resolve_code_origin_filename(f.__code__.co_filename)
         name = f.__qualname__
         module = f.__module__
         self.location = EntrySpanLocation(

--- a/ddtrace/debugging/_signal/tracing.py
+++ b/ddtrace/debugging/_signal/tracing.py
@@ -7,6 +7,7 @@ import typing as t
 import ddtrace
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.debugging._expressions import DDExpressionEvaluationError
+from ddtrace.debugging._origin import resolve_code_origin_filename
 from ddtrace.debugging._probe.model import Probe
 from ddtrace.debugging._probe.model import SpanDecorationFunctionProbe
 from ddtrace.debugging._probe.model import SpanDecorationLineProbe
@@ -67,8 +68,9 @@ class DynamicSpan(Signal):
 
         frame = self.frame
         code = frame.f_code
+        filename = resolve_code_origin_filename(code.co_filename)
         for s in (root, span) if root_co_type is None else (span,):
-            s._set_attribute("_dd.code_origin.frames.0.file", str(Path(code.co_filename).resolve()))
+            s._set_attribute("_dd.code_origin.frames.0.file", filename)
             s._set_attribute("_dd.code_origin.frames.0.line", str(frame.f_lineno))
             s._set_attribute("_dd.code_origin.frames.0.type", probe.module)
             s._set_attribute("_dd.code_origin.frames.0.method", probe.func_qname)

--- a/ddtrace/internal/settings/code_origin.py
+++ b/ddtrace/internal/settings/code_origin.py
@@ -18,9 +18,9 @@ class CodeOriginConfig(DDConfig):
         "file_path_rewrite",
         default="",
         help_type="String",
-        help="Rewrite file paths in code origin tags. Format: 'old_prefix:new_prefix' "
+        help="Rewrite file paths in code origin tags. Format: 'old_prefix=new_prefix' "
         "(pipe-delimited for multiple rules, e.g. "
-        "'/opt/app/site-packages/:src/'). First matching rule wins.",
+        "'/opt/app/site-packages/=src/'). First matching rule wins.",
     )
 
     class SpanCodeOriginConfig(DDConfig):

--- a/ddtrace/internal/settings/code_origin.py
+++ b/ddtrace/internal/settings/code_origin.py
@@ -19,7 +19,8 @@ class CodeOriginConfig(DDConfig):
         default="",
         help_type="String",
         help="Rewrite file paths in code origin tags. Format: 'old_prefix:new_prefix' "
-        "(pipe-delimited for multiple rules, e.g. '/opt/app/site-packages/:src/').",
+        "(pipe-delimited for multiple rules, e.g. "
+        "'/opt/app/site-packages/:src/'). First matching rule wins.",
     )
 
     class SpanCodeOriginConfig(DDConfig):

--- a/ddtrace/internal/settings/code_origin.py
+++ b/ddtrace/internal/settings/code_origin.py
@@ -13,6 +13,15 @@ class CodeOriginConfig(DDConfig):
         private=True,
     )
 
+    file_path_rewrite = DDConfig.v(
+        str,
+        "file_path_rewrite",
+        default="",
+        help_type="String",
+        help="Rewrite file paths in code origin tags. Format: 'old_prefix:new_prefix' "
+        "(pipe-delimited for multiple rules, e.g. '/opt/app/site-packages/:src/').",
+    )
+
     class SpanCodeOriginConfig(DDConfig):
         __prefix__ = "for_spans"
         __item__ = "span"

--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -5,8 +5,8 @@ import typing as t
 from unittest.mock import patch
 
 import ddtrace
+from ddtrace.debugging._origin import apply_path_rewrite
 from ddtrace.debugging._origin.span import SpanCodeOriginProcessorEntry
-from ddtrace.debugging._origin.span import _apply_path_rewrite
 from ddtrace.debugging._session import Session
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -297,22 +297,19 @@ class TestFilePathRewrite:
     def test_apply_path_rewrite_single_rule(self):
         """Test that a single rewrite rule is applied correctly."""
         rules = [("/opt/app/site-packages/myapp/", "src/myapp/")]
-        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _apply_path_rewrite("/opt/app/site-packages/myapp/views.py")
+        with patch("ddtrace.debugging._origin._rewrite_rules", rules):
+            result = apply_path_rewrite("/opt/app/site-packages/myapp/views.py")
             assert result == "src/myapp/views.py"
 
     def test_apply_path_rewrite_multiple_rules(self):
-        """Test that multiple pipe-delimited rules work and first match wins."""
+        """Test that multiple pipe-delimited rules work independently."""
         rules = [
             ("/opt/app/lib/python3.11/site-packages/myapp/", "src/myapp/"),
             ("/opt/app/lib/python3.11/site-packages/otherapp/", "src/otherapp/"),
         ]
-        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _apply_path_rewrite("/opt/app/lib/python3.11/site-packages/myapp/views.py")
-            assert result == "src/myapp/views.py"
-
-            result = _apply_path_rewrite("/opt/app/lib/python3.11/site-packages/otherapp/models.py")
-            assert result == "src/otherapp/models.py"
+        with patch("ddtrace.debugging._origin._rewrite_rules", rules):
+            assert apply_path_rewrite("/opt/app/lib/python3.11/site-packages/myapp/views.py") == "src/myapp/views.py"
+            assert apply_path_rewrite("/opt/app/lib/python3.11/site-packages/otherapp/models.py") == "src/otherapp/models.py"
 
     def test_apply_path_rewrite_first_match_wins(self):
         """Test that only the first matching rule is applied."""
@@ -320,29 +317,31 @@ class TestFilePathRewrite:
             ("/opt/app/", "first/"),
             ("/opt/app/", "second/"),
         ]
-        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _apply_path_rewrite("/opt/app/views.py")
-            assert result == "first/views.py"
+        with patch("ddtrace.debugging._origin._rewrite_rules", rules):
+            assert apply_path_rewrite("/opt/app/views.py") == "first/views.py"
 
     def test_apply_path_rewrite_no_match(self):
         """Test that non-matching paths are returned unchanged."""
         rules = [("/opt/app/site-packages/myapp/", "src/myapp/")]
-        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _apply_path_rewrite("/some/other/path/views.py")
-            assert result == "/some/other/path/views.py"
+        with patch("ddtrace.debugging._origin._rewrite_rules", rules):
+            assert apply_path_rewrite("/some/other/path/views.py") == "/some/other/path/views.py"
 
     def test_apply_path_rewrite_no_rules(self):
         """Test that paths are returned unchanged when no rules are configured."""
-        with patch("ddtrace.debugging._origin.span._rewrite_rules", []):
-            result = _apply_path_rewrite("/opt/app/site-packages/myapp/views.py")
-            assert result == "/opt/app/site-packages/myapp/views.py"
+        with patch("ddtrace.debugging._origin._rewrite_rules", []):
+            assert apply_path_rewrite("/opt/app/site-packages/myapp/views.py") == "/opt/app/site-packages/myapp/views.py"
 
     def test_apply_path_rewrite_empty_replacement(self):
         """Test rewrite with empty replacement to strip a prefix entirely."""
         rules = [("/opt/app/lib/python3.11/site-packages/", "")]
-        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _apply_path_rewrite("/opt/app/lib/python3.11/site-packages/myapp/views.py")
-            assert result == "myapp/views.py"
+        with patch("ddtrace.debugging._origin._rewrite_rules", rules):
+            assert apply_path_rewrite("/opt/app/lib/python3.11/site-packages/myapp/views.py") == "myapp/views.py"
+
+    def test_apply_path_rewrite_windows_path(self):
+        """Test that Windows drive-letter paths work correctly with = delimiter."""
+        rules = [("C:\\app\\site-packages\\", "src/")]
+        with patch("ddtrace.debugging._origin._rewrite_rules", rules):
+            assert apply_path_rewrite("C:\\app\\site-packages\\myapp\\views.py") == "src/myapp\\views.py"
 
 
 def test_instrument_view_benchmark(benchmark):

--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import ddtrace
 from ddtrace.debugging._origin.span import SpanCodeOriginProcessorEntry
-from ddtrace.debugging._origin.span import _rewrite_filename
+from ddtrace.debugging._origin.span import _apply_path_rewrite
 from ddtrace.debugging._session import Session
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -292,49 +292,57 @@ class SpanProbeTestCase(TracerTestCase):
 
 
 class TestFilePathRewrite:
-    """Tests for the DD_CODE_ORIGIN_FILE_PATH_REWRITE config option."""
+    """Tests for the DD_CODE_ORIGIN_FILE_PATH_REWRITE feature."""
 
-    def test_rewrite_single_rule(self):
-        """Test that a single rewrite rule rewrites matching file paths."""
+    def test_apply_path_rewrite_single_rule(self):
+        """Test that a single rewrite rule is applied correctly."""
         rules = [("/opt/app/site-packages/myapp/", "src/myapp/")]
         with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _rewrite_filename("/opt/app/site-packages/myapp/views.py")
-        assert result == "src/myapp/views.py"
+            result = _apply_path_rewrite("/opt/app/site-packages/myapp/views.py")
+            assert result == "src/myapp/views.py"
 
-    def test_rewrite_multiple_rules(self):
-        """Test pipe-delimited multiple rewrite rules (first match wins)."""
+    def test_apply_path_rewrite_multiple_rules(self):
+        """Test that multiple pipe-delimited rules work and first match wins."""
         rules = [
-            ("/opt/app/site-packages/myapp/", "src/myapp/"),
-            ("/opt/app/site-packages/other/", "src/other/"),
+            ("/opt/app/lib/python3.11/site-packages/myapp/", "src/myapp/"),
+            ("/opt/app/lib/python3.11/site-packages/otherapp/", "src/otherapp/"),
         ]
         with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result1 = _rewrite_filename("/opt/app/site-packages/myapp/views.py")
-            result2 = _rewrite_filename("/opt/app/site-packages/other/models.py")
-        assert result1 == "src/myapp/views.py"
-        assert result2 == "src/other/models.py"
+            result = _apply_path_rewrite("/opt/app/lib/python3.11/site-packages/myapp/views.py")
+            assert result == "src/myapp/views.py"
 
-    def test_rewrite_first_match_wins(self):
+            result = _apply_path_rewrite("/opt/app/lib/python3.11/site-packages/otherapp/models.py")
+            assert result == "src/otherapp/models.py"
+
+    def test_apply_path_rewrite_first_match_wins(self):
         """Test that only the first matching rule is applied."""
         rules = [
             ("/opt/app/", "first/"),
             ("/opt/app/", "second/"),
         ]
         with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _rewrite_filename("/opt/app/views.py")
-        assert result == "first/views.py"
+            result = _apply_path_rewrite("/opt/app/views.py")
+            assert result == "first/views.py"
 
-    def test_rewrite_no_match(self):
+    def test_apply_path_rewrite_no_match(self):
         """Test that non-matching paths are returned unchanged."""
-        rules = [("/opt/app/site-packages/", "src/")]
+        rules = [("/opt/app/site-packages/myapp/", "src/myapp/")]
         with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
-            result = _rewrite_filename("/other/path/views.py")
-        assert result == "/other/path/views.py"
+            result = _apply_path_rewrite("/some/other/path/views.py")
+            assert result == "/some/other/path/views.py"
 
-    def test_rewrite_empty_rules(self):
-        """Test that empty rewrite rules leave paths unchanged."""
+    def test_apply_path_rewrite_no_rules(self):
+        """Test that paths are returned unchanged when no rules are configured."""
         with patch("ddtrace.debugging._origin.span._rewrite_rules", []):
-            result = _rewrite_filename("/opt/app/views.py")
-        assert result == "/opt/app/views.py"
+            result = _apply_path_rewrite("/opt/app/site-packages/myapp/views.py")
+            assert result == "/opt/app/site-packages/myapp/views.py"
+
+    def test_apply_path_rewrite_empty_replacement(self):
+        """Test rewrite with empty replacement to strip a prefix entirely."""
+        rules = [("/opt/app/lib/python3.11/site-packages/", "")]
+        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
+            result = _apply_path_rewrite("/opt/app/lib/python3.11/site-packages/myapp/views.py")
+            assert result == "myapp/views.py"
 
 
 def test_instrument_view_benchmark(benchmark):

--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -2,9 +2,11 @@ from functools import partial
 from inspect import unwrap
 from pathlib import Path
 import typing as t
+from unittest.mock import patch
 
 import ddtrace
 from ddtrace.debugging._origin.span import SpanCodeOriginProcessorEntry
+from ddtrace.debugging._origin.span import _rewrite_filename
 from ddtrace.debugging._session import Session
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -287,6 +289,52 @@ class SpanProbeTestCase(TracerTestCase):
         # also did not tag itself because the root already carries an entry.
         assert inner_span.get_tag("_dd.code_origin.type") is None
         assert inner_span.get_tag("_dd.code_origin.frames.0.file") is None
+
+
+class TestFilePathRewrite:
+    """Tests for the DD_CODE_ORIGIN_FILE_PATH_REWRITE config option."""
+
+    def test_rewrite_single_rule(self):
+        """Test that a single rewrite rule rewrites matching file paths."""
+        rules = [("/opt/app/site-packages/myapp/", "src/myapp/")]
+        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
+            result = _rewrite_filename("/opt/app/site-packages/myapp/views.py")
+        assert result == "src/myapp/views.py"
+
+    def test_rewrite_multiple_rules(self):
+        """Test pipe-delimited multiple rewrite rules (first match wins)."""
+        rules = [
+            ("/opt/app/site-packages/myapp/", "src/myapp/"),
+            ("/opt/app/site-packages/other/", "src/other/"),
+        ]
+        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
+            result1 = _rewrite_filename("/opt/app/site-packages/myapp/views.py")
+            result2 = _rewrite_filename("/opt/app/site-packages/other/models.py")
+        assert result1 == "src/myapp/views.py"
+        assert result2 == "src/other/models.py"
+
+    def test_rewrite_first_match_wins(self):
+        """Test that only the first matching rule is applied."""
+        rules = [
+            ("/opt/app/", "first/"),
+            ("/opt/app/", "second/"),
+        ]
+        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
+            result = _rewrite_filename("/opt/app/views.py")
+        assert result == "first/views.py"
+
+    def test_rewrite_no_match(self):
+        """Test that non-matching paths are returned unchanged."""
+        rules = [("/opt/app/site-packages/", "src/")]
+        with patch("ddtrace.debugging._origin.span._rewrite_rules", rules):
+            result = _rewrite_filename("/other/path/views.py")
+        assert result == "/other/path/views.py"
+
+    def test_rewrite_empty_rules(self):
+        """Test that empty rewrite rules leave paths unchanged."""
+        with patch("ddtrace.debugging._origin.span._rewrite_rules", []):
+            result = _rewrite_filename("/opt/app/views.py")
+        assert result == "/opt/app/views.py"
 
 
 def test_instrument_view_benchmark(benchmark):


### PR DESCRIPTION
## Motivation

When `DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true`, ddtrace records absolute container file paths in `_dd.code_origin.frames.*.file` span tags (e.g., `/opt/app/lib/python3.11/site-packages/myapp/views.py`).

Datadog's [Source Code Integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/) needs **repo-relative paths** (e.g., `src/myapp/views.py`) to link spans to source files on GitHub/GitLab. There is currently no built-in way to perform this mapping, forcing users to monkey-patch `EntrySpanWrappingContext.__init__` in every service.

## Solution

This PR adds a new environment variable, `DD_CODE_ORIGIN_FILE_PATH_REWRITE`, that rewrites file path prefixes before they are stored in code origin span tags.

### Format

Uses `=` as the rule delimiter (not `:`) to avoid conflicts with Windows drive letters:

```
DD_CODE_ORIGIN_FILE_PATH_REWRITE="/opt/app/site-packages/myapp/=src/myapp/"
```

Multiple rules can be pipe-delimited (first match wins):

```
DD_CODE_ORIGIN_FILE_PATH_REWRITE="/opt/app/site-packages/myapp/=src/myapp/|/opt/app/site-packages/otherapp/=src/otherapp/"
```

### Implementation

- **Config**: Added `file_path_rewrite` to `CodeOriginConfig` in `ddtrace/internal/settings/code_origin.py`
- **Shared rewrite logic**: `ddtrace/debugging/_origin/__init__.py` exports `apply_path_rewrite()` and `resolve_code_origin_filename()`, used by both entry span and dynamic span code paths
- **Entry spans**: `EntrySpanWrappingContext.__init__` in `ddtrace/debugging/_origin/span.py` uses `resolve_code_origin_filename()`
- **Dynamic span probes**: `DynamicSpan.enter()` in `ddtrace/debugging/_signal/tracing.py` uses `resolve_code_origin_filename()` (previously used raw `Path.resolve()`)
- **Module-level parsing**: Rules are parsed once at import time for zero per-span overhead

### Files changed

1. `ddtrace/internal/settings/code_origin.py` — new `file_path_rewrite` config variable
2. `ddtrace/debugging/_origin/__init__.py` — shared `apply_path_rewrite()` and `resolve_code_origin_filename()` helpers
3. `ddtrace/debugging/_origin/span.py` — uses shared `resolve_code_origin_filename()`
4. `ddtrace/debugging/_signal/tracing.py` — uses shared `resolve_code_origin_filename()` for dynamic span probes
5. `tests/debugging/origin/test_span.py` — `TestFilePathRewrite` class with 7 test cases including Windows path handling

### Example usage

```dockerfile
ENV DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true
ENV DD_CODE_ORIGIN_FILE_PATH_REWRITE="/opt/app/lib/python3.11/site-packages/myapp/=src/myapp/"
```

This eliminates the need for monkey-patching and makes Source Code Integration work out of the box for containerized deployments where installed package paths differ from repository paths.
