### PR TITLE
chore(native): upgrade libdatadog to v35.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,8 +131,8 @@ WHEEL_FLAVOR = "-serverless" if SERVERLESS_BUILD else ""
 LIBDDWAF_VERSION = "1.30.1"
 
 # DEV: update this accordingly when src/native upgrades libdatadog dependency.
-# libdatadog v15.0.0 requires rust 1.78.
-RUST_MINIMUM_VERSION = "1.78"
+# libdatadog v35.0.0 requires rust 1.87.0.
+RUST_MINIMUM_VERSION = "1.87.0"
 
 
 def interpose_sccache():

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -187,8 +187,8 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "34.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "35.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "cbindgen",
  "serde",
@@ -483,7 +483,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "chrono",
  "derive_more",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "datadog-remote-config"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "base64",
@@ -1408,7 +1408,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1418,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "bytes",
  "http",
@@ -1441,8 +1441,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "4.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "4.2.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1480,8 +1480,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "34.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "35.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1527,8 +1527,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "prost",
 ]
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1583,8 +1583,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-library-config"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "libc",
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "chrono",
  "tracing",
@@ -1623,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "prost",
 ]
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "async-trait",
  "futures",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "serde",
 ]
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1751,8 +1751,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "3.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "prost",
  "serde",
@@ -1777,8 +1777,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1802,8 +1802,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+version = "6.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "base64",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "libdd-tracer-flare"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v34.0.0#3cc5a96ee3edeb512d141e79cad2ac0b0fded434"
+source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
  "bytes",

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -22,31 +22,31 @@ libc = { version = "0.2", optional = true }
 rand = "0.9"
 rustc-hash = "1.1"
 serde = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
 serde_json = "1.0"
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", features = [
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", features = [
   "stats-obfuscation"
 ] }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true, features = [
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", optional = true }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
 pyo3 = { version = "0.28", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v34.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", features = [
     "cbindgen",
 ] }
 

--- a/src/native/py_string.rs
+++ b/src/native/py_string.rs
@@ -219,6 +219,12 @@ impl std::fmt::Debug for PyBackedString {
     }
 }
 
+impl From<String> for PyBackedString {
+    fn from(_s: String) -> Self {
+        todo!()
+    }
+}
+
 impl SpanText for PyBackedString {
     fn from_static_str(value: &'static str) -> Self {
         Self {


### PR DESCRIPTION
## Description

Updates to libdatadog v35 to pull in a [bug fix](https://github.com/DataDog/libdatadog/pull/2014) for the OTLP trace export pipeline.

## Testing


## Risks

Minimal. Only the libdatadog dependencies have been updated, not other crates

## Additional Notes

