### PR TITLE
chore(llmobs): tag span.finished telemetry with intake path

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -3,20 +3,12 @@ from typing import Final
 
 
 class LLMObsExportMode(str, Enum):
-    """Top-level shape of how an LLMObs span is exported.
+    """How LLMObs span data is submitted to Datadog.
 
-    Picks which path is used for the LLMObs payload and (for APM_AGENTLESS) for the
-    underlying APM trace. The actual transport for the LLMObs writer (agentless to the
-    LLMObs intake vs. via the agent's EVP proxy) is a separate axis driven by
-    ``config._llmobs_agentless_enabled``.
-
-    LLMOBS_DIRECT  — APM trace dropped (DD_APM_TRACING_ENABLED=false); LLMObs payload
-                     ships via LLMObsSpanWriter only.
-    APM_AGENTLESS  — APM trace writer swapped to AgentlessTraceWriter; LLMObs payload
-                     rides the APM trace as ``meta_struct["_llmobs"]`` to the APM intake.
-    APM_AGENT      — APM trace ships through the agent normally (without the LLMObs
-                     payload, which is stripped before send); LLMObs payload ships
-                     separately via LLMObsSpanWriter.
+    LLMOBS_DIRECT  — span events go through LLMObsSpanWriter directly.
+                     Used when DD_APM_TRACING_ENABLED=false.
+    APM_AGENTLESS  — span data rides the APM trace; APM writer switches to agentless.
+    APM_AGENT      — span data rides the APM trace; APM writer stays agent-based.
     """
 
     LLMOBS_DIRECT = "llmobs_direct"

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -3,17 +3,25 @@ from typing import Final
 
 
 class LLMObsExportMode(str, Enum):
-    """How LLMObs span data is submitted to Datadog.
+    """Top-level shape of how an LLMObs span is exported.
 
-    LLMOBS_DIRECT  — span events go through LLMObsSpanWriter directly.
-                     Used when DD_APM_TRACING_ENABLED=false.
-    APM_AGENTLESS  — span data rides the APM trace; APM writer switches to agentless.
-    APM_AGENT_PROXY  — span data rides the APM trace; APM writer stays agent-based.
+    Picks which path is used for the LLMObs payload and (for APM_AGENTLESS) for the
+    underlying APM trace. The actual transport for the LLMObs writer (agentless to the
+    LLMObs intake vs. via the agent's EVP proxy) is a separate axis driven by
+    ``config._llmobs_agentless_enabled``.
+
+    LLMOBS_DIRECT  — APM trace dropped (DD_APM_TRACING_ENABLED=false); LLMObs payload
+                     ships via LLMObsSpanWriter only.
+    APM_AGENTLESS  — APM trace writer swapped to AgentlessTraceWriter; LLMObs payload
+                     rides the APM trace as ``meta_struct["_llmobs"]`` to the APM intake.
+    APM_AGENT      — APM trace ships through the agent normally (without the LLMObs
+                     payload, which is stripped before send); LLMObs payload ships
+                     separately via LLMObsSpanWriter.
     """
 
     LLMOBS_DIRECT = "llmobs_direct"
     APM_AGENTLESS = "apm_agentless"
-    APM_AGENT_PROXY = "apm_agent"
+    APM_AGENT = "apm_agent"
 
 
 SESSION_ID = "_ml_obs.session_id"

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -513,7 +513,7 @@ class LLMObs(Service):
         elif llmobs_apm_trace_agentless_enabled():
             self._export_mode = LLMObsExportMode.APM_AGENTLESS
         else:
-            self._export_mode = LLMObsExportMode.APM_AGENT_PROXY
+            self._export_mode = LLMObsExportMode.APM_AGENT
         # Test-only: when set, _on_span_finish skips the meta_struct["_llmobs"] scrub
         # so spans captured by tests' DummyWriter retain LLMObsSpanData for assertion.
         # Set by integration test conftests via the _DD_LLMOBS_TEST_KEEP_META_STRUCT env
@@ -580,7 +580,7 @@ class LLMObs(Service):
         if not span_event:
             # Dropped by user processor / error during preparation/assembly.
             # Record telemetry before clearing meta_struct so tag getters still see data.
-            telemetry.record_span_created(span, self._export_mode, dropped=True)
+            telemetry.record_span_created(span, "dropped")
             span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
 
@@ -588,16 +588,17 @@ class LLMObs(Service):
             self._evaluator_runner.enqueue(span_event, span)
 
         if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
-            # LLMOBS_DIRECT and APM_AGENT_PROXY both route through the LLMObs span writer
-            # (direct intake or agent EVP proxy respectively), preserving origin/main behavior.
-            # APM_AGENTLESS is the only mode where data rides the APM trace instead.
+            # LLMOBS_DIRECT and APM_AGENT both route the LLMObs payload through
+            # LLMObsSpanWriter. The writer's transport (agentless vs. agent EVP proxy)
+            # is independent of the export mode and tracked by config._llmobs_agentless_enabled.
             span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
             self._llmobs_span_writer.enqueue(span_event)
-            telemetry.record_span_created(span, self._export_mode)
+            intake = "llmobs_agentless" if config._llmobs_agentless_enabled else "llmobs_agent_proxy"
+            telemetry.record_span_created(span, intake)
             if not self._test_mode_keep_meta_struct:
                 span._remove_struct_tag(LLMOBS_STRUCT.KEY)
         else:
-            telemetry.record_span_created(span, self._export_mode)
+            telemetry.record_span_created(span, "apm_agentless")
 
     def _apply_user_span_processor(self, span: Span, llmobs_span: LLMObsSpan) -> Optional[LLMObsSpan]:
         """Run the user span processor.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -561,7 +561,7 @@ class LLMObs(Service):
     def _on_span_finish(self, span: Span) -> None:
         if not self.enabled or span.span_type != SpanTypes.LLM:
             return
-        telemetry.record_span_created(span)
+        telemetry.record_span_created(span, self._export_mode)
 
         span_kind = get_llmobs_span_kind(span)
         if span_kind == "llm":

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -579,26 +579,25 @@ class LLMObs(Service):
 
         if not span_event:
             # Dropped by user processor / error during preparation/assembly.
-            # Record telemetry before clearing meta_struct so tag getters still see data.
-            telemetry.record_span_created(span, "dropped")
             span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
+
+        if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
+            intake = "apm_agentless"
+        elif config._llmobs_agentless_enabled:
+            intake = "llmobs_agentless"
+        else:
+            intake = "llmobs_agent_proxy"
+        telemetry.record_span_created(span, intake)
 
         if self._evaluator_runner and span_kind == "llm":
             self._evaluator_runner.enqueue(span_event, span)
 
         if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
-            # LLMOBS_DIRECT and APM_AGENT both route the LLMObs payload through
-            # LLMObsSpanWriter. The writer's transport (agentless vs. agent EVP proxy)
-            # is independent of the export mode and tracked by config._llmobs_agentless_enabled.
             span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
             self._llmobs_span_writer.enqueue(span_event)
-            intake = "llmobs_agentless" if config._llmobs_agentless_enabled else "llmobs_agent_proxy"
-            telemetry.record_span_created(span, intake)
             if not self._test_mode_keep_meta_struct:
                 span._remove_struct_tag(LLMOBS_STRUCT.KEY)
-        else:
-            telemetry.record_span_created(span, "apm_agentless")
 
     def _apply_user_span_processor(self, span: Span, llmobs_span: LLMObsSpan) -> Optional[LLMObsSpan]:
         """Run the user span processor.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -561,6 +561,7 @@ class LLMObs(Service):
     def _on_span_finish(self, span: Span) -> None:
         if not self.enabled or span.span_type != SpanTypes.LLM:
             return
+        telemetry.record_span_created(span, self._export_mode)
 
         span_kind = get_llmobs_span_kind(span)
         if span_kind == "llm":
@@ -578,22 +579,17 @@ class LLMObs(Service):
             )
 
         if not span_event:
