### PR TITLE
Update type hint for _get_span_inputs function

### DIFF
--- a/ddtrace/llmobs/decorators.py
+++ b/ddtrace/llmobs/decorators.py
@@ -4,9 +4,9 @@ from inspect import iscoroutinefunction
 from inspect import isgeneratorfunction
 from inspect import signature
 import sys
+from typing import Any
 from typing import Callable
 from typing import Optional
-from typing import OrderedDict
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs import LLMObs

--- a/ddtrace/llmobs/decorators.py
+++ b/ddtrace/llmobs/decorators.py
@@ -32,7 +32,7 @@ def _get_llmobs_span_options(name, model_name, func):
     return traced_model_name, span_name
 
 
-def _get_span_inputs(args: OrderedDict) -> dict:
+def _get_span_inputs(args: dict[str, Any]) -> dict[str, Any]:
     return {arg: value for arg, value in args.items() if arg != "self"}
 
 


### PR DESCRIPTION
This function gets passed the `.args` attribute of the `inspect.BoundArguments` structure, which is in fact a dict, not an OrderedDict. We're fixing this in typeshed python/typeshed#15853; this PR will make it so your type checker won't start emitting errors here when you next update your typeshed.
