### PR TITLE
test(profiling): regression test for fork+gthread worker thread visibility

### DIFF
--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "tests/profiling/preload_fork_gthread.py"
       - "tests/profiling/test_preload_fork_gthread.py"
+      - "tests/profiling/check_fork_pprof.py"
       - ".github/workflows/profiling-fork-regression.yml"
 
 jobs:
@@ -40,7 +41,6 @@ jobs:
         run: |
           python -m venv /tmp/ddvenv
           /tmp/ddvenv/bin/pip install -q "ddtrace==${{ matrix.ddtrace }}" protobuf zstandard  # ci-deps: allow-no-version
-          # Verify — run from /tmp so repo's ddtrace/ dir is not on sys.path
           cd /tmp
           ACTUAL=$(/tmp/ddvenv/bin/python -c "import ddtrace; print(ddtrace.__version__)")
           echo "Installed ddtrace: $ACTUAL"
@@ -48,36 +48,6 @@ jobs:
             echo "::error::Expected ${{ matrix.ddtrace }}, got $ACTUAL"
             exit 1
           fi
-
-      - name: Write pprof checker script
-        run: |
-          cat > /tmp/check_pprof.py << 'PYEOF'
-import sys, glob
-sys.path.insert(0, sys.argv[1])  # repo root for pprof_utils
-from tests.profiling.collector import pprof_utils
-
-prefix = sys.argv[2]
-child_pid = sys.argv[3]
-full_prefix = f"{prefix}.{child_pid}"
-files = glob.glob(f"{full_prefix}.*pprof")
-if not files:
-    print(f"NO_PPROF child={child_pid}")
-    sys.exit(2)
-
-profile = pprof_utils.parse_newest_profile(full_prefix, allow_penultimate=True)
-wt = pprof_utils.get_samples_with_value_type(profile, "wall-time")
-names = set()
-for s in wt:
-    lbl = pprof_utils.get_label_with_key(profile.string_table, s, "thread name")
-    if lbl:
-        names.add(profile.string_table[lbl.str])
-workers = {n for n in names if n != "MainThread"}
-print(f"samples={len(wt)} threads={sorted(names)}")
-if not workers:
-    print("BUG_PRESENT")
-    sys.exit(1)
-print("OK")
-PYEOF
 
       - name: Run fork+gthread regression (10 iterations)
         env:
@@ -89,8 +59,6 @@ PYEOF
           for i in $(seq 1 10); do
             cd /tmp
 
-            # Write child PID to file to avoid set-e triggering on non-zero
-            # exit from command substitution (bash -e footgun).
             /tmp/ddvenv/bin/python "${REPO}/tests/profiling/preload_fork_gthread.py" \
               > /tmp/childpid_${i}.txt \
               2>/tmp/stderr_${i}.txt
@@ -104,15 +72,17 @@ PYEOF
               continue
             fi
 
-            RESULT=$(/tmp/ddvenv/bin/python /tmp/check_pprof.py \
-              "${REPO}" "/tmp/pprof_run${i}" "${CHILD_PID}" 2>&1) || true
+            /tmp/ddvenv/bin/python "${REPO}/tests/profiling/check_fork_pprof.py" \
+              "${REPO}" "/tmp/pprof_run${i}" "${CHILD_PID}" \
+              > /tmp/result_${i}.txt 2>&1 || true
             RC=$?
+            RESULT=$(cat /tmp/result_${i}.txt)
 
             if [ "${RC}" = "0" ]; then
               echo "Run ${i}: PASS — ${RESULT}"
               PASSES=$((PASSES+1))
             else
-              echo "Run ${i}: FAIL — ${RESULT}"
+              echo "Run ${i}: FAIL (rc=${RC}) — ${RESULT}"
               BUGS=$((BUGS+1))
             fi
           done

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -49,14 +49,21 @@ jobs:
             exit 1
           fi
 
-      - name: Run fork+gthread regression (10 iterations)
+      - name: Run fork+gthread regression (20 iterations under CPU stress)
         env:
           REPO: ${{ github.workspace }}
         run: |
