### PR TITLE
fix: ensure line number in wrapping context footer

### DIFF
--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -659,7 +659,7 @@ class _UniversalWrappingContext(BaseWrappingContext):
 
             bc.append(bytecode.TryEnd(last_try_begin))
             bc.append(except_label)
-            bc.extend(CONTEXT_FOOT.bind({"context_exit": self._exit}))
+            bc.extend(CONTEXT_FOOT.bind({"context_exit": self._exit}, lineno=code.co_firstlineno))
 
             # Mark the function as wrapped by a wrapping context
             t.cast(ContextWrappedFunction, f).__dd_context_wrapped__ = self
@@ -775,7 +775,7 @@ class _UniversalWrappingContext(BaseWrappingContext):
             *bc[i:i], except_label = CONTEXT_HEAD.bind({"context": self}, lineno=code.co_firstlineno)
 
             bc.append(except_label)
-            bc.extend(CONTEXT_FOOT.bind())
+            bc.extend(CONTEXT_FOOT.bind(lineno=code.co_firstlineno))
 
             # Mark the function as wrapped by a wrapping context
             t.cast(ContextWrappedFunction, f).__dd_context_wrapped__ = self

--- a/releasenotes/notes/fix-wrapping-context-foot-lineno-6bef33444e7af257.yaml
+++ b/releasenotes/notes/fix-wrapping-context-foot-lineno-6bef33444e7af257.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    code origin: fixed an issue that could have caused pytest to crash
+    internally when inspecting the call stack from an exception thrown by a view
+    function when Code Origin is enabled.

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -1301,3 +1301,65 @@ async def test_lazy_async_wrapper_throw_forwarding():
             f"[call {call_index}] CancelledError was not forwarded to the inner "
             "coroutine by the lazy wrapper; throw() interception is broken"
         )
+
+
+def test_wrapping_context_foot_has_valid_linenos():
+    """Regression test: CONTEXT_FOOT.bind() must pass lineno to avoid None line numbers.
+
+    The CONTEXT_FOOT assembly (exception-handler epilogue injected by
+    _UniversalWrappingContext.wrap) was previously emitted without line-number
+    information.  inspect.stack() / inspect.getframeinfo() raises TypeError when
+    it encounters a frame whose f_lineno is None, so any tool that inspects the
+    call stack from inside a WrappingContext-wrapped function (e.g. IAST's
+    report_stack) would crash.
+    """
+    stack_from_inside: list = []
+
+    def foo():
+        stack_from_inside.extend(inspect.stack())
+        return 42
+
+    wc = DummyWrappingContext(foo)
+    wc.wrap()
+
+    result = foo()
+    assert result == 42
+
+    for frame_info in stack_from_inside:
+        lineno = frame_info.lineno
+        assert lineno is not None, (
+            f"Frame {frame_info.filename}:{frame_info.function} has lineno=None — "
+            "CONTEXT_FOOT was bound without line-number information"
+        )
+
+
+def test_wrapping_context_foot_has_valid_linenos_on_exception():
+    """Same lineno regression check when the wrapped function raises an exception.
+
+    The CONTEXT_FOOT assembly is only executed when an exception propagates, so
+    the lineno fix must also cover the exception path.
+    """
+    stack_from_handler: list = []
+
+    class _Sentinel(Exception):
+        pass
+
+    class CaptureOnExit(WrappingContext):
+        def __exit__(self, exc_type, exc_value, traceback):
+            stack_from_handler.extend(inspect.stack())
+            return super().__exit__(exc_type, exc_value, traceback)
+
+    def foo():
+        raise _Sentinel("boom")
+
+    CaptureOnExit(foo).wrap()
+
+    with pytest.raises(_Sentinel):
+        foo()
+
+    for frame_info in stack_from_handler:
+        lineno = frame_info.lineno
+        assert lineno is not None, (
+            f"Frame {frame_info.filename}:{frame_info.function} has lineno=None — "
+            "CONTEXT_FOOT exception path was bound without line-number information"
+        )


### PR DESCRIPTION
## Description

We make sure that every bytecode instrumentation block has a valid line number. Many tools/utilities that inspect the call stack expect to find a valid line number instead of None, and would crash otherwise.