### PR TITLE
fix: [SVLS-9168] fix operation_attempt on replay operations

### DIFF
--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
@@ -187,7 +187,11 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
                 operation = checkpoint.operation
                 if operation is not None and operation.step_details is not None:
                     attempt = operation.step_details.attempt
-                    event.operation_attempt = attempt - 1 if is_succeeded else attempt
+                    # AIDEV-NOTE: the `attempt > 0` guard is purely defensive;
+                    # we have NOT observed attempt == 0 on success. It avoids
+                    # emitting operation_attempt = -1 if a succeeded StepDetails
+                    # ever lacks "Attempt" (from_dict defaults it to 0).
+                    event.operation_attempt = (attempt - 1 if attempt > 0 else 0) if is_succeeded else attempt
                 else:
                     event.operation_attempt = 0
     return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
@@ -173,15 +173,24 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
         if isinstance(event, (AwsDurableInvokeEvent, AwsDurableOperationEvent)):
             operation_id = instance.operation_identifier.operation_id
             checkpoint = instance.state.get_checkpoint_result(operation_id)
-            event.replayed = checkpoint.is_succeeded()
+            is_succeeded = checkpoint.is_succeeded()
+            event.replayed = is_succeeded
             event.id = operation_id
-            # AIDEV-NOTE: step_details.attempt equals the number of prior failed
-            # attempts (0-indexed): absent on the first attempt (default 0), 1
-            # after the first failure, 2 after the second, etc.
+            # AIDEV-NOTE: we report operation_attempt as a 0-indexed attempt
+            # index (0 = original attempt, 1 = first retry, ...) so a fresh
+            # execution and a later replay of the same operation agree.
+            # step_details.attempt is read at different lifecycle points:
+            #   - pending/retry checkpoint: it holds the number of prior failed
+            #     attempts, which already equals the 0-indexed index of the
+            #     attempt about to run (e.g. 1 after the first failure).
+            #   - succeeded checkpoint (read on a replay): it holds the
+            #     1-indexed number of the attempt that ultimately succeeded
+            #     (1 for a first-try success), so subtract 1 to normalize.
             if isinstance(event, AwsDurableOperationEvent) and event.operation in _RETRYABLE_OPERATIONS:
                 operation = checkpoint.operation
                 if operation is not None and operation.step_details is not None:
-                    event.operation_attempt = operation.step_details.attempt
+                    attempt = operation.step_details.attempt
+                    event.operation_attempt = max(0, attempt - 1) if is_succeeded else attempt
                 else:
                     event.operation_attempt = 0
     return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
@@ -176,22 +176,16 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
             is_succeeded = checkpoint.is_succeeded()
             event.replayed = is_succeeded
             event.id = operation_id
-            # AIDEV-NOTE: we report operation_attempt as a 0-indexed attempt
-            # index (0 = original attempt, 1 = first retry, ...) so a fresh
-            # execution and a later replay of the same operation agree.
-            # step_details.attempt is read at different lifecycle points:
-            #   - pending/retry checkpoint: it holds the number of prior failed
-            #     attempts, which already equals the 0-indexed index of the
-            #     attempt about to run (e.g. 1 after the first failure).
-            #   - succeeded checkpoint (read on a replay): it holds the
-            #     1-indexed number of the attempt that ultimately succeeded
-            #     (1 for a first-try success), so subtract 1 to normalize.
+            # AIDEV-NOTE: report operation_attempt 0-indexed (0 = original, 1 =
+            # first retry) so a fresh execution and its replay agree. The
+            # server-maintained step_details.attempt is read at two points: a
+            # pending checkpoint holds the prior-failure count (already the
+            # 0-indexed index of the attempt about to run), while a succeeded
+            # checkpoint (read on a replay) holds the 1-indexed attempt that
+            # succeeded -- observed, not SDK-enforced; pinned by the unit test.
             if isinstance(event, AwsDurableOperationEvent) and event.operation in _RETRYABLE_OPERATIONS:
                 operation = checkpoint.operation
                 if operation is not None and operation.step_details is not None:
