### PR TITLE
fix(protobuf): restore DSM schema extraction broken by missing return fix

### DIFF
--- a/ddtrace/contrib/internal/protobuf/patch.py
+++ b/ddtrace/contrib/internal/protobuf/patch.py
@@ -79,7 +79,9 @@ def _wrap_message(message_descriptor, message_class):
 def _traced_build(func, instance, args, kwargs):
     file_des = args[0]
 
-    pin = Pin.get_from(instance)
+    # BuildTopDescriptorsAndMessages is a module-level function; wrapt passes instance=None.
+    # Pin is set on the builder module in patch(), so look it up there directly.
+    pin = Pin.get_from(builder)
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 

--- a/releasenotes/notes/protobuf-fix-schema-extraction-pin-instance-e987973e48a0cb20.yaml
+++ b/releasenotes/notes/protobuf-fix-schema-extraction-pin-instance-e987973e48a0cb20.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    protobuf: Fixes an issue where Data Streams Monitoring schema extraction
+    failed to set the ``schema.definition`` span tag. ``_traced_build`` wraps a
+    module-level function, so wrapt passes ``instance=None`` to the wrapper.
+    ``Pin.get_from(None)`` returned ``None``, causing an early return before
+    message classes were wrapped and schema tags could be applied.


### PR DESCRIPTION
## Summary

- `_traced_build` wraps `BuildTopDescriptorsAndMessages`, a module-level function. wrapt passes `instance=None` for such wrappers.
- `Pin.get_from(None)` returns `None`, so the guard `if not pin or not pin.enabled(): return func(...)` (added in #18101 to fix missing return values) caused early exit before `_wrap_message` was called.
- Message classes were never wrapped, so `_traced_serialize_message`/`_traced_deserialize_message` were never invoked and `schema.definition` was never set.
- Fix: use `Pin.get_from(builder)` directly, since `patch()` attaches the Pin to the `builder` module via `Pin().onto(builder)`.

## Test plan

- regression tests that are already in place.

## Linked issues

Regression introduced by #18101.