### PR TITLE
chore(crashtracking): analyze crash claude skill

### DIFF
--- a/.claude/skills/analyze-crash/SKILL.md
+++ b/.claude/skills/analyze-crash/SKILL.md
@@ -543,10 +543,10 @@ and web search results. Explain WHY this attribution was chosen.}
 
 ## Output File Management
 
-1. **Create output directory**: `mkdir -p ~/.claude/analysis && echo ~/.claude/analysis`
+1. **Create output directory**: `mkdir -p .claude/skills/analyze-crash/reports`
 2. **Generate filename**: `crash-analysis-{YYYYMMDD-HHMMSS}.md`
-3. **Save file**: Write the markdown analysis to the file
-4. **Tell the user** the full path where the analysis was saved
+3. **Save file**: Write the markdown analysis to `.claude/skills/analyze-crash/reports/{filename}`
+4. **Tell the user** the path where the analysis was saved
 
 ---
 

--- a/.claude/skills/analyze-crash/SKILL.md
+++ b/.claude/skills/analyze-crash/SKILL.md
@@ -35,23 +35,48 @@ The user has provided a native crash stack trace. The format is typically:
 Frames may have: hex address only, hex address + symbol, or symbol + `.so` name + offset. Parse
 all available information.
 
+### Determine the source revision
+
+The crash may come from a released wheel or a branch other than `main`. GitHub links must point
+at the exact revision that built the crashing binary so that line numbers match.
+
+**Ask the user**: Before starting analysis, ask:
+
+> Do you know the commit SHA or release tag for the dd-trace-py version that crashed?
+> (e.g., `v2.18.0`, `abc1234`). If not, I'll use `main`.
+
+**Resolution order** (use the first that succeeds):
+
+1. **User-provided value** — commit SHA or tag supplied in the prompt or in response to the
+   question above. Use it verbatim as `GIT_REF`.
+2. **Version string in the stack trace** — if the wheel filename or ddtrace version appears in
+   the trace (e.g., `ddtrace-2.18.0`), try the corresponding git tag (`v2.18.0`). Verify it
+   exists: `git rev-parse --verify "v2.18.0" 2>/dev/null`.
+3. **Current checkout** — if the local repo is not on `main`, use `git rev-parse HEAD` to get
+   the current SHA.
+4. **Fallback** — use `main`.
+
+Store the resolved value as `GIT_REF` and use it in all GitHub links for the rest of the
+analysis. State which ref you are using and why at the top of the report (in Additional Context).
+
 ## Analysis Workflow
 
 ### GitHub Link Generation
 
-When referencing files in dd-trace-py, always provide clickable GitHub links:
+When referencing files in dd-trace-py, always provide clickable GitHub links using the resolved
+`GIT_REF` (see "Determine the source revision" above).
 
 **Format**:
 ```
-[filename:line](https://github.com/DataDog/dd-trace-py/blob/main/path/to/file#Lline)
+[filename:line](https://github.com/DataDog/dd-trace-py/blob/{GIT_REF}/path/to/file#Lline)
 ```
 
-**Examples**:
-- Single line: `[_threads.cpp:226](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/internal/_threads.cpp#L226)`
-- Range: `[_threads.cpp:226-252](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/internal/_threads.cpp#L226-L252)`
+**Examples** (assuming `GIT_REF=v2.18.0`):
+- Single line: `[_threads.cpp:226](https://github.com/DataDog/dd-trace-py/blob/v2.18.0/ddtrace/internal/_threads.cpp#L226)`
+- Range: `[_threads.cpp:226-252](https://github.com/DataDog/dd-trace-py/blob/v2.18.0/ddtrace/internal/_threads.cpp#L226-L252)`
 