-                    # On a succeeded checkpoint the stored attempt is the
-                    # 1-indexed number of the attempt that succeeded (always
-                    # >= 1), so subtract 1 to reach the 0-indexed convention.
                     attempt = operation.step_details.attempt
                     event.operation_attempt = attempt - 1 if is_succeeded else attempt
                 else:

--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
@@ -189,8 +189,11 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
             if isinstance(event, AwsDurableOperationEvent) and event.operation in _RETRYABLE_OPERATIONS:
                 operation = checkpoint.operation
                 if operation is not None and operation.step_details is not None:
+                    # On a succeeded checkpoint the stored attempt is the
+                    # 1-indexed number of the attempt that succeeded (always
+                    # >= 1), so subtract 1 to reach the 0-indexed convention.
                     attempt = operation.step_details.attempt
-                    event.operation_attempt = max(0, attempt - 1) if is_succeeded else attempt
+                    event.operation_attempt = attempt - 1 if is_succeeded else attempt
                 else:
                     event.operation_attempt = 0
     return wrapped(*args, **kwargs)

--- a/releasenotes/notes/aws-durable-operation-attempt-replay-ebfaf94dd19318de.yaml
+++ b/releasenotes/notes/aws-durable-operation-attempt-replay-ebfaf94dd19318de.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    aws_durable_execution_sdk_python: This fix resolves an issue where the ``aws.durable.operation_attempt``
+    span tag was reported off by one for replayed durable operations, causing a resumed (replayed) execution
+    to record a different attempt number than the original execution for the same operation. Replayed
+    operations now report the same 0-indexed attempt number as a fresh execution.

--- a/tests/contrib/aws_durable_execution_sdk_python/test_aws_durable_execution_sdk_python.py
+++ b/tests/contrib/aws_durable_execution_sdk_python/test_aws_durable_execution_sdk_python.py
@@ -83,6 +83,36 @@ def test_replayed():
         runner.run()
 
 
+def test_step_attempt_consistent_across_replay(test_spans):
+    """A step that succeeds on its first attempt must report the same 0-indexed
+    operation_attempt (0) whether the span is the fresh execution or a replay
+    that reads the succeeded checkpoint.
+
+    The succeeded checkpoint stores the 1-indexed number of the attempt that
+    succeeded (1 for a first-try success), so without normalization the replay
+    span would report 1 while the fresh execution reports 0.
+    """
+
+    def quick(step_context):
+        return "ok"
+
+    @ades.durable_execution
+    def workflow(event, context):
+        context.step(quick, name="quick", config=_fast_retry(max_attempts=1))
+        # Suspends the workflow so it is re-invoked, replaying the already
+        # succeeded step from its checkpoint.
+        context.wait(Duration.from_seconds(1), name="pause")
+
+    with DurableFunctionTestRunner(workflow) as runner:
+        runner.run()
+
+    step_spans = list(test_spans.filter_spans(name=aws_durable.SPAN_STEP))
+    assert len(step_spans) == 2, "expected a fresh-execution and a replay span for the step"
+    for span in step_spans:
+        assert span.get_metrics().get(aws_durable.TAG_OPERATION_ATTEMPT) == 0
+    assert sorted(span.get_tag(aws_durable.TAG_REPLAYED) for span in step_spans) == ["false", "true"]
+
+
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
 def test_parallel_propagates_trace_context():
     """context.parallel uses TracedThreadPoolExecutor so child step spans inherit the


### PR DESCRIPTION
# Problem
The value of `aws.durable.operation_attempt` span attribute is off by 1 for replays.

For example, if an operation fails for the first attempt, succeeds on the first retry, then replays, the three spans should have:
1. operation_attempt == 0, replayed == false.
2. operation_attempt == 1, replayed == false.
3. operation_attempt == 1, replayed == true. The operation_attempt should be the same as the that of the last span because the replay just loads the result from the last successful attempt.

However, right now the last span has `operation_attempt == 2`.

# This PR
If the operation is succeeded, i.e. it's a replay, then subtract operation_attempt by 1.

# Testing
<img width="712" height="523" alt="image" src="https://github.com/user-attachments/assets/401f72a1-527f-4672-8189-db590eff5cf4" />

The result is correct from the UI. See the "replay" and "attempt" value for the `order_process_payment` operations.