### PR TITLE
fix(di): apply snapshot budget to capture expression probes

### DIFF
--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -115,7 +115,11 @@ class LogProbeFactory(ProbeFactory):
     def update_args(cls, args: dict[str, Any], attribs: dict[str, Any]) -> None:
         take_snapshot = attribs.get("captureSnapshot", False)
 
-        rate = DEFAULT_SNAPSHOT_PROBE_RATE if take_snapshot else DEFAULT_PROBE_RATE
+        # Capture expressions collect variable data like snapshots, so probes
+        # that use them are subject to the snapshot budget unless an explicit
+        # rate is configured.
+        snapshot_budgeted = take_snapshot or bool(attribs.get("captureExpressions"))
+        rate = DEFAULT_SNAPSHOT_PROBE_RATE if snapshot_budgeted else DEFAULT_PROBE_RATE
         sampling = attribs.get("sampling")
         if sampling is not None:
             rate = sampling.get("snapshotsPerSecond", rate)

--- a/releasenotes/notes/di-capture-expression-snapshot-budget-3b06d2ac30775d0a.yaml
+++ b/releasenotes/notes/di-capture-expression-snapshot-budget-3b06d2ac30775d0a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: This fix resolves an issue where probes that use
+    capture expressions were not rate limited by the snapshot budget. Capture
+    expressions collect variable data like snapshots, so probes that use them
+    are now limited to one snapshot per second by default, unless an explicit
+    sampling rate is configured.

--- a/tests/debugging/probe/test_remoteconfig.py
+++ b/tests/debugging/probe/test_remoteconfig.py
@@ -584,6 +584,40 @@ def test_parse_log_probe_default_rates():
     assert probe.rate == DEFAULT_PROBE_RATE
 
 
+def test_parse_capture_expression_probe_uses_snapshot_rate():
+    # A probe with capture expressions collects variable data like a snapshot,
+    # so it is subject to the snapshot budget even without captureSnapshot.
+    probe = build_probe(
+        {
+            "id": "3d338829-21c4-4a8a-8a1a-71fbce995efa",
+            "version": 0,
+            "type": ProbeType.LOG_PROBE,
+            "tags": ["foo:bar"],
+            "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+            "captureSnapshot": False,
+            "captureExpressions": [{"name": "foo", "expr": {"dsl": "foo", "json": {"ref": "foo"}}}],
+        }
+    )
+
+    assert probe.rate == DEFAULT_SNAPSHOT_PROBE_RATE
+
+    # An explicit sampling rate still takes precedence.
+    probe = build_probe(
+        {
+            "id": "3d338829-21c4-4a8a-8a1a-71fbce995efa",
+            "version": 0,
+            "type": ProbeType.LOG_PROBE,
+            "tags": ["foo:bar"],
+            "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+            "captureSnapshot": False,
+            "captureExpressions": [{"name": "foo", "expr": {"dsl": "foo", "json": {"ref": "foo"}}}],
+            "sampling": {"snapshotsPerSecond": 1337},
+        }
+    )
+
+    assert probe.rate == 1337
+
+
 def test_parse_metric_probe_with_probeid_tags():
     probeId = "3d338829-21c4-4a8a-8a1a-71fbce995efa"
     probe = build_probe(


### PR DESCRIPTION
## Description

Probes that use capture expressions (`captureExpressions`) collect variable data much like snapshots do, but the probe rate was assigned solely on `captureSnapshot`. As a result, a capture-expression probe without `captureSnapshot` received the high log-probe rate (`DEFAULT_PROBE_RATE = 5000/s`) instead of the snapshot budget (`DEFAULT_SNAPSHOT_PROBE_RATE = 1/s`), so it was effectively not rate limited.

This change treats the presence of capture expressions as snapshot-budgeted, so such probes default to one snapshot per second. An explicit `sampling.snapshotsPerSecond` still takes precedence, and log-only and snapshot probes are unaffected.

```python
snapshot_budgeted = take_snapshot or bool(attribs.get("captureExpressions"))
rate = DEFAULT_SNAPSHOT_PROBE_RATE if snapshot_budgeted else DEFAULT_PROBE_RATE
```

## Motivation

Found via system-tests: a capture-expression line probe driven 150 times emitted ~105 snapshots in 0.08s on 4.11.0rc1, bypassing the 1/s snapshot budget. Capture expressions ship in 4.11.0, so there is no GA behavior change.

JIRA: DEBUG-5730

## Testing

Added `test_parse_capture_expression_probe_uses_snapshot_rate` in `tests/debugging/probe/test_remoteconfig.py`, asserting a capture-expression probe parses to `DEFAULT_SNAPSHOT_PROBE_RATE` and that explicit sampling still wins. The corresponding system-tests coverage is `Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets` (DataDog/system-tests#7111).

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risk is outlined (including limitations and stability of the change)