### PR TITLE
chore(vendor): preserve raw container ID in DogStatsD header for backward compat

### DIFF
--- a/ddtrace/vendor/dogstatsd/container.py
+++ b/ddtrace/vendor/dogstatsd/container.py
@@ -19,9 +19,10 @@ class ContainerID(object):
     """
     A reader class that retrieves either:
     - The current container ID parsed from the cgroup file (cgroup v1 / host
-      cgroup namespace), prefixed with `ci-`.
+      cgroup namespace), returned as the raw hex ID for backward compatibility
+      with all Agent versions.
     - The cgroup controller inode (cgroup v2 / non-host cgroup namespace),
-      prefixed with `in-`.
+      prefixed with `in-`, understood by Agent >= 7.51.
 
     Both forms are understood by the Datadog Agent's origin detection, which
     uses them to enrich DogStatsD metrics with orchestrator tags such as
@@ -69,9 +70,13 @@ class ContainerID(object):
             return False
 
     def _read_cgroup_path(self) -> Optional[str]:
-        """Read the container ID from the cgroup file, prefixed with `ci-`."""
-        container_id = self._read_container_id(self.CGROUP_PATH)
-        return "ci-{0}".format(container_id) if container_id else None
+        """Read the raw container ID from the cgroup file.
+
+        Returns the unprefixed hex ID so that the DogStatsD ``|c:`` header
+        remains compatible with all Agent versions (pre-7.51 Agents only
+        understand the raw form; newer Agents accept it too).
+        """
+        return self._read_container_id(self.CGROUP_PATH)
 
     def _get_cgroup_from_inode(self) -> Optional[str]:
         """Read the container ID from the cgroup controller inode (`in-<inode>`).

--- a/tests/vendor/test_dogstatsd_container.py
+++ b/tests/vendor/test_dogstatsd_container.py
@@ -1,15 +1,10 @@
 """Tests for the vendored DogStatsD container-ID reader.
 
-Covers the cgroup v2 origin-detection fix (new code):
-  - ContainerID.__init__: delegates to path-read vs inode-fallback
-  - ContainerID._is_host_cgroup_namespace
-  - ContainerID._read_cgroup_path
-  - ContainerID._get_cgroup_from_inode
-
-And the pre-existing _read_container_id helper:
-  - TestReadContainerIdFound
-  - TestReadContainerIdNotFound
-  - TestReadContainerIdErrors
+- ContainerID.__init__: delegates to path-read vs inode-fallback
+- ContainerID._is_host_cgroup_namespace
+- ContainerID._read_cgroup_path (returns raw container ID, no ci- prefix)
+- ContainerID._get_cgroup_from_inode (returns in-<inode>)
+- ContainerID._read_container_id (raw parsing helper)
 """
 
 import errno
@@ -132,17 +127,17 @@ class TestReadCgroupPath:
         reader.CGROUP_PATH = _write_cgroup(cgroup_content)
         return reader
 
-    def test_returns_ci_prefixed_id_for_docker_cgroup_v1(self) -> None:
+    def test_returns_raw_id_for_docker_cgroup_v1(self) -> None:
         reader: ContainerID = self._make_reader(DOCKER_CGROUP_V1)
         try:
-            assert reader._read_cgroup_path() == f"ci-{CONTAINER_ID_64}"
+            assert reader._read_cgroup_path() == CONTAINER_ID_64
         finally:
             os.unlink(reader.CGROUP_PATH)
 
-    def test_returns_ci_prefixed_id_for_k8s_cgroup_v1(self) -> None:
+    def test_returns_raw_id_for_k8s_cgroup_v1(self) -> None:
         reader: ContainerID = self._make_reader(K8S_CGROUP_V1)
         try:
-            assert reader._read_cgroup_path() == f"ci-{CONTAINER_ID_K8S}"
+            assert reader._read_cgroup_path() == CONTAINER_ID_K8S
         finally:
             os.unlink(reader.CGROUP_PATH)
 
@@ -235,14 +230,14 @@ class TestGetCgroupFromInode:
 
 class TestContainerIDInit:
     def test_uses_cgroup_path_when_parseable(self) -> None:
-        # ci- path is always tried first; inode is never consulted when it succeeds.
+        # cgroup path is always tried first; inode is never consulted when it succeeds.
         with (
-            mock.patch.object(ContainerID, "_read_cgroup_path", return_value=f"ci-{CONTAINER_ID_64}") as mock_path,
+            mock.patch.object(ContainerID, "_read_cgroup_path", return_value=CONTAINER_ID_64) as mock_path,
             mock.patch.object(ContainerID, "_is_host_cgroup_namespace") as mock_ns,
             mock.patch.object(ContainerID, "_get_cgroup_from_inode") as mock_inode,
         ):
             reader: ContainerID = ContainerID()
-            assert reader.container_id == f"ci-{CONTAINER_ID_64}"
+            assert reader.container_id == CONTAINER_ID_64
             mock_path.assert_called_once()
             mock_ns.assert_not_called()
             mock_inode.assert_not_called()


### PR DESCRIPTION
## Description

Follow-up to #18388.

Discovered via bot comment: https://github.com/DataDog/dd-trace-py/pull/18407#discussion_r3342037950

The `ci-` prefix added to `_read_cgroup_path()` in that PR introduced a silent regression for deployments running Agents older than 7.51 (pre-DogStatsD v1.4 protocol). Those Agents only understand the raw `|c:<container_id>` form.

This same fix was also applied to both open backport PRs (#18407, #18408).

A separate PR (#18416) will align the full `container.py` with upstream datadogpy 0.52.1 and will carry this fix as one of its documented local patches.

[PROF-14794]: https://datadoghq.atlassian.net/browse/PROF-14794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