### PR TITLE
fix(datastreams): read SQS MessageAttributes from message envelope, not parsed body

### DIFF
--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -137,21 +137,34 @@ def handle_sqs_prepare(params):
 def get_datastreams_context(message):
     """
     Formats we're aware of:
-        - message.Body.MessageAttributes._datadog.Value.decode() (SQS)
+        - message.MessageAttributes._datadog.StringValue (SQS)
         - message.MessageAttributes._datadog.StringValue (SNS -> SQS)
         - message.MessageAttributes._datadog.BinaryValue.decode() (SNS -> SQS, raw)
         - message.messageAttributes._datadog.stringValue (SQS -> lambda)
     """
     context_json = None
-    message_body = message
+    # Parse the Body only to detect SNS-wrapped messages.  For plain SQS messages
+    # (even those with a JSON body), MessageAttributes live at the top level of the
+    # SQS message, not inside the Body.  Overwriting the attributes source with the
+    # parsed body would cause us to miss the _datadog attribute entirely.
+    parsed_body = None
     try:
         body = message.get("Body")
         if body:
-            message_body = json.loads(body)
+            parsed_body = json.loads(body)
     except (ValueError, TypeError):
         log.debug("Unable to parse message body as JSON, treat as non-json")
 
-    message_attributes = message_body.get("MessageAttributes") or message_body.get("messageAttributes")
+    is_sns_notification = parsed_body is not None and parsed_body.get("Type") == "Notification"
+
+    if is_sns_notification:
+        # SNS -> SQS: the notification envelope carries its own MessageAttributes.
+        attributes_source = parsed_body
+    else:
+        # Plain SQS (and SQS -> Lambda): attributes are at the top level of the message.
+        attributes_source = message
+
+    message_attributes = attributes_source.get("MessageAttributes") or attributes_source.get("messageAttributes")
     if not message_attributes:
         log.debug("DataStreams skipped message: %r", message)
         return None
@@ -162,7 +175,7 @@ def get_datastreams_context(message):
 
     datadog_attr = message_attributes["_datadog"]
 
-    if message_body.get("Type") == "Notification":
+    if is_sns_notification:
         # This is potentially a DSM SNS notification
         if datadog_attr.get("Type") == "Binary":
             context_json = json.loads(base64.b64decode(datadog_attr["Value"]).decode())

--- a/tests/datastreams/test_botocore.py
+++ b/tests/datastreams/test_botocore.py
@@ -1,17 +1,21 @@
+import base64
 import json
 
+import pytest
+
 from ddtrace.internal.datastreams.botocore import get_datastreams_context
+
+
+TRACE_CONTEXT = {
+    "x-datadog-trace-id": "123456789",
+    "x-datadog-parent-id": "987654321",
+    "x-datadog-sampling-priority": "1",
+}
 
 
 class TestGetDatastreamsContext:
     def test_sqs_to_lambda_format_with_datadog_context(self):
         """Test SQS -> Lambda format with _datadog messageAttributes."""
