### PR TITLE
chore(debugger): snapshot rate limit for capture expressions

### DIFF
--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -114,8 +114,9 @@ class LogProbeFactory(ProbeFactory):
     @classmethod
     def update_args(cls, args: dict[str, Any], attribs: dict[str, Any]) -> None:
         take_snapshot = attribs.get("captureSnapshot", False)
+        capture_expressions = attribs.get("captureExpressions", [])
 
-        rate = DEFAULT_SNAPSHOT_PROBE_RATE if take_snapshot else DEFAULT_PROBE_RATE
+        rate = DEFAULT_SNAPSHOT_PROBE_RATE if (take_snapshot or capture_expressions) else DEFAULT_PROBE_RATE
         sampling = attribs.get("sampling")
         if sampling is not None:
             rate = sampling.get("snapshotsPerSecond", rate)
@@ -126,7 +127,7 @@ class LogProbeFactory(ProbeFactory):
             limits=CaptureLimits.parse(attribs["capture"]) if "capture" in attribs else DEFAULT_CAPTURE_LIMITS,
             condition_error_rate=DEFAULT_PROBE_CONDITION_ERROR_RATE,  # TODO: should we take rate limit out of Probe?
             take_snapshot=take_snapshot,
-            capture_expressions=[CaptureExpression.parse(_) for _ in attribs.get("captureExpressions", [])],
+            capture_expressions=[CaptureExpression.parse(_) for _ in capture_expressions],
             template=attribs.get("template"),
             segments=[_compile_segment(segment) for segment in attribs.get("segments", [])],
         )


### PR DESCRIPTION
## Description

We make sure to apply the snapshot rate limit to capture expressions to avoid potential performance issues.

Refs: [DEBUG-5743](https://datadoghq.atlassian.net/browse/DEBUG-5743)

[DEBUG-5743]: https://datadoghq.atlassian.net/browse/DEBUG-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