### PR TITLE
fix: ensure line number in wrapping context footer [backport 4.8]

### DIFF
--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -54,7 +54,7 @@ elif PY >= (3, 14):
 
         presend:
             send                            @send
-            yield_value                     0
+            yield_value                     1
             resume                          3
             jump_backward_no_interrupt      @presend
         send:
@@ -179,7 +179,7 @@ elif PY >= (3, 13):
 
         presend:
             send                            @send
-            yield_value                     0
+            yield_value                     1
             resume                          3
             jump_backward_no_interrupt      @presend
         send:
@@ -714,12 +714,12 @@ else:
 def wrap_async(instrs: list[bc.Instr], code: CodeType, lineno: int) -> None:
     if (bc.CompilerFlags.ASYNC_GENERATOR | bc.CompilerFlags.COROUTINE) & code.co_flags:
         if ASYNC_HEAD_ASSEMBLY is not None:
-            instrs[0:0] = ASYNC_HEAD_ASSEMBLY.bind()
+            instrs[0:0] = ASYNC_HEAD_ASSEMBLY.bind(lineno=lineno)
 
         if bc.CompilerFlags.COROUTINE & code.co_flags:
             # DEV: This is just
             # >>> return await wrapper(wrapped, args, kwargs)
-            instrs[-1:-1] = COROUTINE_ASSEMBLY.bind()
+            instrs[-1:-1] = COROUTINE_ASSEMBLY.bind(lineno=lineno)
 
         elif bc.CompilerFlags.ASYNC_GENERATOR & code.co_flags:
-            instrs[-1:] = ASYNC_GEN_ASSEMBLY.bind()
+            instrs[-1:] = ASYNC_GEN_ASSEMBLY.bind(lineno=lineno)

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -657,7 +657,7 @@ class _UniversalWrappingContext(BaseWrappingContext):
 
             bc.append(bytecode.TryEnd(last_try_begin))
             bc.append(except_label)
-            bc.extend(CONTEXT_FOOT.bind({"context_exit": self._exit}))
+            bc.extend(CONTEXT_FOOT.bind({"context_exit": self._exit}, lineno=code.co_firstlineno))
 
             # Mark the function as wrapped by a wrapping context
             t.cast(ContextWrappedFunction, f).__dd_context_wrapped__ = self
@@ -787,7 +787,7 @@ class _UniversalWrappingContext(BaseWrappingContext):
             *bc[i:i], except_label = CONTEXT_HEAD.bind({"context": self}, lineno=code.co_firstlineno)
 
             bc.append(except_label)
-            bc.extend(CONTEXT_FOOT.bind())
+            bc.extend(CONTEXT_FOOT.bind(lineno=code.co_firstlineno))
 
             # Mark the function as wrapped by a wrapping context
             t.cast(ContextWrappedFunction, f).__dd_context_wrapped__ = self