-            # Dropped by user processor / error during preparation/assembly.
+            # clear meta_struct if no event to export (dropped by user processor / error during preparation/assembly)
             span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
-
-        if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
-            intake = "apm_agentless"
-        elif config._llmobs_agentless_enabled:
-            intake = "llmobs_agentless"
-        else:
-            intake = "llmobs_agent_proxy"
-        telemetry.record_span_created(span, intake)
 
         if self._evaluator_runner and span_kind == "llm":
             self._evaluator_runner.enqueue(span_event, span)
 
         if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
+            # LLMOBS_DIRECT and APM_AGENT both route through the LLMObs span writer
+            # (direct intake or agent EVP proxy respectively), preserving origin/main behavior.
+            # APM_AGENTLESS is the only mode where data rides the APM trace instead.
             span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
             self._llmobs_span_writer.enqueue(span_event)
             if not self._test_mode_keep_meta_struct:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -562,47 +562,42 @@ class LLMObs(Service):
         if not self.enabled or span.span_type != SpanTypes.LLM:
             return
 
-        dropped = True
+        span_kind = get_llmobs_span_kind(span)
+        if span_kind == "llm":
+            core.dispatch(DISPATCH_ON_LLM_SPAN_FINISH, (span,))
+
+        span_event = None
         try:
