### PR TITLE
fix(runtime-metrics): resolve DogStatsD origin on cgroup v2 hosts

### DIFF
--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -4,7 +4,9 @@
 # Copyright 2015-Present Datadog, Inc
 
 import errno
+import os
 import re
+from typing import Optional
 
 
 class UnresolvableContainerID(Exception):
@@ -15,7 +17,17 @@ class UnresolvableContainerID(Exception):
 
 class ContainerID(object):
     """
-    A reader class that retrieves the current container ID parsed from a the cgroup file.
+    A reader class that retrieves either:
+    - The current container ID parsed from the cgroup file (cgroup v1 / host
+      cgroup namespace), prefixed with ``ci-``.
+    - The cgroup controller inode (cgroup v2 / non-host cgroup namespace),
+      prefixed with ``in-``.
+
+    Both forms are understood by the Datadog Agent's origin detection, which
+    uses them to enrich DogStatsD metrics with orchestrator tags such as
+    ``pod_name``. The previous implementation only parsed ``/proc/self/cgroup``
+    and therefore returned ``None`` on cgroup v2 nodes, which silently disabled
+    origin detection for those pods.
 
     Returns:
     object: ContainerID
@@ -26,16 +38,80 @@ class ContainerID(object):
     """
 
     CGROUP_PATH = "/proc/self/cgroup"
+    CGROUP_MOUNT_PATH = "/sys/fs/cgroup"  # cgroup mount path.
+    CGROUP_NS_PATH = "/proc/self/ns/cgroup"  # path to the cgroup namespace file.
+    CGROUPV1_BASE_CONTROLLER = "memory"  # controller used to identify the container-id in cgroup v1.
+    CGROUPV2_BASE_CONTROLLER = ""  # controller used to identify the container-id in cgroup v2.
+    HOST_CGROUP_NAMESPACE_INODE = 0xEFFFFFFB  # inode of the host cgroup namespace.
+
     UUID_SOURCE = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
     CONTAINER_SOURCE = r"[0-9a-f]{64}"
     TASK_SOURCE = r"[0-9a-f]{32}-\d+"
     LINE_RE = re.compile(r"^(\d+):([^:]*):(.+)$")
     CONTAINER_RE = re.compile(r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE, CONTAINER_SOURCE, TASK_SOURCE))
 
-    def __init__(self):
-        self.container_id = self._read_container_id(self.CGROUP_PATH)
+    def __init__(self) -> None:
+        if self._is_host_cgroup_namespace():
+            self.container_id = self._read_cgroup_path()
+            return
+        self.container_id = self._get_cgroup_from_inode()
 
-    def _read_container_id(self, fpath):
+    def _is_host_cgroup_namespace(self) -> bool:
+        """Check whether the current process is in the host cgroup namespace.
+
+        When it is (cgroup v1, or v2 without a private namespace) the container
+        ID can be parsed from the cgroup path. Otherwise (typical cgroup v2)
+        we must fall back to the cgroup controller inode.
+        """
+        try:
+            return (
+                os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
+                if os.path.exists(self.CGROUP_NS_PATH)
+                else False
+            )
+        except Exception:
+            return False
+
+    def _read_cgroup_path(self) -> Optional[str]:
+        """Read the container ID from the cgroup file, prefixed with ``ci-``."""
+        container_id = self._read_container_id(self.CGROUP_PATH)
+        return "ci-{0}".format(container_id) if container_id else None
+
+    def _get_cgroup_from_inode(self) -> Optional[str]:
+        """Read the container ID from the cgroup controller inode (``in-<inode>``).
+
+        This is the cgroup v2 fallback: on those nodes ``/proc/self/cgroup``
+        does not contain a parseable container ID, so we resolve the inode of
+        the cgroup controller node, which the Agent maps back to the container.
+        """
+        try:
+            # Map each base controller to its associated cgroup node path.
+            cgroup_controllers_paths: dict[str, str] = {}
+            with open(self.CGROUP_PATH, mode="r") as fp:
+                for line in fp:
+                    tokens = line.strip().split(":")
+                    if len(tokens) != 3:
+                        continue
+                    if tokens[1] in (self.CGROUPV1_BASE_CONTROLLER, self.CGROUPV2_BASE_CONTROLLER):
+                        cgroup_controllers_paths[tokens[1]] = tokens[2]
+
+            for controller in (self.CGROUPV1_BASE_CONTROLLER, self.CGROUPV2_BASE_CONTROLLER):
+                if controller in cgroup_controllers_paths:
+                    node_path = cgroup_controllers_paths[controller]
+                    inode_path = os.path.join(
+                        self.CGROUP_MOUNT_PATH,
+                        controller,
+                        node_path if node_path != "/" else "",
+                    )
+                    inode = os.stat(inode_path).st_ino
+                    # 0 is not a valid inode. 1 is a bad block inode and 2 is the root of a filesystem.
+                    if inode > 2:
+                        return "in-{0}".format(inode)
+        except Exception:
+            return None
+        return None
+
+    def _read_container_id(self, fpath: str) -> Optional[str]:
         try:
             with open(fpath, mode="r") as fp:
                 for line in fp:

--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -112,11 +112,11 @@ class ContainerID(object):
             with open(fpath, mode="r") as fp:
                 for line in fp:
                     line = line.strip()
-                    match = self.LINE_RE.match(line)
+                    match: Optional[re.Match[str]] = self.LINE_RE.match(line)
                     if not match:
                         continue
                     _, _, path = match.groups()
-                    parts = [p for p in path.split("/")]
+                    parts: list[str] = path.split("/")
                     if len(parts):
                         match = self.CONTAINER_RE.match(parts.pop())
                         if match:

--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -101,7 +101,7 @@ class ContainerID(object):
                     inode_path = os.path.join(
                         self.CGROUP_MOUNT_PATH,
                         controller,
-                        node_path if node_path != "/" else "",
+                        node_path.lstrip("/"),
                     )
                     inode = os.stat(inode_path).st_ino
                     # 0 is not a valid inode. 1 is a bad block inode and 2 is the root of a filesystem.

--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -25,9 +25,7 @@ class ContainerID(object):
 
     Both forms are understood by the Datadog Agent's origin detection, which
     uses them to enrich DogStatsD metrics with orchestrator tags such as
-    ``pod_name``. The previous implementation only parsed ``/proc/self/cgroup``
-    and therefore returned ``None`` on cgroup v2 nodes, which silently disabled
-    origin detection for those pods.
+    ``pod_name``.
 
     Returns:
     object: ContainerID
@@ -65,9 +63,8 @@ class ContainerID(object):
         """
         try:
             return (
-                os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
-                if os.path.exists(self.CGROUP_NS_PATH)
-                else False
+                os.path.exists(self.CGROUP_NS_PATH)
+                and os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
             )
         except Exception:
             return False

--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -49,10 +49,9 @@ class ContainerID(object):
     CONTAINER_RE = re.compile(r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE, CONTAINER_SOURCE, TASK_SOURCE))
 
     def __init__(self) -> None:
-        if self._is_host_cgroup_namespace():
-            self.container_id = self._read_cgroup_path()
-            return
-        self.container_id = self._get_cgroup_from_inode()
+        self.container_id = self._read_cgroup_path()
+        if self.container_id is None and not self._is_host_cgroup_namespace():
+            self.container_id = self._get_cgroup_from_inode()
 
     def _is_host_cgroup_namespace(self) -> bool:
         """Check whether the current process is in the host cgroup namespace.

--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -19,13 +19,13 @@ class ContainerID(object):
     """
     A reader class that retrieves either:
     - The current container ID parsed from the cgroup file (cgroup v1 / host
-      cgroup namespace), prefixed with ``ci-``.
+      cgroup namespace), prefixed with `ci-`.
     - The cgroup controller inode (cgroup v2 / non-host cgroup namespace),
-      prefixed with ``in-``.
+      prefixed with `in-`.
 
     Both forms are understood by the Datadog Agent's origin detection, which
     uses them to enrich DogStatsD metrics with orchestrator tags such as
-    ``pod_name``.
+    `pod_name`.
 
     Returns:
     object: ContainerID
@@ -69,14 +69,14 @@ class ContainerID(object):
             return False
 
     def _read_cgroup_path(self) -> Optional[str]:
-        """Read the container ID from the cgroup file, prefixed with ``ci-``."""
+        """Read the container ID from the cgroup file, prefixed with `ci-`."""
         container_id = self._read_container_id(self.CGROUP_PATH)
         return "ci-{0}".format(container_id) if container_id else None
 
     def _get_cgroup_from_inode(self) -> Optional[str]:
-        """Read the container ID from the cgroup controller inode (``in-<inode>``).
+        """Read the container ID from the cgroup controller inode (`in-<inode>`).
 
-        This is the cgroup v2 fallback: on those nodes ``/proc/self/cgroup``
+        This is the cgroup v2 fallback: on those nodes `/proc/self/cgroup`
         does not contain a parseable container ID, so we resolve the inode of
         the cgroup controller node, which the Agent maps back to the container.
         """

--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -86,7 +86,7 @@ class ContainerID(object):
             cgroup_controllers_paths: dict[str, str] = {}
             with open(self.CGROUP_PATH, mode="r") as fp:
                 for line in fp:
-                    tokens = line.strip().split(":")
+                    tokens: list[str] = line.strip().split(":")
                     if len(tokens) != 3:
                         continue
                     if tokens[1] in (self.CGROUPV1_BASE_CONTROLLER, self.CGROUPV2_BASE_CONTROLLER):
@@ -94,13 +94,13 @@ class ContainerID(object):
 
             for controller in (self.CGROUPV1_BASE_CONTROLLER, self.CGROUPV2_BASE_CONTROLLER):
                 if controller in cgroup_controllers_paths:
-                    node_path = cgroup_controllers_paths[controller]
-                    inode_path = os.path.join(
+                    node_path: str = cgroup_controllers_paths[controller]
+                    inode_path: str = os.path.join(
                         self.CGROUP_MOUNT_PATH,
                         controller,
                         node_path.lstrip("/"),
                     )
-                    inode = os.stat(inode_path).st_ino
+                    inode: int = os.stat(inode_path).st_ino
                     # 0 is not a valid inode. 1 is a bad block inode and 2 is the root of a filesystem.
                     if inode > 2:
                         return "in-{0}".format(inode)

--- a/releasenotes/notes/fix-runtime-metrics-origin-detection-cgroupv2-3f2c1d9b7a4e6c80.yaml
+++ b/releasenotes/notes/fix-runtime-metrics-origin-detection-cgroupv2-3f2c1d9b7a4e6c80.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    runtime metrics: Fixes an issue where runtime metrics were missing
+    container and orchestrator tags (such as ``pod_name``) on hosts using
+    cgroup v2. These tags are now added correctly.

--- a/tests/vendor/test_dogstatsd_container.py
+++ b/tests/vendor/test_dogstatsd_container.py
@@ -234,30 +234,46 @@ class TestGetCgroupFromInode:
 
 
 class TestContainerIDInit:
-    def test_uses_cgroup_path_when_host_namespace(self) -> None:
+    def test_uses_cgroup_path_when_parseable(self) -> None:
+        # ci- path is always tried first; inode is never consulted when it succeeds.
         with (
-            mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=True),
             mock.patch.object(ContainerID, "_read_cgroup_path", return_value=f"ci-{CONTAINER_ID_64}") as mock_path,
+            mock.patch.object(ContainerID, "_is_host_cgroup_namespace") as mock_ns,
             mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
         ):
             reader = ContainerID()
             assert reader.container_id == f"ci-{CONTAINER_ID_64}"
             mock_path.assert_called_once()
