### PR TITLE
fix(profiling): placement new for all containers post fork

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -122,19 +122,23 @@ class EchionSampler
         // took its snapshot. Traversing a corrupted list to free nodes would crash.
         frame_cache_.postfork_child();
 
-        // Clear stale entries from parent process.
-        // No lock needed: only one thread exists in child immediately after fork.
-        task_link_map_.clear();
-        weak_task_link_map_.clear();
-        greenlet_info_map_.clear();
-        greenlet_parent_map_.clear();
-        greenlet_thread_map_.clear();
+        // Also use placement new for all containers touched by the sampling thread.
+        // Using placement new means the existing containers are abandoned and
+        // their memory leaked in the child and we may lose some data (e.g. relationships
+        // between asyncio Tasks).
+        // However, this is the only way to safely continue working after fork.
+        new (&thread_info_map_) std::unordered_map<uintptr_t, ThreadInfo::Ptr>();
+        new (&task_link_map_) std::unordered_map<PyObject*, PyObject*>();
+        new (&weak_task_link_map_) std::unordered_map<PyObject*, PyObject*>();
+        new (&greenlet_info_map_) std::unordered_map<GreenletInfo::ID, GreenletInfo::Ptr>();
+        new (&greenlet_parent_map_) std::unordered_map<GreenletInfo::ID, GreenletInfo::ID>();
+        new (&greenlet_thread_map_) std::unordered_map<uintptr_t, GreenletInfo::ID>();
+        new (&previous_task_objects_) std::unordered_set<PyObject*>();
 
-        // Reset the scratch set via placement new instead of clear() for the
-        // same fork-safety reason as frame_cache_: the Sampling Thread may have
-        // been mid-insert (e.g. rehash) when fork snapshotted the set, so
-        // traversing its buckets to free nodes (as clear() does) could crash.
-        // Abandon the old buckets (intentional one-time leak).
+        asyncio_frame_cache_key_.reset();
+        uvloop_frame_cache_key_.reset();
+        asyncio_task_count_ = 0;
+
         new (&seen_frames_scratch_) std::unordered_set<PyObject*>();
 
         // Clear renderer caches to avoid using stale interned IDs from the

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -486,6 +486,7 @@ Sampler::postfork_child()
         echion->postfork_child();
     }
 
+    // Note: the Thread Info Map has been reset in EchionSampler::postfork_child.
     auto& thread_info_map = echion->thread_info_map();
 
     // Refresh the ThreadInfo for the current (only) Thread.
@@ -497,23 +498,17 @@ Sampler::postfork_child()
     auto current_thread_id = reinterpret_cast<uintptr_t>(pthread_self());
 #endif
 
-    // Extract the current ThreadInfo name if possible. All the other information needs to be updated.
-    auto it = thread_info_map.find(current_thread_id);
-    std::string name = it != thread_info_map.end() ? it->second->name : "MainThread";
-
-    // Clear all entries, we have extracted everything we care about.
-    thread_info_map.clear();
-
     // After fork, the current thread is the main (and only) thread,
     // so native_id == pid.
     auto native_id = static_cast<unsigned long>(getpid());
+    const std::string thread_name = "MainThread";
 
-    auto maybe_thread_info = ThreadInfo::create(current_thread_id, native_id, name.c_str());
+    auto maybe_thread_info = ThreadInfo::create(current_thread_id, native_id, thread_name.c_str());
     if (maybe_thread_info) {
         thread_info_map.emplace(current_thread_id, std::move(*maybe_thread_info));
     } else {
         std::cerr << "Failed to register thread: " << std::hex << current_thread_id << std::dec << " (" << native_id
-                  << ") " << name << std::endl;
+                  << ") " << thread_name << std::endl;
     }
 }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -253,8 +253,12 @@ Datadog::StackRenderer::StackRenderer()
 void
 Datadog::StackRenderer::postfork_child()
 {
-    // Clear the caches to avoid using stale interned string/function IDs
-    // from the parent process's dictionary
-    string_id_cache.clear();
-    function_id_cache.clear();
+    // Use placement new instead of clear because the sampling thread may
+    // have been mid-rehash on either cache when fork was called.
+    // Traversing the buckets to free nodes would crash if they were left
+    // in an inconsistent state.
+    new (&string_id_cache) std::unordered_map<StringTable::Key, string_id>();
+    new (&function_id_cache)
+      std::unordered_map<internal::PtrPair, function_id, internal::PtrPairHash, internal::PtrPairEq>();
+    sample = nullptr;
 }

--- a/releasenotes/notes/profiling-fix-post-fork-crashes-00cc0d66244567c2.yaml
+++ b/releasenotes/notes/profiling-fix-post-fork-crashes-00cc0d66244567c2.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: Rare crashes that could happen post-fork in fork-based applications have been fixed.


### PR DESCRIPTION
## Description

This PR fixes more, even rarer post-fork crashes detected through Crash Logs (< 10 per day). 

The fix is to "hard reset" with a placement-`new` instead of `clear` or whatever the "usual" way to reset is. The reason (still) is that the Sampling Thread may be mid-sampling / mid heap operation when the fork happens, in which case the STL containers we use may be left in an inconsistent state in the child process where the previously-working thread doesn't exist anymore. 
