### PR TITLE
feat(gpum): allow SSI users to use injected version

### DIFF
--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -568,7 +568,13 @@ def _inject():
                     for entry in os.getenv("PYTHONPATH", "").split(os.pathsep)
                     if not any(path in entry for path in path_segments_indicating_removal)
                 ]
-                python_path.append(site_pkgs_path)
+                if OVERRIDE_USER_DDTRACE:
+                    # Mirror the precedence applied to the current interpreter's sys.path: the injected
+                    # site-packages must come before any user-controlled PYTHONPATH entries so that child
+                    # processes also resolve `import ddtrace` to the injected (bundled) package.
+                    python_path.insert(0, site_pkgs_path)
+                else:
+                    python_path.append(site_pkgs_path)
                 python_path.insert(0, bootstrap_dir)
                 python_path = os.pathsep.join(python_path)
                 os.environ["PYTHONPATH"] = python_path

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -48,6 +48,7 @@ RUNTIMES_ALLOW_LIST = {
 }
 
 FORCE_INJECT = os.environ.get("DD_INJECT_FORCE", "").lower() in ("true", "1", "t")
+OVERRIDE_USER_DDTRACE = os.environ.get("DD_INJECT_OVERRIDE_USER_DDTRACE", "").lower() in ("true", "1", "t")
 FORWARDER_EXECUTABLE = os.environ.get("DD_TELEMETRY_FORWARDER_PATH", "")
 TELEMETRY_ENABLED = "DD_INJECTION_ENABLED" in os.environ
 DEBUG_MODE = os.environ.get("DD_TRACE_DEBUG", "").lower() in ("true", "1", "t")
@@ -331,6 +332,11 @@ def _inject():
     runtime_incomp = False
     spec = None
     try:
+        if OVERRIDE_USER_DDTRACE:
+            # A user-installed ddtrace is present, but the operator requested that the injected
+            # (bundled) version take precedence. Fall through to the injection path.
+            raise ModuleNotFoundError("ddtrace")
+
         # `find_spec` is only available in Python 3.4+
         # https://docs.python.org/3/library/importlib.html#importlib.util.find_spec
         # DEV: It is ok to fail here on import since it'll only fail on Python versions we don't support / inject into
@@ -345,7 +351,10 @@ def _inject():
         # enable safe instrumentation for ddtrace which won't patch incompatible integrations
         os.environ["DD_TRACE_SAFE_INSTRUMENTATION_ENABLED"] = "true"
 
-        _log("user-installed ddtrace not found, configuring application to use injection site-packages")
+        if OVERRIDE_USER_DDTRACE:
+            _log("DD_INJECT_OVERRIDE_USER_DDTRACE is set, preferring injection site-packages")
+        else:
+            _log("user-installed ddtrace not found, configuring application to use injection site-packages")
 
         current_platform = "manylinux2014" if _get_clib() == "gnu" else "musllinux_1_2"
         # Determine architecture
@@ -506,7 +515,11 @@ def _inject():
             return
 
         # Add the custom site-packages directory to the Python path to load the ddtrace package.
-        sys.path.append(site_pkgs_path)
+        if OVERRIDE_USER_DDTRACE:
+            sys.path.insert(0, site_pkgs_path)
+        else:
+            sys.path.append(site_pkgs_path)
+
         _log("sys.path %s" % sys.path, level="debug")
         # Used to track whether the ddtrace package was successfully injected. Must be set before importing ddtrace
         os.environ["_DD_PY_SSI_INJECT"] = "1"

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -333,8 +333,7 @@ def _inject():
     spec = None
     try:
         if OVERRIDE_USER_DDTRACE:
-            # A user-installed ddtrace is present, but the operator requested that the injected
-            # (bundled) version take precedence. Fall through to the injection path.
+            # If the user wants to override any manually installed tracers, switch to injection.
             raise ModuleNotFoundError("ddtrace")
 
         # `find_spec` is only available in Python 3.4+
@@ -514,7 +513,8 @@ def _inject():
             RESULT_CLASS = "incorrect_installation"
             return
 