--- a/releasenotes/notes/fix-wrapping-context-foot-lineno-6bef33444e7af257.yaml
+++ b/releasenotes/notes/fix-wrapping-context-foot-lineno-6bef33444e7af257.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    code origin: fixed an issue that could have caused pytest to crash
+    internally when inspecting the call stack from an exception thrown by a view
+    function when Code Origin is enabled.

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -1123,3 +1123,206 @@ def test_wrapping_context_lazy_unwrap_before_call():
         assert not _UniversalWrappingContext.is_wrapped(foo)
 
     assert wc.count == 0
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_frames_have_valid_linenos():
+    """Regression test: async wrapping must not inject instructions with lineno=None.
+
+    When wrap() is applied to an async function, the injected COROUTINE_ASSEMBLY
+    instructions (GET_AWAITABLE, SEND, YIELD_VALUE, RESUME, ...) were previously
+    emitted without line-number information, leaving f_lineno=None on the
+    suspended trampoline frame.  inspect.stack() / inspect.getframeinfo() does
+    ``lineno - 1 - context//2`` and raises TypeError when lineno is None.  Any
+    code that inspects the call stack from inside or above a wrapped coroutine
+    (e.g. IAST's report_stack) would therefore crash silently.
+    """
+    stack_from_inside = []
+
+    def wrapper(f, args, kwargs):
+        return f(*args, **kwargs)
+
+    async def coro(x):
+        # Capture the full call stack from inside the coroutine body.
+        stack_from_inside.extend(inspect.stack())
+        return x + 1
+
+    wrap(coro, wrapper)
+
+    result = await coro(41)
+    assert result == 42
+
+    # Every frame captured while the wrapped coroutine was running must have a
+    # valid (non-None) line number so that inspect.getframeinfo() cannot crash.
+    for frame_info in stack_from_inside:
+        lineno = frame_info.lineno
+        assert lineno is not None, (
+            f"Frame {frame_info.filename}:{frame_info.function} has lineno=None — "
+            "async wrapping injected instructions without line-number information"
+        )
+
+
+@pytest.mark.asyncio
+async def test_lazy_async_wrapper_frames_have_valid_linenos():
+    """Same lineno regression check for LazyWrappingContext on async functions.
+
+    LazyWrappingContext applies a trampoline on first call, then promotes to
+    full UniversalWrappingContext bytecode wrapping.  Both phases must produce
+    frames with valid linenos.
+    """
+    for call_index in range(2):
+        stack_from_inside = []
+
+        async def coro(x):
+            stack_from_inside.extend(inspect.stack())
+            return x + 1
+
+        DummyLazyWrappingContext(coro).wrap()
+
+        result = await coro(41)
+        assert result == 42
+
+        for frame_info in stack_from_inside:
+            lineno = frame_info.lineno
+            assert lineno is not None, (
+                f"[call {call_index}] Frame {frame_info.filename}:{frame_info.function} "
+                f"has lineno=None — async wrapping injected instructions without "
+                f"line-number information"
+            )
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_throw_forwarding():
+    """Regression test: throw() on a wrapped coroutine must be forwarded to the inner.
+
+    Python 3.12+ uses CLEANUP_THROW bytecode in compiled ``return await sub_coro``
+    to forward exceptions thrown into the outer coroutine to the inner one.  For
+    Python's own ``_PyGen_yf`` mechanism to work correctly, the wrapping bytecode
+    (COROUTINE_ASSEMBLY) must keep the inner coroutine as the top-of-stack iterator
+    so that a ``throw()`` call on the wrapper is forwarded to the wrapped coroutine
+    rather than absorbed by the wrapper frame.
+    """
+    received_cancel = []
+
+    def wrapper(f, args, kwargs):
+        return f(*args, **kwargs)
+
+    async def inner():
+        try:
+            # Suspension point so throw() can be tested
+            await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            received_cancel.append(True)
+            raise
+
+    wrap(inner, wrapper)
+
+    # Advance wrapped coroutine to its first suspension point, then throw
+    c = inner()
+    try:
+        c.send(None)
+    except StopIteration:
+        pass  # completed without suspending (shouldn't happen here)
+
+    try:
+        c.throw(asyncio.CancelledError())
+    except (asyncio.CancelledError, StopIteration):
+        pass
+
+    assert received_cancel, (
+        "CancelledError was not forwarded to the inner coroutine by the wrapper; throw() interception is broken"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lazy_async_wrapper_throw_forwarding():
+    """Same throw-forwarding regression check for LazyWrappingContext."""
+    for call_index in range(2):
+        received_cancel = []
+
+        async def inner():
+            try:
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                received_cancel.append(True)
+                raise
+
+        DummyLazyWrappingContext(inner).wrap()
+
+        c = inner()
+        try:
+            c.send(None)
+        except StopIteration:
+            pass
+
+        try:
+            c.throw(asyncio.CancelledError())
+        except (asyncio.CancelledError, StopIteration):
+            pass
+
+        assert received_cancel, (
+            f"[call {call_index}] CancelledError was not forwarded to the inner "
+            "coroutine by the lazy wrapper; throw() interception is broken"
+        )
+
+
+def test_wrapping_context_foot_has_valid_linenos():
+    """Regression test: CONTEXT_FOOT.bind() must pass lineno to avoid None line numbers.
+
+    The CONTEXT_FOOT assembly (exception-handler epilogue injected by
+    _UniversalWrappingContext.wrap) was previously emitted without line-number
+    information.  inspect.stack() / inspect.getframeinfo() raises TypeError when
+    it encounters a frame whose f_lineno is None, so any tool that inspects the
+    call stack from inside a WrappingContext-wrapped function (e.g. IAST's
+    report_stack) would crash.
+    """
+    stack_from_inside: list = []
+
+    def foo():
+        stack_from_inside.extend(inspect.stack())
+        return 42
+
+    wc = DummyWrappingContext(foo)
+    wc.wrap()
+
+    result = foo()
+    assert result == 42
+
+    for frame_info in stack_from_inside:
+        lineno = frame_info.lineno
+        assert lineno is not None, (
+            f"Frame {frame_info.filename}:{frame_info.function} has lineno=None — "
+            "CONTEXT_FOOT was bound without line-number information"
+        )
+
+
+def test_wrapping_context_foot_has_valid_linenos_on_exception():
+    """Same lineno regression check when the wrapped function raises an exception.
+
+    The CONTEXT_FOOT assembly is only executed when an exception propagates, so
+    the lineno fix must also cover the exception path.
+    """
+    stack_from_handler: list = []
+
+    class _Sentinel(Exception):
+        pass
+
+    class CaptureOnExit(WrappingContext):
+        def __exit__(self, exc_type, exc_value, traceback):
+            stack_from_handler.extend(inspect.stack())
+            return super().__exit__(exc_type, exc_value, traceback)
+
+    def foo():
+        raise _Sentinel("boom")
+
+    CaptureOnExit(foo).wrap()
+
+    with pytest.raises(_Sentinel):
+        foo()
+
+    for frame_info in stack_from_handler:
+        lineno = frame_info.lineno
+        assert lineno is not None, (
+            f"Frame {frame_info.filename}:{frame_info.function} has lineno=None — "
+            "CONTEXT_FOOT exception path was bound without line-number information"
+        )


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/pull/18411 to 4.8.