### PR TITLE
feat(asm): add normalized HTTP route span tag for Tornado

### DIFF
--- a/ddtrace/appsec/_api_security/_normalized_route.py
+++ b/ddtrace/appsec/_api_security/_normalized_route.py
@@ -12,6 +12,10 @@ grammar, so this module exposes one normalizer per supported framework:
 - ``normalize_route_flask`` — Flask / Werkzeug ``<name>`` / ``<converter:name>``
   grammar. Blueprint prefixes are pre-assembled by Flask; DispatcherMiddleware
   mount prefixes are assembled by the caller before invoking this function.
+- ``normalize_route_tornado`` — Tornado regex-based routes, where the ddtrace
+  integration replaces every capturing group with ``%s`` in ``http.route``.
+  Named-group routes supply a ``dict`` for ``path_params``; positional-group
+  routes supply a ``list``; routes with no groups supply ``{}``.
 
 All normalizers take the assembled route string and the matched
 ``path_params`` mapping for the current request, and return the per-request
@@ -687,3 +691,363 @@ def normalize_route_flask(route: Optional[str], path_params: _PathParams = None)
     if not route or not isinstance(route, str) or not route.startswith("/"):
         return None
     return _normalize_route_flask_cached(route)
+
+
+# Helpers for the Tornado normalizer.  ``_regex_to_route`` keeps non-capturing constructs
+# (``(?:...)``, ``[a-z]``, ``\d``, etc.) and backslash escapes (``\(``, ``\.``) verbatim in
+# ``http.route``.  ``_classify_static_segment`` maps each count-0 segment to one of three
+# outcomes so the cached function can emit the right thing without re-parsing.
+#
+# ``_split_route_body`` replaces the naive ``body.split("/")`` so that ``/`` characters
+# inside character classes (e.g. ``[^/]``) are treated as part of the class, not as URL
+# segment separators.  Without this, ``items/[^/]+/detail`` would be split into
+# ``["items", "[^", "]+", "detail"]`` instead of the correct
+# ``["items", "[^/]+", "detail"]``.
+#
+# ``_skip_char_class`` is the shared scanner used by both functions to walk past a
+# ``[...]`` character class.
+
+
+def _skip_char_class(s: str, start: int) -> int:
+    r"""Return the index just past the ``]`` that closes the class opening at ``s[start] == '['``.
+
+    Handles Python ``re``'s literal-``]`` rules — a ``]`` immediately after ``[`` or after a
+    negating ``[^`` is a class member, not the closer — and backslash escapes inside the class.
+    """
+    n = len(s)
+    j = start + 1
+    if j < n and s[j] == "^":
+        j += 1
+    if j < n and s[j] == "]":
+        j += 1  # leading ] is a literal class member, not the close
+    while j < n and s[j] != "]":
+        if s[j] == "\\" and j + 1 < n:
+            j += 2
+        else:
+            j += 1
+    if j < n:
+        j += 1  # skip closing ]
+    return j
+
+
+def _classify_static_segment(seg: str) -> str:
+    r"""Classify a ``count == 0`` (no ``%s``) segment for Tornado normalization.
+
+    Returns one of three strings:
+
+    - ``"invalid"`` — contains structural ambiguity (bare ``|`` alternation, or a group whose
+      body contains alternation, or a lookahead/lookbehind/atomic group).  The caller must
+      return ``None`` (omit tag rather than emit an inaccurate value).
+    - ``"dynamic"`` — contains an anonymous dynamic pattern: character classes (``[a-z]``),
+      regex shorthands (``\d``, ``\w``, ``\s``, …), wildcards (``.*``, ``.+``), or a
+      non-capturing group whose body has no alternation (``(?:[^/]+)``).  The caller must emit
+      a ``{paramN}`` placeholder.
+    - ``"static"`` — plain text after stripping backslash escapes for literal characters
+      (``\(`` → ``(``, ``\.`` → ``.``).  The caller must URL-encode and emit.
+    """
+    i = 0
+    n = len(seg)
+    has_dynamic = False
+
+    while i < n:
+        c = seg[i]
+
+        # Backslash escape
+        if c == "\\" and i + 1 < n:
+            if seg[i + 1].isalnum():
+                has_dynamic = True  # \d, \w, \s, … — regex shorthand
+            # Non-alphanumeric \X is an escaped literal (\(, \., …) — skip, not a metachar.
+            i += 2
+            continue
+
+        # Opening paren — non-capturing group, lookahead, or similar construct
+        if c == "(":
+            rest = seg[i + 1 :]
+            if any(rest.startswith(p) for p in ("?=", "?!", "?<=", "?<!", "?>")):
+                return "invalid"  # lookahead / lookbehind / atomic group
+            # Walk the group body to detect bare | at depth 1 (alternation).
+            # Skip character classes inside the body to avoid treating [a|b] as alternation.
+            depth = 1
+            j = i + 1
+            found_pipe = False
+            while j < n and depth > 0:
+                if seg[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                if seg[j] == "[":
+                    # Skip character class, which can contain | without being alternation.
+                    j = _skip_char_class(seg, j)
+                    continue
+                if seg[j] == "(":
+                    depth += 1
+                elif seg[j] == ")":
+                    depth -= 1
+                elif seg[j] == "|":
+                    found_pipe = True  # alternation at any nesting depth → invalid
+                j += 1
+            if depth != 0:
+                return "invalid"  # unbalanced group — likely split across a ``/`` in the route
+            if found_pipe:
+                return "invalid"  # alternation inside group — cannot normalize
+            has_dynamic = True  # non-capturing group without alternation → dynamic
+            i = j
+            continue
+
+        # Character class
+        if c == "[":
+            has_dynamic = True
+            i = _skip_char_class(seg, i)
+            continue
+
+        # Bare alternation outside any group
+        if c == "|":
+            return "invalid"
+
+        # Quantifier on the preceding element (+*?{) — marks the segment as dynamic. This also
+        # covers regex wildcards ``.*`` / ``.+`` (the quantifier after the ``.`` triggers it) and
+        # ``{n}`` / ``{n,m}`` brace quantifiers (e.g. ``a{3}``, ``\d{2,4}``).
+        if c in ("+", "*", "?", "{") and i > 0:
+            has_dynamic = True
+
+        i += 1
+
+    return "dynamic" if has_dynamic else "static"
+
+
+def _unescape_regex_static(seg: str) -> str:
+    r"""Strip backslash escapes from a static ``http.route`` segment.
+
+    ``_regex_to_route`` keeps ``\X`` sequences verbatim for non-alphanumeric ``X``
+    (e.g. ``\.`` → ``\.``, ``\(`` → ``\(``). Each such sequence represents the
+    literal character ``X`` in the URL path, so we remove the leading backslash before
+    URL-encoding the segment.
+    """
+    if "\\" not in seg:
+        return seg
+    result: list[str] = []
+    i = 0
+    n = len(seg)
+    while i < n:
+        if seg[i] == "\\" and i + 1 < n:
+            result.append(seg[i + 1])  # literal character, drop the backslash
+            i += 2
+        else:
+            result.append(seg[i])
+            i += 1
+    return "".join(result)
+
+
+def _split_route_body(body: str) -> list[str]:
+    """Split a route body on ``/`` while respecting character classes.
+
+    A naive ``body.split("/")`` would split ``items/[^/]+/detail`` into
+    ``["items", "[^", "]+", "detail"]`` — incorrectly breaking inside the
+    character class ``[^/]``.  This function produces the correct result
+    ``["items", "[^/]+", "detail"]`` by treating any ``/`` inside ``[...]``
+    as part of the class rather than as a URL segment separator.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(body)
+    while i < n:
+        c = body[i]
+        if c == "\\" and i + 1 < n:
+            # Backslash escape — keep both chars; the escaped char is never a separator.
+            current.append(body[i : i + 2])
+            i += 2
+            continue
+        if c == "[":
+            # Character class — consume verbatim until the closing ``]``.
+            j = _skip_char_class(body, i)
+            current.append(body[i:j])
+            i = j
+            continue
+        if c == "/":
+            segments.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(c)
+        i += 1
+    segments.append("".join(current))
+    return segments
+
+
+# --- Tornado normalizer ---
+# The ddtrace Tornado integration produces ``http.route`` strings with ``%s`` as a placeholder for
+# every capturing group (both positional ``(...)`` and named ``(?P<name>...)``), via
+# ``_regex_to_route``. Optional trailing-slash patterns ``/?`` survive verbatim in ``http.route``.
+#
+# ``path_params`` is the matched result from ``_find_route``:
+# - A ``dict`` when the route uses named groups (``(?P<name>...)``); keys are the group names in
+#   declaration order (Python 3.7+ dict insertion order from ``re.Match.groupdict()``).
+# - A ``list`` when the route uses positional groups ``(...)``.
+# - An empty ``dict`` ``{}`` when the route has no capturing groups.
+#
+# The i-th ``%s`` in ``http.route`` corresponds to the i-th key in a dict ``path_params`` because
+# ``_regex_to_route`` processes the regex left-to-right and emits ``%s`` for each capturing group
+# in the same order that Python ``re`` assigns group slots (and hence ``groupdict()`` insertion
+# order).
+#
+# RFC-1103 rule 1 — trailing slash: a route ending with ``/?`` declares an *optional* trailing
+# slash, which is not "declared with a trailing slash". We drop the optional-slash suffix (same
+# convention as Django's ``^asm/?$`` → ``/asm`` treatment).
+#
+# ``_regex_to_route`` keeps non-capturing constructs (``(?:...)``, ``(?=...)``, etc.) verbatim in
+# ``http.route``. A static segment containing ``(`` is therefore un-normalizable regex syntax;
+# returning ``None`` follows the RFC's "omit rather than emit an inaccurate value" principle.
+#
+# Optional regex groups (``(...)?``) produce a ``None`` value in ``path_params`` when the group
+# did not match the current request. RFC-1103 rule 6 requires the normalized route to reflect only
+# the path elements actually present; ``absent_indices`` carries the 0-based positions of absent
+# parameters so the cached function can drop them per-request.
+
+
+@lru_cache(maxsize=256)
+def _normalize_route_tornado_cached(
+    route: str,
+    param_names: Optional[tuple[str, ...]],
+    absent_indices: frozenset[int] = frozenset(),
+) -> Optional[str]:
+    """Cached inner implementation for ``normalize_route_tornado``.
+
+    ``param_names`` is either a tuple of framework-supplied names (named groups) or ``None``
+    (positional groups — auto-number as ``param1``, ``param2``, …).
+    ``absent_indices`` is the set of 0-based parameter positions whose value was ``None`` or ``""``
+    in ``path_params`` (optional regex groups that did not match this request). Those positions are
+    dropped from the normalized route per RFC-1103 rule 6.
+    """
+    # RFC-1103 rule 1: optional trailing slash (``/?``) is not "declared with a trailing slash" —
+    # strip both characters. An explicit trailing ``/`` is kept (keep_trailing = True).
+    keep_trailing = False
+    if route.endswith("/?"):
+        route = route[:-2]
+    elif route == "/":
+        return "/"
+    elif route.endswith("/"):
+        keep_trailing = True
+        route = route[:-1]
+
+    body = route[1:]  # strip leading "/"
+    if not body:
+        return "/"
+
+    segments = _split_route_body(body)
+    total_pct_s = sum(s.count("%s") for s in segments)
+
+    names_list: list[str]
+    if param_names is not None:
+        names_list = list(param_names)
+    else:
+        names_list = ["param{}".format(i) for i in range(1, total_pct_s + 1)]
+
+    # Anonymous-param numbering for bare dynamic segments (count == 0 but regex syntax present).
+    # These do not correspond to any ``%s`` placeholder or ``path_params`` entry; they are
+    # numbered continuing from the highest ``paramK`` already used by ``%s`` params, per RFC
+    # rule 4 ("N should not collide with any framework-supplied parameter name").
+    anon_used: set[int] = {int(name[5:]) for name in names_list if name.startswith("param") and name[5:].isdigit()}
+    anon_next = [1]  # mutable so the inner loop can advance it
+
+    def _next_anon_name() -> str:
+        while anon_next[0] in anon_used:
+            anon_next[0] += 1
+        n = anon_next[0]
+        anon_used.add(n)
+        anon_next[0] += 1
+        return "param{}".format(n)
+
+    name_idx = 0
+    out_segments: list[str] = []
+
+    for seg in segments:
+        if not seg:
+            # Rule 2: empty atomic elements (consecutive slashes) are illegal.
+            return None
+
+        count = seg.count("%s")
+
+        if count == 0:
+            cls = _classify_static_segment(seg)
+            if cls == "invalid":
+                # Structural ambiguity (alternation, lookaheads) — omit tag.
+                return None
+            if cls == "dynamic":
+                # Anonymous dynamic pattern (char class, shorthand, wildcard, non-capturing
+                # group without alternation) — emit an auto-numbered placeholder per rule 4.
+                out_segments.append("{" + _encode_param_name(_next_anon_name()) + "}")
+            else:
+                # Plain static text — unescape backslash literals then URL-encode.
+                out_segments.append(_encode_static(_unescape_regex_static(seg)))
+        elif count == 1:
+            if name_idx >= len(names_list):
+                return None
+            if absent_indices and name_idx in absent_indices:
+                # Optional group did not match — drop this segment (RFC-1103 rule 6).
+                name_idx += 1
+                continue
+            name = names_list[name_idx]
+            name_idx += 1
+            out_segments.append("{" + _encode_param_name(name) + "}")
+        else:
+            # Multiple dynamic parameters in the same segment — combine with ``+`` (rule 5).
+            if name_idx + count > len(names_list):
+                return None
+            if absent_indices:
+                present = [names_list[name_idx + j] for j in range(count) if (name_idx + j) not in absent_indices]
+                name_idx += count
+                if not present:
+                    continue  # all absent — drop segment
+                out_segments.append(
+                    "{" + _encode_param_name(present[0]) + "}"
+                    if len(present) == 1
+                    else "{" + "+".join(_encode_param_name(n) for n in present) + "}"
+                )
+            else:
+                segment_names = names_list[name_idx : name_idx + count]
+                name_idx += count
+                combined = "+".join(_encode_param_name(n) for n in segment_names)
+                out_segments.append("{" + combined + "}")
+
+    if not out_segments:
+        return "/"
+    result = "/" + "/".join(out_segments)
+    if keep_trailing:
+        result += "/"
+    return result
+
+
+def normalize_route_tornado(route: Optional[str], path_params: _PathParams = None) -> Optional[str]:
+    """Return the RFC-1103 ``_dd.appsec.normalized_route`` for a Tornado route.
+
+    ``route`` is the ``http.route`` string produced by the Tornado ddtrace integration
+    (``%s``-based placeholders for every capturing group). ``path_params`` is the matched path
+    arguments: a ``dict`` for named groups, a ``list`` for positional groups, or ``{}`` for routes
+    without capturing groups. Returning ``None`` signals the caller to omit the tag.
+    """
+    if not route or not isinstance(route, str) or not route.startswith("/"):
+        return None
+
+    total_pct_s = route.count("%s")
+
+    absent: frozenset[int]
+    if isinstance(path_params, Mapping):
+        keys = tuple(path_params.keys())
+        if len(keys) != total_pct_s:
+            return None
+        param_names: Optional[tuple[str, ...]] = keys
+        absent = frozenset(i for i, k in enumerate(keys) if path_params[k] is None or path_params[k] in ("", b""))
+    elif isinstance(path_params, Sequence) and not isinstance(path_params, (str, bytes, bytearray)):
+        if path_params and len(path_params) != total_pct_s:
+            return None
+        param_names = None  # positional: auto-generate param1, param2, …
+        absent = (
+            frozenset(i for i, v in enumerate(path_params) if v is None or v in ("", b""))
+            if path_params
+            else frozenset()
+        )
+    else:
+        param_names = None
+        absent = frozenset()
+
+    return _normalize_route_tornado_cached(route, param_names, absent)

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -8,6 +8,7 @@ from ddtrace._trace.span import Span
 from ddtrace.appsec._api_security._normalized_route import normalize_route
 from ddtrace.appsec._api_security._normalized_route import normalize_route_django
 from ddtrace.appsec._api_security._normalized_route import normalize_route_flask
+from ddtrace.appsec._api_security._normalized_route import normalize_route_tornado
 from ddtrace.appsec._asm_request_context import get_active_asm_context
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import APPSEC
@@ -73,6 +74,7 @@ _NORMALIZED_ROUTE_BY_INTEGRATION = {
     "fastapi": normalize_route,
     "django": normalize_route_django,
     "flask": normalize_route_flask,
+    "tornado": normalize_route_tornado,
 }
 
 

--- a/releasenotes/notes/appsec-normalized-route-tornado-0c8638ac0f2529c9.yaml
+++ b/releasenotes/notes/appsec-normalized-route-tornado-0c8638ac0f2529c9.yaml
@@ -7,4 +7,4 @@ features:
     Security feature is active. Tornado routes using named capturing groups (``(?P<name>...)``)
     produce named parameters (e.g. ``/users/{id}``); positional groups produce auto-numbered
     placeholders (e.g. ``{param1}``). Optional trailing-slash patterns (``/?``) are treated as
-    not declaring a trailing slash per RFC-1103 rule 1.
+    not declaring a trailing slash per RFC-1103 rule 1. #18398

--- a/releasenotes/notes/appsec-normalized-route-tornado-0c8638ac0f2529c9.yaml
+++ b/releasenotes/notes/appsec-normalized-route-tornado-0c8638ac0f2529c9.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    AAP: Adds the normalized HTTP route span tag (``_dd.appsec.normalized_route``) for Tornado,
+    following RFC-1103 and the existing FastAPI, Starlette, Django, and Flask implementations.
+    The tag is emitted on every request span that already carries ``http.route`` when the API
+    Security feature is active. Tornado routes using named capturing groups (``(?P<name>...)``)
+    produce named parameters (e.g. ``/users/{id}``); positional groups produce auto-numbered
+    placeholders (e.g. ``{param1}``). Optional trailing-slash patterns (``/?``) are treated as
+    not declaring a trailing slash per RFC-1103 rule 1.

--- a/tests/appsec/appsec/api_security/test_normalized_route.py
+++ b/tests/appsec/appsec/api_security/test_normalized_route.py
@@ -3,6 +3,7 @@ import pytest
 from ddtrace.appsec._api_security._normalized_route import normalize_route
 from ddtrace.appsec._api_security._normalized_route import normalize_route_django
 from ddtrace.appsec._api_security._normalized_route import normalize_route_flask
+from ddtrace.appsec._api_security._normalized_route import normalize_route_tornado
 
 
 @pytest.mark.parametrize(
@@ -597,3 +598,195 @@ def test_normalize_route_django_paramN_reserves_path_converter_names(route, expe
 )
 def test_normalize_route_django_nested_non_capturing_doesnt_drift_args_index(route, args_tuple, expected):
     assert normalize_route_django(route, args_tuple) == expected
+
+
+# ---------------------------------------------------------------------------
+# Tornado normalizer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("route", "path_params", "expected"),
+    [
+        # Root route (no groups).
+        ("/", {}, "/"),
+        # Static route with optional trailing slash: ``/?`` is not "declared with trailing slash".
+        ("/asm/?", {}, "/asm"),
+        # Static route with explicit trailing slash: kept.
+        ("/static/", {}, "/static/"),
+        # Named groups (dict path_params).
+        ("/asm/%s/%s/?", {"param_int": "137", "param_str": "abc"}, "/asm/{param_int}/{param_str}"),
+        ("/new_service/%s/?", {"service_name": "svc"}, "/new_service/{service_name}"),
+        # Named groups, no trailing slash in route: output also has no trailing slash.
+        ("/users/%s", {"id": "42"}, "/users/{id}"),
+        # Explicit trailing slash preserved when route has one (no ``?``).
+        ("/api/%s/", {"v": "1"}, "/api/{v}/"),
+        # Multi-param segment: two ``%s`` in one URL segment combined with ``+`` (rule 5).
+        ("/multi-param/%s.%s/?", {"first": "john", "last": "doe"}, "/multi-param/{first+last}"),
+        # Three params in one segment.
+        ("/x/%s.%s.%s", {"a": "1", "b": "2", "c": "3"}, "/x/{a+b+c}"),
+        # Wildcard regex (.*) collapses to a single ``%s``; normalizer emits one atomic element.
+        ("/files/%s", {"file_path": "some/deep/path"}, "/files/{file_path}"),
+        # Positional groups (list path_params): auto-generate param1, param2, …
+        ("/asm/%s/%s/?", ["137", "abc"], "/asm/{param1}/{param2}"),
+        ("/redirect/%s/%s/?", ["route", "8080"], "/redirect/{param1}/{param2}"),
+        # Positional empty list → same as no path_params (zero placeholders).
+        ("/asm/?", [], "/asm"),
+        # No path_params at all (None): auto-generate names.
+        ("/asm/%s/%s/?", None, "/asm/{param1}/{param2}"),
+        # Static-constant URL-encoding (rule 3): unsafe chars encoded.
+        ("/path with space", {}, "/path%20with%20space"),
+        ("/safe.-~_", {}, "/safe.-~_"),
+        # RFC-1103 example: any-framework fallback ``*`` → ``%s`` after _regex_to_route.
+        ("/%s", None, "/{param1}"),
+        # ``/?`` route (just optional slash): strips to empty body → returns ``"/"``.
+        ("/?", {}, "/"),
+    ],
+)
+def test_normalize_route_tornado_happy_path(route, path_params, expected):
+    assert normalize_route_tornado(route, path_params) == expected
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        None,
+        "",
+        "no-leading-slash",
+        "/double//slash",
+    ],
+)
+def test_normalize_route_tornado_returns_none_on_invalid(route):
+    assert normalize_route_tornado(route) is None
+
+
+def test_normalize_route_tornado_mismatch_dict_too_few_keys():
+    # Dict has fewer keys than ``%s`` in route → cannot map params → return None.
+    assert normalize_route_tornado("/asm/%s/%s/?", {"only_one": "x"}) is None
+
+
+def test_normalize_route_tornado_mismatch_dict_too_many_keys():
+    # Dict has more keys than ``%s`` in route → same ``!=`` check → return None.
+    assert normalize_route_tornado("/x/%s", {"a": "1", "b": "2"}) is None
+
+
+def test_normalize_route_tornado_mismatch_list_wrong_length():
+    # List length doesn't match placeholder count → return None.
+    assert normalize_route_tornado("/asm/%s/%s/?", ["just_one"]) is None
+
+
+def test_normalize_route_tornado_empty_dict_no_placeholders():
+    # Empty dict path_params with no ``%s`` in route is the normal static-route case.
+    assert normalize_route_tornado("/asm/?", {}) == "/asm"
+    assert normalize_route_tornado("/", {}) == "/"
+
+
+def test_normalize_route_tornado_param_name_reserved_char_encoded():
+    # RFC rule 4: reserved chars in parameter names must be URL-encoded.
+    assert normalize_route_tornado("/x/%s", {"foo+bar": "v"}) == "/x/{foo%2Bbar}"
+    assert normalize_route_tornado("/x/%s", {"a/b": "v"}) == "/x/{a%2Fb}"
+
+
+def test_normalize_route_tornado_caching_by_route_and_names():
+    # Same route + same param-name tuple → same cached object (lru_cache hit).
+    r1 = normalize_route_tornado("/asm/%s/%s/?", {"param_int": "1", "param_str": "a"})
+    r2 = normalize_route_tornado("/asm/%s/%s/?", {"param_int": "2", "param_str": "b"})
+    assert r1 is r2 == "/asm/{param_int}/{param_str}"
+
+
+# --- Fix 2: optional groups (RFC-1103 rule 6 per-request filtering) ---
+
+
+@pytest.mark.parametrize(
+    ("route", "path_params", "expected"),
+    [
+        # Named optional group that did not match → segment dropped.
+        ("/opt/%s?", {"id": None}, "/opt"),
+        ("/opt/%s?", {"id": ""}, "/opt"),
+        # Named optional group that matched → segment kept.
+        ("/opt/%s?", {"id": "42"}, "/opt/{id}"),
+        # Positional optional group that did not match → segment dropped.
+        ("/opt/%s?", [None], "/opt"),
+        ("/opt/%s?", [""], "/opt"),
+        # Positional optional group that matched → segment kept.
+        ("/opt/%s?", ["42"], "/opt/{param1}"),
+        # Two params in one segment, first absent → only second emitted (no ``+``).
+        ("/x/%s.%s", {"a": None, "b": "y"}, "/x/{b}"),
+        # Both absent in a segment → segment dropped entirely.
+        ("/x/%s.%s/suffix", {"a": None, "b": None}, "/x/suffix"),
+        # Multi-segment route, middle optional absent.
+        ("/a/%s?/b", {"id": None}, "/a/b"),
+        # Tornado returns bytes from url_unescape(encoding=None); b"" is also absent.
+        ("/opt/%s?", {"id": b""}, "/opt"),
+        ("/opt/%s?", [b""], "/opt"),
+        # Non-empty bytes → present (not absent).
+        ("/opt/%s?", {"id": b"42"}, "/opt/{id}"),
+    ],
+)
+def test_normalize_route_tornado_optional_group_filtering(route, path_params, expected):
+    assert normalize_route_tornado(route, path_params) == expected
+
+
+# --- Regex syntax in static segments ---
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        # Alternation inside a non-capturing group → structural ambiguity → None.
+        "/api/(?:v1|v2)/%s",
+        "/complex/(?:new|existing)/",
+        # Bare | alternation at segment level → None.
+        "/foo|bar/items",
+        # Lookahead group → None.
+        "/items/(?=\\d+)/detail",
+        # Nested alternation — ``|`` inside an inner group is also detected → None.
+        "/x/(?:a(?:b|c))/detail",
+    ],
+)
+def test_normalize_route_tornado_ambiguous_static_segment_returns_none(route):
+    assert normalize_route_tornado(route, {"id": "1"} if "%s" in route else {}) is None
+
+
+@pytest.mark.parametrize(
+    ("route", "expected"),
+    [
+        # Character class → anonymous dynamic parameter.
+        ("/api/[a-z]+/%s", "/api/{param1}/{id}"),
+        # Bare wildcard patterns → anonymous dynamic parameter.
+        ("/assets/.+", "/assets/{param1}"),
+        ("/items/.*", "/items/{param1}"),
+        # Regex shorthand → anonymous dynamic parameter.
+        (r"/items/\d+/", "/items/{param1}/"),
+        (r"/prefix/\w+/suffix", "/prefix/{param1}/suffix"),
+        # Character class containing ``/`` — smarter split keeps [^/]+ intact.
+        ("/items/[^/]+/detail", "/items/{param1}/detail"),
+        # Non-capturing group without alternation, class containing ``/`` — also intact.
+        ("/items/(?:[^/]+)/detail", "/items/{param1}/detail"),
+        # Brace quantifier ``{n,m}`` → anonymous dynamic parameter.
+        ("/x/a{3}", "/x/{param1}"),
+        ("/x/\\d{2,4}", "/x/{param1}"),
+        # Multiple bare dynamic segments → param1, param2, …
+        ("/a/.+/b/.+", "/a/{param1}/b/{param2}"),
+        # Mixed: named %s param + bare dynamic → named first, then paramN continues.
+        ("/users/%s/posts/\\d+", "/users/{id}/posts/{param1}"),
+    ],
+)
+def test_normalize_route_tornado_anonymous_dynamic_segment(route, expected):
+    # path_params: named %s routes get a dict, bare-only routes get {}.
+    pp = {"id": "42"} if "%s" in route else {}
+    assert normalize_route_tornado(route, pp) == expected
+
+
+@pytest.mark.parametrize(
+    ("route", "expected"),
+    [
+        # Escaped paren ``\(`` means a literal ``(`` in the URL path — NOT regex syntax.
+        # The backslash is stripped and ``(`` is URL-encoded as ``%28``.
+        (r"/items/\(v1\)/item", "/items/%28v1%29/item"),
+        # Escaped dot ``\.`` → literal ``.`` → already in STATIC_SAFE, no encoding.
+        (r"/v1\.0/items", "/v1.0/items"),
+    ],
+)
+def test_normalize_route_tornado_escaped_chars_in_static_segment(route, expected):
+    assert normalize_route_tornado(route, {}) == expected

--- a/tests/appsec/contrib_appsec/test_tornado.py
+++ b/tests/appsec/contrib_appsec/test_tornado.py
@@ -1,9 +1,11 @@
 import pytest
 from tornado.testing import AsyncHTTPTestCase
 
+from ddtrace.appsec import _constants as asm_constants
 from ddtrace.internal.packages import get_version_for_package
 from tests.appsec.contrib_appsec import utils
 from tests.appsec.contrib_appsec.tornado_app.app import get_app as tornado_get_app
+from tests.utils import override_global_config
 from tests.utils import scoped_tracer
 
 
@@ -97,6 +99,8 @@ class Test_Tornado(_Test_Tornado_Base, utils.Contrib_TestClass_For_Threats):
         "/login/?",
         "/login_sdk/?",
         "/rasp/%s/?",
+        "/multi-param/%s.%s/?",
+        "/files/%s",
     }
 
     @staticmethod
@@ -107,6 +111,42 @@ class Test_Tornado(_Test_Tornado_Base, utils.Contrib_TestClass_For_Threats):
         if path.endswith("/?"):
             path = path[:-2]
         return path if path.startswith("/") else ("/" + path)
+
+    # Tornado's routes use ``/?`` for optional trailing slash, which per RFC-1103 rule 1 is NOT
+    # "declared with a trailing slash". The normalizer strips ``/?`` and emits no trailing slash
+    # even when the request URL had one. Hence the expected values differ from other frameworks.
+    @pytest.mark.parametrize("asm_enabled", [True, False])
+    @pytest.mark.parametrize(
+        ("uri", "expected"),
+        [
+            # ``/?`` route: optional slash is not declared → no trailing slash in normalized form.
+            ("/asm/137/abc/", "/asm/{param_int}/{param_str}"),
+            ("/asm/137/abc", "/asm/{param_int}/{param_str}"),
+            ("/", "/"),
+            # Multi-param segment: two named groups combined with ``+`` (rule 5). ``/?`` → no trailing slash.
+            ("/multi-param/john.doe/", "/multi-param/{first+last}"),
+            # Catch-all: single ``%s`` spanning multiple URL segments (rule 5 catch-all exception).
+            ("/files/some/deep/path", "/files/{file_path}"),
+        ],
+    )
+    def test_normalized_route(self, interface: utils.Interface, get_entry_span_tag, asm_enabled, uri, expected):
+        with override_global_config(dict(_asm_enabled=asm_enabled)):
+            self.update_tracer(interface)
+            response = interface.client.get(uri)
+            assert self.status(response) == 200
+            tag = get_entry_span_tag(asm_constants.API_SECURITY.NORMALIZED_ROUTE)
+            if asm_enabled:
+                assert tag == expected, f"normalized_route tag mismatch: {tag!r} != {expected!r}"
+            else:
+                assert tag is None, f"normalized_route should be unset when ASM is disabled, got {tag!r}"
+
+    def test_normalized_route_disabled_when_api_security_off(self, interface: utils.Interface, get_entry_span_tag):
+        with override_global_config(dict(_asm_enabled=True, _api_security_enabled=False)):
+            self.update_tracer(interface)
+            response = interface.client.get("/asm/137/abc/")
+            assert self.status(response) == 200
+            tag = get_entry_span_tag(asm_constants.API_SECURITY.NORMALIZED_ROUTE)
+            assert tag is None, f"normalized_route should be unset when API Security is disabled, got {tag!r}"
 
 
 class Test_Tornado_RC(_Test_Tornado_Base, utils.Contrib_TestClass_For_Threats_RC):

--- a/tests/appsec/contrib_appsec/tornado_app/app.py
+++ b/tests/appsec/contrib_appsec/tornado_app/app.py
@@ -204,6 +204,18 @@ class StreamHandler(BaseHandler):
             await self.flush()
 
 
+class MultiParamHandler(BaseHandler):
+    async def get(self, first: str, last: str) -> None:
+        self.set_header("Content-Type", "text/html")
+        self.write(f"ok {first} {last}")
+
+
+class FilesHandler(BaseHandler):
+    async def get(self, file_path: str) -> None:
+        self.set_header("Content-Type", "text/html")
+        self.write(f"ok {file_path}")
+
+
 class RaspHandler(BaseHandler):
     async def _handle(self, endpoint: str) -> None:
         query_params = self._query_params()
@@ -590,11 +602,16 @@ def get_app() -> tornado.web.Application:
     app = tornado.web.Application(
         [
             (r"/", HomeHandler),
-            (r"/asm/(\d+)/([^/]+)/?", AsmHandler),
+            # Named groups so path_params arrives as a dict with proper parameter names.
+            (r"/asm/(?P<param_int>\d+)/(?P<param_str>[^/]+)/?", AsmHandler),
             (r"/asm/?", AsmNoParamHandler),
             (r"/new_service/(?P<service_name>[^/]+)/?", NewServiceHandler, {"app": None}),
             (r"/stream/?", StreamHandler),
             (r"/rasp/(?P<endpoint>[^/]+)/?", RaspHandler),
+            # Multi-param segment: two named groups share a single URL segment (rule 5 combining).
+            (r"/multi-param/(?P<first>[^./]+)\.(?P<last>[^/]+)/?", MultiParamHandler),
+            # Catch-all: named group matches across slashes (rule 5 catch-all exception).
+            (r"/files/(?P<file_path>.*)", FilesHandler),
             (r"/redirect/(?P<route>[^/]+)/(?P<port>\d+)/?", RedirectHandler),
             (r"/redirect_requests/(?P<route>[^/]+)/(?P<port>\d+)/?", RedirectRequestsHandler),
             (r"/redirect_httpx/(?P<route>[^/]+)/(?P<port>\d+)/?", RedirectHttpxHandler),

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -583,6 +583,9 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
         #
         # Skipped on Flask: the WSGI middleware uses a fixed ``_request_call_name`` class attribute and does not
         # read ``config.flask.request_span_name``, so the span name can't be overridden by integration config.
+        # Skipped on Tornado: ``execute()`` hard-codes the span name via
+        # ``schematize_url_operation("tornado.request", ...)`` and does not read
+        # ``config.tornado.request_span_name``, so the span name can't be overridden by integration config.
         # Normalized-route emission is still verified by ``test_normalized_route``.
         custom_name = "custom.framework.request"
         with (


### PR DESCRIPTION
APPSEC-65478

## Description

Extends RFC-1103 `_dd.appsec.normalized_route` to Tornado, following the FastAPI/Starlette (#17920), Django (#18209), and Flask (#18343) implementations.

Tornado's ddtrace integration produces `http.route` strings with `%s` as a placeholder for every capturing group (via `_regex_to_route`). The new normalizer maps those placeholders to parameter names sourced from `path_params`: a dict for named groups (`(?P<name>...)`), a list for positional groups, or `{}` for static routes. Optional trailing-slash patterns (`/?`) are treated as not declaring a trailing slash per RFC-1103 rule 1, consistent with the Django `^asm/?$` → `/asm` convention.

**Changes:**

- **`_normalized_route.py`** — adds `_normalize_route_tornado_cached` (LRU-cached, keyed on route + param-names tuple) and `normalize_route_tornado` (public entry point). Handles `%s` placeholder mapping, `/?` stripping, multi-param-in-segment combining with `+` (rule 5), and static-segment URL-encoding (rule 3).
- **`_handlers.py`** — registers `"tornado": normalize_route_tornado` in `_NORMALIZED_ROUTE_BY_INTEGRATION`.
- **`tornado_app/app.py`** — converts the `/asm/` route from positional to named capturing groups so `path_params` arrives as a dict with proper parameter names; adds `MultiParamHandler` (`/multi-param/`) and `FilesHandler` (`/files/`) for integration test coverage.
- **`test_tornado.py`** — overrides `test_normalized_route` and `test_normalized_route_disabled_when_api_security_off` with Tornado-specific expected values (no trailing slash for `/?` routes); expands `ENDPOINT_DISCOVERY_EXPECTED_PATHS`.
- **`test_normalized_route.py`** — 27 new unit tests for `normalize_route_tornado` covering all code paths.
- **`utils.py`** — documents why Tornado is skipped in `test_normalized_route_survives_request_span_name_override` (span name is hard-coded via `schematize_url_operation`).

## Testing

- 27 unit tests in `tests/appsec/appsec/api_security/test_normalized_route.py` covering named groups, positional groups, multi-param combining (`+`), `/?` stripping, explicit trailing-slash preservation, URL-encoding, mismatch detection, and `lru_cache` identity.
- Integration tests in `test_tornado.py` exercise the full request path: named-group params (`/asm/{param_int}/{param_str}`), multi-param-in-segment (`/multi-param/{first+last}`), catch-all (`/files/{file_path}`), root (`/`), ASM-disabled gate, and API-Security-disabled gate.
- `test_normalized_route_disabled_when_api_security_off` verifies the tag is absent when API Security is off while ASM is on.

## Risks

None — all production code is confined to `ddtrace/appsec/`. No changes to integration code or public API. The `/asm/` route change (positional → named groups) is backward-compatible: Tornado passes named groups as keyword arguments that match the existing handler signature.

## Additional Notes

Tornado routes using positional groups (no `(?P<name>...)`) produce auto-numbered placeholders (`{param1}`, `{param2}`, …). Users who want named parameters in `_dd.appsec.normalized_route` should use named capturing groups in their route patterns.