### PR TITLE
feat(appsec): emit WAF LLM business-logic event for OpenAI calls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,7 +179,7 @@ src/native/crashtracker*                     @DataDog/profiling-python @DataDog/
 
 # MLObs
 ddtrace/llmobs/                                               @DataDog/ml-observability
-ddtrace/contrib/internal/openai                               @DataDog/ml-observability
+ddtrace/contrib/internal/openai                               @DataDog/ml-observability @DataDog/asm-python
 ddtrace/contrib/internal/langchain                            @DataDog/ml-observability
 ddtrace/contrib/internal/botocore/services/bedrock.py         @DataDog/ml-observability
 ddtrace/contrib/internal/botocore/services/bedrock_agents.py  @DataDog/ml-observability

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -231,6 +231,8 @@ class WAF_DATA_NAMES(metaclass=Constant_Class):
     PAYMENT_CANCELLATION: Literal["server.business_logic.payment.cancellation"] = (
         "server.business_logic.payment.cancellation"
     )
+    # Persistent: WAF deduplicates, so only the first LLM call per request is surfaced (by design).
+    LLM_EVENT: Literal["server.business_logic.llm.event"] = "server.business_logic.llm.event"
     PERSISTENT_ADDRESSES = frozenset(
         (
             REQUEST_BODY,
@@ -251,6 +253,7 @@ class WAF_DATA_NAMES(metaclass=Constant_Class):
             PAYMENT_SUCCESS,
             PAYMENT_FAILURE,
             PAYMENT_CANCELLATION,
+            LLM_EVENT,
         )
     )
 

--- a/ddtrace/appsec/_contrib/openai/handlers.py
+++ b/ddtrace/appsec/_contrib/openai/handlers.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from ddtrace.appsec._asm_request_context import call_waf_callback
+from ddtrace.appsec._asm_request_context import in_asm_context
+from ddtrace.internal import core
+from ddtrace.internal.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def _on_openai_llm_call(kwargs: Any) -> None:
+    if not in_asm_context():
+        return
+    # Azure OpenAI uses "engine" instead of "model".
+    model = kwargs.get("model") or kwargs.get("engine") or ""
+    try:
+        call_waf_callback({"LLM_EVENT": {"provider": "openai", "model": model}})
+    except Exception:
+        logger.debug("Failed to emit LLM event to WAF", exc_info=True)
+
+
+def listen() -> None:
+    core.on("openai.chat.completions.create.before", _on_openai_llm_call)
+    core.on("openai.responses.create.before", _on_openai_llm_call)
+    core.on("openai.completions.create.before", _on_openai_llm_call)

--- a/ddtrace/appsec/_listeners.py
+++ b/ddtrace/appsec/_listeners.py
@@ -74,6 +74,7 @@ def load_appsec(reconfigure_tracer: bool = False, origin: str = "") -> bool:
     from ddtrace.appsec._contrib.django import listen as django_listen
     from ddtrace.appsec._contrib.fastapi import listen as fastapi_listen
     from ddtrace.appsec._contrib.flask import listen as flask_listen
+    from ddtrace.appsec._contrib.openai.handlers import listen as openai_listen
     from ddtrace.appsec._contrib.stripe.handlers import listen as stripe_listen
     from ddtrace.appsec._contrib.tornado import listen as tornado_listen
     from ddtrace.appsec._handlers import listen
@@ -89,6 +90,7 @@ def load_appsec(reconfigure_tracer: bool = False, origin: str = "") -> bool:
         fastapi_listen()
         import ddtrace.appsec._contrib.httpx.subscribers  # noqa: F401
 
+        openai_listen()
         stripe_listen()
         tornado_listen()
 

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -300,7 +300,7 @@ class AppSecSpanProcessor(SpanProcessor):
                 if key in custom_data:
                     ephemeral_data[waf_name] = _serialize_address_values(waf_name, custom_data.get(key))
 
-            elif self._is_needed(waf_name) or force_keys:
+            elif self._is_needed(waf_name) or force_keys or (custom_data and key in custom_data):
                 value = None
                 if custom_data is not None and custom_data.get(key) is not None:
                     value = custom_data.get(key)

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -300,7 +300,7 @@ class AppSecSpanProcessor(SpanProcessor):
                 if key in custom_data:
                     ephemeral_data[waf_name] = _serialize_address_values(waf_name, custom_data.get(key))
 
-            elif self._is_needed(waf_name) or force_keys or (custom_data and key in custom_data):
+            elif self._is_needed(waf_name) or force_keys:
                 value = None
                 if custom_data is not None and custom_data.get(key) is not None:
                     value = custom_data.get(key)

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -250,7 +250,31 @@ def _patched_endpoint(patch_hook):
         is_chat = patch_hook in _CHAT_COMPLETION_HOOKS
         is_response = patch_hook in _RESPONSE_HOOKS
         is_completion = patch_hook in _COMPLETION_HOOKS
-        is_raw_streaming = kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False)
+        if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
+            # Raw-response streaming: dispatch .before for AppSec listeners but
+            # do NOT create an LLMObs span — existing tests assert 0 spans for
+            # this path, and there is no response to trace anyway.
+            # If dispatch raises (e.g. a future block), open+close a span so the
+            # error is recorded before re-raising.
+            event = ""
+            if is_chat:
+                event = "openai.chat.completions.create"
+            elif is_response:
+                event = "openai.responses.create"
+            elif is_completion:
+                event = "openai.completions.create"
+            if event:
+                try:
+                    core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
+                except BaseException as dispatch_err:
+                    g = _traced_endpoint(patch_hook, openai._datadog_integration, instance, args, kwargs)
+                    g.send(None)
+                    try:
+                        g.send((None, dispatch_err))
+                    except StopIteration:
+                        pass
+                    raise
+            return func(*args, **kwargs)
 
         integration = openai._datadog_integration
         g = _traced_endpoint(patch_hook, integration, instance, args, kwargs)
