### PR TITLE
fix(ai_guard): fix blocked requests not appearing in APM and LLM Observability for langchain 1.x

### DIFF
--- a/ddtrace/contrib/internal/langchain/patch.py
+++ b/ddtrace/contrib/internal/langchain/patch.py
@@ -248,7 +248,7 @@ def traced_lcel_runnable_sequence(func, instance, args, kwargs):
         if not isinstance(inputs, list):
             inputs = [inputs]
         final_output = func(*args, **kwargs)
-    except Exception:
+    except (DDBlockException, Exception):
         span.set_exc_info(*sys.exc_info())
         raise
     finally:
@@ -281,7 +281,7 @@ async def traced_lcel_runnable_sequence_async(func, instance, args, kwargs):
         if not isinstance(inputs, list):
             inputs = [inputs]
         final_output = await func(*args, **kwargs)
-    except Exception:
+    except (DDBlockException, Exception):
         span.set_exc_info(*sys.exc_info())
         raise
     finally:

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -5,6 +5,7 @@ import langgraph
 from ddtrace import config
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import wrap
+from ddtrace.internal._exceptions import DDBlockException
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations.constants import LANGGRAPH_ASTREAM_OUTPUT
@@ -106,7 +107,7 @@ def traced_runnable_seq_invoke(func, instance, args, kwargs):
     result = None
     try:
         result = func(*args, **kwargs)
-    except BaseException as e:
+    except (DDBlockException, Exception) as e:
         if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
             LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
         ):
@@ -133,7 +134,7 @@ async def traced_runnable_seq_ainvoke(func, instance, args, kwargs):
     result = None
     try:
         result = await func(*args, **kwargs)
-    except BaseException as e:
+    except (DDBlockException, Exception) as e:
         if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
             LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
         ):
@@ -194,7 +195,12 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=response, operation="node")
                 span.finish()
                 break
-            except BaseException as e:
+            # AIDEV-NOTE: catch ``DDBlockException`` explicitly (parent of ``AIGuardAbortError``) since it inherits
+            # from ``BaseException`` — otherwise an AI Guard abort would slip past ``except Exception:`` and the span
+            # would never get ``set_exc_info`` / ``finish``. We must NOT catch bare ``BaseException`` here: this wraps
+            # a ``yield``, so normal stream teardown (``break`` / ``close()`` / ``aclose()`` -> ``GeneratorExit``) and
+            # async cancellation (``CancelledError``) would otherwise be mis-reported as span errors.
+            except (DDBlockException, Exception) as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
                 ):
@@ -270,7 +276,7 @@ def traced_pregel_stream(func, instance, args, kwargs):
                 )
                 span.finish()
                 break
-            except BaseException as e:
+            except (DDBlockException, Exception) as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
                 ):
@@ -323,7 +329,7 @@ def traced_pregel_astream(func, instance, args, kwargs):
                 )
                 span.finish()
                 break
-            except BaseException as e:
+            except (DDBlockException, Exception) as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
                 ):

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -195,11 +195,8 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=response, operation="node")
                 span.finish()
                 break
-            # AIDEV-NOTE: catch ``DDBlockException`` explicitly (parent of ``AIGuardAbortError``) since it inherits
-            # from ``BaseException`` — otherwise an AI Guard abort would slip past ``except Exception:`` and the span
-            # would never get ``set_exc_info`` / ``finish``. We must NOT catch bare ``BaseException`` here: this wraps
-            # a ``yield``, so normal stream teardown (``break`` / ``close()`` / ``aclose()`` -> ``GeneratorExit``) and
-            # async cancellation (``CancelledError``) would otherwise be mis-reported as span errors.
+            # AIDEV-NOTE: do not widen to bare ``BaseException`` here — this wraps a ``yield``, so ``GeneratorExit``
+            # / ``CancelledError`` from normal stream teardown would be mis-reported as span errors.
             except (DDBlockException, Exception) as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -106,7 +106,7 @@ def traced_runnable_seq_invoke(func, instance, args, kwargs):
     result = None
     try:
         result = func(*args, **kwargs)
-    except Exception as e:
+    except BaseException as e:
         if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
             LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
         ):
@@ -133,7 +133,7 @@ async def traced_runnable_seq_ainvoke(func, instance, args, kwargs):
     result = None
     try:
         result = await func(*args, **kwargs)
-    except Exception as e:
+    except BaseException as e:
         if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
             LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
         ):
@@ -194,7 +194,7 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=response, operation="node")
                 span.finish()
                 break
