### PR TITLE
fix(debugging): make code-origin / dynamic-instrumentation deepcopy-safe (Cadwyn / Airflow 3)

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -192,15 +192,7 @@ class DebuggerWrappingContext(WrappingContext):
         super().__exit__(exc_type, exc_val, exc_tb)
 
     def __getstate__(self) -> dict[str, Any]:
-        # AIDEV-NOTE: Drop live runtime collaborators on pickle/deepcopy. They
-        # transitively hold non-picklable ``threading.Lock``/``RLock`` (e.g.
-        # ``ProbeRegistry._lock``, ``SignalQueue._lock`` inside the collector,
-        # ``Tracer._shutdown_lock``) and have no meaning on a clone — the clone
-        # function's bytecode is not trampoline-wrapped, so this context will
-        # never be invoked through it. Keeping these would re-introduce the
-        # original deepcopy crash (issue #16443) under any product enablement
-        # that registers a DebuggerWrappingContext (i.e. Dynamic Instrumentation
-        # with active probes).
+        # Collaborators hold non-picklable Lock/RLock; clones never invoke this context.
         state = super().__getstate__()
         for key in ("_collector", "_probe_registry", "_tracer", "_probe_meter"):
             state.pop(key, None)

--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -191,6 +191,28 @@ class DebuggerWrappingContext(WrappingContext):
             log.exception("Failed to close debugging contexts from exception block")
         super().__exit__(exc_type, exc_val, exc_tb)
 
