### PR TITLE
ci: fix backport action comment

### DIFF
--- a/.github/workflows/backport-validate.yml
+++ b/.github/workflows/backport-validate.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           BACKPORT_LABEL: ${{ github.event.label.name }}
           PR_BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: backport_validation
         run: |


### PR DESCRIPTION
## Description

Claude hallucinated an environment variable that didn't exist and the poor CI engineer I am wasn't able to spot it 💀 

The command is now correct as shown in this comment.

<img width="808" height="236" alt="image" src="https://github.com/user-attachments/assets/221d7a44-ee66-4e05-84ca-9b0292a73534" />
