### PR TITLE
fix(llmobs): surface descriptive API error in claude_agent_sdk error message

### DIFF
--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 from typing import Optional
 
@@ -291,6 +292,10 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
         ``API Error: {...}`` payload returned by the API — lives in the message's
         ``TextBlock`` content, so we surface that text as the error message and fall back
         to the category when no text content is present.
+
+        Uncategorized errors collapse to "unknown", but the embedded ``API Error: {...}``
+        payload often carries a more specific type (e.g. "overloaded_error"). When the
+        category is "unknown" we try to recover that specific type from the message.
         """
         error = _get_attr(msg, "error", None)
         if not error:
@@ -305,7 +310,29 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
                     if text:
                         text_parts.append(str(text))
         error_message = "\n".join(text_parts) or error_type
+        if error_type == "unknown":
+            error_type = self._parse_error_type(error_message) or error_type
         return error_type, error_message
+
+    def _parse_error_type(self, message: str) -> str:
+        """Best-effort extract a specific error type from an ``API Error: {...}`` payload.
+
+        The message embeds a JSON object shaped like
+        ``{"type": "error", "error": {"type": "overloaded_error", ...}}``; return the
+        nested ``error.type`` when present, else "".
+        """
+        start = message.find("{")
+        if start == -1:
+            return ""
+        try:
+            payload, _ = json.JSONDecoder().raw_decode(message[start:])
+        except ValueError:
+            return ""
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict) and error.get("type"):
+                return str(error["type"])
+        return ""
 
     def _extract_usage(self, message: Any) -> dict[str, int]:
         metrics: dict[str, int] = {}

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from typing import Optional
 
@@ -15,6 +14,7 @@ from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
+from ddtrace.llmobs._utils import safe_load_json
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import ToolCall
 from ddtrace.llmobs.types import ToolResult
@@ -317,21 +317,18 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
     def _parse_error_type(self, message: str) -> str:
         """Best-effort extract a specific error type from an ``API Error: {...}`` payload.
 