+          # Saturate all CPUs to increase scheduler pressure and expose the
+          # pthread_atfork timing race (the same race that manifests in production
+          # under Gunicorn/gthread load).
+          stress-ng --cpu $(nproc) &
+          STRESS_PID=$!
+          trap "kill $STRESS_PID 2>/dev/null || true" EXIT
+
           BUGS=0
           PASSES=0
 
-          for i in $(seq 1 10); do
+          for i in $(seq 1 20); do
             cd /tmp
 
             STATUS=0
@@ -91,9 +98,9 @@ jobs:
           done
 
           echo ""
-          echo "Results for ddtrace==${{ matrix.ddtrace }}: ${PASSES}/10 passed, ${BUGS}/10 failed"
+          echo "Results for ddtrace==${{ matrix.ddtrace }}: ${PASSES}/20 passed, ${BUGS}/20 failed"
 
           if [ "${BUGS}" -gt 0 ]; then
-            echo "::error::${BUGS}/10 runs showed the fork+gthread profiler bug on v${{ matrix.ddtrace }}"
+            echo "::error::${BUGS}/20 runs showed the fork+gthread profiler bug on v${{ matrix.ddtrace }}"
             exit 1
           fi

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -43,7 +43,7 @@ jobs:
             "ddtrace==${{ matrix.ddtrace }}" \
             protobuf \
             zstandard
-          # Verify — run from /tmp so the repo's ddtrace/ dir is not on sys.path
+          # Verify — run from /tmp so repo's ddtrace/ dir is not on sys.path
           cd /tmp
           ACTUAL=$(/tmp/ddvenv/bin/python -c "import ddtrace; print(ddtrace.__version__)")
           echo "Installed ddtrace: $ACTUAL"
@@ -52,65 +52,66 @@ jobs:
             exit 1
           fi
 
+      - name: Write pprof checker script
+        run: |
+          cat > /tmp/check_pprof.py << 'PYEOF'
+import sys, glob
+sys.path.insert(0, sys.argv[1])  # repo root for pprof_utils
+from tests.profiling.collector import pprof_utils
+
+prefix = sys.argv[2]
+child_pid = sys.argv[3]
+full_prefix = f"{prefix}.{child_pid}"
+files = glob.glob(f"{full_prefix}.*pprof")
+if not files:
+    print(f"NO_PPROF child={child_pid}")
+    sys.exit(2)
+
+profile = pprof_utils.parse_newest_profile(full_prefix, allow_penultimate=True)
+wt = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+names = set()
+for s in wt:
+    lbl = pprof_utils.get_label_with_key(profile.string_table, s, "thread name")
+    if lbl:
+        names.add(profile.string_table[lbl.str])
+workers = {n for n in names if n != "MainThread"}
+print(f"samples={len(wt)} threads={sorted(names)}")
+if not workers:
+    print("BUG_PRESENT")
+    sys.exit(1)
+print("OK")
+PYEOF
+
       - name: Run fork+gthread regression (10 iterations)
         env:
           REPO: ${{ github.workspace }}
         run: |
-          cat > /tmp/check_pprof.py << 'PYEOF'
-          import sys, glob
-          sys.path.insert(0, sys.argv[1])  # repo root for pprof_utils
-          from tests.profiling.collector import pprof_utils
-
-          prefix = sys.argv[2]
-          child_pid = sys.argv[3]
-          full_prefix = f"{prefix}.{child_pid}"
-          files = glob.glob(f"{full_prefix}.*pprof")
-          if not files:
-              print(f"NO_PPROF child={child_pid}")
-              sys.exit(2)
-
-          profile = pprof_utils.parse_newest_profile(full_prefix, allow_penultimate=True)
-          wt = pprof_utils.get_samples_with_value_type(profile, "wall-time")
-          names = set()
-          for s in wt:
-              lbl = pprof_utils.get_label_with_key(profile.string_table, s, "thread name")
-              if lbl:
-                  names.add(profile.string_table[lbl.str])
-          workers = {n for n in names if n != "MainThread"}
-          print(f"samples={len(wt)} threads={sorted(names)}")
-          if not workers:
-              print("BUG_PRESENT")
-              sys.exit(1)
-          print("OK")
-          PYEOF
-
           BUGS=0
           PASSES=0
 
           for i in $(seq 1 10); do
             cd /tmp
 