+            mock_ns.assert_not_called()
             mock_inode.assert_not_called()
 
-    def test_uses_inode_fallback_when_not_host_namespace(self) -> None:
+    def test_uses_inode_fallback_when_path_empty_and_not_host_namespace(self) -> None:
+        # Typical cgroup v2: path yields None and namespace check is private → inode.
         with (
+            mock.patch.object(ContainerID, "_read_cgroup_path", return_value=None) as mock_path,
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=False),
-            mock.patch.object(ContainerID, "_read_cgroup_path") as mock_path,
             mock.patch.object(ContainerID, "_get_cgroup_from_inode", return_value="in-99999") as mock_inode,
         ):
             reader = ContainerID()
             assert reader.container_id == "in-99999"
+            mock_path.assert_called_once()
             mock_inode.assert_called_once()
-            mock_path.assert_not_called()
+
+    def test_skips_inode_when_host_namespace_and_path_empty(self) -> None:
+        # In the host namespace without a parseable path (bare non-container Linux),
+        # the inode fallback is skipped.
+        with (
+            mock.patch.object(ContainerID, "_read_cgroup_path", return_value=None),
+            mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=True),
+            mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
+        ):
+            reader = ContainerID()
+            assert reader.container_id is None
+            mock_inode.assert_not_called()
 
     def test_container_id_is_none_when_inode_fallback_returns_none(self) -> None:
         with (
+            mock.patch.object(ContainerID, "_read_cgroup_path", return_value=None),
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=False),
             mock.patch.object(ContainerID, "_get_cgroup_from_inode", return_value=None),
         ):

--- a/tests/vendor/test_dogstatsd_container.py
+++ b/tests/vendor/test_dogstatsd_container.py
@@ -26,29 +26,29 @@ from ddtrace.vendor.dogstatsd.container import UnresolvableContainerID
 # Fixtures
 # ---------------------------------------------------------------------------
 
-CONTAINER_ID_64 = "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"
-CONTAINER_ID_K8S = "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"
-TASK_ID_FARGATE = "34dc0b5e626f2c5c4c5170e34b10e765-1234567890"
+CONTAINER_ID_64: str = "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"
+CONTAINER_ID_K8S: str = "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"
+TASK_ID_FARGATE: str = "34dc0b5e626f2c5c4c5170e34b10e765-1234567890"
 
