### PR TITLE
fix(ai_guard): evaluate non-text Bedrock content in Strands integration

### DIFF
--- a/ddtrace/appsec/ai_guard/integrations/strands.py
+++ b/ddtrace/appsec/ai_guard/integrations/strands.py
@@ -79,34 +79,25 @@ _BLOCKED_TOOL_MSG = "[DATADOG AI GUARD] '{}' has been canceled for security reas
 _INVOCATION_CTX_KEY = "_dd_ai_guard_ctx"
 
 
-# Bedrock Converse ``ContentBlock``/``ToolResultContent`` entries that are
-# either handled explicitly elsewhere (tool plumbing) or carry no
-# model-visible payload (caching/reasoning control blocks). Everything else is
-# a model-visible modality (image, document, video, guardContent, ...).
+# Keys handled elsewhere (tool plumbing) or control-only (caching/reasoning);
+# everything else is a model-visible modality (image, document, video, ...).
 _HANDLED_CONTENT_KEYS = frozenset({"text", "toolUse", "toolResult", "json"})
 _CONTROL_CONTENT_KEYS = frozenset({"cachePoint", "reasoningContent"})
 
 # AIDEV-NOTE: APMSP-3089 — non-text content must NOT be silently dropped.
-# Bedrock/Strands content is a union (text, image, document, video,
-# guardContent, ...). Previously only text/toolUse/text+json tool results were
-# extracted; any other block vanished. A document/image-only prompt then
-# produced zero AI Guard messages, so ``_on_before_model_call_base`` skipped
-# evaluation entirely (``if ai_guard_messages``) while the model still received
-# the uninspected content — an AI Guard bypass. We now emit a placeholder
-# marker for every model-visible non-text block so evaluation always triggers
-# and the presence of the modality is signalled to the service.
+# Dropping every non-text block made a document/image-only prompt produce zero
+# AI Guard messages, so evaluation was skipped while the model saw uninspected
+# content (a bypass). We emit a placeholder marker for each model-visible
+# non-text block so evaluation always triggers.
 _NON_TEXT_CONTENT_MARKER = "[non-text content: {kind}]"
 
 
 def _block_to_text(block: Any) -> str | None:
-    """Return the text representation of a single Bedrock Converse content block.
+    """Return the text for a Bedrock Converse content block.
 
-    - ``text`` blocks return their text.
-    - ``guardContent`` blocks unwrap their inner text when present.
-    - Other model-visible modalities (image, document, video, ...) return a
-      placeholder marker so the block is represented rather than dropped.
-    - Blocks handled elsewhere (``toolUse``/``toolResult``) or control-only
-      blocks (``cachePoint``/``reasoningContent``) return ``None``.
+    ``text`` returns its text; ``guardContent`` unwraps inner text; other
+    model-visible modalities return a placeholder marker; handled
+    (``toolUse``/``toolResult``) or control-only blocks return ``None``.
     """
     if not isinstance(block, dict):
         return None
@@ -129,10 +120,8 @@ def _block_to_text(block: Any) -> str | None:
 def _tool_result_text(tool_result: dict) -> str:
     """Extract text from a Bedrock Converse ToolResult.
 
