### PR TITLE
chore(telemetry): exclude OTLP headers from configuration telemetry

### DIFF
--- a/ddtrace/internal/settings/_supported_configurations.py
+++ b/ddtrace/internal/settings/_supported_configurations.py
@@ -936,3 +936,14 @@ DEPRECATED_CONFIGURATIONS: frozenset[str] = frozenset(
         "DD_COMPILE_DEBUG",
     }
 )
+
+SENSITIVE_CONFIGURATIONS: frozenset[str] = frozenset(
+    {
+        "DD_API_KEY",
+        "DD_APP_KEY",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+        "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+    }
+)

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -17,6 +17,7 @@ from ddtrace.internal.settings._otel_remapper import ENV_VAR_MAPPINGS
 from ddtrace.internal.settings._otel_remapper import SUPPORTED_OTEL_ENV_VARS
 from ddtrace.internal.settings._otel_remapper import parse_otel_env
 from ddtrace.internal.settings._supported_configurations import CONFIGURATION_ALIASES
+from ddtrace.internal.settings._supported_configurations import SENSITIVE_CONFIGURATIONS
 from ddtrace.internal.settings.process_tags import process_tags_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.utils.formats import asbool
@@ -55,6 +56,10 @@ def get_config(
 
     effective_val = default
     telemetry_name = envs[0]
+    # Configurations marked ``sensitive: true`` in the registry are excluded from
+    # configuration telemetry, regardless of which source supplies the value.
+    if telemetry_name in SENSITIVE_CONFIGURATIONS:
+        report_telemetry = False
     if report_telemetry:
         telemetry_writer.add_configuration(telemetry_name, default, "default")
 
@@ -128,6 +133,11 @@ def report_configuration(config: DDConfig) -> None:
             continue
 
         env_name = e.full_name
+
+        # Configurations marked ``sensitive: true`` in the registry are excluded
+        # from configuration telemetry.
+        if env_name in SENSITIVE_CONFIGURATIONS:
+            continue
 
         # Get the item value recursively
         env_val = config

--- a/releasenotes/notes/omit-sensitive-config-telemetry-9a7a0d56e600b742.yaml
+++ b/releasenotes/notes/omit-sensitive-config-telemetry-9a7a0d56e600b742.yaml
@@ -1,9 +1,0 @@
----
-other:
-  - |
-    instrumentation telemetry: The ``OTEL_EXPORTER_OTLP_HEADERS``,
-    ``OTEL_EXPORTER_OTLP_TRACES_HEADERS``, ``OTEL_EXPORTER_OTLP_METRICS_HEADERS``, and
-    ``OTEL_EXPORTER_OTLP_LOGS_HEADERS`` configurations are now excluded from configuration
-    telemetry. ``DD_API_KEY`` and ``DD_APP_KEY`` continue to be excluded from configuration
-    telemetry. Other OpenTelemetry exporter configurations (protocol, endpoint, timeout, and
-    so on) are still reported.

--- a/releasenotes/notes/omit-sensitive-config-telemetry-9a7a0d56e600b742.yaml
+++ b/releasenotes/notes/omit-sensitive-config-telemetry-9a7a0d56e600b742.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    instrumentation telemetry: The ``OTEL_EXPORTER_OTLP_HEADERS``,
+    ``OTEL_EXPORTER_OTLP_TRACES_HEADERS``, ``OTEL_EXPORTER_OTLP_METRICS_HEADERS``, and
+    ``OTEL_EXPORTER_OTLP_LOGS_HEADERS`` configurations are now excluded from configuration
+    telemetry. ``DD_API_KEY`` and ``DD_APP_KEY`` continue to be excluded from configuration
+    telemetry. Other OpenTelemetry exporter configurations (protocol, endpoint, timeout, and
+    so on) are still reported.

--- a/scripts/supported_configurations.py
+++ b/scripts/supported_configurations.py
@@ -5,6 +5,8 @@ Reads the JSON registry and produces a Python module with:
 - SUPPORTED_CONFIGURATIONS: frozenset of all registered env var names
 - CONFIGURATION_ALIASES: dict mapping env var name to list of aliases
 - DEPRECATED_CONFIGURATIONS: frozenset of deprecated env var names
+- SENSITIVE_CONFIGURATIONS: frozenset of env var names whose value is excluded
+  from configuration telemetry (marked ``"sensitive": true`` in the registry)
 
 Also verifies that every DD_*/_DD_*/OTEL_*/DATADOG_* var accessed in ddtrace/ is registered.
 
@@ -45,6 +47,7 @@ def generate_module(data: dict) -> str:
     entries = {name: configs[name][0] for name in all_names}
     aliases = {name: e["aliases"] for name, e in entries.items() if e.get("aliases")}
     deprecated = sorted(name for name, e in entries.items() if e.get("deprecated"))
+    sensitive = sorted(name for name, e in entries.items() if e.get("sensitive"))
 
     supported = "\n".join(f'        "{n}",' for n in all_names)
 
@@ -67,6 +70,12 @@ def generate_module(data: dict) -> str:
         if deprecated
         else "DEPRECATED_CONFIGURATIONS: frozenset[str] = frozenset()"
     )
+    sensitive_lines = "\n".join(f'        "{n}",' for n in sensitive)
+    sensitive_block = (
+        f"SENSITIVE_CONFIGURATIONS: frozenset[str] = frozenset(\n    {{\n{sensitive_lines}\n    }}\n)"
+        if sensitive
+        else "SENSITIVE_CONFIGURATIONS: frozenset[str] = frozenset()"
+    )
 
     return f"""\
 {HEADER}
@@ -80,6 +89,8 @@ SUPPORTED_CONFIGURATIONS: frozenset[str] = frozenset(
 {aliases_block}
 
 {deprecated_block}
+
+{sensitive_block}
 """
 
 

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -204,7 +204,8 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "DD_API_SECURITY_DOWNSTREAM_BODY_ANALYSIS_SAMPLE_RATE": [
@@ -407,7 +408,8 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "DD_AREDIS_CMD_MAX_LENGTH": [
@@ -5152,7 +5154,8 @@
       {
         "implementation": "C",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE": [
@@ -5187,7 +5190,8 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_LOGS_INSECURE": [
@@ -5250,7 +5254,8 @@
       {
         "implementation": "B",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_METRICS_INSECURE": [
@@ -5334,7 +5339,8 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_TRACES_INSECURE": [

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -447,21 +447,13 @@ import opentelemetry
             "origin": "env_var",
             "value": "http://localhost:4317",
         },
-        {
-            "name": "OTEL_EXPORTER_OTLP_HEADERS",
-            "origin": "default",
-            "value": "",
-        },
+        # OTEL_EXPORTER_OTLP_HEADERS is excluded from configuration telemetry.
         {
             "name": "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
             "origin": "default",
             "value": f"http://{get_agent_hostname()}:4317",
         },
-        {
-            "name": "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
-            "origin": "default",
-            "value": "",
-        },
+        # OTEL_EXPORTER_OTLP_LOGS_HEADERS is excluded from configuration telemetry.
         {
             "name": "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
             "origin": "default",
@@ -477,11 +469,7 @@ import opentelemetry
             "origin": "default",
             "value": f"http://{get_agent_hostname()}:4317",
         },
-        {
-            "name": "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
-            "origin": "default",
-            "value": "",
-        },
+        # OTEL_EXPORTER_OTLP_METRICS_HEADERS is excluded from configuration telemetry.
         {
             "name": "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
             "origin": "default",
@@ -507,11 +495,7 @@ import opentelemetry
             "origin": "default",
             "value": 10000,
         },
-        {
-            "name": "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
-            "origin": "default",
-            "value": "",
-        },
+        # OTEL_EXPORTER_OTLP_TRACES_HEADERS is excluded from configuration telemetry.
         {
             "name": "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
             "origin": "default",
@@ -1043,6 +1027,95 @@ def test_otel_config_telemetry(test_agent_session, run_python_code_in_subprocess
     env_invalid_metrics = test_agent_session.get_metrics("otel.env.invalid")
     tags = [m["tags"] for m in env_invalid_metrics]
     assert tags == [["config_opentelemetry:otel_logs_exporter"]]
+
+
+def test_otel_exporter_otlp_headers_telemetry_omitted(test_agent_session, run_python_code_in_subprocess):
+    """The OTEL_EXPORTER_OTLP_*_HEADERS family is excluded from configuration telemetry, while
+    non-sensitive OTLP exporter configurations are still reported.
+    """
+    code = """
+# most configurations are reported when ddtrace.auto is imported
+import ddtrace.auto
+# importing opentelemetry triggers reporting of the OTLP exporter configurations
+import opentelemetry
+    """
+
+    # Distinct, recognizable sentinels per OTLP header variant.
+    sentinels = [
+        "SENTINEL_OTLP_BASE",
+        "SENTINEL_OTLP_TRACES",
+        "SENTINEL_OTLP_METRICS",
+        "SENTINEL_OTLP_LOGS",
+    ]
+
+    env = os.environ.copy()
+    env["OTEL_EXPORTER_OTLP_HEADERS"] = "dd-api-key=SENTINEL_OTLP_BASE"
+    env["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = "dd-api-key=SENTINEL_OTLP_TRACES"
+    env["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = "dd-api-key=SENTINEL_OTLP_METRICS"
+    env["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = "dd-api-key=SENTINEL_OTLP_LOGS"
+    # Non-sensitive OTLP exporter configurations that must still be reported.
+    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+
+    _, stderr, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, stderr
+
+    configurations = {c["name"]: c for c in test_agent_session.get_configurations(remove_seq_id=True, effective=True)}
+    assert configurations, "no configuration telemetry was reported"
+
+    # Invariant: no OTLP header sentinel appears in any reported configuration value.
+    for cfg in configurations.values():
+        for sentinel in sentinels:
+            assert sentinel not in str(cfg["value"]), cfg
+
+    # Python omits the OTLP header family entirely.
+    for name in (
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+        "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+        "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+    ):
+        assert name not in configurations, configurations.get(name)
+
+    # Non-sensitive OTLP exporter configurations are still reported.
+    assert configurations["OTEL_EXPORTER_OTLP_ENDPOINT"] == {
+        "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "origin": "env_var",
+        "value": "http://localhost:4318",
+    }
+    # Sibling non-sensitive exporter configs (collected at import) remain present.
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" in configurations
+    assert "OTEL_EXPORTER_OTLP_TIMEOUT" in configurations
+
+
+def test_dd_api_key_app_key_telemetry_omitted(telemetry_writer, test_agent_session):
+    """DD_API_KEY and DD_APP_KEY values are excluded from configuration telemetry.
+
+    Uses the in-process telemetry writer (forced non-agentless) because setting DD_API_KEY would
+    otherwise switch a subprocess's telemetry client into agentless mode and divert it from the
+    test agent.
+    """
+    from ddtrace.internal.telemetry import get_config
+
+    with mock.patch.dict(
+        os.environ,
+        {"DD_API_KEY": "SENTINEL_DD_API_KEY", "DD_APP_KEY": "SENTINEL_DD_APP_KEY"},
+    ):
+        # Read each sensitive key the way settings do; the value must not be queued for telemetry.
+        assert get_config("DD_API_KEY") == "SENTINEL_DD_API_KEY"
+        assert get_config("DD_APP_KEY") == "SENTINEL_DD_APP_KEY"
+        # A non-sensitive control config is still reported, proving reporting is otherwise active.
+        get_config("DD_SITE", "datadoghq.com")
+
+    queued = list(telemetry_writer._queued_configs)
+    queued_names = {c["name"] for c in queued}
+    assert "DD_API_KEY" not in queued_names, queued
+    assert "DD_APP_KEY" not in queued_names, queued
+    for cfg in queued:
+        assert "SENTINEL_DD_API_KEY" not in str(cfg["value"]), cfg
+        assert "SENTINEL_DD_APP_KEY" not in str(cfg["value"]), cfg
+    # Sanity check: the non-sensitive control config was reported.
+    assert "DD_SITE" in queued_names, queued
 
 
 def test_add_error_log(mock_time, telemetry_writer, test_agent_session):


### PR DESCRIPTION
## Description

Marks the OpenTelemetry OTLP exporter header configurations as `sensitive: true` in `supported-configurations.json` and excludes sensitive configurations from configuration telemetry: `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXPORTER_OTLP_METRICS_HEADERS`, and `OTEL_EXPORTER_OTLP_LOGS_HEADERS`. Other exporter configurations (endpoint, protocol, timeout) are unaffected.

## Testing

Unit tests in `tests/telemetry/test_writer.py`.

## Risks

None.

## Additional Notes

Release note included.
