### PR TITLE
ci: improve backport job

### DIFF
--- a/.github/workflows/backport-validate.yml
+++ b/.github/workflows/backport-validate.yml
@@ -51,7 +51,7 @@ jobs:
           fi
           echo "The command used to test backporting was" | tee -a "$GITHUB_OUTPUT"
           echo "\`\`\`" >> "$GITHUB_OUTPUT"
-          echo "git checkout ${TARGET_BRANCH} && git cherry-pick -x --mainline 1 ${MERGE_COMMIT}" | tee -a "$GITHUB_OUTPUT"
+          echo "git fetch origin ${TARGET_BRANCH} && git checkout origin/${TARGET_BRANCH} && git checkout -b backport-${PR_NUMBER}-to-${TARGET_BRANCH} && git cherry-pick -x --mainline 1 ${MERGE_COMMIT}" | tee -a "$GITHUB_OUTPUT"
           echo "\`\`\`" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Description

I propose this improvement for the backport job.

Currently, in case of conflict, we can't just copy-paste the command used to test cherry-picking because it doesn't use the latest version of the target branch, and if the target branch was locally updated (e.g. by accidentally cherry-picking directly on it previously), it will be in a bad state which will make creating the PR more painful than it needs to be.

I propose to:
- Add a `git fetch origin $target` to make sure we have the latest version. This is needed in order to generate a PR against `$target` that is not immediately out of date.
- Checkout `origin/$target` instead of `$target` to make the "real" upstream release branch the source of truth, as opposed to the local one (which as I mentioned may have been "corrupted"). 