### PR TITLE
docs(skill): add platform/fixture troubleshooting to run-tests skill

### DIFF
--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -348,6 +348,71 @@ docker compose down
 - Try running with just 1 venv
 - Use pytest `-k` to run subset of tests
 
+### Platform / arch mismatch on Apple Silicon
+
+The test-runner container defaults to the host architecture. On Apple Silicon (`arm64`/`aarch64`) that means some packages either:
+- Don't publish an `aarch64` wheel and fall back to a from-source build that fails on the toolchain (`Failed building wheel for <pkg>`, `lto-wrapper failed`, missing `aarch64` wheel).
+- Publish only an `x86_64` native extension that fails to import inside an `arm64` interpreter (`ImportError: ... wrong ELF class` or a `ModuleNotFoundError` pointing at a `_native*.so`).
+
+Both are the same root cause — the venv was built for the wrong arch. The fix is to pin the runner to `linux/amd64` (the platform CI uses):
+
+```bash
+DOCKER_DEFAULT_PLATFORM=linux/amd64 scripts/run-tests --venv <hash>
+# or pass --platform linux/amd64 directly to docker compose
+```
+
+Slower than native (Rosetta translation), but it matches CI and reliably resolves wheel-availability and native-extension import errors.
+
+**If a venv was already built under the wrong arch**, prebuilt `.so` files in `ddtrace/**/_native*.so` and the riot venv itself need to be rebuilt under the new platform. Rename the venv aside so the runner rebuilds it cleanly:
+
+```bash
+mv .riot/venv_<hash> .riot/venv_<hash>.bak
+DOCKER_DEFAULT_PLATFORM=linux/amd64 scripts/run-tests --venv <hash>
+```
+
+Do not `rm -rf` the venv — the rename is reversible if the rebuild surfaces unrelated breakage.
+
+### Hardware-gated autouse fixtures (`require_gpu`, `require_docker`, etc.)
+
+Some test packages use a session-scoped `autouse=True` fixture that calls `pytest.skip(...)` when a resource is missing. Symptoms: the suite reports `N skipped, 0 passed` despite tests that don't actually need the gated resource (e.g. pure prompt-parsing tests in a GPU-gated suite).
+
+The fix is to let pure-Python tests bypass the gate without removing the gate for tests that genuinely need it.
+
+**Pattern:** marker-bypass via conftest. In the gating `conftest.py`:
+
+```python
+def pytest_configure(config):
+    config.addinivalue_line("markers", "no_gpu: skip require_gpu autouse fixture")
+
+@pytest.fixture(autouse=True)
+def require_gpu(request):
+    if request.node.get_closest_marker("no_gpu"):
+        return
+    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+        pytest.skip("Skipping tests: GPU not available")
+```
+
+Then in test files that don't need the gated resource, opt out at module level:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.no_gpu
+```
+
+Or per-test with `@pytest.mark.no_gpu` on individual functions.
+
+**Why this shape:**
+- Change the fixture from `scope="session"` to function-scope so the marker check runs per-test, not once for the whole session.
+- Keep the gate intact for tests that DO touch the resource — CI still skips them on a GPU-less runner, exactly as before.
+- The `pytestmark` module-level form is the lightest-weight way to unblock a batch of pure-Python tests (e.g. extractor/parser tests) without per-function annotations.
+
+**Alternatives, in order of preference:**
+
+1. **Marker-bypass (above)** — best when the suite mixes resource-bound and pure-Python tests.
+2. **Move pure-Python tests to a sibling dir** that doesn't inherit the gating conftest. Update `tests/suitespec.yml` to keep them in the suite. Use this when the gated conftest pulls in heavy imports you can't avoid otherwise.
+3. **Delete the autouse decorator and gate at the test level** with explicit `@pytest.fixture` requests. Last resort — only if you can confirm CI still respects the original gate via a different mechanism.
+
 ## Technical Details
 
 ### Architecture


### PR DESCRIPTION
## Description

The `run-tests` skill covered venv selection, the `-s` rebuild rule, and suite matching, but two failure modes that recur on Apple Silicon (and likely any non-amd64) hosts weren't documented. Both came up during a recent attempt to validate a vllm integration locally and cost real iteration time before the workaround was rediscovered.

Two new sections under **Troubleshooting**:

1. **Platform / arch mismatch on Apple Silicon.** Documents the `DOCKER_DEFAULT_PLATFORM=linux/amd64` switch for cases where a transitive dep has no `aarch64` wheel, or where a prebuilt `_native*.so` ends up arch-mismatched with the interpreter. Includes the non-destructive recovery step (`mv .riot/venv_<hash> .riot/venv_<hash>.bak`) for a stale venv built under the wrong arch — explicitly notes that `rm -rf` is the wrong move (reversibility, sandboxed environments often block it).

2. **Hardware-gated autouse fixtures (`require_gpu`, `require_docker`, etc.).** Some suites use a session-scoped `autouse=True` fixture that calls `pytest.skip(...)` when the gated resource is missing, which skips every test in the package — including pure-Python tests that don't actually touch the gated resource. Documents the marker-bypass pattern: `no_gpu` marker + function-scope fixture + module-level `pytestmark = pytest.mark.no_gpu` for files of pure tests. Alternatives listed: move pure-Python tests to a sibling dir without the gating conftest; last-resort delete the autouse decorator entirely.

No code changes; this is a doc-only addition to the skill consumed by Claude Code sessions running tests in this repo.

## Testing

Reviewed against the actual vllm integration suite locally — both patterns described (platform switch and `no_gpu` marker bypass) are the ones that unblocked the suite. No skill-runner / executable component to test.

## Risks

None. Doc-only change to a markdown skill file. If the guidance is wrong in some edge case I haven't hit, the worst outcome is a follow-up doc fix; the existing skill behaviour is unchanged.

## Additional Notes

The marker-bypass example was lifted (lightly edited) from the conftest change that fixed `tests/contrib/vllm/` during a recent integration run. Happy to point at concrete examples in a follow-up if reviewers want to ground-truth the pattern against the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)