### PR TITLE
fix(tracing): fix extra_services race condition in SharedStringFile

### DIFF
--- a/ddtrace/internal/ipc.py
+++ b/ddtrace/internal/ipc.py
@@ -111,7 +111,7 @@ class SharedStringFile:
         # the same process, so concurrent put/snatchall from different threads
         # would race on the Python write buffer vs OS flush window.
         # forksafe.Lock() resets after fork so children don't inherit a locked mutex.
-        self._thread_lock = forksafe.Lock()
+        self._file_thread_lock = forksafe.Lock()
 
     def put_unlocked(self, f: typing.BinaryIO, data: str) -> bool:
         f.seek(0, os.SEEK_END)
@@ -184,7 +184,7 @@ class SharedStringFile:
             # file-like so the context manager always yields and callers get [] from peek.
             yield io.BytesIO(b"")
             return
-        with self._thread_lock:
+        with self._file_thread_lock:
             with open_file(self.filename, "rb") as f, ReadLock(f):
                 yield f
 
@@ -199,7 +199,7 @@ class SharedStringFile:
         # Acquire the thread-level lock first to prevent same-process threads
         # from bypassing the POSIX file lock (fcntl.lockf only blocks across
         # processes, not within the same process).
-        with self._thread_lock:
+        with self._file_thread_lock:
             with open_file(self.filename, "r+b") as f, WriteLock(f):
                 yield f
                 # Flush before releasing the lock. Here we first release the lock,

--- a/ddtrace/internal/ipc.py
+++ b/ddtrace/internal/ipc.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import secrets
 import tempfile
+import threading
 import typing
 
 from ddtrace.internal._unpatched import unpatched_open
@@ -105,6 +106,11 @@ class SharedStringFile:
         )
         if self.filename is not None:
             Path(self.filename).touch(exist_ok=True)
+        # Thread-level lock to serialize access within the same process.
+        # POSIX advisory file locks (fcntl.lockf) do NOT block threads within
+        # the same process, so concurrent put/snatchall from different threads
+        # would race on the Python write buffer vs OS flush window.
+        self._thread_lock = threading.Lock()
 
     def put_unlocked(self, f: typing.BinaryIO, data: str) -> None:
         f.seek(0, os.SEEK_END)
@@ -176,8 +182,9 @@ class SharedStringFile:
             # file-like so the context manager always yields and callers get [] from peek.
             yield io.BytesIO(b"")
             return
-        with open_file(self.filename, "rb") as f, ReadLock(f):
-            yield f
+        with self._thread_lock:
+            with open_file(self.filename, "rb") as f, ReadLock(f):
+                yield f
 
     @contextmanager
     def lock_exclusive(self):
@@ -187,9 +194,13 @@ class SharedStringFile:
             # file-like so the context manager always yields and callers run without failing.
             yield io.BytesIO(b"")
             return
-        with open_file(self.filename, "r+b") as f, WriteLock(f):
-            yield f
-            # Flush before releasing the lock. Here we first release the lock,
-            # then close the file. If a read happens in between these two
-            # operations, the reader might see outdated data.
-            f.flush()
+        # Acquire the thread-level lock first to prevent same-process threads
+        # from bypassing the POSIX file lock (fcntl.lockf only blocks across
+        # processes, not within the same process).
+        with self._thread_lock:
+            with open_file(self.filename, "r+b") as f, WriteLock(f):
+                yield f
+                # Flush before releasing the lock. Here we first release the lock,
+                # then close the file. If a read happens in between these two
+                # operations, the reader might see outdated data.
+                f.flush()

--- a/ddtrace/internal/ipc.py
+++ b/ddtrace/internal/ipc.py
@@ -112,16 +112,17 @@ class SharedStringFile:
         if f.tell() + len(dt) <= MAX_FILE_SIZE:
             f.write(dt)
 
-    def put(self, data: str) -> None:
-        """Put a string into the file."""
+    def put(self, data: str) -> bool:
+        """Put a string into the file. Returns True on success, False on failure."""
         if self.filename is None:
-            return
+            return False
 
         try:
             with self.lock_exclusive() as f:
                 self.put_unlocked(f, data)
+            return True
         except Exception:  # nosec
-            pass
+            return False
 
     def peekall_unlocked(self, f: typing.BinaryIO) -> list[str]:
         f.seek(0)

--- a/ddtrace/internal/ipc.py
+++ b/ddtrace/internal/ipc.py
@@ -4,9 +4,9 @@ import os
 from pathlib import Path
 import secrets
 import tempfile
