### PR TITLE
fix(llmobs): sanitize deeply nested spans [MLOB-7594]

### DIFF
--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -14,9 +14,6 @@ from ddtrace.llmobs._constants import PROXY_REQUEST
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
-from ddtrace.llmobs._integrations.utils import MAX_TOOL_SCHEMA_DEPTH
-from ddtrace.llmobs._integrations.utils import _tool_schema_exceeds_depth
-from ddtrace.llmobs._integrations.utils import _truncate_schema_to_depth
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
@@ -293,8 +290,5 @@ class AnthropicIntegration(BaseLLMIntegration):
                 description="" if is_deferred else tool.get("description", ""),
                 schema={} if is_deferred else tool.get("input_schema", {}),
             )
-            schema = tool_def.get("schema") or {}
-            if _tool_schema_exceeds_depth(tool_def.get("name") or "", schema):
-                tool_def["schema"] = _truncate_schema_to_depth(schema, MAX_TOOL_SCHEMA_DEPTH)
             tool_definitions.append(tool_def)
         return tool_definitions

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -1016,66 +1016,6 @@ def openai_set_meta_tags_from_response(
     _annotate_llmobs_span_data(span, output_messages=output_messages, tool_definitions=tool_definitions)
 
 
-# Maximum nesting depth allowed for a single tool schema
-MAX_TOOL_SCHEMA_DEPTH = 10
-
-
-def _tool_schema_depth(obj: Any) -> int:
-    """Return the maximum nesting depth of a tool schema object."""
-    max_depth = 0
-    stack = [(obj, 0)]
-    while stack:
-        node, depth = stack.pop()
-        if depth > max_depth:
-            max_depth = depth
-        if isinstance(node, dict):
-            for v in node.values():
-                stack.append((v, depth + 1))
-        elif isinstance(node, list):
-            for item in node:
-                stack.append((item, depth + 1))
-    return max_depth
-
-
-def _truncate_schema_to_depth(obj: Any, max_depth: int) -> Any:
-    """Return a copy of obj with any container fields beyond `max_depth` levels replaced with empty containers."""
-    if not isinstance(obj, (dict, list)):
-        return obj
-    root: Any = {} if isinstance(obj, dict) else []
-    stack = [(obj, root, max_depth)]
-    while stack:
-        source, dest, remaining = stack.pop()
-        items = source.items() if isinstance(source, dict) else enumerate(source)
-        for key, val in items:
-            if isinstance(val, (dict, list)):
-                child: Any = {} if isinstance(val, dict) else []
-                if isinstance(dest, list):
-                    dest.append(child)
-                else:
-                    dest[key] = child
-                if remaining > 1:
-                    stack.append((val, child, remaining - 1))
-            else:
-                if isinstance(dest, list):
-                    dest.append(val)
-                else:
-                    dest[key] = val
-    return root
-
-
-def _tool_schema_exceeds_depth(name: str, schema: Any) -> bool:
-    """Return True and emit a warning if the tool schema exceeds MAX_TOOL_SCHEMA_DEPTH."""
-    if _tool_schema_depth(schema) > MAX_TOOL_SCHEMA_DEPTH:
-        logger.warning(
-            "LLMObs: truncating tool %r schema to %d levels of nesting because its depth exceeds "
-            "the maximum allowed. Deeply nested tool schemas are not yet supported. "
-            "LLMObs backend.",
-            name,
-            MAX_TOOL_SCHEMA_DEPTH,
-        )
-        return True
-    return False
-
 
 def _openai_get_tool_definitions(tools: list[Any]) -> list[ToolDefinition]:
     tool_definitions = []
@@ -1111,9 +1051,6 @@ def _openai_get_tool_definitions(tools: list[Any]) -> list[ToolDefinition]:
         if _get_attr(tool, "defer_loading", False):
             tool_definition["description"] = ""
             tool_definition["schema"] = {}
-        schema = tool_definition.get("schema") or {}
-        if _tool_schema_exceeds_depth(tool_definition.get("name") or "", schema):
-            tool_definition["schema"] = _truncate_schema_to_depth(schema, MAX_TOOL_SCHEMA_DEPTH)
         tool_definitions.append(tool_definition)
     return tool_definitions
 

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -1016,7 +1016,6 @@ def openai_set_meta_tags_from_response(
     _annotate_llmobs_span_data(span, output_messages=output_messages, tool_definitions=tool_definitions)
 
 
-
 def _openai_get_tool_definitions(tools: list[Any]) -> list[ToolDefinition]:
     tool_definitions = []
     for tool in tools:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -666,9 +666,7 @@ class LLMObs(Service):
             output_type,
             export_to_llmobs=self._export_mode != LLMObsExportMode.APM_AGENTLESS,
         )
-        llmobs_data[LLMOBS_STRUCT.META] = _sanitize_span_event_depth(
-            llmobs_meta, apm_agentless=self._export_mode == LLMObsExportMode.APM_AGENTLESS
-        )
+        llmobs_data[LLMOBS_STRUCT.META] = _sanitize_span_event_depth(llmobs_meta)
         if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
             # APM agentless path: APM agentless ingestion interprets dots in tag keys as
             # nested-path separators, so replace them with underscores before encoding.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -666,7 +666,9 @@ class LLMObs(Service):
             output_type,
             export_to_llmobs=self._export_mode != LLMObsExportMode.APM_AGENTLESS,
         )