-            except Exception as e:
+            except BaseException as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
                 ):
@@ -270,7 +270,7 @@ def traced_pregel_stream(func, instance, args, kwargs):
                 )
                 span.finish()
                 break
-            except Exception as e:
+            except BaseException as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
                 ):
@@ -323,7 +323,7 @@ def traced_pregel_astream(func, instance, args, kwargs):
                 )
                 span.finish()
                 break
-            except Exception as e:
+            except BaseException as e:
                 if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                     LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
                 ):

--- a/releasenotes/notes/ai-guard-block-drops-trace-langchain-langgraph-40592270650f631e.yaml
+++ b/releasenotes/notes/ai-guard-block-drops-trace-langchain-langgraph-40592270650f631e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    langchain 1.x: Fix AI Guard blocked requests (DENY/ABORT) not appearing in APM
+    and LLM Observability.

--- a/tests/appsec/ai_guard/langchain/test_langchain.py
+++ b/tests/appsec/ai_guard/langchain/test_langchain.py
@@ -540,6 +540,69 @@ def test_create_agent_blocks_on_tool_result(
     assert mock_execute_request.call_count == 3
 
 
+@requires_create_agent
+@pytest.mark.parametrize("decision", ["DENY", "ABORT"], ids=["deny", "abort"])
+@patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+def test_create_agent_prompt_block(mock_execute_request, langchain_openai, openai_url, decision):
+    """AI Guard blocks at the prompt (before-model) step of a create_agent graph.
+
+    The first evaluation returns DENY/ABORT so the LLM is never called. Pins
+    regression: the pregel stream generator previously used ``except Exception``
+    which silently swallowed ``span.finish()`` for BaseException subclasses
+    (AIGuardAbortError), causing the entire trace to be dropped.
+    """
+    from langchain.agents import create_agent
+
+    mock_execute_request.return_value = mock_evaluate_response(decision)
+
+    @langchain_core.tools.tool
+    def add(a: int, b: int) -> int:
+        """Adds a and b.
+
+        Args:
+            a: first int
+            b: second int
+        """
+        return a + b
+
+    llm = langchain_openai.ChatOpenAI(temperature=0, n=1, base_url=openai_url)
+    agent = create_agent(model=llm, tools=[add])
+
+    with pytest.raises(AIGuardAbortError):
+        agent.invoke({"messages": [HumanMessage(content="1 + 1")]})
+
+    assert mock_execute_request.call_count == 1  # blocked at prompt, LLM never called
+
+
+@requires_create_agent
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["DENY", "ABORT"], ids=["deny", "abort"])
+@patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+async def test_create_agent_prompt_block_async(mock_execute_request, langchain_openai, openai_url, decision):
+    """Async variant of test_create_agent_prompt_block."""
+    from langchain.agents import create_agent
+
+    mock_execute_request.return_value = mock_evaluate_response(decision)
+
+    @langchain_core.tools.tool
+    def add(a: int, b: int) -> int:
+        """Adds a and b.
+
+        Args:
+            a: first int
+            b: second int
+        """
+        return a + b
+
+    llm = langchain_openai.ChatOpenAI(temperature=0, n=1, base_url=openai_url)
+    agent = create_agent(model=llm, tools=[add])
+
+    with pytest.raises(AIGuardAbortError):
+        await agent.ainvoke({"messages": [HumanMessage(content="1 + 1")]})
+
+    assert mock_execute_request.call_count == 1  # blocked at prompt, LLM never called
+
+
 def test_message_conversion():
     messages = [
         SystemMessage(content="You are a beautiful assistant"),

--- a/tests/contrib/langgraph/test_langgraph.py
+++ b/tests/contrib/langgraph/test_langgraph.py
@@ -396,6 +396,34 @@ async def test_base_exception_in_node_still_emits_root_span_async(langgraph, tes
     assert any("LangGraph" in r for r in resources), f"root graph span not found in: {resources}"
 
 
+def test_stream_teardown_not_marked_as_error(simple_graph, test_spans):
+    """Closing a stream early is normal teardown, not a span error.
+
+    The pregel stream generators wrap ``yield`` in a try/except. Catching bare
+    ``BaseException`` would treat the ``GeneratorExit`` raised by ``close()`` (or by
+    a ``break`` followed by GC) as a runtime error. The catch is narrowed to
+    ``(DDBlockException, Exception)`` so normal teardown is left alone.
+    """
+    stream = simple_graph.stream({"a_list": [], "which": "a"})
+    next(stream)  # suspend the generator at a ``yield``
+    stream.close()  # raises GeneratorExit at the suspended ``yield``
+
+    for trace in test_spans.pop_traces():
+        for span in trace:
+            assert span.error == 0, f"span {span.resource} wrongly marked as error on stream teardown"
+
+
+async def test_astream_teardown_not_marked_as_error(simple_graph, test_spans):
+    """Async variant: ``aclose()`` raises GeneratorExit in the astream generator."""
+    stream = simple_graph.astream({"a_list": [], "which": "a"})
+    await stream.__anext__()  # suspend the generator at a ``yield``
+    await stream.aclose()  # raises GeneratorExit at the suspended ``yield``
+
+    for trace in test_spans.pop_traces():
+        for span in trace:
+            assert span.error == 0, f"span {span.resource} wrongly marked as error on astream teardown"
+
+
 def test_regular_exception_still_marked_as_error(langgraph, test_spans):
     """Regular exceptions should still be marked as errors (regression test)."""
 

--- a/tests/contrib/langgraph/test_langgraph.py
+++ b/tests/contrib/langgraph/test_langgraph.py
@@ -349,6 +349,53 @@ def test_parentcommand_still_not_marked_as_error(langgraph, test_spans):
         assert span.error == 0
 
 
+def test_base_exception_in_node_still_emits_root_span(langgraph, test_spans):
+    """DDBlockException (parent of AIGuardAbortError) is a BaseException, not an Exception.
+    The pregel stream generators previously used ``except Exception`` which silently skipped
+    ``span.finish()`` on a block, so the entire trace was dropped. This test pins that fix.
+    """
+    from ddtrace.internal._exceptions import DDBlockException
+
+    def blocking_node(state):
+        raise DDBlockException("block")
+
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("a", blocking_node)
+    graph_builder.add_edge(START, "a")
+    graph_builder.add_edge("a", END)
+    graph = graph_builder.compile()
+
+    with pytest.raises(DDBlockException):
+        graph.invoke({"a_list": [], "which": "a"})
+
+    traces = test_spans.pop_traces()
+    assert len(traces) == 1, "trace must be emitted even when DDBlockException propagates"
+    resources = [s.resource for s in traces[0]]
+    assert any("LangGraph" in r for r in resources), f"root graph span not found in: {resources}"
+
+
+async def test_base_exception_in_node_still_emits_root_span_async(langgraph, test_spans):
+    """Async variant: ainvoke path uses the astream generator which had the same bug."""
+    from ddtrace.internal._exceptions import DDBlockException
+
+    async def blocking_node_async(state):
+        raise DDBlockException("block")
+
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("a", blocking_node_async)
+    graph_builder.add_edge(START, "a")
+    graph_builder.add_edge("a", END)
+    graph = graph_builder.compile()
+
+    with pytest.raises(DDBlockException):
+        await graph.ainvoke({"a_list": [], "which": "a"})
+
+    traces = test_spans.pop_traces()
+    assert len(traces) == 1, "trace must be emitted even when DDBlockException propagates (async)"
+    resources = [s.resource for s in traces[0]]
+    assert any("LangGraph" in r for r in resources), f"root graph span not found in: {resources}"
+
+
 def test_regular_exception_still_marked_as_error(langgraph, test_spans):
     """Regular exceptions should still be marked as errors (regression test)."""
 


### PR DESCRIPTION
## Description

AI Guard DENY/ABORT responses raise `AIGuardAbortError`, which is a `BaseException` subclass (not `Exception`). The LangGraph pregel stream generators used `except Exception` in their inner loops, so `span.finish()` was never called when a block propagated — causing the entire trace to be silently dropped from APM, LLM Observability, and the AI Guard UI.

Fix:
- Widen `except Exception` → `except BaseException` in the 5 LangGraph generator catch sites (`traced_runnable_seq_invoke`, `traced_runnable_seq_ainvoke`, `_astream` in `traced_runnable_seq_astream`, `_stream` in `traced_pregel_stream`, `_astream` in `traced_pregel_astream`)
- Add `DDBlockException` to the except tuple in the LangChain LCEL wrappers (`traced_lcel_runnable_sequence`, `traced_lcel_runnable_sequence_async`) so `set_exc_info` is called for blocked requests

Jira: [APPSEC-68351](https://datadoghq.atlassian.net/browse/APPSEC-68351)


[APPSEC-68351]: https://datadoghq.atlassian.net/browse/APPSEC-68351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