-**Path construction**: base URL is `https://github.com/DataDog/dd-trace-py/blob/main/`, then
-append the repo-relative path (strip any build-specific prefixes like `/home/runner/work/`,
+**Path construction**: base URL is `https://github.com/DataDog/dd-trace-py/blob/{GIT_REF}/`,
+then append the repo-relative path (strip any build-specific prefixes like `/home/runner/work/`,
 `/usr/local/lib/`, etc.).
 
 ---
@@ -359,10 +384,13 @@ stack trace and code evidence. Do not prescribe specific fixes.
 
 ### Phase 6: Find Related Code and History
 
-Use Bash + git to find context:
+Use Bash + git to find context. When `GIT_REF` is not `main`, scope history queries to that
+ref so results reflect the code that actually shipped in the crashing binary.
 
-1. Recent commits to affected files: `git log --oneline -10 {file}`
-2. Search for relevant changes: `git log --grep="GIL" --grep="finalize" --grep="crash" --oneline -20`
+1. Recent commits to affected files (up to the crashing revision):
+   `git log --oneline -10 {GIT_REF} -- {file}`
+2. Search for relevant changes:
+   `git log --grep="GIL" --grep="finalize" --grep="crash" --oneline -20 {GIT_REF}`
    (use keywords relevant to the crash area)
 3. For each relevant commit, extract PR numbers from the message (e.g., `(#7659)`) and link:
    `https://github.com/DataDog/dd-trace-py/pull/{number}`
@@ -381,6 +409,7 @@ of each type — cross-reference them when a heuristic from Phase 4 matches.
 ```markdown
 # Crash Analysis Report
 **Generated**: {ISO 8601 timestamp}
+**Source ref**: [`{GIT_REF}`](https://github.com/DataDog/dd-trace-py/tree/{GIT_REF}) {— reason, e.g. "user-provided tag" or "fallback to main"}
 
 ## Attribution
 **{dd-trace-py bug | third-party bug ({library name}) | CPython bug | interaction/race | unknown}**
@@ -467,7 +496,8 @@ If no known pattern matched, say so.}
   stop before suggesting specific code changes.
 - **Continue with missing info**: If a symbol can't be found in source, note it and continue.
 - **Mark uncertainties**: If something is speculative, say so explicitly.
-- **Always include GitHub links**: Every file:line reference should be a clickable link.
+- **Always include GitHub links**: Every file:line reference should be a clickable link using the
+  resolved `GIT_REF` — never hard-code `main` unless it is the resolved ref.
 - **Prefer PR links over commits**: Extract `(#NNNN)` from commit messages and link to the PR.
 
 ## Now Analyze

--- a/.claude/skills/analyze-crash/SKILL.md
+++ b/.claude/skills/analyze-crash/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-crash
-description: Native crash stack trace analysis for dd-trace-py
-argument-hint: <paste-stack-trace>
+description: Native crash log analysis for dd-trace-py
+argument-hint: <crash-uuid-or-paste-log>
 disable-model-invocation: false
 context: fork
 agent: general-purpose
@@ -11,18 +11,49 @@ allowed-tools:
   - Grep
   - Glob
   - TodoWrite
+  - WebSearch
 ---
 
 # Native Crash Stack Trace Analysis for dd-trace-py
 
-You are analyzing a native crash stack trace captured by dd-trace-py's crashtracker. Perform a
-comprehensive investigation to help engineers understand and triage the crash. The crashtracker
-captures **all process-level native crashes**, so the crashing code may or may not be in dd-trace-py
-itself — your first job is to determine attribution.
+You are analyzing a native crash captured by dd-trace-py's crashtracker. Perform a comprehensive
+investigation to help engineers understand and triage the crash. The crashtracker captures **all
+process-level native crashes**, so the crashing code may or may not be in dd-trace-py itself —
+investigate the code and patterns thoroughly before making the attribution call.
 
 ## Input Processing
 
-The user has provided a native crash stack trace. The format is typically:
+The user will provide crash data in one of two ways:
+
+### Option A: Crash UUID (preferred)
+
+The user provides a crash UUID from Datadog crash telemetry. Use the fetch script bundled with
+this skill to retrieve and process the full crash log:
+
+```bash
+cd .claude/skills/analyze-crash && dd-auth .venv/bin/python fetch_crash.py <UUID> [--tracer-version X.Y.Z] [--days 14]
+```
+
+This fetches the crash log from Datadog, processes the stack frames (demangling C++ symbols,
+resolving addresses against `/proc/self/maps`), and outputs structured JSON with:
+- **Metadata**: tracer version, runtime version, service, org, platform, architecture, signal
+- **Processed stack**: each frame with demangled symbol, binary file, offset, source file/line
+- **Binary mappings**: summary of loaded shared objects
+- **Datadog log link**: direct URL to the crash event
+
+If the user provides only a UUID with no other context, ask:
+
+> What is the crash UUID? Any additional filters (tracer version, org ID, language)?
+
+**Setup** (one-time): run `cd .claude/skills/analyze-crash && uv sync` to create the venv and
+install dependencies.
+
+**Authentication**: use `dd-auth` as a command wrapper — it injects Datadog API credentials
+into the environment for the wrapped process.
+
+### Option B: Pasted crash log or stack trace
+
+The user pastes a raw crash log or stack trace directly. The format is typically:
 
 ```
 0x7f6e81c51fb7 PyUnicode_AsUTF8AndSize
@@ -33,7 +64,8 @@ The user has provided a native crash stack trace. The format is typically:
 ```
 
 Frames may have: hex address only, hex address + symbol, or symbol + `.so` name + offset. Parse
-all available information.
+all available information. If the paste includes full crash JSON (with `error.stack` and
+`files./proc/self/maps`), extract the metadata and processed stack from it.
 
 ### Determine the source revision
 
@@ -49,12 +81,14 @@ at the exact revision that built the crashing binary so that line numbers match.
 
 1. **User-provided value** — commit SHA or tag supplied in the prompt or in response to the
    question above. Use it verbatim as `GIT_REF`.
-2. **Version string in the stack trace** — if the wheel filename or ddtrace version appears in
-   the trace (e.g., `ddtrace-2.18.0`), try the corresponding git tag (`v2.18.0`). Verify it
-   exists: `git rev-parse --verify "v2.18.0" 2>/dev/null`.
-3. **Current checkout** — if the local repo is not on `main`, use `git rev-parse HEAD` to get
+2. **Crash metadata** — if the crash was fetched via UUID and includes a `tracer_version`
+   field (e.g., `2.18.0`), try the corresponding git tag (`v2.18.0`). Verify it exists:
+   `git rev-parse --verify "v2.18.0" 2>/dev/null`.
+3. **Version string in the stack trace** — if the wheel filename or ddtrace version appears in
+   the trace (e.g., `ddtrace-2.18.0`), try the corresponding git tag.
+4. **Current checkout** — if the local repo is not on `main`, use `git rev-parse HEAD` to get
    the current SHA.
-4. **Fallback** — use `main`.
+5. **Fallback** — use `main`.
 
 Store the resolved value as `GIT_REF` and use it in all GitHub links for the rest of the
 analysis. State which ref you are using and why at the top of the report (in Additional Context).
@@ -147,28 +181,7 @@ Create a classification table:
 
 ---
 
-### Phase 2: Attribute the Crash
-
-Before diving into code, answer: **Is this a dd-trace-py bug?**
-
-Use these signals:
-
-1. **Is any dd-trace-py native frame in the crashing thread?** If the only dd-trace-py frames are
-   in other threads (not the crashing one), or absent entirely, dd-trace-py may not be the root cause.
-
-2. **Is the crashing `.so` a known third-party library?**
-   - `_native__lib.cpython-*.so` in a `pyroscope/` path → Pyroscope bug
-   - `libev-*.so` in a gevent-using app → gevent/libev interaction
-   - Customer `.so` (e.g., `pycbc`, `grpc`) → third-party extension bug
-
-3. **Does the crash match a known dd-trace-py pattern?** (see Phase 4)
-
-State the attribution clearly: **dd-trace-py bug**, **third-party bug**, **CPython bug**,
-**interaction/race between components**, or **unknown**.
-
----
-
-### Phase 3: Locate dd-trace-py Source Code
+### Phase 2: Locate dd-trace-py Source Code
 
 For each dd-trace-py frame that can be mapped to source code:
 
@@ -200,7 +213,7 @@ Format:
 
 ---
 
-### Phase 4: Apply General Crash Heuristics
+### Phase 3: Apply General Crash Heuristics
 
 dd-trace-py maintains two complementary native code safety references:
 
@@ -210,7 +223,7 @@ dd-trace-py maintains two complementary native code safety references:
 Read **both files now**. Use their framework to classify the crash. The categories below
 summarize the key stack-trace signals; refer to the docs for full rationale and PR history.
 
-#### 4.1 — GIL Lifecycle During Finalization
+#### 3.1 — GIL Lifecycle During Finalization
 
 **Stack signals**: `PyGILState_Ensure`, `PyEval_RestoreThread`, `take_gil`, `new_threadstate`,
 `PyThread_exit_thread`, `pthread_exit`, `abort`, `gsignal`, `__forced_unwind`,
@@ -242,7 +255,7 @@ summarize the key stack-trace signals; refer to the docs for full rationale and 
 `PeriodicThread_start`), `ddtrace/internal/threads.py` (atexit handler),
 `src/native/data_pipeline/mod.rs` (Rust pyo3 GIL release/restore).
 
-#### 4.2 — Fork Safety
+#### 3.2 — Fork Safety
 
 **Stack signals**: `pthread_mutex_lock`, `pthread_cond_wait`, `__lll_lock_wait` deep in a
 thread that recently went through `_after_fork`, `__clone3` / `start_thread` in a crash that
@@ -259,7 +272,7 @@ occurs shortly after a fork event.
 **Key source locations**: `ddtrace/internal/_threads.cpp` (`_before_fork`, `_after_fork`,
 `safe_reset_thread`), `ddtrace/internal/threads.py` (`_before_fork`, `_after_fork_child`).
 
-#### 4.3 — Object Lifetime Across Thread Boundaries (Use-After-Free)
+#### 3.3 — Object Lifetime Across Thread Boundaries (Use-After-Free)
 
 **Stack signals**: SIGSEGV or SIGBUS at a CPython refcount operation (`Py_INCREF`,
 `Py_DECREF`, `_Py_Dealloc`), or inside a `PyObject*` dereference inside a native thread
@@ -275,7 +288,7 @@ shortly after the thread started or while it was shutting down.
 
 **Key source locations**: `ddtrace/internal/_threads.cpp`
 
-#### 4.4 — Memory Safety in Allocator Hooks
+#### 3.4 — Memory Safety in Allocator Hooks
 
 **Stack signals**: Crash inside `_memalloc.cpython-*.so` with CPython allocation functions
 (`PyMem_Malloc`, `PyObject_Malloc`) or frame-walking functions (`PyThreadState_GetFrame`,
@@ -295,7 +308,7 @@ if the crash is a heap corruption SIGABRT or a SIGSEGV inside a seemingly unrela
 **Key source locations**: `ddtrace/profiling/collector/_memalloc.cpp`,
 `ddtrace/profiling/collector/_memalloc_tb.cpp`
 
-#### 4.5 — FFI Exception and Unwind Propagation
+#### 3.5 — FFI Exception and Unwind Propagation
 
 **Stack signals**: `rust_begin_unwind`, `rust_panic`, `__rust_start_panic` in frames from
 `_native.cpython-*.so`; or `abi::__cxa_throw` / `__cxa_rethrow` crossing between `.so`
@@ -314,7 +327,7 @@ files; or `std::terminate` called from inside Rust code.
 **Key source locations**: `src/native/data_pipeline/mod.rs`, `ddtrace/internal/_threads.cpp`
 (thread lambda catch blocks).
 
-#### 4.6 — Unbounded Loops and Recursion
+#### 3.6 — Unbounded Loops and Recursion
 
 **Stack signals**: Deep or repeating identical frames (same function appearing many times),
 deadlock-style hangs with a lock held (visible in thread dumps as `pthread_mutex_lock` with
@@ -330,7 +343,7 @@ no progress), or `SIGABRT` from `std::terminate` after a recursive call depth is
 **Key source locations**: Any loop over `interp->next`, greenlet chains, or stack chunks in
 `ddtrace/internal/datadog/profiling/stack/`.
 
-#### 4.7 — Cython Silent Exception Swallowing
+#### 3.7 — Cython Silent Exception Swallowing
 
 **Stack signals**: Incorrect/unexpected behavior rather than a hard crash; or a crash inside
 a Cython-generated `.so` (`__pyx_*` frames) where a NULL pointer is dereferenced after a
@@ -347,7 +360,7 @@ function returned 0/NULL with no exception set.
 **Key source locations**: `ddtrace/profiling/collector/_exception.pyx`,
 `ddtrace/profiling/collector/_lock.pyx`, `ddtrace/internal/_encoding.pyx`.
 
-#### 4.8 — Stripped Binary Misattribution
+#### 3.8 — Stripped Binary Misattribution
 
 **Stack signals**: Symbol names that don't match the `.so` they appear in, or a crash at an
 address that doesn't correspond to any named symbol in the frame (address-only frames at the
@@ -362,6 +375,45 @@ top of a crashing `.so`).
   and symbol layouts differ between versions.
 - If the reported function seems inconsistent with the rest of the stack, treat it as
   approximate and look at the surrounding frames for the true call site.
+
+---
+
+### Phase 4: Attribute the Crash
+
+Now that you have investigated the source code (Phase 2) and matched against known patterns
+(Phase 3), determine attribution: **Is this a dd-trace-py bug?**
+
+Use these signals:
+
+1. **Frame ownership**: Are any dd-trace-py native frames in the crashing thread? If the only
+   dd-trace-py frames are in other threads (not the crashing one), or absent entirely,
+   dd-trace-py may not be the root cause.
+
+2. **Known third-party library**:
+   - `_native__lib.cpython-*.so` in a `pyroscope/` path → Pyroscope bug
+   - `libev-*.so` in a gevent-using app → gevent/libev interaction
+   - Customer `.so` (e.g., `pycbc`, `grpc`) → third-party extension bug
+
+3. **Pattern match from Phase 3**: Did the crash match a known dd-trace-py pattern?
+
+4. **Code evidence from Phase 2**: Does the source code reveal a bug in dd-trace-py, or does
+   it show dd-trace-py code operating correctly while a third-party or CPython component fails?
+
+5. **Web search for upstream issues**: If the crash appears to involve CPython internals or a
+   third-party library, use `WebSearch` to check whether this is a known upstream bug:
+   - Search for the crashing symbol + "crash" or "segfault" + the library/CPython version
+   - Check the CPython issue tracker (`github.com/python/cpython/issues`)
+   - Check the third-party library's issue tracker
+   - Search for related GitHub issues in `DataDog/dd-trace-py`
+
+   Example searches:
+   - `"take_gil" crash CPython 3.12 pthread_exit site:github.com/python/cpython`
+   - `PyThread_exit_thread finalization crash cpython issue`
+   - `site:github.com/DataDog/dd-trace-py/issues SIGSEGV _memalloc`
+
+State the attribution clearly: **dd-trace-py bug**, **third-party bug** (name the library),
+**CPython bug** (cite the upstream issue if found), **interaction/race between components**,
+or **unknown**.
 
 ---
 
@@ -400,7 +452,7 @@ ref so results reflect the code that actually shipped in the crashing binary.
 
 **Prioritize PR links** — PRs have descriptions and discussion context that commit messages lack.
 The historical examples in `docs/native-code-review.md` also contain PR links for past crashes
-of each type — cross-reference them when a heuristic from Phase 4 matches.
+of each type — cross-reference them when a heuristic from Phase 3 matches.
 
 ---
 
@@ -409,12 +461,20 @@ of each type — cross-reference them when a heuristic from Phase 4 matches.
 ```markdown
 # Crash Analysis Report
 **Generated**: {ISO 8601 timestamp}
-**Source ref**: [`{GIT_REF}`](https://github.com/DataDog/dd-trace-py/tree/{GIT_REF}) {— reason, e.g. "user-provided tag" or "fallback to main"}
+**Source ref**: [`{GIT_REF}`](https://github.com/DataDog/dd-trace-py/tree/{GIT_REF}) {— reason, e.g. "from crash metadata v2.18.0" or "fallback to main"}
 
-## Attribution
-**{dd-trace-py bug | third-party bug ({library name}) | CPython bug | interaction/race | unknown}**
+## Crash Metadata
+{If fetched via UUID, include this section. Omit if the user pasted a raw stack trace.}
 
-{1-2 sentence justification.}
+| Field | Value |
+|-------|-------|
+| Tracer version | {tracer_version} |
+| Runtime version | {runtime_version} |
+| Service | {service} |
+| Platform / Arch | {platform} / {architecture} |
+| Signal | {signal, e.g. SIGSEGV, SIGABRT} |
+| Org ID | {org_id} |
+| Log link | [{log_id}]({log_url}) |
 
 ## Executive Summary
 {2-3 sentences: what crashed, which component, what the crashing thread was doing.
@@ -429,10 +489,6 @@ De-mystify the hex addresses — translate them to human-readable description of
 
 {Note any other threads if provided, but focus on the crashed thread.}
 
-## Pattern Match
-{If a known pattern matched, name it and explain why.
-If no known pattern matched, say so.}
-
 ## Code Context
 
 {For each critical dd-trace-py frame:}
@@ -446,6 +502,16 @@ If no known pattern matched, say so.}
 
 **Analysis**: {what the code does and why it crashed}
 
+## Pattern Match
+{If a known pattern from Phase 3 matched, name it and explain why.
+If no known pattern matched, say so.}
+
+## Attribution
+**{dd-trace-py bug | third-party bug ({library name}) | CPython bug ({link to issue if found}) | interaction/race | unknown}**
+
+{2-3 sentence justification referencing evidence from code investigation, pattern matching,
+and web search results. Explain WHY this attribution was chosen.}
+
 ## Crash Flow Reconstruction
 
 {Step-by-step narrative}
@@ -458,6 +524,9 @@ If no known pattern matched, say so.}
 
 **Relevant PRs and commits**:
 - [#{number}](https://github.com/DataDog/dd-trace-py/pull/{number}): {title} — {why relevant}
+
+**Upstream issues** (if any):
+- [{issue title}]({url}) — {relevance}
 
 **Related code locations**:
 - [{file}:{line}](GitHub link) — {description}
@@ -483,9 +552,10 @@ If no known pattern matched, say so.}
 
 ## Important Guidelines
 
-- **Attribution first**: Always determine whether the crash is in dd-trace-py before diving deep.
-  The crashtracker captures all process crashes — many will be in third-party code (Pyroscope,
-  customer extensions, gevent) and should be clearly labeled as such.
+- **Investigate before attributing**: The crashtracker captures all process crashes — many will
+  be in third-party code (Pyroscope, customer extensions, gevent). Investigate the code and
+  apply heuristics (Phases 2-3) before making the attribution call (Phase 4). The evidence
+  you gather significantly improves attribution accuracy.
 - **Native frames are opaque**: Stack frames often have only a hex address and symbol name, no
   file:line. Use the symbol name + `.so` name to classify and find source.
 - **`_native__lib` vs `_native`**: `_native__lib` (double underscore, in `pyroscope/`) is ALWAYS
@@ -502,5 +572,5 @@ If no known pattern matched, say so.}
 
 ## Now Analyze
 
-Parse the stack trace provided by the user and follow the workflow above to generate a
-comprehensive crash analysis.
+Obtain the crash data (fetch by UUID or parse the pasted log), resolve the source revision,
+and follow the workflow above to generate a comprehensive crash analysis.

--- a/.claude/skills/analyze-crash/SKILL.md
+++ b/.claude/skills/analyze-crash/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: analyze-crash
+description: Native crash stack trace analysis for dd-trace-py
+argument-hint: <paste-stack-trace>
+disable-model-invocation: false
+context: fork
+agent: general-purpose
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - TodoWrite
+---
+
+# Native Crash Stack Trace Analysis for dd-trace-py
+
+You are analyzing a native crash stack trace captured by dd-trace-py's crashtracker. Perform a
+comprehensive investigation to help engineers understand and triage the crash. The crashtracker
+captures **all process-level native crashes**, so the crashing code may or may not be in dd-trace-py
+itself — your first job is to determine attribution.
+
+## Input Processing
+
+The user has provided a native crash stack trace. The format is typically:
+
+```
+0x7f6e81c51fb7 PyUnicode_AsUTF8AndSize
+0x7f6e769d7850 pycbc::Connection::open_bucket(_object*)
+0x7f6e81ccd60c
+0x7f6e81c53239 _PyObject_Call
+...
+```
+
+Frames may have: hex address only, hex address + symbol, or symbol + `.so` name + offset. Parse
+all available information.
+
+## Analysis Workflow
+
+### GitHub Link Generation
+
+When referencing files in dd-trace-py, always provide clickable GitHub links:
+
+**Format**:
+```
+[filename:line](https://github.com/DataDog/dd-trace-py/blob/main/path/to/file#Lline)
+```
+
+**Examples**:
+- Single line: `[_threads.cpp:226](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/internal/_threads.cpp#L226)`
+- Range: `[_threads.cpp:226-252](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/internal/_threads.cpp#L226-L252)`
+
+**Path construction**: base URL is `https://github.com/DataDog/dd-trace-py/blob/main/`, then
+append the repo-relative path (strip any build-specific prefixes like `/home/runner/work/`,
+`/usr/local/lib/`, etc.).
+
+---
+
+### Phase 1: Parse & Classify Stack Frames
+
+Extract all stack frames and classify each one using the categories below.
+
+#### Frame Classification
+
+**CPython Runtime** — the Python interpreter itself:
+- `.so` name: `python3.X`, `libpython3.X.so`, `libpython3.X.so.1.0`
+- Symbols: `_PyEval_EvalFrameDefault`, `PyGILState_Ensure`, `take_gil`, `new_threadstate`,
+  `PyEval_RestoreThread`, `PyEval_SaveThread`, `Py_RunMain`, `PyObject_Call*`, `_Py_*`,
+  `PyThread_exit_thread`, `_PyRuntime`, `_PyThreadState_*`
+
+**dd-trace-py Native (_threads)** — periodic thread / GIL management:
+- `.so` name: `_threads.cpython-*.so`
+- Symbols: `PeriodicThread_start`, `PeriodicThread_stop`, `PeriodicThread_join`,
+  `PeriodicThread__periodic`, `PeriodicThread__before_fork`, `PeriodicThread__after_fork`,
+  `PeriodicThread__on_shutdown`, `PeriodicThread_awake`, `PeriodicThread_dealloc`,
+  `GILGuard`, `AllowThreads`, `PyRef`, `execute_native_thread_routine`
+
+**dd-trace-py Native (_native / Rust)** — crashtracker, data pipeline, tracer utilities:
+- `.so` name: `_native.cpython-*.so` (under `ddtrace/internal/native/`)
+- Symbols: `crashtracker_*`, `TraceExporterPy::send`, `pyo3::*`, `rust_begin_unwind`,
+  `rust_panic`, `libdd_crashtracker::*`, `datadog_profiling_ffi::*`, `ffe::*`, `ddsketch::*`
+
+**dd-trace-py Native (_memalloc)** — memory profiler:
+- `.so` name: `_memalloc.cpython-*.so`
+- Symbols: `memalloc_*`, `Datadog::Sample*` (when called from memalloc context)
+
+**dd-trace-py Native (_ddup / _stack / libdd_wrapper)** — profiling upload/sampling:
+- `.so` names: `_ddup.cpython-*.so`, `_stack.cpython-*.so`, `libdd_wrapper.cpython-*.so`
+- Symbols: `ddup_*`, `Datadog::Profile*`, `Datadog::Sample*`, `Datadog::Uploader*`,
+  `Datadog::Sampler*`, `Datadog::EchionSampler*`, `Datadog::StackRenderer*`, `echion_*`
+
+**dd-trace-py IAST/AppSec Native** — security instrumentation:
+- `.so` name: `_native.cpython-*.so` (under `ddtrace/appsec/`), `_stacktrace.cpython-*.so`
+- Symbols: `taint_*`, `TaintEngine*`, `tainted_ops::*`
+
+**dd-trace-py Cython** — Python-level profiling helpers:
+- `.so` names: `_threading.cpython-*.so`, `_exception.cpython-*.so`, `_sampler.cpython-*.so`,
+  `_lock.cpython-*.so`, `_task.cpython-*.so`, `_encoding.cpython-*.so`
+- Symbols: Cython-generated (often `__pyx_*` prefixes or module function names)
+
+**Third-Party Native (NOT dd-trace-py)** — known third-party libs:
+- `libev-*.so` / `libev.so.4` — gevent's embedded libev (NOT dd-trace-py)
+- `_native__lib.cpython-*.so` — Pyroscope's native extension (path contains `pyroscope/`)
+  **Note:** Pyroscope crashes appear in dd-trace-py crash telemetry because the crashtracker
+  captures all process-level crashes. `_native__lib` (double underscore, in `pyroscope/`) is
+  ALWAYS Pyroscope, never dd-trace-py. dd-trace-py's module is `_native` (single underscore,
+  in `ddtrace/internal/native/`).
+- `anyhow::error::object_drop`, `py_spy::*`, `goblin::*` — Pyroscope/py-spy Rust code
+- Customer application code, third-party Python extensions
+
+**OS/libc** — system libraries:
+- `libc.so.6`, `libpthread.so`, `libm.so`
+- Symbols: `gsignal`, `abort`, `pthread_exit`, `pthread_mutex_lock`, `__clone3`, `start_thread`,
+  `cfree`, `free`, `malloc`
+
+Create a classification table:
+
+| # | Type | Symbol / Location | Description |
+|---|------|------------------|-------------|
+| 0 | {type} | {symbol} | {brief description} |
+| ... | | | |
+
+---
+
+### Phase 2: Attribute the Crash
+
+Before diving into code, answer: **Is this a dd-trace-py bug?**
+
+Use these signals:
+
+1. **Is any dd-trace-py native frame in the crashing thread?** If the only dd-trace-py frames are
+   in other threads (not the crashing one), or absent entirely, dd-trace-py may not be the root cause.
+
+2. **Is the crashing `.so` a known third-party library?**
+   - `_native__lib.cpython-*.so` in a `pyroscope/` path → Pyroscope bug
+   - `libev-*.so` in a gevent-using app → gevent/libev interaction
+   - Customer `.so` (e.g., `pycbc`, `grpc`) → third-party extension bug
+
+3. **Does the crash match a known dd-trace-py pattern?** (see Phase 4)
+
+State the attribution clearly: **dd-trace-py bug**, **third-party bug**, **CPython bug**,
+**interaction/race between components**, or **unknown**.
+
+---
+
+### Phase 3: Locate dd-trace-py Source Code
+
+For each dd-trace-py frame that can be mapped to source code:
+
+1. **Map `.so` name to source file**:
+   - `_threads.cpython-*.so` → `ddtrace/internal/_threads.cpp`
+   - `_native.cpython-*.so` (in `ddtrace/internal/native/`) → `src/native/` (Rust)
+   - `_memalloc.cpython-*.so` → `ddtrace/profiling/collector/_memalloc.cpp`
+   - `_ddup.cpython-*.so` → `ddtrace/internal/datadog/profiling/ddup/`
+   - `_stack.cpython-*.so` → `ddtrace/internal/datadog/profiling/stack/`
+   - `libdd_wrapper.cpython-*.so` → `ddtrace/internal/datadog/profiling/dd_wrapper/`
+
+2. **Find the function** in the source file using Glob/Bash grep.
+
+3. **Read code with context**: find the function body, read 10-15 lines before the relevant
+   line, mark the crash point, read 5-10 lines after. Show enough to understand what the code is
+   doing.
+
+Format:
+```
+### Frame N: {symbol} ([{file}:{line}](GitHub link))
+
+​```cpp
+// {file}:{start}-{end}
+{code with relevant line marked: // >>> CRASH POINT <<<}
+​```
+
+**Analysis**: {what this code does and why it may have failed}
+```
+
+---
+
+### Phase 4: Apply General Crash Heuristics
+
+dd-trace-py maintains two complementary native code safety references:
+
+- `docs/native-code-review.md` — full incident-derived rules with historical PR links (10 sections)
+- `.cursor/rules/native-code.mdc` — compact triage checklist with trigger symbols and stop conditions
+
+Read **both files now**. Use their framework to classify the crash. The categories below
+summarize the key stack-trace signals; refer to the docs for full rationale and PR history.
+
+#### 4.1 — GIL Lifecycle During Finalization
+
+**Stack signals**: `PyGILState_Ensure`, `PyEval_RestoreThread`, `take_gil`, `new_threadstate`,
+`PyThread_exit_thread`, `pthread_exit`, `abort`, `gsignal`, `__forced_unwind`,
+`abi::__cxa_throw`, `std::terminate` — especially combined with thread-entry frames like
+`execute_native_thread_routine` or Rust `extern "C"` boundaries.
+
+**What to check**:
+- Is there a `py_is_finalizing()` / `is_finalizing()` check immediately before each GIL
+  acquire/restore call? These checks are inherently TOCTTOU — finalization can begin in the
+  window between the check and the call.
+- Does the crash involve C++ RAII unwinding? `pthread_exit` on glibc throws
+  `abi::__forced_unwind`; any C++ destructor or `catch(...)` that does not re-throw it will
+  cause `std::terminate` → `SIGABRT`. On musl (Alpine Linux), `pthread_exit` uses `longjmp`
+  instead — `catch(abi::__forced_unwind&)` never fires.
+- For Rust/pyo3 code: `__forced_unwind` cannot propagate through `extern "C"` boundaries.
+  Rust code that calls `PyEval_RestoreThread` (or uses `py.detach()`) needs its own
+  finalization check — the C++ caller's `try/catch` cannot protect it.
+
+**CPython version behavior** (from `docs/native-code-review.md`):
+
+| CPython | Behavior when `take_gil()` detects finalization |
+|---------|------------------------------------------------|
+| 3.12 (all) | `PyThread_exit_thread()` → `pthread_exit()` → crash |
+| 3.13.0–3.13.7 | Same as 3.12 |
+| 3.13.8+ | `PyThread_hang_thread()` → `pause()` forever (hang, not crash) |
+| 3.14+ | Hangs; `PyGILState_Ensure` itself hangs safely in 3.15+ |
+
+**Key source locations**: `ddtrace/internal/_threads.cpp` (`GILGuard`, `AllowThreads`,
+`PeriodicThread_start`), `ddtrace/internal/threads.py` (atexit handler),
+`src/native/data_pipeline/mod.rs` (Rust pyo3 GIL release/restore).
+
+#### 4.2 — Fork Safety
+
+**Stack signals**: `pthread_mutex_lock`, `pthread_cond_wait`, `__lll_lock_wait` deep in a
+thread that recently went through `_after_fork`, `__clone3` / `start_thread` in a crash that
+occurs shortly after a fork event.
+
+**What to check**:
+- Any lock, mutex, or condition variable held by a parent thread is in an undefined state in
+  the child after `fork()`. Child path must **recreate** primitives; parent path must
+  **clear** them (other threads still hold references).
+- Were all periodic threads stopped and joined before the fork? Was `_before_fork()` called?
+- Did a thread fail to stop (blocked in I/O) and get inherited into the child while still
+  holding a lock?
+
+**Key source locations**: `ddtrace/internal/_threads.cpp` (`_before_fork`, `_after_fork`,
+`safe_reset_thread`), `ddtrace/internal/threads.py` (`_before_fork`, `_after_fork_child`).
+
+#### 4.3 — Object Lifetime Across Thread Boundaries (Use-After-Free)
+
+**Stack signals**: SIGSEGV or SIGBUS at a CPython refcount operation (`Py_INCREF`,
+`Py_DECREF`, `_Py_Dealloc`), or inside a `PyObject*` dereference inside a native thread
+shortly after the thread started or while it was shutting down.
+
+**What to check**:
+- Was `Py_INCREF` called *before* `std::thread` creation? If it happens inside the lambda,
+  there is a window where the object can be freed before the thread increments the refcount.
+- Is `Py_DECREF` called after the thread has signaled completion (e.g., after
+  `stopped_event->set()`)? On CPython 3.14+, `_Py_Dealloc` dereferences `tstate`
+  immediately — `Py_DECREF` with a NULL tstate (during finalization) crashes.
+- Does `PyRef` correctly defer the decrement until outside the finalization window?
+
+**Key source locations**: `ddtrace/internal/_threads.cpp`
+
+#### 4.4 — Memory Safety in Allocator Hooks
+
+**Stack signals**: Crash inside `_memalloc.cpython-*.so` with CPython allocation functions
+(`PyMem_Malloc`, `PyObject_Malloc`) or frame-walking functions (`PyThreadState_GetFrame`,
+`PyFrame_GetBack`, `PyFrame_GetCode`, `PyUnicode_AsUTF8AndSize`) in the trace — especially
+if the crash is a heap corruption SIGABRT or a SIGSEGV inside a seemingly unrelated function.
+
+**What to check**:
+- Is the crashing code executing inside a `malloc`/`free`/`realloc` hook? Any Python C API
+  call that can allocate or trigger GC is unsafe there — it causes reentrant hook calls that
+  corrupt internal state.
+- Safe functions inside hooks: `PyThread_get_thread_ident()`, `Py_INCREF`, direct struct
+  field reads. Unsafe: `Py_DECREF`, `PyFrame_GetBack()`, `PyUnicode_AsUTF8AndSize()`,
+  `PyObject_CallObject()`.
+- Is GC explicitly disabled? Verify it is actually compiled in (a previous fix was silently
+  dead code due to a missing `#include`).
+
+**Key source locations**: `ddtrace/profiling/collector/_memalloc.cpp`,
+`ddtrace/profiling/collector/_memalloc_tb.cpp`
+
+#### 4.5 — FFI Exception and Unwind Propagation
+
+**Stack signals**: `rust_begin_unwind`, `rust_panic`, `__rust_start_panic` in frames from
+`_native.cpython-*.so`; or `abi::__cxa_throw` / `__cxa_rethrow` crossing between `.so`
+files; or `std::terminate` called from inside Rust code.
+
+**What to check**:
+- `abi::__forced_unwind` (from `pthread_exit`) cannot propagate through Rust `extern "C"`
+  boundaries — Rust aborts on foreign exceptions.
+- Does any Rust function call `PyEval_RestoreThread` or use `py.detach()` without a
+  finalization check? It needs its own guard; the surrounding C++ `try/catch` cannot help.
+- Does a C++ `catch(...)` exist that swallows `__forced_unwind` without re-throwing? That
+  calls `std::terminate`.
+- Does a native function call `getenv()` or (in Rust) `std::env::var()`? These are not
+  thread-safe when another thread modifies the environment concurrently — can cause SIGSEGV.
+
+**Key source locations**: `src/native/data_pipeline/mod.rs`, `ddtrace/internal/_threads.cpp`
+(thread lambda catch blocks).
+
+#### 4.6 — Unbounded Loops and Recursion
+
+**Stack signals**: Deep or repeating identical frames (same function appearing many times),
+deadlock-style hangs with a lock held (visible in thread dumps as `pthread_mutex_lock` with
+no progress), or `SIGABRT` from `std::terminate` after a recursive call depth is exceeded.
+
+**What to check**:
+- Is there a loop over a CPython internal linked list (interpreters, threads, greenlets) with
+  no upper bound? Corrupted or cyclic structures cause infinite loops.
+- Can any function called from instrumentation code acquire a lock that is also instrumented
+  (e.g., a lock profiler that logs, logging that acquires a lock)?
+- Is there an explicit iteration limit?
+
+**Key source locations**: Any loop over `interp->next`, greenlet chains, or stack chunks in
+`ddtrace/internal/datadog/profiling/stack/`.
+
+#### 4.7 — Cython Silent Exception Swallowing
+
+**Stack signals**: Incorrect/unexpected behavior rather than a hard crash; or a crash inside
+a Cython-generated `.so` (`__pyx_*` frames) where a NULL pointer is dereferenced after a
+function returned 0/NULL with no exception set.
+
+**What to check**:
+- Does every `cdef` function that can raise declare `except *`, `except -1`, or `except? -1`?
+  Without this, exceptions are silently discarded and the caller proceeds with corrupt state.
+- Do `nogil` blocks avoid all Python C API calls and `PyObject*` access? Only pure C/C++
+  operations are safe inside `nogil` — any Python API call there is undefined behaviour.
+- Are `PyUnicode_AsUTF8AndSize` results stored as `string_view` / raw `const char*` while
+  the source Python object may have been garbage collected?
+
+**Key source locations**: `ddtrace/profiling/collector/_exception.pyx`,
+`ddtrace/profiling/collector/_lock.pyx`, `ddtrace/internal/_encoding.pyx`.
+
+#### 4.8 — Stripped Binary Misattribution
+
+**Stack signals**: Symbol names that don't match the `.so` they appear in, or a crash at an
+address that doesn't correspond to any named symbol in the frame (address-only frames at the
+top of a crashing `.so`).
+
+**What to check**:
+- In stripped release builds, the topmost named frame may be the *next* exported symbol
+  *after* the real crash site, not the function that actually crashed. The true crash may be
+  in an inlined or stripped function above it.
+- When comparing a crash address against source, verify against the pinned library version
+  (`src/native/Cargo.toml` for libdatadog, `setup.py` for libddwaf) — not the latest. API
+  and symbol layouts differ between versions.
+- If the reported function seems inconsistent with the rest of the stack, treat it as
+  approximate and look at the surrounding frames for the true call site.
+
+---
+
+### Phase 5: Reconstruct the Crash Flow
+
+Build a narrative explaining the execution flow leading to the crash:
+
+1. **Thread identity**: What kind of thread is this? (main thread, PeriodicThread, OS thread)
+2. **Entry point**: Where did execution start? (thread start function, signal handler, etc.)
+3. **Key operations**: What was the thread trying to do?
+4. **Critical transitions**: Where did control flow between components?
+5. **Failure point**: Where and why did it crash?
+6. **Crash type**: null dereference, use-after-free, race condition (TOCTTOU), `abort` via
+   `pthread_exit`/C++ unwinding, double-free, assertion failure, etc.
+
+Write this as a clear step-by-step narrative. Focus on HOW the crash happened based on the
+stack trace and code evidence. Do not prescribe specific fixes.
+
+---
+
+### Phase 6: Find Related Code and History
+
+Use Bash + git to find context:
+
+1. Recent commits to affected files: `git log --oneline -10 {file}`
+2. Search for relevant changes: `git log --grep="GIL" --grep="finalize" --grep="crash" --oneline -20`
+   (use keywords relevant to the crash area)
+3. For each relevant commit, extract PR numbers from the message (e.g., `(#7659)`) and link:
+   `https://github.com/DataDog/dd-trace-py/pull/{number}`
+4. Grep for `AIDEV-` comments near the crash site: `grep -n "AIDEV" {file}` — these are
+   embedded rationale notes left specifically for AI and developers explaining non-obvious
+   invariants. Read any that are near relevant functions.
+
+**Prioritize PR links** — PRs have descriptions and discussion context that commit messages lack.
+The historical examples in `docs/native-code-review.md` also contain PR links for past crashes
+of each type — cross-reference them when a heuristic from Phase 4 matches.
+
+---
+
+## Output Format
+
+```markdown
+# Crash Analysis Report
+**Generated**: {ISO 8601 timestamp}
+
+## Attribution
+**{dd-trace-py bug | third-party bug ({library name}) | CPython bug | interaction/race | unknown}**
+
+{1-2 sentence justification.}
+
+## Executive Summary
+{2-3 sentences: what crashed, which component, what the crashing thread was doing.
+De-mystify the hex addresses — translate them to human-readable description of the crash.}
+
+## Stack Trace Classification
+
+| # | Type | Symbol / Location | Description |
+|---|------|------------------|-------------|
+| 0 | {type} | {symbol} | {brief desc} |
+| ... | | | |
+
+{Note any other threads if provided, but focus on the crashed thread.}
+
+## Pattern Match
+{If a known pattern matched, name it and explain why.
+If no known pattern matched, say so.}
+
+## Code Context
+
+{For each critical dd-trace-py frame:}
+
+### Frame N: {symbol} ([{file}:{line}](GitHub link))
+
+​```cpp
+// {file}:{start}-{end}
+{code with // >>> CRASH POINT <<< marker}
+​```
+
+**Analysis**: {what the code does and why it crashed}
+
+## Crash Flow Reconstruction
+
+{Step-by-step narrative}
+
+**Crash type**: {e.g., TOCTTOU race → null dereference in new_threadstate}
+
+**How it happened**: {clear explanation based on stack trace + code}
+
+## Related Code
+
+**Relevant PRs and commits**:
+- [#{number}](https://github.com/DataDog/dd-trace-py/pull/{number}): {title} — {why relevant}
+
+**Related code locations**:
+- [{file}:{line}](GitHub link) — {description}
+
+## Additional Context
+{Environment details, Python version, platform, feature flags in use, or other relevant background.}
+
+---
+*Analysis generated by Claude Code /analyze-crash*
+*This analysis is intended for triage. Engineers should review before acting on it.*
+```
+
+---
+
+## Output File Management
+
+1. **Create output directory**: `mkdir -p ~/.claude/analysis && echo ~/.claude/analysis`
+2. **Generate filename**: `crash-analysis-{YYYYMMDD-HHMMSS}.md`
+3. **Save file**: Write the markdown analysis to the file
+4. **Tell the user** the full path where the analysis was saved
+
+---
+
+## Important Guidelines
+
+- **Attribution first**: Always determine whether the crash is in dd-trace-py before diving deep.
+  The crashtracker captures all process crashes — many will be in third-party code (Pyroscope,
+  customer extensions, gevent) and should be clearly labeled as such.
+- **Native frames are opaque**: Stack frames often have only a hex address and symbol name, no
+  file:line. Use the symbol name + `.so` name to classify and find source.
+- **`_native__lib` vs `_native`**: `_native__lib` (double underscore, in `pyroscope/`) is ALWAYS
+  Pyroscope. `_native` (single underscore, in `ddtrace/internal/native/`) is dd-trace-py. Never
+  confuse them.
+- **Focus on triage and understanding**: Explain HOW the crash happened; do not prescribe fixes.
+- **Describe crash types**: Identify the category (null deref, race, abort, use-after-free) but
+  stop before suggesting specific code changes.
+- **Continue with missing info**: If a symbol can't be found in source, note it and continue.
+- **Mark uncertainties**: If something is speculative, say so explicitly.
+- **Always include GitHub links**: Every file:line reference should be a clickable link.
+- **Prefer PR links over commits**: Extract `(#NNNN)` from commit messages and link to the PR.
+
+## Now Analyze
+
+Parse the stack trace provided by the user and follow the workflow above to generate a
+comprehensive crash analysis.

--- a/.claude/skills/analyze-crash/fetch_crash.py
+++ b/.claude/skills/analyze-crash/fetch_crash.py
@@ -9,16 +9,21 @@ Requires: pip install datadog-api-client
 """
 
 import argparse
+from collections import OrderedDict
+from ctypes import CDLL
+from ctypes import c_char_p
+from ctypes import c_int
+from ctypes import c_void_p
 import ctypes.util
+from datetime import datetime
+from datetime import timedelta
 import json
 import re
 import sys
-from collections import OrderedDict
-from ctypes import CDLL, c_char_p, c_int, c_void_p
-from datetime import datetime, timedelta
 from time import sleep
 
-from datadog_api_client import ApiClient, Configuration
+from datadog_api_client import ApiClient
+from datadog_api_client import Configuration
 from datadog_api_client.exceptions import ApiException
 from datadog_api_client.v2.api import logs_api
 from datadog_api_client.v2.model.logs_list_request import LogsListRequest
@@ -37,6 +42,7 @@ class _DateTimeEncoder(json.JSONEncoder):
 # ---------------------------------------------------------------------------
 # C++ symbol demangling
 # ---------------------------------------------------------------------------
+
 
 def _init_demangler():
     lib = ctypes.util.find_library("c++")
@@ -198,9 +204,7 @@ def process_crash_log(raw_attrs):
         if "frames" in stack_data:
             raw_frames = stack_data["frames"]
         elif stack_data.get("incomplete"):
-            raw_frames = [
-                {"ip": "0x0", "sp": "0x0", "names": [{"name": "INCOMPLETE_STACK"}]}
-            ]
+            raw_frames = [{"ip": "0x0", "sp": "0x0", "names": [{"name": "INCOMPLETE_STACK"}]}]
         else:
             raw_frames = []
     elif isinstance(stack_data, list):
@@ -226,16 +230,8 @@ def process_crash_log(raw_attrs):
 
     result = OrderedDict()
     result["tracer_version"] = raw_attrs.get("tracer_version", "unknown")
-    result["runtime_version"] = (
-        raw_attrs.get("language_version")
-        or tag_map.get("runtime_version")
-        or "unknown"
-    )
-    result["service"] = (
-        raw_attrs.get("instrumented_service")
-        or tag_map.get("service")
-        or "unknown"
-    )
+    result["runtime_version"] = raw_attrs.get("language_version") or tag_map.get("runtime_version") or "unknown"
+    result["service"] = raw_attrs.get("instrumented_service") or tag_map.get("service") or "unknown"
     result["org_id"] = raw_attrs.get("org_id", "unknown")
     result["platform"] = os_info.get("os_type") or host.get("os", "unknown")
     result["architecture"] = os_info.get("architecture") or host.get("arch") or "unknown"
@@ -274,9 +270,7 @@ def process_crash_log(raw_attrs):
             name = entry["file"]
             if name not in seen and not name.startswith("["):
                 seen.add(name)
-                binary_mappings.append(
-                    f"  {hex(entry['start'])}-{hex(entry['end'])} {name}"
-                )
+                binary_mappings.append(f"  {hex(entry['start'])}-{hex(entry['end'])} {name}")
         result["binary_mappings_summary"] = binary_mappings[:50]
 
     return result
@@ -346,8 +340,7 @@ def fetch_crash_by_uuid(uuid, lib_language="python", tracer_version="*", org_id=
         processed = process_crash_log(raw_attrs)
         if processed is None:
             print(
-                "Crash log found but could not be processed "
-                "(missing error.stack or unexpected format).",
+                "Crash log found but could not be processed (missing error.stack or unexpected format).",
                 file=sys.stderr,
             )
             json.dump(raw_attrs, sys.stderr, indent=2, cls=_DateTimeEncoder)

--- a/.claude/skills/analyze-crash/fetch_crash.py
+++ b/.claude/skills/analyze-crash/fetch_crash.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Fetch and process a single crash log from Datadog by UUID.
+
+Usage:
+    python fetch_crash.py <uuid> [--lib-language python] [--tracer-version '*'] [--org-id '*'] [--days 14]
+
+Requires DD_API_KEY and DD_APP_KEY environment variables.
+Requires: pip install datadog-api-client
+"""
+
+import argparse
+import ctypes.util
+import json
+import re
+import sys
+from collections import OrderedDict
+from ctypes import CDLL, c_char_p, c_int, c_void_p
+from datetime import datetime, timedelta
+from time import sleep
+
+from datadog_api_client import ApiClient, Configuration
+from datadog_api_client.exceptions import ApiException
+from datadog_api_client.v2.api import logs_api
+from datadog_api_client.v2.model.logs_list_request import LogsListRequest
+from datadog_api_client.v2.model.logs_list_request_page import LogsListRequestPage
+from datadog_api_client.v2.model.logs_query_filter import LogsQueryFilter
+from datadog_api_client.v2.model.logs_sort import LogsSort
+
+
+class _DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+# ---------------------------------------------------------------------------
+# C++ symbol demangling
+# ---------------------------------------------------------------------------
+
+def _init_demangler():
+    lib = ctypes.util.find_library("c++")
+    if lib:
+        cxx = CDLL(lib)
+    else:
+        for name in ("libc++.so", "libc++.dylib", "libstdc++.so.6"):
+            try:
+                cxx = CDLL(name)
+                break
+            except OSError:
+                continue
+        else:
+            return None
+
+    fn = cxx.__cxa_demangle
+    fn.argtypes = [c_char_p, c_void_p, c_void_p, c_int]
+    fn.restype = c_char_p
+    return fn
+
+
+_demangler = None
+try:
+    _demangler = _init_demangler()
+except Exception:
+    pass
+
+
+def demangle(name):
+    if not _demangler or not name:
+        return name
+    try:
+        result = _demangler(name.encode("utf-8"), None, None, 0)
+        if result:
+            return result.decode("utf-8")
+    except Exception:
+        pass
+    return name
+
+
+# ---------------------------------------------------------------------------
+# /proc/self/maps parsing
+# ---------------------------------------------------------------------------
+
+_MAPS_RE = re.compile(
+    r"([0-9a-fA-F]+)-([0-9a-fA-F]+)\s+([rwxsp-]{4})\s+([0-9a-fA-F]+)"
+    r"\s+[0-9a-fA-F]+:[0-9a-fA-F]+\s+\d+\s*(.*)?",
+)
+
+
+def _parse_proc_maps(lines):
+    entries = []
+    for line in lines:
+        if not line:
+            continue
+        m = _MAPS_RE.match(line)
+        if not m:
+            continue
+        entries.append(
+            {
+                "start": int(m.group(1), 16),
+                "end": int(m.group(2), 16),
+                "offset": int(m.group(4), 16),
+                "file": (m.group(5).strip() or "[anonymous]"),
+            }
+        )
+    return entries
+
+
+def _resolve_address(ip, maps):
+    for entry in maps:
+        if entry["start"] <= ip < entry["end"]:
+            return {
+                "binary": entry["file"].rsplit("/", 1)[-1],
+                "binary_path": entry["file"],
+                "offset": hex(ip - entry["start"] + entry["offset"]),
+            }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Stack frame processing
+# ---------------------------------------------------------------------------
+
+
+def _process_frame(frame, maps):
+    try:
+        ip = int(frame["ip"], 16)
+        sp = int(frame["sp"], 16)
+    except (ValueError, KeyError):
+        return []
+
+    # Prefer inline `path` / `relative_address` (new crashtracker format)
+    # over /proc/self/maps resolution.
+    if "path" in frame:
+        binary_path = frame["path"]
+        binary = binary_path.rsplit("/", 1)[-1]
+        offset = frame.get("relative_address", "")
+    else:
+        resolved = _resolve_address(ip, maps)
+        if resolved:
+            binary_path = resolved["binary_path"]
+            binary = resolved["binary"]
+            offset = resolved["offset"]
+        else:
+            binary_path = ""
+            binary = ""
+            offset = ""
+
+    # Build the names list from whichever field is present.
+    if "function" in frame and not frame.get("names"):
+        names = [{"name": frame["function"]}]
+    elif frame.get("names"):
+        names = frame["names"]
+    else:
+        names = [{}]
+
+    frames = []
+    for idx, name_entry in enumerate(names):
+        symbol = demangle(name_entry.get("name", ""))
+        if len(names) > 1:
+            symbol += " (top)" if idx == 0 else " (inlined)"
+
+        f = {
+            "ip": hex(ip),
+            "sp": hex(sp),
+            "symbol": symbol or hex(ip),
+            "source_file": name_entry.get("filename", ""),
+            "source_line": str(name_entry.get("lineno", 0)),
+        }
+        if binary:
+            f["binary"] = binary
+            f["binary_path"] = binary_path
+        if offset:
+            f["offset"] = offset
+        frames.append(f)
+
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Crash log processing
+# ---------------------------------------------------------------------------
+
+
+def process_crash_log(raw_attrs):
+    """Process raw crash log attributes into a structured report."""
+    if "error" not in raw_attrs or "stack" not in raw_attrs["error"]:
+        return None
+
+    maps_lines = raw_attrs.get("files", {}).get("/proc/self/maps", [])
+    maps = _parse_proc_maps(maps_lines)
+
+    stack_data = raw_attrs["error"]["stack"]
+    if isinstance(stack_data, str):
+        stack_data = json.loads(stack_data)
+
+    if isinstance(stack_data, dict):
+        if "frames" in stack_data:
+            raw_frames = stack_data["frames"]
+        elif stack_data.get("incomplete"):
+            raw_frames = [
+                {"ip": "0x0", "sp": "0x0", "names": [{"name": "INCOMPLETE_STACK"}]}
+            ]
+        else:
+            raw_frames = []
+    elif isinstance(stack_data, list):
+        raw_frames = stack_data
+    else:
+        raw_frames = []
+
+    processed_frames = []
+    for frame in raw_frames:
+        processed_frames.extend(_process_frame(frame, maps))
+
+    tags = raw_attrs.get("metadata", {}).get("tags", [])
+    tag_map = {}
+    for tag in tags:
+        if ":" in tag:
+            k, v = tag.split(":", 1)
+            tag_map[k] = v
+
+    error = raw_attrs.get("error", {})
+    sig_info = raw_attrs.get("sig_info", {})
+    host = raw_attrs.get("host", {})
+    os_info = raw_attrs.get("os_info", {})
+
+    result = OrderedDict()
+    result["tracer_version"] = raw_attrs.get("tracer_version", "unknown")
+    result["runtime_version"] = (
+        raw_attrs.get("language_version")
+        or tag_map.get("runtime_version")
+        or "unknown"
+    )
+    result["service"] = (
+        raw_attrs.get("instrumented_service")
+        or tag_map.get("service")
+        or "unknown"
+    )
+    result["org_id"] = raw_attrs.get("org_id", "unknown")
+    result["platform"] = os_info.get("os_type") or host.get("os", "unknown")
+    result["architecture"] = os_info.get("architecture") or host.get("arch") or "unknown"
+
+    result["signal"] = sig_info.get("si_signo_human_readable") or "unknown"
+    result["signal_detail"] = error.get("message", "")
+    result["error_kind"] = error.get("kind", "")
+    result["thread_name"] = error.get("thread_name", "")
+
+    proc_info = raw_attrs.get("proc_info", {})
+    if proc_info:
+        result["pid"] = proc_info.get("pid")
+        result["tid"] = proc_info.get("tid")
+
+    result["tags"] = tag_map
+    result["stack"] = processed_frames
+
+    other_threads = error.get("threads")
+    if isinstance(other_threads, dict):
+        thread_list = other_threads.get("threads", [])
+        result["thread_count"] = other_threads.get("count", len(thread_list))
+    elif isinstance(other_threads, list):
+        result["thread_count"] = len(other_threads)
+
+    runtime_stack = raw_attrs.get("experimental", {}).get("runtime_stack", {})
+    if isinstance(runtime_stack, dict):
+        if runtime_stack.get("stacktrace_string"):
+            result["python_stack"] = runtime_stack["stacktrace_string"]
+        elif runtime_stack.get("frames"):
+            result["python_stack"] = runtime_stack["frames"]
+
+    if maps:
+        seen = set()
+        binary_mappings = []
+        for entry in maps:
+            name = entry["file"]
+            if name not in seen and not name.startswith("["):
+                seen.add(name)
+                binary_mappings.append(
+                    f"  {hex(entry['start'])}-{hex(entry['end'])} {name}"
+                )
+        result["binary_mappings_summary"] = binary_mappings[:50]
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Datadog API
+# ---------------------------------------------------------------------------
+
+
+def fetch_crash_by_uuid(uuid, lib_language="python", tracer_version="*", org_id="*", days=14):
+    """Fetch a single crash log from Datadog by UUID and return processed data."""
+    org_id_str = "*" if org_id == "*" else str(org_id)
+
+    query = f"uuid:{uuid}"
+
+    extra_filters = []
+    if lib_language != "*":
+        extra_filters.append(f"@lib_language:{lib_language}")
+    if org_id_str != "*":
+        extra_filters.append(f"@org_id:{org_id_str}")
+    if tracer_version != "*":
+        extra_filters.append(f"@tracer_version:{tracer_version}")
+    if extra_filters:
+        query += " " + " ".join(extra_filters)
+
+    print(f"Query: {query}", file=sys.stderr)
+
+    configuration = Configuration()
+    configuration.request_timeout = (10, 120)
+    end_time = datetime.now()
+    start_time = end_time - timedelta(days=days)
+
+    with ApiClient(configuration) as api_client:
+        api_instance = logs_api.LogsApi(api_client)
+        body = LogsListRequest(
+            filter=LogsQueryFilter(
+                query=query,
+                _from=str(int(start_time.timestamp() * 1000)),
+                to=str(int(end_time.timestamp() * 1000)),
+            ),
+            sort=LogsSort("timestamp_descending"),
+            page=LogsListRequestPage(limit=1),
+        )
+
+        response = None
+        for attempt in range(3):
+            try:
+                response = api_instance.list_logs(body=body)
+                break
+            except ApiException as e:
+                if e.status != 500 or attempt == 2:
+                    print(f"Datadog API error: {e.status} - {e.reason}", file=sys.stderr)
+                    sys.exit(1)
+                sleep(2**attempt)
+
+        if not response or not response.data:
+            print(f"No crash log found for UUID: {uuid}", file=sys.stderr)
+            print(f"Query used: {query}", file=sys.stderr)
+            sys.exit(1)
+
+        log = response.data[0]
+        raw_attrs = log.attributes.attributes
+        log_id = log.id
+        timestamp = log.attributes.timestamp.isoformat()
+
+        processed = process_crash_log(raw_attrs)
+        if processed is None:
+            print(
+                "Crash log found but could not be processed "
+                "(missing error.stack or unexpected format).",
+                file=sys.stderr,
+            )
+            json.dump(raw_attrs, sys.stderr, indent=2, cls=_DateTimeEncoder)
+            sys.exit(1)
+
+        processed["log_id"] = log_id
+        processed["timestamp"] = timestamp
+        processed["log_url"] = f"https://app.datadoghq.com/logs?event={log_id}"
+        processed["query_used"] = query
+
+        return processed
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch and process a single crash log from Datadog by UUID.",
+    )
+    parser.add_argument("uuid", help="Crash UUID to look up")
+    parser.add_argument(
+        "--lib-language",
+        default="python",
+        help="Library language filter (default: python)",
+    )
+    parser.add_argument(
+        "--tracer-version",
+        default="*",
+        help="Tracer version filter (default: *)",
+    )
+    parser.add_argument(
+        "--org-id",
+        default="*",
+        help="Org ID filter (default: *)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=14,
+        help="Days to look back (default: 14)",
+    )
+    args = parser.parse_args()
+
+    result = fetch_crash_by_uuid(
+        uuid=args.uuid,
+        lib_language=args.lib_language,
+        tracer_version=args.tracer_version,
+        org_id=args.org_id,
+        days=args.days,
+    )
+
+    json.dump(result, sys.stdout, indent=2, cls=_DateTimeEncoder)
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
[PROF-14874
](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-14874)
## Description

Add a Claude Code skill that performs structured analysis of native crash stack traces captured by dd-trace-py's crashtracker. Given a crash log, or crash id, the skill classifies frames (CPython, dd-trace-py native, third-party, OS), attributes the crash to the responsible component, locates relevant source code, matches against known crash patterns (GIL lifecycle, fork safety, use-after-free, allocator hooks, FFI unwinding, etc.), and produces a markdown triage report with GitHub links.

This codifies the crash triage knowledge from `docs/native-code-review.md` and `.cursor/rules/native-code.mdc`, and general knowledge into a repeatable, automated workflow.

This will be continuously iterated upon and improved

## Testing


Crash: https://app.datadoghq.com/logs?event=AwAAAZ6OY9iMmOk3vQAAABhBWjZPWTlpTUFBQmhNZDdNdmc0WlBRQUEAAAAkMDE5ZThlNjctOTk0OS00NmE0LWIyOWItMDM1NWU3MzA2MDJkAACpRw
```
# Crash Analysis Report
**Generated**: 2026-06-03T17:47:09Z
**Source ref**: [`v4.10.0`](https://github.com/DataDog/dd-trace-py/tree/v4.10.0) — from crash metadata tracer_version `4.10.0`; tag verified locally (`git rev-parse --verify v4.10.0` → `84ae72d7f3d2b20faa0c76250f9bf3e675d93075`).

---

## Crash Metadata

| Field | Value |
|-------|-------|
| Tracer version | 4.10.0 |
| Runtime version | CPython 3.11.15 |
| Service | postanatomy |
| Platform / Arch | Amazon Linux AMI / x86_64 |
| Signal | SIGABRT |
| Signal detail | `Process terminated with SI_TKILL (SIGABRT)` |
| Error kind | `Error UnixSignal` |
| Thread name | `predict_plaque` |
| PID / TID | 1454 / 1454 (main thread) |
| Thread count | 68 |
| Org ID | 394016 |
| Log link | [AwAAAZ6OY9iMmOk3vQAAABhBWjZPWTlpTUFBQmhNZDdNdmc0WlBRQUEAAAAkMDE5ZThlNjctOTk0OS00NmE0LWIyOWItMDM1NWU3MzA2MDJkAACpRw](https://app.datadoghq.com/logs?event=AwAAAZ6OY9iMmOk3vQAAABhBWjZPWTlpTUFBQmhNZDdNdmc0WlBRQUEAAAAkMDE5ZThlNjctOTk0OS00NmE0LWIyOWItMDM1NWU3MzA2MDJkAACpRw) |

---

## Executive Summary

The main thread (`predict_plaque`) crashed with SIGABRT (sent via `SI_TKILL` — the process killed itself) while executing a CUDA-accelerated ONNX Runtime inference session via `run_with_iobinding`. The crash originates entirely within ONNX Runtime's CUDA execution provider (`libonnxruntime_providers_cuda.so`) and libstdc++ C++ runtime internals, propagating through `__GI_abort` → `__GI_raise` → `__pthread_kill_implementation`. The Python stack confirms the crash site is `onnxruntime_inference_collection.py:384` (`run_with_iobinding`), called from customer code in `predict_plaque.py`. There is no dd-trace-py native code anywhere in the crashing thread's stack. The 68-thread process includes dd-trace-py periodic background threads, but none are involved in the crash path.

---

## Stack Trace Classification

| # | Type | Symbol / Location | Description |
|---|------|------------------|-------------|
| 0 | OS/libc | `__pthread_kill_implementation` (libc.so.6) | Send SIGABRT to the calling thread via `tkill` syscall |
| 1 | OS/libc | `__GI_raise` (libc.so.6) | Raise signal — wraps `pthread_kill` |
| 2 | OS/libc | `__GI_abort` (libc.so.6) | Call `abort()` — terminates process with SIGABRT |
| 3 | OS/libstdc++ | `0x7fc77ff13d69` (libstdc++.so.6.0.33) | libstdc++ C++ runtime internals (exception handling / terminate) |
| 4 | OS/libstdc++ | `0x7fc77ff25bcc` (libstdc++.so.6.0.33) | libstdc++ (likely `__cxa_throw` or `std::terminate` path) |
| 5 | OS/libstdc++ | `0x7fc77ff13809` (libstdc++.so.6.0.33) | libstdc++ terminate handler |
| 6 | OS/libstdc++ | `0x7fc77ff25451` (libstdc++.so.6.0.33) | libstdc++ unwind glue |
| 7 | OS/libgcc | `0x7fc7819acbf9` (libgcc_s-14-20250110.so.1) | libgcc unwind personality / phase 2 unwinding |
| 8 | OS/libgcc | `0x7fc7819ad6ad` (libgcc_s-14-20250110.so.1) | libgcc unwind support (likely `_Unwind_RaiseException` path) |
| 9 | **Third-Party / onnxruntime CUDA** | `VERS_1.0` (libonnxruntime_providers_cuda.so) | First named frame in CUDA provider — entry point into ORT CUDA EP during inference |
| 10 | Third-Party / onnxruntime CUDA | `0x7fc537b2dc20` (libonnxruntime_providers_cuda.so) | ORT CUDA execution provider internals |
| 11 | Third-Party / onnxruntime pybind | `0x7fc7506532aa` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) | ORT Python binding layer |
| 12 | Third-Party / onnxruntime pybind | `0x7fc7508926d8` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) | ORT Python binding — session execution |
| 13 | Third-Party / onnxruntime pybind | `0x7fc7508de0c7` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) | ORT Python binding — run or run_with_iobinding |
| 14 | Third-Party / onnxruntime pybind | `0x7fc74ff63b80` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) | ORT session execution dispatch |
| 15 | Third-Party / onnxruntime pybind | `0x7fc74ff6473f` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) | ORT provider resolution / kernel dispatch |
| 16 | Third-Party / onnxruntime pybind | `0x7fc74ff23b8a` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) | ORT CUDA graph or kernel scheduling |
| 17 | Third-Party / onnxruntime pybind | `0x7fc74fe9f5a2` (onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so) `VERS_1.0` | ORT Python session public API entry point |
| 18 | CPython Runtime | `0x7fc78228a802` (libpython3.11.so.1.0) | CPython call dispatch |
| 19 | CPython Runtime | `0x7fc7822652ec` (libpython3.11.so.1.0) | CPython call object |
| 20 | CPython Runtime | `0x7fc782270f25` (libpython3.11.so.1.0) | CPython call method |
| 21 | CPython Runtime | `0x7fc782337c70` (libpython3.11.so.1.0) | CPython eval frame |
| 22 | CPython Runtime | `0x7fc782337616` (libpython3.11.so.1.0) | CPython eval frame |
| 23 | CPython Runtime | `0x7fc782358fa4` (libpython3.11.so.1.0) | CPython eval frame |
| 24 | CPython Runtime | `0x7fc782354b2b` (libpython3.11.so.1.0) | CPython eval frame |
| 25 | CPython Runtime | `0x7fc78236ac61` (libpython3.11.so.1.0) | CPython eval loop |
| 26 | CPython Runtime | `0x7fc78236a4f8` (libpython3.11.so.1.0) | CPython eval loop |
| 27 | CPython Runtime | `0x7fc782369d57` (libpython3.11.so.1.0) | CPython eval loop |
| 28 | CPython Runtime | `0x7fc782364456` (libpython3.11.so.1.0) | CPython eval loop |
| 29 | CPython Runtime | `0x7fc78232701d` (libpython3.11.so.1.0) | `Py_RunMain` or interpreter boot |
| 30 | OS/libc | `__libc_start_call_main` (libc.so.6) | libc startup wrapper |
| 31 | OS/libc | `__libc_start_main_alias_2` (libc.so.6) | libc startup |
| 32 | CPython Runtime | `0x560a8296d095` (python3.11) | `_start` — Python interpreter entry point |

**Summary**: The entire crash stack from frame 0 to frame 8 is OS/libstdc++/libgcc runtime; frames 9–17 are exclusively onnxruntime (CUDA provider + pybind11 layer); frames 18–32 are CPython eval loop and startup. **Zero dd-trace-py frames appear in this thread.**

---

## Code Context

There are no dd-trace-py native frames in the crashing thread. The following is provided for completeness to confirm dd-trace-py was not involved.

The Python stack confirms the full call chain from user code:

\```
Current thread 0x00007fc781d99440 (most recent call first):
  File "onnxruntime_inference_collection.py", line 384 in run_with_iobinding
  File "predict_plaque.py", line 472 in predict
  File "predict_plaque.py", line 731 in predict_batches
  File "predict_plaque.py", line 808 in predict_plaque
  File "predict_plaque.py", line 829 in _main
  File "predict_plaque.py", line 852 in main
  File "predict_plaque", line 8 in <module>
\```

The Python execution path is:
1. `predict_plaque` CLI entrypoint
2. → `main()` → `_main()` → `predict_plaque()` → `predict_batches()` → `predict()`
3. → `onnxruntime_inference_collection.InferenceSession.run_with_iobinding()` (line 384)
4. → CUDA ONNX Runtime execution provider → C++ unwind → `abort()`

This confirms the crash is entirely within the ONNX Runtime CUDA execution provider during a GPU inference call.

---

## Pattern Match

None of the standard dd-trace-py crash heuristics (§3.1–§3.8 from `docs/native-code-review.md`) apply here:

- **§3.1 GIL Lifecycle During Finalization**: Not present. No `PyGILState_Ensure`, `take_gil`, `pthread_exit`, `PyEval_RestoreThread`, or `AllowThreads` in the crashing thread.
- **§3.2 Fork Safety**: Not applicable. No `pthread_mutex_lock` in a fork context.
- **§3.3 Object Lifetime Across Thread Boundaries**: Not applicable. No `Py_INCREF`/`Py_DECREF` in the crash path.
- **§3.4 Memory Safety in Allocator Hooks**: Not applicable. No memalloc hooks involved.
- **§3.5 FFI Exception and Unwind Propagation**: The libstdc++ frames (3–6) do suggest a C++ exception or `std::terminate` path inside onnxruntime. The `__GI_abort` at frame 2 is consistent with `std::terminate` being called (which calls `abort()`). However, this is happening entirely within onnxruntime's own code, not at a dd-trace-py FFI boundary.
- **§3.6 Unbounded Loops and Recursion**: Not present.
- **§3.7 Cython Silent Exception Swallowing**: Not applicable.
- **§3.8 Stripped Binary Misattribution**: The many address-only frames in onnxruntime indicate a stripped release binary, making exact attribution within ORT impossible without symbols. The overall pattern is still clear.

The closest match is the well-known onnxruntime CUDA EP pattern of `std::terminate` being triggered during inference or cleanup when an exception propagates through a `noexcept` boundary or destructor inside ORT's CUDA provider (see upstream issues #21207, #15174).

---

## Attribution

**Third-party bug (onnxruntime CUDA Execution Provider)**

The crash originates entirely within `libonnxruntime_providers_cuda.so` and the `onnxruntime_pybind11_state` extension. The call stack shows no dd-trace-py native code in the crashing thread. The libstdc++ frames (3–6) are consistent with `std::terminate` being invoked — typically from an uncaught exception propagating through a `noexcept` function or a destructor during stack unwinding — within ORT's CUDA provider. This matches the known onnxruntime upstream pattern of CUDA driver exceptions (e.g., `cudaEventSynchronize` throwing `OnnxRuntimeException` during CUDA cleanup or inference) escaping through `noexcept` code paths and triggering `abort()`. The crashtracker captured this crash because it monitors all native crashes in the process, not because dd-trace-py caused it.

---

## Crash Flow Reconstruction

1. **Thread identity**: This is the Python main thread (TID = PID = 1454), named `predict_plaque`, running as a command-line script.

2. **Entry point**: Process was launched as `/usr/bin/predict_plaque` → CPython `_start` → `__libc_start_main` → Python interpreter boot → `Py_RunMain` → eval loop.

3. **Application code**: The `predict_plaque` clinical ML script executed through several layers of its own logic to reach `InferenceSession.run_with_iobinding()` — the ONNX Runtime Python API for zero-copy GPU inference using pre-allocated IOBinding buffers.

4. **CUDA EP dispatch**: `run_with_iobinding` (ORT Python layer, `onnxruntime_pybind11_state.so`) dispatched to the CUDA Execution Provider (`libonnxruntime_providers_cuda.so`), passing control to CUDA kernel scheduling and execution.

5. **Exception or CUDA error**: Something went wrong inside the CUDA EP — a CUDA API call likely returned an error code (e.g., illegal memory access, device synchronization failure, driver error) which ORT converted to a C++ exception (`OnnxRuntimeException`).

6. **Unwind through noexcept or destructor**: The exception propagated up through C++ stack frames inside ORT. It encountered either a `noexcept` function, a destructor during unwinding, or a `catch(...)` that called `std::terminate()`. The libstdc++ frames (3–6) and libgcc unwind frames (7–8) represent this C++ stack unwinding sequence.

7. **`std::terminate` → `abort()`**: `std::terminate` called the default terminate handler, which called `abort()` (`__GI_abort` at frame 2), which sent `SIGABRT` to the process via `__GI_raise` → `__pthread_kill_implementation`.

**Crash type**: C++ `std::terminate` triggered by an uncaught exception escaping a `noexcept` boundary or a destructor inside onnxruntime's CUDA Execution Provider, leading to `abort()` → SIGABRT.

**How it happened**: The ONNX Runtime CUDA provider encountered a CUDA error during `run_with_iobinding`, threw a C++ exception, and that exception propagated through a code path that is not exception-safe (a `noexcept` function or destructor), causing `std::terminate` to call `abort()`. This is a known failure mode in onnxruntime's CUDA EP, particularly when CUDA driver state becomes inconsistent (device errors, memory errors, driver shutdown races).

---

## Related Code

**Upstream onnxruntime issues**:
- [ORT #21207 — ORT 1.18 crashes on exit after using CUDA EP](https://github.com/microsoft/onnxruntime/issues/21207) — `std::terminate` called during `ProviderSharedLibrary::Unload()` → `abort()` → SIGABRT; matches this crash pattern.
- [ORT #15174 — terminate called after throwing during CUDA driver shutdown](https://github.com/microsoft/onnxruntime/issues/15174) — `cudaEventSynchronize` throws `OnnxRuntimeException` after CUDA driver has already shut down; identical `std::terminate` → `abort()` path.
- [ORT #10300 — SIGSEGV on `IOBinding.synchronize_inputs()`](https://github.com/microsoft/onnxruntime/issues/10300) — crash specifically during IOBinding operations with CUDA EP; shares context with `run_with_iobinding`.
- [ORT #20885 — CUDA error 700 (illegal memory access) with `run_with_iobinding`](https://github.com/microsoft/onnxruntime/issues/20885) — illegal memory access crash during CUDA EP IOBinding inference.

**dd-trace-py related code** (none involved in crash, but for completeness):
- [`ddtrace/internal/_threads.cpp`](https://github.com/DataDog/dd-trace-py/blob/v4.10.0/ddtrace/internal/_threads.cpp) — manages periodic background threads; correctly implements GIL lifecycle and finalization guards; not involved here.

---

## Additional Context

- **Environment**: Amazon Linux AMI, Python 3.11.15, x86_64, dd-trace-py 4.10.0.
- **GPU stack present**: The binary mappings confirm a full NVIDIA ML stack: `libcuda.so.580.159.03`, `libcudnn_ops.so.9`, `libcudnn_graph.so.9`, `libcublas.so.12`, `libcublasLt.so.12`, `libcurand.so.10`, `libcufft.so.11`, `libcusolver.so.11`, `libcusparse.so.12`, NCCL, NVSHMEM, and NVTX — a large distributed training/inference stack.
- **PyTorch also loaded**: `libtorch_cuda.so`, `libtorch_cpu.so`, `libtorch_python.so` — both PyTorch and onnxruntime are operating in the same process, potentially sharing CUDA state.
- **68 threads**: The 68-thread count reflects the large GPU ML stack (CUDA driver threads, cuDNN worker threads, ORT/Torch thread pools, dd-trace-py periodic threads, etc.).
- **`run_with_iobinding` context**: IOBinding bypasses Python memory copies by binding pre-allocated GPU tensors directly. It is sensitive to CUDA stream synchronization and memory lifecycle issues, making CUDA errors more likely to manifest as exceptions thrown at unexpected points.
- **dd-trace-py role**: dd-trace-py is running as an APM/profiling agent in this process. Its crashtracker captured this crash because it registers a signal handler for all fatal signals. The crash itself is not related to dd-trace-py.

---

*Analysis generated by Claude Code /analyze-crash*
*This analysis is intended for triage. Engineers should review before acting on it.*
```
## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