-        _sanitize_span_event_depth(llmobs_meta, apm_agentless=self._export_mode == LLMObsExportMode.APM_AGENTLESS)
+        llmobs_data[LLMOBS_STRUCT.META] = _sanitize_span_event_depth(
+            llmobs_meta, apm_agentless=self._export_mode == LLMObsExportMode.APM_AGENTLESS
+        )
         if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
             # APM agentless path: APM agentless ingestion interprets dots in tag keys as
             # nested-path separators, so replace them with underscores before encoding.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -137,8 +137,10 @@ from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_parent_prompt
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
+from ddtrace.llmobs._utils import _sanitize_span_event_depth
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
+from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs._utils import add_span_link
 from ddtrace.llmobs._utils import enforce_message_role
 from ddtrace.llmobs._utils import get_asyncio
@@ -665,6 +667,7 @@ class LLMObs(Service):
             output_type,
             export_to_llmobs=self._export_mode != LLMObsExportMode.APM_AGENTLESS,
         )
+        _sanitize_span_event_depth(llmobs_meta)
         if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
             # APM agentless path: APM agentless ingestion interprets dots in tag keys as
             # nested-path separators, so replace them with underscores before encoding.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -140,7 +140,6 @@ from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
 from ddtrace.llmobs._utils import _sanitize_span_event_depth
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
-from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs._utils import add_span_link
 from ddtrace.llmobs._utils import enforce_message_role
 from ddtrace.llmobs._utils import get_asyncio

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -666,7 +666,7 @@ class LLMObs(Service):
             output_type,
             export_to_llmobs=self._export_mode != LLMObsExportMode.APM_AGENTLESS,
         )
-        _sanitize_span_event_depth(llmobs_meta)
+        _sanitize_span_event_depth(llmobs_meta, apm_agentless=self._export_mode == LLMObsExportMode.APM_AGENTLESS)
         if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
             # APM agentless path: APM agentless ingestion interprets dots in tag keys as
             # nested-path separators, so replace them with underscores before encoding.

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -249,32 +249,46 @@ _MAX_NESTED_META_DEPTH_AGENT = 17
 _MAX_NESTED_META_DEPTH_AGENTLESS = 12
 
 