-        # Add the custom site-packages directory to the Python path to load the ddtrace package.
+        # Add the custom site-packages directory to the Python path to load the ddtrace package. Prepend if the user
+        # wishes to override any manual ddtrace install.
         if OVERRIDE_USER_DDTRACE:
             sys.path.insert(0, site_pkgs_path)
         else:

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -48,7 +48,9 @@ RUNTIMES_ALLOW_LIST = {
 }
 
 FORCE_INJECT = os.environ.get("DD_INJECT_FORCE", "").lower() in ("true", "1", "t")
-OVERRIDE_USER_DDTRACE = os.environ.get("DD_INJECT_OVERRIDE_USER_DDTRACE", "").lower() in ("true", "1", "t")
+# When this is set, all ddtrace packages will be preferred over the user installed packages. For example, wrapt,
+# bytecode, and others.
+OVERRIDE_USER_DDTRACE = os.environ.get("DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE", "").lower() in ("true", "1", "t")
 FORWARDER_EXECUTABLE = os.environ.get("DD_TELEMETRY_FORWARDER_PATH", "")
 TELEMETRY_ENABLED = "DD_INJECTION_ENABLED" in os.environ
 DEBUG_MODE = os.environ.get("DD_TRACE_DEBUG", "").lower() in ("true", "1", "t")
@@ -351,7 +353,7 @@ def _inject():
         os.environ["DD_TRACE_SAFE_INSTRUMENTATION_ENABLED"] = "true"
 
         if OVERRIDE_USER_DDTRACE:
-            _log("DD_INJECT_OVERRIDE_USER_DDTRACE is set, preferring injection site-packages")
+            _log("DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE is set, preferring injection site-packages")
         else:
             _log("user-installed ddtrace not found, configuring application to use injection site-packages")
 

--- a/releasenotes/notes/ssi-manual-ddtrace-override-fdbe8cbe3287bc35.yaml
+++ b/releasenotes/notes/ssi-manual-ddtrace-override-fdbe8cbe3287bc35.yaml
@@ -1,5 +1,7 @@
 ---
 features:
   - |
-    This change adds the ability to override a manually installed tracer for Single Step Instrumentation. To ensure
-    the injected library takes precedence, ``DD_INJECT_OVERRIDE_USER_DDTRACE=true`` can be added to the environment.
+    This change adds the ability to override a manually installed tracer for Single Step Instrumentation. When this is
+    set, all ddtrace packages will be preferred over the user installed packages. For example, wrapt, bytecode, and
+    others. To ensure the injected library takes precedence, ``DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE=true`` can
+    be added to the environment.

--- a/releasenotes/notes/ssi-manual-ddtrace-override-fdbe8cbe3287bc35.yaml
+++ b/releasenotes/notes/ssi-manual-ddtrace-override-fdbe8cbe3287bc35.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    This change adds the ability to override a manually installed tracer for Single Step Instrumentation. To ensure
+    the injected library takes precedence, ``DD_INJECT_OVERRIDE_USER_DDTRACE=true`` can be added to the environment.

