### PR TITLE
refactor(profiling): adaptive sampling overhaul (continued)

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -203,15 +203,19 @@ Sampler::adapt_sampling_interval()
     auto current_interval = static_cast<double>(sample_interval_us.load());
 
     // Compute the CPU time budget for the sampler per adaptation window:
-    //   budget = baseline (absolute floor) + o * p_stable
+    //   budget = baseline (absolute floor) + o * max(process_delta, p_stable)
     // Where:
-    //   baseline = configurable absolute floor (prevents starvation on idle apps)
-    //   o        = target overhead fraction
-    //   p_stable = stable (p95) estimate of app CPU usage from rolling window
+    //   baseline      = configurable absolute floor (prevents starvation on idle apps)
+    //   o             = target overhead fraction
+    //   process_delta = current app CPU usage (reacts immediately to spikes)
+    //   p_stable      = slow-decaying p95 estimate (prevents premature backoff after brief idle)
+    //
+    // Taking max(process_delta, p_stable) makes the budget expand instantly when CPU spikes
+    // (quick capture of 0→100 scenarios) while decaying very slowly when CPU drops.
     //
     // The new interval is derived so that s (sampler CPU time) matches the budget:
     //   I' = I * (s / budget)
-    auto budget = baseline_cpu_us_per_adapt_window + target_overhead * p_stable;
+    auto budget = baseline_cpu_us_per_adapt_window + target_overhead * std::max(process_delta, p_stable);
     if (budget <= 0) {
         budget = 1.0; // Avoid division by zero
     }


### PR DESCRIPTION
## Description

Part 1: #18332

This is the second part of the overhaul for adaptive sampling.   The previous PR introduced most of the changes we wanted to make, but we eventually realised there was a gap in the solution. 

The goal of having the sliding window was to eventually converge to the actual CPU usage in case the app has e.g. a CPU usage spike at startup (during the import phase) and then a somewhat low CPU usage until the end. Thanks to the sliding window, if CPU converges to e.g. 200 mcores over time, we will eventually target n% of 200 mcores.  

However, when CPU usage goes _up_, we want to start sampling almost immediately in order to capture the interesting events. We can't afford to wait until the end of the sliding window. 

To work around this, the current PR changes the adaptive sampling logic to immediately go up when CPU goes up, but to still use the sliding window approach for when it goes down.    
This still isn't perfect: in cases where the workload is mostly CPU spikes once every "a long time", we will have the same problem as before (miss the spike when it happens, then over-sample for a while; then start over). However, this should happen very rarely and we could always improve things further by e.g. having two separate loops for sampling and adaptive sampling, such that adaptive sampling could kick in quickly after when a CPU burst starts while still not actually costing as much as taking a sample.  But for now, I'm keeping things simple.

**Note** Marking this as `no-changelog` because we already have the changelog from the first PR and we don't need a separate entry for the changes from this specific PR.