-def _sanitize_span_event_depth(obj: Any, apm_agentless: bool = False) -> None:
-    """Walk a dict/list in-place, replacing any container value that exceeds
-    the safe nesting depth with its JSON string representation.
+def _sanitize_span_event_depth(obj: Any, apm_agentless: bool = False) -> Any:
+    """Return a sanitized copy of obj with any container value that exceeds
+    the safe nesting depth replaced by its JSON string representation.
     A warning is logged for each stringified field, including its dotted path.
     """
     if not isinstance(obj, (dict, list)):
-        return
+        return obj
     max_depth = _MAX_NESTED_META_DEPTH_AGENTLESS if apm_agentless else _MAX_NESTED_META_DEPTH_AGENT
-    stack = [(obj, 0, "")]
+    root: Any = {} if isinstance(obj, dict) else []
+    stack = [(obj, root, 0, "")]
     while stack:
-        node, depth, path = stack.pop()
-        items = list(node.items() if isinstance(node, dict) else enumerate(node))
+        source, dest, depth, path = stack.pop()
+        items = source.items() if isinstance(source, dict) else enumerate(source)
         for key, val in items:
-            if not isinstance(val, (dict, list)):
-                continue
             child_path = f"{path}.{key}" if path else str(key)
-            if depth + 1 >= max_depth:
-                log.warning(
-                    "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be stringified "
-                    "to avoid backend parsing errors.",
-                    child_path,
-                    max_depth,
-                )
-                node[key] = safe_json(val)
+            if isinstance(val, (dict, list)):
+                if depth + 1 >= max_depth:
+                    log.warning(
+                        "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be stringified "
+                        "to avoid backend parsing errors.",
+                        child_path,
+                        max_depth,
+                    )
+                    if isinstance(dest, list):
+                        dest.append(safe_json(val))
+                    else:
+                        dest[key] = safe_json(val)
+                else:
+                    child: Any = {} if isinstance(val, dict) else []
+                    if isinstance(dest, list):
+                        dest.append(child)
+                    else:
+                        dest[key] = child
+                    stack.append((val, child, depth + 1, child_path))
             else:
-                stack.append((val, depth + 1, child_path))
+                if isinstance(dest, list):
+                    dest.append(val)
+                else:
+                    dest[key] = val
+    return root
 
 
 def safe_json(obj, ensure_ascii=True):

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -245,6 +245,52 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
+MAX_NESTED_DEPTH = 14
+
+
+def _nested_depth(obj: Any) -> int:
+    """Return the maximum nesting depth of a dict/list structure."""
+    max_depth = 0
+    stack = [(obj, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > max_depth:
+            max_depth = depth
+        if isinstance(node, dict):
+            for v in node.values():
+                stack.append((v, depth + 1))
+        elif isinstance(node, list):
+            for item in node:
+                stack.append((item, depth + 1))
+    return max_depth
+
+
+def _sanitize_span_event_depth(obj: Any) -> None:
+    """Walk a dict/list in-place, replacing any container value that reaches
+    MAX_NESTED_DEPTH levels from the root with its JSON string representation.
+    A warning is logged for each stringified field, including its dotted path."""
+    if not isinstance(obj, (dict, list)):
+        return
+    stack = [(obj, 0, "")]  # (node, depth, path)
+    while stack:
+        node, depth, path = stack.pop()
+        items = list(node.items() if isinstance(node, dict) else enumerate(node))
+        for key, val in items:
+            if not isinstance(val, (dict, list)):
+                continue
+            child_path = f"{path}.{key}" if path else str(key)
+            if depth + 1 >= MAX_NESTED_DEPTH:
+                log.warning(
+                    "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be stringified "
+                    "to avoid backend parsing errors.",
+                    child_path,
+                    MAX_NESTED_DEPTH,
+                )
+                node[key] = safe_json(val)
+            else:
+                stack.append((val, depth + 1, child_path))
+
+
 def safe_json(obj, ensure_ascii=True):
     if isinstance(obj, str):
         return obj

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -245,16 +245,18 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
-MAX_NESTED_META_DEPTH = 14
+_MAX_NESTED_META_DEPTH_AGENT = 17
+_MAX_NESTED_META_DEPTH_AGENTLESS = 12
 
 
-def _sanitize_span_event_depth(obj: Any) -> None:
-    """Walk a dict/list in-place, replacing any container value that reaches
-    MAX_NESTED_DEPTH levels from the root with its JSON string representation.
+def _sanitize_span_event_depth(obj: Any, apm_agentless: bool = False) -> None:
+    """Walk a dict/list in-place, replacing any container value that exceeds
+    the safe nesting depth with its JSON string representation.
     A warning is logged for each stringified field, including its dotted path.
     """
     if not isinstance(obj, (dict, list)):
         return
+    max_depth = _MAX_NESTED_META_DEPTH_AGENTLESS if apm_agentless else _MAX_NESTED_META_DEPTH_AGENT
     stack = [(obj, 0, "")]
     while stack:
         node, depth, path = stack.pop()
@@ -263,12 +265,12 @@ def _sanitize_span_event_depth(obj: Any) -> None:
             if not isinstance(val, (dict, list)):
                 continue
             child_path = f"{path}.{key}" if path else str(key)
