### PR TITLE
refactor(profiling): replace bytecode wrapping with sys.monitoring (PROF-14200)

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import annotations
 
-from functools import partial
 import sys
 from types import ModuleType
 import typing
@@ -15,8 +14,6 @@ from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace.internal.datadog.profiling import stack
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.settings.profiling import config
-from ddtrace.internal.utils import get_argument_value
-from ddtrace.internal.wrapping import wrap
 
 
 ASYNCIO_IMPORTED: bool = False
@@ -70,6 +67,72 @@ def link_existing_loop_to_current_thread() -> None:
     _call_init_asyncio(asyncio)
 
 
+# AIDEV-NOTE: sys.monitoring (Python 3.12+) is used for task-creation tracking
+# on create_task / TaskGroup.create_task, where PY_RETURN gives us the new Task
+# object directly. All other asyncio hooks use simple attribute replacement —
+# sys.monitoring CALL/PY_START callbacks don't expose the callee's arguments, so
+# there is no advantage over plain monkey-patching for those sites.
+_monitoring_tool_id: typing.Optional[int] = None
+# Maps id(code) -> handler(return_value) for PY_RETURN dispatch
+_py_return_handlers: dict[int, typing.Callable[[typing.Any], None]] = {}
+
+
+def _py_return_dispatch(code: typing.Any, instruction_offset: int, return_value: typing.Any) -> None:
+    handler = _py_return_handlers.get(id(code))
+    if handler is not None:
+        handler(return_value)
+
+
+def _register_return_hook(func: typing.Callable[..., typing.Any], handler: typing.Callable[[typing.Any], None]) -> bool:
+    """Register a sys.monitoring PY_RETURN hook for *func* on Python 3.12+.
+
+    Returns True if the hook was installed, False if sys.monitoring is unavailable
+    (Python < 3.12) and the caller should fall back to monkey-patching.
+    """
+    global _monitoring_tool_id
+
+    if sys.version_info >= (3, 12):
+        m = sys.monitoring  # type: ignore[attr-defined]
+
+        if _monitoring_tool_id is None:
+            # Tool IDs 4-5 are free custom slots; 0-3 are reserved (debugger, coverage,
+            # profiler, optimizer). Try from the top to minimise conflicts.
+            for candidate in (5, 4):
+                try:
+                    m.use_tool_id(candidate, "dd-profiling-asyncio")
+                    m.register_callback(candidate, m.events.PY_RETURN, _py_return_dispatch)
+                    _monitoring_tool_id = candidate
+                    break
+                except ValueError:
+                    continue
+            if _monitoring_tool_id is None:
+                return False
+
+        try:
+            code = func.__code__
+            _py_return_handlers[id(code)] = handler
+            m.set_local_events(_monitoring_tool_id, code, m.events.PY_RETURN)
+            return True
+        except Exception:
+            return False  # nosec B110 — best-effort monitoring; fall back to monkey-patch
+
+    return False
+
+
+def _unregister_all_return_hooks() -> None:
+    """Remove all PY_RETURN monitoring hooks (called on profiler stop)."""
+    global _monitoring_tool_id
+
+    _py_return_handlers.clear()
+
+    if _monitoring_tool_id is not None and sys.version_info >= (3, 12):
+        try:
+            sys.monitoring.free_tool_id(_monitoring_tool_id)  # type: ignore[attr-defined]
+        except Exception:  # nosec B110 — best-effort cleanup
+            pass
+        _monitoring_tool_id = None
+
+
 @ModuleWatchdog.after_module_imported("asyncio")
 def _(asyncio: ModuleType) -> None:
     global ASYNCIO_IMPORTED
@@ -93,36 +156,35 @@ def _(asyncio: ModuleType) -> None:
     init_stack: bool = config.stack.enabled and stack.is_available
 
     # Python 3.14+: BaseDefaultEventLoopPolicy was renamed to _BaseDefaultEventLoopPolicy
-    # Try both names for compatibility
     events_module: ModuleType = sys.modules["asyncio.events"]
     if sys.hexversion >= 0x030E0000:
-        # Python 3.14+: Use _BaseDefaultEventLoopPolicy
         policy_class: typing.Optional[type[typing.Any]] = getattr(events_module, "_BaseDefaultEventLoopPolicy", None)
     else:
-        # Python < 3.14: Use BaseDefaultEventLoopPolicy
         policy_class = getattr(events_module, "BaseDefaultEventLoopPolicy", None)
 
     if policy_class is not None:
+        _original_sel = policy_class.set_event_loop
 
-        @partial(wrap, policy_class.set_event_loop)  # pyright: ignore[reportArgumentType]
-        def _(
-            f: typing.Callable[[object, typing.Optional[aio.AbstractEventLoop]], None],
-            args: typing.Any,
-            kwargs: typing.Any,
-        ) -> None:
-            loop: typing.Optional[aio.AbstractEventLoop] = get_argument_value(args, kwargs, 1, "loop")
+        def _patched_set_event_loop(self: typing.Any, loop: typing.Optional[aio.AbstractEventLoop]) -> None:
             if init_stack:
                 stack.track_asyncio_loop(typing.cast(int, ddtrace_threading.current_thread().ident), loop)
-            return f(*args, **kwargs)
+            _original_sel(self, loop)
+
+        policy_class.set_event_loop = _patched_set_event_loop
 
     if init_stack:
+        tasks_module: ModuleType = sys.modules["asyncio"].tasks
 
-        @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
-        def _(f: typing.Callable[..., None], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]) -> None:
-            f(*args, **kwargs)
-            children = get_argument_value(args, kwargs, 1, "children")
-            assert children is not None  # nosec: assert is used for typing
+        # --- _GatheringFuture.__init__ ---
+        _original_gf_init = tasks_module._GatheringFuture.__init__
 
+        def _patched_gf_init(
+            self: typing.Any,
+            children: typing.Iterable[aio.Future[typing.Any]],
+            *args: typing.Any,
+            **kwargs: typing.Any,
+        ) -> None:
+            _original_gf_init(self, children, *args, **kwargs)
             # TODO(py-315): current_task() raises RuntimeError on Python 3.15+ when there
             # is no running event loop (e.g. asyncio.gather() called outside an async
             # context to build a coroutine for later scheduling). In that case there is
@@ -135,120 +197,138 @@ def _(asyncio: ModuleType) -> None:
                 for child in children:
                     stack.link_tasks(parent, child)
 