@@ -268,25 +292,19 @@ def _patched_endpoint(patch_hook):
             if event:
                 core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
             resp = func(*args, **kwargs)
-            if event and not is_raw_streaming and not kwargs.get("stream") and resp is not None:
+            if event and not kwargs.get("stream") and resp is not None:
                 core.dispatch(f"{event}.after", (kwargs, resp), allow_raise=True)
         except BaseException as e:
             err = e
             raise
         finally:
-            # For raw streaming, pass resp=None so _traced_endpoint always calls
-            # span.finish() instead of trying to wrap a streaming response it
-            # cannot consume.  The real SDK response is returned directly below.
-            send_resp = None if is_raw_streaming else resp
             try:
-                g.send((send_resp, err))
+                g.send((resp, err))
             except StopIteration as e:
                 if err is None:
                     # This return takes priority over the implicit None return
                     override_return = e.value
 
-        if is_raw_streaming:
-            return resp
         if override_return is not None:
             return override_return
 
@@ -416,6 +434,9 @@ def _patched_endpoint_async(patch_hook):
         is_response = patch_hook in _RESPONSE_HOOKS
         is_completion = patch_hook in _COMPLETION_HOOKS
         if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
+            # Raw-response streaming: dispatch .before for AppSec but no LLMObs span
+            # on the success path (same rationale as sync path above).
+            # Dispatch is synchronous; span is created only if it raises.
             event = ""
             if is_chat:
                 event = "openai.chat.completions.create"
@@ -423,32 +444,17 @@ def _patched_endpoint_async(patch_hook):
                 event = "openai.responses.create"
             elif is_completion:
                 event = "openai.completions.create"
-
-            async def async_wrapper_raw():
-                integration = openai._datadog_integration
-                g = _traced_endpoint(patch_hook, integration, instance, args, kwargs)
-                g.send(None)
-                resp, err = None, None
+            if event:
                 try:
-                    if event:
-                        # No coroutine to close on DDBlockException here: func has not
-                        # been called yet, unlike the normal async path where result is
-                        # created before async_wrapper runs.
-                        core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
-                    resp = await func(*args, **kwargs)
-                except BaseException as e:
-                    err = e
-                    raise
-                finally:
-                    # Pass resp=None so _traced_endpoint calls span.finish() immediately
-                    # rather than wrapping the raw streaming response it cannot consume.
+                    core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
+                except BaseException as dispatch_err:
+                    g = _traced_endpoint(patch_hook, openai._datadog_integration, instance, args, kwargs)
+                    g.send(None)
                     try:
-                        g.send((None, err))
+                        g.send((None, dispatch_err))
                     except StopIteration:
                         pass
-                return resp
-
-            return async_wrapper_raw()
+                    raise
         result = func(*args, **kwargs)
         # Detect AsyncPaginator objects (have both __aiter__ and __await__).
         # These must be returned directly (not awaited) to preserve iteration behavior.

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -455,6 +455,9 @@ def _patched_endpoint_async(patch_hook):
                     except StopIteration:
                         pass
                     raise
+            # Return immediately like the sync path: no span and no second
+            # .before dispatch for raw-response streaming on the success path.
+            return func(*args, **kwargs)
         result = func(*args, **kwargs)
         # Detect AsyncPaginator objects (have both __aiter__ and __await__).
         # These must be returned directly (not awaited) to preserve iteration behavior.

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -90,8 +90,6 @@ _RESPONSE_HOOKS = (
     _endpoint_hooks._ResponseParseHook,
 )
 
-# _CompletionWithRawResponseHook is intentionally excluded: it takes the early-return path
-# at the top of _patched_endpoint/_patched_endpoint_async and never reaches this tuple.
 _COMPLETION_HOOKS = (_endpoint_hooks._CompletionHook,)
 
 
@@ -252,15 +250,7 @@ def _patched_endpoint(patch_hook):
         is_chat = patch_hook in _CHAT_COMPLETION_HOOKS
         is_response = patch_hook in _RESPONSE_HOOKS
         is_completion = patch_hook in _COMPLETION_HOOKS
-        if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
-            # Raw-response streaming skips the normal trace path; still dispatch so AppSec listeners fire.
-            if is_chat:
-                core.dispatch("openai.chat.completions.create.before", (kwargs,), allow_raise=True)
-            elif is_response:
-                core.dispatch("openai.responses.create.before", (kwargs,), allow_raise=True)
-            elif is_completion:
-                core.dispatch("openai.completions.create.before", (kwargs,), allow_raise=True)
-            return func(*args, **kwargs)
+        is_raw_streaming = kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False)
 
         integration = openai._datadog_integration
         g = _traced_endpoint(patch_hook, integration, instance, args, kwargs)
@@ -278,7 +268,7 @@ def _patched_endpoint(patch_hook):
             if event:
                 core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
             resp = func(*args, **kwargs)
