### PR TITLE
ci(backporting): automate backport labeling and cherry-picks for fix(*) PRs

### DIFF
--- a/.github/backport-targets.yml
+++ b/.github/backport-targets.yml
@@ -1,0 +1,16 @@
+# Supported minor-version branches for automatic backporting.
+#
+# Policy: the N=3 most recent stable minor branches receive bug-fix backports.
+# Update this list when a new minor is released (add it) or a branch reaches EOL (remove it).
+# All automation (auto-label and auto-backport workflows) reads from this file.
+#
+# "critical" fixes (crashes, data loss, security) should be backported to ALL branches listed here.
+# Routine fixes target the branches listed under `stable`.
+branches:
+  stable:
+    - "4.8"
+    - "4.9"
+    - "4.10"
+  # Release candidates: add here when a branch is cut; move to stable on GA release.
+  rc:
+    - "4.11"

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,0 +1,194 @@
+name: Auto-backport fix(*) PRs
+
+# On merge of any fix(...) PR, automatically open backport PRs for every supported
+# stable branch in .github/backport-targets.yml — no manual labeling required.
+#
+# If a cherry-pick fails (conflict), a GitHub issue is filed instead of failing silently.
+# Authors can suppress auto-backport by adding the "no-backport" label before merging.
+#
+# This workflow is the enforcement layer on top of the existing backport.yml:
+# backport.yml handles label-driven backports; this handles policy-driven backports.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  collect-targets:
+    name: Collect auto-backport targets
+    runs-on: ubuntu-latest
+    outputs:
+      target_branches_json: ${{ steps.targets.outputs.json }}
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'fix(') &&
+      !contains(join(github.event.pull_request.labels.*.name, ','), 'no-backport')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/backport-targets.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Parse supported branches
+        id: targets
+        run: |
+          # Extract stable branches only (not RC); skip branches that already have
+          # a backport label on this PR (backport.yml will handle those).
+          EXISTING_LABELS='${{ join(github.event.pull_request.labels.*.name, ',') }}'
+          python3 - <<'EOF'
+          import json, re, os
+
+          with open('.github/backport-targets.yml') as f:
+              content = f.read()
+
+          # Parse stable block only.
+          in_stable = False
+          branches = []
+          for line in content.splitlines():
+              if re.match(r'\s+stable:', line):
+                  in_stable = True
+              elif re.match(r'\s+\w+:', line):
+                  in_stable = False
+              elif in_stable and re.match(r'\s+-\s+"', line):
+                  branches.append(re.search(r'"([^"]+)"', line).group(1))
+
+          existing_labels = os.environ.get('EXISTING_LABELS', '').split(',')
+          already_labeled = {
+              lbl.replace('backport ', '').strip()
+              for lbl in existing_labels
+              if lbl.startswith('backport ')
+          }
+
+          # Only auto-backport to branches not already covered by a manual label.
+          targets = [b for b in branches if b not in already_labeled]
+
+          print(f"Stable branches: {branches}")
+          print(f"Already labeled: {already_labeled}")
+          print(f"Auto-backport targets: {targets}")
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
+              out.write(f"json={json.dumps(targets)}\n")
+          EOF
+        env:
+          EXISTING_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+  backport:
+    name: Auto-backport to ${{ matrix.target_branch }}
+    needs: collect-targets
+    if: needs.collect-targets.outputs.target_branches_json != '[]' && needs.collect-targets.outputs.target_branches_json != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target_branch: ${{ fromJSON(needs.collect-targets.outputs.target_branches_json) }}
+    permissions:
+      contents: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.backport.create-pr
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Cherry-pick to ${{ matrix.target_branch }}
+        id: cherry-pick
+        env:
+          TARGET_BRANCH: ${{ matrix.target_branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          MERGE_COMMIT=$(git rev-parse HEAD)
+          WORKTREE=".worktrees/auto-backport-${TARGET_BRANCH}"
+          BACKPORT_BRANCH="auto-backport-${PR_NUMBER}-to-${TARGET_BRANCH}"
+
+          git worktree add "${WORKTREE}" "origin/${TARGET_BRANCH}"
+          cd "${WORKTREE}"
+          git branch -D "${BACKPORT_BRANCH}" 2>/dev/null || true
+          git switch --create "${BACKPORT_BRANCH}"
+
+          RC=0
+          CHERRYPICK_OUT=$(git cherry-pick -x --mainline 1 "${MERGE_COMMIT}" 2>&1) || RC=$?
+
+          if [ "${RC}" -ne 0 ]; then
+            git cherry-pick --abort 2>/dev/null || true
+            echo "status=conflict" >> "$GITHUB_OUTPUT"
+            echo "error<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${CHERRYPICK_OUT}" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            echo "branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "branch-from=$(git rev-parse origin/${TARGET_BRANCH})" >> "$GITHUB_OUTPUT"
+            echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push backport branch
+        if: steps.cherry-pick.outputs.status == 'ok'
+        uses: DataDog/commit-headless@05d7b7ee023e2c7d01c47832d420c2503cd416f3 # action/v2.0.3
+        with:
+          branch: ${{ steps.cherry-pick.outputs.branch }}
+          head-sha: ${{ steps.cherry-pick.outputs.branch-from }}
+          target: "DataDog/dd-trace-py"
+          create-branch: true
+          command: push
+          commits: ${{ steps.cherry-pick.outputs.commit }}
+          force: true
+
+      - name: Open backport PR
+        if: steps.cherry-pick.outputs.status == 'ok'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_BRANCH: ${{ matrix.target_branch }}
+          BACKPORT_BRANCH: ${{ steps.cherry-pick.outputs.branch }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          EXISTING=$(gh pr list --state open --base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -z "${EXISTING}" ]; then
+            gh pr create \
+              --title "${PR_TITLE} [backport ${TARGET_BRANCH}]" \
+              --body "Auto-backport of #${PR_NUMBER} to ${TARGET_BRANCH} (policy-driven, see \`.github/backport-targets.yml\`)." \
+              --base "${TARGET_BRANCH}" \
+              --head "${BACKPORT_BRANCH}"
+          else
+            echo "Backport PR already open: #${EXISTING}"
+          fi
+
+      - name: File issue on cherry-pick conflict
+        if: steps.cherry-pick.outputs.status == 'conflict'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          TARGET_BRANCH: ${{ matrix.target_branch }}
+          CHERRY_PICK_ERROR: ${{ steps.cherry-pick.outputs.error }}
+        run: |
+          gh issue create \
+            --title "Manual backport needed: #${PR_NUMBER} → ${TARGET_BRANCH}" \
+            --label "Backporting" \
+            --body "$(cat <<EOF
+          The auto-backport workflow could not cherry-pick **#${PR_NUMBER}** (_${PR_TITLE}_) to \`${TARGET_BRANCH}\` due to a conflict.
+
+          **Action required:** manually backport this fix or close this issue with a justification.
+
+          Use \`scripts/backport ${PR_NUMBER} ${TARGET_BRANCH}\` to attempt a local resolution.
+
+          <details><summary>Cherry-pick error output</summary>
+
+          \`\`\`
+          ${CHERRY_PICK_ERROR}
+          \`\`\`
+
+          </details>
+          EOF
+          )"

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -12,6 +12,16 @@ name: Auto-backport fix(*) PRs
 on:
   pull_request:
     types: [closed]
+  # workflow_dispatch allows manual testing before this workflow is on main:
+  #   gh workflow run auto-backport.yml -f pr_number=<N>
+  # The specified PR must already be merged. Branches already covered by a
+  # manual backport label on the PR are skipped (same deduplication as normal flow).
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Number of an already-merged fix(*) PR to backport"
+        required: true
+        type: string
 
 jobs:
   collect-targets:
@@ -19,10 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_branches_json: ${{ steps.targets.outputs.json }}
+      pr_number: ${{ steps.pr-meta.outputs.pr_number }}
+      pr_title: ${{ steps.pr-meta.outputs.pr_title }}
     if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.title, 'fix(') &&
-      !contains(join(github.event.pull_request.labels.*.name, ','), 'no-backport')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.title, 'fix(') &&
+        !contains(join(github.event.pull_request.labels.*.name, ','), 'no-backport')
+      )
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,12 +45,34 @@ jobs:
           sparse-checkout: .github/backport-targets.yml
           sparse-checkout-cone-mode: false
 
+      - name: Resolve PR metadata
+        id: pr-meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          EVENT_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if [ -n "${DISPATCH_PR}" ]; then
+            PR_NUMBER="${DISPATCH_PR}"
+            PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER})
+            LABELS=$(echo "${PR_DATA}" | jq -r '[.labels[].name] | join(",")')
+            PR_TITLE=$(echo "${PR_DATA}" | jq -r '.title')
+          else
+            PR_NUMBER="${EVENT_PR}"
+            LABELS="${EVENT_LABELS}"
+            PR_TITLE='${{ github.event.pull_request.title }}'
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "labels=${LABELS}" >> "$GITHUB_OUTPUT"
+          echo "pr_title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
+
       - name: Parse supported branches
         id: targets
         run: |
           # Extract stable branches only (not RC); skip branches that already have
           # a backport label on this PR (backport.yml will handle those).
-          EXISTING_LABELS='${{ join(github.event.pull_request.labels.*.name, ',') }}'
+          EXISTING_LABELS='${{ steps.pr-meta.outputs.labels }}'
           python3 - <<'EOF'
           import json, re, os
 
@@ -71,7 +108,7 @@ jobs:
               out.write(f"json={json.dumps(targets)}\n")
           EOF
         env:
-          EXISTING_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          EXISTING_LABELS: ${{ steps.pr-meta.outputs.labels }}
 
   backport:
     name: Auto-backport to ${{ matrix.target_branch }}
@@ -102,7 +139,7 @@ jobs:
         id: cherry-pick
         env:
           TARGET_BRANCH: ${{ matrix.target_branch }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.collect-targets.outputs.pr_number }}
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
@@ -147,8 +184,8 @@ jobs:
       - name: Open backport PR
         if: steps.cherry-pick.outputs.status == 'ok'
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ needs.collect-targets.outputs.pr_title }}
+          PR_NUMBER: ${{ needs.collect-targets.outputs.pr_number }}
           TARGET_BRANCH: ${{ matrix.target_branch }}
           BACKPORT_BRANCH: ${{ steps.cherry-pick.outputs.branch }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/pr-auto-label-backport.yml
+++ b/.github/workflows/pr-auto-label-backport.yml
@@ -8,10 +8,19 @@ name: Auto-label backport targets
 #
 # Uses pull_request_target so that the GITHUB_TOKEN has write access even for
 # fork PRs. No PR code is checked out — only the base repo config file is read.
+#
+# workflow_dispatch allows manual testing before this workflow is on main:
+#   gh workflow run pr-auto-label-backport.yml -f pr_number=<N>
 
 on:
   pull_request_target:
     types: [opened, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to apply backport labels to"
+        required: true
+        type: string
 
 jobs:
   auto-label:
@@ -19,12 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: startsWith(github.event.pull_request.title, 'fix(')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Check out only the base branch (not the PR) — safe for pull_request_target.
-          ref: ${{ github.event.pull_request.base.sha }}
+          # Always check out the base/default branch — never the PR head. Safe for pull_request_target.
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
           sparse-checkout: .github/backport-targets.yml
           sparse-checkout-cone-mode: false
@@ -34,22 +42,35 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const yaml = require('js-yaml');  // available via @actions/github-script environment
 
-            // Parse supported branches from config.
-            const raw = fs.readFileSync('.github/backport-targets.yml', 'utf8');
-            // Simple line-based parse — avoids needing js-yaml in the runner.
-            const stableLines = raw.split('\n')
-              .filter(l => /^\s+-\s+"/.test(l))
-              .map(l => l.match(/"([^"]+)"/)[1]);
+            // Resolve PR number — from event payload or manual dispatch input.
+            const prNumber = context.payload.pull_request?.number
+              ?? parseInt(context.payload.inputs?.pr_number);
+            if (!prNumber) { core.setFailed('No PR number available'); return; }
 
-            const existingLabels = context.payload.pull_request.labels.map(l => l.name);
+            // Fetch current PR state (needed for workflow_dispatch path).
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
 
-            // Suppress entirely if author has opted out.
+            if (!pr.title.startsWith('fix(')) {
+              console.log(`PR title "${pr.title}" does not start with fix( — skipping`);
+              return;
+            }
+
+            const existingLabels = pr.labels.map(l => l.name);
             if (existingLabels.includes('no-backport')) {
               console.log('no-backport label present — skipping');
               return;
             }
+
+            // Parse supported stable branches from config.
+            const raw = fs.readFileSync('.github/backport-targets.yml', 'utf8');
+            const stableLines = raw.split('\n')
+              .filter(l => /^\s+-\s+"/.test(l))
+              .map(l => l.match(/"([^"]+)"/)[1]);
 
             const toAdd = stableLines
               .map(b => `backport ${b}`)
@@ -64,6 +85,6 @@ jobs:
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               labels: toAdd,
             });

--- a/.github/workflows/pr-auto-label-backport.yml
+++ b/.github/workflows/pr-auto-label-backport.yml
@@ -1,0 +1,69 @@
+name: Auto-label backport targets
+
+# For any PR whose title starts with fix(...), automatically apply backport labels
+# for all supported stable branches defined in .github/backport-targets.yml.
+#
+# Authors can remove labels before merge if a specific backport is not needed.
+# Add the "no-backport" label to suppress all backport labels entirely.
+#
+# Uses pull_request_target so that the GITHUB_TOKEN has write access even for
+# fork PRs. No PR code is checked out — only the base repo config file is read.
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+jobs:
+  auto-label:
+    name: Apply backport labels
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: startsWith(github.event.pull_request.title, 'fix(')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out only the base branch (not the PR) — safe for pull_request_target.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/backport-targets.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Apply backport labels
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');  // available via @actions/github-script environment
+
+            // Parse supported branches from config.
+            const raw = fs.readFileSync('.github/backport-targets.yml', 'utf8');
+            // Simple line-based parse — avoids needing js-yaml in the runner.
+            const stableLines = raw.split('\n')
+              .filter(l => /^\s+-\s+"/.test(l))
+              .map(l => l.match(/"([^"]+)"/)[1]);
+
+            const existingLabels = context.payload.pull_request.labels.map(l => l.name);
+
+            // Suppress entirely if author has opted out.
+            if (existingLabels.includes('no-backport')) {
+              console.log('no-backport label present — skipping');
+              return;
+            }
+
+            const toAdd = stableLines
+              .map(b => `backport ${b}`)
+              .filter(l => !existingLabels.includes(l));
+
+            if (toAdd.length === 0) {
+              console.log('All backport labels already present');
+              return;
+            }
+
+            console.log(`Adding labels: ${toAdd.join(', ')}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: toAdd,
+            });

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -83,12 +83,34 @@ Backporting
 
 Each minor version has its own branch.
 
-* **Fix PRs** are backported to the most recent release branch only when they are critically important.
-* **New features** (``feat`` PRs) are not backported.
-* **Chore, documentation, and other PRs** are not backported.
+**Supported branch window**
 
-If your pull request is a critical ``fix`` change, apply the backport labels corresponding to the minor
-versions that need the change.
+Bug fixes are backported to the **N=3 most recent stable minor branches** (currently 4.8, 4.9, 4.10).
+The authoritative list is in `.github/backport-targets.yml <../.github/backport-targets.yml>`_.
+Critical fixes (crashes, data loss, security) should target all branches in that file,
+including release candidates.
+
+**What gets backported**
+
+* **Fix PRs** (``fix(...)`` title prefix) — backported automatically (see below).
+* **New features** (``feat`` PRs) — not backported.
+* **Chore, documentation, refactor, and test PRs** — not backported.
+
+**Automation**
+
+Two workflows handle backports so that manual labeling is a last resort, not the default:
+
+1. **Auto-label** (``.github/workflows/pr-auto-label-backport.yml``): when you open or edit a
+   ``fix(...)`` PR, backport labels are added automatically for all supported stable branches.
+   Remove any labels that are not appropriate for your fix before merging.
+
+2. **Auto-backport** (``.github/workflows/auto-backport.yml``): on merge of a ``fix(...)`` PR,
+   cherry-pick PRs are opened automatically for any supported branches that were not already
+   covered by a manual label. If a cherry-pick cannot be applied cleanly, a GitHub issue is
+   filed instead — see the issue for instructions on manual resolution.
+
+To suppress all automatic backports for a PR (e.g., a fix for a feature that only exists on
+``main``), add the ``no-backport`` label before merging.
 
 Tests
 -----


### PR DESCRIPTION
## What this does

Closes the gap where bug fixes were inconsistently backported across supported minor branches
(discovered: v4.10.2 was missing 6 profiling fixes that v4.8.9 had).

### Changes

- **`.github/backport-targets.yml`** - single source of truth for the supported branch window.
  Currently: 4.8, 4.9, 4.10 (stable) + 4.11 (RC). Updating the window is a one-line change here.

- **`pr-auto-label-backport.yml`** (Option C - auto-label): when a `fix(...)` PR is opened or
  edited, `backport 4.8/4.9/4.10` labels are applied automatically. Author removes any that
  don't apply. Add `no-backport` to suppress entirely.

- **`auto-backport.yml`** (Option B - auto-bot): on merge of any `fix(...)` PR, opens
  cherry-pick PRs for all supported branches not already covered by a manual label.
  Cherry-pick conflicts file a GitHub issue with instructions instead of failing silently.

- **`docs/contributing.rst`** - rewrites the Backporting section with the explicit N=3 policy
  and documents both workflows and the `no-backport` opt-out.

### Why not Option A (fix-forward)?

Fix-forward (targeting oldest branch first, merging forward to main) is a structural guarantee
but requires significant contributor workflow changes. Raised as a discussion item for the guild.

## Testing

Live tests will be run via test PRs before this merges.

- [ ] Option C: open a `fix(` draft PR, verify labels appear
- [ ] Option C: `no-backport` suppresses labels
- [ ] Option B: merge a throwaway `fix(` PR, verify backport PRs open for 4.8/4.9/4.10
- [ ] Option B: conflict path -> issue filed
- [ ] Option B: dedupe - manually labeled branch skipped by auto-bot
