### PR TITLE
fix(llmobs): guard against None candidates/usage in google_genai extractor

### DIFF
--- a/ddtrace/llmobs/_integrations/google_genai.py
+++ b/ddtrace/llmobs/_integrations/google_genai.py
@@ -140,7 +140,7 @@ class GoogleGenAIIntegration(BaseLLMIntegration):
         if not response:
             return [Message(content="", role=GOOGLE_GENAI_DEFAULT_MODEL_ROLE)]
         messages = []
-        candidates = _get_attr(response, "candidates", [])
+        candidates = _get_attr(response, "candidates", None) or []
         for candidate in candidates:
             content = _get_attr(candidate, "content", None)
             if not content:

--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -140,7 +140,13 @@ def extract_generation_metrics_google_genai(response) -> dict[str, Any]:
         output_tokens = None
 
     cached_tokens = _get_attr(usage_metadata, "cached_content_token_count", None)
-    total_tokens = _get_attr(usage_metadata, "total_token_count", None) or input_tokens + output_tokens
+    total_token_count = _get_attr(usage_metadata, "total_token_count", None)
+    if total_token_count is not None:
+        total_tokens = total_token_count
+    elif input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+    else:
+        total_tokens = None
 
     if input_tokens is not None:
         usage[INPUT_TOKENS_METRIC_KEY] = input_tokens

--- a/releasenotes/notes/fix-llmobs-google-genai-none-candidates-usage-3f8a1c2d9e4b.yaml
+++ b/releasenotes/notes/fix-llmobs-google-genai-none-candidates-usage-3f8a1c2d9e4b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    LLM Observability: Fix ``Error extracting LLMObs fields`` crash in the google_genai
+    integration when Google GenAI returns partial response objects where ``candidates``
+    or usage metadata token fields are ``None``. This occurred during streaming chunks
+    and safety-filtered responses. Adds None guards before accessing ``candidates`` and
+    token count fields, returning sensible defaults when absent.


### PR DESCRIPTION
## Description

Fixes #18377

The google_genai LLMObs extractor crashes with `Error extracting LLMObs fields` when Google GenAI returns partial response objects. This happens in two places:

1. `extract_generation_metrics_google_genai` in `google_utils.py`: the fallback computation `input_tokens + output_tokens` on line 143 throws `TypeError` when either value is `None`. This occurs on streaming chunks where usage metadata fields may be absent.

2. `_extract_output_messages` in `google_genai.py`: `_get_attr(response, "candidates", [])` returns `None` (not `[]`) when the attribute exists but holds `None`, causing `TypeError` on iteration. This occurs on safety-filtered responses.

Changes:

- In `extract_generation_metrics_google_genai`: replaced the one-liner `or input_tokens + output_tokens` fallback with an explicit None guard so `total_tokens` is only computed when both operands are available.
- In `_extract_output_messages`: changed `_get_attr(response, "candidates", [])` to `_get_attr(response, "candidates", None) or []` so a `None` attribute value is normalised to an empty list before iteration.

## Testing

Manual logic test against both None scenarios passes. The existing test suite for `google_genai` LLMObs integration continues to cover the normal (non-None) path.

## Risks

Low. Both changes only affect the None/missing-field code path that was previously crashing. Normal responses with populated fields follow the same logic as before.

## Additional Notes

No behaviour change for responses that have valid candidates and token counts.