### PR TITLE
feat(botocore): propagate trace context to Bedrock AgentCore InvokeAgentRuntime

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -1743,6 +1743,7 @@ def listen():
     core.on("botocore.stepfunctions.update_input", _on_botocore_patched_stepfunctions_update_input)
     core.on("botocore.eventbridge.update_messages", _on_botocore_update_messages)
     core.on("botocore.client_context.update_messages", _on_botocore_update_messages)
+    core.on("botocore.agentcore.update_messages", _on_botocore_update_messages)
     core.on("botocore.patched_bedrock_api_call.started", _on_botocore_patched_bedrock_api_call_started)
     core.on("botocore.patched_bedrock_api_call.exception", _on_botocore_patched_bedrock_api_call_exception)
     core.on("botocore.bedrock.process_response", _on_botocore_bedrock_process_response)

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -48,6 +48,7 @@ from .services.sqs import patched_sqs_api_call
 from .services.sqs import update_messages as inject_trace_to_sqs_or_sns_message
 from .services.stepfunctions import patched_stepfunction_api_call
 from .services.stepfunctions import update_stepfunction_input
+from .utils import update_agentcore_traceparent
 from .utils import update_client_context
 from .utils import update_eventbridge_detail
 
@@ -364,6 +365,9 @@ def prep_context_injection(ctx, endpoint_name, operation, trace_operation, param
     if endpoint_name == "states" and (operation == "StartExecution" or operation == "StartSyncExecution"):
         injection_function = update_stepfunction_input
         cloud_service = "stepfunctions"
+    if endpoint_name == "bedrock-agentcore" and operation == "InvokeAgentRuntime":
+        injection_function = update_agentcore_traceparent
+        cloud_service = "bedrock-agentcore"
 
     core.dispatch(
         "botocore.prep_context_injection.post",

--- a/ddtrace/contrib/internal/botocore/utils.py
+++ b/ddtrace/contrib/internal/botocore/utils.py
@@ -89,6 +89,26 @@ def update_eventbridge_detail(ctx: ExecutionContext) -> None:
         entry["Detail"] = detail_json
 
 
+def update_agentcore_traceparent(ctx: ExecutionContext) -> None:
+    """Inject the active trace context into Bedrock AgentCore InvokeAgentRuntime.
+
+    AgentCore exposes W3C trace-context as first-class request *parameters*
+    (``traceParent``/``traceState``/``baggage``) that it forwards to the agent
+    container as the corresponding headers. We map the injected W3C headers onto
+    those params so the agent runtime continues the caller's distributed trace.
+    User-provided values are preserved.
+    """
+    params = ctx["params"]
+    trace_headers: dict = {}
+    core.dispatch("botocore.agentcore.update_messages", (ctx, None, None, trace_headers, None))
+
+    header_to_param = {"traceparent": "traceParent", "tracestate": "traceState", "baggage": "baggage"}
+    for header_key, param_key in header_to_param.items():
+        value = trace_headers.get(header_key)
+        if value and param_key not in params:
+            params[param_key] = value
+
+
 def update_client_context(ctx: ExecutionContext) -> None:
     trace_headers = {}
     core.dispatch("botocore.client_context.update_messages", (ctx, None, None, trace_headers, None))

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1981,7 +1981,9 @@ class LLMObs(Service):
             _INTEGRATIONS_W_PROPAGATION_SUPPORT.values()
         )
         integrations_to_patch: dict[str, Union[list[str], bool]] = {
-            integration: ["bedrock-runtime", "bedrock-agent-runtime"] if integration == "botocore" else True
+            integration: ["bedrock-runtime", "bedrock-agent-runtime", "bedrock-agentcore"]
+            if integration == "botocore"
+            else True
             for integration in llm_integrations
         }
         for module, _ in integrations_to_patch.items():


### PR DESCRIPTION
## Description

Adds distributed-trace context propagation for Amazon Bedrock AgentCore
`InvokeAgentRuntime` calls.

AgentCore exposes W3C trace context as first-class request *parameters*
(`traceParent` / `traceState` / `baggage`) that it forwards to the agent
container as the corresponding HTTP headers. This change injects the active
trace context onto those parameters so the agent runtime continues the caller's
distributed trace — in both APM (via `traceParent`) and LLM Observability (via
the `t.llmobs_*` fields carried in `traceState`).

Changes:
- `contrib/internal/botocore/utils.py`: `update_agentcore_traceparent()` maps the
  injected W3C headers (`traceparent`/`tracestate`/`baggage`) onto the AgentCore
  request params, preserving any user-provided values.
- `contrib/internal/botocore/patch.py`: route `bedrock-agentcore` /
  `InvokeAgentRuntime` to the new injector.
- `_trace/trace_handlers.py`: register the `botocore.agentcore.update_messages`
  listener.
- `llmobs/_llmobs.py`: include `bedrock-agentcore` in the botocore submodules
  patched when LLMObs is enabled (so the injector is not short-circuited).

## Testing

Validated end-to-end against a deployed Strands agent on AgentCore Runtime: a
ddtrace-instrumented client and the agent connect into a single trace in both
APM and LLM Observability (client `invoke-agentcore` workflow → agent
`strands-agent` → `bedrock-runtime` LLM span). Automated tests are a follow-up.

## Risks

Low. Scoped to the `bedrock-agentcore` / `InvokeAgentRuntime` operation;
user-provided `traceParent`/`traceState`/`baggage` params are preserved.

## Additional Notes

Claude session: `d880cf25-602f-4da8-b814-7c84bd27e92a`
Resume: `claude --resume d880cf25-602f-4da8-b814-7c84bd27e92a`