### PR TITLE
chore(pre-commit): follow-imports=skip for test-only mypy

### DIFF
--- a/hooks/scripts/run-mypy.sh
+++ b/hooks/scripts/run-mypy.sh
@@ -18,7 +18,18 @@ if [ -n "$staged_files" ]; then
     done
     deduped="${deduped# }"
     if [ -n "$deduped" ]; then
-        "$LINT_CMD" typing -- $deduped
+        mypy_extra=""
+        all_tests=true
+        for f in $deduped; do
+            case "$f" in
+                tests/*) ;;
+                *) all_tests=false; break ;;
+            esac
+        done
+        if [ "$all_tests" = true ]; then
+            mypy_extra="--follow-imports=skip"
+        fi
+        "$LINT_CMD" typing -- $mypy_extra $deduped
     else
         echo 'Run mypy skipped: all staged stubs have corresponding .py files'
     fi


### PR DESCRIPTION
## Summary

When pre-commit runs mypy on staged files that are **all** under `tests/`, pass `--follow-imports=skip` so isolated test edits are not blocked by unrelated errors in shared test infrastructure (e.g. `tests/utils.py`, `tests/conftest.py`).

## Context

- **`.pyi` / cython-lint**: `main` already skips cython-lint for `.pyi` in `hooks/pre-commit/01-format-and-lint` (ruff only; cython-lint is `.pyx`-only). No change needed there.
- **`4.7` release branch** still uses the older `hatch.toml` `pre-commit-python` path that runs cython-lint on all staged files; that is out of scope here (see customer backport PR).

## Test plan

- [ ] Stage only a file under `tests/` and confirm pre-commit mypy passes when the test file itself is clean
- [ ] Stage a mix of `ddtrace/` + `tests/` files and confirm full import following still runs