-            if event and not kwargs.get("stream") and resp is not None:
+            if event and not is_raw_streaming and not kwargs.get("stream") and resp is not None:
                 core.dispatch(f"{event}.after", (kwargs, resp), allow_raise=True)
         except BaseException as e:
             err = e
@@ -420,16 +410,38 @@ def _patched_endpoint_async(patch_hook):
         is_response = patch_hook in _RESPONSE_HOOKS
         is_completion = patch_hook in _COMPLETION_HOOKS
         if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
-            # Raw-response streaming must still fire .before events (same logic as sync path).
-            # DDBlockException propagates naturally here; unlike the normal async path below
-            # there is no unawaited coroutine to clean up since result is not yet created.
+            event = ""
             if is_chat:
-                core.dispatch("openai.chat.completions.create.before", (kwargs,), allow_raise=True)
+                event = "openai.chat.completions.create"
             elif is_response:
-                core.dispatch("openai.responses.create.before", (kwargs,), allow_raise=True)
+                event = "openai.responses.create"
             elif is_completion:
-                core.dispatch("openai.completions.create.before", (kwargs,), allow_raise=True)
-            return func(*args, **kwargs)
+                event = "openai.completions.create"
+
+            async def async_wrapper_raw():
+                integration = openai._datadog_integration
+                g = _traced_endpoint(patch_hook, integration, instance, args, kwargs)
+                g.send(None)
+                resp, err = None, None
+                override_return = None
+                try:
+                    if event:
+                        core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
+                    resp = await func(*args, **kwargs)
+                except BaseException as e:
+                    err = e
+                    raise
+                finally:
+                    send_resp = await _maybe_preparse_async_response(resp, err)
+                    try:
+                        g.send((send_resp, err))
+                    except StopIteration as e:
+                        if err is None:
+                            override_return = e.value
+                if override_return is not None:
+                    return override_return
+
+            return async_wrapper_raw()
         result = func(*args, **kwargs)
         # Detect AsyncPaginator objects (have both __aiter__ and __await__).
         # These must be returned directly (not awaited) to preserve iteration behavior.

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -274,13 +274,19 @@ def _patched_endpoint(patch_hook):
             err = e
             raise
         finally:
+            # For raw streaming, pass resp=None so _traced_endpoint always calls
+            # span.finish() instead of trying to wrap a streaming response it
+            # cannot consume.  The real SDK response is returned directly below.
+            send_resp = None if is_raw_streaming else resp
             try:
-                g.send((resp, err))
+                g.send((send_resp, err))
             except StopIteration as e:
                 if err is None:
                     # This return takes priority over the implicit None return
                     override_return = e.value
 
+        if is_raw_streaming:
+            return resp
         if override_return is not None:
             return override_return
 
@@ -423,23 +429,24 @@ def _patched_endpoint_async(patch_hook):
                 g = _traced_endpoint(patch_hook, integration, instance, args, kwargs)
                 g.send(None)
                 resp, err = None, None
-                override_return = None
                 try:
                     if event:
+                        # No coroutine to close on DDBlockException here: func has not
+                        # been called yet, unlike the normal async path where result is
+                        # created before async_wrapper runs.
                         core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
                     resp = await func(*args, **kwargs)
                 except BaseException as e:
                     err = e
                     raise
                 finally:
-                    send_resp = await _maybe_preparse_async_response(resp, err)
+                    # Pass resp=None so _traced_endpoint calls span.finish() immediately
+                    # rather than wrapping the raw streaming response it cannot consume.
                     try:
-                        g.send((send_resp, err))
-                    except StopIteration as e:
-                        if err is None:
-                            override_return = e.value
-                if override_return is not None:
-                    return override_return
+                        g.send((None, err))
+                    except StopIteration:
+                        pass
+                return resp
 
             return async_wrapper_raw()
         result = func(*args, **kwargs)

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -90,6 +90,10 @@ _RESPONSE_HOOKS = (
     _endpoint_hooks._ResponseParseHook,
 )
 
+# _CompletionWithRawResponseHook is intentionally excluded: it takes the early-return path
+# at the top of _patched_endpoint/_patched_endpoint_async and never reaches this tuple.
+_COMPLETION_HOOKS = (_endpoint_hooks._CompletionHook,)
+
 
 def patch():
     if getattr(openai, "__datadog_patch", False):
@@ -245,12 +249,20 @@ def _patched_endpoint(patch_hook):
         ):
             kwargs[OPENAI_WITH_RAW_RESPONSE_ARG] = True
             return func(*args, **kwargs)
+        is_chat = patch_hook in _CHAT_COMPLETION_HOOKS
+        is_response = patch_hook in _RESPONSE_HOOKS
+        is_completion = patch_hook in _COMPLETION_HOOKS
         if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
+            # Raw-response streaming skips the normal trace path; still dispatch so AppSec listeners fire.
+            if is_chat:
+                core.dispatch("openai.chat.completions.create.before", (kwargs,), allow_raise=True)
+            elif is_response:
+                core.dispatch("openai.responses.create.before", (kwargs,), allow_raise=True)
+            elif is_completion:
+                core.dispatch("openai.completions.create.before", (kwargs,), allow_raise=True)
             return func(*args, **kwargs)
 
         integration = openai._datadog_integration
-        is_chat = patch_hook in _CHAT_COMPLETION_HOOKS
-        is_response = patch_hook in _RESPONSE_HOOKS
         g = _traced_endpoint(patch_hook, integration, instance, args, kwargs)
         g.send(None)
         resp, err = None, None