-    ``ToolResultContent`` entries may contain ``text`` or ``json`` keys. Other
-    modalities (image, document, video, ...) are represented by a placeholder
-    marker so non-text tool results are never converted to an empty string and
-    silently excluded from evaluation (APMSP-3089).
+    ``text``/``json`` entries are extracted; other modalities return a
+    placeholder marker rather than an empty string (APMSP-3089).
     """
     texts = []
     for entry in tool_result.get("content", []):
@@ -183,11 +172,9 @@ def _convert_strands_messages(
             if not isinstance(content, list):
                 continue
 
-            # Collect text from all content blocks in this message. Non-text
-            # model-visible modalities (image, document, video, ...) are
-            # represented by a placeholder marker rather than dropped, so a
-            # content-only message still produces a Message and evaluation is
-            # not skipped entirely (APMSP-3089).
+            # Non-text blocks become placeholder markers (see _block_to_text)
+            # so a content-only message still produces a Message and evaluation
+            # is not skipped (APMSP-3089).
             texts = [text for block in content if (text := _block_to_text(block)) is not None]
 
             if role == "user":

--- a/ddtrace/appsec/ai_guard/integrations/strands.py
+++ b/ddtrace/appsec/ai_guard/integrations/strands.py
@@ -79,17 +79,75 @@ _BLOCKED_TOOL_MSG = "[DATADOG AI GUARD] '{}' has been canceled for security reas
 _INVOCATION_CTX_KEY = "_dd_ai_guard_ctx"
 
 
+# Bedrock Converse ``ContentBlock``/``ToolResultContent`` entries that are
+# either handled explicitly elsewhere (tool plumbing) or carry no
+# model-visible payload (caching/reasoning control blocks). Everything else is
+# a model-visible modality (image, document, video, guardContent, ...).
+_HANDLED_CONTENT_KEYS = frozenset({"text", "toolUse", "toolResult", "json"})
+_CONTROL_CONTENT_KEYS = frozenset({"cachePoint", "reasoningContent"})
+
+# AIDEV-NOTE: APMSP-3089 — non-text content must NOT be silently dropped.
+# Bedrock/Strands content is a union (text, image, document, video,
+# guardContent, ...). Previously only text/toolUse/text+json tool results were
+# extracted; any other block vanished. A document/image-only prompt then
+# produced zero AI Guard messages, so ``_on_before_model_call_base`` skipped
+# evaluation entirely (``if ai_guard_messages``) while the model still received
+# the uninspected content — an AI Guard bypass. We now emit a placeholder
+# marker for every model-visible non-text block so evaluation always triggers
+# and the presence of the modality is signalled to the service.
+_NON_TEXT_CONTENT_MARKER = "[non-text content: {kind}]"
+
+
+def _block_to_text(block: Any) -> str | None:
+    """Return the text representation of a single Bedrock Converse content block.
+
+    - ``text`` blocks return their text.
+    - ``guardContent`` blocks unwrap their inner text when present.
+    - Other model-visible modalities (image, document, video, ...) return a
+      placeholder marker so the block is represented rather than dropped.
+    - Blocks handled elsewhere (``toolUse``/``toolResult``) or control-only
+      blocks (``cachePoint``/``reasoningContent``) return ``None``.
+    """
+    if not isinstance(block, dict):
+        return None
+    if "text" in block:
+        return str(block["text"])
+    # guardContent wraps text: {"guardContent": {"text": {"text": "..."}}}
+    guard_content = block.get("guardContent")
+    if isinstance(guard_content, dict):
+        text = guard_content.get("text")
+        if isinstance(text, dict) and isinstance(text.get("text"), str):
+            return str(text["text"])
+        return _NON_TEXT_CONTENT_MARKER.format(kind="guardContent")
+    for key in block:
+        if key in _HANDLED_CONTENT_KEYS or key in _CONTROL_CONTENT_KEYS:
+            continue
+        return _NON_TEXT_CONTENT_MARKER.format(kind=key)
+    return None
+
+
 def _tool_result_text(tool_result: dict) -> str:
     """Extract text from a Bedrock Converse ToolResult.
 
