### PR TITLE
chore(internal): implement as_ref and from_vec for PyBackedString

### DIFF
--- a/src/native/py_string.rs
+++ b/src/native/py_string.rs
@@ -193,6 +193,12 @@ impl serde::Serialize for PyBackedString {
     }
 }
 
+impl AsRef<str> for PyBackedString {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
 impl std::borrow::Borrow<str> for PyBackedString {
     fn borrow(&self) -> &str {
         self.deref()
@@ -241,6 +247,18 @@ pub struct Bytes(Vec<u8>);
 impl SpanBytes for Bytes {
     fn from_static_bytes(value: &'static [u8]) -> Self {
         Self(value.to_vec())
+    }
+}
+
+impl Bytes {
+    pub(crate) fn from_vec(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}
+
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 


### PR DESCRIPTION
## Description

We'll need these later for integrating with the libdatadog trace buffer.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
