### PR TITLE
Fix flaky test_periodic_thread_lifecycle_stress

### DIFF
--- a/tests/internal/test_periodic_stress.py
+++ b/tests/internal/test_periodic_stress.py
@@ -70,6 +70,7 @@ def test_periodic_thread_lifecycle_stress():
 
     from ddtrace.internal import periodic
     from ddtrace.internal import service
+    from ddtrace.internal import threads
 
     def _env_int(name, default):
         raw = os.environ.get(name)
@@ -325,6 +326,16 @@ def test_periodic_thread_lifecycle_stress():
         except Exception:
             pass
         pool[i] = None
+
+    for thread in list(threads.periodic_threads.values()):
+        try:
+            thread.stop()
+        except Exception:
+            pass
+        try:
+            thread.join(timeout=2.0)
+        except Exception:
+            pass
 
     gc.collect()
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"12ac1072-4154-426b-9e26-39b92660486a","source":"chat","resourceId":"50cf505d-6e65-4e3a-ada4-5631ba8587f3","workflowId":"5416a111-4952-491a-95fb-86f2074c0629","codeChangeId":"5416a111-4952-491a-95fb-86f2074c0629","sourceType":"test-optimization"} -->
## Description

Fixing `test_periodic_thread_lifecycle_stress[py3.10]` • **Questions?** Ask in #code-gen-flaky-tests

### Motivation
`test_periodic_thread_lifecycle_stress` is a concurrency stress test that intentionally uses `racy_drop`, which can leave native periodic threads running after the pool reference is cleared. In flaky runs, the subprocess completed the test body and then aborted during teardown with `terminate called without an active exception`, indicating leftover thread lifecycle state at process shutdown.

### Changes
- Imported `ddtrace.internal.threads` in `tests/internal/test_periodic_stress.py`.
- Added a final cleanup pass in `test_periodic_thread_lifecycle_stress` to stop and join all still-registered entries in `threads.periodic_threads` before subprocess exit.
- Kept the stress behavior and operation mix intact; only teardown determinism was improved.

## Testing

- Attempted targeted reproduction with `scripts/run-tests` on the `internal` py3.10 venv and the specific test, but sandbox container-network limitations prevented service startup in this environment.
- Ran formatting and linting for the modified file:
  - `ruff format tests/internal/test_periodic_stress.py`
  - `ruff check --fix tests/internal/test_periodic_stress.py`

## Risks

Low. This is a test-only change scoped to deterministic cleanup in the flaky stress test and does not modify production code.

## Additional Notes

Flaky category: concurrency.
Observed failure mode in CI: subprocess exited with status `-6` after printing completion, with stderr ending in `terminate called without an active exception`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/50cf505d-6e65-4e3a-ada4-5631ba8587f3)

Comment @datadog to request changes