### PR TITLE
chore: product plugin dist allowlist

### DIFF
--- a/ddtrace/internal/products.py
+++ b/ddtrace/internal/products.py
@@ -20,6 +20,15 @@ from ddtrace.internal.uwsgi import uWSGIMasterProcess
 
 log = get_logger(__name__)
 
+# The ddtrace.products entry-point group is currently internal-only. We reject
+# plugins from any distribution other than "ddtrace" to prevent supply-chain
+# attacks where a malicious third-party package registers a plugin that would be
+# automatically loaded into every instrumented process.
+# Distribution names are matched exactly (case-insensitively); module paths are
+# matched as prefixes so all ddtrace.* submodules are covered.
+_TRUSTED_PRODUCT_DISTRIBUTIONS = frozenset({"ddtrace"})
+_TRUSTED_PRODUCT_MODULE_PREFIXES = frozenset({"ddtrace."})
+
 
 if sys.version_info >= (3, 10):
 
@@ -57,6 +66,37 @@ class ProductManager:
         for product_plugin in get_product_entry_points():
             name = product_plugin.name
             log.debug("Discovered product plugin '%s'", name)
+
+            # Check both the distribution name and the entry point module path. The
+            # distribution name check is a fast first filter, but it is self-declared
+            # and can be spoofed. The module path check is the stronger guard: a
+            # plugin whose code does not live under the ddtrace namespace cannot be
+            # part of the trusted ddtrace package.
+            module_path, _, _ = product_plugin.value.partition(":")
+            # dist may be absent on Python < 3.10 with the legacy entry_points() API;
+            # in that case skip the dist check and rely solely on the module path. A
+            # dist name that is explicitly None (malformed metadata) is treated as
+            # untrusted.
+            dist = getattr(product_plugin, "dist", None)
+            # Three cases:
+            #  - dist attribute absent (Python < 3.10): no dist info, skip dist check
+            #  - dist is None: no dist info available, skip dist check
+            #  - dist present and not None: check Name; None Name means malformed metadata → reject
+            dist_name: t.Optional[str] = None
+            if not hasattr(product_plugin, "dist") or dist is None:
+                trusted_dist = True
+            else:
+                dist_name = dist.metadata["Name"]
+                trusted_dist = dist_name is not None and dist_name.lower() in _TRUSTED_PRODUCT_DISTRIBUTIONS
+            trusted_module = any(module_path.startswith(p) for p in _TRUSTED_PRODUCT_MODULE_PREFIXES)
+            if not (trusted_dist and trusted_module):
+                log.warning(
+                    "Refusing to load product plugin '%s' from untrusted distribution '%s' (module: %s)",
+                    name,
+                    dist_name,
+                    module_path,
+                )
+                continue
 
             # Load the product protocol object
             try:

--- a/tests/internal/test_products.py
+++ b/tests/internal/test_products.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import pytest
 
 from ddtrace.internal.products import Product
@@ -152,6 +155,120 @@ def test_product_manager_restart():
         os._exit(0)
 
     os.waitpid(pid, 0)
+
+
+def _make_entry_point(name, dist_name, module_path, product_obj):
+    ep = MagicMock()
+    ep.name = name
+    ep.value = f"{module_path}:module"
+    ep.dist = MagicMock()
+    ep.dist.metadata = {"Name": dist_name}
+    ep.load.return_value = product_obj
+    return ep
+
+
+def test_load_products_trusted():
+    product = BaseProduct()
+    ep = _make_entry_point("tracer", "ddtrace", "ddtrace._trace.product", product)
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "tracer" in manager.__products__
+
+
+def test_load_products_trusted_mixed_case_dist():
+    product = BaseProduct()
+    ep = _make_entry_point("tracer", "DDTrace", "ddtrace._trace.product", product)
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "tracer" in manager.__products__
+
+
+def test_load_products_untrusted_dist():
+    product = BaseProduct()
+    ep = _make_entry_point("evil", "evil-package", "ddtrace._trace.product", product)
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "evil" not in manager.__products__
+
+
+def test_load_products_untrusted_dist_with_ddtrace_prefix():
+    """A package named 'ddtrace-evil' must not be treated as trusted (exact match only)."""
+    product = BaseProduct()
+    ep = _make_entry_point("evil", "ddtrace-evil", "ddtrace._trace.product", product)
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "evil" not in manager.__products__
+
+
+def test_load_products_spoofed_dist_name():
+    """A package that sets metadata Name='ddtrace' but ships code outside the ddtrace namespace."""
+    product = BaseProduct()
+    ep = _make_entry_point("evil", "ddtrace", "evil_package.product", product)
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "evil" not in manager.__products__
+
+
+def test_load_products_no_dist_metadata():
+    """When dist is present but None, trust relies solely on the module path."""
+    product = BaseProduct()
+    ep = _make_entry_point("tracer", "ddtrace", "ddtrace._trace.product", product)
+    ep.dist = None
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "tracer" in manager.__products__
+
+
+def test_load_products_no_dist_attribute():
+    """When EntryPoint.dist is absent (Python < 3.10), trust relies solely on the module path."""
+    product = BaseProduct()
+    ep = _make_entry_point("tracer", "ddtrace", "ddtrace._trace.product", product)
+    del ep.dist
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "tracer" in manager.__products__
+
+
+def test_load_products_no_dist_attribute_untrusted_module():
+    """When EntryPoint.dist is absent and the module path is outside ddtrace, reject."""
+    product = BaseProduct()
+    ep = _make_entry_point("evil", "ddtrace", "evil_package.product", product)
+    del ep.dist
+
+    manager = ProductManager()
+    manager.__products__ = {}
+    with patch("ddtrace.internal.products.get_product_entry_points", return_value=[ep]):
+        manager._load_products()
+
+    assert "evil" not in manager.__products__
 
 
 def test_product_manager_is_enabled():


### PR DESCRIPTION
## Description

We introduce a dist check against an allowlist for the product plugin interface to ensure that all registered product plugins come from trusted distributions. Since the interface is internal, currently the only allowed distribution is ddtrace itself.