@@ -260,6 +272,8 @@ def _patched_endpoint(patch_hook):
             event = "openai.chat.completions.create"
         elif is_response:
             event = "openai.responses.create"
+        elif is_completion:
+            event = "openai.completions.create"
         try:
             if event:
                 core.dispatch(f"{event}.before", (kwargs,), allow_raise=True)
@@ -402,11 +416,20 @@ def _patched_endpoint_async(patch_hook):
         ):
             kwargs[OPENAI_WITH_RAW_RESPONSE_ARG] = True
             return func(*args, **kwargs)
-        if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
-            return func(*args, **kwargs)
-
         is_chat = patch_hook in _CHAT_COMPLETION_HOOKS
         is_response = patch_hook in _RESPONSE_HOOKS
+        is_completion = patch_hook in _COMPLETION_HOOKS
+        if kwargs.pop(OPENAI_WITH_RAW_RESPONSE_ARG, False) and kwargs.get("stream", False):
+            # Raw-response streaming must still fire .before events (same logic as sync path).
+            # DDBlockException propagates naturally here; unlike the normal async path below
+            # there is no unawaited coroutine to clean up since result is not yet created.
+            if is_chat:
+                core.dispatch("openai.chat.completions.create.before", (kwargs,), allow_raise=True)
+            elif is_response:
+                core.dispatch("openai.responses.create.before", (kwargs,), allow_raise=True)
+            elif is_completion:
+                core.dispatch("openai.completions.create.before", (kwargs,), allow_raise=True)
+            return func(*args, **kwargs)
         result = func(*args, **kwargs)
         # Detect AsyncPaginator objects (have both __aiter__ and __await__).
         # These must be returned directly (not awaited) to preserve iteration behavior.
@@ -424,6 +447,8 @@ def _patched_endpoint_async(patch_hook):
                 event = "openai.chat.completions.create"
             elif is_response:
                 event = "openai.responses.create"
+            elif is_completion:
+                event = "openai.completions.create"
             try:
                 if event:
                     try:

--- a/releasenotes/notes/appsec-openai-llm-business-logic-events-490ea63c3f2e43ad.yaml
+++ b/releasenotes/notes/appsec-openai-llm-business-logic-events-490ea63c3f2e43ad.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    AppSec: Detect OpenAI LLM usage within API endpoints. When AppSec is enabled and an OpenAI
+    ``chat.completions``, ``completions``, or ``responses`` call is made during a web request,
+    the WAF address ``server.business_logic.llm.event`` is emitted with the provider and model
+    name. This enables WAF rules to tag the trace with ``appsec.events.llm.call.provider`` and
+    ``appsec.events.llm.call.model``, surfacing LLM-backed endpoints in the API Endpoint Catalog.
+    Supports both sync and async OpenAI clients, Azure OpenAI (``engine`` kwarg), and streaming.
+    Only the first LLM call per request is recorded (endpoint-level detection, not per-invocation).

--- a/tests/appsec/appsec/rules-llm.json
+++ b/tests/appsec/appsec/rules-llm.json
@@ -1,0 +1,52 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "rules_llm"
+  },
+  "rules": [
+    {
+      "id": "llm-001-000",
+      "name": "LLM call",
+      "tags": {
+        "type": "llm.event",
+        "category": "business_logic",
+        "module": "business_logic"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.business_logic.llm.event",
+                "key_path": [
+                  "provider"
+                ]
+              }
+            ]
+          },
+          "operator": "exists"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": true,
+        "attributes": {
+          "appsec.events.llm.call.provider": {
+            "address": "server.business_logic.llm.event",
+            "key_path": [
+              "provider"
+            ]
+          },
+          "appsec.events.llm.call.model": {
+            "address": "server.business_logic.llm.event",
+            "key_path": [
+              "model"
+            ]
+          }
+        }
+      },
+      "on_match": []
+    }
+  ]
+}

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -761,6 +761,7 @@ CUSTOM_RULE_METHOD = [
                                     {"address": "server.business_logic.payment.cancellation", "key_path": ["id"]},
                                     {"address": "server.business_logic.payment.failure", "key_path": ["id"]},
                                     {"address": "server.business_logic.payment.success", "key_path": ["id"]},
+                                    {"address": "server.business_logic.llm.event", "key_path": ["provider"]},
                                 ],
                                 "type": "string",
                                 "value": "stripe",
@@ -811,6 +812,7 @@ def test_required_addresses():
         "server.business_logic.payment.creation",
         "server.business_logic.payment.success",
         "server.business_logic.payment.failure",
+        "server.business_logic.llm.event",
         "usr.id",
         "usr.login",
     }

