### PR TITLE
docs(ai_guard): add AI Guard rules and security-isolation guidance

### DIFF
--- a/.cursor/rules/ai-guard.mdc
+++ b/.cursor/rules/ai-guard.mdc
@@ -1,0 +1,212 @@
+---
+description: AI Guard - LLM/agentic workflow safety evaluation - how it works and development guidelines
+globs:
+  - "**/appsec/_ai_guard/**"
+  - "**/appsec/ai_guard/**"
+  - "**/tests/appsec/ai_guard/**"
+---
+
+# AI Guard Development Guide
+
+**Note:** General development patterns, code style, and testing guidelines are in
+`AGENTS.md`. Cross-product isolation rules are in
+`.cursor/rules/isolated-responsibility.mdc` — read it before touching any contrib
+dispatch site.
+
+## What is AI Guard?
+
+AI Guard evaluates LLM prompts, tool calls, and tool results in agentic AI
+workflows to decide whether an action is safe to execute. It protects against
+threats such as prompt injection, harmful tool usage, and sensitive-data
+exposure by sending the in-flight conversation to the Datadog AI Guard service
+and acting on its verdict.
+
+**Official Documentation:**
+- [Datadog AI Guard Overview](https://docs.datadoghq.com/security/ai_guard/)
+
+### Evaluation outcomes
+
+The service returns one of three actions (see `ACTIONS` in
+`ddtrace/appsec/ai_guard/_api_client.py`):
+
+| Action | Meaning |
+|--------|---------|
+| `ALLOW` | The action is safe; execution proceeds. |
+| `DENY`  | The action is unsafe; when blocking is enabled, execution is aborted. |
+| `ABORT` | The agent should stop the whole workflow; when blocking is enabled, execution is aborted. |
+
+When blocking is enabled and the action is not `ALLOW`, the client raises
+`AIGuardAbortError`. This inherits from `DDBlockException` (a
+`BaseException` subclass) **on purpose**, so a generic `except Exception:` in
+user code cannot accidentally swallow a block decision.
+
+## Package layout
+
+AI Guard lives in two sibling packages under `ddtrace/appsec/`:
+
+```
+ddtrace/appsec/
+├── ai_guard/               # PUBLIC SDK (user-facing, stable API)
+│   ├── __init__.py         # re-exports: new_ai_guard_client, AIGuardClient,
+│   │                       #   AIGuardClientError, AIGuardAbortError, Message,
+│   │                       #   Evaluation, Options, ToolCall, Function, …
+│   ├── _api_client.py      # AIGuardClient.evaluate() + HTTP transport + types
+│   └── integrations/       # framework SDK plugins resolved lazily
+│       ├── litellm.py
+│       └── strands.py      # AIGuardStrandsPlugin / AIGuardStrandsHookProvider
+│
+└── _ai_guard/              # PRIVATE internals (listeners + converters)
+    ├── __init__.py         # init_ai_guard(): lazy, gated on DD_AI_GUARD_ENABLED
+    ├── _listener.py        # ai_guard_listen(): registers all core.on(...) hooks
+    ├── _context.py         # contextvar depth counter to avoid double-scanning
+    ├── _common.py          # _get(), wrap_abort_error() shared helpers
+    ├── _openai.py          # OpenAI common helpers
+    ├── _openai_chat.py     # Chat Completions API converters + listeners
+    ├── _openai_responses.py# Responses API converters + listeners
+    ├── _openai_errors.py   # OpenAI-compatible abort error class
+    ├── _anthropic.py       # Anthropic Messages API converters + listeners
+    ├── _anthropic_errors.py# Anthropic-compatible abort error class
+    ├── _langchain.py       # LangChain agent/chatmodel/llm listeners
+    ├── _streaming.py       # streaming response evaluation
+    └── messages.py         # message formatting helpers
+```
+
+**Rule of thumb:**
+- `ai_guard/` (no underscore) = **public**, stable contract. Don't break it.
+- `_ai_guard/` (underscore) = **private**, listeners and provider converters.
+
+## How AI Guard Works: High-Level Architecture
+
+### 1. Lazy, opt-in initialization
+
+`init_ai_guard()` (in `ddtrace/appsec/_ai_guard/__init__.py`) is a one-shot
+loader gated on `DD_AI_GUARD_ENABLED`. When enabled, it imports
+`ai_guard_listen()` from `_listener.py`, which constructs a single
+`AIGuardClient` and registers all event listeners. When disabled, nothing is
+imported and there is zero overhead.
+
+### 2. Event-driven integration (NO contrib imports)
+
+AI Guard **never imports** integration code into `ddtrace/contrib/internal/*`,
+and contrib **never imports** AI Guard. Instead, the contrib patching layer
+emits events and AI Guard subscribes to them. See
+`.cursor/rules/isolated-responsibility.mdc` for the full rationale.
+
+**Producer side** — contrib dispatches an event around the wrapped SDK call:
+
+```python
+# ddtrace/contrib/internal/openai/patch.py
+core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
+resp = func(*args, **kwargs)
+core.dispatch(f"{event}.after", (kwargs, resp), allow_raise=True)
+```
+
+`allow_raise=True` is essential: it lets an AI Guard listener raise
+`AIGuardAbortError` *up through* the dispatch and out of the patched method,
+so a `DENY`/`ABORT` decision actually stops the SDK call.
+
+**Consumer side** — `_listener.py` registers listeners with `core.on(...)`:
+
+```python
+# ddtrace/appsec/_ai_guard/_listener.py
+core.on("openai.chat.completions.create.before",
+        partial(_openai_chat_completion_before, client))
+core.on("openai.chat.completions.create.after",
+        partial(_openai_chat_completion_after, client))
+```
+
+Events currently consumed:
+
+| Producer | Events |
+|----------|--------|
+| OpenAI Chat | `openai.chat.completions.create.before` / `.after` |
+| OpenAI Responses | `openai.responses.create.before` / `.after` |
+| Anthropic | `anthropic.messages.create.before` / `.after` |
+| LangChain | `langchain.{chatmodel,llm}.{generate,agenerate,stream}.{before,started,finally}` |
+| HTTP (client IP) | `set_http_meta_for_asm` |
+
+### 3. Provider converters → canonical `Message` shape
+
+Each provider listener converts that SDK's native message/response objects
+into AI Guard's canonical `Message` / `ToolCall` / `Function` types
+(`_api_client.py`) before calling `client.evaluate(messages, options)`. Use
+the shared `_get()` helper (`_common.py`) to read fields, since inputs may be
+plain dicts *or* SDK objects.
+
+### 4. Evaluation + span enrichment
+
+`AIGuardClient.evaluate()`:
+1. Opens an `ai_guard` span and sets `target` (`prompt` vs `tool`) tags.
+2. Truncates messages to `DD_AI_GUARD_MAX_MESSAGES_LENGTH` /
+   `DD_AI_GUARD_MAX_CONTENT_SIZE` and attaches them as a meta-struct.
+3. POSTs to the AI Guard `/evaluate` endpoint.
+4. Tags the span with the action/reason, marks the root span
+   (`_aiguard_manual_keep`, `ai_guard` event tag, client IP), and emits
+   telemetry.
+5. Raises `AIGuardAbortError` when blocking applies, otherwise returns an
+   `Evaluation`.
+
+### 5. Double-scan avoidance (`_context.py`)
+
+A framework integration (LangChain, Strands) and a provider integration
+(OpenAI, Anthropic) can both fire for the same call. To avoid scanning twice,
+the framework wraps its dispatch + LLM call with the `aiguard_context()`
+context manager (a contextvar depth counter), and provider listeners
+short-circuit when `is_aiguard_context_active()` returns `True`.
+
+## Configuration
+
+All configuration is via environment variables, parsed in
+`ddtrace/internal/settings/asm.py` (`AIGuardConfig`, exported as
+`ai_guard_config`). Constants live in `ddtrace/appsec/_constants.py` (`AI_GUARD`).
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `DD_AI_GUARD_ENABLED` | `false` | Master switch; nothing loads unless `true`. |
+| `DD_AI_GUARD_ENDPOINT` | (derived from site) | Override the AI Guard service endpoint. |
+| `DD_AI_GUARD_BLOCK` | `true` | Whether non-`ALLOW` decisions raise `AIGuardAbortError`. |
+| `DD_AI_GUARD_MAX_CONTENT_SIZE` | `524288` | Per-message content truncation threshold (bytes). |
+| `DD_AI_GUARD_MAX_MESSAGES_LENGTH` | `16` | Max trailing messages sent to the service. |
+| `DD_AI_GUARD_TIMEOUT` | `10000` | HTTP request timeout (ms). |
+
+`new_ai_guard_client()` additionally requires `DD_API_KEY` and `DD_APP_KEY`.
+
+## Public SDK usage
+
+```python
+from ddtrace.appsec.ai_guard import new_ai_guard_client, AIGuardAbortError
+
+client = new_ai_guard_client()
+try:
+    evaluation = client.evaluate(messages, options={"block": True})
+    # evaluation["action"] in ("ALLOW", "DENY", "ABORT")
+except AIGuardAbortError as e:
+    # blocked: e.action, e.reason, e.tags
+    ...
+```
+
+Framework plugins (`AIGuardStrandsPlugin`, `AIGuardStrandsHookProvider`) are
+re-exported lazily from `ai_guard/__init__.py` via a module-level
+`__getattr__`; see the `AIDEV-NOTE` there before changing import timing.
+
+## Development guidelines
+
+- **Never import AI Guard from `ddtrace/contrib/internal/*`.** Communicate via
+  `core.dispatch(...)` (producer) / `core.on(...)` (consumer). See
+  `.cursor/rules/isolated-responsibility.mdc`.
+- **Keep public/private boundaries.** New user-facing API goes through
+  `ai_guard/__init__.py.__all__`; internals stay in `_ai_guard/`.
+- **Converters must be defensive.** Use `_get()`; wrap conversion in
+  `try/except` and `logger.debug(...)` so a malformed SDK object degrades
+  gracefully instead of breaking the user's LLM call. Surface anomalies via
+  telemetry (`_report_converter_error` in `_anthropic.py`) rather than
+  silently dropping data.
+- **`allow_raise=True` is required** at dispatch sites that must be able to
+  block, so `AIGuardAbortError` can propagate out of the patched call.
+- **Respect the context counter.** When adding a framework integration that
+  may nest over a provider integration, wrap with `aiguard_context()` and have
+  the provider listener honor `is_aiguard_context_active()`.
+- **Preserve `AIDEV-NOTE` anchors** (lazy import timing, stream counter
+  lifecycle, legacy message translation) — they encode non-obvious invariants.
+- **Tests** live under `tests/appsec/ai_guard/`. Use the `run-tests` skill;
+  never run `pytest` directly.

--- a/.cursor/rules/isolated-responsibility.mdc
+++ b/.cursor/rules/isolated-responsibility.mdc
@@ -1,0 +1,114 @@
+---
+description: Isolated responsibility - keep security products decoupled from contrib integrations via core events
+globs:
+  - "**/contrib/**"
+  - "**/appsec/**"
+alwaysApply: false
+---
+
+# Isolated Responsibility: Security Products vs. Shared Integrations
+
+## The shared-integration problem
+
+Security products — **AI Guard**, **IAST**, and **AppSec (AAP/WAF/RASP)** —
+need to observe the same libraries that base products instrument: web
+frameworks (Django, Flask, FastAPI, Tornado, …) and LLM SDKs (OpenAI,
+Anthropic, LangChain, …). Those same integrations are also used by base
+products such as **APM Tracing**, **Profiling**, and **LLM Observability**.
+
+The integration code for each library lives in **one** place:
+`ddtrace/contrib/internal/<library>/`.
+
+## The rule
+
+> **Security products are not mandatory base products of dd-trace-py.**
+> Their logic MUST stay isolated, and we MUST NEVER add imports from a security
+> product into `ddtrace/contrib/internal/*`.
+
+Concretely:
+
+- ❌ Do **not** `from ddtrace.appsec... import ...` inside
+  `ddtrace/contrib/internal/*`.
+- ❌ Do **not** call AI Guard / IAST / AppSec functions directly from a
+  contrib patch.
+- ❌ Do **not** make a contrib integration's behavior depend on a security
+  product being installed/enabled.
+
+Why: contrib integrations ship and run for every dd-trace-py user, including
+those who only use APM/Profiling/LLM Observability. A direct import would
+couple an optional security product into a base code path — adding import cost,
+breaking the modular boundary, and risking circular imports
+(see the `circular-import-analysis` skill).
+
+## How to share data instead: core events
+
+When a security product needs data from (or needs to intercept) a shared
+integration, use the **core event bus** in `ddtrace/internal/core`.
+
+### Producer — inside `ddtrace/contrib/internal/*`
+
+Emit an event at the relevant point in the patch. Use `allow_raise=True` when a
+listener must be able to stop the wrapped call (e.g. an AI Guard block
+decision):
+
+```python
+from ddtrace.internal import core
+
+core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
+resp = func(*args, **kwargs)
+core.dispatch(f"{event}.after", (kwargs, resp), allow_raise=True)
+```
+
+The contrib layer knows **nothing** about who (if anyone) is listening.
+
+### Consumer — inside the security product
+
+Register listeners with `core.on(...)`. The canonical example is
+`ddtrace/appsec/_ai_guard/_listener.py`:
+
+```python
+from functools import partial
+from ddtrace.internal import core
+
+def ai_guard_listen():
+    client = new_ai_guard_client()
+    core.on("openai.chat.completions.create.before",
+            partial(_openai_chat_completion_before, client))
+    core.on("openai.chat.completions.create.after",
+            partial(_openai_chat_completion_after, client))
+    core.on("anthropic.messages.create.before",
+            partial(_anthropic_messages_create_before, client))
+    # ...
+```
+
+Listeners are only registered when the product is **enabled** (e.g. AI Guard's
+`init_ai_guard()` is gated on `DD_AI_GUARD_ENABLED`). When disabled, the events
+are still dispatched but have no subscribers — a cheap no-op.
+
+## Mental model
+
+```
+        ddtrace/contrib/internal/<lib>/   (shared, base-product code)
+                      │
+                      │  core.dispatch("<event>.before"/".after", ...)
+                      ▼
+        ┌─────────────────────────────────┐
+        │     ddtrace/internal/core        │   (event bus — decoupling layer)
+        └─────────────────────────────────┘
+              ▲            ▲            ▲
+   core.on(…) │ core.on(…) │ core.on(…) │
+        AI Guard         IAST         AppSec     (optional security products)
+```
+
+Contrib emits; security products subscribe. Neither side imports the other.
+
+## Checklist when wiring a security feature into an integration
+
+1. Is there an existing core event at the right spot? Reuse it.
+2. If not, add a `core.dispatch(...)` in the contrib patch — no security
+   imports. Pass `allow_raise=True` only if a listener must be able to block.
+3. Register the listener with `core.on(...)` inside the security product,
+   guarded by the product's enable flag.
+4. Convert SDK-native data to the product's own types inside the listener
+   (not in contrib).
+5. Run the `circular-import-analysis` skill if you added/moved modules.

--- a/.cursor/rules/repo-structure.mdc
+++ b/.cursor/rules/repo-structure.mdc
@@ -41,6 +41,8 @@ dd-trace-py/
 │   │   ├── _iast/            # Interactive Application Security Testing
 │   │   ├── _ddwaf/          # Datadog Web Application Firewall
 │   │   ├── _exploit_prevention/ # Runtime exploit prevention
+│   │   ├── ai_guard/         # AI Guard PUBLIC SDK (client + framework plugins)
+│   │   ├── _ai_guard/        # AI Guard internals (core.on listeners + converters)
 │   │   └── trace_utils.py    # AppSec trace enrichment
 │   │
 │   ├── internal/             # Core implementation utilities (private)
@@ -143,7 +145,7 @@ dd-trace-py/
 ### Core Library (`ddtrace/`)
 - **Main Package**: Contains the primary tracing functionality and public APIs
 - **Contrib**: 100+ integrations with popular Python libraries (Django, Flask, Redis, etc.)
-- **AppSec**: Application security features including IAST and WAF protection
+- **AppSec**: Application security features including IAST, WAF protection, and AI Guard (LLM/agentic workflow safety). See `.cursor/rules/ai-guard.mdc`. Security products stay decoupled from `contrib/` integrations via core events — see `.cursor/rules/isolated-responsibility.mdc`.
 - **Profiling**: Continuous profiling capabilities for CPU, memory, and I/O
 - **Internal**: Implementation details not part of the public API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Use the Skill tool to invoke these. **Always prefer skills over raw commands.**
 |--------|-------|-------|
 | Application Security (AppSec) | `.cursor/rules/appsec.mdc` | `ddtrace/appsec/`, `tests/appsec/` |
 | IAST | `.cursor/rules/iast.mdc` | `ddtrace/appsec/_iast/`, `tests/appsec/iast*/` |
+| AI Guard | `.cursor/rules/ai-guard.mdc` | `ddtrace/appsec/ai_guard/`, `ddtrace/appsec/_ai_guard/`, `tests/appsec/ai_guard/` |
+| Isolated Responsibility (security vs. shared integrations) | `.cursor/rules/isolated-responsibility.mdc` | `ddtrace/contrib/`, `ddtrace/appsec/` |
 | Native Code (C/C++/Rust/Cython) | `.cursor/rules/native-code.mdc` | `*.c`, `*.cc`, `*.cpp`, `*.h`, `*.hh`, `*.hpp`, `*.rs`, `*.pyx`, `*.pxd` |
 | Repository Structure | `.cursor/rules/repo-structure.mdc` | — |
 | Linting | `.cursor/rules/linting.mdc` | — |


### PR DESCRIPTION
## Description

Adds AI coding-assistant context for **AI Guard** and documents a cross-cutting architectural rule: **security products must stay isolated from `ddtrace/contrib/` integrations.**

### What's added

- **`.cursor/rules/ai-guard.mdc`** — AI Guard domain guide: what it is, the public (`ddtrace/appsec/ai_guard/`) vs. private (`ddtrace/appsec/_ai_guard/`) package split, the lazy `DD_AI_GUARD_ENABLED` init flow, the event-driven wiring, provider converters, `evaluate()` + span enrichment, double-scan avoidance, config env vars, and SDK usage. Sourced from the code and [the official docs](https://docs.datadoghq.com/security/ai_guard/).
- **`.cursor/rules/isolated-responsibility.mdc`** — explains that security products (AI Guard, IAST, AppSec) **share** many integrations with base products (APM Tracing, Profiling, LLM Observability) — Django, Flask, FastAPI, Tornado, OpenAI, Anthropic, LangChain, etc. Because security products are **not** mandatory base products of dd-trace-py, their logic must stay isolated and **we must never add imports from those products into `ddtrace/contrib/internal/*`**. Data is shared instead via the core event bus:

  ```python
  # producer (contrib)
  core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
  # consumer (security product)
  core.on("openai.chat.completions.create.before", listener)
  ```

  using `ddtrace/appsec/_ai_guard/_listener.py` as the canonical example.

### What's updated

- **`.cursor/rules/repo-structure.mdc`** — adds `ai_guard/` and `_ai_guard/` to the `appsec/` tree and references both new rules.
- **`AGENTS.md`** — links both rules in the Domain Guides table.

## Motivation

AI Guard had no dedicated assistant guide, and the contrib-isolation invariant (verified: `grep ai_guard ddtrace/contrib/` returns nothing today) was undocumented and easy to violate accidentally — a stray import would couple an optional security product into a base code path, add import cost, and risk circular imports.

## Testing

Documentation-only change (`.cursor/rules/*.mdc` + `AGENTS.md`). No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