--- a/tests/lib_injection/test_override_user_ddtrace.py
+++ b/tests/lib_injection/test_override_user_ddtrace.py
@@ -1,0 +1,155 @@
+import json
+import os
+import subprocess
+
+import pytest
+
+
+# A marker baked into the stub "user-installed" ddtrace so we can tell which package
+# actually got imported by the application.
+USER_STUB_VERSION = "0.0.0-user-stub"
+
+
+def _make_user_ddtrace_stub(stub_root):
+    """Create a minimal stub ``ddtrace`` package to simulate a user-installed copy.
+
+    The stub lives in its own directory tree so it can be placed on ``PYTHONPATH``
+    independently of the injected (bundled) ddtrace site-packages. It carries a
+    distinctive ``__version__`` so tests can assert which package was imported.
+
+    Returns the directory that should be added to ``PYTHONPATH``.
+    """
+    stub_pkg_dir = os.path.join(stub_root, "ddtrace")
+    os.makedirs(stub_pkg_dir, exist_ok=True)
+    with open(os.path.join(stub_pkg_dir, "__init__.py"), "w") as f:
+        f.write("__version__ = %r\n" % USER_STUB_VERSION)
+    return stub_root
+
+
+# Script that reports which ddtrace package the application ended up importing.
+REPORT_DDTRACE_SCRIPT = """
+import ddtrace
+
+print("LOADED_DDTRACE_FILE=" + str(getattr(ddtrace, "__file__", "unknown")))
+print("LOADED_DDTRACE_VERSION=" + str(getattr(ddtrace, "__version__", "unknown")))
+"""
+
+
+def _run_app(python_executable, env, venv_dir):
+    return subprocess.run(
+        [python_executable, "-c", REPORT_DDTRACE_SCRIPT],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=venv_dir,
+        check=True,
+        timeout=180,
+    )
+
+
+def test_override_user_ddtrace_prefers_injected(test_venv, mock_telemetry_forwarder, tmp_path):
+    """When DD_INJECT_OVERRIDE_USER_DDTRACE is set, the injected (bundled) ddtrace
+    takes precedence even though a user-installed ddtrace is present on the path.
+    """
+    python_executable, sitecustomize_dir, base_env, venv_dir = test_venv({})
+
+    user_site = _make_user_ddtrace_stub(str(tmp_path / "user_site"))
+
+    env = base_env.copy()
+    venv_pythonpath = base_env.get("PYTHONPATH", "")
+    # Order: sitecustomize first, then the user stub, then the venv's own path. The stub
+    # appears *before* any injection, so only the override flag should cause it to be skipped.
+    env["PYTHONPATH"] = os.pathsep.join([sitecustomize_dir, user_site, venv_pythonpath])
+    env["DD_TRACE_DEBUG"] = "true"
+    env["DD_INJECTION_ENABLED"] = "true"
+    env["DD_TRACE_AGENT_URL"] = "http://localhost:9126"
+    env["DD_INJECT_FORCE"] = "false"
+    env["DD_INJECT_OVERRIDE_USER_DDTRACE"] = "true"
+    telemetry_file = mock_telemetry_forwarder(env, python_executable)
+
+    try:
+        result = _run_app(python_executable, env, venv_dir)
+        stderr = result.stderr
+        stdout = result.stdout
+
+        # The override path logs a distinct message instead of "user-installed ddtrace not found".
+        assert "DD_INJECT_OVERRIDE_USER_DDTRACE is set, preferring injection site-packages" in stderr, (
+            f"override log message not found. stderr: {stderr}"
+        )
+
+        # The injected (bundled) ddtrace was imported, NOT the user stub.
+        file_line = next((line for line in stdout.splitlines() if line.startswith("LOADED_DDTRACE_FILE=")), "")
+        assert "ddtrace_pkgs" in file_line, f"expected injected ddtrace to be loaded, got: {file_line!r}"
+        assert "user_site" not in file_line, f"user-installed ddtrace was loaded instead of injected: {file_line!r}"
+        assert ("LOADED_DDTRACE_VERSION=" + USER_STUB_VERSION) not in stdout, (
+            f"user stub ddtrace was loaded, stdout: {stdout}"
+        )
+
+        # Telemetry reflects a successful injection, not an abort.
+        assert telemetry_file.is_file()
+        telemetry_data = json.loads(telemetry_file.read_text())
+        assert telemetry_data["metadata"]["result"] == "success"
+        assert telemetry_data["metadata"]["result_class"] == "success"
+        points = telemetry_data["points"]
+        assert len(points) == 1
+        complete_metric = points[0]
+        assert complete_metric["name"] == "library_entrypoint.complete"
+        assert "injection_forced:false" in complete_metric["tags"]
+
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"Subprocess failed:\nExit Code: {e.returncode}\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")
+    except subprocess.TimeoutExpired as e:
+        pytest.fail(f"Subprocess timed out:\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")
+
+
+def test_user_ddtrace_present_without_override_aborts(test_venv, mock_telemetry_forwarder, tmp_path):
+    """Without the override flag, an existing user-installed ddtrace wins and injection aborts.
+
+    This is the contrast case for ``test_override_user_ddtrace_prefers_injected`` and
+    documents the default precedence behavior.
+    """
+    python_executable, sitecustomize_dir, base_env, venv_dir = test_venv({})
+
+    user_site = _make_user_ddtrace_stub(str(tmp_path / "user_site"))
+
+    env = base_env.copy()
+    venv_pythonpath = base_env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join([sitecustomize_dir, user_site, venv_pythonpath])
+    env["DD_TRACE_DEBUG"] = "true"
+    env["DD_INJECTION_ENABLED"] = "true"
+    env["DD_TRACE_AGENT_URL"] = "http://localhost:9126"
+    env["DD_INJECT_FORCE"] = "false"
+    # DD_INJECT_OVERRIDE_USER_DDTRACE deliberately unset.
+    telemetry_file = mock_telemetry_forwarder(env, python_executable)
+
+    try:
+        result = _run_app(python_executable, env, venv_dir)
+        stderr = result.stderr
+        stdout = result.stdout
+
+        # Injection detects the user-installed ddtrace and aborts.
+        assert "user-installed ddtrace found" in stderr, f"expected abort log, stderr: {stderr}"
+        assert "DD_INJECT_OVERRIDE_USER_DDTRACE is set" not in stderr
+
+        # The user stub is what the application imported.
+        file_line = next((line for line in stdout.splitlines() if line.startswith("LOADED_DDTRACE_FILE=")), "")
+        assert "user_site" in file_line, f"expected user-installed ddtrace to be loaded, got: {file_line!r}"
+        assert ("LOADED_DDTRACE_VERSION=" + USER_STUB_VERSION) in stdout, (
+            f"expected user stub ddtrace to be loaded, stdout: {stdout}"
+        )
+
+        # Telemetry reports the abort with the already-instrumented classification.
+        assert telemetry_file.is_file()
+        telemetry_data = json.loads(telemetry_file.read_text())
+        assert telemetry_data["metadata"]["result"] == "abort"
+        assert telemetry_data["metadata"]["result_class"] == "already_instrumented"
+        points = telemetry_data["points"]
+        assert len(points) == 1
+        abort_metric = points[0]
+        assert abort_metric["name"] == "library_entrypoint.abort"
+        assert "reason:ddtrace_already_present" in abort_metric["tags"]
+
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"Subprocess failed:\nExit Code: {e.returncode}\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")
+    except subprocess.TimeoutExpired as e:
+        pytest.fail(f"Subprocess timed out:\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")

