### PR TITLE
feat(test-management): support DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES in testing/internal plugin

### DIFF
--- a/ddtrace/testing/internal/settings_data.py
+++ b/ddtrace/testing/internal/settings_data.py
@@ -47,9 +47,12 @@ class TestManagementSettings:
     @classmethod
     def from_attributes(cls, test_management_attributes: dict[str, t.Any]) -> TestManagementSettings:
         attempt_to_fix_retries_env = env.get("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES")
-        if attempt_to_fix_retries_env and attempt_to_fix_retries_env.isdigit():
-            attempt_to_fix_retries = int(attempt_to_fix_retries_env)
-            log.debug("Number of Attempt to Fix retries obtained from environment: %d", attempt_to_fix_retries)
+        if attempt_to_fix_retries_env:
+            if not attempt_to_fix_retries_env.isdigit():
+                log.warning("Invalid number of Attempt to Fix retries set: %s", attempt_to_fix_retries_env)
+            else:
+                attempt_to_fix_retries = int(attempt_to_fix_retries_env)
+                log.debug("Number of Attempt to Fix retries obtained from environment: %d", attempt_to_fix_retries)
         else:
             attempt_to_fix_retries = test_management_attributes["attempt_to_fix_retries"]
             log.debug("Number of Attempt to Fix retries obtained from API: %d", attempt_to_fix_retries)

--- a/ddtrace/testing/internal/settings_data.py
+++ b/ddtrace/testing/internal/settings_data.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+import logging
+import os
 import typing as t
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -40,9 +44,16 @@ class TestManagementSettings:
 
     @classmethod
     def from_attributes(cls, test_management_attributes: dict[str, t.Any]) -> TestManagementSettings:
+        attempt_to_fix_retries_env = os.environ.get("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES")
+        if attempt_to_fix_retries_env and attempt_to_fix_retries_env.isdigit():
+            attempt_to_fix_retries = int(attempt_to_fix_retries_env)
+            log.debug("Number of Attempt to Fix retries obtained from environment: %d", attempt_to_fix_retries)
+        else:
+            attempt_to_fix_retries = test_management_attributes["attempt_to_fix_retries"]
+            log.debug("Number of Attempt to Fix retries obtained from API: %d", attempt_to_fix_retries)
         test_management_settings = cls(
             enabled=test_management_attributes["enabled"],
-            attempt_to_fix_retries=test_management_attributes["attempt_to_fix_retries"],
+            attempt_to_fix_retries=attempt_to_fix_retries,
         )
         return test_management_settings
 

--- a/ddtrace/testing/internal/settings_data.py
+++ b/ddtrace/testing/internal/settings_data.py
@@ -7,6 +7,7 @@ import typing as t
 
 from ddtrace.internal.settings import env
 
+
 log = logging.getLogger(__name__)
 
 

--- a/ddtrace/testing/internal/settings_data.py
+++ b/ddtrace/testing/internal/settings_data.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 import logging
-import os
 import typing as t
+
+from ddtrace.internal.settings import env
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class TestManagementSettings:
 
     @classmethod
     def from_attributes(cls, test_management_attributes: dict[str, t.Any]) -> TestManagementSettings:
-        attempt_to_fix_retries_env = os.environ.get("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES")
+        attempt_to_fix_retries_env = env.get("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES")
         if attempt_to_fix_retries_env and attempt_to_fix_retries_env.isdigit():
             attempt_to_fix_retries = int(attempt_to_fix_retries_env)
             log.debug("Number of Attempt to Fix retries obtained from environment: %d", attempt_to_fix_retries)

--- a/ddtrace/testing/internal/settings_data.py
+++ b/ddtrace/testing/internal/settings_data.py
@@ -50,6 +50,8 @@ class TestManagementSettings:
         if attempt_to_fix_retries_env:
             if not attempt_to_fix_retries_env.isdigit():
                 log.warning("Invalid number of Attempt to Fix retries set: %s", attempt_to_fix_retries_env)
+                attempt_to_fix_retries = test_management_attributes["attempt_to_fix_retries"]
+                log.debug("Number of Attempt to Fix retries obtained from API: %d", attempt_to_fix_retries)
             else:
                 attempt_to_fix_retries = int(attempt_to_fix_retries_env)
                 log.debug("Number of Attempt to Fix retries obtained from environment: %d", attempt_to_fix_retries)