-            if depth + 1 >= MAX_NESTED_META_DEPTH:
+            if depth + 1 >= max_depth:
                 log.warning(
                     "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be stringified "
                     "to avoid backend parsing errors.",
                     child_path,
-                    MAX_NESTED_META_DEPTH,
+                    max_depth,
                 )
                 node[key] = safe_json(val)
             else:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -254,6 +254,7 @@ def _sanitize_span_event_depth(obj: Any) -> Any:
     The original structure is never mutated.
     A warning is logged for each stringified field, including its dotted path.
     """
+
     def _walk(node: Any, depth: int, path: str) -> Any:
         if not isinstance(node, (dict, list)):
             return node

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -268,7 +268,8 @@ def _nested_depth(obj: Any) -> int:
 def _sanitize_span_event_depth(obj: Any) -> None:
     """Walk a dict/list in-place, replacing any container value that reaches
     MAX_NESTED_DEPTH levels from the root with its JSON string representation.
-    A warning is logged for each stringified field, including its dotted path."""
+    A warning is logged for each stringified field, including its dotted path.
+    """
     if not isinstance(obj, (dict, list)):
         return
     stack = [(obj, 0, "")]  # (node, depth, path)

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -245,50 +245,31 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
-_MAX_NESTED_META_DEPTH_AGENT = 17
-_MAX_NESTED_META_DEPTH_AGENTLESS = 12
+_MAX_NESTED_META_DEPTH = 13
 
 
-def _sanitize_span_event_depth(obj: Any, apm_agentless: bool = False) -> Any:
+def _sanitize_span_event_depth(obj: Any) -> Any:
     """Return a sanitized copy of obj with any container value that exceeds
-    the safe nesting depth replaced by its JSON string representation.
+    _MAX_NESTED_META_DEPTH levels from the root replaced by its JSON string representation.
+    The original structure is never mutated.
     A warning is logged for each stringified field, including its dotted path.
     """
-    if not isinstance(obj, (dict, list)):
-        return obj
-    max_depth = _MAX_NESTED_META_DEPTH_AGENTLESS if apm_agentless else _MAX_NESTED_META_DEPTH_AGENT
-    root: Any = {} if isinstance(obj, dict) else []
-    stack = [(obj, root, 0, "")]
-    while stack:
-        source, dest, depth, path = stack.pop()
-        items = source.items() if isinstance(source, dict) else enumerate(source)
-        for key, val in items:
-            child_path = f"{path}.{key}" if path else str(key)
-            if isinstance(val, (dict, list)):
-                if depth + 1 >= max_depth:
-                    log.warning(
-                        "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be stringified "
-                        "to avoid backend parsing errors.",
-                        child_path,
-                        max_depth,
-                    )
-                    if isinstance(dest, list):
-                        dest.append(safe_json(val))
-                    else:
-                        dest[key] = safe_json(val)
-                else:
-                    child: Any = {} if isinstance(val, dict) else []
-                    if isinstance(dest, list):
-                        dest.append(child)
-                    else:
-                        dest[key] = child
-                    stack.append((val, child, depth + 1, child_path))
-            else:
-                if isinstance(dest, list):
-                    dest.append(val)
-                else:
-                    dest[key] = val
-    return root
+    def _walk(node: Any, depth: int, path: str) -> Any:
+        if not isinstance(node, (dict, list)):
+            return node
+        if depth >= _MAX_NESTED_META_DEPTH:
+            log.warning(
+                "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be "
+                "stringified to avoid backend parsing errors.",
+                path,
+                _MAX_NESTED_META_DEPTH,
+            )
+            return safe_json(node)
+        if isinstance(node, dict):
+            return {k: _walk(v, depth + 1, f"{path}.{k}" if path else str(k)) for k, v in node.items()}
+        return [_walk(v, depth + 1, f"{path}[{i}]" if path else str(i)) for i, v in enumerate(node)]
+
+    return _walk(obj, 0, "")
 
 
 def safe_json(obj, ensure_ascii=True):

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -248,23 +248,6 @@ def _unserializable_default_repr(obj):
 MAX_NESTED_DEPTH = 14
 
 
-def _nested_depth(obj: Any) -> int:
-    """Return the maximum nesting depth of a dict/list structure."""
-    max_depth = 0
-    stack = [(obj, 0)]
-    while stack:
-        node, depth = stack.pop()
-        if depth > max_depth:
-            max_depth = depth
-        if isinstance(node, dict):
-            for v in node.values():
-                stack.append((v, depth + 1))
-        elif isinstance(node, list):
-            for item in node:
-                stack.append((item, depth + 1))
-    return max_depth
-
-
 def _sanitize_span_event_depth(obj: Any) -> None:
     """Walk a dict/list in-place, replacing any container value that reaches
     MAX_NESTED_DEPTH levels from the root with its JSON string representation.
@@ -272,7 +255,7 @@ def _sanitize_span_event_depth(obj: Any) -> None:
     """
     if not isinstance(obj, (dict, list)):
         return
