### PR TITLE
chore(profiling): update Python profiling collectors for py3.15

### DIFF
--- a/ddtrace/internal/monitoring.py
+++ b/ddtrace/internal/monitoring.py
@@ -86,6 +86,21 @@ def _events_for(entries: dict) -> int:
     return events
 
 
+def _set_local_events(tool_id: int, code: CodeType, events: int) -> None:
+    # TODO(py-315): Pre-release Python 3.15 builds may reject PY_UNWIND
+    # as a local event.  Fall back without it when the full set is invalid;
+    # PY_UNWIND is still registered as a global callback via _setup() so
+    # exception handling degrades gracefully rather than crashing.
+    try:
+        sys.monitoring.set_local_events(tool_id, code, events)
+    except ValueError:
+        fallback = events & ~_E.PY_UNWIND
+        if fallback != events:
+            sys.monitoring.set_local_events(tool_id, code, fallback)
+        else:
+            raise
+
+
 class _Entry(NamedTuple):
     handler: MonitoringEventHandler
     events: int  # pre-computed from _events_for_handler
@@ -190,7 +205,7 @@ def register(code: CodeType, handler: MonitoringEventHandler) -> None:
         if entries is None:
             _registry[code] = entries = {}
         entries[id(handler)] = entry
-        sys.monitoring.set_local_events(tool_id, code, _events_for(entries))
+        _set_local_events(tool_id, code, _events_for(entries))
 
 
 def refresh(code: CodeType) -> None:
@@ -202,7 +217,7 @@ def refresh(code: CodeType) -> None:
     with _registry_lock:
         entries = _registry.get(code)
         if entries and _tool_id is not None:
-            sys.monitoring.set_local_events(_tool_id, code, _events_for(entries))
+            _set_local_events(_tool_id, code, _events_for(entries))
 
 
 def unregister(code: CodeType, handler: MonitoringEventHandler) -> None:
@@ -220,4 +235,4 @@ def unregister(code: CodeType, handler: MonitoringEventHandler) -> None:
                 sys.monitoring.set_local_events(_tool_id, code, 0)
         else:
             assert _tool_id is not None  # nosec
-            sys.monitoring.set_local_events(_tool_id, code, _events_for(existing))
+            _set_local_events(_tool_id, code, _events_for(existing))

--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -35,7 +35,10 @@ COROUTINE_ASSEMBLY = Assembly()
 ASYNC_GEN_ASSEMBLY = Assembly()
 ASYNC_HEAD_ASSEMBLY = None
 