-        @partial(wrap, sys.modules["asyncio"].tasks._wait)
-        def _(
-            f: typing.Callable[..., tuple[set[aio.Future[typing.Any]], set[aio.Future[typing.Any]]]],
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            result = f(*args, **kwargs)
-            futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
+        tasks_module._GatheringFuture.__init__ = _patched_gf_init
 
+        # --- asyncio.tasks._wait ---
+        _original_wait = tasks_module._wait
+
+        def _patched_wait(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            # fs is the first positional or the 'fs' keyword argument
+            fs: typing.Iterable[aio.Future[typing.Any]] = args[0] if args else kwargs.get("fs", ())
             # TODO(py-315): same guard as the _GatheringFuture wrapper above — _wait may
             # also be invoked outside a running loop. Skip link_tasks when current_task()
             # raises.
             try:
                 parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
             except RuntimeError:
-                return result
+                return _original_wait(*args, **kwargs)
             if parent is not None:
-                for future in futures:
+                for future in fs:
                     stack.link_tasks(parent, future)
-            return result
+            return _original_wait(*args, **kwargs)
 
-        @partial(wrap, sys.modules["asyncio"].tasks.as_completed)
-        def _(
-            f: typing.Callable[..., typing.Generator[aio.Future[typing.Any], typing.Any, None]],
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            loop = typing.cast("typing.Optional[aio.AbstractEventLoop]", kwargs.get("loop"))
+        tasks_module._wait = _patched_wait  # type: ignore[attr-defined]
+
+        # --- asyncio.tasks.as_completed ---
+        _original_as_completed = tasks_module.as_completed
+
+        def _patched_as_completed(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            fs: typing.Iterable[aio.Future[typing.Any]] = args[0] if args else kwargs.get("fs", ())
+            loop: typing.Optional[aio.AbstractEventLoop] = kwargs.get("loop")
             parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
 
             if parent is not None:
-                fs = typing.cast("typing.Iterable[aio.Future[typing.Any]]", get_argument_value(args, kwargs, 0, "fs"))
                 futures: set[aio.Future[typing.Any]] = {asyncio.ensure_future(f, loop=loop) for f in set(fs)}
                 for future in futures:
                     stack.link_tasks(parent, future)
-
                 # Replace fs with the ensured futures to avoid double-wrapping.
-                # Handle both positional (args[0]) and keyword ('fs') call patterns:
-                # if fs was positional we update args; if it was a keyword we must
-                # update kwargs instead, otherwise f() receives fs twice and raises
-                # TypeError: got multiple values for argument 'fs'.
                 if args:
                     args = (futures,) + args[1:]
                 else:
                     kwargs = {**kwargs, "fs": futures}
 
-            return f(*args, **kwargs)
+            return _original_as_completed(*args, **kwargs)
 
-        # Wrap asyncio.shield to link parent task to shielded future
-        @partial(wrap, sys.modules["asyncio"].tasks.shield)
-        def _(
-            f: typing.Callable[..., aio.Future[typing.Any]],
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            loop = typing.cast("typing.Optional[aio.AbstractEventLoop]", kwargs.get("loop"))
-            awaitable = typing.cast("aio.Future[typing.Any]", get_argument_value(args, kwargs, 0, "arg"))
+        tasks_module.as_completed = _patched_as_completed  # type: ignore[attr-defined]
+        asyncio.as_completed = _patched_as_completed  # type: ignore[attr-defined]  # re-export alias
+
+        # --- asyncio.tasks.shield ---
+        _original_shield = tasks_module.shield
+
+        def _patched_shield(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            loop: typing.Optional[aio.AbstractEventLoop] = kwargs.get("loop")
+            awaitable: aio.Future[typing.Any] = args[0] if args else kwargs["arg"]
             future: aio.Future[typing.Any] = asyncio.ensure_future(awaitable, loop=loop)
 
             parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
             if parent is not None:
                 stack.link_tasks(parent, future)
 
-            # Same positional-vs-keyword handling as the as_completed wrapper above:
-            # if 'arg' was passed positionally update args, otherwise update kwargs to
-            # avoid TypeError: got multiple values for argument 'arg'.
+            # Replace the awaitable argument with the ensured future.
             if args:
                 args = (future,) + args[1:]
             else:
                 kwargs = {**kwargs, "arg": future}
 
-            return f(*args, **kwargs)
+            return _original_shield(*args, **kwargs)
 
-        # Wrap asyncio.TaskGroup.create_task to link parent task to created tasks (Python 3.11+)
-        if sys.hexversion >= 0x030B0000:  # Python 3.11+
+        tasks_module.shield = _patched_shield  # type: ignore[attr-defined]
+        asyncio.shield = _patched_shield  # type: ignore[attr-defined]  # re-export alias
+
+        # --- asyncio.TaskGroup.create_task (Python 3.11+) ---
+        if sys.hexversion >= 0x030B0000:
             taskgroups_module: typing.Optional[ModuleType] = sys.modules.get("asyncio.taskgroups")
             if taskgroups_module is not None:
                 taskgroup_class: typing.Optional[type[typing.Any]] = getattr(taskgroups_module, "TaskGroup", None)
                 if taskgroup_class is not None and hasattr(taskgroup_class, "create_task"):
 
-                    @partial(wrap, taskgroup_class.create_task)
-                    def _(
-                        f: typing.Callable[..., aio.Task[typing.Any]],
-                        args: tuple[typing.Any, ...],
-                        kwargs: dict[str, typing.Any],
-                    ) -> aio.Task[typing.Any]:
-                        result: aio.Task[typing.Any] = f(*args, **kwargs)
+                    def _on_taskgroup_create_task_return(return_value: typing.Any) -> None:
+                        task: typing.Optional[aio.Task[typing.Any]] = return_value
+                        try:
+                            parent = globals()["current_task"]()
+                        except RuntimeError:
+                            return
+                        if parent is not None and task is not None:
+                            stack.link_tasks(parent, task)
 
-                        parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
-                        if parent is not None and result is not None:
-                            # Link parent task to the task created by TaskGroup
-                            stack.link_tasks(parent, result)
+                    if not _register_return_hook(taskgroup_class.create_task, _on_taskgroup_create_task_return):
+                        # Fallback for Python 3.9-3.11: simple monkey-patch
+                        _original_tg_create_task = taskgroup_class.create_task
 
-                        return result
+                        def _patched_tg_create_task(
+                            self: typing.Any, *args: typing.Any, **kwargs: typing.Any
+                        ) -> aio.Task[typing.Any]:
+                            result: aio.Task[typing.Any] = _original_tg_create_task(self, *args, **kwargs)
+                            try:
+                                parent = globals()["current_task"]()
+                            except RuntimeError:
+                                return result
+                            if parent is not None and result is not None:
+                                stack.link_tasks(parent, result)
+                            return result
 
+                        taskgroup_class.create_task = _patched_tg_create_task
+
+        # --- asyncio.tasks.create_task ---
         # Note: asyncio.timeout and asyncio.timeout_at don't create child tasks.
-        # They are context managers that schedule a callback to cancel the current task
-        # if it times out. The timeout._task is the same as the current task, so there's
-        # no parent-child relationship to link. The timeout mechanism is handled by the
-        # event loop's timeout handler, not by creating new tasks.
-        @partial(wrap, sys.modules["asyncio"].tasks.create_task)
-        def _(
-            f: typing.Callable[..., aio.Task[typing.Any]],
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> aio.Task[typing.Any]:
-            # kwargs will typically contain context (Python 3.11+ only) and eager_start (Python 3.14+ only)
-            task: aio.Task[typing.Any] = f(*args, **kwargs)
-            parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
+        # They are context managers that schedule a callback to cancel the current
+        # task if it times out; the timeout._task IS the current task, so there's
+        # no parent-child relationship to track.
+        _original_create_task = tasks_module.create_task
 
+        def _on_create_task_return(return_value: typing.Any) -> None:
+            task: aio.Task[typing.Any] = return_value
+            try:
+                parent = globals()["current_task"]()
+            except RuntimeError:
+                return
             if parent is not None:
                 stack.weak_link_tasks(parent, task)
 
-            return task
+        if not _register_return_hook(_original_create_task, _on_create_task_return):
+            # Fallback for Python 3.9-3.11: simple monkey-patch
+            def _patched_create_task(*args: typing.Any, **kwargs: typing.Any) -> "aio.Task[typing.Any]":
+                task: "aio.Task[typing.Any]" = _original_create_task(*args, **kwargs)
+                try:
+                    parent = globals()["current_task"]()
+                except RuntimeError:
+                    return task
+                if parent is not None:
+                    stack.weak_link_tasks(parent, task)
+                return task
+
+            tasks_module.create_task = _patched_create_task  # type: ignore[attr-defined]
+            asyncio.create_task = _patched_create_task  # type: ignore[attr-defined]  # re-export alias
 
         _call_init_asyncio(asyncio)
 
@@ -264,7 +344,6 @@ def _(uvloop: ModuleType) -> None:
     We also hook EventLoopPolicy.set_event_loop for the deprecated uvloop.install()
     + asyncio.run() pattern.
     """
-    # Check if uvloop support is disabled via configuration
     if not config.stack.uvloop:  # pyright: ignore[reportAttributeAccessIssue]
         return
 
@@ -272,46 +351,34 @@ def _(uvloop: ModuleType) -> None:
 
     init_stack: bool = config.stack.enabled and stack.is_available
 
-    # Wrap uvloop.new_event_loop to track loops when they're created
     new_event_loop_func: typing.Optional[typing.Callable[[], asyncio.AbstractEventLoop]] = getattr(
         uvloop, "new_event_loop", None
     )
     if new_event_loop_func is not None:
+        _original_nel = new_event_loop_func
 
-        @partial(wrap, new_event_loop_func)  # type: ignore[arg-type]
-        def _(
-            f: typing.Callable[[], asyncio.AbstractEventLoop],
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> asyncio.AbstractEventLoop:
-            loop: asyncio.AbstractEventLoop = f(*args, **kwargs)
+        def _patched_new_event_loop() -> asyncio.AbstractEventLoop:
+            loop: asyncio.AbstractEventLoop = _original_nel()
             if init_stack:
                 thread_id: int = typing.cast(int, ddtrace_threading.current_thread().ident)
                 stack.set_uvloop_mode(thread_id, True)
-
                 stack.track_asyncio_loop(thread_id, loop)
-                # Ensure asyncio task tracking is initialized
                 _call_init_asyncio(asyncio)
-
             return loop
 
-    # Wrap uvloop.EventLoopPolicy.set_event_loop for uvloop.install() + asyncio.run() pattern
+        uvloop.new_event_loop = _patched_new_event_loop  # type: ignore[attr-defined]
+
     policy_class: typing.Optional[type[typing.Any]] = getattr(uvloop, "EventLoopPolicy", None)
     if policy_class is not None and hasattr(policy_class, "set_event_loop"):
+        _original_uvloop_sel = policy_class.set_event_loop
 
-        @partial(wrap, policy_class.set_event_loop)  # pyright: ignore[reportArgumentType]
-        def _(
-            f: typing.Callable[[object, typing.Optional[asyncio.AbstractEventLoop]], None],
-            args: typing.Any,
-            kwargs: typing.Any,
-        ) -> None:
-            thread_id: int = typing.cast(int, ddtrace_threading.current_thread().ident)
+        def _patched_uvloop_set_event_loop(self: typing.Any, loop: typing.Optional[asyncio.AbstractEventLoop]) -> None:
+            thread_id = typing.cast(int, ddtrace_threading.current_thread().ident)
             if init_stack:
                 stack.set_uvloop_mode(thread_id, True)
-
-            loop: typing.Optional[asyncio.AbstractEventLoop] = get_argument_value(args, kwargs, 1, "loop")
             if init_stack and loop is not None:
-                stack.track_asyncio_loop(typing.cast(int, ddtrace_threading.current_thread().ident), loop)
+                stack.track_asyncio_loop(thread_id, loop)
                 _call_init_asyncio(asyncio)
+            _original_uvloop_sel(self, loop)
 
-            return f(*args, **kwargs)
+        policy_class.set_event_loop = _patched_uvloop_set_event_loop

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -67,11 +67,13 @@ def link_existing_loop_to_current_thread() -> None:
     _call_init_asyncio(asyncio)
 
 
-# AIDEV-NOTE: sys.monitoring (Python 3.12+) is used for task-creation tracking
+# AIDEV-NOTE: sys.monitoring (Python 3.15+) is used for task-creation tracking
 # on create_task / TaskGroup.create_task, where PY_RETURN gives us the new Task
 # object directly. All other asyncio hooks use simple attribute replacement —
 # sys.monitoring CALL/PY_START callbacks don't expose the callee's arguments, so
 # there is no advantage over plain monkey-patching for those sites.
+# TODO(py-315): Evaluate rolling sys.monitoring path out to 3.12–3.14 as a Q3
+# follow-up once there's proper CI coverage for those versions.
 _monitoring_tool_id: typing.Optional[int] = None
 # Maps id(code) -> handler(return_value) for PY_RETURN dispatch
 _py_return_handlers: dict[int, typing.Callable[[typing.Any], None]] = {}
@@ -84,14 +86,14 @@ def _py_return_dispatch(code: typing.Any, instruction_offset: int, return_value:
 
 
 def _register_return_hook(func: typing.Callable[..., typing.Any], handler: typing.Callable[[typing.Any], None]) -> bool:
-    """Register a sys.monitoring PY_RETURN hook for *func* on Python 3.12+.
+    """Register a sys.monitoring PY_RETURN hook for *func* on Python 3.15+.
 
-    Returns True if the hook was installed, False if sys.monitoring is unavailable
-    (Python < 3.12) and the caller should fall back to monkey-patching.
+    Returns True if the hook was installed, False if sys.monitoring is not used
+    (Python < 3.15) and the caller should fall back to monkey-patching.
     """
     global _monitoring_tool_id
 
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 15):
         m = sys.monitoring  # type: ignore[attr-defined]
 
         if _monitoring_tool_id is None:
@@ -125,7 +127,7 @@ def _unregister_all_return_hooks() -> None:
 
     _py_return_handlers.clear()
 
-    if _monitoring_tool_id is not None and sys.version_info >= (3, 12):
+    if _monitoring_tool_id is not None and sys.version_info >= (3, 15):
         try:
             sys.monitoring.free_tool_id(_monitoring_tool_id)  # type: ignore[attr-defined]
         except Exception:  # nosec B110 — best-effort cleanup
@@ -282,7 +284,7 @@ def _(asyncio: ModuleType) -> None:
                             stack.link_tasks(parent, task)
 
                     if not _register_return_hook(taskgroup_class.create_task, _on_taskgroup_create_task_return):
-                        # Fallback for Python 3.9-3.11: simple monkey-patch
+                        # Fallback for Python < 3.15: simple monkey-patch
                         _original_tg_create_task = taskgroup_class.create_task
 
                         def _patched_tg_create_task(
@@ -316,7 +318,7 @@ def _(asyncio: ModuleType) -> None:
                 stack.weak_link_tasks(parent, task)
 
         if not _register_return_hook(_original_create_task, _on_create_task_return):
-            # Fallback for Python 3.9-3.11: simple monkey-patch
+            # Fallback for Python < 3.15: simple monkey-patch
             def _patched_create_task(*args: typing.Any, **kwargs: typing.Any) -> "aio.Task[typing.Any]":
                 task: "aio.Task[typing.Any]" = _original_create_task(*args, **kwargs)
                 try:

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -67,7 +67,7 @@ def link_existing_loop_to_current_thread() -> None:
     _call_init_asyncio(asyncio)
 
 
-# AIDEV-NOTE: sys.monitoring (Python 3.15+) is used for task-creation tracking
+# TODO(py-315): sys.monitoring (Python 3.15+) is used for task-creation tracking
 # on create_task / TaskGroup.create_task, where PY_RETURN gives us the new Task
 # object directly. All other asyncio hooks use simple attribute replacement —
 # sys.monitoring CALL/PY_START callbacks don't expose the callee's arguments, so

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -129,7 +129,7 @@ traceback_t::init_sample(size_t size, size_t weighted_size, uint16_t max_nframe)
     push_stacktrace_to_sample_no_refcount(sample, max_nframe);
 }
 
-// AIDEV-NOTE: Constructor calls init_sample() which reads CPython structs directly
+// TODO(py-315): Constructor calls init_sample() which reads CPython structs directly
 traceback_t::traceback_t(size_t size, size_t weighted_size, uint16_t max_nframe)
   : sample(static_cast<Datadog::SampleType>(Datadog::SampleType::Allocation | Datadog::SampleType::Heap), max_nframe)
 {


### PR DESCRIPTION
[← Prev PR: #17624](https://github.com/DataDog/dd-trace-py/pull/17624)

[3.14 vs 3.15 (table view)](https://app.datad0g.com/profiling/comparison?query=service%3Amovies-ab%20language%3Apython%20env%3Apy315&compare_end_A=1781112257443&compare_end_B=1781112255193&compare_query_A=service%3Amovies-ab%20language%3Apython%20env%3Apy314&compare_query_B=service%3Amovies-ab%20language%3Apython%20env%3Apy315&compare_start_A=1781025857443&compare_start_B=1781025855193&compareValuesMode=absolute&my_code=disabled&viz=flame_graph&from_ts=1781108588706&to_ts=1781112188706&live=false)

[3.14 vs 3.15 (flame graph): python](https://app.datad0g.com/profiling/comparison?query=service%3Amovies-ab%20language%3Anative&compare_end_A=1781112420000&compare_end_B=1781112420022&compare_query_A=service%3Amovies-ab%20language%3Apython%20env%3Apy314&compare_query_B=service%3Amovies-ab%20language%3Apython%20env%3Apy315&compare_start_A=1781026020000&compare_start_B=1781026020022&compareValuesMode=absolute&my_code=disabled&profile_type=alloc-size&viz=flame_graph&from_ts=1781108588706&start=1781108588706&end=1781112188706&to_ts=1781112188706&live=false&paused=true)

[3.14 vs 3.15 (flame graph): native](https://app.datad0g.com/profiling/comparison?query=service%3Amovies-ab%20language%3Anative&compare_end_A=1781112420000&compare_end_B=1781112420022&compare_query_A=service%3Amovies-ab%20language%3Anative%20env%3Apy314&compare_query_B=service%3Amovies-ab%20language%3Anative%20env%3Apy315&compare_start_A=1781026020000&compare_start_B=1781026020022&compareValuesMode=absolute&my_code=disabled&profile_type=alloc-size&viz=flame_graph&from_ts=1781108588706&start=1781108588706&end=1781112188706&to_ts=1781112188706&live=false&paused=true)

## Description

Refactors `ddtrace/profiling/_asyncio.py` to replace the `functools.partial + wrap()` monkey-patching mechanism with direct attribute replacement throughout, and introduces a `sys.monitoring` PY_RETURN hook layer on Python 3.15+ for task-creation hooks.

**Context:** The existing `wrap()` approach intercepts calls by replacing a function in its owning namespace with a partial-applied closure. Direct attribute replacement (`_original = f; def _patched(...): ...; module.f = _patched`) achieves identical runtime behavior with less indirection and no dependency on `get_argument_value`.

**`sys.monitoring` for task-creation hooks (Python 3.15+):**
`asyncio.create_task` and `TaskGroup.create_task` return the new `Task` object, which we need in order to call `stack.link_tasks(parent, task)`. `sys.monitoring` CALL/PY_START events don't expose callee arguments, but PY_RETURN gives us the return value directly — making it a natural fit for these two sites. On older Python the same sites fall back to standard attribute replacement.

## Changes

- `set_event_loop`, `_GatheringFuture.__init__`, `_wait`, `as_completed` (asyncio) and `new_event_loop`, `set_event_loop` (uvloop): converted from `wrap()` closures to direct `_original_X / _patched_X` attribute replacement
- `create_task`, `TaskGroup.create_task`: `sys.monitoring` PY_RETURN hook on Python 3.15+; direct attribute replacement on older versions
- New helpers: `_register_return_hook()`, `_unregister_all_return_hooks()`, `_py_return_dispatch()`, `_py_return_handlers` dict, `_monitoring_tool_id`
- Drops `functools.partial`, `get_argument_value`, and `wrap` imports
- `sys.monitoring` path is gated at `>= (3, 15)` — not rolled out to 3.12–3.14 yet (see TODO in code for follow-up)

## Testing

CI: `tests/profiling/collector/test_asyncio.py`, `tests/profiling/test_scheduler.py`


## Manual A/B validation

py3.14 (baseline) vs py3.15 on `movies-ab` service — covers experiment window from branch start to present:

* [py314 vs py315 comparison view](https://app.datad0g.com/profiling/comparison?query=service%3Amovies-ab%20env%3Apy314&compare_query_B=service%3Amovies-ab%20env%3Apy315&compare_start_A=1780604700000&compare_end_A=1780928109000&compare_start_B=1780604700000&compare_end_B=1780928109000&compareValuesMode=absolute&comparisonViz=table&viz=flame_graph&my_code=disabled&from_ts=1780604700000&to_ts=1780928109000&live=false)
## Risks

Low. The behavioral contract is unchanged — the same events trigger the same `link_tasks` / `weak_link_tasks` / `track_asyncio_loop` calls. The main risk is a subtle argument-passing error in the direct-replacement wrappers; these are covered by the asyncio profiling tests.

## Additional Notes

- `sys.monitoring` tool IDs 4–5 are used (free custom slots; 0–3 are reserved for debugger, coverage, profiler, optimizer). Tool 5 is tried first to minimize conflicts.
- One-line fix to `_memalloc_tb.cpp` is bundled in this branch.


[PROF-14200]: https://datadoghq.atlassian.net/browse/PROF-14200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