-    stack = [(obj, 0, "")]  # (node, depth, path)
+    stack = [(obj, 0, "")]
     while stack:
         node, depth, path = stack.pop()
         items = list(node.items() if isinstance(node, dict) else enumerate(node))

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -245,7 +245,7 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
-MAX_NESTED_DEPTH = 14
+MAX_NESTED_META_DEPTH = 14
 
 
 def _sanitize_span_event_depth(obj: Any) -> None:
@@ -263,12 +263,12 @@ def _sanitize_span_event_depth(obj: Any) -> None:
             if not isinstance(val, (dict, list)):
                 continue
             child_path = f"{path}.{key}" if path else str(key)
-            if depth + 1 >= MAX_NESTED_DEPTH:
+            if depth + 1 >= MAX_NESTED_META_DEPTH:
                 log.warning(
                     "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be stringified "
                     "to avoid backend parsing errors.",
                     child_path,
-                    MAX_NESTED_DEPTH,
+                    MAX_NESTED_META_DEPTH,
                 )
                 node[key] = safe_json(val)
             else:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -245,7 +245,7 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
-_MAX_NESTED_META_DEPTH = 13
+_MAX_NESTED_META_DEPTH = 12
 
 
 def _sanitize_span_event_depth(obj: Any) -> Any:

--- a/releasenotes/notes/handle-nested-span-data-c17ce825d1225776.yaml
+++ b/releasenotes/notes/handle-nested-span-data-c17ce825d1225776.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where LLM Observability spans exceeding the maximum allowed JSON depth
+    were not being sanitized properly. The LLM Observability integration now detects nested fields in spans
+    that exceed the allowed depth and stringifies them, preserving all data while ensuring the span is
+    processed correctly.

--- a/releasenotes/notes/handle-nested-span-data-c17ce825d1225776.yaml
+++ b/releasenotes/notes/handle-nested-span-data-c17ce825d1225776.yaml
@@ -3,5 +3,4 @@ fixes:
   - |
     LLM Observability: Fixes an issue where spans with very large JSON depth nested fields
     were being submitted but dropped by Datadog. The LLM Observability integration now detects nested fields
-    that exceed the allowed depth and stringifies them, preserving all data while ensuring the span is
-    processed correctly.
+    that exceed the allowed depth and stringifies them, ensuring spans will not be dropped due to JSON depth limits in Datadog.

--- a/releasenotes/notes/handle-nested-span-data-c17ce825d1225776.yaml
+++ b/releasenotes/notes/handle-nested-span-data-c17ce825d1225776.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes an issue where LLM Observability spans exceeding the maximum allowed JSON depth
-    were not being sanitized properly. The LLM Observability integration now detects nested fields in spans
+    LLM Observability: Fixes an issue where spans with very large JSON depth nested fields
+    were being submitted but dropped by Datadog. The LLM Observability integration now detects nested fields
     that exceed the allowed depth and stringifies them, preserving all data while ensuring the span is
     processed correctly.

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -1667,7 +1667,11 @@ class TestLLMObsAnthropic:
                                                 "properties": {
                                                     "l4": {
                                                         "type": "object",
-                                                        "properties": '{"l5": {"properties": {"l6": {"properties": {"l7": {"type": "string"}}, "type": "object"}}, "type": "object"}}',
+                                                        "properties": (
+                                                            '{"l5": {"properties": {"l6": {"properties":'
+                                                            ' {"l7": {"type": "string"}}, "type": "object"}},'
+                                                            ' "type": "object"}}'
+                                                        ),
                                                     }
                                                 },
                                             }

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -1612,10 +1612,10 @@ class TestLLMObsAnthropic:
             ],
         )
 
