### PR TITLE
fix(llmobs): correctly nest parallel tool spans under step span [MLOB-7551]

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -343,10 +343,13 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         tool_id = getattr(block, "id", "")
         tool_name = getattr(block, "name", "unknown_tool")
         tool_input = getattr(block, "input", {})
+        # Tool spans belong to the current step, not the active tracer context (which is the
+        # previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
         tool_span = self.integration.trace(
             "claude_agent_sdk.tool",
             submit_to_llmobs=True,
             span_name=f"claude_agent_sdk.tool.{tool_name}",
+            parent_context=self.current_step_span,
         )
         if self._last_llm_span_ref is not None:
             add_span_link(

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -343,8 +343,10 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         tool_id = getattr(block, "id", "")
         tool_name = getattr(block, "name", "unknown_tool")
         tool_input = getattr(block, "input", {})
-        # Tool spans belong to the current step, not the active tracer context (which is the
-        # previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
+        # AIDEV-NOTE: Tool spans belong to the current step, not the active tracer context (which
+        # is the previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
+        # BaseLLMIntegration.trace() hardcodes activate=True, so each opened tool span becomes
+        # the active context — without an explicit parent_context, tool#k would chain on tool#k-1.
         tool_span = self.integration.trace(
             "claude_agent_sdk.tool",
             submit_to_llmobs=True,

--- a/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue with the ``claude_agent_sdk`` integration where
+    parallel tool spans were incorrectly nested in a chain (``tool#2`` parented on ``tool#1``)
+    instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
+    parented on the current step span explicitly, so parallel ``ToolUseBlock``s — whether the SDK
+    delivers them in one ``AssistantMessage`` or across several — render as siblings in the
+    trace tree.

--- a/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
@@ -2,8 +2,8 @@
 fixes:
   - |
     LLM Observability: This fix resolves an issue with the ``claude_agent_sdk`` integration where
-    parallel tool spans were incorrectly nested in a chain (``tool#2`` parented on ``tool#1``)
-    instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
-    parented on the current step span explicitly, so parallel ``ToolUseBlock``s — whether the SDK
-    delivers them in one ``AssistantMessage`` or across several — render as siblings in the
-    trace tree.
+    parallel tool spans were incorrectly recorded as a chain (each tool parented on the previous
+    tool) instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
+    parented on the current step span explicitly, so parallel tool calls — whether the SDK
+    delivers them in one assistant message or across several — share the correct parent in the
+    span data.

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -14,6 +14,7 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_RESPONSE_SEQUENC
 from tests.contrib.claude_agent_sdk.utils import MOCK_CLIENT_RAW_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_DOUBLE_ASSISTANT_NO_TOOLS_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_GREP_TOOL_RESPONSE_SEQUENCE
+from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_TOOL_USE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE
@@ -94,6 +95,12 @@ def mock_internal_client_tool_use(claude_agent_sdk):
 @pytest.fixture
 def mock_internal_client_parallel_tool_use(claude_agent_sdk):
     with _create_mock_internal_client(MOCK_PARALLEL_TOOL_USE_SEQUENCE):
+        yield
+
+
+@pytest.fixture
+def mock_internal_client_parallel_tool_use_separate_messages(claude_agent_sdk):
+    with _create_mock_internal_client(MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES):
         yield
 
 

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -899,8 +899,9 @@ class TestLLMObsClaudeAgentSdk:
 
         Every parallel tool span gets a link from the same llm span
         (``llm#1 → tool#k``), every parallel tool span links to the next llm
-        span (``tool#k → llm#2``), and no tool span links to any other tool
-        span (parallel tools are siblings, not a chain).
+        span (``tool#k → llm#2``), no tool span links to any other tool span,
+        and every tool span shares the same ``parent_id`` (= step#1) so the
+        trace data records them as siblings, not a chain (MLOB-7551).
         """
         prompt = "Run three Bash commands in parallel."
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -980,6 +981,14 @@ class TestLLMObsClaudeAgentSdk:
         for tool_span in tool_spans:
             _assert_span_link(llm_spans[0], tool_span, "output", "input")
             _assert_span_link(tool_span, llm_spans[1], "output", "input")
+
+        # No tool → tool link: parallel tools are siblings, not chained.
+        for tool_span in tool_spans:
+            for link in get_llmobs_span_links(tool_span) or []:
+                assert link["span_id"] not in {str(s.span_id) for s in tool_spans}, (
+                    f"Tool span {tool_span.span_id} unexpectedly links to another tool span "
+                    f"({link['span_id']}); parallel tools should be siblings, not chained."
+                )
 
         # Step-to-step link is still emitted alongside the fan-out.
         _assert_span_link(step_spans[0], step_spans[1], "output", "input")

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -919,6 +919,10 @@ class TestLLMObsClaudeAgentSdk:
         assert len(tool_spans) == 3
         assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
 
+        # Regression: MLOB-7551 — parallel tools must be siblings under step#1, not chained.
+        for tool_span in tool_spans:
+            assert tool_span.parent_id == step_spans[0].span_id
+
         # Fan-out: each tool gets one incoming link from llm#1.
         for tool_span in tool_spans:
             _assert_span_link(llm_spans[0], tool_span, "output", "input")
@@ -934,6 +938,48 @@ class TestLLMObsClaudeAgentSdk:
                     f"Tool span {tool_span.span_id} unexpectedly links to another tool span "
                     f"({link['span_id']}); parallel tools should be siblings, not chained."
                 )
+
+        # Step-to-step link is still emitted alongside the fan-out.
+        _assert_span_link(step_spans[0], step_spans[1], "output", "input")
+
+    async def test_llmobs_parallel_tool_use_separate_messages_nests_under_one_step(
+        self,
+        claude_agent_sdk,
+        mock_internal_client_parallel_tool_use_separate_messages,
+        claude_agent_sdk_llmobs,
+        test_spans,
+    ):
+        """N separate AssistantMessages (one ToolUseBlock each) followed by one UserMessage with
+        all N ToolResultBlocks still fan out under one step span: parent_id, fan-out from llm#1,
+        and fan-in to llm#2 all match the single-AssistantMessage case.
+        """
+        prompt = "Run three Bash commands in parallel (one AssistantMessage each)."
+        async for _ in claude_agent_sdk.query(prompt=prompt):
+            pass
+
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        llm_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.llm"], key=lambda s: s.start_ns)
+        step_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.step"], key=lambda s: s.start_ns)
+        tool_spans = [s for s in spans if "tool" in s.name]
+
+        # Sequence: 3 × assistant(1 ToolUseBlock) → user(3 ToolResultBlocks) → final assistant(text)
+        # → result. The three ToolUseBlocks land before any ToolResultBlock, so they share one
+        # step span (step#1). The final text-only assistant message opens step#2 + llm#2.
+        assert len(step_spans) == 2
+        assert len(llm_spans) == 2
+        assert len(tool_spans) == 3
+        assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
+
+        # Regression: MLOB-7551 — parallel tools must be siblings under step#1, not chained.
+        for tool_span in tool_spans:
+            assert tool_span.parent_id == step_spans[0].span_id
+
+        # Fan-out and fan-in span links must hold for the separate-messages wire pattern too:
+        # every tool links from llm#1 (the only llm span that observed a ToolUseBlock) and
+        # forward into llm#2 (the next inference cycle).
+        for tool_span in tool_spans:
+            _assert_span_link(llm_spans[0], tool_span, "output", "input")
+            _assert_span_link(tool_span, llm_spans[1], "output", "input")
 
         # Step-to-step link is still emitted alongside the fan-out.
         _assert_span_link(step_spans[0], step_spans[1], "output", "input")

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -294,6 +294,25 @@ MOCK_PARALLEL_TOOL_USE_SEQUENCE = [
 ]
 
 
+# Parallel tools delivered as N AssistantMessages (1 ToolUseBlock each) + 1 UserMessage
+# carrying all N ToolResultBlocks — the wire pattern the SDK emits in practice (MLOB-7551).
+MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES = [
+    MOCK_SYSTEM_MESSAGE,
+    create_mock_assistant_message_with_tool_use(
+        [("Bash", {"command": "echo first"}, MOCK_PARALLEL_BASH_TOOL_IDS[0])],
+    ),
+    create_mock_assistant_message_with_tool_use(
+        [("Bash", {"command": "echo second"}, MOCK_PARALLEL_BASH_TOOL_IDS[1])],
+    ),
+    create_mock_assistant_message_with_tool_use(
+        [("Bash", {"command": "echo third"}, MOCK_PARALLEL_BASH_TOOL_IDS[2])],
+    ),
+    MOCK_PARALLEL_TOOL_RESULT_USER,
+    MOCK_FINAL_ASSISTANT,
+    MOCK_MULTI_TURN_RESULT_MESSAGE,
+]
+
+
 MOCK_TOOL_ERROR_MESSAGE = "Permission denied: /etc/hostname"
 MOCK_TOOL_ERROR_USER_READ = create_mock_user_message_with_tool_result(
     [(MOCK_READ_TOOL_ID, MOCK_TOOL_ERROR_MESSAGE)],


### PR DESCRIPTION
## Description

Fixes [MLOB-7551](https://datadoghq.atlassian.net/browse/MLOB-7551). Parallel `ToolUseBlock` spans in `claude_agent_sdk` chained (`tool#2.parent = tool#1`) instead of becoming siblings under one `claude_agent_sdk.step`. APM flame graph and any `parent_id` consumer saw a wrong agent shape. Span links from #18270 are independent of `parent_id`, so the Execution Graph view was unaffected.

**Root cause.** `BaseLLMIntegration.trace()` defaults `parent_context` to `tracer.context_provider.active()` and hardcodes `activate=True`. `_handle_tool_use_block` didn't pass `parent_context`, so each new tool's default parent was the previous tool (still active inside the loop, not yet finalized).

**Fix.** Pass `parent_context=self.current_step_span` explicitly. One added kwarg + an `AIDEV-NOTE` explaining why.

## Testing

- `parent_id` regression guard added to the existing parallel test (previously only asserted span links — the bug went uncaught).
- New `test_llmobs_parallel_tool_use_separate_messages_nests_under_one_step` covers the real-SDK wire pattern (3 separate `AssistantMessage`s × 1 `ToolUseBlock`; the original mock assumed 1×N).
- Both parallel tests fail without the fix and pass with it. Full `tests/contrib/claude_agent_sdk/` 48/48 green under `scripts/run-tests` venv 16dd69c (Py 3.12). Lint + banned-terms clean.

**Live preprod evidence** — `parent_id` printed at tool-span creation, real Claude API via AI Gateway:

```
BEFORE  step.span_id = 12109069949826373390
  tool#1.parent_id = 12109069949826373390  ✓ (= step)
  tool#2.parent_id = 13287564766609276538  ✗ (= tool#1 — CHAIN)
  tool#3.parent_id = 5356634624914070624   ✗ (= tool#2 — CHAIN)

AFTER   step.span_id = 11192547564728748346
  tool#1/2/3.parent_id = 11192547564728748346   ✓ (all = step — SIBLINGS)
```

- BEFORE trace: https://dd.datad0g.com/llm/traces?query=trace_id:6a1f0b41000000002202be8a5b6ccbbd
- AFTER trace: https://dd.datad0g.com/llm/traces?query=trace_id:6a1f0bc000000000ef98adffb8a2c1d0

## Risks

Integration-local. One-line revert if anything regresses. Sibling integrations (`openai_agents`, `crewai`, `pydantic_ai`, `langgraph`) don't have long-lived overlapping spans inside a tight loop, so they aren't susceptible to this bug class.

[MLOB-7551]: https://datadoghq.atlassian.net/browse/MLOB-7551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