-            CHILD_PID=$(
-              DD_PROFILING_ENABLED=1 \
-              DD_PROFILING_OUTPUT_PPROF=/tmp/pprof_run${i} \
-              _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0 \
-              /tmp/ddvenv/bin/python "${REPO}/tests/profiling/preload_fork_gthread.py" \
-                2>/tmp/stderr_${i}.txt
-            )
+            # Write child PID to file to avoid set-e triggering on non-zero
+            # exit from command substitution (bash -e footgun).
+            /tmp/ddvenv/bin/python "${REPO}/tests/profiling/preload_fork_gthread.py" \
+              > /tmp/childpid_${i}.txt \
+              2>/tmp/stderr_${i}.txt
             STATUS=$?
+            CHILD_PID=$(cat /tmp/childpid_${i}.txt 2>/dev/null || true)
 
-            if [ "$STATUS" != "0" ]; then
-              echo "Run ${i}: CRASH (exit=${STATUS})"
+            if [ "$STATUS" != "0" ] || [ -z "$CHILD_PID" ]; then
+              echo "Run ${i}: CRASH (exit=${STATUS} pid='${CHILD_PID}')"
               cat /tmp/stderr_${i}.txt || true
               BUGS=$((BUGS+1))
               continue
             fi
 
             RESULT=$(/tmp/ddvenv/bin/python /tmp/check_pprof.py \
-              "${REPO}" "/tmp/pprof_run${i}" "$CHILD_PID" 2>&1)
+              "${REPO}" "/tmp/pprof_run${i}" "${CHILD_PID}" 2>&1) || true
             RC=$?
 
-            if [ "$RC" = "0" ]; then
+            if [ "${RC}" = "0" ]; then
               echo "Run ${i}: PASS — ${RESULT}"
               PASSES=$((PASSES+1))
             else
@@ -122,7 +123,7 @@ jobs:
           echo ""
           echo "Results for ddtrace==${{ matrix.ddtrace }}: ${PASSES}/10 passed, ${BUGS}/10 failed"
 
-          if [ "$BUGS" -gt 0 ]; then
+          if [ "${BUGS}" -gt 0 ]; then
             echo "::error::${BUGS}/10 runs showed the fork+gthread profiler bug on v${{ matrix.ddtrace }}"
             exit 1
           fi

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -74,7 +74,7 @@ jobs:
 
             /tmp/ddvenv/bin/python "${REPO}/tests/profiling/check_fork_pprof.py" \
               "${REPO}" "/tmp/pprof_run${i}" "${CHILD_PID}" \
-              > /tmp/result_${i}.txt 2>&1 || true
+              > /tmp/result_${i}.txt 2>&1
             RC=$?
             RESULT=$(cat /tmp/result_${i}.txt)
 

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install ddtrace ${{ matrix.ddtrace }} in isolated venv
         run: |
           python -m venv /tmp/ddvenv
-          /tmp/ddvenv/bin/pip install -q \
+          /tmp/ddvenv/bin/pip install -q \  # ci-deps: allow
             "ddtrace==${{ matrix.ddtrace }}" \
             protobuf \
             zstandard

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install ddtrace ${{ matrix.ddtrace }} in isolated venv
         run: |
           python -m venv /tmp/ddvenv
-          /tmp/ddvenv/bin/pip install -q "ddtrace==${{ matrix.ddtrace }}" protobuf zstandard  # ci-deps: allow
+          /tmp/ddvenv/bin/pip install -q "ddtrace==${{ matrix.ddtrace }}" protobuf zstandard  # ci-deps: allow-no-version
           # Verify — run from /tmp so repo's ddtrace/ dir is not on sys.path
           cd /tmp
           ACTUAL=$(/tmp/ddvenv/bin/python -c "import ddtrace; print(ddtrace.__version__)")

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -59,10 +59,13 @@ jobs:
           for i in $(seq 1 10); do
             cd /tmp
 
