### PR TITLE
test(protobuf): reset schema samplers per test to fix flaky schema.definition assertion

### DIFF
--- a/tests/contrib/protobuf/conftest.py
+++ b/tests/contrib/protobuf/conftest.py
@@ -16,16 +16,20 @@ def ddtrace_global_config():
 
 @pytest.fixture
 def protobuf(ddtrace_global_config):
-    from ddtrace.internal.datastreams.schemas.schema_sampler import SchemaSampler
-
-    SchemaSampler.SAMPLE_INTERVAL_MILLIS = 0  # change to ensure we sample each schema
+    from ddtrace.internal.datastreams import data_streams_processor
 
     global_config = default_global_config()
     global_config.update(ddtrace_global_config)
     with override_global_config(global_config):
         patch()
+        # The schema sampler is a process-global singleton keyed by the generic
+        # operation type ("serialization"/"deserialization"), shared across schemas,
+        # and only samples a key once per 30s window. Clearing its state per test
+        # ensures every test samples its schema independently, regardless of the
+        # order tests run in (pytest-randomly) — otherwise the `schema.definition`
+        # tag is dropped for tests that aren't first-in-window for their key.
+        data_streams_processor()._schema_samplers.clear()
         from google import protobuf
 
         yield protobuf
         unpatch()
-        SchemaSampler.SAMPLE_INTERVAL_MILLIS = 30000


### PR DESCRIPTION
## Summary

Fixes intermittent failures in `tests/contrib/protobuf/test_protobuf.py` where schema tests fail with `KeyError: 'schema.definition'` (the span is created correctly — `error == 0`, right name — but the `schema.definition` tag is missing). The failure is order-dependent and unrelated to the branch under test; it surfaces on unrelated PRs' CI runs.

## Root cause

The schema sampler (`SchemaSampler`) lives on a **process-global singleton** (`data_streams_processor()`), is keyed by the **generic operation type** (`"serialization"` / `"deserialization"`) rather than by schema, and samples a given key **at most once per 30s window**. Consequently:

- `test_basic_schema_serialize` (OtherMessage) and `test_complex_schema_serialize` (MyMessage) share one sampler keyed `"serialization"`.
- `test_basic_schema_deserialize` and `test_advanced_schema_deserialize` share one keyed `"deserialization"`.

Whichever test runs second within the window gets `weight == 0` from the sampler, so `schema.definition` is never attached → `KeyError`.

The prior workaround toggled the global `SchemaSampler.SAMPLE_INTERVAL_MILLIS` class attribute (`0` in fixture setup, `30000` in teardown). That shared mutable state is fragile under `pytest-randomly` ordering and can be bypassed, which is what lets the flake through.

## Fix

Clear the processor's per-process `_schema_samplers` in fixture setup so every test starts with fresh sampler state and samples its schema independently, regardless of execution order. The global interval toggle is removed.

## Testing

- 30/30 randomized orderings pass (`pytest -p randomly`) with the fix.
- A single run confirms all 5 tests execute and assert real tag values (`5 passed`).

Test-only change; no release note required.

Claude session: `57c443da-3789-4426-8fc9-a1dac0ceb529`
Resume: `claude --resume 57c443da-3789-4426-8fc9-a1dac0ceb529`

🤖 Generated with [Claude Code](https://claude.com/claude-code)