### PR TITLE
fix(pydantic_ai): swap operation/resource names to match APM convention [18150]

### DIFF
--- a/ddtrace/contrib/internal/pydantic_ai/patch.py
+++ b/ddtrace/contrib/internal/pydantic_ai/patch.py
@@ -98,9 +98,7 @@ async def traced_tool_run(func, instance, args, kwargs, tool_name):
     integration = pydantic_ai._datadog_integration
     resp = None
     try:
-        span = integration.trace(
-            tool_name, span_name="pydantic_ai.tool", submit_to_llmobs=True, kind="tool"
-        )
+        span = integration.trace(tool_name, span_name="pydantic_ai.tool", submit_to_llmobs=True, kind="tool")
         resp = await func(*args, **kwargs)
         return resp
     except Exception:

--- a/ddtrace/contrib/internal/pydantic_ai/patch.py
+++ b/ddtrace/contrib/internal/pydantic_ai/patch.py
@@ -28,13 +28,20 @@ def _supported_versions() -> dict[str, str]:
 PYDANTIC_AI_VERSION = parse_version(get_version())
 
 
+def _agent_resource(instance) -> str:
+    return getattr(instance, "name", None) or "Pydantic Agent"
+
+
 def traced_agent_run_stream(func, instance, args, kwargs):
     integration = pydantic_ai._datadog_integration
     integration._run_stream_active = True
     span = integration.trace(
-        "Pydantic Agent", submit_to_llmobs=True, model=getattr(instance, "model", None), kind="agent"
+        _agent_resource(instance),
+        span_name="pydantic_ai.agent",
+        submit_to_llmobs=True,
+        model=getattr(instance, "model", None),
+        kind="agent",
     )
-    span.name = getattr(instance, "name", None) or "Pydantic Agent"
 
     result = func(*args, **kwargs)
     kwargs["instance"] = instance
@@ -48,9 +55,12 @@ def traced_agent_iter(func, instance, args, kwargs):
         integration._run_stream_active = False
         return func(*args, **kwargs)
     span = integration.trace(
-        "Pydantic Agent", submit_to_llmobs=True, model=getattr(instance, "model", None), kind="agent"
+        _agent_resource(instance),
+        span_name="pydantic_ai.agent",
+        submit_to_llmobs=True,
+        model=getattr(instance, "model", None),
+        kind="agent",
     )
-    span.name = getattr(instance, "name", None) or "Pydantic Agent"
 
     result = func(*args, **kwargs)
     kwargs["instance"] = instance
@@ -88,8 +98,9 @@ async def traced_tool_run(func, instance, args, kwargs, tool_name):
     integration = pydantic_ai._datadog_integration
     resp = None
     try:
-        span = integration.trace("Pydantic Tool", submit_to_llmobs=True, kind="tool")
-        span.name = tool_name
+        span = integration.trace(
+            tool_name, span_name="pydantic_ai.tool", submit_to_llmobs=True, kind="tool"
+        )
         resp = await func(*args, **kwargs)
         return resp
     except Exception:

--- a/releasenotes/notes/fix-pydantic-ai-apm-span-naming-3746b4f51b9538e0.yaml
+++ b/releasenotes/notes/fix-pydantic-ai-apm-span-naming-3746b4f51b9538e0.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    pydantic_ai: Fixes APM span naming so ``operation_name`` and ``resource_name`` follow
+    Datadog APM convention. Previously, Pydantic AI integration spans surfaced the specific
+    tool/agent name as ``operation_name`` and the generic ``"Pydantic Tool"`` / ``"Pydantic Agent"``
+    label as ``resource_name`` — the reverse of the convention used elsewhere in APM. Service
+    pages, resource breakdowns, and flamegraphs now correctly group spans by
+    ``resource_name=<tool name>`` (e.g. ``calculate_square_tool``) or
+    ``resource_name=<agent name>`` (e.g. ``test_agent``), with ``operation_name=pydantic_ai.tool``
+    / ``operation_name=pydantic_ai.agent`` as the generic category. LLM Observability
+    views are unaffected: the displayed span name is read from the LLMObs metastruct,
+    which the integration already populates with the specific tool/agent name. See
+    https://github.com/DataDog/dd-trace-py/issues/18148.

--- a/releasenotes/notes/fix-pydantic-ai-apm-span-naming-3746b4f51b9538e0.yaml
+++ b/releasenotes/notes/fix-pydantic-ai-apm-span-naming-3746b4f51b9538e0.yaml
@@ -1,14 +1,8 @@
 ---
 fixes:
   - |
-    pydantic_ai: Fixes APM span naming so ``operation_name`` and ``resource_name`` follow
-    Datadog APM convention. Previously, Pydantic AI integration spans surfaced the specific
-    tool/agent name as ``operation_name`` and the generic ``"Pydantic Tool"`` / ``"Pydantic Agent"``
-    label as ``resource_name`` — the reverse of the convention used elsewhere in APM. Service
-    pages, resource breakdowns, and flamegraphs now correctly group spans by
-    ``resource_name=<tool name>`` (e.g. ``calculate_square_tool``) or
-    ``resource_name=<agent name>`` (e.g. ``test_agent``), with ``operation_name=pydantic_ai.tool``
-    / ``operation_name=pydantic_ai.agent`` as the generic category. LLM Observability
-    views are unaffected: the displayed span name is read from the LLMObs metastruct,
-    which the integration already populates with the specific tool/agent name. See
-    https://github.com/DataDog/dd-trace-py/issues/18148.
+    pydantic_ai: Fixes APM span naming so the operation name is the generic category
+    (``pydantic_ai.tool`` / ``pydantic_ai.agent``) and the resource name is the specific
+    tool or agent name, matching Datadog APM convention. This restores per-tool and
+    per-agent grouping on APM service and resource pages. LLM Observability views are
+    unaffected.

--- a/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run.json
+++ b/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "test_agent",
+    "name": "pydantic_ai.agent",
     "service": "tests.contrib.pydantic_ai",
-    "resource": "Pydantic Agent",
+    "resource": "test_agent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run_error.json
+++ b/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_run_error.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "test_agent",
+    "name": "pydantic_ai.agent",
     "service": "tests.contrib.pydantic_ai",
-    "resource": "Pydantic Agent",
+    "resource": "test_agent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,

--- a/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_with_tools.json
+++ b/tests/snapshots/tests.contrib.pydantic_ai.test_pydantic_ai.test_agent_with_tools.json
@@ -1,8 +1,8 @@
 [[
   {
-    "name": "test_agent",
+    "name": "pydantic_ai.agent",
     "service": "tests.contrib.pydantic_ai",
-    "resource": "Pydantic Agent",
+    "resource": "test_agent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -28,9 +28,9 @@
     "start": 1776698460779545137
   },
      {
-       "name": "calculate_square_tool",
+       "name": "pydantic_ai.tool",
        "service": "tests.contrib.pydantic_ai",
-       "resource": "Pydantic Tool",
+       "resource": "calculate_square_tool",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-py/pull/18150
**Original Author:** @relston
**Original Branch:** relston/dd-trace-py:fix/pydantic-ai-apm-span-naming

Closes #18150

---

*This is an automated mirror created to run CI checks. See scripts/mirror-community-pull-request.sh for details.*