### PR TITLE
chore(native): adapt crashtracker and tracer_flare for pyo3 0.28 on Python 3.14/3.15 (PROF-15849)

### DIFF
--- a/src/native/crashtracker.rs
+++ b/src/native/crashtracker.rs
@@ -11,8 +11,8 @@ use pyo3::prelude::*;
 
 mod crashtracker_runtime_stacks;
 use crashtracker_runtime_stacks::{
-    get_cached_dump_traceback_fn, init_dump_traceback_fn, native_runtime_stack_frame_callback,
-    native_runtime_stack_string_callback,
+    get_cached_dump_traceback_fn, init_dump_traceback_fn, init_frame_get_back_fn,
+    native_runtime_stack_frame_callback, native_runtime_stack_string_callback,
 };
 
 pub trait RustWrapper {
@@ -172,10 +172,14 @@ impl RustWrapper for CrashtrackerReceiverConfigPy {
     }
 }
 
+// TODO(py-315)(pyo3 0.28): `skip_from_py_object` opts out of the Clone-driven
+// automatic FromPyObject derive that pyo3 deprecated in 0.28. This type is
+// only consumed through `PyRefMut<CrashtrackerMetadataPy>`, never extracted
+// as an owned value, so skipping is safe.
 #[pyclass(
-    skip_from_py_object,
     name = "CrashtrackerMetadata",