--- a/tests/appsec/rules.py
+++ b/tests/appsec/rules.py
@@ -17,6 +17,7 @@ RULES_EXPLOIT_PREVENTION_BLOCKING = os.path.join(ROOT_DIR, "rules-rasp-blocking.
 RULES_EXPLOIT_PREVENTION_REDIRECTING = os.path.join(ROOT_DIR, "rules-rasp-redirecting.json")
 RULES_EXPLOIT_PREVENTION_DISABLED = os.path.join(ROOT_DIR, "rules-rasp-disabled.json")
 RULES_TRACE_TAGGING = os.path.join(ROOT_DIR, "rules-trace-tagging.json")
+RULES_LLM = os.path.join(ROOT_DIR, "rules-llm.json")
 
 RESPONSE_CUSTOM_JSON = os.path.join(ROOT_DIR, "response-custom.json")
 RESPONSE_CUSTOM_HTML = os.path.join(ROOT_DIR, "response-custom.html")

--- a/tests/contrib/openai/test_openai_appsec_llm_events.py
+++ b/tests/contrib/openai/test_openai_appsec_llm_events.py
@@ -1,0 +1,563 @@
+"""Unit and integration tests for the AppSec OpenAI LLM business logic events handler.
+
+Tests verify that:
+- OpenAI chat/completions/responses calls dispatch the correct core events.
+- The AppSec handler calls call_waf_callback with the expected LLM event data.
+- No WAF call is made when there is no active ASM context.
+- Azure OpenAI (engine kwarg) is handled correctly.
+- WAF exceptions do not propagate to the caller.
+- Streaming calls still emit the before event.
+- Async paths dispatch correctly.
+- Only the first LLM call per request reaches the WAF (PERSISTENT_ADDRESSES dedup).
+- A real ASM context + WAF rule sets the expected span tags.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from ddtrace.internal import core
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the handler function
+# ---------------------------------------------------------------------------
+
+
+class TestOnOpenAILlmCall:
+    def test_calls_waf_callback_with_provider_and_model(self):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+        ):
+            _on_openai_llm_call({"model": "gpt-4.1", "messages": [{"role": "user", "content": "hi"}]})
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}})
+
+    def test_no_waf_call_when_no_asm_context(self):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=False),
+            patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+        ):
+            _on_openai_llm_call({"model": "gpt-4.1"})
+
+        mock_waf.assert_not_called()
+
+    def test_missing_model_passed_as_empty_string(self):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+        ):
+            _on_openai_llm_call({})
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": ""}})
+
+    def test_none_model_passed_as_empty_string(self):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+        ):
+            _on_openai_llm_call({"model": None})
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": ""}})
+
+    def test_engine_kwarg_used_for_azure(self):
+        """Azure OpenAI passes 'engine' instead of 'model'."""
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+        ):
+            _on_openai_llm_call({"engine": "my-gpt4-deployment"})
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": "my-gpt4-deployment"}})
+
+    def test_model_takes_precedence_over_engine(self):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+        ):
+            _on_openai_llm_call({"model": "gpt-4.1", "engine": "other"})
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}})
+
+    def test_waf_exception_does_not_propagate(self):
+        """Exceptions from call_waf_callback must not bubble up to the OpenAI caller."""
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch(
+                "ddtrace.appsec._contrib.openai.handlers.call_waf_callback",
+                side_effect=RuntimeError("waf exploded"),
+            ),
+        ):
+            # Must not raise
+            _on_openai_llm_call({"model": "gpt-4.1"})
+
+
+# ---------------------------------------------------------------------------
+# Mock HTTP transports
+# ---------------------------------------------------------------------------
+
+
+def _fake_chat_completion_response() -> httpx.Response:
+    body = json.dumps(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "gpt-4.1",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    ).encode()
+    return httpx.Response(200, headers={"content-type": "application/json"}, content=body)
+
+
+def _fake_completion_response() -> httpx.Response:
+    body = json.dumps(
+        {
+            "id": "cmpl-test",
+            "object": "text_completion",
+            "created": 0,
+            "model": "gpt-3.5-turbo-instruct",
+            "choices": [{"text": "ok", "index": 0, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    ).encode()
+    return httpx.Response(200, headers={"content-type": "application/json"}, content=body)
+
+
+def _fake_responses_response() -> httpx.Response:
+    body = json.dumps(
+        {
+            "id": "resp-test",
+            "object": "response",
+            "created_at": 0,
+            "model": "gpt-4.1",
+            "status": "completed",
+            "output": [
+                {
+                    "id": "msg-test",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+                }
+            ],
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+            "metadata": {},
+            "parallel_tool_calls": True,
+            "previous_response_id": None,
+            "temperature": 1.0,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": 1.0,
+        }
+    ).encode()
+    return httpx.Response(200, headers={"content-type": "application/json"}, content=body)
+
+
+def _fake_stream_chunks() -> bytes:
+    chunks = [
+        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"delta": {"role": "assistant"}}]},
+        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"delta": {"content": "hi"}}]},
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+        },
+    ]
+    lines = [b"data: " + json.dumps(c).encode() + b"\n\n" for c in chunks]
+    lines.append(b"data: [DONE]\n\n")
+    return b"".join(lines)
+
+
+class _SyncMockTransport(httpx.BaseTransport):
+    def __init__(self, response_factory):
+        self._factory = response_factory
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return self._factory()
+
+
+class _AsyncMockTransport(httpx.AsyncBaseTransport):
+    def __init__(self, response_factory):
+        self._factory = response_factory
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return self._factory()
+
+
+@pytest.fixture
+def openai_sdk():
+    from ddtrace.contrib.internal.openai.patch import patch as openai_patch
+    from ddtrace.contrib.internal.openai.patch import unpatch as openai_unpatch
+    from tests.utils import override_env
+
+    with override_env({"OPENAI_API_KEY": "<test-key>"}):
+        openai_patch()
+        import openai
+
+        try:
+            yield openai
+        finally:
+            openai_unpatch()
+
+
+# ---------------------------------------------------------------------------
+# Tests for core event dispatch (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestCoreEventDispatch:
+    """Test that the OpenAI patch dispatches the correct core events."""
+
+    def test_chat_completions_dispatches_before_event(self, openai_sdk):
+        received = []
+        core.on("openai.chat.completions.create.before", received.append)
+        try:
+            client = openai_sdk.OpenAI(
+                api_key="<test-key>",
+                http_client=httpx.Client(transport=_SyncMockTransport(_fake_chat_completion_response)),
+            )
+            client.chat.completions.create(model="gpt-4.1", messages=[{"role": "user", "content": "hi"}])
+        finally:
+            core.reset_listeners("openai.chat.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"
+
+    def test_completions_dispatches_before_event(self, openai_sdk):
+        received = []
+        core.on("openai.completions.create.before", received.append)
+        try:
+            client = openai_sdk.OpenAI(
+                api_key="<test-key>",
+                http_client=httpx.Client(transport=_SyncMockTransport(_fake_completion_response)),
+            )
+            client.completions.create(model="gpt-3.5-turbo-instruct", prompt="say hi")
+        finally:
+            core.reset_listeners("openai.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-3.5-turbo-instruct"
+
+    def test_responses_dispatches_before_event(self, openai_sdk):
+        try:
+            import openai.resources.responses  # noqa: F401
+        except ImportError:
+            pytest.skip("openai.resources.responses not available")
+
+        received = []
+        core.on("openai.responses.create.before", received.append)
+        try:
+            client = openai_sdk.OpenAI(
+                api_key="<test-key>",
+                http_client=httpx.Client(transport=_SyncMockTransport(_fake_responses_response)),
+            )
+            client.responses.create(model="gpt-4.1", input="hi")
+        finally:
+            core.reset_listeners("openai.responses.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"
+
+    def test_streaming_chat_completions_dispatches_before_event(self, openai_sdk):
+        """stream=True still fires the .before event."""
+        received = []
+        core.on("openai.chat.completions.create.before", received.append)
+        try:
+            client = openai_sdk.OpenAI(
+                api_key="<test-key>",
+                http_client=httpx.Client(
+                    transport=_SyncMockTransport(
+                        lambda: httpx.Response(
+                            200,
+                            headers={"content-type": "text/event-stream"},
+                            stream=httpx.ByteStream(_fake_stream_chunks()),
+                        )
+                    )
+                ),
+            )
+            stream = client.chat.completions.create(
+                model="gpt-4.1", messages=[{"role": "user", "content": "hi"}], stream=True
+            )
+            for _ in stream:
+                pass
+        finally:
+            core.reset_listeners("openai.chat.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"
+
+
+# ---------------------------------------------------------------------------
+# Tests for core event dispatch (async)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCoreEventDispatch:
+    """Test that async OpenAI methods also dispatch .before events."""
+
+    def test_async_chat_completions_dispatches_before_event(self, openai_sdk):
+        received = []
+        core.on("openai.chat.completions.create.before", received.append)
+        try:
+
+            async def run():
+                client = openai_sdk.AsyncOpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.AsyncClient(transport=_AsyncMockTransport(_fake_chat_completion_response)),
+                )
+                await client.chat.completions.create(model="gpt-4.1", messages=[{"role": "user", "content": "hi"}])
+
+            asyncio.run(run())
+        finally:
+            core.reset_listeners("openai.chat.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"
+
+    def test_async_completions_dispatches_before_event(self, openai_sdk):
+        received = []
+        core.on("openai.completions.create.before", received.append)
+        try:
+
+            async def run():
+                client = openai_sdk.AsyncOpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.AsyncClient(transport=_AsyncMockTransport(_fake_completion_response)),
+                )
+                await client.completions.create(model="gpt-3.5-turbo-instruct", prompt="hi")
+
+            asyncio.run(run())
+        finally:
+            core.reset_listeners("openai.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-3.5-turbo-instruct"
+
+    def test_async_responses_dispatches_before_event(self, openai_sdk):
+        try:
+            import openai.resources.responses  # noqa: F401
+        except ImportError:
+            pytest.skip("openai.resources.responses not available")
+
+        received = []
+        core.on("openai.responses.create.before", received.append)
+        try:
+
+            async def run():
+                client = openai_sdk.AsyncOpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.AsyncClient(transport=_AsyncMockTransport(_fake_responses_response)),
+                )
+                await client.responses.create(model="gpt-4.1", input="hi")
+
+            asyncio.run(run())
+        finally:
+            core.reset_listeners("openai.responses.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"
+
+
+# ---------------------------------------------------------------------------
+# Integration: handler + WAF callback chain
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerIntegration:
+    """Test _on_openai_llm_call is triggered by the .before event, calling call_waf_callback."""
+
+    def test_chat_completions_calls_waf_callback(self, openai_sdk):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        core.on("openai.chat.completions.create.before", _on_openai_llm_call)
+        try:
+            with (
+                patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+                patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+            ):
+                client = openai_sdk.OpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.Client(transport=_SyncMockTransport(_fake_chat_completion_response)),
+                )
+                client.chat.completions.create(model="gpt-4.1", messages=[{"role": "user", "content": "hi"}])
+        finally:
+            core.reset_listeners("openai.chat.completions.create.before")
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}})
+
+    def test_completions_calls_waf_callback(self, openai_sdk):
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        core.on("openai.completions.create.before", _on_openai_llm_call)
+        try:
+            with (
+                patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+                patch("ddtrace.appsec._contrib.openai.handlers.call_waf_callback") as mock_waf,
+            ):
+                client = openai_sdk.OpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.Client(transport=_SyncMockTransport(_fake_completion_response)),
+                )
+                client.completions.create(model="gpt-3.5-turbo-instruct", prompt="hi")
+        finally:
+            core.reset_listeners("openai.completions.create.before")
+
+        mock_waf.assert_called_once_with({"LLM_EVENT": {"provider": "openai", "model": "gpt-3.5-turbo-instruct"}})
+
+    def test_handler_calls_waf_callback_on_each_invocation(self):
+        """The handler forwards every LLM call to call_waf_callback; WAF processor dedup is downstream."""
+        from ddtrace.appsec._contrib.openai.handlers import _on_openai_llm_call
+
+        waf_calls = []
+        with (
+            patch("ddtrace.appsec._contrib.openai.handlers.in_asm_context", return_value=True),
+            patch(
+                "ddtrace.appsec._contrib.openai.handlers.call_waf_callback", side_effect=lambda d: waf_calls.append(d)
+            ),
+        ):
+            _on_openai_llm_call({"model": "gpt-4.1"})
+            _on_openai_llm_call({"model": "o1-mini"})
+
+        assert len(waf_calls) == 2
+        assert waf_calls[0] == {"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}}
+        assert waf_calls[1] == {"LLM_EVENT": {"provider": "openai", "model": "o1-mini"}}
+
+
+# ---------------------------------------------------------------------------
+# Integration: real ASM context + WAF rule → span tags
+# ---------------------------------------------------------------------------
+
+
+class TestWAFIntegration:
+    """Verify the full path: call_waf_callback → WAF rule → span meta tags."""
+
+    def test_waf_sets_span_tags_from_llm_event(self):
+        from ddtrace.appsec._asm_request_context import call_waf_callback
+        from tests.appsec.rules import RULES_LLM
+        from tests.appsec.utils import asm_context
+
+        config = {"_asm_static_rule_file": RULES_LLM, "_asm_enabled": True}
+        with asm_context(config=config) as span:
+            call_waf_callback({"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}})
+
+        assert span.get_tag("appsec.events.llm.call.provider") == "openai"
+        assert span.get_tag("appsec.events.llm.call.model") == "gpt-4.1"
+
+    def test_waf_keep_set_on_llm_event(self):
+        """The LLM rule has keep:true, so sampling priority must be USER_KEEP."""
+        from ddtrace.appsec._asm_request_context import call_waf_callback
+        from ddtrace.constants import USER_KEEP
+        from tests.appsec.rules import RULES_LLM
+        from tests.appsec.utils import asm_context
+
+        config = {"_asm_static_rule_file": RULES_LLM, "_asm_enabled": True}
+        with asm_context(config=config) as span:
+            call_waf_callback({"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}})
+
+        assert span.context.sampling_priority == USER_KEEP
+
+    def test_waf_dedup_only_first_llm_call_per_request(self):
+        """PERSISTENT_ADDRESSES dedup: only the first LLM call's model is surfaced on the span."""
+        from ddtrace.appsec._asm_request_context import call_waf_callback
+        from tests.appsec.rules import RULES_LLM
+        from tests.appsec.utils import asm_context
+
+        config = {"_asm_static_rule_file": RULES_LLM, "_asm_enabled": True}
+        with asm_context(config=config) as span:
+            call_waf_callback({"LLM_EVENT": {"provider": "openai", "model": "gpt-4.1"}})
+            call_waf_callback({"LLM_EVENT": {"provider": "openai", "model": "o1-mini"}})
+
+        # Only the first call's model reaches the WAF rule (persistent address dedup).
+        assert span.get_tag("appsec.events.llm.call.model") == "gpt-4.1"
+
+
+class TestRawResponseStreaming:
+    """Test that raw-response + stream=True still fires the .before event."""
+
+    def test_raw_response_streaming_dispatches_before_event(self, openai_sdk):
+        received = []
+        core.on("openai.completions.create.before", received.append)
+        try:
+            client = openai_sdk.OpenAI(
+                api_key="<test-key>",
+                http_client=httpx.Client(
+                    transport=_SyncMockTransport(
+                        lambda: httpx.Response(
+                            200,
+                            headers={"content-type": "text/event-stream"},
+                            stream=httpx.ByteStream(
+                                b"data: "
+                                b'{"id":"cmpl-test","object":"text_completion",'
+                                b'"choices":[{"text":"hi","finish_reason":null,"index":0}],'
+                                b'"model":"gpt-3.5-turbo-instruct"}\n\n'
+                                b"data: [DONE]\n\n"
+                            ),
+                        )
+                    )
+                ),
+            )
+            raw = client.completions.with_raw_response.create(model="gpt-3.5-turbo-instruct", prompt="hi", stream=True)
+            for _ in raw.parse():
+                pass
+        except Exception:
+            pass  # stream parsing may raise; .before was already dispatched
+        finally:
+            core.reset_listeners("openai.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-3.5-turbo-instruct"
+
+    def test_raw_response_chat_streaming_dispatches_before_event(self, openai_sdk):
+        received = []
+        core.on("openai.chat.completions.create.before", received.append)
+        try:
+            client = openai_sdk.OpenAI(
+                api_key="<test-key>",
+                http_client=httpx.Client(
+                    transport=_SyncMockTransport(
+                        lambda: httpx.Response(
+                            200,
+                            headers={"content-type": "text/event-stream"},
+                            stream=httpx.ByteStream(_fake_stream_chunks()),
+                        )
+                    )
+                ),
+            )
+            raw = client.chat.completions.with_raw_response.create(
+                model="gpt-4.1", messages=[{"role": "user", "content": "hi"}], stream=True
+            )
+            for _ in raw.parse():
+                pass
+        except Exception:
+            pass
+        finally:
+            core.reset_listeners("openai.chat.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"

--- a/tests/contrib/openai/test_openai_appsec_llm_events.py
+++ b/tests/contrib/openai/test_openai_appsec_llm_events.py
@@ -181,12 +181,12 @@ def _fake_responses_response() -> httpx.Response:
 
 def _fake_stream_chunks() -> bytes:
     chunks = [
-        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"delta": {"role": "assistant"}}]},
-        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"delta": {"content": "hi"}}]},
+        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {"role": "assistant"}}]},
+        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {"content": "hi"}}]},
         {
             "id": "chatcmpl-test",
             "object": "chat.completion.chunk",
-            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
         },
     ]
     lines = [b"data: " + json.dumps(c).encode() + b"\n\n" for c in chunks]

