### PR TITLE
fix(litellm): use Azure OpenAI response model for LLMObs model_name

### DIFF
--- a/ddtrace/contrib/internal/litellm/utils.py
+++ b/ddtrace/contrib/internal/litellm/utils.py
@@ -32,7 +32,10 @@ class BaseLiteLLMStreamHandler:
         if not getattr(self, "response_model", None):
             chunk_model = getattr(chunk, "model", None)
             if chunk_model:
-                self.response_model = chunk_model
+                try:
+                    self.response_model = chunk_model
+                except (AttributeError, FrozenInstanceError):
+                     pass
         for choice in getattr(chunk, "choices", []):
             choice_index = getattr(choice, "index", 0)
             self.chunks[choice_index].append(choice)

--- a/ddtrace/contrib/internal/litellm/utils.py
+++ b/ddtrace/contrib/internal/litellm/utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from dataclasses import FrozenInstanceError
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
@@ -35,7 +36,7 @@ class BaseLiteLLMStreamHandler:
                 try:
                     self.response_model = chunk_model
                 except (AttributeError, FrozenInstanceError):
-                     pass
+                    pass
         for choice in getattr(chunk, "choices", []):
             choice_index = getattr(choice, "index", 0)
             self.chunks[choice_index].append(choice)

--- a/ddtrace/contrib/internal/litellm/utils.py
+++ b/ddtrace/contrib/internal/litellm/utils.py
@@ -26,6 +26,12 @@ class BaseLiteLLMStreamHandler:
         self.spans.append((span, kwargs))
 
     def _process_chunk(self, chunk, iterator=None):
+        # Capture the first non-empty response model. Only emitted as a span tag for azure/azure_text
+        # providers (in finalize_stream), where the request model is an arbitrary deployment name.
+        if not getattr(self, "response_model", None):
+            chunk_model = getattr(chunk, "model", None)
+            if chunk_model:
+                self.response_model = chunk_model
         for choice in getattr(chunk, "choices", []):
             choice_index = getattr(choice, "index", 0)
             self.chunks[choice_index].append(choice)
@@ -35,6 +41,11 @@ class BaseLiteLLMStreamHandler:
     def finalize_stream(self, exception=None):
         formatted_completions = None
         for span, kwargs in self.spans:
+            response_model = getattr(self, "response_model", None)
+            if response_model:
+                _, provider = self.integration._model_map.get(kwargs.get("model", ""), ("", ""))
+                if provider in ("azure", "azure_text"):
+                    span.set_tag("litellm.response.model", response_model)
             if not formatted_completions:
                 formatted_completions = self._process_finished_stream(span)
             self.integration.llmobs_set_tags(

--- a/ddtrace/contrib/internal/litellm/utils.py
+++ b/ddtrace/contrib/internal/litellm/utils.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import LITELLM_ROUTER_INSTANCE_KEY
 from ddtrace.llmobs._integrations.base_stream_handler import AsyncStreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import StreamHandler
@@ -43,13 +44,16 @@ class BaseLiteLLMStreamHandler:
         for span, kwargs in self.spans:
             response_model = getattr(self, "response_model", None)
             if response_model:
-                _, provider = self.integration._model_map.get(kwargs.get("model", ""), ("", ""))
+                # Resolve the requested model from args or kwargs (callers may pass it positionally,
+                # e.g. litellm.completion("azure/<deployment>", ...)) so provider detection works.
+                requested_model = get_argument_value(self.request_args, kwargs, 0, "model", optional=True) or ""
+                _, provider = self.integration._model_map.get(requested_model, ("", ""))
                 if provider in ("azure", "azure_text"):
                     span.set_tag("litellm.response.model", response_model)
             if not formatted_completions:
                 formatted_completions = self._process_finished_stream(span)
             self.integration.llmobs_set_tags(
-                span, args=[], kwargs=kwargs, response=formatted_completions, operation=span.resource
+                span, args=self.request_args, kwargs=kwargs, response=formatted_completions, operation=span.resource
             )
             span.finish()
 

--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -69,6 +69,14 @@ class LiteLLMIntegration(BaseLLMIntegration):
         model_name = get_argument_value(args, kwargs, 0, "model", False) or ""
         model_name, model_provider = self._model_map.get(model_name, (model_name, UNKNOWN_MODEL_PROVIDER))
 
+        # For azure/azure_text, the request model is an arbitrary deployment name; prefer the canonical
+        # model from the response. Exact provider match — substring would wrongly include azure_ai, where
+        # LiteLLM rewrites response.model to "azure_ai/<deployment>".
+        if model_provider in ("azure", "azure_text"):
+            response_model = span.get_tag("litellm.response.model") or _get_attr(response, "model", None)
+            if response_model:
+                model_name = response_model
+
         span_kind = self._get_span_kind(span, kwargs, model_name, operation)
         metrics = self._extract_llmobs_metrics(response, span_kind)
         # Set kind before helpers so that input/output messages are routed correctly
@@ -167,6 +175,10 @@ class LiteLLMIntegration(BaseLLMIntegration):
     def _set_apm_shadow_tags(self, span, args, kwargs, response=None, operation=""):
         model_name = get_argument_value(args, kwargs, 0, "model", False) or ""
         model_name, model_provider = self._model_map.get(model_name, (model_name, UNKNOWN_MODEL_PROVIDER))
+        if model_provider in ("azure", "azure_text"):
+            response_model = span.get_tag("litellm.response.model") or _get_attr(response, "model", None)
+            if response_model:
+                model_name = response_model
         span_kind = self._get_span_kind(span, kwargs, model_name, operation)
         metrics = self._extract_llmobs_metrics(response, span_kind)
         self._apply_shadow_metrics(

--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -166,14 +166,16 @@ class LiteLLMIntegration(BaseLLMIntegration):
         is_openai_model = any(prefix in model_lower for prefix in ("gpt", "openai", "azure"))
         return is_openai_model and not stream and LLMObs._integration_is_enabled("openai")
 
-    def _resolve_model_name(self, span, response, model_name, model_provider):
+    def _resolve_model_name(
+        self, span: Span, response: Optional[Any], model_name: str, model_provider: str
+    ) -> str:
         # Azure requires an arbitrary deployment name as the request model; the canonical model
         # comes from the response. azure_ai is excluded — LiteLLM rewrites its response model to
         # "azure_ai/<deployment>", which would not match the cost catalog.
         if model_provider in ("azure", "azure_text"):
             response_model = span.get_tag("litellm.response.model") or _get_attr(response, "model", None)
             if response_model:
-                return response_model
+                return str(response_model)
         return model_name
 
     def _set_apm_shadow_tags(self, span, args, kwargs, response=None, operation=""):

--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -166,9 +166,7 @@ class LiteLLMIntegration(BaseLLMIntegration):
         is_openai_model = any(prefix in model_lower for prefix in ("gpt", "openai", "azure"))
         return is_openai_model and not stream and LLMObs._integration_is_enabled("openai")
 
-    def _resolve_model_name(
-        self, span: Span, response: Optional[Any], model_name: str, model_provider: str
-    ) -> str:
+    def _resolve_model_name(self, span: Span, response: Optional[Any], model_name: str, model_provider: str) -> str:
         # Azure requires an arbitrary deployment name as the request model; the canonical model
         # comes from the response. azure_ai is excluded — LiteLLM rewrites its response model to
         # "azure_ai/<deployment>", which would not match the cost catalog.

--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -69,13 +69,7 @@ class LiteLLMIntegration(BaseLLMIntegration):
         model_name = get_argument_value(args, kwargs, 0, "model", False) or ""
         model_name, model_provider = self._model_map.get(model_name, (model_name, UNKNOWN_MODEL_PROVIDER))
 
-        # For azure/azure_text, the request model is an arbitrary deployment name; prefer the canonical
-        # model from the response. Exact provider match — substring would wrongly include azure_ai, where
-        # LiteLLM rewrites response.model to "azure_ai/<deployment>".
-        if model_provider in ("azure", "azure_text"):
-            response_model = span.get_tag("litellm.response.model") or _get_attr(response, "model", None)
-            if response_model:
-                model_name = response_model
+        model_name = self._resolve_model_name(span, response, model_name, model_provider)
 
         span_kind = self._get_span_kind(span, kwargs, model_name, operation)
         metrics = self._extract_llmobs_metrics(response, span_kind)
@@ -172,13 +166,20 @@ class LiteLLMIntegration(BaseLLMIntegration):
         is_openai_model = any(prefix in model_lower for prefix in ("gpt", "openai", "azure"))
         return is_openai_model and not stream and LLMObs._integration_is_enabled("openai")
 
-    def _set_apm_shadow_tags(self, span, args, kwargs, response=None, operation=""):
-        model_name = get_argument_value(args, kwargs, 0, "model", False) or ""
-        model_name, model_provider = self._model_map.get(model_name, (model_name, UNKNOWN_MODEL_PROVIDER))
+    def _resolve_model_name(self, span, response, model_name, model_provider):
+        # Azure requires an arbitrary deployment name as the request model; the canonical model
+        # comes from the response. azure_ai is excluded — LiteLLM rewrites its response model to
+        # "azure_ai/<deployment>", which would not match the cost catalog.
         if model_provider in ("azure", "azure_text"):
             response_model = span.get_tag("litellm.response.model") or _get_attr(response, "model", None)
             if response_model:
-                model_name = response_model
+                return response_model
+        return model_name
+
+    def _set_apm_shadow_tags(self, span, args, kwargs, response=None, operation=""):
+        model_name = get_argument_value(args, kwargs, 0, "model", False) or ""
+        model_name, model_provider = self._model_map.get(model_name, (model_name, UNKNOWN_MODEL_PROVIDER))
+        model_name = self._resolve_model_name(span, response, model_name, model_provider)
         span_kind = self._get_span_kind(span, kwargs, model_name, operation)
         metrics = self._extract_llmobs_metrics(response, span_kind)
         self._apply_shadow_metrics(

--- a/releasenotes/notes/litellm-azure-streaming-model-name-fix-9ab1160bb21db033.yaml
+++ b/releasenotes/notes/litellm-azure-streaming-model-name-fix-9ab1160bb21db033.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where Azure OpenAI streaming calls via the LiteLLM integration
+    tagged ``model_name`` with the request deployment name (e.g. ``my-deployment``) instead of the
+    canonical model returned by the API (e.g. ``gpt-4o-2024-08-06``). This caused cost attribution
+    to fail for deployments whose names differ from the canonical model identifier. The fix applies
+    only to ``azure`` and ``azure_text`` providers, where the response ``model`` field reliably
+    carries the canonical identifier.

--- a/releasenotes/notes/litellm-azure-streaming-model-name-fix-9ab1160bb21db033.yaml
+++ b/releasenotes/notes/litellm-azure-streaming-model-name-fix-9ab1160bb21db033.yaml
@@ -2,9 +2,6 @@
 fixes:
   - |
     LLM Observability: Resolves an issue where Azure OpenAI calls through the LiteLLM integration
-    tagged ``model_name`` with the request deployment name (for example ``my-deployment``) instead
-    of the canonical model returned by the API (for example ``gpt-4o-2024-08-06``). Because Azure
-    requires an arbitrary deployment name in the request, this broke cost attribution for
-    deployments whose names differ from the canonical model identifier. The integration now prefers
-    the response model for the ``azure`` and ``azure_text`` providers, on both the LLM Observability
-    span and the APM shadow tag. ``azure_ai`` is intentionally unaffected.
+    tagged ``model_name`` with the request deployment name (e.g. ``my-deployment``) instead
+    of the canonical model returned by the API (e.g. ``gpt-4o-2024-08-06``). The integration now prefers
+    the response model for the ``azure`` and ``azure_text`` providers.

--- a/releasenotes/notes/litellm-azure-streaming-model-name-fix-9ab1160bb21db033.yaml
+++ b/releasenotes/notes/litellm-azure-streaming-model-name-fix-9ab1160bb21db033.yaml
@@ -1,9 +1,10 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes an issue where Azure OpenAI streaming calls via the LiteLLM integration
-    tagged ``model_name`` with the request deployment name (e.g. ``my-deployment``) instead of the
-    canonical model returned by the API (e.g. ``gpt-4o-2024-08-06``). This caused cost attribution
-    to fail for deployments whose names differ from the canonical model identifier. The fix applies
-    only to ``azure`` and ``azure_text`` providers, where the response ``model`` field reliably
-    carries the canonical identifier.
+    LLM Observability: Resolves an issue where Azure OpenAI calls through the LiteLLM integration
+    tagged ``model_name`` with the request deployment name (for example ``my-deployment``) instead
+    of the canonical model returned by the API (for example ``gpt-4o-2024-08-06``). Because Azure
+    requires an arbitrary deployment name in the request, this broke cost attribution for
+    deployments whose names differ from the canonical model identifier. The integration now prefers
+    the response model for the ``azure`` and ``azure_text`` providers, on both the LLM Observability
+    span and the APM shadow tag. ``azure_ai`` is intentionally unaffected.

--- a/tests/contrib/litellm/cassettes/completion_azure_stream.yaml
+++ b/tests/contrib/litellm/cassettes/completion_azure_stream.yaml
@@ -1,0 +1,139 @@
+interactions:
+- request:
+    body: '{"messages":[{"content":"Hey, what is up?","role":"user"}],"model":"gpt-5.2_2025-12-11","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '142'
+      Content-Type:
+      - application/json
+      Host:
+      - test-azure.openai.azure.com
+      User-Agent:
+      - AzureOpenAI/Python 2.24.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.24.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.12.13
+      x-stainless-read-timeout:
+      - '600.0'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://test-azure.openai.azure.com/openai/deployments/gpt-5.2_2025-12-11/chat/completions?api-version=2024-12-01-preview
+  response:
+    body:
+      string: "data: {\"choices\":[],\"created\":0,\"id\":\"\",\"model\":\"\",\"object\":\"\",\"prompt_filter_results\":[{\"prompt_index\":0,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"jailbreak\":{\"detected\":false,\"filtered\":false},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}]}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{},\"delta\":{\"content\":\"\",\"refusal\":null,\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"8A9QeP6E\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"Not\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"i67G4fc\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        much\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"ZrWJi\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"\u2014\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"p7ud4gd2D\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"here\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"ENFnJr\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        and\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"K7gTZ6\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        ready\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"MQnN\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        to\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"blsGqbk\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        help\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"kfPml\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\".\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"grpWulxTj\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        What\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"SJA9s\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        do\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"YFiTc0R\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        you\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"NHWdJD\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        want\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"jO9ZW\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        to\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"GSsQFLn\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        talk\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"T49ak\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        about\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"mCKM\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        or\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"K8I2U7W\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        work\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"qBzRW\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"
+        on\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"8r27wFO\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{\"protected_material_text\":{\"detected\":false,\"filtered\":false}},\"delta\":{\"content\":\"?\"},\"finish_reason\":null,\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"fSB4uubIG\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[{\"content_filter_results\":{},\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null}],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"MBKG\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":null}\n\ndata:
+        {\"choices\":[],\"created\":1780491942,\"id\":\"chatcmpl-DmfZu2BjJmBGSSHpj9hWtFQYBUxYn\",\"latency_checkpoint\":{\"engine_tbt_ms\":10,\"engine_ttft_ms\":80,\"engine_ttlt_ms\":320,\"pre_inference_ms\":82,\"service_tbt_ms\":10,\"service_ttft_ms\":664,\"service_ttlt_ms\":886,\"total_duration_ms\":811,\"user_visible_ttft_ms\":582},\"model\":\"gpt-5.2-2025-12-11\",\"obfuscation\":\"G4BB73VtsguJe\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"usage\":{\"completion_tokens\":24,\"completion_tokens_details\":{\"accepted_prediction_tokens\":0,\"audio_tokens\":0,\"reasoning_tokens\":0,\"rejected_prediction_tokens\":0},\"prompt_tokens\":12,\"prompt_tokens_details\":{\"audio_tokens\":0,\"cached_tokens\":0},\"total_tokens\":36}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 13:05:42 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      apim-request-id:
+      - 1335a065-1914-4b5b-a597-cafbd2016e0e
+      azureai-fe-is-streaming:
+      - 'True'
+      azureml-model-session:
+      - d20260526124601-421ae15f
+      skip-error-remapping:
+      - 'true'
+      x-accel-buffering:
+      - 'no'
+      x-content-type-options:
+      - nosniff
+      x-ms-deployment-name:
+      - gpt-5.2_2025-12-11
+      x-ms-is-spilled-over:
+      - 'false'
+      x-ms-rai-invoked:
+      - 'true'
+      x-ms-region:
+      - East US 2
+      x-ms-served-model:
+      - gpt-5.2-2025-12-11
+      x-ratelimit-abusepenalty-active:
+      - 'False'
+      x-ratelimit-key:
+      - gpt-5.2_2025-12-11
+      x-ratelimit-limit-requests:
+      - '2500'
+      x-ratelimit-limit-tokens:
+      - '250000'
+      x-ratelimit-remaining-requests:
+      - '2499'
+      x-ratelimit-remaining-tokens:
+      - '249988'
+      x-ratelimit-renewalperiod-requests:
+      - '60'
+      x-ratelimit-renewalperiod-tokens:
+      - '60'
+      x-ratelimit-reset-requests:
+      - '0'
+      x-ratelimit-reset-tokens:
+      - '0'
+      x-request-id:
+      - 0013bac0-a3b6-4983-bc12-ddfce22c1081
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -993,20 +993,31 @@ def test_azure_ai_model_name_unchanged(tracer):
 
 
 @pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
-def test_azure_streaming_completion_e2e(litellm, request_vcr, litellm_llmobs, test_spans, consume_stream, monkeypatch):
+@pytest.mark.parametrize("positional_model", [False, True])
+def test_azure_streaming_completion_e2e(
+    litellm, request_vcr, litellm_llmobs, test_spans, consume_stream, positional_model, monkeypatch
+):
     """End-to-end: azure streaming via litellm.completion tags the canonical response model,
     not the deployment name. Exercises the stream handler -> litellm.response.model tag -> override.
+    Covers the model passed both as a keyword and positionally (the positional form is not present
+    in kwargs, so provider detection must read it from args).
     """
     monkeypatch.setenv("AZURE_API_KEY", "<not-a-real-key>")
     monkeypatch.setenv("AZURE_API_BASE", "https://test-azure.openai.azure.com")
     monkeypatch.setenv("AZURE_API_VERSION", "2024-12-01-preview")
+    messages = [{"content": "Hey, what is up?", "role": "user"}]
     with request_vcr.use_cassette("completion_azure_stream.yaml"):
-        resp = litellm.completion(
-            model="azure/gpt-5.2_2025-12-11",
-            messages=[{"content": "Hey, what is up?", "role": "user"}],
-            stream=True,
-            stream_options={"include_usage": True},
-        )
+        if positional_model:
+            resp = litellm.completion(
+                "azure/gpt-5.2_2025-12-11", messages=messages, stream=True, stream_options={"include_usage": True}
+            )
+        else:
+            resp = litellm.completion(
+                model="azure/gpt-5.2_2025-12-11",
+                messages=messages,
+                stream=True,
+                stream_options={"include_usage": True},
+            )
         consume_stream(resp, 1)
 
     spans = [s for trace in test_spans.pop_traces() for s in trace]

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -990,3 +990,29 @@ def test_azure_ai_model_name_unchanged(tracer):
         integration._llmobs_set_tags(span, ["azure_ai/my_deployment"], {}, response=None, operation="chat")
 
     assert _get_llmobs_data_metastruct(span).get("meta", {}).get("model_name") == "my_deployment"
+
+
+@pytest.mark.parametrize("consume_stream", [consume_stream_iter, consume_stream_next])
+def test_azure_streaming_completion_e2e(litellm, request_vcr, litellm_llmobs, test_spans, consume_stream, monkeypatch):
+    """End-to-end: azure streaming via litellm.completion tags the canonical response model,
+    not the deployment name. Exercises the stream handler -> litellm.response.model tag -> override.
+    """
+    monkeypatch.setenv("AZURE_API_KEY", "<not-a-real-key>")
+    monkeypatch.setenv("AZURE_API_BASE", "https://test-azure.openai.azure.com")
+    monkeypatch.setenv("AZURE_API_VERSION", "2024-12-01-preview")
+    with request_vcr.use_cassette("completion_azure_stream.yaml"):
+        resp = litellm.completion(
+            model="azure/gpt-5.2_2025-12-11",
+            messages=[{"content": "Hey, what is up?", "role": "user"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        consume_stream(resp, 1)
+
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    assert spans[0].get_tag("litellm.response.model") == "gpt-5.2-2025-12-11"
+    meta = _get_llmobs_data_metastruct(spans[0]).get("meta", {})
+    assert meta.get("model_name") == "gpt-5.2-2025-12-11"
+    assert meta.get("model_name") != "gpt-5.2_2025-12-11"
+    assert meta.get("model_provider") == "azure"

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -102,7 +102,8 @@ class TestLLMObsLiteLLM:
     def test_completion_with_tools(self, litellm, request_vcr, litellm_llmobs, test_spans, stream, n, consume_stream):
         if stream and n > 1:
             pytest.skip(
-                "Streamed responses with multiple completions and tool calls are not supported: see open issue https://github.com/BerriAI/litellm/issues/8977"
+                "Streamed responses with multiple completions and tool calls are not supported: "
+                "see open issue https://github.com/BerriAI/litellm/issues/8977"
             )
         with request_vcr.use_cassette(get_cassette_name(stream, n, tools=True)):
             messages = [{"content": "What is the weather like in San Francisco, CA?", "role": "user"}]
@@ -833,6 +834,22 @@ def test_shadow_tags_completion_when_llmobs_disabled(tracer):
     assert span.get_metric("_dd.llmobs.total_tokens") == 10
 
 
+def test_azure_shadow_tags_use_response_model(tracer):
+    """For azure provider, shadow model_name uses the response model, not the deployment name."""
+    from unittest.mock import MagicMock
+
+    from ddtrace.llmobs._integrations.litellm import LiteLLMIntegration
+
+    integration = LiteLLMIntegration(MagicMock())
+    integration._model_map["azure/my_deployment_name"] = ("my_deployment_name", "azure")
+
+    with tracer.trace("litellm.request") as span:
+        span.set_tag("litellm.response.model", "gpt-4o-2024-08-06")
+        integration._set_apm_shadow_tags(span, ["azure/my_deployment_name"], {}, response=None, operation="chat")
+
+    assert span.get_tag("_dd.llmobs.model_name") == "gpt-4o-2024-08-06"
+
+
 def test_shadow_tags_completion_with_cache_tokens(tracer):
     """Verify cache-token shadow metrics propagate from litellm usage to APM span."""
     from unittest.mock import MagicMock
@@ -854,3 +871,122 @@ def test_shadow_tags_completion_with_cache_tokens(tracer):
 
     assert span.get_metric("_dd.llmobs.cache_read_input_tokens") == 7
     assert span.get_metric("_dd.llmobs.cache_write_input_tokens") == 4
+
+
+# --- Azure streaming model name tests ---
+
+
+def test_stream_handler_captures_chunk_model():
+    """Stream handler records the first non-empty chunk.model as response_model."""
+    from collections import defaultdict
+    from unittest.mock import MagicMock
+
+    from ddtrace.contrib.internal.litellm.utils import BaseLiteLLMStreamHandler
+
+    handler = BaseLiteLLMStreamHandler.__new__(BaseLiteLLMStreamHandler)
+    handler.chunks = defaultdict(list)
+    handler.spans = []
+
+    chunk = MagicMock()
+    chunk.model = "gpt-4o-2024-08-06"
+    chunk.choices = []
+    chunk.usage = None
+
+    handler._process_chunk(chunk)
+    assert handler.response_model == "gpt-4o-2024-08-06"
+
+    # Second chunk does not override the first captured model.
+    chunk2 = MagicMock()
+    chunk2.model = "different-model"
+    chunk2.choices = []
+    chunk2.usage = None
+    handler._process_chunk(chunk2)
+    assert handler.response_model == "gpt-4o-2024-08-06"
+
+
+def test_stream_handler_skips_empty_chunk_model():
+    """Stream handler ignores chunks with no model field."""
+    from collections import defaultdict
+    from unittest.mock import MagicMock
+
+    from ddtrace.contrib.internal.litellm.utils import BaseLiteLLMStreamHandler
+
+    handler = BaseLiteLLMStreamHandler.__new__(BaseLiteLLMStreamHandler)
+    handler.chunks = defaultdict(list)
+    handler.spans = []
+
+    empty_chunk = MagicMock()
+    empty_chunk.model = None
+    empty_chunk.choices = []
+    empty_chunk.usage = None
+    handler._process_chunk(empty_chunk)
+    assert not getattr(handler, "response_model", None)
+
+
+def test_azure_streaming_model_name_uses_response_model(tracer):
+    """For azure provider, _llmobs_set_tags prefers the litellm.response.model span tag."""
+    from unittest.mock import MagicMock
+
+    from ddtrace.llmobs._integrations.litellm import LiteLLMIntegration
+
+    integration = LiteLLMIntegration(MagicMock())
+    integration._model_map["azure/my_deployment_name"] = ("my_deployment_name", "azure")
+
+    with tracer.trace("litellm.request") as span:
+        span.set_tag("litellm.response.model", "gpt-4o-2024-08-06")
+        integration._llmobs_set_tags(span, ["azure/my_deployment_name"], {}, response=None, operation="chat")
+
+    assert _get_llmobs_data_metastruct(span).get("meta", {}).get("model_name") == "gpt-4o-2024-08-06"
+
+
+def test_azure_non_streaming_model_name_uses_response_model(tracer):
+    """For azure provider, _llmobs_set_tags prefers response.model on non-streaming responses."""
+    from unittest.mock import MagicMock
+
+    from ddtrace.llmobs._integrations.litellm import LiteLLMIntegration
+
+    integration = LiteLLMIntegration(MagicMock())
+    integration._model_map["azure/my_deployment_name"] = ("my_deployment_name", "azure")
+
+    response = MagicMock()
+    response.model = "gpt-4o-2024-08-06"
+    response.usage.prompt_tokens = 5
+    response.usage.completion_tokens = 3
+    response.usage.total_tokens = 8
+
+    with tracer.trace("litellm.request") as span:
+        integration._llmobs_set_tags(span, ["azure/my_deployment_name"], {}, response=response, operation="chat")
+
+    assert _get_llmobs_data_metastruct(span).get("meta", {}).get("model_name") == "gpt-4o-2024-08-06"
+
+
+def test_non_azure_streaming_model_name_unchanged(tracer):
+    """For non-azure providers, model_name is not overridden and litellm.response.model is not set."""
+    from unittest.mock import MagicMock
+
+    from ddtrace.llmobs._integrations.litellm import LiteLLMIntegration
+
+    integration = LiteLLMIntegration(MagicMock())
+    integration._model_map["openai/gpt-4o"] = ("gpt-4o", "openai")
+
+    with tracer.trace("litellm.request") as span:
+        integration._llmobs_set_tags(span, ["openai/gpt-4o"], {}, response=None, operation="chat")
+
+    assert _get_llmobs_data_metastruct(span).get("meta", {}).get("model_name") == "gpt-4o"
+    assert span.get_tag("litellm.response.model") is None
+
+
+def test_azure_ai_model_name_unchanged(tracer):
+    """azure_ai provider is not affected — its response.model is 'azure_ai/<deployment>' and must not be preferred."""
+    from unittest.mock import MagicMock
+
+    from ddtrace.llmobs._integrations.litellm import LiteLLMIntegration
+
+    integration = LiteLLMIntegration(MagicMock())
+    integration._model_map["azure_ai/my_deployment"] = ("my_deployment", "azure_ai")
+
+    with tracer.trace("litellm.request") as span:
+        span.set_tag("litellm.response.model", "azure_ai/my_deployment")
+        integration._llmobs_set_tags(span, ["azure_ai/my_deployment"], {}, response=None, operation="chat")
+
+    assert _get_llmobs_data_metastruct(span).get("meta", {}).get("model_name") == "my_deployment"


### PR DESCRIPTION
## Description

Azure OpenAI requires an arbitrary deployment name as the request `model` (e.g. `gpt-5.2_2025-12-11`) - see [Azure's docs](https://learn.microsoft.com/en-us/azure/foundry-classic/openai/how-to/create-resource?pivots=web-portal#deploy-a-model). dd-trace tagged this deployment name as the LLMObs `model_name`. The cost catalog keys on the canonical model the API returns (`gpt-5.2-2025-12-11`), so deployments whose names don't match a catalog entry got no cost attribution (`skipped_unsupported_model_pricing`).

For `azure`/`azure_text` only, prefer the response model over the request deployment name: the LiteLLM stream handler captures `chunk.model` into a `litellm.response.model` span tag, and `_llmobs_set_tags`/`_set_apm_shadow_tags` use that (or `response.model` for non-streaming), falling back to the deployment name when absent. The guard is an exact `azure`/`azure_text` match (see Additional Notes re: `azure_ai`).

## Testing

- **Unit tests**: stream-handler model capture, Azure stream/non-stream override, shadow-tag path, and non-Azure/`azure_ai` no-ops.
- **End-to-end VCR test** recorded against a real Azure deployment: asserts the streamed span is tagged with the canonical model, not the deployment name.
- **Snapshot tests** updated for the new `litellm.response.model` tag.
- **Live repro**: `model_name` flips `gpt-5.2_2025-12-11` to `gpt-5.2-2025-12-11`, catalog MATCH.

**Before**
<img width="1599" height="87" alt="image" src="https://github.com/user-attachments/assets/437e894d-2d74-493c-9c95-d19acc580fc2" />

**After**
<img width="1579" height="66" alt="image" src="https://github.com/user-attachments/assets/31fe8688-a12a-4b8b-8814-736f01f726cc" />


## Risks

Low. Gated on provider being exactly `azure`/`azure_text` with a non-empty response model; all other paths keep existing behavior. No change to non-Azure providers.

## Additional Notes

`azure_ai` (Azure AI Foundry) is intentionally excluded: LiteLLM rewrites its response model to `azure_ai/<deployment>`, so preferring the response there would be worse than the bare deployment name. It has the same underlying symptom and is tracked separately.
