### PR TITLE
chore(profiling): implement native test install subdirs (PROF-14200)

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -36,7 +36,12 @@ if(DO_VALGRIND)
 endif()
 
 function(dd_wrapper_add_test name)
-    add_executable(${name} ${ARGN})
+    # Optional keyword argument: INSTALL_SUBDIR <dir> Installs the test binary to test/<dir>/ instead of test/. Use for
+    # version-specific binaries (e.g. INSTALL_SUBDIR py315) to prevent CI artifact collisions when build_base_venvs runs
+    # in parallel across Python versions and GitLab merges all artifacts into a shared directory.
+    cmake_parse_arguments(_ARG "" "INSTALL_SUBDIR" "" ${ARGN})
+    set(_SOURCES ${_ARG_UNPARSED_ARGUMENTS})
+    add_executable(${name} ${_SOURCES})
     target_include_directories(${name} PRIVATE ../include)
     # this has to refer to the stack extension name to properly link against
     target_link_libraries(${name} PRIVATE gmock gtest_main ${EXTENSION_NAME})
@@ -72,7 +77,11 @@ function(dd_wrapper_add_test name)
     endif()
 
     if(LIB_INSTALL_DIR)
-        install(TARGETS ${name} RUNTIME DESTINATION ${LIB_INSTALL_DIR}/../test)
+        if(_ARG_INSTALL_SUBDIR)
+            install(TARGETS ${name} RUNTIME DESTINATION ${LIB_INSTALL_DIR}/../test/${_ARG_INSTALL_SUBDIR})
+        else()
+            install(TARGETS ${name} RUNTIME DESTINATION ${LIB_INSTALL_DIR}/../test)
+        endif()
     endif()
 endfunction()
 


### PR DESCRIPTION
[← Gab's #17849](https://github.com/DataDog/dd-trace-py/pull/17849) | [Next → #17624](https://github.com/DataDog/dd-trace-py/pull/17624)

## Description

Adds an optional `INSTALL_SUBDIR` keyword argument to the `dd_wrapper_add_test` CMake
function in `ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt`.

When specified, the test binary is installed to `test/<subdir>/` instead of the shared
`test/` directory. Without the keyword, behavior is identical to before.

Motivation: `build_base_venvs` in GitLab CI runs as a parallel matrix across all Python
versions, and GitLab merges all job artifacts into a single directory for downstream jobs.
A version-specific test binary (e.g. one compiled against `libpython3.15`) placed in the
shared `test/` directory will be picked up by the pytest gtest plugin in a py3.10 test
environment and crash immediately — reported as a silent "C++ failure" with no test output.

`INSTALL_SUBDIR py315` (used in the next PR in the stack) isolates py3.15-only test
binaries so this collision cannot happen.

Also adds `cmakeformat_fix` script to `hatch.toml` (needed by the `07-run-cmake-format`
pre-commit hook) and updates `hooks/README.md` to document the in-place formatting +
re-stage behavior.

Part of the Python 3.15 support stack. Relates to #17809.

## Testing

- No behavior change for existing tests (`test_thread_span_links`, `test_cpython_layout_contracts`) — they call `dd_wrapper_add_test` without `INSTALL_SUBDIR` and install to the same `test/` path as before.
- The `INSTALL_SUBDIR` keyword is exercised in the next PR (`vlad/ddtracepy-315-profiling-only`), where `test_frame_state_315` uses `INSTALL_SUBDIR py315`.

## Risks

None. The CMake function change is backward-compatible: `INSTALL_SUBDIR` is optional and the default path is unchanged.

## Additional Notes

- `cmake_parse_arguments` separates the keyword from source file arguments via `_ARG_UNPARSED_ARGUMENTS`, so adding the keyword does not affect how source files are passed to `add_executable`.
- This pattern can be extended to `dd_wrapper/test/CMakeLists.txt` if that test directory ever needs similar isolation.


[PROF-14200]: https://datadoghq.atlassian.net/browse/PROF-14200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