-    def test_tool_with_deep_schema_has_schema_truncated(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
-        """Tool schemas exceeding MAX_TOOL_SCHEMA_DEPTH should be truncated at the depth limit,
-        replacing over-limit containers with empty containers while preserving name, description,
-        and all fields within the limit. Tools with shallow schemas are unaffected.
+    def test_tool_with_deep_schema_has_schema_stringified(self, anthropic, anthropic_llmobs, test_spans, request_vcr):
+        """Tool schemas that exceed the maximum nested depth are stringified at the point where
+        they exceed the limit, preserving all data as a JSON string while keeping shallower
+        structure intact. Tools with shallow schemas are unaffected.
         """
         llm = anthropic.Anthropic()
         with request_vcr.use_cassette("anthropic_completion_tools_deep_schema.yaml"):
@@ -1667,7 +1667,12 @@ class TestLLMObsAnthropic:
                                                 "properties": {
                                                     "l4": {
                                                         "type": "object",
-                                                        "properties": {"l5": {}},
+                                                        "properties": {
+                                                            "l5": {
+                                                                "type": "object",
+                                                                "properties": '{"l6": {"type": "string"}}',
+                                                            }
+                                                        },
                                                     }
                                                 },
                                             }

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -1667,19 +1667,7 @@ class TestLLMObsAnthropic:
                                                 "properties": {
                                                     "l4": {
                                                         "type": "object",
-                                                        "properties": {
-                                                            "l5": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "l6": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "l7": '{"type": "string"}',
-                                                                        },
-                                                                    }
-                                                                },
-                                                            }
-                                                        },
+                                                        "properties": '{"l5": {"properties": {"l6": {"properties": {"l7": {"type": "string"}}, "type": "object"}}, "type": "object"}}',
                                                     }
                                                 },
                                             }

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -1670,7 +1670,14 @@ class TestLLMObsAnthropic:
                                                         "properties": {
                                                             "l5": {
                                                                 "type": "object",
-                                                                "properties": '{"l6": {"type": "string"}}',
+                                                                "properties": {
+                                                                    "l6": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "l7": '{"type": "string"}',
+                                                                        },
+                                                                    }
+                                                                },
                                                             }
                                                         },
                                                     }

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -2893,7 +2893,11 @@ MUL: "*"
                                                 "properties": {
                                                     "l4": {
                                                         "type": "object",
-                                                        "properties": '{"l5": {"properties": {"l6": {"properties": {"l7": {"type": "string"}}, "type": "object"}}, "type": "object"}}',
+                                                        "properties": (
+                                                            '{"l5": {"properties": {"l6": {"properties":'
+                                                            ' {"l7": {"type": "string"}}, "type": "object"}},'
+                                                            ' "type": "object"}}'
+                                                        ),
                                                     }
                                                 },
                                             }

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -2848,10 +2848,10 @@ MUL: "*"
     @pytest.mark.skipif(
         parse_version(openai_module.version.VERSION) < (1, 1), reason="Tool calls available after v1.1.0"
     )
-    def test_tool_with_deep_schema_has_schema_truncated(self, openai, openai_llmobs, test_spans):
-        """Tool schemas exceeding MAX_TOOL_SCHEMA_DEPTH should be truncated at the depth limit,
-        replacing over-limit containers with empty containers while preserving name, description,
-        and all fields within the limit. Tools with shallow schemas are unaffected.
+    def test_tool_with_deep_schema_has_schema_stringified(self, openai, openai_llmobs, test_spans):
+        """Tool schemas that exceed the maximum nested depth are stringified at the point where
+        they exceed the limit, preserving all data as a JSON string while keeping shallower
+        structure intact. Tools with shallow schemas are unaffected.
         """
         deep_tool = {
             "type": "function",
@@ -2893,7 +2893,12 @@ MUL: "*"
                                                 "properties": {
                                                     "l4": {
                                                         "type": "object",
-                                                        "properties": {"l5": {}},
+                                                        "properties": {
+                                                            "l5": {
+                                                                "type": "object",
+                                                                "properties": '{"l6": {"type": "string"}}',
+                                                            }
+                                                        },
                                                     }
                                                 },
                                             }

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -2893,19 +2893,7 @@ MUL: "*"
                                                 "properties": {
                                                     "l4": {
                                                         "type": "object",
-                                                        "properties": {
-                                                            "l5": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "l6": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "l7": '{"type": "string"}',
-                                                                        },
-                                                                    }
-                                                                },
-                                                            }
-                                                        },
+                                                        "properties": '{"l5": {"properties": {"l6": {"properties": {"l7": {"type": "string"}}, "type": "object"}}, "type": "object"}}',
                                                     }
                                                 },
                                             }

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -2896,7 +2896,14 @@ MUL: "*"
                                                         "properties": {
                                                             "l5": {
                                                                 "type": "object",
-                                                                "properties": '{"l6": {"type": "string"}}',
+                                                                "properties": {
+                                                                    "l6": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "l7": '{"type": "string"}',
+                                                                        },
+                                                                    }
+                                                                },
                                                             }
                                                         },
                                                     }

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -40,7 +40,12 @@ DEEP_TOOL_SCHEMA = {
                             "properties": {
                                 "l4": {
                                     "type": "object",
-                                    "properties": {"l5": {"type": "string"}},
+                                    "properties": {
+                                        "l5": {
+                                            "type": "object",
+                                            "properties": {"l6": {"type": "string"}},
+                                        }
+                                    },
                                 }
                             },
                         }

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -43,7 +43,12 @@ DEEP_TOOL_SCHEMA = {
                                     "properties": {
                                         "l5": {
                                             "type": "object",
-                                            "properties": {"l6": {"type": "string"}},
+                                            "properties": {
+                                                "l6": {
+                                                    "type": "object",
+                                                    "properties": {"l7": {"type": "string"}},
+                                                }
+                                            },
                                         }
                                     },
                                 }


