### PR TITLE
chore(internal): implement SpanData.build_v04_span

### DIFF
--- a/src/native/py_string.rs
+++ b/src/native/py_string.rs
@@ -193,6 +193,12 @@ impl serde::Serialize for PyBackedString {
     }
 }
 
+impl AsRef<str> for PyBackedString {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
 impl std::borrow::Borrow<str> for PyBackedString {
     fn borrow(&self) -> &str {
         self.deref()
@@ -241,6 +247,18 @@ pub struct Bytes(Vec<u8>);
 impl SpanBytes for Bytes {
     fn from_static_bytes(value: &'static [u8]) -> Self {
         Self(value.to_vec())
+    }
+}
+
+impl Bytes {
+    pub(crate) fn from_vec(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}
+
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 

--- a/src/native/py_string.rs
+++ b/src/native/py_string.rs
@@ -10,7 +10,6 @@ use pyo3::{
 };
 
 use libdd_trace_utils::span::{SpanBytes, SpanText, TraceData};
-use serde::Serialize;
 use std::borrow::Borrow;
 
 /// A Python bytes/str backed utf-8 string we can read without needing access to the GIL
@@ -241,30 +240,100 @@ impl SpanText for PyBackedString {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Serialize)]
-pub struct Bytes(Vec<u8>);
-
-impl SpanBytes for Bytes {
-    fn from_static_bytes(value: &'static [u8]) -> Self {
-        Self(value.to_vec())
-    }
+/// A Python bytes object we can read without the GIL.
+///
+/// Mirrors the storage semantics of [`PyBackedString`]: `data` is a raw pointer into
+/// the Python bytes buffer; `storage` keeps the owning `PyBytes` alive.  When built
+/// from a `&'static [u8]` (via [`SpanBytes::from_static_bytes`]) `storage` is `None`
+/// and `data` points directly at the static data.
+///
+/// `PyBytes` is immutable after creation, so reading `data` without the GIL is safe
+/// for the same reasons as `PyBackedString`.
+pub struct Bytes {
+    data: ptr::NonNull<[u8]>,
+    /// Keeps the owning `PyBytes` alive. Never read — the keepalive is the purpose.
+    #[allow(dead_code)]
+    storage: Option<Py<PyAny>>,
 }
 
 impl Bytes {
-    pub(crate) fn from_vec(v: Vec<u8>) -> Self {
-        Self(v)
+    /// Zero-copy constructor from a Python bytes object.
+    #[allow(dead_code)] // used by build_native_span in trace_buffer.rs (separate PR)
+    pub(crate) fn from_py_bytes(py_bytes: &pyo3::Bound<'_, pyo3::types::PyBytes>) -> Self {
+        let bytes = py_bytes.as_bytes();
+        let data = ptr::NonNull::from(bytes);
+        Self {
+            storage: Some(py_bytes.clone().unbind().into_any()),
+            data,
+        }
+    }
+}
+
+// SAFETY: PyBytes is immutable after creation; the raw pointer is stable for its lifetime.
+unsafe impl Send for Bytes {}
+unsafe impl Sync for Bytes {}
+
+impl SpanBytes for Bytes {
+    fn from_static_bytes(value: &'static [u8]) -> Self {
+        Self {
+            // SAFETY: value is a 'static [u8] reference, guaranteed to be non-null.
+            data: unsafe { ptr::NonNull::new_unchecked(value as *const [u8] as *mut _) },
+            storage: None,
+        }
+    }
+}
+
+impl Default for Bytes {
+    fn default() -> Self {
+        Self::from_static_bytes(b"")
+    }
+}
+
+impl std::ops::Deref for Bytes {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe { self.data.as_ref() }
     }
 }
 
 impl AsRef<[u8]> for Bytes {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self
     }
 }
 
 impl Borrow<[u8]> for Bytes {
     fn borrow(&self) -> &[u8] {
-        &self.0
+        self
+    }
+}
+
+impl PartialEq for Bytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.deref() == other.deref()
+    }
+}
+
+impl Eq for Bytes {}
+
+impl std::hash::Hash for Bytes {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.deref().hash(state);
+    }
+}
+
+impl std::fmt::Debug for Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+impl serde::Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(self.deref())
     }
 }
 