-        The message embeds a JSON object shaped like
-        ``{"type": "error", "error": {"type": "overloaded_error", ...}}``; return the
-        nested ``error.type`` when present, else "".
+        The content text isn't valid JSON on its own — it's prefixed with a human-readable
+        label (e.g. ``API Error: {...}``) — so we decode from the first ``{``. The embedded
+        object is shaped like ``{"type": "error", "error": {"type": "overloaded_error", ...}}``;
+        return the nested ``error.type`` when present, else "".
         """
         start = message.find("{")
         if start == -1:
             return ""
-        try:
-            payload, _ = json.JSONDecoder().raw_decode(message[start:])
-        except ValueError:
-            return ""
-        if isinstance(payload, dict):
-            error = payload.get("error")
-            if isinstance(error, dict) and error.get("type"):
-                return str(error["type"])
+        payload = safe_load_json(message[start:])
+        error = payload.get("error") if isinstance(payload, dict) else None
+        if isinstance(error, dict) and error.get("type"):
+            return str(error["type"])
         return ""
 
     def _extract_usage(self, message: Any) -> dict[str, int]:

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -14,7 +14,6 @@ from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
-from ddtrace.llmobs._utils import safe_load_json
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import ToolCall
 from ddtrace.llmobs.types import ToolResult
@@ -288,14 +287,11 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
         """Return (error_type, error_message) for an AssistantMessage carrying an error.
 
         The SDK's ``AssistantMessage.error`` is a coarse category literal (e.g. "unknown",
-        "invalid_request", "rate_limit"). The descriptive message — such as the raw
-        ``API Error: {...}`` payload returned by the API — lives in the message's
-        ``TextBlock`` content, so we surface that text as the error message and fall back
-        to the category when no text content is present.
-
-        Uncategorized errors collapse to "unknown", but the embedded ``API Error: {...}``
-        payload often carries a more specific type (e.g. "overloaded_error"). When the
-        category is "unknown" we try to recover that specific type from the message.
+        "invalid_request", "rate_limit") with no structured payload — the descriptive
+        message, such as the raw ``API Error: {...}`` text returned by the API, lives in
+        the message's ``TextBlock`` content instead. We keep the category as the error type
+        and surface that content text as the error message, falling back to the category
+        when no text content is present.
         """
         error = _get_attr(msg, "error", None)
         if not error:
@@ -310,26 +306,7 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
                     if text:
                         text_parts.append(str(text))
         error_message = "\n".join(text_parts) or error_type
-        if error_type == "unknown":
-            error_type = self._parse_error_type(error_message) or error_type
         return error_type, error_message
-
-    def _parse_error_type(self, message: str) -> str:
-        """Best-effort extract a specific error type from an ``API Error: {...}`` payload.
-
-        The content text isn't valid JSON on its own — it's prefixed with a human-readable
-        label (e.g. ``API Error: {...}``) — so we decode from the first ``{``. The embedded
-        object is shaped like ``{"type": "error", "error": {"type": "overloaded_error", ...}}``;
-        return the nested ``error.type`` when present, else "".
-        """
-        start = message.find("{")
-        if start == -1:
-            return ""
-        payload = safe_load_json(message[start:])
-        error = payload.get("error") if isinstance(payload, dict) else None
-        if isinstance(error, dict) and error.get("type"):
-            return str(error["type"])
-        return ""
 
     def _extract_usage(self, message: Any) -> dict[str, int]:
         metrics: dict[str, int] = {}

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -82,11 +82,11 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             output_messages = self.parse_content_blocks("assistant", content)
             if _get_attr(response, "usage", None):
                 metrics = self._extract_usage(response)
-            error = _get_attr(response, "error", None)
-            if error:
+            error_type, error_message = self._extract_assistant_error(response)
+            if error_type:
                 span.error = 1
-                span.set_tag(ERROR_TYPE, error)
-                span.set_tag(ERROR_MSG, error)
+                span.set_tag(ERROR_TYPE, error_type)
+                span.set_tag(ERROR_MSG, error_message)
         input_messages: list[Message] = (kwargs or {}).get("input_messages") or []
         _annotate_llmobs_span_data(
             span,
@@ -130,10 +130,11 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             )
             if stop_reason:
                 metadata["stop_reason"] = stop_reason
-            if assistant_error:
+            error_type, error_message = assistant_error
+            if error_type:
                 span.error = 1
-                span.set_tag(ERROR_TYPE, assistant_error)
-                span.set_tag(ERROR_MSG, assistant_error)
+                span.set_tag(ERROR_TYPE, error_type)
+                span.set_tag(ERROR_MSG, error_message)
 
         agent_manifest = self._build_agent_manifest(model, metadata, init_system_message)
 
@@ -235,15 +236,17 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
 
         return messages
 
-    def _extract_output_data(self, response: Any) -> tuple[list[Message], dict[str, int], dict[str, Any], str, str]:
+    def _extract_output_data(
+        self, response: Any
+    ) -> tuple[list[Message], dict[str, int], dict[str, Any], str, tuple[str, str]]:
         """Extract output data from response, including output messages, usage metrics, init system message,
-        stop reason, and assistant error.
+        stop reason, and assistant error as a (error_type, error_message) tuple.
         """
         output_messages: list[Message] = []
         metrics: dict[str, int] = {}
         init_system_message: dict[str, Any] = {}
         stop_reason: str = ""
-        assistant_error: str = ""
+        assistant_error: tuple[str, str] = ("", "")
 
         if not response or not isinstance(response, list):
             return [Message(content="")], metrics, init_system_message, stop_reason, assistant_error
@@ -253,8 +256,8 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             if msg_type == "AssistantMessage":
                 content = _get_attr(msg, "content", []) or []
                 output_messages.extend(self.parse_content_blocks("assistant", content))
-                if not assistant_error:
-                    assistant_error = _get_attr(msg, "error", "") or ""
+                if not assistant_error[0]:
+                    assistant_error = self._extract_assistant_error(msg)
             elif msg_type == "SystemMessage":
                 data = _get_attr(msg, "data", {}) or {}
                 if data:
@@ -279,6 +282,30 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
                     )
 
         return output_messages or [Message(content="")], metrics, init_system_message, stop_reason, assistant_error
+
+    def _extract_assistant_error(self, msg: Any) -> tuple[str, str]:
+        """Return (error_type, error_message) for an AssistantMessage carrying an error.
+
+        The SDK's ``AssistantMessage.error`` is a coarse category literal (e.g. "unknown",
+        "invalid_request", "rate_limit"). The descriptive message — such as the raw
+        ``API Error: {...}`` payload returned by the API — lives in the message's
+        ``TextBlock`` content, so we surface that text as the error message and fall back
+        to the category when no text content is present.
+        """
+        error = _get_attr(msg, "error", None)
+        if not error:
+            return "", ""
+        error_type = str(error)
+        content = _get_attr(msg, "content", []) or []
+        text_parts: list[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if type(block).__name__ == "TextBlock":
+                    text = _get_attr(block, "text", "") or ""
+                    if text:
+                        text_parts.append(str(text))
+        error_message = "\n".join(text_parts) or error_type
+        return error_type, error_message
 
     def _extract_usage(self, message: Any) -> dict[str, int]:
         metrics: dict[str, int] = {}

--- a/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where an agent or
+    LLM span's error message was set to the SDK's coarse error category (e.g. ``unknown``) for both the
+    error type and message, producing an unhelpful ``unknown: unknown`` error. The descriptive API error
+    text (e.g. an ``overloaded_error`` payload) carried in the assistant message content is now surfaced
+    as the error message, while the category is retained as the error type.

--- a/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
@@ -1,8 +1,7 @@
 ---
 fixes:
   - |
-    LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where an agent or
-    LLM span's error message was set to the SDK's coarse error category (e.g. ``unknown``) for both the
-    error type and message, producing an unhelpful ``unknown: unknown`` error. The descriptive API error
-    text (e.g. an ``overloaded_error`` payload) carried in the assistant message content is now surfaced
-    as the error message, while the category is retained as the error type.
+    LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where a span's
+    error message showed an uncategorized ``unknown`` error category from the upstream Claude Agent SDK
+    instead of a descriptive API error. The integration now surfaces a detailed error message from the
+    assistant message content.

--- a/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
@@ -4,5 +4,4 @@ fixes:
     LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where a span's
     error type and message showed an uncategorized ``unknown`` error category from the upstream Claude
     Agent SDK instead of a descriptive API error. The integration now surfaces a detailed error message
-    from the assistant message content, and recovers the specific error type (e.g. ``overloaded_error``)
-    from that content when the SDK reports only the ``unknown`` category.
+    and error type from the assistant message content.

--- a/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where a span's
-    error type and message showed an uncategorized ``unknown`` error category from the upstream Claude
-    Agent SDK instead of a descriptive API error. The integration now surfaces a detailed error message
-    and error type from the assistant message content.
+    error message showed an uncategorized ``unknown`` error category from the upstream Claude Agent SDK
+    instead of a descriptive API error. The integration now surfaces the detailed error message from the
+    assistant message content.

--- a/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-error-message-7c3e1d9b2a4f6058.yaml
@@ -2,6 +2,7 @@
 fixes:
   - |
     LLM Observability: This fix resolves an issue in the Claude Agent SDK integration where a span's
-    error message showed an uncategorized ``unknown`` error category from the upstream Claude Agent SDK
-    instead of a descriptive API error. The integration now surfaces a detailed error message from the
-    assistant message content.
+    error type and message showed an uncategorized ``unknown`` error category from the upstream Claude
+    Agent SDK instead of a descriptive API error. The integration now surfaces a detailed error message
+    from the assistant message content, and recovers the specific error type (e.g. ``overloaded_error``)
+    from that content when the SDK reports only the ``unknown`` category.

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -10,6 +10,7 @@ from ddtrace.contrib.internal.claude_agent_sdk.patch import patch
 from ddtrace.contrib.internal.claude_agent_sdk.patch import unpatch
 from ddtrace.llmobs import LLMObs
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_SEQUENCE
+from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TEXT_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_CLIENT_RAW_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_GREP_TOOL_RESPONSE_SEQUENCE
@@ -122,6 +123,12 @@ def mock_internal_client_with_usage(claude_agent_sdk):
 @pytest.fixture
 def mock_internal_client_assistant_message_error(claude_agent_sdk):
     with _create_mock_internal_client(MOCK_ASSISTANT_MESSAGE_ERROR_SEQUENCE):
+        yield
+
+
+@pytest.fixture
+def mock_internal_client_assistant_message_error_text(claude_agent_sdk):
+    with _create_mock_internal_client(MOCK_ASSISTANT_MESSAGE_ERROR_TEXT_SEQUENCE):
         yield
 
 

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -10,6 +10,8 @@ from tests.contrib.claude_agent_sdk.utils import EXPECTED_ASSISTANT_USAGE
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_QUERY_USAGE
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_SYSTEM_MESSAGE_DATA
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR
+from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TEXT
+from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TYPE
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_ID
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_INPUT
 from tests.contrib.claude_agent_sdk.utils import MOCK_FINAL_ASSISTANT_TEXT
@@ -272,6 +274,65 @@ class TestLLMObsClaudeAgentSdk:
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
             metrics=EXPECTED_QUERY_USAGE,
             error={"type": MOCK_ASSISTANT_MESSAGE_ERROR, "message": MOCK_ASSISTANT_MESSAGE_ERROR, "stack": ANY},
+            tags=COMMON_TAGS,
+        )
+
+    async def test_llmobs_assistant_message_error_uses_content_text_as_message(
+        self, claude_agent_sdk, mock_internal_client_assistant_message_error_text, claude_agent_sdk_llmobs, test_spans
+    ):
+        """When the SDK reports a coarse error category (e.g. "unknown") but the descriptive
+        API error lives in the assistant message content, the error message should be the
+        content text rather than the category literal.
+        """
+        prompt = "Hello"
+        async for _ in claude_agent_sdk.query(prompt=prompt):
+            pass
+
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 3
+        agent_span = spans[0]
+        step_span = next(s for s in spans if s.name == "claude_agent_sdk.step")
+        llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
+
+        input_msgs = [{"content": prompt, "role": "user"}]
+        expected_error = {
+            "type": MOCK_ASSISTANT_MESSAGE_ERROR_TYPE,
+            "message": MOCK_ASSISTANT_MESSAGE_ERROR_TEXT,
+            "stack": ANY,
+        }
+
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
+            span_kind="llm",
+            model_name=MOCK_MODEL,
+            model_provider="anthropic",
+            input_messages=input_msgs,
+            output_messages=[{"content": MOCK_ASSISTANT_MESSAGE_ERROR_TEXT, "role": "assistant"}],
+            error=expected_error,
+            tags=COMMON_TAGS,
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(step_span),
+            span_kind="step",
+            input_value=safe_json(input_msgs),
+            output_value=safe_json([{"content": MOCK_ASSISTANT_MESSAGE_ERROR_TEXT, "role": "assistant"}]),
+            error=expected_error,
+            tags=COMMON_TAGS,
+        )
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(agent_span),
+            span_kind="agent",
+            input_value=safe_json(input_msgs),
+            output_value=safe_json(
+                [
+                    {"content": safe_json(EXPECTED_SYSTEM_MESSAGE_DATA), "role": "system"},
+                    {"content": MOCK_ASSISTANT_MESSAGE_ERROR_TEXT, "role": "assistant"},
+                    {"content": "4", "role": "assistant"},
+                ]
+            ),
+            metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
+            metrics=EXPECTED_QUERY_USAGE,
+            error=expected_error,
             tags=COMMON_TAGS,
         )
 

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -11,7 +11,7 @@ from tests.contrib.claude_agent_sdk.utils import EXPECTED_QUERY_USAGE
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_SYSTEM_MESSAGE_DATA
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TEXT
-from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_PARSED_ERROR_TYPE
+from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TYPE
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_ID
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_INPUT
 from tests.contrib.claude_agent_sdk.utils import MOCK_FINAL_ASSISTANT_TEXT
@@ -282,8 +282,8 @@ class TestLLMObsClaudeAgentSdk:
     ):
         """When the SDK reports a coarse error category (e.g. "unknown") but the descriptive
         API error lives in the assistant message content, the error message should be the