-    ToolResultContent entries may contain ``text`` or ``json`` keys.
+    ``ToolResultContent`` entries may contain ``text`` or ``json`` keys. Other
+    modalities (image, document, video, ...) are represented by a placeholder
+    marker so non-text tool results are never converted to an empty string and
+    silently excluded from evaluation (APMSP-3089).
     """
     texts = []
     for entry in tool_result.get("content", []):
+        if not isinstance(entry, dict):
+            continue
         if "text" in entry:
             texts.append(entry["text"])
         elif "json" in entry:
             texts.append(try_format_json(entry["json"]))
+        else:
+            for key in entry:
+                if key in _CONTROL_CONTENT_KEYS:
+                    continue
+                texts.append(_NON_TEXT_CONTENT_MARKER.format(kind=key))
+                break
     return " ".join(texts)
 
 
@@ -125,8 +183,12 @@ def _convert_strands_messages(
             if not isinstance(content, list):
                 continue
 
-            # Collect text from all text content blocks in this message
-            texts = [block["text"] for block in content if "text" in block]
+            # Collect text from all content blocks in this message. Non-text
+            # model-visible modalities (image, document, video, ...) are
+            # represented by a placeholder marker rather than dropped, so a
+            # content-only message still produces a Message and evaluation is
+            # not skipped entirely (APMSP-3089).
+            texts = [text for block in content if (text := _block_to_text(block)) is not None]
 
             if role == "user":
                 if texts:

--- a/releasenotes/notes/ai-guard-strands-non-text-content-fbd64fd4e01eb83a.yaml
+++ b/releasenotes/notes/ai-guard-strands-non-text-content-fbd64fd4e01eb83a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    AI Guard: This fix resolves an issue where the Strands integration silently
+    dropped non-text Bedrock content (images, documents, video), which could
+    cause evaluation to be skipped for prompts or tool results with no text.

--- a/tests/appsec/ai_guard/strands_hooks/test_strands.py
+++ b/tests/appsec/ai_guard/strands_hooks/test_strands.py
@@ -56,6 +56,25 @@ class TestToolResultText:
     def test_missing_content(self):
         assert _tool_result_text({}) == ""
 
+    def test_non_text_content_uses_placeholder(self):
+        """APMSP-3089: non-text tool result content is represented, not dropped."""
+        tr = {"content": [{"image": {"format": "png", "source": {"bytes": b"..."}}}]}
+        assert _tool_result_text(tr) == "[non-text content: image]"
+
+    def test_mixed_text_and_non_text_content(self):
+        """APMSP-3089: text is kept and non-text content is flagged."""
+        tr = {"content": [{"text": "see attached"}, {"document": {"name": "secret.pdf"}}]}
+        assert _tool_result_text(tr) == "see attached [non-text content: document]"
+
+    def test_control_content_skipped(self):
+        """cachePoint is a caching control block with no model-visible payload."""
+        tr = {"content": [{"cachePoint": {"type": "default"}}]}
+        assert _tool_result_text(tr) == ""
+
+    def test_non_dict_entry_skipped(self):
+        tr = {"content": ["not a dict", {"text": "ok"}]}
+        assert _tool_result_text(tr) == "ok"
+
 
 # ---------------------------------------------------------------------------
 # _convert_strands_messages
@@ -228,6 +247,51 @@ class TestConvertStrandsMessages:
         result = _convert_strands_messages(messages)
         assert result == []
 
+    def test_document_only_user_message(self):
+        """APMSP-3089: a document-only prompt still yields a user Message."""
+        messages = [{"role": "user", "content": [{"document": {"name": "data.pdf"}}]}]
+        result = _convert_strands_messages(messages)
+        assert result == [Message(role="user", content="[non-text content: document]")]
+
+    def test_image_only_user_message(self):
+        """APMSP-3089: an image-only prompt still yields a user Message."""
+        messages = [{"role": "user", "content": [{"image": {"format": "png", "source": {"bytes": b"x"}}}]}]
+        result = _convert_strands_messages(messages)
+        assert result == [Message(role="user", content="[non-text content: image]")]
+
+    def test_mixed_text_and_document_user_message(self):
+        """APMSP-3089: benign text and non-text content are both represented."""
+        messages = [
+            {
+                "role": "user",
+                "content": [{"text": "Please summarize"}, {"document": {"name": "data.pdf"}}],
+            }
+        ]
+        result = _convert_strands_messages(messages)
+        assert result == [Message(role="user", content="Please summarize [non-text content: document]")]
+
+    def test_guard_content_text_unwrapped(self):
+        """guardContent wrapping text is unwrapped to its inner text."""
+        messages = [{"role": "user", "content": [{"guardContent": {"text": {"text": "guarded"}}}]}]
+        result = _convert_strands_messages(messages)
+        assert result == [Message(role="user", content="guarded")]
+
+    def test_cache_point_block_ignored(self):
+        """cachePoint is a control block and produces no Message on its own."""
+        messages = [{"role": "user", "content": [{"cachePoint": {"type": "default"}}]}]
+        result = _convert_strands_messages(messages)
+        assert result == []
+
+    def test_non_text_tool_result_uses_placeholder(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [{"toolResult": {"toolUseId": "tc1", "content": [{"image": {"format": "png"}}]}}],
+            }
+        ]
+        result = _convert_strands_messages(messages)
+        assert result == [Message(role="tool", tool_call_id="tc1", content="[non-text content: image]")]
+
 
 # ---------------------------------------------------------------------------
 # _on_before_model_call_base (via BeforeModelCallEvent)
@@ -320,6 +384,33 @@ class TestBeforeModelCall:
         # Tool results should be excluded
         tool_msgs = [m for m in sent_messages if m.get("role") == "tool"]
         assert len(tool_msgs) == 0
+
+    @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+    def test_document_only_prompt_is_evaluated(self, mock_execute_request, ai_guard_strands_hook):
+        """APMSP-3089 regression: a document-only prompt must not skip evaluation."""
+        mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+        event = before_model_event(
+            messages=[{"role": "user", "content": [{"document": {"name": "malicious.pdf"}}]}],
+        )
+
+        ai_guard_strands_hook._on_before_model_call_base(event)
+
+        mock_execute_request.assert_called_once()
+        payload = mock_execute_request.call_args[0][1]
+        sent_messages = payload["data"]["attributes"]["messages"]
+        assert sent_messages == [{"role": "user", "content": "[non-text content: document]"}]
+
+    @pytest.mark.parametrize("decision", ["DENY", "ABORT"], ids=["deny", "abort"])
+    @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+    def test_document_only_prompt_can_be_blocked(self, mock_execute_request, ai_guard_strands_hook, decision):
+        """APMSP-3089 regression: a document-only prompt can be blocked, not bypassed."""
+        mock_execute_request.return_value = mock_evaluate_response(decision)
+        event = before_model_event(
+            messages=[{"role": "user", "content": [{"document": {"name": "malicious.pdf"}}]}],
+        )
+
+        with pytest.raises(AIGuardAbortError):
+            ai_guard_strands_hook._on_before_model_call_base(event)
 
 
 # ---------------------------------------------------------------------------
@@ -543,6 +634,28 @@ class TestAfterToolCall:
         assert sent_messages[2]["role"] == "tool"
         assert sent_messages[2]["tool_call_id"] == "tc1"
         assert sent_messages[2]["content"] == "result data"
+
+    @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+    def test_non_text_tool_result_included_in_payload(self, mock_execute_request, ai_guard_strands_hook):
+        """APMSP-3089 regression: non-text tool results are flagged, not sent as empty."""
+        mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+        event = after_tool_event(
+            tool_use={"toolUseId": "tc1", "name": "fetch_file", "input": {}},
+            tool_result={
+                "toolUseId": "tc1",
+                "content": [{"document": {"name": "exfil.pdf"}}],
+                "status": "success",
+            },
+            messages=[{"role": "user", "content": [{"text": "Get the file"}]}],
+        )
+
+        ai_guard_strands_hook._on_after_tool_call_base(event)
+
+        payload = mock_execute_request.call_args[0][1]
+        sent_messages = payload["data"]["attributes"]["messages"]
+        tool_msgs = [m for m in sent_messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "[non-text content: document]"
 
     @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
     def test_error_status_result(self, mock_execute_request, ai_guard_strands_hook):


### PR DESCRIPTION
## Description

**JIRA:** [APMSP-3089](https://datadoghq.atlassian.net/browse/APMSP-3089)

The AI Guard Strands integration converted Bedrock Converse messages by extracting only `text`, `toolUse`, and `text`/`json` `toolResult` blocks. Other model-visible content blocks (`image`, `document`, `video`, `guardContent`, ...) were silently dropped.

As a result, a prompt or tool result containing **only** non-text content produced zero AI Guard messages, so `_on_before_model_call_base` skipped evaluation entirely (`if ai_guard_messages`) while the model still received the uninspected content — an AI Guard bypass for multimodal/document prompt injection and data exfiltration. Non-text tool results were likewise converted to an empty string and then excluded from later `BeforeModelCall` evaluation.

This change introduces `_block_to_text()`, which represents every model-visible non-text block with a placeholder marker (`[non-text content: <kind>]`) instead of dropping it. `guardContent` text is unwrapped; control-only blocks (`cachePoint`, `reasoningContent`) are still ignored. `_tool_result_text()` applies the same handling. This guarantees a content-only message still yields an evaluable message and the presence of the modality is reported to AI Guard.

Resolves [APMSP-3089](https://datadoghq.atlassian.net/browse/APMSP-3089).

## Testing

Added unit tests in `tests/appsec/ai_guard/strands_hooks/test_strands.py`:
- `_tool_result_text`: non-text content → placeholder, mixed text/non-text, control-block and non-dict entries skipped.
- `_convert_strands_messages`: document-only and image-only user messages, mixed text+document, `guardContent` unwrapping, `cachePoint` ignored, non-text tool results.
- Regression: document-only prompt is now evaluated (and can be blocked) via `BeforeModelCall`; non-text tool result content reaches the AI Guard payload.

All 130 tests in the `appsec::ai_guard_strands` suite pass (Python 3.11). `lint fmt`, `typing`, and `spelling` pass.

## Risks

Low. Behavior is unchanged for text-only conversations. The only difference is that previously-dropped non-text blocks now appear as short placeholder strings in the AI Guard payload, which can cause evaluation to run where it previously did not — the intended fix.

## Additional Notes

The placeholder approach avoids assumptions about extracting raw bytes from binary modalities while closing the silent-skip bypass. Forwarding richer representations (e.g. images as `image_url` content parts) could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APMSP-3089]: https://datadoghq.atlassian.net/browse/APMSP-3089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMSP-3089]: https://datadoghq.atlassian.net/browse/APMSP-3089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