### PR TITLE
fix(protobuf): look up Pin on the builder module so schema tracking works

### DIFF
--- a/ddtrace/contrib/internal/protobuf/patch.py
+++ b/ddtrace/contrib/internal/protobuf/patch.py
@@ -79,7 +79,8 @@ def _wrap_message(message_descriptor, message_class):
 def _traced_build(func, instance, args, kwargs):
     file_des = args[0]
 
-    pin = Pin.get_from(instance)
+    # ``instance`` is None for this module-level function; the Pin lives on the ``builder`` module.
+    pin = Pin.get_from(builder)
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
@@ -88,10 +89,9 @@ def _traced_build(func, instance, args, kwargs):
     finally:
         if config._data_streams_enabled:
             generated_message_classes = args[2]
-            message_descriptors = file_des.message_types_by_name.items()
-            for message_idx in range(len(message_descriptors)):
-                message_class_name = message_descriptors[message_idx][0]
-                message_descriptor = message_descriptors[message_idx][1]
+            # Iterate the mapping directly: under the pure-Python runtime ``.items()`` is a
+            # ``dict_items`` view (not indexable), and under the C/upb runtime it is a list.
+            for message_class_name, message_descriptor in file_des.message_types_by_name.items():
                 message_class = generated_message_classes[message_class_name]
                 _wrap_message(message_descriptor=message_descriptor, message_class=message_class)
 

--- a/releasenotes/notes/protobuf-schema-tracking-builder-pin-7c1f9a0e2b3d4f56.yaml
+++ b/releasenotes/notes/protobuf-schema-tracking-builder-pin-7c1f9a0e2b3d4f56.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    protobuf: This fix resolves an issue where Data Streams Monitoring schema tags were
+    missing from protobuf spans due to incorrect patching of generated message classes.


### PR DESCRIPTION
## Summary

Restores Data Streams Monitoring schema tracking on protobuf spans. Since #18101, the protobuf schema tests fail **deterministically** (all serialize/deserialize tests) with `KeyError: 'schema.definition'` — the span is created correctly but carries no schema tags.

## Root cause

`_traced_build` wraps `BuildTopDescriptorsAndMessages`, a **module-level** function, so wrapt invokes the wrapper with `instance=None`:

```python
def _traced_build(func, instance, args, kwargs):
    pin = Pin.get_from(instance)        # instance is None -> pin is None
    if not pin or not pin.enabled():
        return func(*args, **kwargs)    # early return added in #18101
    try:
        return func(*args, **kwargs)
    finally:
        # instruments message classes so serialize/deserialize get schema tags
```

`Pin.get_from(None)` always returns `None`, so the early `return` (added in #18101) fires every time and the `finally` block that instruments message classes never runs. Message `SerializeToString`/`ParseFromString` calls are therefore never wrapped, `msg_descriptor` is `None`, and no schema tags are attached. (Before #18101 the same `pin is None` path fell through to the `finally`, so instrumentation still happened — which is why this only began failing recently; the regression shipped in `v4.11.0rc1`.)

## Fix

1. **Pin lookup** — look the Pin up on the `builder` module (where `patch()` attaches it via `Pin().onto(builder)`) instead of on the always-`None` `instance`.
2. **Descriptor loop** — restoring instrumentation exposed a latent bug: the loop indexed `message_types_by_name.items()` by position. That works under the C/upb runtime (`.items()` is a list) but raises `TypeError: 'dict_items' object is not subscriptable` under the pure-Python runtime (`PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`) when DSM is enabled. Now iterates the mapping directly so both runtimes work.

## Testing

Against current `main`:
- Before fix: `4 failed, 1 passed` (matches CI).
- After fix: `5 passed` under **both** the upb runtime and `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`; 0/20 failures across randomized orderings.

Claude session: `57c443da-3789-4426-8fc9-a1dac0ceb529`
Resume: `claude --resume 57c443da-3789-4426-8fc9-a1dac0ceb529`

🤖 Generated with [Claude Code](https://claude.com/claude-code)