### PR TITLE
fix(internal): avoid crash at exit

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -618,6 +618,66 @@ PeriodicThread__on_shutdown(PeriodicThread* self)
 }
 
 // ----------------------------------------------------------------------------
+/**
+ * Cooperatively tear down the gevent Hub bound to the *current* native thread,
+ * if any, while this thread still owns a valid PyThreadState and holds the GIL.
+ *
+ * A native PeriodicThread that touches a gevent-monkeypatched API lazily
+ * creates a gevent Hub (a greenlet owning a libev loop) bound to this thread
+ * and stored in the thread's tstate dict via _thread._local. If we let that
+ * Hub be torn down implicitly by PyThreadState_Clear when this thread exits,
+ * older greenlet versions switch into the now-defunct Hub greenlet to finalize
+ * it, running gevent teardown against a half-cleared tstate and crashing in
+ * PyErr_Restore (see crash28). gevent's own Hub.destroy() documents that hubs
+ * used from native threads must be destroyed explicitly, ideally from the
+ * owning thread — which is exactly what we do here.
+ *
+ * Best-effort and never raises: any failure is swallowed. We only act if gevent
+ * is already imported; we never import it ourselves.
+ */
+static void
+release_gevent_hub() noexcept
+{
+    // Start from a clean error state so we can safely call into Python; restore
+    // nothing on the way out (teardown must not surface errors).
+    PyErr_Clear();
+
+    PyObject* modname = PyUnicode_InternFromString("gevent._hub_local");
+    if (modname == nullptr) {
+        PyErr_Clear();
+        return;
+    }
+
+    // Borrowed-or-new ref to the module iff it is already in sys.modules;
+    // NULL (no exception) when gevent is not in use.
+    PyObject* mod = PyImport_GetModule(modname);
+    Py_DECREF(modname);
+    if (mod == nullptr) {
+        PyErr_Clear();
+        return;
+    }
+
+    // get_hub_if_exists() never creates a hub, so threads that never touched
+    // gevent pay nothing beyond the attribute lookup.
+    PyObject* hub = PyObject_CallMethod(mod, "get_hub_if_exists", nullptr);
+    Py_DECREF(mod);
+    if (hub == nullptr) {
+        PyErr_Clear();
+        return;
+    }
+
+    if (hub != Py_None) {
+        PyObject* res = PyObject_CallMethod(hub, "destroy", nullptr);
+        if (res == nullptr) {
+            PyErr_Clear();
+        } else {
+            Py_DECREF(res);
+        }
+    }
+    Py_DECREF(hub);
+}
+
+// ----------------------------------------------------------------------------
 // Internal helper: launches the thread after ensuring preconditions.
 // If reset_next_call_time is true (normal start), _next_call_time is initialised
 // to now + interval before starting; otherwise it is left untouched (important
@@ -764,6 +824,12 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
 
                         // Remove the thread from the mapping of active threads.
                         PyDict_DelItem(state->periodic_threads, self->ident);
+
+                        // Cooperatively destroy this thread's gevent Hub (if it
+                        // created one) while the tstate is still valid, instead
+                        // of letting GILGuard's PyThreadState_Clear tear it down
+                        // unsafely. See release_gevent_hub() and crash28.
+                        release_gevent_hub();
                     }
 
                     // Inner scope ends here. GILGuard::~GILGuard releases the GIL and

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -236,8 +236,27 @@ class GILGuard
     }
     inline ~GILGuard()
     {
-        if (_acquired && !_mstate->is_finalizing() && PyGILState_Check())
+        if (!_acquired || _mstate->is_finalizing() || !PyGILState_Check()) {
+            return;
+        }
+
+        if (_gil_state == PyGILState_UNLOCKED) {
+            // PyGILState_Release(UNLOCKED) calls PyThreadState_DeleteCurrent, which
+            // sets the current tstate to null before calling PyThreadState_Clear.
+            // Any Python callback triggered during the clear (e.g. a Cython __dealloc__
+            // or a weakref finalizer) that calls PyErr_Restore will dereference the
+            // null tstate and crash.
+            //
+            // To avoid this, we call PyThreadState_Clear ourselves while tstate is
+            // still current, so any callbacks see a valid tstate. We then release the
+            // GIL via PyEval_ReleaseThread. The now-empty tstate becomes an orphan and
+            // is reclaimed by the interpreter during finalization.
+            PyThreadState* tstate = PyThreadState_Get();
+            PyThreadState_Clear(tstate);
+            PyEval_ReleaseThread(tstate);
+        } else {
             PyGILState_Release(_gil_state);
+        }
     }
 
     GILGuard(const GILGuard&) = delete;

