### PR TITLE
chore(codeowners): make asm-python the owner of AI Guard files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ tests/contrib/                      @DataDog/apm-core-python @DataDog/apm-idm-py
 tests/internal/peer_service         @DataDog/apm-core-python @DataDog/apm-idm-python
 tests/internal/service_name         @DataDog/apm-core-python @DataDog/apm-idm-python
 tests/errortracking/                @DataDog/apm-core-python
-tests/contrib/grpc                  @DataDog/apm-idm-python @DataDog/asm-python
+tests/contrib/grpc                  @DataDog/apm-idm-python
 tests/integration/                  @DataDog/apm-core-python
 
 # Files which can be approved by anyone
@@ -134,6 +134,7 @@ tests/internal/symbol_db/           @DataDog/debugger-python
 # Config and benchmarks
 .cursor/rules/appsec.mdc            @DataDog/asm-python
 .cursor/rules/iast.mdc              @DataDog/asm-python
+.cursor/rules/ai-guard.mdc          @DataDog/asm-python
 .gitlab/templates/appsec            @DataDog/asm-python
 .gitlab/tests/appsec.yml            @DataDog/asm-python
 benchmarks/appsec*                  @DataDog/asm-python
@@ -149,6 +150,7 @@ ddtrace/contrib/internal/webbrowser          @DataDog/asm-python
 ddtrace/internal/_exceptions.py     @DataDog/asm-python
 ddtrace/internal/appsec/            @DataDog/asm-python
 ddtrace/internal/iast/              @DataDog/asm-python
+ddtrace/internal/sca/               @DataDog/asm-python
 ddtrace/internal/settings/asm.py             @DataDog/asm-python
 # tests files
 tests/appsec/                       @DataDog/asm-python
@@ -323,12 +325,6 @@ tests/contrib/**/test_*dsm.py                             @DataDog/data-streams-
 tests/**/*appsec*                       @DataDog/asm-python
 tests/**/*iast*                         @DataDog/asm-python
 tests/tracer/test_propagation.py        @DataDog/apm-sdk-capabilities-python @DataDog/asm-python
-
-# AI Guard (order matters — overrides ASM)
-ddtrace/appsec/ai_guard/                  @DataDog/k9-ai-guard
-ddtrace/appsec/_ai_guard/                 @DataDog/k9-ai-guard
-tests/appsec/ai_guard/                    @DataDog/k9-ai-guard
-tests/appsec/integrations/langchain_tests @DataDog/k9-ai-guard
 
 # Fuzzing
 .gitlab/fuzz.yml                  @DataDog/chaos-engineering @DataDog/profiling-python


### PR DESCRIPTION
## Description

Updates `.github/CODEOWNERS` so that **AppSec (`@DataDog/asm-python`) is now the owner of the AI Guard files** in this repository, and refreshes a few related ownership entries.

### Ownership changes

- **AI Guard → AppSec (ASM).** Removes the dedicated "AI Guard (order matters — overrides ASM)" override block that assigned AI Guard sources/tests to `@DataDog/k9-ai-guard`. With the override gone, these paths now resolve to `@DataDog/asm-python` through the existing ASM rules:
  - `ddtrace/appsec/ai_guard/` and `ddtrace/appsec/_ai_guard/` → covered by `ddtrace/appsec/`
  - `tests/appsec/ai_guard/` (and `tests/appsec/integrations/langchain_tests`) → covered by `tests/appsec/`
- **New AI Guard rule guide.** Adds `.cursor/rules/ai-guard.mdc → @DataDog/asm-python` (pairs with #18499, which introduces that file).
- **SCA folder.** Adds `ddtrace/internal/sca/ → @DataDog/asm-python`.
- **grpc tests.** Drops `@DataDog/asm-python` from `tests/contrib/grpc` (now `@DataDog/apm-idm-python` only).

## Motivation

AppSec now maintains the AI Guard integration in this repo, so ownership should reflect that rather than routing reviews to `k9-ai-guard`. The SCA folder and the new AI Guard rule guide were also missing explicit owners.

## Testing

CODEOWNERS-only change; no code paths touched. Ownership resolution verified against the existing `ddtrace/appsec/` and `tests/appsec/` ASM rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