--- a/releasenotes/notes/test-management-attempt-to-fix-retries-env-var-b9d1bca7db009181.yaml
+++ b/releasenotes/notes/test-management-attempt-to-fix-retries-env-var-b9d1bca7db009181.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    test management: The ``DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES`` environment variable is now
+    respected by the ``ddtrace.testing`` internal pytest plugin. When set to a valid integer, it
+    overrides the retry count returned by the Datadog API for "attempt to fix" tests.

--- a/releasenotes/notes/test-management-attempt-to-fix-retries-env-var-b9d1bca7db009181.yaml
+++ b/releasenotes/notes/test-management-attempt-to-fix-retries-env-var-b9d1bca7db009181.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    test management: The ``DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES`` environment variable is now
+    CI Visibility: The ``DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES`` environment variable is now
     respected by the ``ddtrace.testing`` internal pytest plugin. When set to a valid integer, it
     overrides the retry count returned by the Datadog API for "attempt to fix" tests.

--- a/tests/testing/internal/test_settings_data.py
+++ b/tests/testing/internal/test_settings_data.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from ddtrace.testing.internal.settings_data import TestManagementSettings
+
+
+SAMPLE_ATTRIBUTES = {
+    "enabled": True,
+    "attempt_to_fix_retries": 30,
+}
+
+
+class TestTestManagementSettingsFromAttributes:
+    def test_retries_from_api(self) -> None:
+        """When the env var is not set, the API value is used."""
+        settings = TestManagementSettings.from_attributes(SAMPLE_ATTRIBUTES)
+        assert settings.attempt_to_fix_retries == 30
+
+    def test_retries_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the env var is set to a valid integer, it overrides the API value."""
+        monkeypatch.setenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES", "5")
+        settings = TestManagementSettings.from_attributes(SAMPLE_ATTRIBUTES)
+        assert settings.attempt_to_fix_retries == 5
+
+    def test_retries_env_var_overrides_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The env var takes precedence over a non-default API value."""
+        monkeypatch.setenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES", "10")
+        attributes = {**SAMPLE_ATTRIBUTES, "attempt_to_fix_retries": 99}
+        settings = TestManagementSettings.from_attributes(attributes)
+        assert settings.attempt_to_fix_retries == 10
+
+    def test_retries_env_var_invalid_non_digit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the env var is not a valid integer, the API value is used."""
+        monkeypatch.setenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES", "not-a-number")
+        settings = TestManagementSettings.from_attributes(SAMPLE_ATTRIBUTES)
+        assert settings.attempt_to_fix_retries == 30
+
+    def test_retries_env_var_empty_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the env var is an empty string, the API value is used."""
+        monkeypatch.setenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES", "")
+        settings = TestManagementSettings.from_attributes(SAMPLE_ATTRIBUTES)
+        assert settings.attempt_to_fix_retries == 30
+
+    def test_enabled_from_attributes(self) -> None:
+        """The enabled flag is always taken from the API attributes."""
+        settings = TestManagementSettings.from_attributes(SAMPLE_ATTRIBUTES)
+        assert settings.enabled is True
+
+        disabled_settings = TestManagementSettings.from_attributes({**SAMPLE_ATTRIBUTES, "enabled": False})
+        assert disabled_settings.enabled is False

--- a/tests/testing/internal/test_settings_data.py
+++ b/tests/testing/internal/test_settings_data.py
@@ -31,7 +31,7 @@ class TestTestManagementSettingsFromAttributes:
         assert settings.attempt_to_fix_retries == 10
 
     def test_retries_env_var_invalid_non_digit(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When the env var is not a valid integer, the API value is used."""
+        """When the env var is not a valid integer, a warning is logged and the API value is used."""
         monkeypatch.setenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES", "not-a-number")
         settings = TestManagementSettings.from_attributes(SAMPLE_ATTRIBUTES)
         assert settings.attempt_to_fix_retries == 30


### PR DESCRIPTION
## Summary

- Adds support for `DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES` in the `ddtrace.testing` internal pytest plugin (`ddtrace/testing/internal/settings_data.py`)
- When the env var is set to a valid integer, it overrides the "attempt to fix" retry count returned by the Datadog API, matching the behaviour already present in `_plugin_v2`
- Adds unit tests covering: env var override, env var takes precedence over API value, invalid/empty env var falls back to API value