--- a/src/native/py_string.rs
+++ b/src/native/py_string.rs
@@ -258,7 +258,7 @@ pub struct Bytes {
 
 impl Bytes {
     /// Zero-copy constructor from a Python bytes object.
-    #[allow(dead_code)] // used by build_native_span in trace_buffer.rs (separate PR)
+    #[allow(dead_code)] // used by build_v04_span in trace_buffer.rs (separate PR)
     pub(crate) fn from_py_bytes(py_bytes: &pyo3::Bound<'_, pyo3::types::PyBytes>) -> Self {
         let bytes = py_bytes.as_bytes();
         let data = ptr::NonNull::from(bytes);

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -9,7 +9,7 @@ use pyo3::{
 
 use super::attributes::{AttrKey, AttributeMap, AttributeValue};
 use crate::ddtrace_utils::flatten_key_value_vec as flatten_key_value_vec_fn;
-use crate::py_string::{PyBackedString, PyTraceData};
+use crate::py_string::{Bytes, PyBackedString, PyTraceData};
 use libdd_trace_utils::span::{
     v04::{
         AttributeAnyValue, AttributeArrayValue, SpanEvent as NativeSpanEvent,
@@ -74,6 +74,94 @@ impl SpanData {
         if !self.has_attribute(k) {
             let _ = self.set_attribute(k, v);
         }
+    }
+
+    /// Build a libdatadog v0.4 `Span<PyTraceData>` from the span's current state.
+    ///
+    /// This is a snapshot — the `SpanData` fields are left intact so that callers
+    /// can still read `span_id`, `duration`, `get_tag()`, etc. after the span has
+    /// been submitted to the writer.
+    ///
+    /// `span_links` and `span_events` are **moved** out of `self` via
+    /// `std::mem::take`: they are not typically accessed after span finish and
+    /// moving avoids a costly deep clone.
+    ///
+    /// `packb` is an optional reference to `ddtrace.internal._encoding.packb`.
+    /// Pass `None` to skip meta_struct serialisation.
+    ///
+    /// # GIL requirement
+    /// Must be called with the GIL held — `AttrKey::as_bound` and
+    /// `AttributeValue::Str` dereference Python objects.
+    // `&mut self` is required because span_links/span_events are moved out via `std::mem::take`.
+    #[allow(dead_code)] // called from trace_buffer.rs (separate PR)
+    pub(crate) fn build_native_span(
+        &mut self,
+        py: Python<'_>,
+        packb: Option<&Bound<'_, PyAny>>,
+    ) -> libdd_trace_utils::span::v04::Span<PyTraceData> {
+        // Use struct initialization so all fields are set in one expression.
+        // Fields not listed here default via Default::default().
+        let mut out = libdd_trace_utils::span::v04::Span::<PyTraceData> {
+            trace_id: self.trace_id,
+            span_id: self.span_id,
+            parent_id: self.parent_id,
+            start: self.start,
+            // duration is Option<i64>; the libdatadog Span uses i64 with -1 as "unset".
+            duration: self.duration.unwrap_or(-1),
+            error: self.error,
+            // Clone PyBackedString fields — O(1) refcount increment, no heap allocation.
+            name: self.name.clone_ref(py),
+            service: self.service.clone_ref(py),
+            resource: self.resource.clone_ref(py),
+            r#type: self.span_type.clone_ref(py),
+            // Move span_links / span_events — not accessed after span finish.
+            span_links: std::mem::take(&mut self.span_links),
+            span_events: std::mem::take(&mut self.span_events),
+            ..Default::default()
+        };
+
+        // Materialise attributes into out.meta (Str) and out.metrics (Int/Float).
+        // Iterate rather than drain so self.attributes stays intact for post-finish
+        // get_tag / get_metric calls.
+        for (key, value) in &self.attributes {
+            let Ok(key_backed) = PyBackedString::try_from(key.as_bound(py).clone()) else {
+                continue;
+            };
+            match value {
+                AttributeValue::Str(s) => {
+                    let Ok(val) = PyBackedString::try_from(s.bind(py).clone()) else {
+                        continue;
+                    };
+                    out.meta.insert(key_backed, val);
+                }
+                AttributeValue::Int(i) => {
+                    out.metrics.insert(key_backed, *i as f64);
+                }
+                AttributeValue::Float(f) => {
+                    out.metrics.insert(key_backed, *f);
+                }
+            }
+        }
+
+        // Serialise meta_struct entries with packb.  Iterates (does not take) so
+        // post-finish _get_struct_tag calls still work.
+        if let (Some(meta_struct), Some(packb)) = (&self.meta_struct, packb) {
+            for (k, v) in meta_struct.bind(py).iter() {
+                let Ok(key_backed) = k.extract::<PyBackedString>() else {
+                    continue;
+                };
+                let Ok(result) = packb.call1((&v,)) else {
+                    continue;
+                };
+                let Ok(py_bytes) = result.cast::<pyo3::types::PyBytes>() else {
+                    continue;
+                };
+                out.meta_struct
+                    .insert(key_backed, Bytes::from_py_bytes(py_bytes));
+            }
+        }
+
+        out
     }
 }
 

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -94,7 +94,7 @@ impl SpanData {
     /// `AttributeValue::Str` dereference Python objects.
     // `&mut self` is required because span_links/span_events are moved out via `std::mem::take`.
     #[allow(dead_code)] // called from trace_buffer.rs (separate PR)
-    pub(crate) fn build_native_span(
+    pub(crate) fn build_v04_span(
         &mut self,
         py: Python<'_>,
         packb: Option<&Bound<'_, PyAny>>,


### PR DESCRIPTION
## Description

Adding helper method to SpanData to build a libdatadog native v0.4 Span from the SpanData structure.

This PR has no meaningful changes to existing code, it is setting up new code to be used in future follow-up PRs.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
