### PR TITLE
ci: update system tests version pin

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@a374e76a2f2b2382adf386e40e14c882a48c8541
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@16f17557c29a294334d1f5a47e4cb6b3ce45f31d
     secrets: inherit
     with:
       library: python_lambda
-      ref: 'a374e76a2f2b2382adf386e40e14c882a48c8541'
+      ref: '16f17557c29a294334d1f5a47e4cb6b3ce45f31d'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@a374e76a2f2b2382adf386e40e14c882a48c8541
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@16f17557c29a294334d1f5a47e4cb6b3ce45f31d
     secrets: inherit
     with:
       library: python
-      ref: 'a374e76a2f2b2382adf386e40e14c882a48c8541'
+      ref: '16f17557c29a294334d1f5a47e4cb6b3ce45f31d'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@a374e76a2f2b2382adf386e40e14c882a48c8541
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@16f17557c29a294334d1f5a47e4cb6b3ce45f31d
     with:
       library: python
-      ref: 'a374e76a2f2b2382adf386e40e14c882a48c8541'
+      ref: '16f17557c29a294334d1f5a47e4cb6b3ce45f31d'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "a374e76a2f2b2382adf386e40e14c882a48c8541"
+  SYSTEM_TESTS_REF: "16f17557c29a294334d1f5a47e4cb6b3ce45f31d"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Description

Update system tests version, to skip flaky system test: https://github.com/DataDog/system-tests/pull/7061

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