-        trace_context = {
-            "x-datadog-trace-id": "123456789",
-            "x-datadog-parent-id": "987654321",
-            "x-datadog-sampling-priority": "1",
-        }
-
         lambda_record = {
             "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
             "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -24,7 +28,7 @@ class TestGetDatastreamsContext:
             },
             "messageAttributes": {
                 "_datadog": {
-                    "stringValue": json.dumps(trace_context),
+                    "stringValue": json.dumps(TRACE_CONTEXT),
                     "stringListValues": [],
                     "binaryListValues": [],
                     "dataType": "String",
@@ -45,7 +49,104 @@ class TestGetDatastreamsContext:
         result = get_datastreams_context(lambda_record)
 
         assert result is not None
-        assert result == trace_context
-        assert result["x-datadog-trace-id"] == "123456789"
-        assert result["x-datadog-parent-id"] == "987654321"
-        assert result["x-datadog-sampling-priority"] == "1"
+        assert result == TRACE_CONTEXT
+
+    def test_plain_sqs_with_json_body_reads_top_level_message_attributes(self):
+        """Plain SQS message with a JSON body must use top-level MessageAttributes.
+
+        Regression test for DSMS-149: the old code overwrote the attributes source
+        with the parsed Body, causing MessageAttributes to be read from the JSON
+        payload instead of from the SQS message envelope.
+        """
+        sqs_message = {
+            "MessageId": "abc123",
+            "ReceiptHandle": "handle...",
+            "Body": json.dumps({"order_id": 42, "status": "placed"}),
+            "MessageAttributes": {
+                "_datadog": {
+                    "StringValue": json.dumps(TRACE_CONTEXT),
+                    "DataType": "String",
+                }
+            },
+        }
+
+        result = get_datastreams_context(sqs_message)
+
+        assert result == TRACE_CONTEXT
+
+    def test_plain_sqs_with_non_json_body_reads_top_level_message_attributes(self):
+        """Plain SQS message with a plain-text body still finds top-level attributes."""
+        sqs_message = {
+            "MessageId": "abc124",
+            "ReceiptHandle": "handle...",
+            "Body": "plain text body",
+            "MessageAttributes": {
+                "_datadog": {
+                    "StringValue": json.dumps(TRACE_CONTEXT),
+                    "DataType": "String",
+                }
+            },
+        }
+
+        result = get_datastreams_context(sqs_message)
+
+        assert result == TRACE_CONTEXT
+
+    def test_sns_wrapped_sqs_reads_attributes_from_notification_envelope(self):
+        """SNS -> SQS: MessageAttributes must come from the SNS notification Body."""
+        sns_notification = {
+            "Type": "Notification",
+            "MessageId": "sns-msg-id",
+            "Message": "Hello from SNS",
+            "MessageAttributes": {
+                "_datadog": {
+                    "Type": "Binary",
+                    "Value": base64.b64encode(json.dumps(TRACE_CONTEXT).encode()).decode(),
+                }
+            },
+        }
+        sqs_message = {
+            "MessageId": "sqs-msg-id",
+            "ReceiptHandle": "handle...",
+            "Body": json.dumps(sns_notification),
+            "MessageAttributes": {},
+        }
+
+        result = get_datastreams_context(sqs_message)
+
+        assert result == TRACE_CONTEXT
+
+    def test_sqs_json_body_without_datadog_attribute_returns_none(self):
+        """JSON body with no _datadog attribute at the top level returns None, not an error."""
+        sqs_message = {
+            "MessageId": "abc125",
+            "ReceiptHandle": "handle...",
+            "Body": json.dumps({"some": "payload"}),
+            "MessageAttributes": {},
+        }
+
+        result = get_datastreams_context(sqs_message)
+
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            json.dumps({"order_id": 1}),
+            "plain text",
+            "",
+            None,
+        ],
+    )
+    def test_sqs_missing_datadog_attribute_returns_none(self, body):
+        """Messages with no _datadog MessageAttribute must return None regardless of body type."""
+        sqs_message = {
+            "MessageId": "abc126",
+            "ReceiptHandle": "handle...",
+            "Body": body,
+            "MessageAttributes": {"other": {"StringValue": "x", "DataType": "String"}},
+        }
+
+        result = get_datastreams_context(sqs_message)
+
+        assert result is None


### PR DESCRIPTION
## Summary

`get_datastreams_context()` in `ddtrace/internal/datastreams/botocore.py` was losing DSM context for plain SQS messages whose body is valid JSON (i.e. the vast majority of production workloads).

**Root cause:** The function overwrote `message_body` with the parsed `Body` JSON before checking whether the message was SNS-wrapped.  The `MessageAttributes` lookup on the next line then read from the parsed payload instead of the top-level SQS message envelope, where `dd-trace-py` injects the `_datadog` attribute.

**Fix:** Parse `Body` into a separate `parsed_body` local variable without replacing the attributes source.  SNS notifications (`Type == "Notification"`) continue to use the parsed envelope; every other message correctly reads `MessageAttributes` from the top-level SQS message.

## Affected path

```
SQS producer (dd-trace-py)
  → injects _datadog into MessageAttributes (top-level)
  → SQS Body is {"order_id": 42, ...}   ← valid JSON

SQS consumer (dd-trace-py, buggy)
  → parses Body as JSON → overwrites message_body with {"order_id": 42, ...}
  → reads MessageAttributes from {"order_id": 42, ...}  → None
  → DSM context lost / pathway broken
```

## Tests

Five new unit tests added to `tests/datastreams/test_botocore.py`:

- `test_plain_sqs_with_json_body_reads_top_level_message_attributes` — the primary regression
- `test_plain_sqs_with_non_json_body_reads_top_level_message_attributes`
- `test_sns_wrapped_sqs_reads_attributes_from_notification_envelope` — ensures the SNS path still works
- `test_sqs_json_body_without_datadog_attribute_returns_none`
- `test_sqs_missing_datadog_attribute_returns_none` (parametrized)

Related: DSMS-149 / ZD-2906797 (Juno, org 1389288, us5.prod.dog)
Customer workaround: monkey-patched `get_datastreams_context` + upgraded dd-trace-js to 5.62.0.