### PR TITLE
chore: bump version to 4.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.10.2"
+version = "4.10.3"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Bumps version to `4.10.3` to prepare the patch release.

Includes fix from #18421 (backport #18471): LLM Observability spans with deeply nested metadata or tool schemas were silently dropped by the backend due to exceeding the Event Platform's JSON nesting limit.