+            STATUS=0
+            DD_PROFILING_ENABLED=1 \
+            DD_PROFILING_OUTPUT_PPROF="/tmp/pprof_run${i}" \
+            _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0 \
             /tmp/ddvenv/bin/python "${REPO}/tests/profiling/preload_fork_gthread.py" \
               > /tmp/childpid_${i}.txt \
-              2>/tmp/stderr_${i}.txt
-            STATUS=$?
+              2>/tmp/stderr_${i}.txt || STATUS=$?
             CHILD_PID=$(cat /tmp/childpid_${i}.txt 2>/dev/null || true)
 
             if [ "$STATUS" != "0" ] || [ -z "$CHILD_PID" ]; then
@@ -72,10 +75,10 @@ jobs:
               continue
             fi
 
+            RC=0
             /tmp/ddvenv/bin/python "${REPO}/tests/profiling/check_fork_pprof.py" \
               "${REPO}" "/tmp/pprof_run${i}" "${CHILD_PID}" \
-              > /tmp/result_${i}.txt 2>&1
-            RC=$?
+              > /tmp/result_${i}.txt 2>&1 || RC=$?
             RESULT=$(cat /tmp/result_${i}.txt)
 
             if [ "${RC}" = "0" ]; then

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -1,0 +1,128 @@
+name: Profiling fork+gthread regression
+
+# Regression test for the preload_app=True / admission-injection scenario:
+# profiler starts in master before fork, worker creates threads after fork.
+# Guards against PRs #17183, #17042, #18063 (v4.7.x bugs).
+#
+# Each matrix job installs an isolated ddtrace version (no local repo on sys.path)
+# and runs the fork script 10 times, checking that worker threads appear in
+# wall-time profiles. A bug manifests as only "MainThread" visible, or a crash.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "vlad/profiling-fork-regression-ci"
+    paths:
+      - "tests/profiling/preload_fork_gthread.py"
+      - "tests/profiling/test_preload_fork_gthread.py"
+      - ".github/workflows/profiling-fork-regression.yml"
+
+jobs:
+  fork-regression:
+    name: "ddtrace v${{ matrix.ddtrace }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ddtrace: ["4.7.1", "4.8.0", "4.8.8", "4.9.0", "4.10.0", "4.10.2"]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install ddtrace ${{ matrix.ddtrace }} in isolated venv
+        run: |
+          python -m venv /tmp/ddvenv
+          /tmp/ddvenv/bin/pip install -q \
+            "ddtrace==${{ matrix.ddtrace }}" \
+            protobuf \
+            zstandard
+          # Verify — run from /tmp so the repo's ddtrace/ dir is not on sys.path
+          cd /tmp
+          ACTUAL=$(/tmp/ddvenv/bin/python -c "import ddtrace; print(ddtrace.__version__)")
+          echo "Installed ddtrace: $ACTUAL"
+          if [ "$ACTUAL" != "${{ matrix.ddtrace }}" ]; then
+            echo "::error::Expected ${{ matrix.ddtrace }}, got $ACTUAL"
+            exit 1
+          fi
+
+      - name: Run fork+gthread regression (10 iterations)
+        env:
+          REPO: ${{ github.workspace }}
+        run: |
+          cat > /tmp/check_pprof.py << 'PYEOF'
+          import sys, glob
+          sys.path.insert(0, sys.argv[1])  # repo root for pprof_utils
+          from tests.profiling.collector import pprof_utils
+
+          prefix = sys.argv[2]
+          child_pid = sys.argv[3]
+          full_prefix = f"{prefix}.{child_pid}"
+          files = glob.glob(f"{full_prefix}.*pprof")
+          if not files:
+              print(f"NO_PPROF child={child_pid}")
+              sys.exit(2)
+
+          profile = pprof_utils.parse_newest_profile(full_prefix, allow_penultimate=True)
+          wt = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+          names = set()
+          for s in wt:
+              lbl = pprof_utils.get_label_with_key(profile.string_table, s, "thread name")
+              if lbl:
+                  names.add(profile.string_table[lbl.str])
+          workers = {n for n in names if n != "MainThread"}
+          print(f"samples={len(wt)} threads={sorted(names)}")
+          if not workers:
+              print("BUG_PRESENT")
+              sys.exit(1)
+          print("OK")
+          PYEOF
+
+          BUGS=0
+          PASSES=0
+
+          for i in $(seq 1 10); do
+            cd /tmp
+
+            CHILD_PID=$(
+              DD_PROFILING_ENABLED=1 \
+              DD_PROFILING_OUTPUT_PPROF=/tmp/pprof_run${i} \
+              _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0 \
+              /tmp/ddvenv/bin/python "${REPO}/tests/profiling/preload_fork_gthread.py" \
+                2>/tmp/stderr_${i}.txt
+            )
+            STATUS=$?
+
+            if [ "$STATUS" != "0" ]; then
+              echo "Run ${i}: CRASH (exit=${STATUS})"
+              cat /tmp/stderr_${i}.txt || true
+              BUGS=$((BUGS+1))
+              continue
+            fi
+
+            RESULT=$(/tmp/ddvenv/bin/python /tmp/check_pprof.py \
+              "${REPO}" "/tmp/pprof_run${i}" "$CHILD_PID" 2>&1)
+            RC=$?
+
+            if [ "$RC" = "0" ]; then
+              echo "Run ${i}: PASS — ${RESULT}"
+              PASSES=$((PASSES+1))
+            else
+              echo "Run ${i}: FAIL — ${RESULT}"
+              BUGS=$((BUGS+1))
+            fi
+          done
+
+          echo ""
+          echo "Results for ddtrace==${{ matrix.ddtrace }}: ${PASSES}/10 passed, ${BUGS}/10 failed"
+
+          if [ "$BUGS" -gt 0 ]; then
+            echo "::error::${BUGS}/10 runs showed the fork+gthread profiler bug on v${{ matrix.ddtrace }}"
+            exit 1
+          fi

