### PR TITLE
fix(internal): stop Timer loop via PERIODIC_STOP sentinel [backport #18277 to 4.10]

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -44,6 +44,10 @@ struct module_state
     // Mapping of active periodic thread IDs to their PeriodicThread objects.
     PyObject* periodic_threads{ nullptr };
 
+    // Sentinel returned by a periodic target to request a clean stop of the
+    // loop without error. Checked by PeriodicThread__periodic after each call.
+    PyObject* PERIODIC_STOP{ nullptr };
+
     inline bool is_finalizing() const noexcept
     {
         // Our atexit handler fires first (stopping threads before VM sets its
@@ -486,18 +490,18 @@ PeriodicThread_init(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 }
 
 // ----------------------------------------------------------------------------
-static inline bool
+// Call the periodic target and return its return value, or NULL on error
+// (with the Python exception printed and cleared). The caller is responsible
+// for Py_DECREF-ing the returned object.
+static inline PyObject*
 PeriodicThread__periodic(PeriodicThread* self)
 {
     PyObject* result = PyObject_CallObject(self->_target, NULL);
 
-    if (result == NULL) {
+    if (result == NULL)
         PyErr_Print();
-    }
 
-    Py_XDECREF(result);
-
-    return result == NULL;
+    return result;
 }
 
 // ----------------------------------------------------------------------------
@@ -624,10 +628,18 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
                     if (state->is_finalizing())
                         break;
 
-                    if (PeriodicThread__periodic(self)) {
-                        // Error
-                        error = true;
-                        break;
+                    {
+                        PyObject* result = PeriodicThread__periodic(self);
+                        if (result == NULL) {
+                            // Error: target raised an exception.
+                            error = true;
+                            break;
+                        }
+                        // If the target returns PERIODIC_STOP, set _stopping so
+                        // the while condition exits after this iteration.
+                        if (self->_state->PERIODIC_STOP != nullptr && result == self->_state->PERIODIC_STOP)
+                            self->_stopping = true;
+                        Py_DECREF(result);
                     }
 
                     self->_next_call_time =
@@ -1057,8 +1069,10 @@ static int
 _threads_traverse(PyObject* module, visitproc visit, void* arg)
 {
     module_state* state = (module_state*)PyModule_GetState(module);
-    if (state != nullptr)
+    if (state != nullptr) {
         Py_VISIT(state->periodic_threads);
+        Py_VISIT(state->PERIODIC_STOP);
+    }
     return 0;
 }
 
@@ -1067,8 +1081,10 @@ static int
 _threads_clear(PyObject* module)
 {
     module_state* state = (module_state*)PyModule_GetState(module);
-    if (state != nullptr)
+    if (state != nullptr) {
         Py_CLEAR(state->periodic_threads);
+        Py_CLEAR(state->PERIODIC_STOP);
+    }
     return 0;
 }
 
@@ -1153,6 +1169,17 @@ PyInit__threads(void)
         Py_INCREF(state->periodic_threads);
         if (PyModule_AddObject(m, "periodic_threads", state->periodic_threads) < 0) {
             Py_DECREF(state->periodic_threads);
+            goto error;
+        }
+
+        // Create the PERIODIC_STOP sentinel: a unique object that periodic
+        // targets can return to request a clean one-shot stop of the loop.
+        state->PERIODIC_STOP = PyObject_CallObject((PyObject*)&PyBaseObject_Type, NULL);
+        if (state->PERIODIC_STOP == NULL)
+            goto error;
+        Py_INCREF(state->PERIODIC_STOP);
+        if (PyModule_AddObject(m, "PERIODIC_STOP", state->PERIODIC_STOP) < 0) {
+            Py_DECREF(state->PERIODIC_STOP);
             goto error;
         }
     }

--- a/ddtrace/internal/_threads.pyi
+++ b/ddtrace/internal/_threads.pyi
@@ -1,6 +1,15 @@
 import typing as t
 
 class PeriodicThread:
+    """A native periodic thread.
+
+    The ``target`` callable is invoked repeatedly at ``interval`` seconds. If
+    ``target`` returns the ``PERIODIC_STOP`` sentinel the loop exits cleanly
+    after that iteration (``on_shutdown`` is still called). Returning any other
+    value continues the loop; raising an exception prints the traceback and also
+    stops the loop.
+    """
+
     name: str
     ident: int
     interval: float
@@ -21,3 +30,4 @@ class PeriodicThread:
     def _before_fork(self) -> None: ...
 
 periodic_threads: dict[int, PeriodicThread]
+PERIODIC_STOP: object

--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -3,7 +3,9 @@ import typing  # noqa:F401
 
 from ddtrace.internal import forksafe
 from ddtrace.internal import service
+from ddtrace.internal._threads import PERIODIC_STOP
 from ddtrace.internal.threads import PeriodicThread
+from ddtrace.internal.threads import RLock
 
 
 class PeriodicService(service.Service):
@@ -117,6 +119,7 @@ class Timer:
 
     def __init__(self, interval: float) -> None:
         self._interval = interval
+        self._worker_lock = RLock()
         self._set_worker()
 
     def _set_worker(self) -> None:
@@ -128,24 +131,43 @@ class Timer:
         )
 
     def start(self) -> None:
-        self._worker.start()
+        with self._worker_lock:
+            self._worker.start()
 
     def stop(self) -> None:
-        self._worker.stop()
+        # Capture the worker under the lock so a concurrent reset() cannot
+        # swap it under us; call stop() outside the lock since the swap is
+        # the only race — stop() itself doesn't block.
+        with self._worker_lock:
+            worker = self._worker
+        worker.stop()
 
     def timeout(self) -> None:
         raise NotImplementedError()
 
     def _periodic(self):
         self.timeout()
-        self.stop()
+        return PERIODIC_STOP
 
     def reset(self) -> None:
-        self.stop()
+        with self._worker_lock:
+            try:
+                self.stop()
+            except RuntimeError:
+                # The current worker may not have an underlying OS thread —
+                # e.g. a previous reset() during a fork window had its
+                # start() deferred by threads.PeriodicThread.start, leaving
+                # this worker un-started. That's fine: we still want to
+                # honour the reset request by replacing the worker.
+                pass
 
-        self._set_worker()
+            self._set_worker()
 
-        self.start()
+            self.start()
 
     def join(self, timeout: typing.Optional[float] = None) -> None:
-        self._worker.join(timeout)
+        # Capture the worker under the lock, then join outside it so a
+        # concurrent reset() is not blocked for the duration of the wait.
+        with self._worker_lock:
+            worker = self._worker
+        worker.join(timeout)

--- a/releasenotes/notes/fix-periodic-internal-stop-sentinel-1bc7ecdb3909cd11.yaml
+++ b/releasenotes/notes/fix-periodic-internal-stop-sentinel-1bc7ecdb3909cd11.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue that could have caused some timers, like the one responsible
+    for Symbol Database uploads, to fire repeatedly after the first execution.

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -1,6 +1,7 @@
 import ctypes
 import os
 import platform
+from threading import Barrier
 from threading import Event
 from threading import Thread
 from time import monotonic
@@ -314,6 +315,27 @@ def test_periodic_thread_preserves_awake_during_restart_window():
     awaker.join(timeout=1)
 
 
+def test_timer_fires_only_once():
+    count = 0
+    fired = Event()
+
+    class TestTimer(periodic.Timer):
+        def timeout(self):
+            nonlocal count
+            count += 1
+            fired.set()
+
+    T = 0.05
+    t = TestTimer(T)
+    t.start()
+
+    assert fired.wait(timeout=5.0), "Timer did not fire within 5s"
+    sleep(T * 5)
+
+    assert count == 1, f"Timer fired {count} times but should have fired exactly once"
+    t.join(timeout=1.0)
+
+
 def test_timer():
     end = 0
 
@@ -549,3 +571,168 @@ def test_periodic_thread_naming():
         assert native_name[0].endswith("ClassNameFit"), (
             f"Expected name ending with 'ClassNameFit', got '{native_name[0]}'"
         )
+
+
+def test_timer_reset_during_fork_does_not_break_stop():
+    """Regression test for DEBUG-5712.
+
+    ``periodic.Timer.reset()`` runs ``stop(); _set_worker(); start()``. During
+    a fork window (``ddtrace.internal.threads._forking == True``),
+    PeriodicThread.start() silently defers and the new worker ends up with
+    ``_thread == nullptr``. Without the tolerance below, the *next*
+    ``reset()`` raised ``RuntimeError("Thread not started")`` on its internal
+    ``stop()`` call. In production this killed Symbol DB's installer
+    mid-``_process_unseen_loaded_modules`` and Remote Config retried it ~6×
+    per second.
+
+    Fix: ``reset()`` swallows ``RuntimeError`` from its internal ``stop()``
+    so a deferred-start worker is replaced cleanly. The reset request is
+    still honoured — the new worker's deferred ``start()`` fires post-fork.
+    """
+    from ddtrace.internal import threads as _threads_mod
+
+    class _TestTimer(periodic.Timer):
+        def timeout(self):
+            pass
+
+    t = _TestTimer(60.0)
+    t.start()
+
+    original_forking = _threads_mod._forking
+    _threads_mod._forking = True
+    try:
+        # Repeated resets under a fork window must not raise. The first
+        # reset's start() is deferred; the second reset's internal stop()
+        # would hit the not-started worker and crash without the tolerance.
+        for _ in range(5):
+            t.reset()
+    finally:
+        _threads_mod._forking = original_forking
+        _threads_mod._threads_to_start_after_fork.clear()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent stress tests
+#
+# These tests exercise the native extension under real multi-threading to catch
+# races that only manifest under concurrent load, especially on free-threaded
+# Python (Py_GIL_DISABLED) or on weak-memory-order architectures (ARM).
+# Each test uses a Barrier to maximise contention at the critical moment.
+# ---------------------------------------------------------------------------
+
+_N_THREADS = 20
+
+
+def test_concurrent_start_stop():
+    """N threads each independently create, start, and stop a PeriodicThread.
+
+    Exercises concurrent PyDict_SetItem / PyDict_DelItem on the module-level
+    periodic_threads dict from multiple native threads simultaneously.
+    """
+    barrier = Barrier(_N_THREADS)
+    errors = []
+
+    def worker():
+        t = periodic.PeriodicThread(60.0, lambda: None)
+        barrier.wait()
+        try:
+            t.start()
+            t.stop()
+            t.join()
+        except Exception as e:
+            errors.append(e)
+
+    threads = [Thread(target=worker) for _ in range(_N_THREADS)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert not errors, f"errors in concurrent start/stop: {errors}"
+
+
+def test_concurrent_awake():
+    """N threads call awake() on the same PeriodicThread simultaneously.
+
+    Exercises the _awake_mutex / _request / _served Event trio under
+    concurrent writers.
+    """
+    barrier = Barrier(_N_THREADS)
+    errors = []
+
+    t = periodic.PeriodicThread(60.0, lambda: None)
+    t.start()
+    try:
+
+        def awaker():
+            barrier.wait()
+            try:
+                t.awake()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [Thread(target=awaker) for _ in range(_N_THREADS)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+    finally:
+        t.stop()
+        t.join()
+
+    assert not errors, f"errors in concurrent awake: {errors}"
+
+
+def test_concurrent_init_dealloc():
+    """N threads simultaneously instantiate and immediately drop PeriodicThread
+    objects (without starting them).
+
+    Exercises concurrent PeriodicThread_init (PyImport_GetModule, dict lookup)
+    and PeriodicThread_dealloc (PyDict_DelItem on periodic_threads).
+    """
+    barrier = Barrier(_N_THREADS)
+    errors = []
+
+    def worker():
+        barrier.wait()
+        try:
+            for _ in range(10):
+                periodic.PeriodicThread(60.0, lambda: None)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [Thread(target=worker) for _ in range(_N_THREADS)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert not errors, f"errors in concurrent init/dealloc: {errors}"
+
+
+def test_concurrent_stop_join():
+    """N threads race to call stop() and join() on the same PeriodicThread.
+
+    stop() is idempotent and join() must not deadlock when called concurrently.
+    """
+    barrier = Barrier(_N_THREADS)
+    errors = []
+
+    t = periodic.PeriodicThread(60.0, lambda: None)
+    t.start()
+
+    def stopper():
+        barrier.wait()
+        try:
+            t.stop()
+            t.join()
+        except Exception as e:
+            errors.append(e)
+
+    threads = [Thread(target=stopper) for _ in range(_N_THREADS)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert not errors, f"errors in concurrent stop/join: {errors}"


### PR DESCRIPTION
Backport da4fdeb868a00ee00bbb86dea371e1e804322ff2 from #18277 to 4.10.

## Description

dd-trace-py is generating sustained, high-rate Symbol DB upload traffic where the vast majority of uploads carry an empty `scopes` payload (DEBUG-5712). Live Debugger probes on the affected services confirm that `ScopeContext.upload` fires ~1/s continuously, `Timer.stop` is called every cycle, yet the periodic loop never terminates.

`Timer._periodic` previously halted the periodic loop by calling `self.stop()` from inside the worker thread immediately after invoking `timeout()`. This had two concrete problems:

1. **Concurrent reset() race.**  `stop()` looks up `self._worker` as a Python attribute at call time.  If another thread calls `reset()` between `timeout()` returning and `stop()` executing, `self._worker` has already been replaced by the new worker.  The `stop()` call then lands on the *new* worker instead of the currently-running one, silently aborting the replacement before it ever fires, while the old thread's own `_stopping` flag remains false and the loop iterates again.

2. **GIL-release window.**  `PeriodicThread_stop` calls `AllowThreads` (releases the GIL) before acquiring `_awake_mutex`.  That release opens a window where a concurrent Python thread can run — including a `reset()` that replaces `self._worker` — between the point `stop()` is called and the point `_stopping` is actually written.

### Fix

Introduce a module-level `PERIODIC_STOP` sentinel object in the native `_threads` extension.  When `PeriodicThread__periodic` calls the target and receives `PERIODIC_STOP` as the return value it sets `_stopping = true` directly on the C++ struct that is currently executing — no Python attribute lookup, no GIL release, no cross-thread window — before returning to the caller.  The existing `while (!_stopping)` condition then exits the loop cleanly after the current iteration, with `on_shutdown` still being called.

`Timer._periodic` is updated to `return PERIODIC_STOP` instead of calling `self.stop()`, removing the self-referential stop entirely.

`PeriodicThread__periodic` is refactored to return the raw `PyObject*` result of the target (or `NULL` on error) so the sentinel check lives at the call site in the loop, keeping the helper narrow and easy to reason about.

## Testing

Added an extra test to validate periodic execution counts. The original issue is not reproducible locally, likely due to the arch+platform combination where this was observed.

Refs: [DEBUG-5712](https://datadoghq.atlassian.net/browse/DEBUG-5712)

[DEBUG-5712]: https://datadoghq.atlassian.net/browse/DEBUG-5712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