--- a/tests/contrib/openai/test_openai_appsec_llm_events.py
+++ b/tests/contrib/openai/test_openai_appsec_llm_events.py
@@ -181,8 +181,16 @@ def _fake_responses_response() -> httpx.Response:
 
 def _fake_stream_chunks() -> bytes:
     chunks = [
-        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {"role": "assistant"}}]},
-        {"id": "chatcmpl-test", "object": "chat.completion.chunk", "choices": [{"index": 0, "delta": {"content": "hi"}}]},
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"role": "assistant"}}],
+        },
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"content": "hi"}}],
+        },
         {
             "id": "chatcmpl-test",
             "object": "chat.completion.chunk",

--- a/tests/contrib/openai/test_openai_appsec_llm_events.py
+++ b/tests/contrib/openai/test_openai_appsec_llm_events.py
@@ -569,3 +569,77 @@ class TestRawResponseStreaming:
 
         assert len(received) == 1
         assert received[0].get("model") == "gpt-4.1"
+
+    def test_async_raw_response_streaming_dispatches_before_event_once(self, openai_sdk):
+        """Async raw-response streaming must dispatch .before exactly once (no double dispatch)."""
+        received = []
+        core.on("openai.completions.create.before", received.append)
+        try:
+
+            async def run():
+                client = openai_sdk.AsyncOpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.AsyncClient(
+                        transport=_AsyncMockTransport(
+                            lambda: httpx.Response(
+                                200,
+                                headers={"content-type": "text/event-stream"},
+                                stream=httpx.ByteStream(
+                                    b"data: "
+                                    b'{"id":"cmpl-test","object":"text_completion",'
+                                    b'"choices":[{"text":"hi","finish_reason":null,"index":0}],'
+                                    b'"model":"gpt-3.5-turbo-instruct"}\n\n'
+                                    b"data: [DONE]\n\n"
+                                ),
+                            )
+                        )
+                    ),
+                )
+                raw = await client.completions.with_raw_response.create(
+                    model="gpt-3.5-turbo-instruct", prompt="hi", stream=True
+                )
+                async for _ in raw.parse():
+                    pass
+
+            asyncio.run(run())
+        except Exception:
+            pass  # stream parsing may raise; .before was already dispatched
+        finally:
+            core.reset_listeners("openai.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-3.5-turbo-instruct"
+
+    def test_async_raw_response_chat_streaming_dispatches_before_event_once(self, openai_sdk):
+        """Async raw-response chat streaming must dispatch .before exactly once."""
+        received = []
+        core.on("openai.chat.completions.create.before", received.append)
+        try:
+
+            async def run():
+                client = openai_sdk.AsyncOpenAI(
+                    api_key="<test-key>",
+                    http_client=httpx.AsyncClient(
+                        transport=_AsyncMockTransport(
+                            lambda: httpx.Response(
+                                200,
+                                headers={"content-type": "text/event-stream"},
+                                stream=httpx.ByteStream(_fake_stream_chunks()),
+                            )
+                        )
+                    ),
+                )
+                raw = await client.chat.completions.with_raw_response.create(
+                    model="gpt-4.1", messages=[{"role": "user", "content": "hi"}], stream=True
+                )
+                async for _ in raw.parse():
+                    pass
+
+            asyncio.run(run())
+        except Exception:
+            pass
+        finally:
+            core.reset_listeners("openai.chat.completions.create.before")
+
+        assert len(received) == 1
+        assert received[0].get("model") == "gpt-4.1"


### PR DESCRIPTION
APPSEC-68345

## Description

Emit `server.business_logic.llm.event` to the WAF when AppSec is enabled and an OpenAI `chat.completions`, `completions`, or `responses` call is made during a web request. Enables WAF rules to tag LLM-backed endpoints in the API Endpoint Catalog.

- New `ddtrace/appsec/_contrib/openai/` listener dispatches the WAF address with provider and model on each call
- `_constants.py` registers `LLM_EVENT` as a persistent WAF address
- `patch.py` fixes raw-response streaming early-return path to still fire AppSec `.before` events; adds `completions` endpoint dispatch

## Testing

`tests/contrib/openai/test_openai_appsec_llm_events.py` covers sync/async, chat/completions/responses, Azure OpenAI (`engine` kwarg), and streaming paths.

Also validated with https://github.com/DataDog/system-tests/pull/7127

## Risks

No-op when AppSec is off or outside a request context. WAF deduplicates persistent addresses so only the first LLM call per request is surfaced (by design).