-        content text and the error type should be the specific type parsed from that
-        content (e.g. "overloaded_error") rather than the category literal.
+        content text rather than the category literal, while the error type stays the
+        category reported by the SDK.
         """
         prompt = "Hello"
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -297,7 +297,7 @@ class TestLLMObsClaudeAgentSdk:
 
         input_msgs = [{"content": prompt, "role": "user"}]
         expected_error = {
-            "type": MOCK_ASSISTANT_MESSAGE_PARSED_ERROR_TYPE,
+            "type": MOCK_ASSISTANT_MESSAGE_ERROR_TYPE,
             "message": MOCK_ASSISTANT_MESSAGE_ERROR_TEXT,
             "stack": ANY,
         }

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -11,7 +11,7 @@ from tests.contrib.claude_agent_sdk.utils import EXPECTED_QUERY_USAGE
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_SYSTEM_MESSAGE_DATA
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TEXT
-from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TYPE
+from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_PARSED_ERROR_TYPE
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_ID
 from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_INPUT
 from tests.contrib.claude_agent_sdk.utils import MOCK_FINAL_ASSISTANT_TEXT
@@ -282,7 +282,8 @@ class TestLLMObsClaudeAgentSdk:
     ):
         """When the SDK reports a coarse error category (e.g. "unknown") but the descriptive
         API error lives in the assistant message content, the error message should be the
