### PR TITLE
chore(crashtracking): remove stale comment

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -189,11 +189,6 @@ def start(additional_tags: Optional[dict[str, str]] = None) -> bool:
             log.error("Failed to start crashtracker: failed to construct crashtracker configuration")
             return False
 
-        # TODO: Add this back in post Code Freeze (need to update config registry)
-        # crashtracker_init(
-        #     config, receiver_config, metadata, emit_runtime_stacks=crashtracker_config.emit_runtime_stacks
-        # )
-
         crashtracker_init(config, receiver_config, metadata)
 
         def crashtracker_fork_handler():


### PR DESCRIPTION
## Description

Remove stale comment. It has been discussed previously that runtime stack emission is just a part of crash reporting; it failing does not block report collection and emission.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