-import threading
 import typing
 
+from ddtrace.internal import forksafe
 from ddtrace.internal._unpatched import unpatched_open
 from ddtrace.internal.logger import get_logger
 
@@ -110,13 +110,16 @@ class SharedStringFile:
         # POSIX advisory file locks (fcntl.lockf) do NOT block threads within
         # the same process, so concurrent put/snatchall from different threads
         # would race on the Python write buffer vs OS flush window.
-        self._thread_lock = threading.Lock()
+        # forksafe.Lock() resets after fork so children don't inherit a locked mutex.
+        self._thread_lock = forksafe.Lock()
 
-    def put_unlocked(self, f: typing.BinaryIO, data: str) -> None:
+    def put_unlocked(self, f: typing.BinaryIO, data: str) -> bool:
         f.seek(0, os.SEEK_END)
         dt = (data + "\x00").encode()
         if f.tell() + len(dt) <= MAX_FILE_SIZE:
             f.write(dt)
+            return True
+        return False
 
     def put(self, data: str) -> bool:
         """Put a string into the file. Returns True on success, False on failure."""
@@ -125,8 +128,7 @@ class SharedStringFile:
 
         try:
             with self.lock_exclusive() as f:
-                self.put_unlocked(f, data)
-            return True
+                return self.put_unlocked(f, data)
         except Exception:  # nosec
             return False
 

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -780,8 +780,8 @@ class Config(object):
         if service_name == self.service or service_name in self._extra_services_sent:
             return
 
-        self._extra_services_queue.put(service_name)
-        self._extra_services_sent.add(service_name)
+        if self._extra_services_queue.put(service_name):
+            self._extra_services_sent.add(service_name)
 
     def _get_extra_services(self) -> set[str]:
         if self._extra_services_queue is None:

--- a/releasenotes/notes/fix-extra-services-silent-write-failure-f052a49089e7bdd0.yaml
+++ b/releasenotes/notes/fix-extra-services-silent-write-failure-f052a49089e7bdd0.yaml
@@ -1,10 +1,5 @@
 ---
 fixes:
   - |
-    tracing: Fixes an issue where a silent write failure in the shared IPC file used to track
-    extra service names caused those names to be permanently excluded from Remote Configuration
-    payloads. Previously, if ``SharedStringFile.put()`` failed (for example, when the file was
-    unavailable), the service name was still recorded as "already sent" in an in-memory set,
-    preventing any future retry. This resulted in the ``extra_services`` field being empty in
-    all subsequent ``/v0.7/config`` requests to the agent. The fix makes ``put()`` return a
-    boolean and only marks the service as sent when the write actually succeeds.
+    tracing: Fixes a race condition where extra service names could be silently dropped from
+    Remote Configuration ``/v0.7/config`` payloads in multi-threaded applications (e.g. uWSGI).

--- a/releasenotes/notes/fix-extra-services-silent-write-failure-f052a49089e7bdd0.yaml
+++ b/releasenotes/notes/fix-extra-services-silent-write-failure-f052a49089e7bdd0.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    tracing: Fixes an issue where a silent write failure in the shared IPC file used to track
+    extra service names caused those names to be permanently excluded from Remote Configuration
+    payloads. Previously, if ``SharedStringFile.put()`` failed (for example, when the file was
+    unavailable), the service name was still recorded as "already sent" in an in-memory set,
+    preventing any future retry. This resulted in the ``extra_services`` field being empty in
+    all subsequent ``/v0.7/config`` requests to the agent. The fix makes ``put()`` return a
+    boolean and only marks the service as sent when the write actually succeeds.


### PR DESCRIPTION
APPSEC-68195 — Fixes a flaky `Test_RemoteConfigurationExtraServices` system test on `uwsgi-poc`.

**Root cause:** `fcntl.lockf` POSIX advisory locks don't block threads within the same process. In multi-threaded apps (uWSGI), the RC polling thread's `snatchall()` races with a request handler's `put()` in the window between the Python write-buffer and the OS flush, permanently dropping extra service names from `/v0.7/config` payloads.

**Fix:**
- Add `forksafe.Lock()` to `SharedStringFile` to serialize same-process thread access (fork-safe, unlike `threading.Lock`).
- `put_unlocked` now returns `bool`; `put()` propagates it so callers don't mark a service as sent on file-full or write failure.

## Test plan
- [x] `tests/internal/service_name/test_extra_services_names.py` passes locally
- [ ] System test `Test_RemoteConfigurationExtraServices` on `uwsgi-poc` no longer flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)