--- a/releasenotes/notes/internal-fix-crash-at-exit-ba5283dba993a50a.yaml
+++ b/releasenotes/notes/internal-fix-crash-at-exit-ba5283dba993a50a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Internal: A rare crash that could happen at exit has been fixed.


### PR DESCRIPTION
## Description

We currently have a crash originating from `dd-trace-py` and that has a current impact of 100-1000 crashes per day. ([source](https://app.datadoghq.com/logs?query=service%3Ainstrumentation-telemetry-data-python%20%40error.stack.frames.function%3APyErr_Restore&agg_m=count&agg_m_source=base&agg_q=%40language_version%2Cversion%2C%40org_id&agg_t=count&cols=%40language_version%2Cversion&filter=scanning%2Cerror%2Cstopped%2Ccancelled%2Ccomplete&flat_group_bys=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=time%2Cdesc&top_n=250&top_o=top&viz=sunburst&x_missing=true&from_ts=1780667074758&to_ts=1781271874758&live=true))

<img width="1477" height="354" alt="image" src="https://github.com/user-attachments/assets/d04f448e-d32a-4a3e-aadb-fab263259370" />


````
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x000000000056c836 PyErr_Restore 
#1   0x00007f19990d32f9 __pyx_tp_dealloc_6gevent_5libev_8corecext_loop 
#2   0x00007f199904553d __pyx_tp_dealloc_6gevent_29_gevent_c_greenlet_primitives_SwitchOutGreenletWithLoop 
#3   0x000000000058c746  
#4   0x000000000052dace  
#5   0x000000000054efca PyDict_DelItem 
#6   0x00000000005110c7  
#7   0x0000000000553a1f  
#8   0x000000000056bd67 PyObject_CallOneArg 
#9   0x000000000062d413  
#10  0x000000000058d6cf PyObject_ClearWeakRefs 
#11  0x0000000000498f95  
#12  0x000000000052dace  
#13  0x00000000006428c4 PyThreadState_Clear 
#14  0x000000000046a64c  
#15  0x00007f19aaeeccda GILGuard::~GILGuard() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/_threads.cpp:188)
#16  0x00007f19aaeec128 std::__shared_ptr<Event, (__gnu_cxx::_Lock_policy)2>::get() const (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:1325)
#17  0x00007f19aaeec128 std::__shared_ptr_access<Event, (__gnu_cxx::_Lock_policy)2, false, false>::_M_get() const (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:1024)
#18  0x00007f19aaeec128 std::__shared_ptr_access<Event, (__gnu_cxx::_Lock_policy)2, false, false>::operator->() const (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/shared_ptr_base.h:1018)
#19  0x00007f19aaeec128 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/_threads.cpp:701)
#20  0x00007f19aaeec128 __invoke_impl<void, _PeriodicThread_do_start(PeriodicThread*, bool)::<lambda()> > (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/invoke.h:60)
#21  0x00007f19aaeec128 __invoke<_PeriodicThread_do_start(PeriodicThread*, bool)::<lambda()> > (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/invoke.h:95)
#22  0x00007f19aaeec128 _M_invoke<0> (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:264)
#23  0x00007f19aaeec128 operator() (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:271)
#24  0x00007f19aaeec128 std::thread::_State_impl<std::thread::_Invoker<std::tuple<_PeriodicThread_do_start(periodic_thread*, bool)::{lambda()#1}> > >::_M_run() [clone .cold] (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:215)
#25  0x00007f19aaeece70 execute_native_thread_routine 
#26  0x00007f19ab9acac3 start_thread (nptl/nptl/pthread_create.c:442)
#27  0x00007f19aba3da04 __GI___clone 
````
