### PR TITLE
fix(iast): fix crashes at teardown

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
@@ -137,6 +137,10 @@ TaintEngineContext::get_tainted_object_map(PyObject* obj)
         return nullptr;
     }
 
+    if (shutting_down.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
+
     // 1) Direct text objects
     if (is_text(obj)) {
         auto map = get_tainted_object_map_from_pyobject(obj);
@@ -317,6 +321,9 @@ TaintEngineContext::debug_num_tainted_objects(size_t ctx_id)
 TaintedObjectMapTypePtr
 TaintEngineContext::get_tainted_object_map_by_ctx_id(size_t ctx_id)
 {
+    if (shutting_down.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
     const auto cap = request_context_slots.size();
     if (ctx_id >= cap) {
         return nullptr;
@@ -355,6 +362,8 @@ pyexport_taint_engine_context(py::module& m)
       "is_in_taint_map",
       [](py::object tainted_obj, std::optional<size_t> context_id) {
           if (!taint_engine_context)
+              return false;
+          if (TaintEngineContext::is_shutting_down())
               return false;
           if (context_id.has_value()) {
               // Request-scoped check: only consult the calling request's slot.

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
@@ -62,6 +62,7 @@ class TaintEngineContext
 
     // Lifecycle control: mark the context as shutting down to prevent further access.
     static void set_shutting_down(bool v);
+    static bool is_shutting_down() { return shutting_down.load(std::memory_order_acquire); }
 
     // Fast-path: get the taint map for a known context_id (slot index).
     // Returns nullptr if the slot is empty or out of lifecycle.

--- a/releasenotes/notes/iast-fix-crash-at-interpreter-teardown-7baa1217ec0d6595.yaml
+++ b/releasenotes/notes/iast-fix-crash-at-interpreter-teardown-7baa1217ec0d6595.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    ASM: A crash that could happen at interpreter teardown has been fixed.

--- a/releasenotes/notes/iast-fix-crash-at-interpreter-teardown-7baa1217ec0d6595.yaml
+++ b/releasenotes/notes/iast-fix-crash-at-interpreter-teardown-7baa1217ec0d6595.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    ASM: A crash that could happen at interpreter teardown has been fixed.
+    IAST: A crash that could happen at interpreter teardown has been fixed.


### PR DESCRIPTION
## Description

This PR fixes crashes (caught by Crash Tracking) caused by IAST trying to access freed memories during interpreter shutdown. 

`is_text` supposedly safely access objects but can only check whether the addresses make sense, it can't know  whether objects have been freed.

https://github.com/DataDog/dd-trace-py/blob/160d0fb6ac1a4f8487825d35064acb7489392f7c/ddtrace/appsec/_iast/_taint_tracking/utils/string_utils.h#L50-L67

When uvloop's `run_until_complete` unwinds (`Py_XDECREF` in frames 57 to 61), custom type objects can be freed by the cyclic GC before all of their instances finish cleanup. An instance can still have a positive refcount, its pointer is non-null and aligned, `ob_type` is non-null, but the type it points to has been deallocated.

There's already a `shutting_down` guard in `get_tainted_object_map_from_pyobject`, but `get_tainted_object_map` calls `is_text(obj)` before reaching that.

https://github.com/DataDog/dd-trace-py/blob/c641709fa9381957ef114f605b5eadb3fa79ceeb/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp#L140-L147

**Example crashing stack**

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x000061dcfbfffe73 PyType_IsSubtype (/usr/src/python/Objects/typeobject.c:2137)
#1   0x0000000000000000 PyObject_TypeCheck (/opt/python/cp312-cp312/include/python3.12/object.h:381)
#2   0x0000000000000000 is_text(_object const*) (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/utils/string_utils.h:66)
#3   0x0000000000000000 is_text(_object const*) (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/utils/string_utils.h:51)
#4   0x000074d4052a7de1 PyObject_TypeCheck (/opt/python/cp312-cp312/include/python3.12/object.h:381)
#5   0x000074d4052a7de1 is_text(_object const*) (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/utils/string_utils.h:66)
#6   0x000074d4052a7de1 is_text(_object const*) (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/utils/string_utils.h:51)
#7   0x000074d4052a7de1 TaintEngineContext::get_tainted_object_map(_object*) (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp:141)
#8   0x0000000000000000 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:732)
#9   0x0000000000000000 std::__shared_ptr<absl::lts_20250127::node_hash_map<unsigned long, std::pair<long, std::shared_ptr<TaintedObject> >, absl::lts_20250127::hash_internal::Hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::pair<long, std::shared_ptr<TaintedObject> > > > >, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:1183)
#10  0x0000000000000000 std::shared_ptr<absl::lts_20250127::node_hash_map<unsigned long, std::pair<long, std::shared_ptr<TaintedObject> >, absl::lts_20250127::hash_internal::Hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::pair<long, std::shared_ptr<TaintedObject> > > > > >::~shared_ptr() (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr.h:121)
#11  0x0000000000000000 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp:357)
#12  0x0000000000000000 call_impl<bool, pyexport_taint_engine_context(pybind11::module&)::<lambda(pybind11::object)>&, 0, pybind11::detail::void_type> (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/cast.h:2137)
#13  0x0000000000000000 call<bool, pybind11::detail::void_type, pyexport_taint_engine_context(pybind11::module&)::<lambda(pybind11::object)>&> (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/cast.h:2105)
#14  0x0000000000000000 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/pybind11.h:430)
#15  0x000074d4052a8a70 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:732)
#16  0x000074d4052a8a70 std::__shared_ptr<absl::lts_20250127::node_hash_map<unsigned long, std::pair<long, std::shared_ptr<TaintedObject> >, absl::lts_20250127::hash_internal::Hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::pair<long, std::shared_ptr<TaintedObject> > > > >, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:1183)
#17  0x000074d4052a8a70 std::shared_ptr<absl::lts_20250127::node_hash_map<unsigned long, std::pair<long, std::shared_ptr<TaintedObject> >, absl::lts_20250127::hash_internal::Hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::pair<long, std::shared_ptr<TaintedObject> > > > > >::~shared_ptr() (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr.h:121)
#18  0x000074d4052a8a70 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp:357)
#19  0x000074d4052a8a70 call_impl<bool, pyexport_taint_engine_context(pybind11::module&)::<lambda(pybind11::object)>&, 0, pybind11::detail::void_type> (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/cast.h:2137)
#20  0x000074d4052a8a70 call<bool, pybind11::detail::void_type, pyexport_taint_engine_context(pybind11::module&)::<lambda(pybind11::object)>&> (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/cast.h:2105)
#21  0x000074d4052a8a70 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/pybind11.h:430)
#22  0x000074d4052a8a70 pybind11::cpp_function::initialize<pyexport_taint_engine_context(pybind11::module_&)::{lambda(pybind11::object)#5}, bool, pybind11::object, pybind11::name, pybind11::scope, pybind11::sibling>(pyexport_taint_engine_context(pybind11::module_&)::{lambda(pybind11::object&&)#5}, bool (*)(pybind11::object), pybind11::name const, pybind11::scope&, pybind11::sibling)::{lambda(pybind11::detail::function_call&)#3}::_FUN(pybind11::detail::function_call&) [clone .cold] (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/pybind11.h:400)
#23  0x000074d40525fd00 pybind11::cpp_function::dispatcher(_object*, _object*, _object*) (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/include/pybind11/pybind11.h:1063)
#24  0x000061dcfbff87cf cfunction_call (/usr/src/python/Objects/methodobject.c:551)
#25  0x000061dcfbfe95de _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:245)
#26  0x000061dcfc010357 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2719)
#27  0x000061dcfc0d8a91 _PyObject_VectorcallTstate (/usr/src/python/./Include/internal/pycore_call.h:93)
#28  0x000061dcfbfcd894 partial_vectorcall (/usr/src/python/./Modules/_functoolsmodule.c:269)
#29  0x000061dcfbfe9ad4 object_vacall (/usr/src/python/Objects/call.c:850)
#30  0x000061dcfc046d3e PyObject_CallFunctionObjArgs (/usr/src/python/Objects/call.c:961)
#31  0x000074d40e7d4d0a WraptBoundFunctionWrapper_call (/project/src/wrapt/_wrappers.c:3024)
#32  0x000061dcfbfe95de _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:245)
#33  0x000061dcfc010357 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2719)
#34  0x000061dcfbfeca86 gen_send_ex2 (/usr/src/python/Objects/genobject.c:238)
#35  0x000074d40fdeadc7 task_step_impl (/usr/src/python/Modules/_asynciomodule.c:2869)
#36  0x000074d40fdeb5a2 task_step (/usr/src/python/Modules/_asynciomodule.c:3188)
#37  0x0000000000000000 __Pyx_PyObject_Call (/project/uvloop/loop.c:191431)
#38  0x000074d3f24978eb __Pyx_PyObject_Call (/project/uvloop/loop.c:191431)
#39  0x000074d3f24978eb __Pyx_PyObject_FastCallDict (/project/uvloop/loop.c:191552)
#40  0x000074d3f2573a69 __pyx_f_6uvloop_4loop_6Handle__run (/project/uvloop/loop.c:66873)
#41  0x000074d3f257796b __pyx_f_6uvloop_4loop_4Loop__on_idle (/project/uvloop/loop.c:17975)
#42  0x000074d3f2571e52 __pyx_f_6uvloop_4loop_6Handle__run (/project/uvloop/loop.c:66927)
#43  0x000074d3f2573c88 __pyx_f_6uvloop_4loop_cb_idle_callback (/project/uvloop/loop.c:87335)
#44  0x0000000000000000 uv__queue_empty (/project/build/libuv-x86_64/src/queue.h:33)
#45  0x000074d3f258f311 uv__queue_empty (/project/build/libuv-x86_64/src/queue.h:33)
#46  0x000074d3f258f311 uv__run_idle (/project/build/libuv-x86_64/src/unix/loop-watcher.c:68)
#47  0x000074d3f258c647 uv_run (/project/build/libuv-x86_64/src/unix/core.c:440)
#48  0x000074d3f24addb5 __pyx_f_6uvloop_4loop_4Loop__Loop__run (/project/uvloop/loop.c:18471)
#49  0x000074d3f2515e50 __pyx_f_6uvloop_4loop_4Loop__run (/project/uvloop/loop.c:18876)
#50  0x0000000000000000 __pyx_pf_6uvloop_4loop_4Loop_24run_forever (/project/uvloop/loop.c:31528)
#51  0x000074d3f2526cf0 __pyx_pf_6uvloop_4loop_4Loop_24run_forever (/project/uvloop/loop.c:31528)
#52  0x000074d3f2526cf0 __pyx_pw_6uvloop_4loop_4Loop_25run_forever (/project/uvloop/loop.c:31331)
#53  0x000061dcfbfea47c PyObject_VectorcallMethod (/usr/src/python/Objects/call.c:887)
#54  0x0000000000000000 Py_DECREF (/opt/_internal/cpython-3.12.11/include/python3.12/object.h:700)
#55  0x0000000000000000 Py_XDECREF (/opt/_internal/cpython-3.12.11/include/python3.12/object.h:798)
#56  0x000074d3f252ad60 Py_DECREF (/opt/_internal/cpython-3.12.11/include/python3.12/object.h:700)
#57  0x000074d3f252ad60 Py_XDECREF (/opt/_internal/cpython-3.12.11/include/python3.12/object.h:798)
#58  0x000074d3f252ad60 __pyx_pf_6uvloop_4loop_4Loop_44run_until_complete (/project/uvloop/loop.c:33769)
#59  0x0000000000000000 Py_XDECREF (/opt/_internal/cpython-3.12.11/include/python3.12/object.h:797)
#60  0x000074d3f252c591 Py_XDECREF (/opt/_internal/cpython-3.12.11/include/python3.12/object.h:797)
#61  0x000074d3f252c591 __pyx_pw_6uvloop_4loop_4Loop_45run_until_complete (/project/uvloop/loop.c:33322)
#62  0x000061dcfbfe98f8 PyObject_Vectorcall (/usr/src/python/Objects/call.c:325)
#63  0x000061dcfc010357 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:2719)
#64  0x000061dcfbfeca86 gen_send_ex2 (/usr/src/python/Objects/genobject.c:238)
#65  0x000074d40fdeadc7 task_step_impl (/usr/src/python/Modules/_asynciomodule.c:2869)
#66  0x000074d40fdeb5a2 task_step (/usr/src/python/Modules/_asynciomodule.c:3188)
#67  0x000061dcfbfe95de _PyObject_MakeTpCall (/usr/src/python/Objects/call.c:245)
#68  0x000061dcfbf6c77a context_run (/usr/src/python/Python/context.c:668)
#69  0x000061dcfc05bbeb cfunction_vectorcall_FASTCALL_KEYWORDS (/usr/src/python/Objects/methodobject.c:439)
#70  0x000061dcfbf62275 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:3227)
#71  0x000061dcfc093679 PyEval_EvalCode (/usr/src/python/Python/ceval.c:579)
#72  0x000061dcfc0b12bc run_eval_code_obj (/usr/src/python/Python/pythonrun.c:1723)
#73  0x000061dcfc0b1234 run_mod (/usr/src/python/Python/pythonrun.c:1744)
#74  0x000061dcfc0b0df1 pyrun_file (/usr/src/python/Python/pythonrun.c:1643)
#75  0x000061dcfc0b0c37 _PyRun_SimpleFileObject (/usr/src/python/Python/pythonrun.c:433)
#76  0x000061dcfc0b0a57 _PyRun_AnyFileObject (/usr/src/python/Python/pythonrun.c:78)
#77  0x000061dcfc0bafb0 Py_RunMain (/usr/src/python/Modules/main.c:713)
#78  0x000061dcfc0bab3d Py_BytesMain (/usr/src/python/Modules/main.c:768)
#79  0x000074d411000d90 __libc_start_call_main (sysdeps/nptl/libc_start_call_main.h:58)
#80  0x0000000000000000 call_init (csu/libc-start.c:128)
#81  0x000074d411000e40 call_init (csu/libc-start.c:128)
#82  0x000074d411000e40 __libc_start_main_alias_2 (csu/libc-start.c:379)
#83  0x000061dcfc033075 _start 
```