+    def __getstate__(self) -> dict[str, Any]:
+        # AIDEV-NOTE: Drop live runtime collaborators on pickle/deepcopy. They
+        # transitively hold non-picklable ``threading.Lock``/``RLock`` (e.g.
+        # ``ProbeRegistry._lock``, ``SignalQueue._lock`` inside the collector,
+        # ``Tracer._shutdown_lock``) and have no meaning on a clone — the clone
+        # function's bytecode is not trampoline-wrapped, so this context will
+        # never be invoked through it. Keeping these would re-introduce the
+        # original deepcopy crash (issue #16443) under any product enablement
+        # that registers a DebuggerWrappingContext (i.e. Dynamic Instrumentation
+        # with active probes).
+        state = super().__getstate__()
+        for key in ("_collector", "_probe_registry", "_tracer", "_probe_meter"):
+            state.pop(key, None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        super().__setstate__(state)
+        self._collector = None  # type: ignore[assignment]
+        self._probe_registry = None  # type: ignore[assignment]
+        self._tracer = None  # type: ignore[assignment]
+        self._probe_meter = None  # type: ignore[assignment]
+
 
 class Debugger(Service):
     _instance: Optional["Debugger"] = None

--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -244,10 +244,7 @@ class BudgetRateLimiterWithJitter:
         return limited_f
 
     def __getstate__(self) -> dict:
-        # _thread.lock is not picklable; strip it so deepcopy/pickle of any
-        # object graph that transitively holds a BudgetRateLimiterWithJitter
-        # (e.g. an EntrySpanProbe attached to a FastAPI route by code-origin)
-        # does not fail with "cannot pickle '_thread.lock' object".
+        # _thread.lock is not picklable.
         state = self.__dict__.copy()
         state.pop("_lock", None)
         return state

--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -244,11 +244,16 @@ class BudgetRateLimiterWithJitter:
         return limited_f
 
     def __getstate__(self) -> dict:
-        # _thread.lock is not picklable.
+        # _lock (a _thread.lock) is not picklable. on_exceed is also dropped
+        # because debugging/code-origin probes set it to a local lambda (see
+        # RateLimitMixin.__post_init__), which is not picklable either. Cloned
+        # limiters are never invoked, so losing the callback is harmless.
         state = self.__dict__.copy()
         state.pop("_lock", None)
+        state.pop("on_exceed", None)
         return state
 
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
+        self.on_exceed = None
         self._lock = threading.Lock()

--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -242,3 +242,16 @@ class BudgetRateLimiterWithJitter:
             return self.limit(f, *args, **kwargs)
 
         return limited_f
+
+    def __getstate__(self) -> dict:
+        # _thread.lock is not picklable; strip it so deepcopy/pickle of any
+        # object graph that transitively holds a BudgetRateLimiterWithJitter
+        # (e.g. an EntrySpanProbe attached to a FastAPI route by code-origin)
+        # does not fail with "cannot pickle '_thread.lock' object".
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()

--- a/releasenotes/notes/fix-rate-limiter-deepcopy-lock-66891a4ea4aeac6f.yaml
+++ b/releasenotes/notes/fix-rate-limiter-deepcopy-lock-66891a4ea4aeac6f.yaml
@@ -1,9 +1,6 @@
 ---
 fixes:
   - |
-    debugging: Strips internal ``threading.Lock``/``RLock`` from
-    ``BudgetRateLimiterWithJitter`` and ``DebuggerWrappingContext`` on
-    pickle/deepcopy so FastAPI/Starlette route copying (e.g. Cadwyn under
-    Airflow 3.x) no longer fails with
-    ``TypeError: cannot pickle '_thread.lock' object`` when Code Origin for
-    Spans or Dynamic Instrumentation is enabled.
+    debugging: make ``BudgetRateLimiterWithJitter`` and ``DebuggerWrappingContext``
+    picklable/deep-copyable so FastAPI route copying (e.g. Cadwyn under Airflow 3.x)
+    no longer fails with ``TypeError: cannot pickle '_thread.lock' object``.

--- a/releasenotes/notes/fix-rate-limiter-deepcopy-lock-66891a4ea4aeac6f.yaml
+++ b/releasenotes/notes/fix-rate-limiter-deepcopy-lock-66891a4ea4aeac6f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    tracing: Strips the internal ``threading.Lock`` from ``BudgetRateLimiterWithJitter``
+    on pickle/deepcopy so FastAPI route copying (e.g. Cadwyn) no longer fails with
+    ``TypeError: cannot pickle '_thread.lock' object``.

--- a/releasenotes/notes/fix-rate-limiter-deepcopy-lock-66891a4ea4aeac6f.yaml
+++ b/releasenotes/notes/fix-rate-limiter-deepcopy-lock-66891a4ea4aeac6f.yaml
@@ -1,6 +1,9 @@
 ---
 fixes:
   - |
-    tracing: Strips the internal ``threading.Lock`` from ``BudgetRateLimiterWithJitter``
-    on pickle/deepcopy so FastAPI route copying (e.g. Cadwyn) no longer fails with
-    ``TypeError: cannot pickle '_thread.lock' object``.
+    debugging: Strips internal ``threading.Lock``/``RLock`` from
+    ``BudgetRateLimiterWithJitter`` and ``DebuggerWrappingContext`` on
+    pickle/deepcopy so FastAPI/Starlette route copying (e.g. Cadwyn under
+    Airflow 3.x) no longer fails with
+    ``TypeError: cannot pickle '_thread.lock' object`` when Code Origin for
+    Spans or Dynamic Instrumentation is enabled.

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1794,3 +1794,38 @@ def test_on_run_module_via_m_flag():
     out, err, status, _ = call_program("ddtrace-run", sys.executable, "-m", "target", cwd=str(cwd), env=env)
 
     assert out.strip() == b"OK", err.decode()
+
+
+def test_debugger_wrapping_context_is_deepcopyable():
+    # Regression test for https://github.com/DataDog/dd-trace-py/issues/16443:
+    # when Dynamic Instrumentation is enabled, a DebuggerWrappingContext is
+    # registered on instrumented endpoints. Its runtime collaborators
+    # (collector, probe registry, tracer, probe meter) transitively hold
+    # threading.Lock / RLock that are not picklable, which used to break
+    # copy.deepcopy of any object graph that reached the wrapped function
+    # (e.g. Cadwyn copying a FastAPI APIRoute when building its versioned
+    # router under Airflow 3.x).
+    import copy
+    import threading
+
+    class _Holder:
+        def __init__(self):
+            self._lock = threading.RLock()
+
+    def endpoint():
+        return 1
+
+    ctx = DebuggerWrappingContext(
+        endpoint,
+        collector=_Holder(),
+        registry=_Holder(),
+        tracer=_Holder(),
+        probe_meter=_Holder(),
+    )
+
+    clone = copy.deepcopy(ctx)
+    assert clone is not ctx
+    assert clone._collector is None
+    assert clone._probe_registry is None
+    assert clone._tracer is None
+    assert clone._probe_meter is None

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1797,14 +1797,7 @@ def test_on_run_module_via_m_flag():
 
 
 def test_debugger_wrapping_context_is_deepcopyable():
-    # Regression test for https://github.com/DataDog/dd-trace-py/issues/16443:
-    # when Dynamic Instrumentation is enabled, a DebuggerWrappingContext is
-    # registered on instrumented endpoints. Its runtime collaborators
-    # (collector, probe registry, tracer, probe meter) transitively hold
-    # threading.Lock / RLock that are not picklable, which used to break
-    # copy.deepcopy of any object graph that reached the wrapped function
-    # (e.g. Cadwyn copying a FastAPI APIRoute when building its versioned
-    # router under Airflow 3.x).
+    # Regression test for https://github.com/DataDog/dd-trace-py/issues/16443.
     import copy
     import threading
 

--- a/tests/tracer/test_rate_limiter.py
+++ b/tests/tracer/test_rate_limiter.py
@@ -1,3 +1,5 @@
+import copy
+import pickle
 import time
 
 import mock
@@ -278,3 +280,25 @@ def test_rate_limiter_with_jitter_not_raise():
     limiter = BudgetRateLimiterWithJitter(limit_rate=1, raise_on_exceed=False)
 
     assert [limiter.limit(lambda: None) for _ in range(10)][1:] == [RateLimitExceeded] * 9
+
+
+def test_budget_rate_limiter_with_jitter_is_deepcopyable():
+    # Regression test for https://github.com/DataDog/dd-trace-py/issues/16443.
+    # When a BudgetRateLimiterWithJitter ends up in an object graph that gets
+    # deep-copied (e.g. an EntrySpanProbe attached to a FastAPI route that
+    # Cadwyn deepcopies while building its versioned router), the internal
+    # threading.Lock used to make limit() thread-safe must not break the copy.
+    limiter = BudgetRateLimiterWithJitter(limit_rate=5)
+    clone = copy.deepcopy(limiter)
+    assert clone is not limiter
+    assert clone._lock is not limiter._lock
+    assert clone.limit_rate == limiter.limit_rate
+    # The clone must still be usable after deepcopy.
+    clone.limit(lambda: None)
+
+
+def test_budget_rate_limiter_with_jitter_is_picklable():
+    limiter = BudgetRateLimiterWithJitter(limit_rate=5)
+    restored = pickle.loads(pickle.dumps(limiter))
+    assert restored.limit_rate == limiter.limit_rate
+    restored.limit(lambda: None)

--- a/tests/tracer/test_rate_limiter.py
+++ b/tests/tracer/test_rate_limiter.py
@@ -284,16 +284,11 @@ def test_rate_limiter_with_jitter_not_raise():
 
 def test_budget_rate_limiter_with_jitter_is_deepcopyable():
     # Regression test for https://github.com/DataDog/dd-trace-py/issues/16443.
-    # When a BudgetRateLimiterWithJitter ends up in an object graph that gets
-    # deep-copied (e.g. an EntrySpanProbe attached to a FastAPI route that
-    # Cadwyn deepcopies while building its versioned router), the internal
-    # threading.Lock used to make limit() thread-safe must not break the copy.
     limiter = BudgetRateLimiterWithJitter(limit_rate=5)
     clone = copy.deepcopy(limiter)
     assert clone is not limiter
     assert clone._lock is not limiter._lock
     assert clone.limit_rate == limiter.limit_rate
-    # The clone must still be usable after deepcopy.
     clone.limit(lambda: None)
 
 

--- a/tests/tracer/test_rate_limiter.py
+++ b/tests/tracer/test_rate_limiter.py
@@ -297,3 +297,22 @@ def test_budget_rate_limiter_with_jitter_is_picklable():
     restored = pickle.loads(pickle.dumps(limiter))
     assert restored.limit_rate == limiter.limit_rate
     restored.limit(lambda: None)
+
+
+def test_budget_rate_limiter_with_jitter_with_local_callback_is_copyable():
+    # Debugging/code-origin probes set on_exceed to a local lambda, which is not
+    # picklable. Cloning must drop it instead of failing (see issue #16443).
+    limiter = BudgetRateLimiterWithJitter(
+        limit_rate=5,
+        on_exceed=lambda: None,
+        call_once=True,
+        raise_on_exceed=False,
+    )
+
+    deep_clone = copy.deepcopy(limiter)
+    assert deep_clone.on_exceed is None
+    deep_clone.limit(lambda: None)
+
+    pickle_clone = pickle.loads(pickle.dumps(limiter))
+    assert pickle_clone.on_exceed is None
+    pickle_clone.limit(lambda: None)


### PR DESCRIPTION
Resolves #16443.

## Problem

When **Code Origin for Spans** (`DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true`) or **Dynamic Instrumentation** is enabled, ddtrace attaches wrapping contexts to instrumented FastAPI / Starlette endpoints. Those contexts hold `threading.Lock` / `RLock` objects:

- `BudgetRateLimiterWithJitter._lock` (via `EntrySpanProbe`), and
- under DI, the collector / probe-registry / tracer locks held by `DebuggerWrappingContext`.

These contexts live on the endpoint's `__dict__`. Any `copy.deepcopy` of an instrumented route therefore walks into a lock and raises `TypeError: cannot pickle '_thread.lock' object`.

Airflow 3 hits this because Cadwyn deep-copies routes when generating versioned routers, but it is not Airflow-specific — it reproduces with any Cadwyn user, OpenAPI generators, or pickling a route handler. The `ContextVar` half of #16443 was fixed in #16643; this PR closes the `_thread.lock` half.

## Fix

Make the lock-holding objects safe to copy by stripping and recreating locks:

- `ddtrace/internal/rate_limiter.py`: `BudgetRateLimiterWithJitter` gets `__getstate__` / `__setstate__` that drop and recreate `_lock`.
- `ddtrace/debugging/_debugger.py`: `DebuggerWrappingContext` gets `__getstate__` / `__setstate__` that drop `_collector` / `_probe_registry` / `_tracer` / `_probe_meter` and restore them as `None`. The cloned context is never invoked, so there is no runtime behavior change.

This follows the existing pattern used for `Context._lock` and `BaseWrappingContext._storage`.

## Test plan

- `tests/tracer/test_rate_limiter.py`: `BudgetRateLimiterWithJitter` is deepcopy- and pickle-able.
- `tests/debugging/test_debugger.py`: `DebuggerWrappingContext` is deepcopy-able.
- A minimal FastAPI + Cadwyn app under `DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true` crashes on `main` and passes with this PR.