-            span_kind = get_llmobs_span_kind(span)
-            if span_kind == "llm":
-                core.dispatch(DISPATCH_ON_LLM_SPAN_FINISH, (span,))
-
-            span_event = None
-            try:
-                if self._prepare_llmobs_span_data(span, span_kind):
-                    span_event = self._llmobs_span_event(span)
-            except (KeyError, TypeError, ValueError):
-                log.error(
-                    "Error generating LLMObs span event for span %s, likely due to malformed span",
-                    span,
-                    exc_info=True,
-                )
-
-            if not span_event:
-                # Dropped by user processor / error during preparation/assembly.
-                return
-
-            if self._evaluator_runner and span_kind == "llm":
-                self._evaluator_runner.enqueue(span_event, span)
-
-            if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
-                # LLMOBS_DIRECT and APM_AGENT_PROXY both route through the LLMObs span writer
-                # (direct intake or agent EVP proxy respectively), preserving origin/main behavior.
-                # APM_AGENTLESS is the only mode where data rides the APM trace instead.
-                span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
-                self._llmobs_span_writer.enqueue(span_event)
-            dropped = False
-        finally:
-            telemetry.record_span_created(span, self._export_mode, dropped=dropped)
-            # Clear meta_struct unless this span needs to keep it to ride the APM trace
-            # (un-dropped APM_AGENTLESS) or unless a test fixture asks us to preserve it.
-            keep_for_apm = not dropped and self._export_mode == LLMObsExportMode.APM_AGENTLESS
-            keep_for_test = (
-                not dropped and self._export_mode != LLMObsExportMode.APM_AGENTLESS and self._test_mode_keep_meta_struct
+            if self._prepare_llmobs_span_data(span, span_kind):
+                span_event = self._llmobs_span_event(span)
+        except (KeyError, TypeError, ValueError):
+            log.error(
+                "Error generating LLMObs span event for span %s, likely due to malformed span",
+                span,
+                exc_info=True,
             )
-            if not keep_for_apm and not keep_for_test:
+
+        if not span_event:
+            # Dropped by user processor / error during preparation/assembly.
+            # Record telemetry before clearing meta_struct so tag getters still see data.
+            telemetry.record_span_created(span, self._export_mode, dropped=True)
+            span._remove_struct_tag(LLMOBS_STRUCT.KEY)
+            return
+
+        if self._evaluator_runner and span_kind == "llm":
+            self._evaluator_runner.enqueue(span_event, span)
+
+        if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
+            # LLMOBS_DIRECT and APM_AGENT_PROXY both route through the LLMObs span writer
+            # (direct intake or agent EVP proxy respectively), preserving origin/main behavior.
+            # APM_AGENTLESS is the only mode where data rides the APM trace instead.
+            span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
+            self._llmobs_span_writer.enqueue(span_event)
+            telemetry.record_span_created(span, self._export_mode)
+            if not self._test_mode_keep_meta_struct:
                 span._remove_struct_tag(LLMOBS_STRUCT.KEY)
+        else:
+            telemetry.record_span_created(span, self._export_mode)
 
     def _apply_user_span_processor(self, span: Span, llmobs_span: LLMObsSpan) -> Optional[LLMObsSpan]:
         """Run the user span processor.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -561,7 +561,6 @@ class LLMObs(Service):
     def _on_span_finish(self, span: Span) -> None:
         if not self.enabled or span.span_type != SpanTypes.LLM:
             return
-        telemetry.record_span_created(span, self._export_mode)
 
         span_kind = get_llmobs_span_kind(span)
         if span_kind == "llm":
@@ -579,7 +578,10 @@ class LLMObs(Service):
             )
 
         if not span_event:
-            # clear meta_struct if no event to export (dropped by user processor / error during preparation/assembly)
+            # No event to export (dropped by user processor / error during preparation/assembly).
+            # Record telemetry before clearing meta_struct so the span.finished tag getters
+            # still have data to read.
+            telemetry.record_span_created(span, "dropped")
             span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
 
@@ -592,8 +594,11 @@ class LLMObs(Service):
             # APM_AGENTLESS is the only mode where data rides the APM trace instead.
             span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
             self._llmobs_span_writer.enqueue(span_event)
+            telemetry.record_span_created(span, "llmobs")
             if not self._test_mode_keep_meta_struct:
                 span._remove_struct_tag(LLMOBS_STRUCT.KEY)
+        else:
+            telemetry.record_span_created(span, "apm")
 
     def _apply_user_span_processor(self, span: Span, llmobs_span: LLMObsSpan) -> Optional[LLMObsSpan]:
         """Run the user span processor.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -562,43 +562,47 @@ class LLMObs(Service):
         if not self.enabled or span.span_type != SpanTypes.LLM:
             return
 
-        span_kind = get_llmobs_span_kind(span)
-        if span_kind == "llm":
-            core.dispatch(DISPATCH_ON_LLM_SPAN_FINISH, (span,))
-
-        span_event = None
+        dropped = True
         try:
-            if self._prepare_llmobs_span_data(span, span_kind):
-                span_event = self._llmobs_span_event(span)
-        except (KeyError, TypeError, ValueError):
-            log.error(
-                "Error generating LLMObs span event for span %s, likely due to malformed span",
-                span,
-                exc_info=True,
+            span_kind = get_llmobs_span_kind(span)
+            if span_kind == "llm":
+                core.dispatch(DISPATCH_ON_LLM_SPAN_FINISH, (span,))
+
+            span_event = None
+            try:
+                if self._prepare_llmobs_span_data(span, span_kind):
+                    span_event = self._llmobs_span_event(span)
+            except (KeyError, TypeError, ValueError):
+                log.error(
+                    "Error generating LLMObs span event for span %s, likely due to malformed span",
+                    span,
+                    exc_info=True,
+                )
+
+            if not span_event:
+                # Dropped by user processor / error during preparation/assembly.
+                return
+
+            if self._evaluator_runner and span_kind == "llm":
+                self._evaluator_runner.enqueue(span_event, span)
+
+            if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
+                # LLMOBS_DIRECT and APM_AGENT_PROXY both route through the LLMObs span writer
+                # (direct intake or agent EVP proxy respectively), preserving origin/main behavior.
+                # APM_AGENTLESS is the only mode where data rides the APM trace instead.
+                span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
+                self._llmobs_span_writer.enqueue(span_event)
+            dropped = False
+        finally:
+            telemetry.record_span_created(span, self._export_mode, dropped=dropped)
+            # Clear meta_struct unless this span needs to keep it to ride the APM trace
+            # (un-dropped APM_AGENTLESS) or unless a test fixture asks us to preserve it.
+            keep_for_apm = not dropped and self._export_mode == LLMObsExportMode.APM_AGENTLESS
+            keep_for_test = (
+                not dropped and self._export_mode != LLMObsExportMode.APM_AGENTLESS and self._test_mode_keep_meta_struct
             )
-
-        if not span_event:
-            # No event to export (dropped by user processor / error during preparation/assembly).
-            # Record telemetry before clearing meta_struct so the span.finished tag getters
-            # still have data to read.
-            telemetry.record_span_created(span, "dropped")
-            span._remove_struct_tag(LLMOBS_STRUCT.KEY)
-            return
-
-        if self._evaluator_runner and span_kind == "llm":
-            self._evaluator_runner.enqueue(span_event, span)
-
-        if self._export_mode != LLMObsExportMode.APM_AGENTLESS:
-            # LLMOBS_DIRECT and APM_AGENT_PROXY both route through the LLMObs span writer
-            # (direct intake or agent EVP proxy respectively), preserving origin/main behavior.
-            # APM_AGENTLESS is the only mode where data rides the APM trace instead.
-            span.set_tag(LLMOBS_SUBMITTED_TAG_KEY, "1")
-            self._llmobs_span_writer.enqueue(span_event)
-            telemetry.record_span_created(span, "llmobs")
-            if not self._test_mode_keep_meta_struct:
+            if not keep_for_apm and not keep_for_test:
                 span._remove_struct_tag(LLMOBS_STRUCT.KEY)
-        else:
-            telemetry.record_span_created(span, "apm")
 
     def _apply_user_span_processor(self, span: Span, llmobs_span: LLMObsSpan) -> Optional[LLMObsSpan]:
         """Run the user span processor.

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -6,7 +6,6 @@ from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
-from ddtrace.llmobs._constants import LLMObsExportMode
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -102,7 +101,17 @@ def record_span_started():
     )
 
 
-def record_span_created(span: Span, export_mode: LLMObsExportMode):
+def record_span_created(span: Span, intake: str):
+    """Record a finished LLMObs span.
+
+    ``intake`` reflects the actual outcome of this span (set by the caller):
+      - ``"llmobs"``  — enqueued to ``LLMObsSpanWriter`` (LLMOBS_DIRECT agentless or
+                        APM_AGENT_PROXY via the agent EVP proxy).
+      - ``"apm"``     — ``meta_struct["_llmobs"]`` left intact to ride the APM trace
+                        to the APM intake (APM_AGENTLESS mode).
+      - ``"dropped"`` — user processor returned ``None``, span was malformed, or
+                        event assembly raised; no LLMObs payload was shipped.
+    """
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
     has_session_id = get_llmobs_session_id(span) is not None
@@ -112,10 +121,6 @@ def record_span_created(span: Span, export_mode: LLMObsExportMode):
     span_kind = get_llmobs_span_kind(span)
     model_provider = get_llmobs_model_provider(span)
     ml_app = get_llmobs_ml_app(span)
-    # APM_AGENTLESS rides the APM trace as meta_struct["_llmobs"] to the APM intake;
-    # LLMOBS_DIRECT (agentless) and APM_AGENT_PROXY (agent EVP proxy) both go straight
-    # to the LLMObs intake via the LLMObs span writer.
-    intake = "apm" if export_mode == LLMObsExportMode.APM_AGENTLESS else "llmobs"
 
     tags = [
         ("autoinstrumented", str(int(autoinstrumented))),

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -6,7 +6,6 @@ from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
-from ddtrace.llmobs._constants import LLMObsExportMode
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -102,17 +101,16 @@ def record_span_started():
     )
 
 
-def record_span_created(span: Span, export_mode: LLMObsExportMode, dropped: bool = False):
+def record_span_created(span: Span, intake: str):
     """Record a finished LLMObs span.
 
-    ``intake`` is derived from ``export_mode`` and reflects the configured destination:
-      - ``"llmobs"`` — LLMObsSpanWriter (LLMOBS_DIRECT agentless or APM_AGENT_PROXY via EVP proxy).
-      - ``"apm"``    — ``meta_struct["_llmobs"]`` riding the APM trace (APM_AGENTLESS).
-
-    ``dropped`` reports whether the span actually reached that destination. A span is
-    dropped when the user processor returns ``None``, the span is malformed, or event
-    assembly raises — in which case no LLMObs payload is shipped even though the
-    configured intake is still recorded.
+    ``intake`` is the path the LLMObs payload actually took:
+      - ``"apm_agentless"``      — payload rode the APM trace to the APM intake
+                                   (LLMObsExportMode.APM_AGENTLESS).
+      - ``"llmobs_agentless"``   — LLMObsSpanWriter posted directly to the LLMObs intake.
+      - ``"llmobs_agent_proxy"`` — LLMObsSpanWriter posted via the agent's EVP proxy.
+      - ``"dropped"``            — user processor returned ``None``, span was malformed,
+                                   or event assembly raised; no LLMObs payload shipped.
     """
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
@@ -123,7 +121,6 @@ def record_span_created(span: Span, export_mode: LLMObsExportMode, dropped: bool
     span_kind = get_llmobs_span_kind(span)
     model_provider = get_llmobs_model_provider(span)
     ml_app = get_llmobs_ml_app(span)
-    intake = "apm" if export_mode == LLMObsExportMode.APM_AGENTLESS else "llmobs"
 
     tags = [
         ("autoinstrumented", str(int(autoinstrumented))),
@@ -134,7 +131,6 @@ def record_span_created(span: Span, export_mode: LLMObsExportMode, dropped: bool
         ("ml_app", ml_app or "N/A"),
         ("error", str(span.error)),
         ("intake", intake),
-        ("dropped", str(int(dropped))),
     ]
     if not autoinstrumented:
         tags.append(("decorator", str(int(decorator))))

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -6,6 +6,7 @@ from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
+from ddtrace.llmobs._constants import LLMObsExportMode
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -101,16 +102,17 @@ def record_span_started():
     )
 
 
-def record_span_created(span: Span, intake: str):
+def record_span_created(span: Span, export_mode: LLMObsExportMode, dropped: bool = False):
     """Record a finished LLMObs span.
 
-    ``intake`` reflects the actual outcome of this span (set by the caller):
-      - ``"llmobs"``  — enqueued to ``LLMObsSpanWriter`` (LLMOBS_DIRECT agentless or
-                        APM_AGENT_PROXY via the agent EVP proxy).
-      - ``"apm"``     — ``meta_struct["_llmobs"]`` left intact to ride the APM trace
-                        to the APM intake (APM_AGENTLESS mode).
-      - ``"dropped"`` — user processor returned ``None``, span was malformed, or
-                        event assembly raised; no LLMObs payload was shipped.
+    ``intake`` is derived from ``export_mode`` and reflects the configured destination:
+      - ``"llmobs"`` — LLMObsSpanWriter (LLMOBS_DIRECT agentless or APM_AGENT_PROXY via EVP proxy).
+      - ``"apm"``    — ``meta_struct["_llmobs"]`` riding the APM trace (APM_AGENTLESS).
+
+    ``dropped`` reports whether the span actually reached that destination. A span is
+    dropped when the user processor returns ``None``, the span is malformed, or event
+    assembly raises — in which case no LLMObs payload is shipped even though the
+    configured intake is still recorded.
     """
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
@@ -121,6 +123,7 @@ def record_span_created(span: Span, intake: str):
     span_kind = get_llmobs_span_kind(span)
     model_provider = get_llmobs_model_provider(span)
     ml_app = get_llmobs_ml_app(span)
+    intake = "apm" if export_mode == LLMObsExportMode.APM_AGENTLESS else "llmobs"
 
     tags = [
         ("autoinstrumented", str(int(autoinstrumented))),
@@ -131,6 +134,7 @@ def record_span_created(span: Span, intake: str):
         ("ml_app", ml_app or "N/A"),
         ("error", str(span.error)),
         ("intake", intake),
+        ("dropped", str(int(dropped))),
     ]
     if not autoinstrumented:
         tags.append(("decorator", str(int(decorator))))

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -2,10 +2,12 @@ import time
 from typing import Any
 from typing import Optional
 
+from ddtrace import config
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
+from ddtrace.llmobs._constants import LLMObsExportMode
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -101,17 +103,13 @@ def record_span_started():
     )
 
 
-def record_span_created(span: Span, intake: str):
-    """Record a finished LLMObs span that is about to be shipped.
+def record_span_created(span: Span, export_mode: LLMObsExportMode):
+    """Record a finished LLMObs span.
 
-    Not emitted for spans that were dropped before any LLMObs payload could ship
-    (user processor returned ``None``, malformed span, assembly error).
-
-    ``intake`` is the path the LLMObs payload took:
-      - ``"apm_agentless"``      — payload rode the APM trace to the APM intake
-                                   (LLMObsExportMode.APM_AGENTLESS).
-      - ``"llmobs_agentless"``   — LLMObsSpanWriter posted directly to the LLMObs intake.
-      - ``"llmobs_agent_proxy"`` — LLMObsSpanWriter posted via the agent's EVP proxy.
+    ``intake`` is derived from the export mode and writer-transport config:
+      - ``"apm_agentless"``      — APM_AGENTLESS mode; LLMObs payload rides the APM trace.
+      - ``"llmobs_agentless"``   — LLMObsSpanWriter posts directly to the LLMObs intake.
+      - ``"llmobs_agent_proxy"`` — LLMObsSpanWriter posts via the agent's EVP proxy.
     """
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
@@ -122,6 +120,12 @@ def record_span_created(span: Span, intake: str):
     span_kind = get_llmobs_span_kind(span)
     model_provider = get_llmobs_model_provider(span)
     ml_app = get_llmobs_ml_app(span)
+    if export_mode == LLMObsExportMode.APM_AGENTLESS:
+        intake = "apm_agentless"
+    elif config._llmobs_agentless_enabled:
+        intake = "llmobs_agentless"
+    else:
+        intake = "llmobs_agent_proxy"
 
     tags = [
         ("autoinstrumented", str(int(autoinstrumented))),

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -104,13 +104,6 @@ def record_span_started():
 
 
 def record_span_created(span: Span, export_mode: LLMObsExportMode):
-    """Record a finished LLMObs span.
-
-    ``intake`` is derived from the export mode and writer-transport config:
-      - ``"apm_agentless"``      — APM_AGENTLESS mode; LLMObs payload rides the APM trace.
-      - ``"llmobs_agentless"``   — LLMObsSpanWriter posts directly to the LLMObs intake.
-      - ``"llmobs_agent_proxy"`` — LLMObsSpanWriter posts via the agent's EVP proxy.
-    """
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
     has_session_id = get_llmobs_session_id(span) is not None

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -6,6 +6,7 @@ from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
+from ddtrace.llmobs._constants import LLMObsExportMode
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -101,7 +102,7 @@ def record_span_started():
     )
 
 
-def record_span_created(span: Span):
+def record_span_created(span: Span, export_mode: LLMObsExportMode):
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}
     has_session_id = get_llmobs_session_id(span) is not None
@@ -111,6 +112,10 @@ def record_span_created(span: Span):
     span_kind = get_llmobs_span_kind(span)
     model_provider = get_llmobs_model_provider(span)
     ml_app = get_llmobs_ml_app(span)
+    # APM_AGENTLESS rides the APM trace as meta_struct["_llmobs"] to the APM intake;
+    # LLMOBS_DIRECT (agentless) and APM_AGENT_PROXY (agent EVP proxy) both go straight
+    # to the LLMObs intake via the LLMObs span writer.
+    intake = "apm" if export_mode == LLMObsExportMode.APM_AGENTLESS else "llmobs"
 
     tags = [
         ("autoinstrumented", str(int(autoinstrumented))),
@@ -120,6 +125,7 @@ def record_span_created(span: Span):
         ("integration", integration or "N/A"),
         ("ml_app", ml_app or "N/A"),
         ("error", str(span.error)),
+        ("intake", intake),
     ]
     if not autoinstrumented:
         tags.append(("decorator", str(int(decorator))))

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -102,15 +102,16 @@ def record_span_started():
 
 
 def record_span_created(span: Span, intake: str):
-    """Record a finished LLMObs span.
+    """Record a finished LLMObs span that is about to be shipped.
 
-    ``intake`` is the path the LLMObs payload actually took:
+    Not emitted for spans that were dropped before any LLMObs payload could ship
+    (user processor returned ``None``, malformed span, assembly error).
+
+    ``intake`` is the path the LLMObs payload took:
       - ``"apm_agentless"``      — payload rode the APM trace to the APM intake
                                    (LLMObsExportMode.APM_AGENTLESS).
       - ``"llmobs_agentless"``   — LLMObsSpanWriter posted directly to the LLMObs intake.
       - ``"llmobs_agent_proxy"`` — LLMObsSpanWriter posted via the agent's EVP proxy.
-      - ``"dropped"``            — user processor returned ``None``, span was malformed,
-                                   or event assembly raised; no LLMObs payload shipped.
     """
     is_root_span = get_llmobs_parent_id(span) == ROOT_PARENT_ID
     llmobs_tags = get_llmobs_tags(span) or {}

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -235,7 +235,7 @@ def test_export_mode_apm_agent_when_agentless_disabled():
     from ddtrace.llmobs._constants import LLMObsExportMode
 
     llmobs_service.enable(agentless_enabled=False)
-    assert llmobs_service._instance._export_mode == LLMObsExportMode.APM_AGENT_PROXY
+    assert llmobs_service._instance._export_mode == LLMObsExportMode.APM_AGENT
 
 
 @pytest.mark.subprocess(
@@ -1202,7 +1202,7 @@ def test_tag_dot_keys_preserved_on_direct_llmobs_path():
     err=None,
 )
 def test_tag_dot_keys_preserved_on_apm_agent_path():
-    """APM_AGENT_PROXY path: dots in tag keys are not modified (agent handles encoding)."""
+    """APM_AGENT path: dots in tag keys are not modified (agent handles encoding)."""
     from ddtrace.llmobs import LLMObs as llmobs_service
     from ddtrace.llmobs._utils import get_llmobs_tags
 


### PR DESCRIPTION
## Summary

Adds an `intake` tag to the `dd.trace.mlobs.span.finished` telemetry metric so we can see, per finished LLMObs span, where the LLMObs payload is configured to ship:

- `apm_agentless` — `LLMObsExportMode.APM_AGENTLESS` (rides the APM trace to the APM intake)
- `llmobs_agentless` — `LLMObsSpanWriter` posts directly to the LLMObs intake
- `llmobs_agent_proxy` — `LLMObsSpanWriter` posts via the agent's EVP proxy

The tag is derived inside `record_span_created()` from `(export_mode, config._llmobs_agentless_enabled)`. Useful for tracking the APM/LLMObs convergence rollout (MLOB-4925).

Also renames `LLMObsExportMode.APM_AGENT_PROXY` → `APM_AGENT` (the old name suggested LLMObs data is proxied via the APM agent, which isn't what happens). The enum string value (`"apm_agent"`) is unchanged.

## Test plan

- [x] `scripts/lint fmt` + `scripts/lint style` pass
- [x] CI green
- [ ] Follow-up: add unit tests asserting the `intake` value for each of the three configurations

Claude session: `74bbf344-03cf-464b-bb42-2c56d2d3e17f`
Resume: `claude --resume 74bbf344-03cf-464b-bb42-2c56d2d3e17f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)