-DOCKER_CGROUP_V1 = f"11:memory:/docker/{CONTAINER_ID_64}\n10:cpu,cpuacct:/docker/{CONTAINER_ID_64}\n"
-K8S_CGROUP_V1 = (
+DOCKER_CGROUP_V1: str = f"11:memory:/docker/{CONTAINER_ID_64}\n10:cpu,cpuacct:/docker/{CONTAINER_ID_64}\n"
+K8S_CGROUP_V1: str = (
     f"9:memory:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/{CONTAINER_ID_K8S}\n"
     f"1:name=systemd:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/{CONTAINER_ID_K8S}\n"
 )
-ECS_CGROUP_V1 = (
+ECS_CGROUP_V1: str = (
     f"8:memory:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/{CONTAINER_ID_64}\n"
     f"1:blkio:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/{CONTAINER_ID_64}\n"
 )
-FARGATE_14_CGROUP = (
+FARGATE_14_CGROUP: str = (
     f"10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/{TASK_ID_FARGATE}\n1:name=systemd:/ecs/{TASK_ID_FARGATE}\n"
 )
-K8S_SLICE_SCOPE = (
+K8S_SLICE_SCOPE: str = (
     f"1:name=systemd:/kubepods.slice/kubepods-burstable.slice/"
     f"kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/"
     f"docker-{CONTAINER_ID_64}.scope\n"
 )
-CGROUP_V2_UNIFIED = "0::/\n"
-NON_CONTAINERISED = (
+CGROUP_V2_UNIFIED: str = "0::/\n"
+NON_CONTAINERISED: str = (
     "11:blkio:/user.slice/user-0.slice/session-14.scope\n"
     "10:memory:/user.slice/user-0.slice/session-14.scope\n"
     "1:name=systemd:/user.slice/user-0.slice/session-14.scope\n"
@@ -69,8 +69,8 @@ def _write_cgroup(content: str) -> str:
 
 def _read(content: str) -> Optional[str]:
     """Write ``content`` to a temp file and run _read_container_id against it."""
-    reader = ContainerID.__new__(ContainerID)
-    path = _write_cgroup(content)
+    reader: ContainerID = ContainerID.__new__(ContainerID)
+    path: str = _write_cgroup(content)
     try:
         return reader._read_container_id(path)
     finally:
@@ -84,14 +84,14 @@ def _read(content: str) -> Optional[str]:
 
 class TestIsHostCgroupNamespace:
     def test_returns_false_when_ns_path_missing(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         reader.CGROUP_NS_PATH = "/nonexistent/ns/cgroup"
         assert reader._is_host_cgroup_namespace() is False
 
     def test_returns_false_when_inode_does_not_match(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            path = fp.name
+            path: str = fp.name
         try:
             reader.CGROUP_NS_PATH = path
             # Real inode of a temp file is never 0xEFFFFFFB.
@@ -100,11 +100,11 @@ class TestIsHostCgroupNamespace:
             os.unlink(path)
 
     def test_returns_true_when_inode_matches(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            path = fp.name
+            path: str = fp.name
         try:
-            real_inode = os.stat(path).st_ino
+            real_inode: int = os.stat(path).st_ino
             reader.CGROUP_NS_PATH = path
             reader.HOST_CGROUP_NAMESPACE_INODE = real_inode
             assert reader._is_host_cgroup_namespace() is True
@@ -112,7 +112,7 @@ class TestIsHostCgroupNamespace:
             os.unlink(path)
 
     def test_returns_false_on_unexpected_exception(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         reader.CGROUP_NS_PATH = "/nonexistent"
         with (
             mock.patch("os.path.exists", return_value=True),
@@ -128,33 +128,33 @@ class TestIsHostCgroupNamespace:
 
 class TestReadCgroupPath:
     def _make_reader(self, cgroup_content: str) -> ContainerID:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         reader.CGROUP_PATH = _write_cgroup(cgroup_content)
         return reader
 
     def test_returns_ci_prefixed_id_for_docker_cgroup_v1(self) -> None:
-        reader = self._make_reader(DOCKER_CGROUP_V1)
+        reader: ContainerID = self._make_reader(DOCKER_CGROUP_V1)
         try:
             assert reader._read_cgroup_path() == f"ci-{CONTAINER_ID_64}"
         finally:
             os.unlink(reader.CGROUP_PATH)
 
     def test_returns_ci_prefixed_id_for_k8s_cgroup_v1(self) -> None:
-        reader = self._make_reader(K8S_CGROUP_V1)
+        reader: ContainerID = self._make_reader(K8S_CGROUP_V1)
         try:
             assert reader._read_cgroup_path() == f"ci-{CONTAINER_ID_K8S}"
         finally:
             os.unlink(reader.CGROUP_PATH)
 
     def test_returns_none_for_cgroup_v2_unified(self) -> None:
-        reader = self._make_reader(CGROUP_V2_UNIFIED)
+        reader: ContainerID = self._make_reader(CGROUP_V2_UNIFIED)
         try:
             assert reader._read_cgroup_path() is None
         finally:
             os.unlink(reader.CGROUP_PATH)
 
     def test_returns_none_when_cgroup_file_missing(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         reader.CGROUP_PATH = "/nonexistent/cgroup"
         assert reader._read_cgroup_path() is None
 
@@ -166,19 +166,19 @@ class TestReadCgroupPath:
 
 class TestGetCgroupFromInode:
     def _make_reader(self, cgroup_content: str, mount_dir: Optional[str] = None) -> ContainerID:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         reader.CGROUP_PATH = _write_cgroup(cgroup_content)
         reader.CGROUP_MOUNT_PATH = mount_dir or tempfile.mkdtemp()
         return reader
 
     def test_returns_in_prefixed_inode_for_cgroup_v2(self) -> None:
-        mount_dir = tempfile.mkdtemp()
-        reader = self._make_reader(CGROUP_V2_UNIFIED, mount_dir)
+        mount_dir: str = tempfile.mkdtemp()
+        reader: ContainerID = self._make_reader(CGROUP_V2_UNIFIED, mount_dir)
         try:
-            result = reader._get_cgroup_from_inode()
+            result: Optional[str] = reader._get_cgroup_from_inode()
             assert result is not None
             assert result.startswith("in-")
-            inode = int(result[3:])
+            inode: int = int(result[3:])
             assert inode > 2
         finally:
             os.unlink(reader.CGROUP_PATH)
@@ -186,14 +186,14 @@ class TestGetCgroupFromInode:
 
     def test_returns_in_prefixed_inode_for_cgroup_v1_memory_controller(self) -> None:
         # cgroup v1 memory controller path exists → inode lookup succeeds.
-        mount_dir = tempfile.mkdtemp()
+        mount_dir: str = tempfile.mkdtemp()
         # Create a sub-directory mimicking /sys/fs/cgroup/memory/<cgroup-node>.
-        mem_dir = os.path.join(mount_dir, "memory", "docker", "abc123")
+        mem_dir: str = os.path.join(mount_dir, "memory", "docker", "abc123")
         os.makedirs(mem_dir)
-        content = "5:memory:/docker/abc123\n"
-        reader = self._make_reader(content, mount_dir)
+        content: str = "5:memory:/docker/abc123\n"
+        reader: ContainerID = self._make_reader(content, mount_dir)
         try:
-            result = reader._get_cgroup_from_inode()
+            result: Optional[str] = reader._get_cgroup_from_inode()
             assert result is not None
             assert result.startswith("in-")
         finally:
@@ -204,13 +204,13 @@ class TestGetCgroupFromInode:
             os.rmdir(mount_dir)
 
     def test_returns_none_when_cgroup_file_missing(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         reader.CGROUP_PATH = "/nonexistent/cgroup"
         reader.CGROUP_MOUNT_PATH = "/nonexistent/sys/fs/cgroup"
         assert reader._get_cgroup_from_inode() is None
 
     def test_returns_none_when_mount_path_missing(self) -> None:
-        reader = self._make_reader(CGROUP_V2_UNIFIED, "/nonexistent/mount")
+        reader: ContainerID = self._make_reader(CGROUP_V2_UNIFIED, "/nonexistent/mount")
         try:
             assert reader._get_cgroup_from_inode() is None
         finally:
@@ -218,7 +218,7 @@ class TestGetCgroupFromInode:
 
     def test_returns_none_when_inode_is_root(self) -> None:
         # Simulate an inode <= 2 (root of a filesystem), which should be skipped.
-        reader = self._make_reader(CGROUP_V2_UNIFIED)
+        reader: ContainerID = self._make_reader(CGROUP_V2_UNIFIED)
         try:
             with mock.patch("os.stat") as mock_stat:
                 mock_stat.return_value = mock.Mock(st_ino=2)
@@ -241,7 +241,7 @@ class TestContainerIDInit:
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace") as mock_ns,
             mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
         ):
-            reader = ContainerID()
+            reader: ContainerID = ContainerID()
             assert reader.container_id == f"ci-{CONTAINER_ID_64}"
             mock_path.assert_called_once()
             mock_ns.assert_not_called()
@@ -254,7 +254,7 @@ class TestContainerIDInit:
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=False),
             mock.patch.object(ContainerID, "_get_cgroup_from_inode", return_value="in-99999") as mock_inode,
         ):
-            reader = ContainerID()
+            reader: ContainerID = ContainerID()
             assert reader.container_id == "in-99999"
             mock_path.assert_called_once()
             mock_inode.assert_called_once()
@@ -267,7 +267,7 @@ class TestContainerIDInit:
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=True),
             mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
         ):
-            reader = ContainerID()
+            reader: ContainerID = ContainerID()
             assert reader.container_id is None
             mock_inode.assert_not_called()
 
@@ -277,7 +277,7 @@ class TestContainerIDInit:
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=False),
             mock.patch.object(ContainerID, "_get_cgroup_from_inode", return_value=None),
         ):
-            reader = ContainerID()
+            reader: ContainerID = ContainerID()
             assert reader.container_id is None
 
 
@@ -316,12 +316,12 @@ class TestReadContainerIdNotFound:
 
 class TestReadContainerIdErrors:
     def test_file_not_found_returns_none(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         assert reader._read_container_id("/nonexistent/proc/self/cgroup") is None
 
     def test_non_enoent_io_error_raises_not_implemented(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
-        io_err = IOError()
+        reader: ContainerID = ContainerID.__new__(ContainerID)
+        io_err: IOError = IOError()
         io_err.errno = errno.EACCES
         with mock.patch("builtins.open", side_effect=io_err):
             try:
@@ -331,7 +331,7 @@ class TestReadContainerIdErrors:
                 pass
 
     def test_unexpected_exception_raises_unresolvable(self) -> None:
-        reader = ContainerID.__new__(ContainerID)
+        reader: ContainerID = ContainerID.__new__(ContainerID)
         with mock.patch("builtins.open", side_effect=RuntimeError("boom")):
             try:
                 reader._read_container_id("/some/path")

--- a/tests/vendor/test_dogstatsd_container.py
+++ b/tests/vendor/test_dogstatsd_container.py
@@ -1,0 +1,227 @@
+"""Tests for the vendored DogStatsD container-ID reader.
+
+Coverage for code added in the cgroup v2 origin-detection fix:
+  - ContainerID.__init__: delegates to path-read vs inode-fallback
+  - ContainerID._is_host_cgroup_namespace
+  - ContainerID._read_cgroup_path
+  - ContainerID._get_cgroup_from_inode
+
+Tests for the pre-existing _read_container_id helper live in a separate PR to
+keep this change focused on the new code.
+"""
+
+import os
+import tempfile
+from typing import Optional
+from unittest import mock
+
+from ddtrace.vendor.dogstatsd.container import ContainerID
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DOCKER_CGROUP_V1 = (
+    "11:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n"
+    "10:cpu,cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n"
+)
+K8S_CGROUP_V1 = "9:memory:/kubepods/test/pod3d274242/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n"
+CGROUP_V2_UNIFIED = "0::/\n"
+
+
+def _write_cgroup(content: str) -> str:
+    fp = tempfile.NamedTemporaryFile(mode="w", suffix=".cgroup", delete=False)
+    fp.write(content)
+    fp.close()
+    return fp.name
+
+
+# ---------------------------------------------------------------------------
+# _is_host_cgroup_namespace
+# ---------------------------------------------------------------------------
+
+
+class TestIsHostCgroupNamespace:
+    def test_returns_false_when_ns_path_missing(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        reader.CGROUP_NS_PATH = "/nonexistent/ns/cgroup"
+        assert reader._is_host_cgroup_namespace() is False
+
+    def test_returns_false_when_inode_does_not_match(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            path = fp.name
+        try:
+            reader.CGROUP_NS_PATH = path
+            # Real inode of a temp file is never 0xEFFFFFFB.
+            assert reader._is_host_cgroup_namespace() is False
+        finally:
+            os.unlink(path)
+
+    def test_returns_true_when_inode_matches(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            path = fp.name
+        try:
+            real_inode = os.stat(path).st_ino
+            reader.CGROUP_NS_PATH = path
+            reader.HOST_CGROUP_NAMESPACE_INODE = real_inode
+            assert reader._is_host_cgroup_namespace() is True
+        finally:
+            os.unlink(path)
+
+    def test_returns_false_on_unexpected_exception(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        reader.CGROUP_NS_PATH = "/nonexistent"
+        with (
+            mock.patch("os.path.exists", return_value=True),
+            mock.patch("os.stat", side_effect=PermissionError("denied")),
+        ):
+            assert reader._is_host_cgroup_namespace() is False
+
+
+# ---------------------------------------------------------------------------
+# _read_cgroup_path
+# ---------------------------------------------------------------------------
+
+
+class TestReadCgroupPath:
+    def _make_reader(self, cgroup_content: str) -> ContainerID:
+        reader = ContainerID.__new__(ContainerID)
+        reader.CGROUP_PATH = _write_cgroup(cgroup_content)
+        return reader
+
+    def test_returns_ci_prefixed_id_for_docker_cgroup_v1(self) -> None:
+        reader = self._make_reader(DOCKER_CGROUP_V1)
+        try:
+            result = reader._read_cgroup_path()
+            assert result == "ci-3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+
+    def test_returns_ci_prefixed_id_for_k8s_cgroup_v1(self) -> None:
+        reader = self._make_reader(K8S_CGROUP_V1)
+        try:
+            result = reader._read_cgroup_path()
+            assert result == "ci-3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+
+    def test_returns_none_for_cgroup_v2_unified(self) -> None:
+        reader = self._make_reader(CGROUP_V2_UNIFIED)
+        try:
+            assert reader._read_cgroup_path() is None
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+
+    def test_returns_none_when_cgroup_file_missing(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        reader.CGROUP_PATH = "/nonexistent/cgroup"
+        assert reader._read_cgroup_path() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_cgroup_from_inode
+# ---------------------------------------------------------------------------
+
+
+class TestGetCgroupFromInode:
+    def _make_reader(self, cgroup_content: str, mount_dir: Optional[str] = None) -> ContainerID:
+        reader = ContainerID.__new__(ContainerID)
+        reader.CGROUP_PATH = _write_cgroup(cgroup_content)
+        reader.CGROUP_MOUNT_PATH = mount_dir or tempfile.mkdtemp()
+        return reader
+
+    def test_returns_in_prefixed_inode_for_cgroup_v2(self) -> None:
+        mount_dir = tempfile.mkdtemp()
+        reader = self._make_reader(CGROUP_V2_UNIFIED, mount_dir)
+        try:
+            result = reader._get_cgroup_from_inode()
+            assert result is not None
+            assert result.startswith("in-")
+            inode = int(result[3:])
+            assert inode > 2
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+            os.rmdir(mount_dir)
+
+    def test_returns_in_prefixed_inode_for_cgroup_v1_memory_controller(self) -> None:
+        # cgroup v1 memory controller path exists → inode lookup succeeds.
+        mount_dir = tempfile.mkdtemp()
+        # Create a sub-directory mimicking /sys/fs/cgroup/memory/<cgroup-node>.
+        mem_dir = os.path.join(mount_dir, "memory", "docker", "abc123")
+        os.makedirs(mem_dir)
+        content = "5:memory:/docker/abc123\n"
+        reader = self._make_reader(content, mount_dir)
+        try:
+            result = reader._get_cgroup_from_inode()
+            assert result is not None
+            assert result.startswith("in-")
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+            os.rmdir(mem_dir)
+            os.rmdir(os.path.join(mount_dir, "memory", "docker"))
+            os.rmdir(os.path.join(mount_dir, "memory"))
+            os.rmdir(mount_dir)
+
+    def test_returns_none_when_cgroup_file_missing(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        reader.CGROUP_PATH = "/nonexistent/cgroup"
+        reader.CGROUP_MOUNT_PATH = "/nonexistent/sys/fs/cgroup"
+        assert reader._get_cgroup_from_inode() is None
+
+    def test_returns_none_when_mount_path_missing(self) -> None:
+        reader = self._make_reader(CGROUP_V2_UNIFIED, "/nonexistent/mount")
+        try:
+            assert reader._get_cgroup_from_inode() is None
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+
+    def test_returns_none_when_inode_is_root(self) -> None:
+        # Simulate an inode <= 2 (root of a filesystem), which should be skipped.
+        reader = self._make_reader(CGROUP_V2_UNIFIED)
+        try:
+            with mock.patch("os.stat") as mock_stat:
+                mock_stat.return_value = mock.Mock(st_ino=2)
+                assert reader._get_cgroup_from_inode() is None
+        finally:
+            os.unlink(reader.CGROUP_PATH)
+            os.rmdir(reader.CGROUP_MOUNT_PATH)
+
+
+# ---------------------------------------------------------------------------
+# __init__ (branching logic)
+# ---------------------------------------------------------------------------
+
+
+class TestContainerIDInit:
+    def test_uses_cgroup_path_when_host_namespace(self) -> None:
+        with (
+            mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=True),
+            mock.patch.object(ContainerID, "_read_cgroup_path", return_value="ci-abc123") as mock_path,
+            mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
+        ):
+            reader = ContainerID()
+            assert reader.container_id == "ci-abc123"
+            mock_path.assert_called_once()
+            mock_inode.assert_not_called()
+
+    def test_uses_inode_fallback_when_not_host_namespace(self) -> None:
+        with (
+            mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=False),
+            mock.patch.object(ContainerID, "_read_cgroup_path") as mock_path,
+            mock.patch.object(ContainerID, "_get_cgroup_from_inode", return_value="in-99999") as mock_inode,
+        ):
+            reader = ContainerID()
+            assert reader.container_id == "in-99999"
+            mock_inode.assert_called_once()
+            mock_path.assert_not_called()
+
+    def test_container_id_is_none_when_inode_fallback_returns_none(self) -> None:
+        with (
+            mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=False),
+            mock.patch.object(ContainerID, "_get_cgroup_from_inode", return_value=None),
+        ):
+            reader = ContainerID()
+            assert reader.container_id is None

--- a/tests/vendor/test_dogstatsd_container.py
+++ b/tests/vendor/test_dogstatsd_container.py
@@ -1,33 +1,63 @@
 """Tests for the vendored DogStatsD container-ID reader.
 
-Coverage for code added in the cgroup v2 origin-detection fix:
+Covers the cgroup v2 origin-detection fix (new code):
   - ContainerID.__init__: delegates to path-read vs inode-fallback
   - ContainerID._is_host_cgroup_namespace
   - ContainerID._read_cgroup_path
   - ContainerID._get_cgroup_from_inode
 
-Tests for the pre-existing _read_container_id helper live in a separate PR to
-keep this change focused on the new code.
+And the pre-existing _read_container_id helper:
+  - TestReadContainerIdFound
+  - TestReadContainerIdNotFound
+  - TestReadContainerIdErrors
 """
 
+import errno
 import os
 import tempfile
 from typing import Optional
 from unittest import mock
 
 from ddtrace.vendor.dogstatsd.container import ContainerID
+from ddtrace.vendor.dogstatsd.container import UnresolvableContainerID
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CONTAINER_ID_64 = "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"
+CONTAINER_ID_K8S = "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"
+TASK_ID_FARGATE = "34dc0b5e626f2c5c4c5170e34b10e765-1234567890"
+
+DOCKER_CGROUP_V1 = f"11:memory:/docker/{CONTAINER_ID_64}\n10:cpu,cpuacct:/docker/{CONTAINER_ID_64}\n"
+K8S_CGROUP_V1 = (
+    f"9:memory:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/{CONTAINER_ID_K8S}\n"
+    f"1:name=systemd:/kubepods/test/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/{CONTAINER_ID_K8S}\n"
+)
+ECS_CGROUP_V1 = (
+    f"8:memory:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/{CONTAINER_ID_64}\n"
+    f"1:blkio:/ecs/test-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/{CONTAINER_ID_64}\n"
+)
+FARGATE_14_CGROUP = (
+    f"10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/{TASK_ID_FARGATE}\n1:name=systemd:/ecs/{TASK_ID_FARGATE}\n"
+)
+K8S_SLICE_SCOPE = (
+    f"1:name=systemd:/kubepods.slice/kubepods-burstable.slice/"
+    f"kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/"
+    f"docker-{CONTAINER_ID_64}.scope\n"
+)
+CGROUP_V2_UNIFIED = "0::/\n"
+NON_CONTAINERISED = (
+    "11:blkio:/user.slice/user-0.slice/session-14.scope\n"
+    "10:memory:/user.slice/user-0.slice/session-14.scope\n"
+    "1:name=systemd:/user.slice/user-0.slice/session-14.scope\n"
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-DOCKER_CGROUP_V1 = (
-    "11:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n"
-    "10:cpu,cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860\n"
-)
-K8S_CGROUP_V1 = "9:memory:/kubepods/test/pod3d274242/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1\n"
-CGROUP_V2_UNIFIED = "0::/\n"
 
 
 def _write_cgroup(content: str) -> str:
@@ -35,6 +65,16 @@ def _write_cgroup(content: str) -> str:
     fp.write(content)
     fp.close()
     return fp.name
+
+
+def _read(content: str) -> Optional[str]:
+    """Write ``content`` to a temp file and run _read_container_id against it."""
+    reader = ContainerID.__new__(ContainerID)
+    path = _write_cgroup(content)
+    try:
+        return reader._read_container_id(path)
+    finally:
+        os.unlink(path)
 
 
 # ---------------------------------------------------------------------------
@@ -95,16 +135,14 @@ class TestReadCgroupPath:
     def test_returns_ci_prefixed_id_for_docker_cgroup_v1(self) -> None:
         reader = self._make_reader(DOCKER_CGROUP_V1)
         try:
-            result = reader._read_cgroup_path()
-            assert result == "ci-3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860"
+            assert reader._read_cgroup_path() == f"ci-{CONTAINER_ID_64}"
         finally:
             os.unlink(reader.CGROUP_PATH)
 
     def test_returns_ci_prefixed_id_for_k8s_cgroup_v1(self) -> None:
         reader = self._make_reader(K8S_CGROUP_V1)
         try:
-            result = reader._read_cgroup_path()
-            assert result == "ci-3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"
+            assert reader._read_cgroup_path() == f"ci-{CONTAINER_ID_K8S}"
         finally:
             os.unlink(reader.CGROUP_PATH)
 
@@ -199,11 +237,11 @@ class TestContainerIDInit:
     def test_uses_cgroup_path_when_host_namespace(self) -> None:
         with (
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace", return_value=True),
-            mock.patch.object(ContainerID, "_read_cgroup_path", return_value="ci-abc123") as mock_path,
+            mock.patch.object(ContainerID, "_read_cgroup_path", return_value=f"ci-{CONTAINER_ID_64}") as mock_path,
             mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
         ):
             reader = ContainerID()
-            assert reader.container_id == "ci-abc123"
+            assert reader.container_id == f"ci-{CONTAINER_ID_64}"
             mock_path.assert_called_once()
             mock_inode.assert_not_called()
 
@@ -225,3 +263,62 @@ class TestContainerIDInit:
         ):
             reader = ContainerID()
             assert reader.container_id is None
+
+
+# ---------------------------------------------------------------------------
+# _read_container_id
+# ---------------------------------------------------------------------------
+
+
+class TestReadContainerIdFound:
+    def test_docker_cgroup_v1(self) -> None:
+        assert _read(DOCKER_CGROUP_V1) == CONTAINER_ID_64
+
+    def test_k8s_cgroup_v1(self) -> None:
+        assert _read(K8S_CGROUP_V1) == CONTAINER_ID_K8S
+
+    def test_ecs_classic(self) -> None:
+        assert _read(ECS_CGROUP_V1) == CONTAINER_ID_64
+
+    def test_fargate_14_uuid_task_id(self) -> None:
+        assert _read(FARGATE_14_CGROUP) == TASK_ID_FARGATE
+
+    def test_k8s_slice_scope_path(self) -> None:
+        assert _read(K8S_SLICE_SCOPE) == CONTAINER_ID_64
+
+
+class TestReadContainerIdNotFound:
+    def test_cgroup_v2_unified(self) -> None:
+        assert _read(CGROUP_V2_UNIFIED) is None
+
+    def test_non_containerised_linux(self) -> None:
+        assert _read(NON_CONTAINERISED) is None
+
+    def test_empty_file(self) -> None:
+        assert _read("") is None
+
+
+class TestReadContainerIdErrors:
+    def test_file_not_found_returns_none(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        assert reader._read_container_id("/nonexistent/proc/self/cgroup") is None
+
+    def test_non_enoent_io_error_raises_not_implemented(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        io_err = IOError()
+        io_err.errno = errno.EACCES
+        with mock.patch("builtins.open", side_effect=io_err):
+            try:
+                reader._read_container_id("/some/path")
+                assert False, "expected NotImplementedError"
+            except NotImplementedError:
+                pass
+
+    def test_unexpected_exception_raises_unresolvable(self) -> None:
+        reader = ContainerID.__new__(ContainerID)
+        with mock.patch("builtins.open", side_effect=RuntimeError("boom")):
+            try:
+                reader._read_container_id("/some/path")
+                assert False, "expected UnresolvableContainerID"
+            except UnresolvableContainerID:
+                pass


### PR DESCRIPTION
## Description

I found this issue when troubleshooting the new Python memory-leak workflow in web-ui. There's a step
that checks `runtime.python.*` metrics are available, and that they are scoped to the specific pod being
investigated.

For the `ai_gateway` service in staging, this workflow worked fine for some pods, but not others:

> [Memory-leak workflow failing for pod `ai-gateway-f8bb55896-d52mr` (internal)](https://app-dev-local.datadoghq.com/apm/entity/service%3Aai_gateway?dependencyMap.showNetworkMetrics=false&errors=qson%3A%28data%3A%28issueSort%3AFIRST_SEEN%2CcodeGenFixStateFilter%3A%5BSTATE_COMPLETED%5D%29%2Cversion%3A%210%29&fromUser=false&graphType=flamegraph&groupMapByOperation=null&historicalData=true&operationName=http.request&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&profiling-memory__memoryLeaks=service%3Aai_gateway%20container_id%3A6b14c17b805e4177ef70390285f5c170842991b5a554cac6e9c9ce77e619afc6%20host%3Ai-05fd7403ef3ae98b3%20kube_container_name%3Aai-gateway%20pod_name%3Aai-gateway-7f97cb7f44-nz9qh&refresh_mode=sliding&shouldShowLegend=true&spanKind=server&traceQuery=&start=1780343472352&end=1780347072352&paused=false#memoryLeaks)

<img width="903" height="796" alt="Screenshot 2026-06-01 at 4 52 21 PM" src="https://github.com/user-attachments/assets/6a835942-6160-4206-bf62-5f2220d5120f" />

Investigating via the Metrics Explorer showed that `runtime.python.thread_count`
**was** being emitted for the service+host, but it had `runtime-id:N/A` and no
`pod_name` tag, rendering it unusable for workflow step progression.

> [Metrics Explorer showing `runtime.python.*` with `runtime-id:N/A`, no `pod_name` (internal)](https://app-dev-local.datadoghq.com/metric/explorer?fromUser=false&graph_layout=stacked&start=1780340216814&end=1780343816814&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMjaeCJqcAB08lhMUo1MRhhQTpn49cB+FRDZyBgQTjCecGDYPAAEAEZY88CiGggYItkAtNA8IDwAulSu7niYoeFnqhcYMaXxhycgG1hoOaDyGB8ICDlJHAwXqXDQjRJoURwJxyRTKdKQqAQqFOehMZQiNweNCHfgQeyYLAwhQAyEiJTHHh8V7ySEIADCUmEMBQIguaB4QA)

**note:** the pod in question is the right-most, with N/A tag, in the legend
<img width="1159" height="587" alt="image" src="https://github.com/user-attachments/assets/6b951649-be39-416f-8c53-4e2a0bd565e3" />


### Root cause

We failed to parse `/proc/self/cgroup` on **cgroup v2** nodes, which returned `0::/` instead of parseable container ID. Therefore, the agent couldn't attach `pod_name`, breaking the flow. _note: Pods on
cgroup v1 nodes do work OK._

### Fix

- If in the host cgroup namespace → parse the cgroup path → `ci-<id>`
- Otherwise (typical cgroup v2) → cgroup controller inode → `in-<inode>`

Both forms are accepted by the Agent.

## Testing

* One-off A/B testing on
[`vlad/container-fix-cgroup-v2-pod-name-reporting-testing`](https://github.com/DataDog/dd-trace-py/tree/vlad/container-fix-cgroup-v2-pod-name-reporting-testing)
(`repro_container_id.py`) resolves the pod_name as it would've been sent for cgroup v1 and
v2. It runs on main, with an expected failure, on the fix branch, with success.

| cgroup layout | A: `main` | B: this branch |
|---|---|---|
| v1 (docker) | `3726…9860` — sent | `ci-3726…9860` — sent |
| v2 (`0::/`)  | **`None` — not sent** | **`in-<inode>` — sent** |
| exit code | `1` (bug) | `0` (fixed) |

```bash
git show origin/main:ddtrace/vendor/dogstatsd/container.py > /tmp/container_main_A.py
python3 repro_container_id.py /tmp/container_main_A.py  # exit 1, cgroup v2 -> None
python3 repro_container_id.py                           # exit 0, cgroup v2 -> in-<inode>
```

[PROF-14794]: https://datadoghq.atlassian.net/browse/PROF-14794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