### PR TITLE
docs(llmobs): correct DD_LLMOBS_SAMPLE_RATE version_added

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -419,7 +419,7 @@ Traces
          metrics are always computed from 100% of traffic regardless of the configured rate.
 
      version_added:
-        v4.12.0:
+        v4.11.0:
 
 Trace Context propagation
 -------------------------


### PR DESCRIPTION
## Description

#18392 added the `DD_LLMOBS_SAMPLE_RATE` configuration entry to `docs/configuration.rst` with `version_added: v4.12.0`. However, that change is being backported to 4.11 (#18569), so the feature will actually ship in v4.11.0, not v4.12.0.

This corrects the documented `version_added` to `v4.11.0`.

## Testing

Docs-only change.

Claude session: `1003a255-7e91-4f15-b863-883820845ee3`
Resume: `claude --resume 1003a255-7e91-4f15-b863-883820845ee3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)