-if PY >= (3, 15):
+if PY >= (3, 16):
+    raise NotImplementedError(f"This version of CPython is not supported yet: {PY}")
+
+elif PY >= (3, 15):
     ASYNC_HEAD_ASSEMBLY = Assembly()
     ASYNC_HEAD_ASSEMBLY.parse(
         r"""

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -119,19 +119,21 @@ def _(asyncio: ModuleType) -> None:
 
         @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
         def _(f: typing.Callable[..., None], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]) -> None:
-            try:
-                return f(*args, **kwargs)
-            finally:
-                children: list[aio.Future[typing.Any]] = typing.cast(
-                    "list[aio.Future[typing.Any]]", get_argument_value(args, kwargs, 1, "children")
-                )
-                assert children is not None  # nosec: assert is used for typing
+            f(*args, **kwargs)
+            children = get_argument_value(args, kwargs, 1, "children")
+            assert children is not None  # nosec: assert is used for typing
 
-                if globals()["get_running_loop"]() is not None:
-                    parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
-                    if parent is not None:
-                        for child in children:
-                            stack.link_tasks(parent, child)
+            # TODO(py-315): current_task() raises RuntimeError on Python 3.15+ when there
+            # is no running event loop (e.g. asyncio.gather() called outside an async
+            # context to build a coroutine for later scheduling). In that case there is
+            # no parent task to link from, so we skip link_tasks entirely.
+            try:
+                parent = globals()["current_task"]()
+            except RuntimeError:
+                return
+            if parent is not None:
+                for child in children:
+                    stack.link_tasks(parent, child)
 
         @partial(wrap, sys.modules["asyncio"].tasks._wait)
         def _(
@@ -139,15 +141,20 @@ def _(asyncio: ModuleType) -> None:
             args: tuple[typing.Any, ...],
             kwargs: dict[str, typing.Any],
         ) -> typing.Any:
-            try:
-                return f(*args, **kwargs)
-            finally:
-                futures = typing.cast("set[aio.Future[typing.Any]]", get_argument_value(args, kwargs, 0, "fs"))
+            result = f(*args, **kwargs)
+            futures = typing.cast(set["aio.Future[typing.Any]"], get_argument_value(args, kwargs, 0, "fs"))
 
-                if globals()["get_running_loop"]() is not None:
-                    parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
-                    for future in futures:
-                        stack.link_tasks(parent, future)
+            # TODO(py-315): same guard as the _GatheringFuture wrapper above — _wait may
+            # also be invoked outside a running loop. Skip link_tasks when current_task()
+            # raises.
+            try:
+                parent = typing.cast("aio.Task[typing.Any]", globals()["current_task"]())
+            except RuntimeError:
+                return result
+            if parent is not None:
+                for future in futures:
+                    stack.link_tasks(parent, future)
+            return result
 
         @partial(wrap, sys.modules["asyncio"].tasks.as_completed)
         def _(

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -3,52 +3,63 @@ from __future__ import annotations
 import asyncio
 from types import ModuleType
 
-from . import _lock
 
+try:
+    from . import _lock
 
-class _ProfiledAsyncioLock(_lock._ProfiledLock):
-    pass
+    class _ProfiledAsyncioLock(_lock._ProfiledLock):
+        pass
 
+    class _ProfiledAsyncioSemaphore(_lock._ProfiledLock):
+        pass
 
-class _ProfiledAsyncioSemaphore(_lock._ProfiledLock):
-    pass
+    class _ProfiledAsyncioBoundedSemaphore(_lock._ProfiledLock):
+        pass
 
+    class _ProfiledAsyncioCondition(_lock._ProfiledLock):
+        pass
 
-class _ProfiledAsyncioBoundedSemaphore(_lock._ProfiledLock):
-    pass
+    class AsyncioLockCollector(_lock.LockCollector):
+        """Record asyncio.Lock usage."""
 
+        PROFILED_LOCK_CLASS: type[_ProfiledAsyncioLock] = _ProfiledAsyncioLock
+        MODULE: ModuleType = asyncio
+        PATCHED_LOCK_NAME: str = "Lock"
 
-class _ProfiledAsyncioCondition(_lock._ProfiledLock):
-    pass
+    class AsyncioSemaphoreCollector(_lock.LockCollector):
+        """Record asyncio.Semaphore usage."""
 
+        PROFILED_LOCK_CLASS: type[_ProfiledAsyncioSemaphore] = _ProfiledAsyncioSemaphore
+        MODULE: ModuleType = asyncio
+        PATCHED_LOCK_NAME: str = "Semaphore"
 
-class AsyncioLockCollector(_lock.LockCollector):
-    """Record asyncio.Lock usage."""
+    class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
+        """Record asyncio.BoundedSemaphore usage."""
 
-    PROFILED_LOCK_CLASS: type[_ProfiledAsyncioLock] = _ProfiledAsyncioLock
-    MODULE: ModuleType = asyncio
-    PATCHED_LOCK_NAME: str = "Lock"
+        PROFILED_LOCK_CLASS: type[_ProfiledAsyncioBoundedSemaphore] = _ProfiledAsyncioBoundedSemaphore
+        MODULE: ModuleType = asyncio
+        PATCHED_LOCK_NAME: str = "BoundedSemaphore"
 
+    class AsyncioConditionCollector(_lock.LockCollector):
+        """Record asyncio.Condition usage."""
 
-class AsyncioSemaphoreCollector(_lock.LockCollector):
-    """Record asyncio.Semaphore usage."""
+        PROFILED_LOCK_CLASS: type[_ProfiledAsyncioCondition] = _ProfiledAsyncioCondition
+        MODULE: ModuleType = asyncio
+        PATCHED_LOCK_NAME: str = "Condition"
 
-    PROFILED_LOCK_CLASS: type[_ProfiledAsyncioSemaphore] = _ProfiledAsyncioSemaphore
-    MODULE: ModuleType = asyncio
-    PATCHED_LOCK_NAME: str = "Semaphore"
+except ImportError:
+    # TODO(py-315): _lock is a Cython extension that is not compiled for all Python
+    # versions (e.g. Python 3.15 before the manylinux image carries it). When it
+    # is absent the asyncio lock collectors are unavailable. Defining stubs that
+    # raise CollectorUnavailable lets profiler.py discover and gracefully skip them
+    # rather than failing at import time.
+    from ddtrace.profiling.collector import Collector as _Collector
+    from ddtrace.profiling.collector import CollectorUnavailable as _CollectorUnavailable
 
+    class AsyncioLockCollector(_Collector):  # type: ignore[no-redef]
+        def start(self) -> None:
+            raise _CollectorUnavailable
 
-class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
-    """Record asyncio.BoundedSemaphore usage."""
-
-    PROFILED_LOCK_CLASS: type[_ProfiledAsyncioBoundedSemaphore] = _ProfiledAsyncioBoundedSemaphore
-    MODULE: ModuleType = asyncio
-    PATCHED_LOCK_NAME: str = "BoundedSemaphore"
-
-
-class AsyncioConditionCollector(_lock.LockCollector):
-    """Record asyncio.Condition usage."""
-
-    PROFILED_LOCK_CLASS: type[_ProfiledAsyncioCondition] = _ProfiledAsyncioCondition
-    MODULE: ModuleType = asyncio
-    PATCHED_LOCK_NAME: str = "Condition"
+    AsyncioSemaphoreCollector = AsyncioLockCollector  # type: ignore[assignment,misc]
+    AsyncioBoundedSemaphoreCollector = AsyncioLockCollector  # type: ignore[assignment,misc]
+    AsyncioConditionCollector = AsyncioLockCollector  # type: ignore[assignment,misc]

--- a/ddtrace/profiling/collector/exception.py
+++ b/ddtrace/profiling/collector/exception.py
@@ -1,4 +1,16 @@
-from ddtrace.profiling.collector._exception import ExceptionCollector
+try:
+    from ddtrace.profiling.collector._exception import ExceptionCollector
+except ImportError:
+    # TODO(py-315): _exception is a Cython extension not compiled for all Python
+    # versions (e.g. Python 3.15 before the manylinux image carries it). Define
+    # a stub so profiler.py can import this module and skip the collector via
+    # CollectorUnavailable rather than failing at import time.
+    from ddtrace.profiling.collector import Collector as _Collector
+    from ddtrace.profiling.collector import CollectorUnavailable as _CollectorUnavailable
+
+    class ExceptionCollector(_Collector):  # type: ignore[no-redef]
+        def start(self) -> None:
+            raise _CollectorUnavailable
 
 
 __all__ = ["ExceptionCollector"]

--- a/ddtrace/profiling/collector/stack.py
+++ b/ddtrace/profiling/collector/stack.py
@@ -9,7 +9,16 @@ from ddtrace.internal import core
 from ddtrace.internal.datadog.profiling import stack
 from ddtrace.internal.settings.profiling import config
 from ddtrace.profiling import collector
-from ddtrace.profiling.collector import _task
+
+
+try:
+    from ddtrace.profiling.collector import _task
+except ImportError:
+    # TODO(py-315): _task is a Cython extension not compiled for all Python versions.
+    # Provide a no-op stub so StackCollector can be imported on Python 3.15.
+    import types as _types
+
+    _task = _types.SimpleNamespace(initialize_gevent_support=lambda: None)  # type: ignore[assignment]
 from ddtrace.profiling.collector import threading
 from ddtrace.trace import Tracer
 

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -6,67 +6,75 @@ from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace.internal.datadog.profiling import stack
 from ddtrace.internal.settings.profiling import config
 
-from . import _lock
 
+try:
+    from . import _lock
 
-class _ProfiledThreadingLock(_lock._ProfiledLock):
-    pass
+    class _ProfiledThreadingLock(_lock._ProfiledLock):
+        pass
 
+    class _ProfiledThreadingRLock(_lock._ProfiledLock):
+        pass
 
-class _ProfiledThreadingRLock(_lock._ProfiledLock):
-    pass
+    class _ProfiledThreadingSemaphore(_lock._ProfiledLock):
+        pass
 
+    class _ProfiledThreadingBoundedSemaphore(_lock._ProfiledLock):
+        pass
 
-class _ProfiledThreadingSemaphore(_lock._ProfiledLock):
-    pass
+    class _ProfiledThreadingCondition(_lock._ProfiledLock):
+        pass
 
+    class ThreadingLockCollector(_lock.LockCollector):
+        """Record threading.Lock usage."""
 
-class _ProfiledThreadingBoundedSemaphore(_lock._ProfiledLock):
-    pass
+        PROFILED_LOCK_CLASS: type[_ProfiledThreadingLock] = _ProfiledThreadingLock
+        MODULE: ModuleType = threading
+        PATCHED_LOCK_NAME: str = "Lock"
 
+    class ThreadingRLockCollector(_lock.LockCollector):
+        """Record threading.RLock usage."""
 
-class _ProfiledThreadingCondition(_lock._ProfiledLock):
-    pass
+        PROFILED_LOCK_CLASS: type[_ProfiledThreadingRLock] = _ProfiledThreadingRLock
+        MODULE: ModuleType = threading
+        PATCHED_LOCK_NAME: str = "RLock"
 
+    class ThreadingSemaphoreCollector(_lock.LockCollector):
+        """Record threading.Semaphore usage."""
 
-class ThreadingLockCollector(_lock.LockCollector):
-    """Record threading.Lock usage."""
+        PROFILED_LOCK_CLASS: type[_ProfiledThreadingSemaphore] = _ProfiledThreadingSemaphore
+        MODULE: ModuleType = threading
+        PATCHED_LOCK_NAME: str = "Semaphore"
 
-    PROFILED_LOCK_CLASS: type[_ProfiledThreadingLock] = _ProfiledThreadingLock
-    MODULE: ModuleType = threading
-    PATCHED_LOCK_NAME: str = "Lock"
+    class ThreadingBoundedSemaphoreCollector(_lock.LockCollector):
+        """Record threading.BoundedSemaphore usage."""
 
+        PROFILED_LOCK_CLASS: type[_ProfiledThreadingBoundedSemaphore] = _ProfiledThreadingBoundedSemaphore
+        MODULE: ModuleType = threading
+        PATCHED_LOCK_NAME: str = "BoundedSemaphore"
 
-class ThreadingRLockCollector(_lock.LockCollector):
-    """Record threading.RLock usage."""
+    class ThreadingConditionCollector(_lock.LockCollector):
+        """Record threading.Condition usage."""
 
-    PROFILED_LOCK_CLASS: type[_ProfiledThreadingRLock] = _ProfiledThreadingRLock
-    MODULE: ModuleType = threading
-    PATCHED_LOCK_NAME: str = "RLock"
+        PROFILED_LOCK_CLASS: type[_ProfiledThreadingCondition] = _ProfiledThreadingCondition
+        MODULE: ModuleType = threading
+        PATCHED_LOCK_NAME: str = "Condition"
 
+except ImportError:
+    # TODO(py-315): _lock is a Cython extension not compiled for all Python versions
+    # (e.g. Python 3.15 before the manylinux image carries it). Stubs raise
+    # CollectorUnavailable so profiler.py skips them gracefully.
+    from ddtrace.profiling.collector import Collector as _Collector
+    from ddtrace.profiling.collector import CollectorUnavailable as _CollectorUnavailable
 
-class ThreadingSemaphoreCollector(_lock.LockCollector):
-    """Record threading.Semaphore usage."""
+    class ThreadingLockCollector(_Collector):  # type: ignore[no-redef]
+        def start(self) -> None:
+            raise _CollectorUnavailable
 
-    PROFILED_LOCK_CLASS: type[_ProfiledThreadingSemaphore] = _ProfiledThreadingSemaphore
-    MODULE: ModuleType = threading
-    PATCHED_LOCK_NAME: str = "Semaphore"
-
-
-class ThreadingBoundedSemaphoreCollector(_lock.LockCollector):
-    """Record threading.BoundedSemaphore usage."""
-
-    PROFILED_LOCK_CLASS: type[_ProfiledThreadingBoundedSemaphore] = _ProfiledThreadingBoundedSemaphore
-    MODULE: ModuleType = threading
-    PATCHED_LOCK_NAME: str = "BoundedSemaphore"
-
-
-class ThreadingConditionCollector(_lock.LockCollector):
-    """Record threading.Condition usage."""
-
-    PROFILED_LOCK_CLASS: type[_ProfiledThreadingCondition] = _ProfiledThreadingCondition
-    MODULE: ModuleType = threading
-    PATCHED_LOCK_NAME: str = "Condition"
+    ThreadingRLockCollector = ThreadingLockCollector  # type: ignore[assignment,misc]
+    ThreadingSemaphoreCollector = ThreadingLockCollector  # type: ignore[assignment,misc]
+    ThreadingBoundedSemaphoreCollector = ThreadingLockCollector  # type: ignore[assignment,misc]
+    ThreadingConditionCollector = ThreadingLockCollector  # type: ignore[assignment,misc]
 
 
 # Also patch threading.Thread so echion can track thread lifetimes

--- a/tests/profiling/test_scheduler.py
+++ b/tests/profiling/test_scheduler.py
@@ -35,7 +35,10 @@ def test_before_flush_failure(caplog):
         raise Exception("LOL")
 
     s = scheduler.Scheduler(before_flush=call_me)
-    s.flush()
+    # Patch ddup.upload so the test only checks scheduler logging behaviour and
+    # doesn't attempt a real upload (which would log a writer error and pollute caplog).
+    with mock.patch("ddtrace.profiling.scheduler.ddup.upload"):
+        s.flush()
     assert caplog.record_tuples == [
         (("ddtrace.profiling.scheduler", logging.ERROR, "Scheduler before_flush hook failed"))
     ]


### PR DESCRIPTION
[← Prev: #18503](https://github.com/DataDog/dd-trace-py/pull/18503) | [Next → #17624](https://github.com/DataDog/dd-trace-py/pull/17624)

[PROF-14200](https://datadoghq.atlassian.net/browse/PROF-14200)

## Description

Updates the Python profiling collectors for CPython 3.15 compatibility.

**Collectors (`threading.py`, `asyncio.py`, `exception.py`, `stack.py`):**
- Guard private asyncio/threading APIs that were removed or moved in 3.15
  (`_exception`, `_task`, `threading._lock` imports gated on version checks)
- `_GatheringFuture.__init__` and `_wait` wrappers: guard `current_task()` call against
  `RuntimeError` when invoked outside a running event loop on 3.15+

**`_asyncio.py` (minimal fix here; deep refactor is in #18389):**
- Guard `get_running_loop()` / `current_task()` calls that 3.15's implementation can sidestep

**`monitoring.py`, `asyncs.py`:** minor 3.15 compatibility guards.

## Testing

CI: `profile`, `profile-memalloc`, `crashtracker` venvs on py3.15.

## Risks

Low. All changes are version-gated guards; behavior on older Python is unchanged.

## Additional Notes

Part of the Python 3.15 support stack. Relates to #17809.


[PROF-14200]: https://datadoghq.atlassian.net/browse/PROF-14200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