-        content text rather than the category literal.
+        content text and the error type should be the specific type parsed from that
+        content (e.g. "overloaded_error") rather than the category literal.
         """
         prompt = "Hello"
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -296,7 +297,7 @@ class TestLLMObsClaudeAgentSdk:
 
         input_msgs = [{"content": prompt, "role": "user"}]
         expected_error = {
-            "type": MOCK_ASSISTANT_MESSAGE_ERROR_TYPE,
+            "type": MOCK_ASSISTANT_MESSAGE_PARSED_ERROR_TYPE,
             "message": MOCK_ASSISTANT_MESSAGE_ERROR_TEXT,
             "stack": ANY,
         }

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -181,10 +181,14 @@ MOCK_ASSISTANT_MESSAGE_ERROR_TEXT = (
     'API Error: {"type":"error","error":{"details":null,"type":"overloaded_error",'
     '"message":"Overloaded"},"request_id":"req_011Cbd5D168oye3XGdgSjVog"}'
 )
+# The descriptive payload above embeds a more specific error type than the coarse
+# "unknown" category the SDK reports; the integration parses it back out.
+MOCK_ASSISTANT_MESSAGE_PARSED_ERROR_TYPE = "overloaded_error"
 MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT = AssistantMessage(
-    content=[TextBlock(text=MOCK_ASSISTANT_MESSAGE_ERROR_TEXT)], model=MOCK_MODEL
+    content=[TextBlock(text=MOCK_ASSISTANT_MESSAGE_ERROR_TEXT)],
+    model=MOCK_MODEL,
+    error=MOCK_ASSISTANT_MESSAGE_ERROR_TYPE,
 )
-MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT.error = MOCK_ASSISTANT_MESSAGE_ERROR_TYPE
 MOCK_ASSISTANT_MESSAGE_ERROR_TEXT_SEQUENCE = [
     MOCK_SYSTEM_MESSAGE,
     MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT,

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -181,9 +181,6 @@ MOCK_ASSISTANT_MESSAGE_ERROR_TEXT = (
     'API Error: {"type":"error","error":{"details":null,"type":"overloaded_error",'
     '"message":"Overloaded"},"request_id":"req_011Cbd5D168oye3XGdgSjVog"}'
 )
-# The descriptive payload above embeds a more specific error type than the coarse
-# "unknown" category the SDK reports; the integration parses it back out.
-MOCK_ASSISTANT_MESSAGE_PARSED_ERROR_TYPE = "overloaded_error"
 MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT = AssistantMessage(
     content=[TextBlock(text=MOCK_ASSISTANT_MESSAGE_ERROR_TEXT)],
     model=MOCK_MODEL,

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -173,6 +173,24 @@ MOCK_ASSISTANT_MESSAGE_ERROR_SEQUENCE = [
     MOCK_RESULT_MESSAGE,
 ]
 
+# Reproduces an API error surfaced in the assistant message content (e.g. an
+# overloaded_error). The SDK maps the uncategorized error to the "unknown" literal
+# while the descriptive payload lives in a TextBlock.
+MOCK_ASSISTANT_MESSAGE_ERROR_TYPE = "unknown"
+MOCK_ASSISTANT_MESSAGE_ERROR_TEXT = (
+    'API Error: {"type":"error","error":{"details":null,"type":"overloaded_error",'
+    '"message":"Overloaded"},"request_id":"req_011Cbd5D168oye3XGdgSjVog"}'
+)
+MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT = AssistantMessage(
+    content=[TextBlock(text=MOCK_ASSISTANT_MESSAGE_ERROR_TEXT)], model=MOCK_MODEL
+)
+MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT.error = MOCK_ASSISTANT_MESSAGE_ERROR_TYPE
+MOCK_ASSISTANT_MESSAGE_ERROR_TEXT_SEQUENCE = [
+    MOCK_SYSTEM_MESSAGE,
+    MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT,
+    MOCK_RESULT_MESSAGE,
+]
+
 MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE = [
     MOCK_SYSTEM_MESSAGE,
     MOCK_ASSISTANT_RESPONSE_WITH_USAGE,

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -181,11 +181,12 @@ MOCK_ASSISTANT_MESSAGE_ERROR_TEXT = (
     'API Error: {"type":"error","error":{"details":null,"type":"overloaded_error",'
     '"message":"Overloaded"},"request_id":"req_011Cbd5D168oye3XGdgSjVog"}'
 )
+# NOTE: assign ``error`` after construction rather than as a constructor kwarg — older
+# claude-agent-sdk versions (e.g. 0.0.23) don't accept ``error`` in AssistantMessage.__init__.
 MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT = AssistantMessage(
-    content=[TextBlock(text=MOCK_ASSISTANT_MESSAGE_ERROR_TEXT)],
-    model=MOCK_MODEL,
-    error=MOCK_ASSISTANT_MESSAGE_ERROR_TYPE,
+    content=[TextBlock(text=MOCK_ASSISTANT_MESSAGE_ERROR_TEXT)], model=MOCK_MODEL
 )
+MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT.error = MOCK_ASSISTANT_MESSAGE_ERROR_TYPE
 MOCK_ASSISTANT_MESSAGE_ERROR_TEXT_SEQUENCE = [
     MOCK_SYSTEM_MESSAGE,
     MOCK_ASSISTANT_MESSAGE_WITH_ERROR_TEXT,


### PR DESCRIPTION
## Summary

Fixes an issue where a Claude Agent SDK span's `error.message` showed `unknown: unknown` instead of the actual API error (e.g. an `overloaded_error`).

The SDK's `AssistantMessage.error` is a coarse category literal (`unknown`, `rate_limit`, etc.), and uncategorized errors like `overloaded_error` fall under `unknown`. The descriptive payload lives in the message content `TextBlock`, but the integration used the bare `unknown` literal for both the error type *and* message.

The fix adds `_extract_assistant_error()`, which keeps the SDK category as the error type but surfaces the content text as the error message (falling back to the category when there's no text). Wired into both the agent and LLM span paths.

## Testing

- Added a test reproducing the `overloaded_error` scenario, asserting the descriptive message propagates to the agent, step, and llm spans.
- Existing empty-content error test still passes via the category fallback.
- Full `claude_agent_sdk` LLMObs suite passes locally.

Claude session: `7d212457-e77a-4d11-b945-86e69fd9e433`
Resume: `claude --resume 7d212457-e77a-4d11-b945-86e69fd9e433`

🤖 Generated with [Claude Code](https://claude.com/claude-code)