--- a/.github/workflows/profiling-fork-regression.yml
+++ b/.github/workflows/profiling-fork-regression.yml
@@ -39,10 +39,7 @@ jobs:
       - name: Install ddtrace ${{ matrix.ddtrace }} in isolated venv
         run: |
           python -m venv /tmp/ddvenv
-          /tmp/ddvenv/bin/pip install -q \  # ci-deps: allow
-            "ddtrace==${{ matrix.ddtrace }}" \
-            protobuf \
-            zstandard
+          /tmp/ddvenv/bin/pip install -q "ddtrace==${{ matrix.ddtrace }}" protobuf zstandard  # ci-deps: allow
           # Verify — run from /tmp so repo's ddtrace/ dir is not on sys.path
           cd /tmp
           ACTUAL=$(/tmp/ddvenv/bin/python -c "import ddtrace; print(ddtrace.__version__)")

--- a/tests/profiling/check_fork_pprof.py
+++ b/tests/profiling/check_fork_pprof.py
@@ -1,0 +1,44 @@
+"""
+Helper for the fork+gthread CI regression workflow.
+
+Usage:
+    python check_fork_pprof.py <repo_root> <pprof_prefix> <child_pid>
+
+Exits 0 if worker threads appear in wall-time samples, 1 if only
+MainThread is visible (bug present), 2 if no pprof file was found.
+"""
+
+import glob
+import sys
+
+
+sys.path.insert(0, sys.argv[1])  # repo root so tests.profiling.collector is importable
+from tests.profiling.collector import pprof_utils  # noqa: E402
+
+
+prefix = sys.argv[2]
+child_pid = sys.argv[3]
+full_prefix = f"{prefix}.{child_pid}"
+
+files = glob.glob(f"{full_prefix}.*pprof")
+if not files:
+    print(f"NO_PPROF child={child_pid}")
+    sys.exit(2)
+
+profile = pprof_utils.parse_newest_profile(full_prefix, allow_penultimate=True)
+wt = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+
+names = set()
+for s in wt:
+    lbl = pprof_utils.get_label_with_key(profile.string_table, s, "thread name")
+    if lbl:
+        names.add(profile.string_table[lbl.str])
+
+workers = {n for n in names if n != "MainThread"}
+print(f"samples={len(wt)} threads={sorted(names)}")
+
+if not workers:
+    print("BUG_PRESENT")
+    sys.exit(1)
+
+print("OK")