--- a/tests/lib_injection/test_override_user_ddtrace.py
+++ b/tests/lib_injection/test_override_user_ddtrace.py
@@ -35,6 +35,34 @@ print("LOADED_DDTRACE_VERSION=" + str(getattr(ddtrace, "__version__", "unknown")
 """
 
 
+# Script that imports ddtrace (triggering the injected sitecustomize to rewrite PYTHONPATH for
+# children), then spawns a child interpreter inheriting that environment and reports which
+# ddtrace package the *child* resolves. This exercises the subprocess code path that rewrites
+# os.environ["PYTHONPATH"].
+SPAWN_CHILD_SCRIPT = """
+import os
+import subprocess
+import sys
+
+import ddtrace
+
+child = subprocess.run(
+    [
+        sys.executable,
+        "-c",
+        "import ddtrace; print('CHILD_DDTRACE_FILE=' + str(getattr(ddtrace, '__file__', 'unknown')))",
+    ],
+    capture_output=True,
+    text=True,
+    env=os.environ.copy(),
+    timeout=120,
+)
+print("PARENT_DDTRACE_FILE=" + str(getattr(ddtrace, "__file__", "unknown")))
+sys.stdout.write(child.stdout)
+sys.stderr.write(child.stderr)
+"""
+
+
 def _run_app(python_executable, env, venv_dir):
     return subprocess.run(
         [python_executable, "-c", REPORT_DDTRACE_SCRIPT],
@@ -148,6 +176,56 @@ def test_user_ddtrace_present_without_override_aborts(test_venv, mock_telemetry_
         abort_metric = points[0]
         assert abort_metric["name"] == "library_entrypoint.abort"
         assert "reason:ddtrace_already_present" in abort_metric["tags"]
+
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"Subprocess failed:\nExit Code: {e.returncode}\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")
+    except subprocess.TimeoutExpired as e:
+        pytest.fail(f"Subprocess timed out:\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")
+
+
+def test_override_user_ddtrace_prefers_injected_in_child_process(test_venv, mock_telemetry_forwarder, tmp_path):
+    """The override precedence is propagated to spawned child processes via PYTHONPATH.
+
+    With a user-installed ddtrace reachable through PYTHONPATH, the rewritten PYTHONPATH must
+    place the injected site-packages ahead of the user entry so that a child interpreter (which
+    rebuilds sys.path from PYTHONPATH) also resolves ``import ddtrace`` to the injected package.
+    """
+    python_executable, sitecustomize_dir, base_env, venv_dir = test_venv({})
+
+    user_site = _make_user_ddtrace_stub(str(tmp_path / "user_site"))
+
+    env = base_env.copy()
+    venv_pythonpath = base_env.get("PYTHONPATH", "")
+    # The user stub is reachable via PYTHONPATH (not just site-packages); this is the configuration
+    # in which a tail-appended injected path would lose to the user copy in a child interpreter.
+    env["PYTHONPATH"] = os.pathsep.join([sitecustomize_dir, user_site, venv_pythonpath])
+    env["DD_TRACE_DEBUG"] = "true"
+    env["DD_INJECTION_ENABLED"] = "true"
+    env["DD_TRACE_AGENT_URL"] = "http://localhost:9126"
+    env["DD_INJECT_FORCE"] = "false"
+    env["DD_INJECT_OVERRIDE_USER_DDTRACE"] = "true"
+    mock_telemetry_forwarder(env, python_executable)
+
+    try:
+        result = subprocess.run(
+            [python_executable, "-c", SPAWN_CHILD_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=venv_dir,
+            check=True,
+            timeout=180,
+        )
+        stdout = result.stdout
+
+        # Both the parent and the spawned child resolve the injected (bundled) ddtrace.
+        parent_line = next((line for line in stdout.splitlines() if line.startswith("PARENT_DDTRACE_FILE=")), "")
+        child_line = next((line for line in stdout.splitlines() if line.startswith("CHILD_DDTRACE_FILE=")), "")
+
+        assert "ddtrace_pkgs" in parent_line, f"parent did not load injected ddtrace: {parent_line!r}"
+        assert child_line, f"child did not report a ddtrace path. stdout: {stdout}"
+        assert "ddtrace_pkgs" in child_line, f"child did not load injected ddtrace: {child_line!r}"
+        assert "user_site" not in child_line, f"child loaded user-installed ddtrace: {child_line!r}"
 
     except subprocess.CalledProcessError as e:
         pytest.fail(f"Subprocess failed:\nExit Code: {e.returncode}\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")

--- a/tests/lib_injection/test_override_user_ddtrace.py
+++ b/tests/lib_injection/test_override_user_ddtrace.py
@@ -76,7 +76,7 @@ def _run_app(python_executable, env, venv_dir):
 
 
 def test_override_user_ddtrace_prefers_injected(test_venv, mock_telemetry_forwarder, tmp_path):
-    """When DD_INJECT_OVERRIDE_USER_DDTRACE is set, the injected (bundled) ddtrace
+    """When DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE is set, the injected (bundled) ddtrace
     takes precedence even though a user-installed ddtrace is present on the path.
     """
     python_executable, sitecustomize_dir, base_env, venv_dir = test_venv({})
@@ -92,7 +92,7 @@ def test_override_user_ddtrace_prefers_injected(test_venv, mock_telemetry_forwar
     env["DD_INJECTION_ENABLED"] = "true"
     env["DD_TRACE_AGENT_URL"] = "http://localhost:9126"
     env["DD_INJECT_FORCE"] = "false"
-    env["DD_INJECT_OVERRIDE_USER_DDTRACE"] = "true"
+    env["DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE"] = "true"
     telemetry_file = mock_telemetry_forwarder(env, python_executable)
 
     try:
@@ -101,7 +101,7 @@ def test_override_user_ddtrace_prefers_injected(test_venv, mock_telemetry_forwar
         stdout = result.stdout
 
         # The override path logs a distinct message instead of "user-installed ddtrace not found".
-        assert "DD_INJECT_OVERRIDE_USER_DDTRACE is set, preferring injection site-packages" in stderr, (
+        assert "DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE is set, preferring injection site-packages" in stderr, (
             f"override log message not found. stderr: {stderr}"
         )
 
@@ -147,7 +147,7 @@ def test_user_ddtrace_present_without_override_aborts(test_venv, mock_telemetry_
     env["DD_INJECTION_ENABLED"] = "true"
     env["DD_TRACE_AGENT_URL"] = "http://localhost:9126"
     env["DD_INJECT_FORCE"] = "false"
-    # DD_INJECT_OVERRIDE_USER_DDTRACE deliberately unset.
+    # DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE deliberately unset.
     telemetry_file = mock_telemetry_forwarder(env, python_executable)
 
     try:
@@ -157,7 +157,7 @@ def test_user_ddtrace_present_without_override_aborts(test_venv, mock_telemetry_
 
         # Injection detects the user-installed ddtrace and aborts.
         assert "user-installed ddtrace found" in stderr, f"expected abort log, stderr: {stderr}"
-        assert "DD_INJECT_OVERRIDE_USER_DDTRACE is set" not in stderr
+        assert "DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE is set" not in stderr
 
         # The user stub is what the application imported.
         file_line = next((line for line in stdout.splitlines() if line.startswith("LOADED_DDTRACE_FILE=")), "")
@@ -203,7 +203,7 @@ def test_override_user_ddtrace_prefers_injected_in_child_process(test_venv, mock
     env["DD_INJECTION_ENABLED"] = "true"
     env["DD_TRACE_AGENT_URL"] = "http://localhost:9126"
     env["DD_INJECT_FORCE"] = "false"
-    env["DD_INJECT_OVERRIDE_USER_DDTRACE"] = "true"
+    env["DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE"] = "true"
     mock_telemetry_forwarder(env, python_executable)
 
     try:


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->
When an SSI user attempts to use SSI with ddtrace installed, we abort injection. This commit allows the user to override that behavior and enforce the injected version takes precedence by setting `DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE=true` in the environment.

## Testing

<!-- Describe your testing strategy or note what tests are included -->
 I added a unit test. 

I also used injector-dev to use the built artifact from this pipeline against this demo app: https://github.com/DataDog/injector-dev/pull/203

```
injector-dev apply -f scenario.yaml
``` 

<details>

<summary>scenario.yaml</summary>

 ```yaml
helm:
  apps:
    - name: python
      namespace: application
      values:
        env:
          - name: DD_TRACE_DEBUG
            value: "true"
          - name: DD_APM_INSTRUMENTATION_DEBUG
            value: "true"
          - name: DD_INJECT_EXPERIMENTAL_OVERRIDE_USER_DDTRACE
            value: "true"
        image:
          repository: registry.ddbuild.io/ci/injector-dev/python
          tag: 96ff7915
        podLabels:
          tags.datadoghq.com/env: local
          admission.datadoghq.com/enabled: "true"
        podAnnotations:
          admission.datadoghq.com/python-lib.custom-image: registry.ddbuild.io/ssi/dd-lib-python-init:glci116860856
        service:
          port: "8080"
  versions:
    agent: 7.79.1
    cluster_agent: 7.79.1
    injector: 0.60.0
  config:
    agents:
      containers:
        agent:
          env:
            - name: DD_HOSTNAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
    datadog: {}
```
With flag set:
```
kubectl -n application logs python-6777566964-5t7bh | grep sys.path
Defaulted container "app" out of: app, datadog-lib-python-init (init), datadog-init-apm-inject (init)
[2026-06-03 20:44:50] [DEBUG] datadog.autoinstrumentation(pid: 1): sys.path ['/opt/datadog/apm/library/python/ddtrace_pkgs/site-packages-ddtrace-py3.14-manylinux2014-aarch64', '/opt/datadog/apm/library/python', '/usr/local/lib/python314.zip', '/usr/local/lib/python3.14', '/usr/local/lib/python3.14/lib-dynload', '/usr/local/lib/python3.14/site-packages']
```

Without flag set:
```
 kubectl -n application logs python-bd5f5c45d-bmmml | grep 'user-installed ddtrace found'
Defaulted container "app" out of: app, datadog-lib-python-init (init), datadog-init-apm-inject (init)
[2026-06-03 20:46:09] [WARNING] datadog.autoinstrumentation(pid: 1): user-installed ddtrace found: /usr/local/lib/python3.14/site-packages/ddtrace/__init__.py, aborting site-packages injection
```


</details>

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

There is no risk to existing customers. User who use this flag could experience bugs given it puts the injected version first in the `sys.path`.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
We need this to test out libraries internally when a `ddtrace` library is already installed.
