### PR TITLE
ci: add skip_venv_artifacts and skip_pip_cache knobs to JobSpec

### DIFF
--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -60,6 +60,8 @@ class JobSpec:
     only: t.Optional[set[str]] = None  # ignored
     gpu: bool = False
     type: str = "test"  # ignored
+    skip_venv_artifacts: bool = False
+    skip_pip_cache: bool = False
 
     python_versions: t.Optional[set[str]] = None
 
@@ -130,6 +132,8 @@ class JobSpec:
         lines.append(f"    key: v1-pip-${'{PIP_CACHE_KEY}'}-{TESTRUNNER_IMAGE_HASH}-cache")
         lines.append("    paths:")
         lines.append("      - .cache")
+        if self.skip_pip_cache:
+            lines.append("    policy: pull")
 
         lines.append("  variables:")
         for key, value in env.items():
@@ -151,6 +155,16 @@ class JobSpec:
 
         if self.allow_failure:
             lines.append("  allow_failure: true")
+
+        if self.skip_venv_artifacts:
+            lines.append("  artifacts:")
+            lines.append("    when: always")
+            lines.append("    paths:")
+            lines.append("      - core.*")
+            lines.append("      - ddtrace/**/*.so*")
+            lines.append("    reports:")
+            lines.append("      junit: test-results/junit*.xml")
+            lines.append("    expire_in: 1 week")
 
         return "\n".join(lines)
 

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -128,12 +128,11 @@ class JobSpec:
         env["PIP_CACHE_KEY"] = (
             subprocess.check_output([".gitlab/scripts/get-riot-pip-cache-key.sh", suite_name]).decode().strip()
         )
-        lines.append("  cache:")
-        lines.append(f"    key: v1-pip-${'{PIP_CACHE_KEY}'}-{TESTRUNNER_IMAGE_HASH}-cache")
-        lines.append("    paths:")
-        lines.append("      - .cache")
-        if self.skip_pip_cache:
-            lines.append("    policy: pull")
+        if not self.skip_pip_cache:
+            lines.append("  cache:")
+            lines.append(f"    key: v1-pip-${'{PIP_CACHE_KEY}'}-{TESTRUNNER_IMAGE_HASH}-cache")
+            lines.append("    paths:")
+            lines.append("      - .cache")
 
         lines.append("  variables:")
         for key, value in env.items():


### PR DESCRIPTION
## Summary
- Adds `skip_venv_artifacts` flag to `JobSpec`: when `true`, overrides the default artifact config to exclude `.riot/venv_*` paths (useful for suites with very large dependencies like torch)
- Adds `skip_pip_cache` flag to `JobSpec`: when `true`, sets `policy: pull` on the pip cache so jobs read from cache but never upload it back (prevents S3 upload timeouts on large pip caches)

Both flags are no-ops unless explicitly set in `tests/contrib/suitespec.yml` for a given suite.

## Test plan
- [x] CI passes (no test jobs affected — flags are unused until a suite opts in)
- Part of the pytorch integration split: the pytorch PR will opt in to both flags