--- a/tests/profiling/check_fork_pprof.py
+++ b/tests/profiling/check_fork_pprof.py
@@ -12,7 +12,7 @@ import glob
 import sys
 
 
-sys.path.insert(0, sys.argv[1])  # repo root so tests.profiling.collector is importable
+sys.path.append(sys.argv[1])  # repo root appended so venv's compiled ddtrace takes priority
 from tests.profiling.collector import pprof_utils  # noqa: E402
 
 

--- a/tests/profiling/preload_fork_gthread.py
+++ b/tests/profiling/preload_fork_gthread.py
@@ -1,0 +1,49 @@
+"""
+Regression script: profiler starts before fork, worker creates threads after fork.
+
+Simulates:
+  - Admission-injection / sitecustomize startup (profiler starts before fork)
+  - Gunicorn preload_app=True (app loaded in master, workers forked)
+  - gthread worker class (multiple threads handle requests inside each worker)
+
+The parent prints the child PID so the test can locate the child's pprof files.
+"""
+
+import os
+import sys
+import threading
+import time
+
+# Simulate admission injection: profiler starts in the master process before fork.
+import ddtrace.profiling.auto  # noqa: F401
+
+
+def fib(n: int) -> int:
+    if n <= 1:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+
+def worker_task() -> None:
+    """CPU-bound work so the sampler captures stack frames on this thread."""
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        fib(25)
+
+
+child_pid = os.fork()
+
+if child_pid == 0:
+    # Worker process: spin up threads like Gunicorn's gthread worker does.
+    threads = [threading.Thread(target=worker_task, name=f"WorkerThread-{i}") for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # Clean exit triggers atexit → profiler.stop(flush=True) → pprof written to disk.
+    sys.exit(0)
+else:
+    # Master process: print child PID for the test, then wait.
+    print(child_pid)
+    _, status = os.waitpid(child_pid, 0)
+    sys.exit(os.WEXITSTATUS(status))

--- a/tests/profiling/test_preload_fork_gthread.py
+++ b/tests/profiling/test_preload_fork_gthread.py
@@ -85,3 +85,54 @@ def test_worker_threads_appear_in_fork_child_profiles(
         "Expected WorkerThread-N threads created after fork to be visible. "
         "This indicates a profiler fork ordering bug — see PRs #17183, #17042."
     )
+
+
+def test_ddup_atfork_handler_registered_before_stack_sampler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ddup.start() must be called before stack.start() so that ddup's pthread_atfork
+    child handler is registered first.
+
+    POSIX guarantees FIFO ordering for post-fork child handlers, so ddup's handler
+    runs first — resetting the profile state — before the stack sampler clears and
+    rebuilds its thread map.  If the order is reversed, the stack sampler wipes the
+    thread map before ddup has rebuilt the profile, leaving only MainThread visible
+    in fork-child profiles.
+
+    Regression guard for PRs #17183, #17042, #18063.
+    """
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling import profiler as prof_module
+    from ddtrace.profiling.collector import stack as stack_collector_module
+
+    call_order: list[str] = []
+
+    original_ddup_start = ddup.start
+
+    def recording_ddup_start(*args, **kwargs):
+        call_order.append("ddup.start")
+        return original_ddup_start(*args, **kwargs)
+
+    monkeypatch.setattr(ddup, "start", recording_ddup_start)
+
+    # Stub _init to record when the stack sampler would register its pthread_atfork
+    # handler (via stack.start → Sampler::one_time_setup) without starting real threads.
+    def recording_stack_init(self) -> None:
+        call_order.append("stack._init")
+
+    monkeypatch.setattr(stack_collector_module.StackCollector, "_init", recording_stack_init)
+    monkeypatch.setattr(stack_collector_module.StackCollector, "_stop_service", lambda self: None)
+
+    p = prof_module.Profiler()
+    p.start()
+    p.stop(flush=False)
+
+    assert "ddup.start" in call_order, "ddup.start() was never called during profiler startup"
+    assert "stack._init" in call_order, "StackCollector._init() was never called during profiler startup"
+
+    ddup_idx = call_order.index("ddup.start")
+    stack_idx = call_order.index("stack._init")
+    assert ddup_idx < stack_idx, (
+        f"ddup.start() must come before StackCollector._init() so that ddup's "
+        f"pthread_atfork child handler is registered first (POSIX FIFO ordering). "
+        f"Got call order: {call_order}. "
+        "Regression of PRs #17183/#17042/#18063."
+    )

--- a/tests/profiling/test_preload_fork_gthread.py
+++ b/tests/profiling/test_preload_fork_gthread.py
@@ -1,0 +1,87 @@
+"""
+Regression test: worker threads created after fork must appear in profiles.
+
+Scenario under test:
+  - Profiler starts in master before fork (admission injection / preload_app=True)
+  - Worker creates threads after fork (gthread pattern)
+  - Worker threads must appear in wall-time samples, not just MainThread
+
+Guards against:
+  - PR #17183: incorrect pthread_atfork ordering between ddup and the stack
+    sampler caused the sampling thread to race against ddup's Profile reset,
+    producing empty or corrupt worker profiles (only MainThread visible).
+  - PR #17042: fork mid-LRU-cache mutation caused SIGABRT in workers.
+  - PR #18063: stale string tables post-fork caused SIGSEGV in workers.
+
+Failure signature on affected versions (v4.7.x):
+  - Worker profiles are empty, or
+  - Only "MainThread" appears in wall-time samples.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from tests.profiling.collector import pprof_utils
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="os.fork() not available on Windows")
+def test_worker_threads_appear_in_fork_child_profiles(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pprof_prefix = str(tmp_path / "preload_fork")
+
+    env = {
+        **os.environ,
+        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_OUTPUT_PPROF": pprof_prefix,
+        # Disable adaptive sampling so every interval produces samples.
+        "_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED": "0",
+    }
+
+    script = os.path.join(os.path.dirname(__file__), "preload_fork_gthread.py")
+    result = subprocess.run(
+        [sys.executable, script],
+        env=env,
+        timeout=30,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"Script exited with code {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    child_pid = int(result.stdout.strip())
+
+    # Parse the worker's pprof — the child PID is embedded in the filename.
+    profile = pprof_utils.parse_newest_profile(
+        f"{pprof_prefix}.{child_pid}",
+        allow_penultimate=True,
+    )
+
+    wall_time_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+    assert len(wall_time_samples) > 0, (
+        f"Worker (pid={child_pid}) produced no wall-time samples. "
+        "The profiler may not have started in the child process."
+    )
+
+    # Collect every thread name that appears across wall-time samples.
+    thread_names: set[str] = set()
+    for sample in wall_time_samples:
+        label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
+        if label is not None:
+            thread_names.add(profile.string_table[label.str])
+
+    worker_thread_names = {n for n in thread_names if n != "MainThread"}
+    assert worker_thread_names, (
+        f"Only 'MainThread' appeared in worker wall-time samples (all names: {thread_names}). "
+        "Expected WorkerThread-N threads created after fork to be visible. "
+        "This indicates a profiler fork ordering bug — see PRs #17183, #17042."
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/profiling/preload_fork_gthread.py` — fork script simulating admission-injection / `preload_app=True` + gthread (profiler starts in master before fork, workers create threads after fork)
- Adds `tests/profiling/test_preload_fork_gthread.py` — pytest regression test asserting all worker threads appear in wall-time profiles
- Adds `.github/workflows/profiling-fork-regression.yml` — CI job testing ddtrace v4.7.1–v4.10.2 on real Linux x86_64

## Background

Guards against three bugs that caused Gunicorn `preload_app=True` + gthread workers to show only MainThread in profiles (or crash) on v4.7.x:

- **PR #17183**: incorrect pthread_atfork ordering between ddup and stack sampler caused sampling thread to race against Profile reset
- **PR #17042**: fork mid-LRU-cache mutation caused SIGABRT in workers
- **PR #18063**: stale string tables post-fork caused SIGSEGV in workers

## Test plan

- [ ] CI workflow runs on push — expect v4.7.1 to fail and v4.8.0+ to pass on Linux x86_64 runners
- [ ] profiling::profile suite passes with current main (verified locally on Python 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)