-    module = "datadog.internal._native"
+    module = "datadog.internal._native",
+    skip_from_py_object
 )]
 #[derive(Clone)]
 pub struct CrashtrackerMetadataPy {
@@ -262,6 +266,7 @@ pub fn crashtracker_init<'py>(
         {
             unsafe {
                 init_dump_traceback_fn();
+                init_frame_get_back_fn();
             }
             let dump_fn_available = unsafe { get_cached_dump_traceback_fn().is_some() };
             if dump_fn_available {

--- a/src/native/crashtracker/crashtracker_runtime_stacks.rs
+++ b/src/native/crashtracker/crashtracker_runtime_stacks.rs
@@ -16,24 +16,38 @@ extern "C" {
 }
 
 /************************************************************
- Emit runtime stacktrace as string using _Py_DumpTracebackThreads
+ Emit runtime stacktrace as string using _Py_DumpTracebackThreads /
+ PyUnstable_DumpTracebackThreads
 ************************************************************/
 
-// Function pointer type for _Py_DumpTracebackThreads
+// CPython 3.15 renamed _Py_DumpTracebackThreads to PyUnstable_DumpTracebackThreads
+// and added a 4th `max_threads` parameter.  We use the 4-arg signature universally:
+// on older CPython the extra register argument is harmless (x86_64 SysV / ARM64 AAPCS
+// pass the first >=4 integer args in registers), and on 3.15+ passing 0 means
+// "use the default limit".
 type PyDumpTracebackThreadsFn = unsafe extern "C" fn(
     fd: c_int,
     interp: *mut pyo3_ffi::PyInterpreterState,
     current_tstate: *mut pyo3_ffi::PyThreadState,
+    max_threads: isize,
 ) -> *const c_char;
 
-// Cached function pointer to avoid dlsym during crash
+// Function pointer type for PyFrame_GetBack
+type PyFrameGetBackFn =
+    unsafe extern "C" fn(*mut pyo3_ffi::PyFrameObject) -> *mut pyo3_ffi::PyFrameObject;
+
+// Cached function pointers to avoid dlsym during crash
 static mut DUMP_TRACEBACK_FN: Option<PyDumpTracebackThreadsFn> = None;
 static DUMP_TRACEBACK_INIT: Once = Once::new();
+static mut FRAME_GET_BACK_FN: Option<PyFrameGetBackFn> = None;
+static FRAME_GET_BACK_INIT: Once = Once::new();
 
 const MAX_TRACEBACK_SIZE: usize = 8 * 1024; // 8KB
 
-// Attempt to resolve _Py_DumpTracebackThreads at runtime
-// Try to link once during registration
+// Attempt to resolve the CPython traceback-dump function at runtime.
+// CPython <= 3.14 exports `_Py_DumpTracebackThreads` (3 args).
+// CPython >= 3.15 replaced it with `PyUnstable_DumpTracebackThreads` (4 args, adds max_threads).
+// We try the new name first, then fall back to the old one.
 pub unsafe fn init_dump_traceback_fn() {
     DUMP_TRACEBACK_INIT.call_once(|| {
         #[cfg(unix)]
@@ -47,7 +61,13 @@ pub unsafe fn init_dump_traceback_fn() {
 
             const RTLD_DEFAULT: *mut std::ffi::c_void = ptr::null_mut();
 
-            let symbol_ptr = dlsym(RTLD_DEFAULT, c"_Py_DumpTracebackThreads".as_ptr());
+            // Try the CPython 3.15+ public unstable name first.
+            let mut symbol_ptr = dlsym(RTLD_DEFAULT, c"PyUnstable_DumpTracebackThreads".as_ptr());
+
+            // Fall back to the private name used through CPython 3.14.
+            if symbol_ptr.is_null() {
+                symbol_ptr = dlsym(RTLD_DEFAULT, c"_Py_DumpTracebackThreads".as_ptr());
+            }
 
             if !symbol_ptr.is_null() {
                 DUMP_TRACEBACK_FN =
@@ -65,6 +85,45 @@ pub unsafe fn init_dump_traceback_fn() {
 // Get the cached function pointer; should only be called after init_dump_traceback_fn
 pub unsafe fn get_cached_dump_traceback_fn() -> Option<PyDumpTracebackThreadsFn> {
     DUMP_TRACEBACK_FN
+}
+
+// PyFrame_GetBack is in CPython's public C API through 3.14+,
+// but is absent from the limited API (Py_LIMITED_API). Rather than using compile-time
+// cfg guards that break under PYO3_USE_ABI3_FORWARD_COMPATIBILITY, we resolve the symbol
+// at runtime by using dlsym. This is safe because init runs at crashtracker registration time,
+// not during the crash signal handler.
+pub unsafe fn init_frame_get_back_fn() {
+    FRAME_GET_BACK_INIT.call_once(|| {
+        #[cfg(unix)]
+        {
+            extern "C" {
+                fn dlsym(
+                    handle: *mut std::ffi::c_void,
+                    symbol: *const std::ffi::c_char,
+                ) -> *mut std::ffi::c_void;
+            }
+
+            const RTLD_DEFAULT: *mut std::ffi::c_void = ptr::null_mut();
+
+            let symbol_ptr = dlsym(RTLD_DEFAULT, c"PyFrame_GetBack".as_ptr());
+
+            if !symbol_ptr.is_null() {
+                FRAME_GET_BACK_FN = Some(std::mem::transmute::<*mut c_void, PyFrameGetBackFn>(
+                    symbol_ptr,
+                ));
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            // FRAME_GET_BACK_FN remains None on non-Unix platforms
+        }
+    });
+}
+
+#[cfg(Py_LIMITED_API)]
+unsafe fn get_cached_frame_get_back_fn() -> Option<PyFrameGetBackFn> {
+    FRAME_GET_BACK_FN
 }
 
 unsafe fn dump_python_traceback_as_string(
@@ -102,7 +161,8 @@ unsafe fn dump_python_traceback_as_string(
     }
 
     // Use null thread state for signal-safety; CPython will dump all threads.
-    let error_msg = dump_fn(write_fd, ptr::null_mut(), ptr::null_mut());
+    // max_threads=0 tells CPython 3.15+ to use its default limit.
+    let error_msg = dump_fn(write_fd, ptr::null_mut(), ptr::null_mut(), 0);
 
     // Ignore close return: EINTR cannot occur on Linux for close, and
     // any other error means the fd is already gone — nothing to recover.
@@ -215,7 +275,18 @@ unsafe fn advance_frame(frame: *mut pyo3_ffi::PyFrameObject) -> *mut pyo3_ffi::P
     if frame.is_null() {
         return ptr::null_mut();
     }
+    // PyFrame_GetBack is absent from pyo3-ffi's stable/limited-API bindings (Py_LIMITED_API),
+    // which is activated for Python 3.15+ via PYO3_USE_ABI3_FORWARD_COMPATIBILITY.
+    // On Py_LIMITED_API builds the crashtracker captures only the top frame rather than the full stack.
+    #[cfg(not(Py_LIMITED_API))]
     let back = pyo3_ffi::PyFrame_GetBack(frame);
+
+    #[cfg(Py_LIMITED_API)]
+    let back = match get_cached_frame_get_back_fn() {
+        Some(get_back) => get_back(frame),
+        None => ptr::null_mut(),
+    };
+
     pyo3_ffi::Py_DecRef(frame as *mut pyo3_ffi::PyObject);
     back
 }
@@ -235,7 +306,7 @@ unsafe fn emit_python_frame(
     #[cfg(not(Py_3_11))]
     let function_view = get_code_attr_utf8_view(frame, b"co_name\0");
 
-    // For verions 3.11+, we should use qualified name
+    // For versions 3.11+, we should use qualified name
     #[cfg(Py_3_11)]
     let function_view = get_code_attr_utf8_view(frame, b"co_qualname\0");
 

--- a/src/native/tracer_flare.rs
+++ b/src/native/tracer_flare.rs
@@ -58,7 +58,11 @@ fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 /// Python wrapper for FlareAction
-#[pyclass(from_py_object, name = "FlareAction")]
+// TODO(py-315)(pyo3 0.28): `from_py_object` preserves the automatic FromPyObject
+// derive for Clone-able pyclasses, which pyo3 deprecated as opt-in in 0.28.
+// Required because `FlareActionPy` is accepted as an argument to
+// `TracerFlareManagerPy.zip_and_send`.
+#[pyclass(name = "FlareAction", from_py_object)]
 #[derive(Clone)]
 pub struct FlareActionPy {
     inner: FlareAction,


### PR DESCRIPTION
Closes #18473. Part of [#17809](https://github.com/DataDog/dd-trace-py/issues/17809) (Python 3.15 integration parity — Tier A).

## Description

Make the native Rust extension build and run correctly under Python 3.14/3.15 with pyo3 0.28:

### Changes
* **Try to link to PyUnstable_Dumptraceback`**
* **Try to link to `PyFrame_GetBack` directly, not through pyo3**



* **pyo3 0.28 `FromPyObject` derive changes**

pyo3 0.28 deprecated the implicit auto-`FromPyObject` derive on `#[pyclass]` types. Two classes needed updating:
- `CrashtrackerMetadataPy` (`crashtracker.rs`): opted out with `skip_from_py_object` — it is never extracted from Python, only passed in.
- `FlareActionPy` (`tracer_flare.rs`): opted in with `from_py_object` — it is extracted as an owned value in the flare handler.

## Testing

- Builds clean on Python 3.14 and 3.15 (via `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`) with no Rust compiler warnings.
- Crashtracker tests pass on 3.14 and 3.15 — frame capture degrades gracefully to top-frame-only rather than crashing.
- No behavior change on Python ≤ 3.13; the `PyFrame_GetBack` path is preserved by the cfg gate.

## Risks

**Low.** The `We try to link the PyUnstable_DumpTraceback`, then fall back to linking `GetBack`, and if both are unavailable, runtime stacks for crashtracker are skipped.

## Additional Notes
