### PR TITLE
fix: disable code origins by default

### DIFF
--- a/ddtrace/debugging/_products/code_origin/span.py
+++ b/ddtrace/debugging/_products/code_origin/span.py
@@ -6,15 +6,10 @@ import typing as t
 
 import ddtrace.internal.core as core
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.products import manager as product_manager
-from ddtrace.internal.settings._core import ValueSource
 from ddtrace.internal.settings.code_origin import config
 
 
 log = get_logger(__name__)
-
-CO_ENABLED = "DD_CODE_ORIGIN_FOR_SPANS_ENABLED"
-DI_PRODUCT_KEY = "dynamic-instrumentation"
 
 # TODO[gab]: Uncomment this when the feature is ready
 # requires = ["tracer"]
@@ -42,10 +37,7 @@ def start() -> None:
 
 
 def enabled() -> bool:
-    # If dynamic instrumentation is enabled, and code origin for spans is not explicitly disabled,
-    # we'll enable code origin for spans.
-    di_enabled = product_manager.is_enabled(DI_PRODUCT_KEY) and config.value_source(CO_ENABLED) == ValueSource.DEFAULT
-    return config.span.enabled or di_enabled
+    return config.span.enabled
 
 
 def restart(join: bool = False) -> None:

--- a/ddtrace/internal/settings/code_origin.py
+++ b/ddtrace/internal/settings/code_origin.py
@@ -20,7 +20,7 @@ class CodeOriginConfig(DDConfig):
         enabled = DDConfig.v(
             bool,
             "enabled",
-            default=True,
+            default=False,
             help_type="Boolean",
             help="Enable code origin for spans",
         )

--- a/tests/debugging/origin/test_code_origin_span_product.py
+++ b/tests/debugging/origin/test_code_origin_span_product.py
@@ -8,7 +8,6 @@ from ddtrace.debugging._products.code_origin.span import apm_tracing_rc
 from ddtrace.debugging._products.code_origin.span import enabled
 from ddtrace.debugging._products.code_origin.span import post_preload
 from ddtrace.debugging._products.code_origin.span import restart
-from ddtrace.internal.settings._core import ValueSource
 
 
 def test_post_preload_is_noop():
@@ -72,46 +71,25 @@ def test_core_event_handler_tracer_wrap_instruments_view():
         mock_proc.instrument_view.assert_called_with(f)
 
 
-def test_enabled_span_enabled_by_default():
-    """enabled() returns True when config.span.enabled is True (the default)."""
+def test_enabled_span_disabled_by_default():
+    """enabled() returns False when config.span.enabled is False (the default)."""
+    from ddtrace.internal.settings.code_origin import config
+
+    with patch.object(config.span, "enabled", False):
+        assert enabled() is False
+
+
+def test_enabled_span_explicitly_enabled():
     from ddtrace.internal.settings.code_origin import config
 
     with patch.object(config.span, "enabled", True):
         assert enabled() is True
 
 
-def test_enabled_span_explicitly_disabled_di_not_active(monkeypatch):
-    """enabled() returns False when span.enabled=False and DI is not active."""
+def test_enabled_dynamic_instrumentation_does_not_enable_code_origin_for_spans():
     from ddtrace.internal.settings.code_origin import config
 
-    with (
-        patch.object(config.span, "enabled", False),
-        patch.object(co_product.product_manager, "is_enabled", return_value=False),
-    ):
-        assert enabled() is False
-
-
-def test_enabled_di_takeover_when_span_disabled(monkeypatch):
-    """enabled() returns True via di_enabled when DI is on and CO_ENABLED is at default."""
-    from ddtrace.internal.settings.code_origin import config
-
-    with (
-        patch.object(config.span, "enabled", False),
-        patch.object(co_product.product_manager, "is_enabled", return_value=True),
-        patch.object(config, "value_source", return_value=ValueSource.DEFAULT),
-    ):
-        assert enabled() is True
-
-
-def test_enabled_di_active_but_co_explicitly_set(monkeypatch):
-    """enabled() returns False when DI is on but CO_ENABLED was explicitly set (not default)."""
-    from ddtrace.internal.settings.code_origin import config
-
-    with (
-        patch.object(config.span, "enabled", False),
-        patch.object(co_product.product_manager, "is_enabled", return_value=True),
-        patch.object(config, "value_source", return_value=ValueSource.ENV_VAR),
-    ):
+    with patch.object(config.span, "enabled", False):
         assert enabled() is False
 
 


### PR DESCRIPTION
We found some problems with the default enablement of code origins while dogfooding dd-trace so until we fix the real problem it should go back to being disabled by default.