### PR DESCRIPTION
## Description

LLM Observability spans containing deeply nested JSON structures (e.g. OpenAI structured output schemas passed via `response_format.json_schema`) were silently dropped by the backend because they exceeded the supported JSON nesting limit.

This PR adds `_sanitize_span_event_depth` — an iterative in-place walk of the `_Meta` dict that stringifies any container value whose nesting depth from the `_Meta` root reaches the max nesting depth. The walk runs in `_prepare_llmobs_span_data` after normalization and before the struct tag is written, so it covers all export modes including `APM_AGENTLESS`.

As part of this change, the integration-level tool schema truncation from #17356 is removed in favor of this uniform stringification approach, which covers all `_Meta` fields rather than only `tool_definitions`.

## Testing

- Updated `test_tool_with_deep_schema_has_schema_stringified` in both the OpenAI and Anthropic test suites to assert the new stringification behaviour (previously tested truncation).

### Manual Testing
I tried submitting a payload via manual instrumentation that exceeds the 20 nested field limit. 

```
def _make_nested_schema(depth):
    """Build a JSON schema with `depth` levels of properties nesting."""
    node = {"type": "string"}
    for i in range(depth, 0, -1):
        node = {"type": "object", "properties": {f"l{i}": node}}
    return node


SCHEMA_DEPTH = 20 
DEEPLY_NESTED_SCHEMA = _make_nested_schema(SCHEMA_DEPTH)
RESPONSE_FORMAT = {
    "type": "json_schema",
    "json_schema": {
        "name": "deeply_nested_demo",
        "schema": DEEPLY_NESTED_SCHEMA,
        "strict": False,
    },
}

with LLMObs.llm(model_name="gpt-4o", model_provider="openai", name="deeply_nested_schema_span") as span:
    LLMObs.annotate(
        span,
        input_data=[{"role": "user", "content": "hello"}],
        output_data=[{"role": "assistant", "content": "hi"}],
        metadata={"response_format": RESPONSE_FORMAT},
    )
```

Before these changes, the outcome is that the span is dropped silently in our backend. 

After these changes, we are able to see the entire span content in LLM Observability.
<img width="1515" height="597" alt="Screenshot 2026-06-03 at 1 49 07 PM" src="https://github.com/user-attachments/assets/5de7ac6f-d234-40c2-ac63-ade9b836d030" />

[trace](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ6J_j21Bra2EAAAABhBWjZKX2oyMUFBRHcxb3l1alNHSEFBQUEAAAAkMDE5ZThhMDctNjEzNy00YzExLTljZWYtYTkxOTc5OTUzNTI3AAIO3Q%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=1087204631738795712&start=1780422536541&end=1780508936541&paused=false)

## Caveats
- Based on my testing, it seems like we can theoretically handle a nested depth of 17 when in Agent mode; however, the limit is much lower (13) for agentless. We are defaulting to the more restrictive limit in all cases.

## Risks

Spans whose metadata contains containers nested beyond the max nesting depth from the `_Meta` root will have those values stringified rather than stored as nested JSON. All data is preserved (as a JSON string), but it will not be queryable by field. This only affects pathological schemas that would otherwise be silently dropped.