### PR TITLE
feat(llmobs): add GEPA prompt optimization strategy

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1276,6 +1276,7 @@ class LLMObs(Service):
         stopping_condition: Optional[Callable[[dict[str, dict[str, Any]]], bool]] = None,
         dataset_split: Union[bool, tuple[float, ...]] = False,
         test_dataset: Optional[str] = None,
+        method: str = "metaprompting",
     ) -> PromptOptimization:
         """Initialize a PromptOptimization to iteratively improve prompts using experiments.
 
@@ -1334,6 +1335,9 @@ class LLMObs(Service):
                             pulled automatically, the main dataset is split into train/valid (80/20),
                             and the test dataset is used for the final unbiased score.
                             Implicitly enables dataset splitting.
+        :param method: Optimization method to use. ``"metaprompting"`` (default) uses the built-in
+                      iterative optimization loop. ``"gepa"`` uses the GEPA evolutionary optimizer
+                      (requires ``pip install ddtrace[gepa]``).
         :return: PromptOptimization object. Call ``.run()`` to execute the optimization.
         :raises TypeError: If task, optimization_task, evaluators, or dataset have incorrect types
                           or signatures.
@@ -1423,6 +1427,7 @@ class LLMObs(Service):
             stopping_condition=stopping_condition,
             dataset_split=dataset_split,
             test_dataset=pulled_test_dataset,
+            method=method,
         )
 
     @classmethod

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1277,6 +1277,8 @@ class LLMObs(Service):
         dataset_split: Union[bool, tuple[float, ...]] = False,
         test_dataset: Optional[str] = None,
         method: str = "metaprompting",
+        dataset_split_seed: int = 42,
+        gepa_config: Optional[dict] = None,
     ) -> PromptOptimization:
         """Initialize a PromptOptimization to iteratively improve prompts using experiments.
 
@@ -1338,6 +1340,12 @@ class LLMObs(Service):
         :param method: Optimization method to use. ``"metaprompting"`` (default) uses the built-in
                       iterative optimization loop. ``"gepa"`` uses the GEPA evolutionary optimizer
                       (requires ``pip install ddtrace[gepa]``).
+        :param dataset_split_seed: Random seed for dataset shuffling when ``dataset_split`` is enabled.
+                                   Default is 42. Change to get a different train/valid/test partition.
+        :param gepa_config: Optional dict of GEPA-specific kwargs forwarded directly to ``gepa.optimize()``,
+                            taking precedence over equivalent keys in ``config``. Supported keys include
+                            ``max_metric_calls`` (default 150), ``seed``, and
+                            ``candidate_selection_strategy``. Only used with ``method="gepa"``.
         :return: PromptOptimization object. Call ``.run()`` to execute the optimization.
         :raises TypeError: If task, optimization_task, evaluators, or dataset have incorrect types
                           or signatures.
@@ -1428,6 +1436,8 @@ class LLMObs(Service):
             dataset_split=dataset_split,
             test_dataset=pulled_test_dataset,
             method=method,
+            dataset_split_seed=dataset_split_seed,
+            gepa_config=gepa_config,
         )
 
     @classmethod

--- a/ddtrace/llmobs/_optimizers/gepa_strategy.py
+++ b/ddtrace/llmobs/_optimizers/gepa_strategy.py
@@ -1,0 +1,310 @@
+"""GEPA adapter for dd-trace-py prompt optimization.
+
+Bridges the dd-trace-py task/evaluators/optimization_task interface with GEPA's
+evolutionary optimization loop via the ``GEPAAdapter`` protocol.
+"""
+
+from typing import Any
+from typing import Callable
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+from typing import TypedDict
+
+from ddtrace.internal.logger import get_logger
+from ddtrace.llmobs._evaluators import BaseEvaluator
+from ddtrace.llmobs._experiment import ConfigType
+from ddtrace.llmobs._experiment import Dataset
+from ddtrace.llmobs._experiment import EvaluatorType
+
+
+log = get_logger(__name__)
+
+
+class TrajectoryRecord(TypedDict):
+    """A single task execution record for reflection."""
+
+    input_data: dict
+    expected_output: Any
+    output: Any
+    evaluations: dict
+    score: float
+
+
+class LLMObsGEPAAdapter:
+    """Bridges dd-trace-py task/evaluators/optimization_task with GEPA.
+
+    Implements GEPA's ``GEPAAdapter`` protocol:
+    - ``evaluate``: runs the user's task and evaluators on a batch of records
+    - ``make_reflective_dataset``: builds feedback entries from trajectories
+    - ``propose_new_texts``: wraps the user's ``optimization_task`` to produce
+      improved prompts using our system prompt template
+    """
+
+    def __init__(
+        self,
+        task: Callable,
+        evaluators: Sequence[EvaluatorType],
+        optimization_task: Callable[[str, str, ConfigType], str],
+        config: ConfigType,
+        labelization_function: Optional[Callable[[dict[str, Any]], str]] = None,
+    ) -> None:
+        self._task = task
+        self._evaluators = evaluators
+        self._optimization_task = optimization_task
+        self._config = config
+        self._labelization_function = labelization_function
+
+    # ------------------------------------------------------------------
+    # GEPAAdapter protocol
+    # ------------------------------------------------------------------
+
+    def evaluate(self, batch: list, candidate: dict, capture_traces: bool = False) -> Any:
+        """Run the user's task and evaluators on *batch* with *candidate* prompt.
+
+        :param batch: List of dataset record dicts (``input_data``, ``expected_output``, …).
+        :param candidate: Dict with at least ``{"system_prompt": str}``.
+        :param capture_traces: Whether to capture trajectory records for reflection.
+        :returns: ``gepa.EvaluationBatch`` with outputs, scores, and optional trajectories.
+        """
+        from gepa import EvaluationBatch
+
+        outputs: list = []
+        scores: list[float] = []
+        trajectories: list[TrajectoryRecord] | None = [] if capture_traces else None
+
+        # Inject candidate prompt into config
+        modified_config = dict(self._config)
+        modified_config["prompt"] = candidate["system_prompt"]
+
+        for record in batch:
+            input_data = record.get("input_data", record)
+            expected_output = record.get("expected_output")
+
+            # Run the user's task
+            try:
+                output = self._task(input_data=input_data, config=modified_config)
+            except Exception:
+                log.debug("Task failed for record", exc_info=True)
+                output = None
+
+            outputs.append(output)
+
+            # Run the first evaluator to get a score
+            evaluations: dict = {}
+            score = 0.0
+            for evaluator in self._evaluators:
+                try:
+                    if isinstance(evaluator, BaseEvaluator):
+                        from ddtrace.llmobs._experiment import EvaluatorContext
+
+                        ctx = EvaluatorContext(
+                            input_data=input_data,
+                            output_data=output,
+                            expected_output=expected_output,
+                            metadata={},
+                            span_id="",
+                            trace_id="",
+                        )
+                        result = evaluator.evaluate(ctx)
+                    else:
+                        result = evaluator(
+                            input_data=input_data,
+                            output_data=output,
+                            expected_output=expected_output,
+                        )
+                    eval_name = getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "evaluator")
+                    evaluations[eval_name] = result
+                    # Use the first evaluator's result as the score
+                    if score == 0.0:
+                        score = self._to_numeric_score(result)
+                except Exception:
+                    log.debug("Evaluator failed for record", exc_info=True)
+
+            scores.append(score)
+
+            if trajectories is not None:
+                trajectories.append(
+                    TrajectoryRecord(
+                        input_data=input_data,
+                        expected_output=expected_output,
+                        output=output,
+                        evaluations=evaluations,
+                        score=score,
+                    )
+                )
+
+        return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
+
+    def make_reflective_dataset(
+        self, candidate: dict, eval_batch: Any, components_to_update: list
+    ) -> Mapping[str, list]:
+        """Convert trajectories into the standard reflective format for GEPA.
+
+        :param candidate: Current candidate dict.
+        :param eval_batch: ``EvaluationBatch`` from ``evaluate()``.
+        :param components_to_update: List of component names to update.
+        :returns: Mapping of component name to list of reflective entries.
+        """
+        items: list[dict] = []
+        trajectories = eval_batch.trajectories or []
+        for traj in trajectories:
+            feedback = self._build_feedback(traj)
+            items.append(
+                {
+                    "Inputs": traj["input_data"],
+                    "Generated Outputs": traj["output"],
+                    "Feedback": feedback,
+                }
+            )
+        return {"system_prompt": items}
+
+    def propose_new_texts(
+        self, candidate: dict, reflective_dataset: Mapping, components_to_update: list
+    ) -> dict[str, str]:
+        """Generate an improved prompt using the user's optimization_task.
+
+        Loads the system prompt template, builds a user prompt from the reflective
+        dataset entries, and calls the user's ``optimization_task``.
+
+        :param candidate: Current candidate dict with ``system_prompt``.
+        :param reflective_dataset: Output from ``make_reflective_dataset()``.
+        :param components_to_update: List of component names to update.
+        :returns: Dict mapping component name to new text, e.g. ``{"system_prompt": "..."}``.
+        """
+        from ddtrace.llmobs._prompt_optimization import load_optimization_system_prompt
+
+        current_prompt = candidate["system_prompt"]
+        entries = reflective_dataset.get("system_prompt", [])
+
+        # Step 1: Load system prompt (reuse existing template logic)
+        system_prompt = load_optimization_system_prompt(self._config)
+
+        # Step 2: Build user prompt from reflective dataset entries
+        user_prompt = self._build_user_prompt_from_reflective(current_prompt, entries)
+
+        # Step 3: Call the user's optimization_task
+        try:
+            new_prompt = self._optimization_task(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                config=self._config,
+            )
+        except Exception:
+            log.error("propose_new_texts: optimization_task failed", exc_info=True)
+            new_prompt = ""
+
+        if not new_prompt:
+            return {"system_prompt": current_prompt}  # keep current on failure
+        return {"system_prompt": new_prompt}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_user_prompt_from_reflective(self, current_prompt: str, entries: list[dict]) -> str:
+        """Build a user prompt from reflective dataset entries.
+
+        Follows a structure similar to ``OptimizationIteration._build_user_prompt()``.
+
+        :param current_prompt: The current prompt being optimized.
+        :param entries: List of reflective entries from ``make_reflective_dataset()``.
+        :returns: User prompt string.
+        """
+        parts = [f"Initial Prompt:\n{current_prompt}\n"]
+
+        if entries:
+            parts.append("## Examples from Current Evaluation\n")
+            for idx, entry in enumerate(entries, 1):
+                parts.append(f"### Example {idx}")
+                parts.append(f"Input: {entry.get('Inputs', '')}")
+                parts.append(f"Actual Output: {entry.get('Generated Outputs', '')}")
+                parts.append(f"Feedback: {entry.get('Feedback', '')}")
+                parts.append("")  # spacing
+
+        return "\n".join(parts)
+
+    def _build_feedback(self, traj: TrajectoryRecord) -> str:
+        """Build a feedback string from a trajectory record.
+
+        Includes expected output and evaluator results/reasoning to give the
+        optimizer actionable information about failures.
+
+        :param traj: A ``TrajectoryRecord`` dict.
+        :returns: Feedback string.
+        """
+        parts = []
+        expected = traj.get("expected_output")
+        if expected is not None:
+            parts.append(f"Expected Output: {expected}")
+
+        parts.append(f"Score: {traj['score']:.2f}")
+
+        evaluations = traj.get("evaluations", {})
+        for eval_name, eval_data in evaluations.items():
+            if isinstance(eval_data, dict):
+                value = eval_data.get("value")
+                reasoning = eval_data.get("reasoning")
+                if value is not None:
+                    parts.append(f"{eval_name}: {value}")
+                if reasoning:
+                    parts.append(f"{eval_name} reasoning: {reasoning}")
+            else:
+                parts.append(f"{eval_name}: {eval_data}")
+
+        return "\n".join(parts) if parts else "No feedback available."
+
+    @staticmethod
+    def _to_numeric_score(result: Any) -> float:
+        """Convert an evaluator result to a numeric score.
+
+        Handles various return types from evaluators:
+        - float/int: returned directly
+        - bool: True -> 1.0, False -> 0.0
+        - EvaluatorResult: recurse on .value
+        - dict with "value" key: recurse on ["value"]
+        - Known pass strings: 1.0
+        - Other strings: 0.0
+
+        :param result: Evaluator return value.
+        :returns: Numeric score as float.
+        """
+        if isinstance(result, (float, int)) and not isinstance(result, bool):
+            return float(result)
+
+        if isinstance(result, bool):
+            return 1.0 if result else 0.0
+
+        # EvaluatorResult or similar with .value attribute
+        if hasattr(result, "value"):
+            return LLMObsGEPAAdapter._to_numeric_score(result.value)
+
+        if isinstance(result, dict) and "value" in result:
+            return LLMObsGEPAAdapter._to_numeric_score(result["value"])
+
+        if isinstance(result, str):
+            pass_strings = {"true_positive", "true_negative", "correct", "pass"}
+            if result.lower() in pass_strings:
+                return 1.0
+            return 0.0
+
+        log.warning("Unexpected evaluator result type %s, returning 0.0", type(result).__name__)
+        return 0.0
+
+    @staticmethod
+    def _dataset_to_gepa_format(dataset: Dataset) -> list[dict]:
+        """Convert a Dataset to the list-of-dicts format expected by GEPA.
+
+        :param dataset: An LLMObs ``Dataset``.
+        :returns: List of dicts with ``input_data``, ``expected_output``, ``metadata``.
+        """
+        records = []
+        for record in dataset:
+            records.append(
+                {
+                    "input_data": record.get("input_data", record.get("input", {})),
+                    "expected_output": record.get("expected_output"),
+                    "metadata": record.get("metadata", {}),
+                }
+            )
+        return records

--- a/ddtrace/llmobs/_optimizers/gepa_strategy.py
+++ b/ddtrace/llmobs/_optimizers/gepa_strategy.py
@@ -4,6 +4,8 @@ Bridges the dd-trace-py task/evaluators/optimization_task interface with GEPA's
 evolutionary optimization loop via the ``GEPAAdapter`` protocol.
 """
 
+from __future__ import annotations
+
 from typing import Any
 from typing import Callable
 from typing import Mapping
@@ -80,6 +82,7 @@ class LLMObsGEPAAdapter:
         for record in batch:
             input_data = record.get("input_data", record)
             expected_output = record.get("expected_output")
+            metadata = record.get("metadata", {})
 
             # Run the user's task
             try:
@@ -90,9 +93,9 @@ class LLMObsGEPAAdapter:
 
             outputs.append(output)
 
-            # Run the first evaluator to get a score
+            # Score = average across all evaluators
             evaluations: dict = {}
-            score = 0.0
+            numeric_scores: list[float] = []
             for evaluator in self._evaluators:
                 try:
                     if isinstance(evaluator, BaseEvaluator):
@@ -102,7 +105,7 @@ class LLMObsGEPAAdapter:
                             input_data=input_data,
                             output_data=output,
                             expected_output=expected_output,
-                            metadata={},
+                            metadata=metadata,
                             span_id="",
                             trace_id="",
                         )
@@ -115,11 +118,11 @@ class LLMObsGEPAAdapter:
                         )
                     eval_name = getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "evaluator")
                     evaluations[eval_name] = result
-                    # Use the first evaluator's result as the score
-                    if score == 0.0:
-                        score = self._to_numeric_score(result)
+                    numeric_scores.append(self._to_numeric_score(result))
                 except Exception:
                     log.debug("Evaluator failed for record", exc_info=True)
+
+            score = sum(numeric_scores) / len(numeric_scores) if numeric_scores else 0.0
 
             scores.append(score)
 

--- a/ddtrace/llmobs/_optimizers/gepa_strategy.py
+++ b/ddtrace/llmobs/_optimizers/gepa_strategy.py
@@ -28,10 +28,10 @@ log = get_logger(__name__)
 class TrajectoryRecord(TypedDict):
     """A single task execution record for reflection."""
 
-    input_data: dict
+    input_data: dict[str, Any]
     expected_output: Any
     output: Any
-    evaluations: dict
+    evaluations: dict[str, Any]
     score: float
 
 
@@ -47,12 +47,12 @@ class LLMObsGEPAAdapter:
 
     def __init__(
         self,
-        task: Callable,
+        task: Callable[..., Any],
         evaluators: Sequence[EvaluatorType],
         optimization_task: Callable[[str, str, ConfigType], str],
         config: ConfigType,
         labelization_function: Optional[Callable[[dict[str, Any]], str]] = None,
-        compute_score: Optional[Callable[[dict], float]] = None,
+        compute_score: Optional[Callable[[dict[str, Any]], float]] = None,
         summary_evaluators: Optional[Sequence[SummaryEvaluatorType]] = None,
     ) -> None:
         self._task = task
@@ -71,7 +71,7 @@ class LLMObsGEPAAdapter:
     # GEPAAdapter protocol
     # ------------------------------------------------------------------
 
-    def evaluate(self, batch: list, candidate: dict, capture_traces: bool = False) -> Any:
+    def evaluate(self, batch: list[dict[str, Any]], candidate: dict[str, Any], capture_traces: bool = False) -> Any:
         """Run the user's task and evaluators on *batch* with *candidate* prompt.
 
         :param batch: List of dataset record dicts (``input_data``, ``expected_output``, …).
@@ -81,10 +81,10 @@ class LLMObsGEPAAdapter:
         """
         from gepa import EvaluationBatch
 
-        outputs: list = []
-        all_evaluations: list[dict] = []
-        all_inputs: list = []
-        all_expected: list = []
+        outputs: list[Any] = []
+        all_evaluations: list[dict[str, Any]] = []
+        all_inputs: list[Any] = []
+        all_expected: list[Any] = []
         per_record_scores: list[float] = []
         trajectories: list[TrajectoryRecord] | None = [] if capture_traces else None
 
@@ -109,7 +109,7 @@ class LLMObsGEPAAdapter:
             all_expected.append(expected_output)
 
             # Run per-record evaluators
-            evaluations: dict = {}
+            evaluations: dict[str, Any] = {}
             numeric_scores: list[float] = []
             for evaluator in self._evaluators:
                 try:
@@ -126,12 +126,12 @@ class LLMObsGEPAAdapter:
                         )
                         result = evaluator.evaluate(ctx)
                     else:
-                        result = evaluator(
+                        result = evaluator(  # type: ignore[call-arg, operator]
                             input_data=input_data,
                             output_data=output,
                             expected_output=expected_output,
                         )
-                    eval_name = getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "evaluator")
+                    eval_name = str(getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "evaluator"))
                     evaluations[eval_name] = result
                     numeric_scores.append(self._to_numeric_score(result))
                 except Exception:
@@ -170,8 +170,8 @@ class LLMObsGEPAAdapter:
         return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
 
     def make_reflective_dataset(
-        self, candidate: dict, eval_batch: Any, components_to_update: list
-    ) -> Mapping[str, list]:
+        self, candidate: dict[str, Any], eval_batch: Any, components_to_update: list[str]
+    ) -> Mapping[str, list[Any]]:
         """Convert trajectories into the standard reflective format for GEPA.
 
         :param candidate: Current candidate dict.
@@ -179,7 +179,7 @@ class LLMObsGEPAAdapter:
         :param components_to_update: List of component names to update.
         :returns: Mapping of component name to list of reflective entries.
         """
-        items: list[dict] = []
+        items: list[dict[str, Any]] = []
         trajectories = eval_batch.trajectories
         if not trajectories:
             log.warning(
@@ -200,7 +200,7 @@ class LLMObsGEPAAdapter:
         return {"system_prompt": items}
 
     def _propose_new_texts_impl(
-        self, candidate: dict, reflective_dataset: Mapping, components_to_update: list
+        self, candidate: dict[str, Any], reflective_dataset: Mapping[str, Any], components_to_update: list[str]
     ) -> dict[str, str]:
         """Generate an improved prompt using the user's optimization_task.
 
@@ -225,7 +225,7 @@ class LLMObsGEPAAdapter:
 
         # Step 3: Call the user's optimization_task
         try:
-            new_prompt = self._optimization_task(
+            new_prompt = self._optimization_task(  # type: ignore[call-arg]
                 system_prompt=system_prompt,
                 user_prompt=user_prompt,
                 config=self._config,
@@ -242,7 +242,7 @@ class LLMObsGEPAAdapter:
     # Helpers
     # ------------------------------------------------------------------
 
-    def _build_user_prompt_from_reflective(self, current_prompt: str, entries: list[dict]) -> str:
+    def _build_user_prompt_from_reflective(self, current_prompt: str, entries: list[dict[str, Any]]) -> str:
         """Build a user prompt from reflective dataset entries.
 
         Follows a structure similar to ``OptimizationIteration._build_user_prompt()``.
@@ -333,11 +333,11 @@ class LLMObsGEPAAdapter:
 
     def _run_summary_evaluators(
         self,
-        inputs: list,
-        outputs: list,
-        expected_outputs: list,
-        all_evaluations: list[dict],
-    ) -> dict:
+        inputs: list[Any],
+        outputs: list[Any],
+        expected_outputs: list[Any],
+        all_evaluations: list[dict[str, Any]],
+    ) -> dict[str, Any]:
         """Run summary evaluators and return aggregated results in LLMObs summary format.
 
         :param inputs: Per-record input_data values.
@@ -348,14 +348,14 @@ class LLMObsGEPAAdapter:
         """
         from ddtrace.llmobs._experiment import SummaryEvaluatorContext
 
-        evaluators_results: dict[str, list] = {}
+        evaluators_results: dict[str, list[Any]] = {}
         for record_evals in all_evaluations:
             for eval_name, eval_result in record_evals.items():
                 evaluators_results.setdefault(eval_name, []).append(eval_result)
 
-        summary: dict = {}
+        summary: dict[str, Any] = {}
         for evaluator in self._summary_evaluators:
-            eval_name = getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "summary_evaluator")
+            eval_name = str(getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "summary_evaluator"))
             try:
                 if isinstance(evaluator, BaseSummaryEvaluator):
                     ctx = SummaryEvaluatorContext(
@@ -363,11 +363,11 @@ class LLMObsGEPAAdapter:
                         outputs=outputs,
                         expected_outputs=expected_outputs,
                         evaluation_results=evaluators_results,
-                        metadata={},
+                        metadata=[],
                     )
                     result = evaluator.evaluate(ctx)
                 else:
-                    result = evaluator(inputs, outputs, expected_outputs, evaluators_results)
+                    result = evaluator(inputs, outputs, expected_outputs, evaluators_results)  # type: ignore[arg-type]
                 summary[eval_name] = {"value": result, "error": None}
             except Exception:
                 log.debug("Summary evaluator %s failed", eval_name, exc_info=True)
@@ -375,7 +375,7 @@ class LLMObsGEPAAdapter:
         return summary
 
     @staticmethod
-    def _dataset_to_gepa_format(dataset: Dataset) -> list[dict]:
+    def _dataset_to_gepa_format(dataset: Dataset) -> list[dict[str, Any]]:
         """Convert a Dataset to the list-of-dicts format expected by GEPA.
 
         :param dataset: An LLMObs ``Dataset``.

--- a/ddtrace/llmobs/_optimizers/gepa_strategy.py
+++ b/ddtrace/llmobs/_optimizers/gepa_strategy.py
@@ -56,6 +56,10 @@ class LLMObsGEPAAdapter:
         self._optimization_task = optimization_task
         self._config = config
         self._labelization_function = labelization_function
+        # Assign as instance field so GEPA's duck-typed protocol check finds it
+        # (GEPAAdapter declares `propose_new_texts` as an optional callable field,
+        # not a method).
+        self.propose_new_texts = self._propose_new_texts_impl
 
     # ------------------------------------------------------------------
     # GEPAAdapter protocol
@@ -150,7 +154,14 @@ class LLMObsGEPAAdapter:
         :returns: Mapping of component name to list of reflective entries.
         """
         items: list[dict] = []
-        trajectories = eval_batch.trajectories or []
+        trajectories = eval_batch.trajectories
+        if not trajectories:
+            log.warning(
+                "make_reflective_dataset called with no trajectories. "
+                "Ensure evaluate() was called with capture_traces=True. "
+                "Returning empty reflective dataset."
+            )
+            return {"system_prompt": []}
         for traj in trajectories:
             feedback = self._build_feedback(traj)
             items.append(
@@ -162,7 +173,7 @@ class LLMObsGEPAAdapter:
             )
         return {"system_prompt": items}
 
-    def propose_new_texts(
+    def _propose_new_texts_impl(
         self, candidate: dict, reflective_dataset: Mapping, components_to_update: list
     ) -> dict[str, str]:
         """Generate an improved prompt using the user's optimization_task.

--- a/ddtrace/llmobs/_optimizers/gepa_strategy.py
+++ b/ddtrace/llmobs/_optimizers/gepa_strategy.py
@@ -15,9 +15,11 @@ from typing import TypedDict
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._evaluators import BaseEvaluator
+from ddtrace.llmobs._evaluators import BaseSummaryEvaluator
 from ddtrace.llmobs._experiment import ConfigType
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import EvaluatorType
+from ddtrace.llmobs._experiment import SummaryEvaluatorType
 
 
 log = get_logger(__name__)
@@ -50,12 +52,16 @@ class LLMObsGEPAAdapter:
         optimization_task: Callable[[str, str, ConfigType], str],
         config: ConfigType,
         labelization_function: Optional[Callable[[dict[str, Any]], str]] = None,
+        compute_score: Optional[Callable[[dict], float]] = None,
+        summary_evaluators: Optional[Sequence[SummaryEvaluatorType]] = None,
     ) -> None:
         self._task = task
         self._evaluators = evaluators
         self._optimization_task = optimization_task
         self._config = config
         self._labelization_function = labelization_function
+        self._compute_score = compute_score
+        self._summary_evaluators = summary_evaluators or []
         # Assign as instance field so GEPA's duck-typed protocol check finds it
         # (GEPAAdapter declares `propose_new_texts` as an optional callable field,
         # not a method).
@@ -76,7 +82,10 @@ class LLMObsGEPAAdapter:
         from gepa import EvaluationBatch
 
         outputs: list = []
-        scores: list[float] = []
+        all_evaluations: list[dict] = []
+        all_inputs: list = []
+        all_expected: list = []
+        per_record_scores: list[float] = []
         trajectories: list[TrajectoryRecord] | None = [] if capture_traces else None
 
         # Inject candidate prompt into config
@@ -96,8 +105,10 @@ class LLMObsGEPAAdapter:
                 output = None
 
             outputs.append(output)
+            all_inputs.append(input_data)
+            all_expected.append(expected_output)
 
-            # Score = average across all evaluators
+            # Run per-record evaluators
             evaluations: dict = {}
             numeric_scores: list[float] = []
             for evaluator in self._evaluators:
@@ -126,9 +137,9 @@ class LLMObsGEPAAdapter:
                 except Exception:
                     log.debug("Evaluator failed for record", exc_info=True)
 
-            score = sum(numeric_scores) / len(numeric_scores) if numeric_scores else 0.0
-
-            scores.append(score)
+            record_score = sum(numeric_scores) / len(numeric_scores) if numeric_scores else 0.0
+            per_record_scores.append(record_score)
+            all_evaluations.append(evaluations)
 
             if trajectories is not None:
                 trajectories.append(
@@ -137,9 +148,24 @@ class LLMObsGEPAAdapter:
                         expected_output=expected_output,
                         output=output,
                         evaluations=evaluations,
-                        score=score,
+                        score=record_score,
                     )
                 )
+
+        # Align GEPA's evolutionary scoring with compute_score when available.
+        # compute_score operates on aggregated summary evaluations; we run the
+        # summary evaluators on this batch and use the result as a uniform
+        # per-record score so that mean(scores) == compute_score(batch).
+        if self._compute_score is not None and self._summary_evaluators:
+            try:
+                summary_evals = self._run_summary_evaluators(all_inputs, outputs, all_expected, all_evaluations)
+                batch_score = float(self._compute_score(summary_evals))
+                scores = [batch_score] * len(batch)
+            except Exception:
+                log.debug("compute_score alignment failed; falling back to per-record average", exc_info=True)
+                scores = per_record_scores
+        else:
+            scores = per_record_scores
 
         return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
 
@@ -304,6 +330,49 @@ class LLMObsGEPAAdapter:
 
         log.warning("Unexpected evaluator result type %s, returning 0.0", type(result).__name__)
         return 0.0
+
+    def _run_summary_evaluators(
+        self,
+        inputs: list,
+        outputs: list,
+        expected_outputs: list,
+        all_evaluations: list[dict],
+    ) -> dict:
+        """Run summary evaluators and return aggregated results in LLMObs summary format.
+
+        :param inputs: Per-record input_data values.
+        :param outputs: Per-record task outputs.
+        :param expected_outputs: Per-record expected outputs.
+        :param all_evaluations: Per-record evaluator results dicts.
+        :returns: Dict keyed by evaluator name matching ``summary_evaluations`` format.
+        """
+        from ddtrace.llmobs._experiment import SummaryEvaluatorContext
+
+        evaluators_results: dict[str, list] = {}
+        for record_evals in all_evaluations:
+            for eval_name, eval_result in record_evals.items():
+                evaluators_results.setdefault(eval_name, []).append(eval_result)
+
+        summary: dict = {}
+        for evaluator in self._summary_evaluators:
+            eval_name = getattr(evaluator, "name", None) or getattr(evaluator, "__name__", "summary_evaluator")
+            try:
+                if isinstance(evaluator, BaseSummaryEvaluator):
+                    ctx = SummaryEvaluatorContext(
+                        inputs=inputs,
+                        outputs=outputs,
+                        expected_outputs=expected_outputs,
+                        evaluation_results=evaluators_results,
+                        metadata={},
+                    )
+                    result = evaluator.evaluate(ctx)
+                else:
+                    result = evaluator(inputs, outputs, expected_outputs, evaluators_results)
+                summary[eval_name] = {"value": result, "error": None}
+            except Exception:
+                log.debug("Summary evaluator %s failed", eval_name, exc_info=True)
+                summary[eval_name] = {"value": None, "error": "failed"}
+        return summary
 
     @staticmethod
     def _dataset_to_gepa_format(dataset: Dataset) -> list[dict]:

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -3,7 +3,6 @@
 from copy import deepcopy
 from dataclasses import dataclass
 import inspect
-import os
 import random
 from typing import TYPE_CHECKING
 from typing import Any
@@ -151,7 +150,7 @@ _DATASET_SPLIT_SEED = 42  # Fixed seed for reproducible dataset shuffling
 def load_optimization_system_prompt(config: ConfigType) -> str:
     """Load and prepare the optimization system prompt.
 
-    Loads the template from _prompt_optimization.md and replaces placeholders.
+    Loads the template from ``_prompt_optimization_prompt.py`` and replaces placeholders.
     Adds evaluation model information and random tip at the end.
 
     :param config: Configuration dictionary with optional keys:
@@ -159,14 +158,9 @@ def load_optimization_system_prompt(config: ConfigType) -> str:
         - ``model_name``: Model name to add as context for the optimizer.
     :return: System prompt string with output format injected.
     """
+    from ddtrace.llmobs._prompt_optimization_prompt import OPTIMIZATION_SYSTEM_PROMPT_TEMPLATE
 
-    # Get the directory of this file
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    template_path = os.path.join(current_dir, "_prompt_optimization.md")
-
-    # Load template
-    with open(template_path, "r", encoding="utf-8") as f:
-        template = f.read()
+    template = OPTIMIZATION_SYSTEM_PROMPT_TEMPLATE
 
     output_format = config.get("evaluation_output_format")
     structure_placeholder = ""
@@ -1065,7 +1059,7 @@ class PromptOptimization:
         )
         log.info("GEPA final score: %.3f", final_score)
 
-        best_iteration = 1 if final_score > baseline_score else 0
+        best_iteration = 1 if (final_score or 0.0) > (baseline_score or 0.0) else 0
 
         return OptimizationResult(
             name=self.name,
@@ -1129,7 +1123,7 @@ class PromptOptimization:
         )
         log.info("GEPA final score (valid): %.3f", final_score)
 
-        best_iteration = 1 if final_score > baseline_score else 0
+        best_iteration = 1 if (final_score or 0.0) > (baseline_score or 0.0) else 0
         best_prompt = all_iterations[best_iteration]["prompt"]
 
         # Test phase with best prompt

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from dataclasses import dataclass
 import inspect
+import os
 import random
 from typing import TYPE_CHECKING
 from typing import Any
@@ -158,7 +159,6 @@ def load_optimization_system_prompt(config: ConfigType) -> str:
         - ``model_name``: Model name to add as context for the optimizer.
     :return: System prompt string with output format injected.
     """
-    import os
 
     # Get the directory of this file
     current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -631,9 +631,12 @@ class PromptOptimization:
         :param _llmobs_instance: Internal LLMObs instance.
         :param tags: Optional tags to associate with the optimization.
         :param max_iterations: Maximum number of optimization iterations to run.
-        :param stopping_condition: Optional function to determine when to stop optimization.
+                              Only used with ``method="metaprompting"``. For ``method="gepa"``,
+                              control the search budget via ``config["max_metric_calls"]`` instead.
+        :param stopping_condition: Optional function to determine when to stop optimization early.
                                    Takes summary_evaluations dict from the experiment result
                                    and returns True if should stop.
+                                   Only used with ``method="metaprompting"``. Ignored for ``method="gepa"``.
         :param dataset_split: Controls dataset splitting. Accepts:
             - ``False`` (default): No splitting, use full dataset for everything.
             - ``True``: Split with default ratios (60/20/20 without test_dataset, 80/20 with).
@@ -793,6 +796,16 @@ class PromptOptimization:
         log.info("Starting prompt optimization: %s (method=%s)", self.name, self._method)
 
         if self._method == "gepa":
+            if self._stopping_condition is not None:
+                log.warning(
+                    "stopping_condition is not used with method='gepa' and will be ignored. "
+                    "GEPA manages its own stopping via config['max_metric_calls']."
+                )
+            if self._max_iterations != 5:
+                log.warning(
+                    "max_iterations is not used with method='gepa' and will be ignored. "
+                    "Control the search budget via config['max_metric_calls'] instead."
+                )
             if self._dataset_split_enabled:
                 return self._run_gepa_with_split(jobs)
             return self._run_gepa_without_split(jobs)

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -147,6 +147,67 @@ TIPS = {
 _DATASET_SPLIT_SEED = 42  # Fixed seed for reproducible dataset shuffling
 
 
+def load_optimization_system_prompt(config: ConfigType) -> str:
+    """Load and prepare the optimization system prompt.
+
+    Loads the template from _prompt_optimization.md and replaces placeholders.
+    Adds evaluation model information and random tip at the end.
+
+    :param config: Configuration dictionary with optional keys:
+        - ``evaluation_output_format``: Output format to inject into the template.
+        - ``model_name``: Model name to add as context for the optimizer.
+    :return: System prompt string with output format injected.
+    """
+    import os
+
+    # Get the directory of this file
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    template_path = os.path.join(current_dir, "_prompt_optimization.md")
+
+    # Load template
+    with open(template_path, "r", encoding="utf-8") as f:
+        template = f.read()
+
+    output_format = config.get("evaluation_output_format")
+    structure_placeholder = ""
+    if output_format:
+        structure_placeholder = "\n".join(
+            [
+                "## Prompt Output Format Requirements",
+                "The optimized prompt must guide the LLM to produce JSON output with this structure:",
+                "\n",
+                str(output_format),
+                "\n",
+                "**If this output format is not clearly specified in the initial prompt**",
+                "**add it as your first improvement step**",
+            ]
+        )
+
+    system_prompt = template.replace("{{STRUCTURE_PLACEHOLDER}}", structure_placeholder)
+
+    # Add evaluation model information at the end
+    additional_parts = []
+    if "model_name" in config:
+        eval_model = config["model_name"]
+        additional_parts.append(
+            f"\n\nIMPORTANT: The improved prompt will be applied to this evaluation model: {eval_model}"
+        )
+        additional_parts.append(
+            "Consider the capabilities, limitations, and characteristics of this specific model "
+            "when optimizing the prompt."
+        )
+
+    # Add random tip at the end
+    tip_key = random.choice(list(TIPS.keys()))  # nosec B311
+    tip_text = TIPS[tip_key]
+    additional_parts.append(f"\n\n**TIP: {tip_text}**")
+
+    if additional_parts:
+        system_prompt += "\n".join(additional_parts)
+
+    return system_prompt
+
+
 class IterationData(TypedDict, total=False):
     """Data for a single optimization iteration."""
 
@@ -247,55 +308,11 @@ class OptimizationIteration:
     def _load_system_prompt(self) -> str:
         """Load and prepare the optimization system prompt.
 
-        Loads the template from _prompt_optimization_prompt.py and replaces placeholders.
-        Adds evaluation model information and random tip at the end.
+        Delegates to the module-level :func:`load_optimization_system_prompt`.
 
         :return: System prompt string with output format injected.
         """
-        import random
-
-        from ddtrace.llmobs._prompt_optimization_prompt import OPTIMIZATION_SYSTEM_PROMPT_TEMPLATE
-
-        template = OPTIMIZATION_SYSTEM_PROMPT_TEMPLATE
-
-        output_format = self._config.get("evaluation_output_format")
-        structure_placeholder = ""
-        if output_format:
-            structure_placeholder = "\n".join(
-                [
-                    "## Prompt Output Format Requirements",
-                    "The optimized prompt must guide the LLM to produce JSON output with this structure:",
-                    "\n",
-                    str(output_format),
-                    "\n",
-                    "**If this output format is not clearly specified in the initial prompt**",
-                    "**add it as your first improvement step**",
-                ]
-            )
-
-        system_prompt = template.replace("{{STRUCTURE_PLACEHOLDER}}", structure_placeholder)
-
-        # Add evaluation model information at the end
-        additional_parts = []
-        if "model_name" in self._config:
-            eval_model = self._config["model_name"]
-            additional_parts.append(
-                f"\n\nIMPORTANT: The improved prompt will be applied to this evaluation model: {eval_model}"
-            )
-            additional_parts.append(
-                "Consider the capabilities, limitations, and characteristics of this specific model "
-                "when optimizing the prompt."
-            )
-
-        # Add random tip at the end
-        tip_key = random.choice(list(TIPS.keys()))  # nosec B311
-        tip_text = TIPS[tip_key]
-        additional_parts.append(f"\n\n**TIP: {tip_text}**")
-
-        if additional_parts:
-            system_prompt += "\n".join(additional_parts)
-
-        return system_prompt
+        return load_optimization_system_prompt(self._config)
 
     def _add_examples(self, individual_results: list[ExperimentRowResult]) -> str:
         """Add examples of each label type using the labelization function.
@@ -586,6 +603,7 @@ class PromptOptimization:
         stopping_condition: Optional[Callable[[dict[str, dict[str, Any]]], bool]] = None,
         dataset_split: Union[bool, tuple[float, ...]] = False,
         test_dataset: Optional[Dataset] = None,
+        method: str = "metaprompting",
     ) -> None:
         """Initialize a prompt optimization.
 
@@ -632,7 +650,11 @@ class PromptOptimization:
         :param test_dataset: Optional separate test dataset. When provided, the main dataset is split
                             into train/valid (80/20) and this dataset is used for the final test.
                             Implicitly enables dataset splitting.
-        :raises ValueError: If required config parameters or compute_score are missing.
+        :param method: Optimization method to use. ``"metaprompting"`` (default) uses the built-in
+                      iterative optimization loop. ``"gepa"`` uses the GEPA evolutionary optimizer
+                      (requires ``pip install ddtrace[gepa]``).
+        :raises ValueError: If required config parameters or compute_score are missing, or if
+                           method is not recognized.
         """
         self.name = name
         self._task = task
@@ -672,6 +694,12 @@ class PromptOptimization:
             self._split_ratios = (0.6, 0.2, 0.2)  # Default 3-way
         else:
             self._split_ratios = None  # No split
+
+        # Optimization method
+        _VALID_METHODS = ("metaprompting", "gepa")
+        if method not in _VALID_METHODS:
+            raise ValueError(f"Unknown optimization method {method!r}. Must be one of {_VALID_METHODS}.")
+        self._method = method
 
     def _make_sub_dataset(self, split_name: str, records: list[DatasetRecord]) -> Dataset:
         """Create a sub-dataset from a list of records.
@@ -768,7 +796,12 @@ class PromptOptimization:
                 "and create the optimization via `LLMObs.prompt_optimization(...)` before running."
             )
 
-        log.info("Starting prompt optimization: %s", self.name)
+        log.info("Starting prompt optimization: %s (method=%s)", self.name, self._method)
+
+        if self._method == "gepa":
+            if self._dataset_split_enabled:
+                return self._run_gepa_with_split(jobs)
+            return self._run_gepa_without_split(jobs)
 
         if self._dataset_split_enabled:
             return self._run_with_split(jobs)
@@ -980,6 +1013,187 @@ class PromptOptimization:
             best_iteration=best_iteration,
             test_phase=TestPhaseResult(results=test_results, score=test_score, experiment_url=test_url),
         )
+
+    def _run_gepa_without_split(self, jobs: int) -> OptimizationResult:
+        """Run GEPA optimization without dataset splitting.
+
+        1. Run baseline experiment (full dataset) to measure initial performance.
+        2. Run GEPA evolutionary optimization on the full dataset.
+        3. Run final experiment with the optimized prompt.
+        4. Return the best of baseline vs optimized.
+
+        :param jobs: Number of parallel jobs for experiment execution.
+        :return: OptimizationResult containing baseline and final iteration results.
+        """
+        all_iterations: list[IterationData] = []
+
+        # Baseline experiment
+        current_prompt = str(self._initial_prompt)
+        baseline_results, baseline_url = self._run_experiment(0, current_prompt, jobs)
+        baseline_evals = baseline_results.get("summary_evaluations", {})
+        baseline_score = self._compute_score(baseline_evals)
+
+        all_iterations.append(
+            IterationData(
+                iteration=0,
+                prompt=current_prompt,
+                results=baseline_results,
+                score=baseline_score,
+                experiment_url=baseline_url,
+                summary_evaluations=baseline_evals,
+            )
+        )
+        log.info("GEPA baseline score: %.3f", baseline_score)
+
+        # Run GEPA
+        optimized_prompt = self._run_gepa_core(self._dataset, self._dataset)
+
+        # Final experiment with optimized prompt
+        final_results, final_url = self._run_experiment(1, optimized_prompt, jobs)
+        final_evals = final_results.get("summary_evaluations", {})
+        final_score = self._compute_score(final_evals)
+
+        all_iterations.append(
+            IterationData(
+                iteration=1,
+                prompt=optimized_prompt,
+                results=final_results,
+                score=final_score,
+                experiment_url=final_url,
+                summary_evaluations=final_evals,
+            )
+        )
+        log.info("GEPA final score: %.3f", final_score)
+
+        best_iteration = 1 if final_score > baseline_score else 0
+
+        return OptimizationResult(
+            name=self.name,
+            initial_prompt=str(self._initial_prompt),
+            iterations=all_iterations,
+            best_iteration=best_iteration,
+        )
+
+    def _run_gepa_with_split(self, jobs: int) -> OptimizationResult:
+        """Run GEPA optimization with train/valid/test dataset splitting.
+
+        1. Split dataset into train/valid/test.
+        2. Run baseline on valid set to measure initial performance.
+        3. Run GEPA with train set for optimization, valid set for scoring.
+        4. Run final experiment on valid set with optimized prompt.
+        5. Pick best of baseline vs optimized.
+        6. Run test experiment on test set with the best prompt.
+
+        :param jobs: Number of parallel jobs for experiment execution.
+        :return: OptimizationResult with test phase results.
+        """
+        train_ds, valid_ds, test_ds = self._create_split_datasets()
+
+        all_iterations: list[IterationData] = []
+
+        # Baseline on valid set
+        current_prompt = str(self._initial_prompt)
+        baseline_results, baseline_url = self._run_experiment(0, current_prompt, jobs, dataset=valid_ds, suffix="valid")
+        baseline_evals = baseline_results.get("summary_evaluations", {})
+        baseline_score = self._compute_score(baseline_evals)
+
+        all_iterations.append(
+            IterationData(
+                iteration=0,
+                prompt=current_prompt,
+                results=baseline_results,
+                score=baseline_score,
+                experiment_url=baseline_url,
+                summary_evaluations=baseline_evals,
+            )
+        )
+        log.info("GEPA baseline score (valid): %.3f", baseline_score)
+
+        # Run GEPA with train/valid split
+        optimized_prompt = self._run_gepa_core(train_ds, valid_ds)
+
+        # Final experiment on valid set
+        final_results, final_url = self._run_experiment(1, optimized_prompt, jobs, dataset=valid_ds, suffix="valid")
+        final_evals = final_results.get("summary_evaluations", {})
+        final_score = self._compute_score(final_evals)
+
+        all_iterations.append(
+            IterationData(
+                iteration=1,
+                prompt=optimized_prompt,
+                results=final_results,
+                score=final_score,
+                experiment_url=final_url,
+                summary_evaluations=final_evals,
+            )
+        )
+        log.info("GEPA final score (valid): %.3f", final_score)
+
+        best_iteration = 1 if final_score > baseline_score else 0
+        best_prompt = all_iterations[best_iteration]["prompt"]
+
+        # Test phase with best prompt
+        log.info("Running GEPA test experiment with best prompt (iteration %s)", best_iteration)
+        test_results, test_url = self._run_experiment(best_iteration, best_prompt, jobs, dataset=test_ds, suffix="test")
+        test_summary_evals = test_results.get("summary_evaluations", {})
+        test_score = self._compute_score(test_summary_evals)
+        log.info("GEPA test score: %.3f", test_score)
+
+        return OptimizationResult(
+            name=self.name,
+            initial_prompt=str(self._initial_prompt),
+            iterations=all_iterations,
+            best_iteration=best_iteration,
+            test_phase=TestPhaseResult(results=test_results, score=test_score, experiment_url=test_url),
+        )
+
+    def _run_gepa_core(self, train_ds: Dataset, valid_ds: Dataset) -> str:
+        """Run GEPA evolutionary optimization and return the best prompt.
+
+        :param train_ds: Dataset used for GEPA's training evaluations.
+        :param valid_ds: Dataset used for GEPA's validation scoring.
+        :returns: The best prompt found by GEPA, or the initial prompt on failure.
+        """
+        try:
+            import gepa as gepa_pkg
+        except ImportError:
+            raise ImportError("gepa package is required for method='gepa'. Install with: pip install ddtrace[gepa]")
+
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        adapter = LLMObsGEPAAdapter(
+            task=self._task,
+            evaluators=self._evaluators,
+            optimization_task=self._optimization_task,
+            config=self._config,
+            labelization_function=self._labelization_function,
+        )
+        train_data = LLMObsGEPAAdapter._dataset_to_gepa_format(train_ds)
+        val_data = LLMObsGEPAAdapter._dataset_to_gepa_format(valid_ds)
+
+        gepa_kwargs: dict[str, Any] = {
+            "seed_candidate": {"system_prompt": self._initial_prompt},
+            "trainset": train_data,
+            "valset": val_data,
+            "adapter": adapter,
+            "display_progress_bar": True,
+            "max_metric_calls": self._config.get("max_metric_calls", 150),
+        }
+
+        # Optional GEPA params from config
+        for config_key, gepa_key in [
+            ("gepa_seed", "seed"),
+            ("candidate_selection_strategy", "candidate_selection_strategy"),
+        ]:
+            if config_key in self._config:
+                gepa_kwargs[gepa_key] = self._config[config_key]
+
+        try:
+            result = gepa_pkg.optimize(**gepa_kwargs)
+            return result.best_candidate["system_prompt"]
+        except Exception as e:
+            log.error("GEPA optimization failed: %s", e)
+            return self._initial_prompt  # fallback
 
     def _run_experiment(
         self,

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -223,6 +223,17 @@ class TestPhaseResult:
     experiment_url: str
 
 
+@dataclass
+class GEPAOptimizerMetadata:
+    """Metadata captured from the GEPA optimization run."""
+
+    num_candidates: int
+    best_valset_score: float
+    total_metric_calls: Optional[int]
+    num_full_val_evals: Optional[int]
+    seed: Optional[int]
+
+
 class OptimizationIteration:
     """Represents a single iteration in the prompt optimization process.
 
@@ -450,6 +461,8 @@ class OptimizationResult:
         iterations: list[IterationData],
         best_iteration: int,
         test_phase: Optional[TestPhaseResult] = None,
+        gepa_metadata: Optional[GEPAOptimizerMetadata] = None,
+        optimizer_error: Optional[str] = None,
     ) -> None:
         """Initialize optimization results.
 
@@ -458,12 +471,16 @@ class OptimizationResult:
         :param iterations: list of results from each iteration (IterationData).
         :param best_iteration: Index of the iteration with best performance.
         :param test_phase: Results from the final test phase (when dataset splitting is enabled).
+        :param gepa_metadata: Metadata from the GEPA optimizer run (method='gepa' only).
+        :param optimizer_error: Error message if the optimizer failed and fell back to the initial prompt.
         """
         self.name = name
         self.initial_prompt = initial_prompt
         self.iterations = iterations
         self.best_iteration = best_iteration
         self._test_phase = test_phase
+        self.gepa_metadata = gepa_metadata
+        self.optimizer_error = optimizer_error
 
     @property
     def best_prompt(self) -> str:
@@ -541,6 +558,18 @@ class OptimizationResult:
             f"Best score: {self.best_score:.4f}" if self.best_score is not None else "Best score: N/A",
         ]
 
+        if self.optimizer_error:
+            lines.append(f"Optimizer error (fell back to initial prompt): {self.optimizer_error}")
+
+        if self.gepa_metadata:
+            m = self.gepa_metadata
+            lines.append(
+                f"GEPA: {m.num_candidates} candidates, "
+                f"best valset score {m.best_valset_score:.4f}"
+                + (f", {m.total_metric_calls} metric calls" if m.total_metric_calls is not None else "")
+                + (f", seed {m.seed}" if m.seed is not None else "")
+            )
+
         if self.test_score is not None:
             lines.append(f"Test score: {self.test_score:.4f}")
             if self.test_experiment_url:
@@ -598,6 +627,8 @@ class PromptOptimization:
         dataset_split: Union[bool, tuple[float, ...]] = False,
         test_dataset: Optional[Dataset] = None,
         method: str = "metaprompting",
+        dataset_split_seed: int = 42,
+        gepa_config: Optional[dict] = None,
     ) -> None:
         """Initialize a prompt optimization.
 
@@ -650,6 +681,12 @@ class PromptOptimization:
         :param method: Optimization method to use. ``"metaprompting"`` (default) uses the built-in
                       iterative optimization loop. ``"gepa"`` uses the GEPA evolutionary optimizer
                       (requires ``pip install ddtrace[gepa]``).
+        :param dataset_split_seed: Random seed for dataset shuffling when splitting. Default 42.
+                                   Change to get a different train/valid/test partition.
+        :param gepa_config: Optional dict of GEPA-specific kwargs passed directly to ``gepa.optimize()``,
+                            taking precedence over the equivalent keys in ``config``. Supported keys:
+                            ``max_metric_calls`` (default 150), ``seed``, ``candidate_selection_strategy``.
+                            Only used with ``method="gepa"``.
         :raises ValueError: If required config parameters or compute_score are missing, or if
                            method is not recognized.
         """
@@ -697,6 +734,8 @@ class PromptOptimization:
         if method not in _VALID_METHODS:
             raise ValueError(f"Unknown optimization method {method!r}. Must be one of {_VALID_METHODS}.")
         self._method = method
+        self._dataset_split_seed = dataset_split_seed
+        self._gepa_config: dict = gepa_config or {}
 
     def _make_sub_dataset(self, split_name: str, records: list[DatasetRecord]) -> Dataset:
         """Create a sub-dataset from a list of records.
@@ -735,8 +774,8 @@ class PromptOptimization:
             raise ValueError("_split_dataset called without split ratios")
         records = list(self._dataset)
 
-        # Shuffle with fixed seed for reproducibility
-        rng = random.Random(_DATASET_SPLIT_SEED)  # nosec B311
+        # Shuffle with configurable seed for reproducibility
+        rng = random.Random(self._dataset_split_seed)  # nosec B311
         rng.shuffle(records)
 
         if self._test_dataset is not None:
@@ -1053,7 +1092,29 @@ class PromptOptimization:
         log.info("GEPA baseline score: %.3f", baseline_score)
 
         # Run GEPA
-        optimized_prompt = self._run_gepa_core(self._dataset, self._dataset)
+        optimized_prompt, gepa_metadata, optimizer_error = self._run_gepa_core(self._dataset, self._dataset)
+
+        # Skip final experiment if GEPA failed or returned the same prompt (no-op)
+        if optimized_prompt == current_prompt:
+            log.info("GEPA returned unchanged prompt; skipping final experiment")
+            all_iterations.append(
+                IterationData(
+                    iteration=1,
+                    prompt=optimized_prompt,
+                    results=baseline_results,
+                    score=baseline_score,
+                    experiment_url=baseline_url,
+                    summary_evaluations=baseline_evals,
+                )
+            )
+            return OptimizationResult(
+                name=self.name,
+                initial_prompt=str(self._initial_prompt),
+                iterations=all_iterations,
+                best_iteration=0,
+                gepa_metadata=gepa_metadata,
+                optimizer_error=optimizer_error,
+            )
 
         # Final experiment with optimized prompt
         final_results, final_url = self._run_experiment(1, optimized_prompt, jobs)
@@ -1079,6 +1140,8 @@ class PromptOptimization:
             initial_prompt=str(self._initial_prompt),
             iterations=all_iterations,
             best_iteration=best_iteration,
+            gepa_metadata=gepa_metadata,
+            optimizer_error=optimizer_error,
         )
 
     def _run_gepa_with_split(self, jobs: int) -> OptimizationResult:
@@ -1117,26 +1180,41 @@ class PromptOptimization:
         log.info("GEPA baseline score (valid): %.3f", baseline_score)
 
         # Run GEPA with train/valid split
-        optimized_prompt = self._run_gepa_core(train_ds, valid_ds)
+        optimized_prompt, gepa_metadata, optimizer_error = self._run_gepa_core(train_ds, valid_ds)
 
-        # Final experiment on valid set
-        final_results, final_url = self._run_experiment(1, optimized_prompt, jobs, dataset=valid_ds, suffix="valid")
-        final_evals = final_results.get("summary_evaluations", {})
-        final_score = self._compute_score(final_evals)
-
-        all_iterations.append(
-            IterationData(
-                iteration=1,
-                prompt=optimized_prompt,
-                results=final_results,
-                score=final_score,
-                experiment_url=final_url,
-                summary_evaluations=final_evals,
+        # Skip final valid experiment if GEPA failed or returned the same prompt (no-op)
+        if optimized_prompt == current_prompt:
+            log.info("GEPA returned unchanged prompt; skipping final valid experiment")
+            all_iterations.append(
+                IterationData(
+                    iteration=1,
+                    prompt=optimized_prompt,
+                    results=baseline_results,
+                    score=baseline_score,
+                    experiment_url=baseline_url,
+                    summary_evaluations=baseline_evals,
+                )
             )
-        )
-        log.info("GEPA final score (valid): %.3f", final_score)
+            best_iteration = 0
+        else:
+            # Final experiment on valid set
+            final_results, final_url = self._run_experiment(1, optimized_prompt, jobs, dataset=valid_ds, suffix="valid")
+            final_evals = final_results.get("summary_evaluations", {})
+            final_score = self._compute_score(final_evals)
 
-        best_iteration = 1 if (final_score or 0.0) > (baseline_score or 0.0) else 0
+            all_iterations.append(
+                IterationData(
+                    iteration=1,
+                    prompt=optimized_prompt,
+                    results=final_results,
+                    score=final_score,
+                    experiment_url=final_url,
+                    summary_evaluations=final_evals,
+                )
+            )
+            log.info("GEPA final score (valid): %.3f", final_score)
+            best_iteration = 1 if (final_score or 0.0) > (baseline_score or 0.0) else 0
+
         best_prompt = all_iterations[best_iteration]["prompt"]
 
         # Test phase with best prompt
@@ -1152,19 +1230,31 @@ class PromptOptimization:
             iterations=all_iterations,
             best_iteration=best_iteration,
             test_phase=TestPhaseResult(results=test_results, score=test_score, experiment_url=test_url),
+            gepa_metadata=gepa_metadata,
+            optimizer_error=optimizer_error,
         )
 
-    def _run_gepa_core(self, train_ds: Dataset, valid_ds: Dataset) -> str:
-        """Run GEPA evolutionary optimization and return the best prompt.
+    def _run_gepa_core(
+        self, train_ds: Dataset, valid_ds: Dataset
+    ) -> tuple[str, Optional[GEPAOptimizerMetadata], Optional[str]]:
+        """Run GEPA evolutionary optimization and return (prompt, metadata, error).
 
         :param train_ds: Dataset used for GEPA's training evaluations.
         :param valid_ds: Dataset used for GEPA's validation scoring.
-        :returns: The best prompt found by GEPA, or the initial prompt on failure.
+        :returns: Tuple of (best_prompt, gepa_metadata, optimizer_error).
+                  On failure, best_prompt is the initial prompt, metadata is None,
+                  and optimizer_error contains the error message.
         """
+        import sys
+
         try:
             import gepa as gepa_pkg
         except ImportError:
-            raise ImportError("gepa package is required for method='gepa'. Install with: pip install ddtrace[gepa]")
+            py = f"{sys.version_info.major}.{sys.version_info.minor}"
+            raise ImportError(
+                f"gepa package is required for method='gepa' (requires Python >=3.10, current: {py}). "
+                "Install with: pip install ddtrace[gepa]"
+            )
 
         from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
 
@@ -1174,10 +1264,13 @@ class PromptOptimization:
             optimization_task=self._optimization_task,
             config=self._config,
             labelization_function=self._labelization_function,
+            compute_score=self._compute_score,
+            summary_evaluators=self._summary_evaluators,
         )
         train_data = LLMObsGEPAAdapter._dataset_to_gepa_format(train_ds)
         val_data = LLMObsGEPAAdapter._dataset_to_gepa_format(valid_ds)
 
+        # Base GEPA kwargs from config; gepa_config overrides
         gepa_kwargs: dict[str, Any] = {
             "seed_candidate": {"system_prompt": self._initial_prompt},
             "trainset": train_data,
@@ -1186,21 +1279,31 @@ class PromptOptimization:
             "display_progress_bar": True,
             "max_metric_calls": self._config.get("max_metric_calls", 150),
         }
-
-        # Optional GEPA params from config
+        # Legacy config keys (kept for backward compat)
         for config_key, gepa_key in [
             ("gepa_seed", "seed"),
             ("candidate_selection_strategy", "candidate_selection_strategy"),
         ]:
             if config_key in self._config:
                 gepa_kwargs[gepa_key] = self._config[config_key]
+        # gepa_config takes precedence over all of the above
+        gepa_kwargs.update(self._gepa_config)
 
         try:
             result = gepa_pkg.optimize(**gepa_kwargs)
-            return result.best_candidate["system_prompt"]
+            best_prompt = result.best_candidate["system_prompt"]
+            metadata = GEPAOptimizerMetadata(
+                num_candidates=result.num_candidates,
+                best_valset_score=result.val_aggregate_scores[result.best_idx],
+                total_metric_calls=result.total_metric_calls,
+                num_full_val_evals=result.num_full_val_evals,
+                seed=result.seed,
+            )
+            return best_prompt, metadata, None
         except Exception as e:
-            log.error("GEPA optimization failed: %s", e)
-            return self._initial_prompt  # fallback
+            error_msg = str(e)
+            log.error("GEPA optimization failed: %s", error_msg)
+            return self._initial_prompt, None, error_msg
 
     def _run_experiment(
         self,
@@ -1235,6 +1338,17 @@ class PromptOptimization:
         if runs_value is not None and isinstance(runs_value, int):
             runs_int = runs_value
 
+        phase = suffix if suffix else ("baseline" if iteration == 0 else "optimization")
+        experiment_tags = dict(self._tags)
+        experiment_tags.update(
+            {
+                "prompt_optimization_method": self._method,
+                "prompt_optimization_phase": phase,
+                "prompt_optimization_iteration": str(iteration),
+                "prompt_optimization_split_seed": str(self._dataset_split_seed),
+            }
+        )
+
         experiment = self._llmobs_instance.experiment(  # type: ignore[union-attr]
             name=f"{self.name}_{iteration_name}",
             project_name=self._tags["project_name"],
@@ -1244,6 +1358,7 @@ class PromptOptimization:
             summary_evaluators=self._summary_evaluators,
             config=experiment_config,
             runs=runs_int,
+            tags=experiment_tags,
         )
 
         experiment_results = experiment.run(

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -677,7 +677,7 @@ class PromptOptimization:
         if not isinstance(config, dict) or "prompt" not in config:
             raise ValueError("config must contain a 'prompt' key")
 
-        self._initial_prompt = config["prompt"]
+        self._initial_prompt: str = str(config["prompt"])
         self._model_name = config.get("model_name")
         self._config = config
 

--- a/lib-injection/sources/requirements.csv
+++ b/lib-injection/sources/requirements.csv
@@ -9,3 +9,4 @@ opentelemetry-api,">=1,<2",
 wrapt,">=1,!=2.2.0,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",
+gepa,>=0.0.26,python_version >= '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ opentelemetry = [
     "opentelemetry-exporter-otlp>=1,<2",
 ]
 gepa = [
-    "gepa>=0.0.26",
+    "gepa>=0.0.26; python_version >= '3.10'",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ opentracing = [
 opentelemetry = [
     "opentelemetry-exporter-otlp>=1,<2",
 ]
+gepa = [
+    "gepa>=0.0.26",
+]
 
 [project.scripts]
 ddtrace-run = "ddtrace.commands.ddtrace_run:main"

--- a/releasenotes/notes/llmobs-gepa-prompt-optimization-7c1a2b3d4e5f6a7b.yaml
+++ b/releasenotes/notes/llmobs-gepa-prompt-optimization-7c1a2b3d4e5f6a7b.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    LLM Observability: This adds a ``method`` parameter to prompt optimization, allowing selection
+    between the built-in ``"metaprompting"`` loop (default) and the ``"gepa"`` evolutionary optimizer
+    (requires ``pip install ddtrace[gepa]``). A ``gepa_config`` parameter forwards GEPA-specific
+    options such as ``max_metric_calls`` and ``candidate_selection_strategy``, and a
+    ``dataset_split_seed`` parameter controls the train/valid/test partition when dataset splitting
+    is enabled.

--- a/requirements.csv
+++ b/requirements.csv
@@ -9,3 +9,4 @@ opentelemetry-api,">=1,<2",
 wrapt,">=1,!=2.2.0,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",
+gepa,>=0.0.26,python_version >= '3.10'

--- a/tests/llmobs/test_prompt_optimization.py
+++ b/tests/llmobs/test_prompt_optimization.py
@@ -1,0 +1,1264 @@
+"""Tests for ddtrace.llmobs._prompt_optimization and ddtrace.llmobs._optimizers.gepa_strategy."""
+# python -m pytest tests/llmobs/test_prompt_optimization.py -v --no-header --tb=short --override-ini="addopts=" 2>&1
+
+import random
+import sys
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ddtrace.llmobs._evaluators import BaseEvaluator
+from ddtrace.llmobs._experiment import ConfigType
+from ddtrace.llmobs._experiment import Dataset
+from ddtrace.llmobs._experiment import DatasetRecord
+from ddtrace.llmobs._experiment import EvaluatorResult
+from ddtrace.llmobs._experiment import ExperimentResult
+from ddtrace.llmobs._experiment import ExperimentRowResult
+from ddtrace.llmobs._experiment import Project
+from ddtrace.llmobs._prompt_optimization import TIPS
+from ddtrace.llmobs._prompt_optimization import IterationData
+from ddtrace.llmobs._prompt_optimization import OptimizationIteration
+from ddtrace.llmobs._prompt_optimization import OptimizationResult
+from ddtrace.llmobs._prompt_optimization import PromptOptimization
+from ddtrace.llmobs._prompt_optimization import TestPhaseResult
+from ddtrace.llmobs._prompt_optimization import load_optimization_system_prompt
+from ddtrace.llmobs._prompt_optimization import validate_dataset
+from ddtrace.llmobs._prompt_optimization import validate_dataset_split
+from ddtrace.llmobs._prompt_optimization import validate_evaluators
+from ddtrace.llmobs._prompt_optimization import validate_optimization_task
+from ddtrace.llmobs._prompt_optimization import validate_task
+from ddtrace.llmobs._prompt_optimization import validate_test_dataset
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def dummy_task(input_data, config):
+    return input_data
+
+
+def dummy_optimization_task(system_prompt, user_prompt, config):
+    return "improved prompt"
+
+
+def dummy_evaluator(input_data, output_data, expected_output):
+    return int(output_data == expected_output)
+
+
+def dummy_summary_evaluator(inputs, outputs, expected_outputs, evaluators_results):
+    correct = sum(1 for r in evaluators_results.get("dummy_evaluator", []) if r == 1)
+    return {"accuracy": correct / len(inputs) if inputs else 0.0}
+
+
+def dummy_compute_score(summary_evals):
+    return summary_evals.get("dummy_summary_evaluator", {}).get("value", {}).get("accuracy", 0.0)
+
+
+def dummy_labelization(result):
+    val = result.get("evaluations", {}).get("dummy_evaluator", {}).get("value", 0)
+    return "correct" if val == 1 else "incorrect"
+
+
+def _make_dataset(name="test_ds", num_records=5):
+    project: Project = {"name": "test_project", "_id": "proj-123"}
+    records = []
+    for i in range(num_records):
+        rec: DatasetRecord = {
+            "record_id": f"rec-{i}",
+            "input_data": {"question": f"q{i}"},
+            "expected_output": {"answer": f"a{i}"},
+            "metadata": {"idx": i},
+        }
+        records.append(rec)
+    return Dataset(
+        name=name,
+        project=project,
+        dataset_id="ds-123",
+        records=records,
+        description="test dataset",
+        latest_version=1,
+        version=1,
+        _dne_client=MagicMock(),
+    )
+
+
+def _make_experiment_result(score_value=0.5, num_rows=2):
+    """Build a minimal ExperimentResult TypedDict with controlled summary and rows."""
+    rows = []
+    for i in range(num_rows):
+        row: ExperimentRowResult = {
+            "idx": i,
+            "record_id": f"rec-{i}",
+            "span_id": f"span-{i}",
+            "trace_id": f"trace-{i}",
+            "timestamp": 1000000 + i,
+            "input": {"question": f"q{i}"},
+            "output": {"answer": f"a{i}"},
+            "expected_output": {"answer": f"a{i}"},
+            "evaluations": {
+                "dummy_evaluator": {"value": 1, "error": None},
+            },
+            "metadata": {},
+            "error": {"message": None, "stack": None, "type": None},
+        }
+        rows.append(row)
+    result: ExperimentResult = {
+        "summary_evaluations": {
+            "dummy_summary_evaluator": {
+                "value": {"accuracy": score_value},
+                "error": None,
+            }
+        },
+        "rows": rows,
+        "runs": [],
+    }
+    return result
+
+
+def _make_prompt_optimization(**overrides):
+    """Build a PromptOptimization instance with sensible defaults."""
+    mock_llmobs = MagicMock()
+    mock_llmobs.enabled = True
+    defaults = {
+        "name": "test_opt",
+        "task": dummy_task,
+        "optimization_task": dummy_optimization_task,
+        "dataset": _make_dataset(),
+        "evaluators": [dummy_evaluator],
+        "project_name": "test_project",
+        "config": {"prompt": "initial prompt", "model_name": "gpt-4"},
+        "summary_evaluators": [dummy_summary_evaluator],
+        "compute_score": dummy_compute_score,
+        "labelization_function": dummy_labelization,
+        "_llmobs_instance": mock_llmobs,
+    }
+    defaults.update(overrides)
+    return PromptOptimization(**defaults)
+
+
+# ===========================================================================
+# 1. Validation Functions
+# ===========================================================================
+
+
+class TestValidationFunctions:
+    def test_validate_task_valid(self):
+        validate_task(dummy_task)  # should not raise
+
+    def test_validate_task_not_callable(self):
+        with pytest.raises(TypeError, match="task must be a callable"):
+            validate_task("not_a_function")
+
+    def test_validate_task_missing_input_data(self):
+        def bad_task(config):
+            pass
+
+        with pytest.raises(TypeError, match="input_data"):
+            validate_task(bad_task)
+
+    def test_validate_task_missing_config(self):
+        def bad_task(input_data):
+            pass
+
+        with pytest.raises(TypeError, match="config"):
+            validate_task(bad_task)
+
+    def test_validate_optimization_task_valid(self):
+        validate_optimization_task(dummy_optimization_task)  # should not raise
+
+    def test_validate_optimization_task_not_callable(self):
+        with pytest.raises(TypeError, match="optimization_task must be a callable"):
+            validate_optimization_task(42)
+
+    def test_validate_optimization_task_missing_params(self):
+        def bad_opt_task(system_prompt):
+            pass
+
+        with pytest.raises(TypeError, match="user_prompt"):
+            validate_optimization_task(bad_opt_task)
+
+    def test_validate_dataset_valid(self):
+        ds = _make_dataset()
+        validate_dataset(ds)  # should not raise
+
+    def test_validate_dataset_invalid_type(self):
+        with pytest.raises(TypeError, match="Dataset must be an LLMObs Dataset"):
+            validate_dataset({"records": []})
+
+    def test_validate_test_dataset_none(self):
+        validate_test_dataset(None)  # should not raise
+
+    def test_validate_test_dataset_string(self):
+        validate_test_dataset("my_test_dataset")  # should not raise
+
+    def test_validate_test_dataset_invalid(self):
+        with pytest.raises(TypeError, match="test_dataset must be a dataset name"):
+            validate_test_dataset(123)
+
+    def test_validate_dataset_split_valid_3_tuple(self):
+        validate_dataset_split((0.6, 0.2, 0.2), None)  # should not raise
+
+    def test_validate_dataset_split_valid_2_tuple_with_test(self):
+        validate_dataset_split((0.8, 0.2), "test_ds")  # should not raise
+
+    def test_validate_dataset_split_bad_sum(self):
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            validate_dataset_split((0.5, 0.2, 0.1), None)
+
+    def test_validate_dataset_split_out_of_range(self):
+        with pytest.raises(ValueError, match="between 0 and 1"):
+            validate_dataset_split((0.0, 0.5, 0.5), None)
+
+    def test_validate_dataset_split_wrong_length(self):
+        with pytest.raises(ValueError, match="must have 2 or 3 elements"):
+            validate_dataset_split((0.25, 0.25, 0.25, 0.25), None)
+
+    def test_validate_dataset_split_3_tuple_with_test_dataset_conflict(self):
+        with pytest.raises(ValueError, match="Cannot use a 3-tuple"):
+            validate_dataset_split((0.6, 0.2, 0.2), "external_test")
+
+    def test_validate_dataset_split_2_tuple_without_test_dataset(self):
+        with pytest.raises(ValueError, match="requires test_dataset"):
+            validate_dataset_split((0.8, 0.2), None)
+
+    def test_validate_dataset_split_bool_passthrough(self):
+        # Non-tuple values (bool) are not validated
+        validate_dataset_split(True, None)  # should not raise
+        validate_dataset_split(False, None)  # should not raise
+
+    def test_validate_evaluators_valid_callable(self):
+        validate_evaluators([dummy_evaluator])  # should not raise
+
+    def test_validate_evaluators_valid_base_evaluator(self):
+        class MyEval(BaseEvaluator):
+            def evaluate(self, context):
+                return 1.0
+
+        validate_evaluators([MyEval(name="my_eval")])  # should not raise
+
+    def test_validate_evaluators_empty(self):
+        with pytest.raises(TypeError, match="non-empty list"):
+            validate_evaluators([])
+
+    def test_validate_evaluators_non_callable(self):
+        with pytest.raises(TypeError, match="callable function"):
+            validate_evaluators(["not_a_function"])
+
+    def test_validate_evaluators_missing_params(self):
+        def bad_eval(input_data):
+            pass
+
+        with pytest.raises(TypeError, match="parameters"):
+            validate_evaluators([bad_eval])
+
+
+# ===========================================================================
+# 2. load_optimization_system_prompt
+# ===========================================================================
+
+
+class TestLoadOptimizationSystemPrompt:
+    def test_loads_template(self):
+        result = load_optimization_system_prompt({})
+        assert result
+        assert "prompt engineering expert" in result
+
+    def test_injects_output_format(self):
+        config = {"evaluation_output_format": '{"key": "value"}'}
+        result = load_optimization_system_prompt(config)
+        assert "Prompt Output Format Requirements" in result
+
+    def test_no_output_format(self):
+        result = load_optimization_system_prompt({})
+        assert "{{STRUCTURE_PLACEHOLDER}}" not in result
+
+    def test_adds_model_name(self):
+        config: ConfigType = {"model_name": "gpt-4o"}
+        result = load_optimization_system_prompt(config)
+        assert "gpt-4o" in result
+        assert "evaluation model" in result
+
+    def test_adds_tip(self):
+        random.seed(42)
+        result = load_optimization_system_prompt({})
+        assert "**TIP:" in result
+        # Verify it contains an actual tip value
+        found = any(tip in result for tip in TIPS.values())
+        assert found
+
+
+# ===========================================================================
+# 3. OptimizationIteration
+# ===========================================================================
+
+
+class TestOptimizationIteration:
+    def _make_iteration(self, **overrides):
+        defaults = {
+            "iteration": 1,
+            "current_prompt": "current prompt",
+            "current_results": _make_experiment_result(),
+            "optimization_task": dummy_optimization_task,
+            "config": {"prompt": "current prompt"},
+            "labelization_function": dummy_labelization,
+        }
+        defaults.update(overrides)
+        return OptimizationIteration(**defaults)
+
+    def test_run_returns_improved_prompt(self):
+        it = self._make_iteration(optimization_task=lambda system_prompt, user_prompt, config: "better prompt")
+        result = it.run()
+        assert result == "better prompt"
+
+    def test_run_fallback_on_empty(self):
+        it = self._make_iteration(optimization_task=lambda system_prompt, user_prompt, config: "")
+        result = it.run()
+        assert result == "current prompt"
+
+    def test_run_fallback_on_exception(self):
+        def failing_task(system_prompt, user_prompt, config):
+            raise RuntimeError("boom")
+
+        it = self._make_iteration(optimization_task=failing_task)
+        result = it.run()
+        assert result == "current prompt"
+
+    def test_build_user_prompt_content(self):
+        it = self._make_iteration()
+        user_prompt = it._build_user_prompt()
+        assert "Initial Prompt:" in user_prompt
+        assert "current prompt" in user_prompt
+
+    def test_add_examples_with_labelization(self):
+        it = self._make_iteration()
+        rows = _make_experiment_result()["rows"]
+        result = it._add_examples(rows)
+        assert "Examples from Current Evaluation" in result
+        assert "correct" in result
+
+    def test_add_examples_none_labelization(self):
+        it = self._make_iteration(labelization_function=None)
+        rows = _make_experiment_result()["rows"]
+        result = it._add_examples(rows)
+        assert result == ""
+
+    def test_load_system_prompt_delegates(self):
+        it = self._make_iteration()
+        with patch(
+            "ddtrace.llmobs._prompt_optimization.load_optimization_system_prompt",
+            return_value="mocked system prompt",
+        ) as mock_load:
+            result = it._load_system_prompt()
+            mock_load.assert_called_once_with(it._config)
+            assert result == "mocked system prompt"
+
+
+# ===========================================================================
+# 4. OptimizationResult
+# ===========================================================================
+
+
+class TestOptimizationResult:
+    def _make_iterations(self, scores):
+        iterations = []
+        for i, score in enumerate(scores):
+            data: IterationData = {
+                "iteration": i,
+                "prompt": f"prompt_{i}",
+                "results": _make_experiment_result(score),
+                "score": score,
+                "experiment_url": f"https://example.com/exp/{i}",
+                "summary_evaluations": {"dummy_summary_evaluator": {"value": {"accuracy": score}, "error": None}},
+            }
+            iterations.append(data)
+        return iterations
+
+    def test_best_prompt(self):
+        iterations = self._make_iterations([0.3, 0.8, 0.5])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        assert result.best_prompt == "prompt_1"
+
+    def test_best_score(self):
+        iterations = self._make_iterations([0.3, 0.8, 0.5])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        assert result.best_score == 0.8
+
+    def test_best_experiment_url(self):
+        iterations = self._make_iterations([0.3, 0.8])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        assert result.best_experiment_url == "https://example.com/exp/1"
+
+    def test_best_prompt_fallback_empty(self):
+        result = OptimizationResult("test", "initial", [], best_iteration=0)
+        assert result.best_prompt == "initial"
+
+    def test_best_prompt_fallback_out_of_range(self):
+        iterations = self._make_iterations([0.5])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=99)
+        assert result.best_prompt == "initial"
+
+    def test_best_score_fallback(self):
+        result = OptimizationResult("test", "initial", [], best_iteration=0)
+        assert result.best_score is None
+
+    def test_total_iterations(self):
+        iterations = self._make_iterations([0.3, 0.5, 0.8])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=2)
+        assert result.total_iterations == 3
+
+    def test_test_score_with_phase(self):
+        iterations = self._make_iterations([0.5])
+        test_phase = TestPhaseResult(results=_make_experiment_result(0.9), score=0.9, experiment_url="https://test/url")
+        result = OptimizationResult("test", "initial", iterations, best_iteration=0, test_phase=test_phase)
+        assert result.test_score == 0.9
+
+    def test_test_experiment_url_with_phase(self):
+        iterations = self._make_iterations([0.5])
+        test_phase = TestPhaseResult(results=_make_experiment_result(0.9), score=0.9, experiment_url="https://test/url")
+        result = OptimizationResult("test", "initial", iterations, best_iteration=0, test_phase=test_phase)
+        assert result.test_experiment_url == "https://test/url"
+
+    def test_test_results_with_phase(self):
+        exp = _make_experiment_result(0.9)
+        test_phase = TestPhaseResult(results=exp, score=0.9, experiment_url="https://test/url")
+        iterations = self._make_iterations([0.5])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=0, test_phase=test_phase)
+        assert result.test_results is exp
+
+    def test_test_score_without_phase(self):
+        iterations = self._make_iterations([0.5])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=0)
+        assert result.test_score is None
+        assert result.test_experiment_url is None
+        assert result.test_results is None
+
+    def test_get_history(self):
+        iterations = self._make_iterations([0.3, 0.8])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        assert result.get_history() is iterations
+
+    def test_get_score_history(self):
+        iterations = self._make_iterations([0.3, 0.8, 0.5])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        assert result.get_score_history() == [0.3, 0.8, 0.5]
+
+    def test_get_prompt_history(self):
+        iterations = self._make_iterations([0.3, 0.8])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        assert result.get_prompt_history() == ["prompt_0", "prompt_1"]
+
+    def test_summary_basic(self):
+        iterations = self._make_iterations([0.3, 0.8])
+        result = OptimizationResult("test", "initial", iterations, best_iteration=1)
+        s = result.summary()
+        assert "test" in s
+        assert "0.8000" in s
+        assert "BEST" in s
+
+    def test_summary_with_test_phase(self):
+        iterations = self._make_iterations([0.5])
+        test_phase = TestPhaseResult(results=_make_experiment_result(0.9), score=0.9, experiment_url="https://test/url")
+        result = OptimizationResult("test", "initial", iterations, best_iteration=0, test_phase=test_phase)
+        s = result.summary()
+        assert "Test score: 0.9000" in s
+        assert "https://test/url" in s
+
+
+# ===========================================================================
+# 5. PromptOptimization Init
+# ===========================================================================
+
+
+class TestPromptOptimizationInit:
+    def test_valid_metaprompting(self):
+        opt = _make_prompt_optimization(method="metaprompting")
+        assert opt._method == "metaprompting"
+
+    def test_valid_gepa(self):
+        opt = _make_prompt_optimization(method="gepa")
+        assert opt._method == "gepa"
+
+    def test_invalid_method(self):
+        with pytest.raises(ValueError, match="Unknown optimization method"):
+            _make_prompt_optimization(method="invalid")
+
+    def test_missing_config(self):
+        with pytest.raises(ValueError, match="config parameter is required"):
+            _make_prompt_optimization(config=None)
+
+    def test_config_without_prompt(self):
+        with pytest.raises(ValueError, match="must contain a 'prompt' key"):
+            _make_prompt_optimization(config={"model_name": "gpt-4"})
+
+    def test_split_ratios_true(self):
+        opt = _make_prompt_optimization(dataset_split=True)
+        assert opt._dataset_split_enabled is True
+        assert opt._split_ratios == (0.6, 0.2, 0.2)
+
+    def test_split_ratios_custom(self):
+        opt = _make_prompt_optimization(dataset_split=(0.7, 0.15, 0.15))
+        assert opt._split_ratios == (0.7, 0.15, 0.15)
+
+    def test_split_ratios_2_tuple_with_test_dataset(self):
+        test_ds = _make_dataset("test_ext", 3)
+        opt = _make_prompt_optimization(dataset_split=(0.8, 0.2), test_dataset=test_ds)
+        assert opt._split_ratios == (0.8, 0.2)
+        assert opt._dataset_split_enabled is True
+
+    def test_test_dataset_implies_split(self):
+        test_ds = _make_dataset("test_ext", 3)
+        opt = _make_prompt_optimization(test_dataset=test_ds)
+        assert opt._dataset_split_enabled is True
+        # Default 2-way split when test_dataset provided
+        assert opt._split_ratios == (0.8, 0.2)
+
+
+# ===========================================================================
+# 6. Run Routing
+# ===========================================================================
+
+
+class TestRunRouting:
+    def test_llmobs_not_enabled_raises(self):
+        mock_llmobs = MagicMock()
+        mock_llmobs.enabled = False
+        opt = _make_prompt_optimization(_llmobs_instance=mock_llmobs)
+        with pytest.raises(ValueError, match="LLMObs is not enabled"):
+            opt.run()
+
+    @patch.object(PromptOptimization, "_run_without_split")
+    def test_metaprompting_no_split(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="metaprompting", dataset_split=False)
+        opt.run()
+        mock_run.assert_called_once()
+
+    @patch.object(PromptOptimization, "_run_with_split")
+    def test_metaprompting_with_split(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="metaprompting", dataset_split=True)
+        opt.run()
+        mock_run.assert_called_once()
+
+    @patch.object(PromptOptimization, "_run_gepa_without_split")
+    def test_gepa_no_split(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="gepa", dataset_split=False)
+        opt.run()
+        mock_run.assert_called_once()
+
+    @patch.object(PromptOptimization, "_run_gepa_with_split")
+    def test_gepa_with_split(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="gepa", dataset_split=True)
+        opt.run()
+        mock_run.assert_called_once()
+
+
+# ===========================================================================
+# 7. _run_without_split (metaprompting)
+# ===========================================================================
+
+
+class TestRunWithoutSplit:
+    @patch.object(OptimizationIteration, "run", return_value="improved")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_runs_baseline_plus_iterations(self, mock_exp, mock_iter_run):
+        scores = [0.5, 0.6, 0.7]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(max_iterations=2)
+        result = opt._run_without_split(jobs=1)
+        assert result.total_iterations == 3  # baseline + 2
+        assert result.best_score == 0.7
+
+    @patch.object(OptimizationIteration, "run", return_value="improved")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_best_iteration_selected(self, mock_exp, mock_iter_run):
+        # Baseline scores highest
+        scores = [0.9, 0.3, 0.5]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(max_iterations=2)
+        result = opt._run_without_split(jobs=1)
+        assert result.best_iteration == 0
+        assert result.best_score == 0.9
+
+    @patch.object(OptimizationIteration, "run", return_value="improved")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_stopping_condition_halts_early(self, mock_exp, mock_iter_run):
+        scores = [0.3, 0.95]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(
+            max_iterations=5,
+            stopping_condition=lambda evals: True,  # always stop
+        )
+        result = opt._run_without_split(jobs=1)
+        # Baseline + 1 iteration (stopped after first)
+        assert result.total_iterations == 2
+
+    @patch.object(OptimizationIteration, "run", return_value="improved_v2")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_optimizes_from_best_prompt(self, mock_exp, mock_iter_run):
+        """Verify OptimizationIteration is constructed with the best prompt so far."""
+        scores = [0.3, 0.8, 0.5]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+
+        captured_prompts = []
+        original_init = OptimizationIteration.__init__
+
+        def tracking_init(self_iter, *args, **kwargs):
+            original_init(self_iter, *args, **kwargs)
+            captured_prompts.append(self_iter.current_prompt)
+
+        with patch.object(OptimizationIteration, "__init__", tracking_init):
+            opt = _make_prompt_optimization(max_iterations=2)
+            opt._run_without_split(jobs=1)
+
+        # First iteration: starts with initial prompt
+        assert captured_prompts[0] == "initial prompt"
+        # Second iteration: starts with best (iteration 1 had 0.8 > baseline 0.3)
+        assert captured_prompts[1] == "improved_v2"
+
+
+# ===========================================================================
+# 8. _run_with_split (metaprompting)
+# ===========================================================================
+
+
+class TestRunWithSplit:
+    @patch.object(OptimizationIteration, "run", return_value="improved")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_creates_splits_and_test_phase(self, mock_split, mock_exp, mock_iter_run):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        scores = [0.5, 0.5, 0.6, 0.6, 0.9]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(max_iterations=1, dataset_split=True)
+        result = opt._run_with_split(jobs=1)
+        assert result.test_score is not None
+        assert result._test_phase is not None
+
+    @patch.object(OptimizationIteration, "run", return_value="improved")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_scores_from_valid_set(self, mock_split, mock_exp, mock_iter_run):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        # train=0.3, valid=0.7, train=0.5, valid=0.8, test=0.9
+        scores = [0.3, 0.7, 0.5, 0.8, 0.9]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(max_iterations=1, dataset_split=True)
+        result = opt._run_with_split(jobs=1)
+        # Best valid score is 0.8 (iteration 1)
+        assert result.best_iteration == 1
+
+    @patch.object(OptimizationIteration, "run", return_value="improved")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_has_test_phase_result(self, mock_split, mock_exp, mock_iter_run):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        scores = [0.3, 0.7, 0.5, 0.8, 0.9]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(max_iterations=1, dataset_split=True)
+        result = opt._run_with_split(jobs=1)
+        assert isinstance(result._test_phase, TestPhaseResult)
+        assert result._test_phase.score is not None
+
+
+# ===========================================================================
+# 9. _create_split_datasets
+# ===========================================================================
+
+
+class TestCreateSplitDatasets:
+    def test_default_3_way_split(self):
+        opt = _make_prompt_optimization(dataset_split=True, dataset=_make_dataset(num_records=10))
+        train_ds, valid_ds, test_ds = opt._create_split_datasets()
+        assert len(train_ds) == 6
+        assert len(valid_ds) == 2
+        assert len(test_ds) == 2
+
+    def test_2_way_with_test_dataset(self):
+        ext_test = _make_dataset("ext_test", 3)
+        opt = _make_prompt_optimization(
+            dataset_split=(0.8, 0.2), test_dataset=ext_test, dataset=_make_dataset(num_records=10)
+        )
+        train_ds, valid_ds, test_ds = opt._create_split_datasets()
+        assert len(train_ds) == 8
+        assert len(valid_ds) == 2
+        assert test_ds is ext_test
+
+    def test_custom_ratios(self):
+        opt = _make_prompt_optimization(dataset_split=(0.5, 0.3, 0.2), dataset=_make_dataset(num_records=10))
+        train_ds, valid_ds, test_ds = opt._create_split_datasets()
+        assert len(train_ds) == 5
+        assert len(valid_ds) == 3
+        assert len(test_ds) == 2
+
+    def test_reproducible(self):
+        ds = _make_dataset(num_records=10)
+        opt1 = _make_prompt_optimization(dataset_split=True, dataset=ds)
+        opt2 = _make_prompt_optimization(dataset_split=True, dataset=ds)
+        train1, valid1, test1 = opt1._create_split_datasets()
+        train2, valid2, test2 = opt2._create_split_datasets()
+        assert [r["record_id"] for r in train1] == [r["record_id"] for r in train2]
+        assert [r["record_id"] for r in valid1] == [r["record_id"] for r in valid2]
+        assert [r["record_id"] for r in test1] == [r["record_id"] for r in test2]
+
+    def test_too_few_records_raises(self):
+        opt = _make_prompt_optimization(dataset_split=True, dataset=_make_dataset(num_records=2))
+        with pytest.raises(ValueError, match="too few for splitting"):
+            opt._create_split_datasets()
+
+
+# ===========================================================================
+# 10. _to_numeric_score
+# ===========================================================================
+
+
+class TestToNumericScore:
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            (0.75, 0.75),
+            (1, 1.0),
+            (True, 1.0),
+            (False, 0.0),
+            ("pass", 1.0),
+            ("correct", 1.0),
+            ("true_positive", 1.0),
+            ("true_negative", 1.0),
+            ("incorrect", 0.0),
+            ("PASS", 1.0),
+            ("fail", 0.0),
+        ],
+    )
+    def test_basic_types(self, input_val, expected):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        assert LLMObsGEPAAdapter._to_numeric_score(input_val) == expected
+
+    def test_evaluator_result(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        er = EvaluatorResult(value=0.8)
+        assert LLMObsGEPAAdapter._to_numeric_score(er) == 0.8
+
+    def test_dict_with_value(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        assert LLMObsGEPAAdapter._to_numeric_score({"value": 0.9}) == 0.9
+
+    def test_unexpected_type(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        assert LLMObsGEPAAdapter._to_numeric_score([1, 2, 3]) == 0.0
+
+
+# ===========================================================================
+# 11. GEPA Adapter Helpers
+# ===========================================================================
+
+
+class TestGEPAAdapterHelpers:
+    def _make_adapter(self, **overrides):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        defaults = {
+            "task": dummy_task,
+            "evaluators": [dummy_evaluator],
+            "optimization_task": dummy_optimization_task,
+            "config": {"prompt": "test prompt"},
+        }
+        defaults.update(overrides)
+        return LLMObsGEPAAdapter(**defaults)
+
+    def test_build_feedback_with_expected(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import TrajectoryRecord
+
+        adapter = self._make_adapter()
+        traj: TrajectoryRecord = {
+            "input_data": {"q": "hello"},
+            "expected_output": "world",
+            "output": "wrong",
+            "evaluations": {"accuracy": 0.0},
+            "score": 0.0,
+        }
+        feedback = adapter._build_feedback(traj)
+        assert "Expected Output: world" in feedback
+        assert "Score: 0.00" in feedback
+
+    def test_build_feedback_no_expected(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import TrajectoryRecord
+
+        adapter = self._make_adapter()
+        traj: TrajectoryRecord = {
+            "input_data": {"q": "hello"},
+            "expected_output": None,
+            "output": "result",
+            "evaluations": {},
+            "score": 0.5,
+        }
+        feedback = adapter._build_feedback(traj)
+        assert "Expected Output" not in feedback
+        assert "Score: 0.50" in feedback
+
+    def test_build_feedback_with_reasoning(self):
+        adapter = self._make_adapter()
+        traj = {
+            "input_data": {"q": "hello"},
+            "expected_output": "world",
+            "output": "wrong",
+            "evaluations": {
+                "my_eval": {"value": 0.0, "reasoning": "totally wrong"},
+            },
+            "score": 0.0,
+        }
+        feedback = adapter._build_feedback(traj)
+        assert "my_eval reasoning: totally wrong" in feedback
+
+    def test_build_user_prompt_from_reflective(self):
+        adapter = self._make_adapter()
+        entries = [
+            {"Inputs": {"q": "test"}, "Generated Outputs": "out", "Feedback": "good"},
+        ]
+        result = adapter._build_user_prompt_from_reflective("current prompt", entries)
+        assert "Initial Prompt:" in result
+        assert "current prompt" in result
+        assert "Example 1" in result
+
+    def test_build_user_prompt_from_reflective_empty(self):
+        adapter = self._make_adapter()
+        result = adapter._build_user_prompt_from_reflective("current prompt", [])
+        assert "Initial Prompt:" in result
+        assert "Example" not in result
+
+    def test_dataset_to_gepa_format(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        ds = _make_dataset(num_records=3)
+        records = LLMObsGEPAAdapter._dataset_to_gepa_format(ds)
+        assert len(records) == 3
+        assert "input_data" in records[0]
+        assert "expected_output" in records[0]
+        assert "metadata" in records[0]
+
+    def test_dataset_to_gepa_format_empty(self):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        ds = _make_dataset(num_records=0)
+        records = LLMObsGEPAAdapter._dataset_to_gepa_format(ds)
+        assert records == []
+
+
+# ===========================================================================
+# 12. GEPA Adapter evaluate
+# ===========================================================================
+
+
+class TestGEPAAdapterEvaluate:
+    def _make_adapter(self, **overrides):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        defaults = {
+            "task": dummy_task,
+            "evaluators": [dummy_evaluator],
+            "optimization_task": dummy_optimization_task,
+            "config": {"prompt": "test prompt"},
+        }
+        defaults.update(overrides)
+        return LLMObsGEPAAdapter(**defaults)
+
+    def _mock_gepa_module(self):
+        """Create a mock gepa module with EvaluationBatch."""
+        mock_module = MagicMock()
+
+        class FakeEvaluationBatch:
+            def __init__(self, outputs, scores, trajectories=None):
+                self.outputs = outputs
+                self.scores = scores
+                self.trajectories = trajectories
+
+        mock_module.EvaluationBatch = FakeEvaluationBatch
+        return mock_module
+
+    def test_runs_task_and_evaluators(self):
+        mock_gepa = self._mock_gepa_module()
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            adapter = self._make_adapter()
+            batch = [
+                {"input_data": {"answer": "a0"}, "expected_output": {"answer": "a0"}},
+                {"input_data": {"answer": "a1"}, "expected_output": {"answer": "wrong"}},
+            ]
+            result = adapter.evaluate(batch, {"system_prompt": "test"}, capture_traces=False)
+            assert len(result.outputs) == 2
+            assert len(result.scores) == 2
+            assert result.trajectories is None
+
+    def test_capture_traces(self):
+        mock_gepa = self._mock_gepa_module()
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            adapter = self._make_adapter()
+            batch = [{"input_data": {"answer": "a0"}, "expected_output": {"answer": "a0"}}]
+            result = adapter.evaluate(batch, {"system_prompt": "test"}, capture_traces=True)
+            assert result.trajectories is not None
+            assert len(result.trajectories) == 1
+
+    def test_task_exception_returns_none_output(self):
+        def failing_task(input_data, config):
+            raise RuntimeError("boom")
+
+        mock_gepa = self._mock_gepa_module()
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            adapter = self._make_adapter(task=failing_task)
+            batch = [{"input_data": {"q": "test"}, "expected_output": "answer"}]
+            result = adapter.evaluate(batch, {"system_prompt": "test"}, capture_traces=False)
+            assert result.outputs[0] is None
+            assert result.scores[0] == 0.0
+
+    def test_candidate_prompt_injected(self):
+        captured_configs = []
+
+        def tracking_task(input_data, config):
+            captured_configs.append(dict(config))
+            return input_data
+
+        mock_gepa = self._mock_gepa_module()
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            adapter = self._make_adapter(task=tracking_task)
+            batch = [{"input_data": {"q": "test"}, "expected_output": "answer"}]
+            adapter.evaluate(batch, {"system_prompt": "injected_prompt"}, capture_traces=False)
+            assert captured_configs[0]["prompt"] == "injected_prompt"
+
+
+# ===========================================================================
+# 13. GEPA Adapter propose_new_texts
+# ===========================================================================
+
+
+class TestGEPAAdapterProposeNewTexts:
+    def _make_adapter(self, **overrides):
+        from ddtrace.llmobs._optimizers.gepa_strategy import LLMObsGEPAAdapter
+
+        defaults = {
+            "task": dummy_task,
+            "evaluators": [dummy_evaluator],
+            "optimization_task": dummy_optimization_task,
+            "config": {"prompt": "test prompt"},
+        }
+        defaults.update(overrides)
+        return LLMObsGEPAAdapter(**defaults)
+
+    @patch("ddtrace.llmobs._prompt_optimization.load_optimization_system_prompt", return_value="sys prompt")
+    def test_success(self, mock_load):
+        def opt_task(system_prompt, user_prompt, config):
+            return "new prompt"
+
+        adapter = self._make_adapter(optimization_task=opt_task)
+        result = adapter.propose_new_texts({"system_prompt": "old"}, {"system_prompt": []}, ["system_prompt"])
+        assert result == {"system_prompt": "new prompt"}
+
+    @patch("ddtrace.llmobs._prompt_optimization.load_optimization_system_prompt", return_value="sys prompt")
+    def test_empty_keeps_current(self, mock_load):
+        def opt_task(system_prompt, user_prompt, config):
+            return ""
+
+        adapter = self._make_adapter(optimization_task=opt_task)
+        result = adapter.propose_new_texts({"system_prompt": "old"}, {"system_prompt": []}, ["system_prompt"])
+        assert result == {"system_prompt": "old"}
+
+    @patch("ddtrace.llmobs._prompt_optimization.load_optimization_system_prompt", return_value="sys prompt")
+    def test_exception_keeps_current(self, mock_load):
+        def opt_task(system_prompt, user_prompt, config):
+            raise RuntimeError("fail")
+
+        adapter = self._make_adapter(optimization_task=opt_task)
+        result = adapter.propose_new_texts({"system_prompt": "old"}, {"system_prompt": []}, ["system_prompt"])
+        assert result == {"system_prompt": "old"}
+
+
+# ===========================================================================
+# 14. _run_gepa_core
+# ===========================================================================
+
+
+class TestRunGEPACore:
+    def test_success(self):
+        mock_gepa = MagicMock()
+        mock_result = MagicMock()
+        mock_result.best_candidate = {"system_prompt": "GEPA optimized"}
+        mock_gepa.optimize.return_value = mock_result
+
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            opt = _make_prompt_optimization(method="gepa")
+            ds = _make_dataset()
+            result = opt._run_gepa_core(ds, ds)
+            assert result == "GEPA optimized"
+
+    def test_gepa_not_installed(self):
+        # Ensure gepa is not available
+        with patch.dict(sys.modules, {"gepa": None}):
+            opt = _make_prompt_optimization(method="gepa")
+            ds = _make_dataset()
+            with pytest.raises(ImportError, match="gepa package is required"):
+                opt._run_gepa_core(ds, ds)
+
+    def test_optimize_raises_falls_back(self):
+        mock_gepa = MagicMock()
+        mock_gepa.optimize.side_effect = RuntimeError("GEPA crashed")
+
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            opt = _make_prompt_optimization(method="gepa")
+            ds = _make_dataset()
+            result = opt._run_gepa_core(ds, ds)
+            assert result == "initial prompt"  # fallback to initial
+
+    def test_config_params_forwarded(self):
+        mock_gepa = MagicMock()
+        mock_result = MagicMock()
+        mock_result.best_candidate = {"system_prompt": "optimized"}
+        mock_gepa.optimize.return_value = mock_result
+
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            opt = _make_prompt_optimization(
+                method="gepa",
+                config={
+                    "prompt": "initial prompt",
+                    "max_metric_calls": 200,
+                    "gepa_seed": 99,
+                    "candidate_selection_strategy": "elite",
+                },
+            )
+            ds = _make_dataset()
+            opt._run_gepa_core(ds, ds)
+
+            call_kwargs = mock_gepa.optimize.call_args[1]
+            assert call_kwargs["max_metric_calls"] == 200
+            assert call_kwargs["seed"] == 99
+            assert call_kwargs["candidate_selection_strategy"] == "elite"
+
+
+# ===========================================================================
+# 15. _run_gepa_without_split
+# ===========================================================================
+
+
+class TestRunGEPAWithoutSplit:
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_baseline_and_final(self, mock_exp, mock_gepa_core):
+        scores = [0.5, 0.8]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa")
+        result = opt._run_gepa_without_split(jobs=1)
+        assert result.total_iterations == 2
+        assert result._test_phase is None
+
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_best_iteration_selected(self, mock_exp, mock_gepa_core):
+        # Baseline better than optimized
+        scores = [0.9, 0.3]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa")
+        result = opt._run_gepa_without_split(jobs=1)
+        assert result.best_iteration == 0
+
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    def test_optimized_better(self, mock_exp, mock_gepa_core):
+        scores = [0.3, 0.9]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa")
+        result = opt._run_gepa_without_split(jobs=1)
+        assert result.best_iteration == 1
+        assert result.best_prompt == "optimized prompt"
+
+
+# ===========================================================================
+# 16. _run_gepa_with_split
+# ===========================================================================
+
+
+class TestRunGEPAWithSplit:
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_creates_splits_and_test(self, mock_split, mock_exp, mock_gepa_core):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        # baseline_valid, final_valid, test
+        scores = [0.5, 0.8, 0.75]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa", dataset_split=True)
+        result = opt._run_gepa_with_split(jobs=1)
+        assert result.total_iterations == 2
+        assert result._test_phase is not None
+        assert result._test_phase.score is not None
+
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_test_runs_with_best_prompt(self, mock_split, mock_exp, mock_gepa_core):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        scores = [0.5, 0.8, 0.75]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa", dataset_split=True)
+        result = opt._run_gepa_with_split(jobs=1)
+        # Final iteration is better (0.8 > 0.5), so best is iteration 1
+        assert result.best_iteration == 1
+        # Test phase runs with best prompt
+        test_call = mock_exp.call_args_list[-1]
+        assert test_call[0][1] == "optimized prompt"
+
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_has_test_phase(self, mock_split, mock_exp, mock_gepa_core):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        scores = [0.5, 0.8, 0.9]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa", dataset_split=True)
+        result = opt._run_gepa_with_split(jobs=1)
+        assert isinstance(result._test_phase, TestPhaseResult)
+
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_experiment")
+    @patch.object(PromptOptimization, "_create_split_datasets")
+    def test_baseline_wins(self, mock_split, mock_exp, mock_gepa_core):
+        train_ds = _make_dataset("train", 6)
+        valid_ds = _make_dataset("valid", 2)
+        test_ds = _make_dataset("test", 2)
+        mock_split.return_value = (train_ds, valid_ds, test_ds)
+
+        # baseline_valid=0.9, final_valid=0.3, test=0.85
+        scores = [0.9, 0.3, 0.85]
+        call_idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            idx = call_idx["i"]
+            call_idx["i"] += 1
+            return _make_experiment_result(scores[idx]), f"https://exp/{idx}"
+
+        mock_exp.side_effect = side_effect
+        opt = _make_prompt_optimization(method="gepa", dataset_split=True)
+        result = opt._run_gepa_with_split(jobs=1)
+        assert result.best_iteration == 0
+        # Test runs with baseline (initial) prompt
+        test_call = mock_exp.call_args_list[-1]
+        assert test_call[0][1] == "initial prompt"

--- a/tests/llmobs/test_prompt_optimization.py
+++ b/tests/llmobs/test_prompt_optimization.py
@@ -1123,8 +1123,10 @@ class TestRunGEPACore:
         with patch.dict(sys.modules, {"gepa": mock_gepa}):
             opt = _make_prompt_optimization(method="gepa")
             ds = _make_dataset()
-            result = opt._run_gepa_core(ds, ds)
-            assert result == "GEPA optimized"
+            prompt, metadata, error = opt._run_gepa_core(ds, ds)
+            assert prompt == "GEPA optimized"
+            assert error is None
+            assert metadata is not None
 
     def test_gepa_not_installed(self):
         # Ensure gepa is not available
@@ -1141,8 +1143,10 @@ class TestRunGEPACore:
         with patch.dict(sys.modules, {"gepa": mock_gepa}):
             opt = _make_prompt_optimization(method="gepa")
             ds = _make_dataset()
-            result = opt._run_gepa_core(ds, ds)
-            assert result == "initial prompt"  # fallback to initial
+            prompt, metadata, error = opt._run_gepa_core(ds, ds)
+            assert prompt == "initial prompt"  # fallback to initial
+            assert metadata is None
+            assert error is not None
 
     def test_config_params_forwarded(self):
         mock_gepa = MagicMock()
@@ -1189,7 +1193,7 @@ class TestRunGEPACore:
 
 
 class TestRunGEPAWithoutSplit:
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     def test_baseline_and_final(self, mock_exp, mock_gepa_core):
         scores = [0.5, 0.8]
@@ -1206,7 +1210,7 @@ class TestRunGEPAWithoutSplit:
         assert result.total_iterations == 2
         assert result._test_phase is None
 
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     def test_best_iteration_selected(self, mock_exp, mock_gepa_core):
         # Baseline better than optimized
@@ -1223,7 +1227,7 @@ class TestRunGEPAWithoutSplit:
         result = opt._run_gepa_without_split(jobs=1)
         assert result.best_iteration == 0
 
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     def test_optimized_better(self, mock_exp, mock_gepa_core):
         scores = [0.3, 0.9]
@@ -1247,7 +1251,7 @@ class TestRunGEPAWithoutSplit:
 
 
 class TestRunGEPAWithSplit:
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     @patch.object(PromptOptimization, "_create_split_datasets")
     def test_creates_splits_and_test(self, mock_split, mock_exp, mock_gepa_core):
@@ -1272,7 +1276,7 @@ class TestRunGEPAWithSplit:
         assert result._test_phase is not None
         assert result._test_phase.score is not None
 
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     @patch.object(PromptOptimization, "_create_split_datasets")
     def test_test_runs_with_best_prompt(self, mock_split, mock_exp, mock_gepa_core):
@@ -1298,7 +1302,7 @@ class TestRunGEPAWithSplit:
         test_call = mock_exp.call_args_list[-1]
         assert test_call[0][1] == "optimized prompt"
 
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     @patch.object(PromptOptimization, "_create_split_datasets")
     def test_has_test_phase(self, mock_split, mock_exp, mock_gepa_core):
@@ -1320,7 +1324,7 @@ class TestRunGEPAWithSplit:
         result = opt._run_gepa_with_split(jobs=1)
         assert isinstance(result._test_phase, TestPhaseResult)
 
-    @patch.object(PromptOptimization, "_run_gepa_core", return_value="optimized prompt")
+    @patch.object(PromptOptimization, "_run_gepa_core", return_value=("optimized prompt", None, None))
     @patch.object(PromptOptimization, "_run_experiment")
     @patch.object(PromptOptimization, "_create_split_datasets")
     def test_baseline_wins(self, mock_split, mock_exp, mock_gepa_core):

--- a/tests/llmobs/test_prompt_optimization.py
+++ b/tests/llmobs/test_prompt_optimization.py
@@ -557,6 +557,33 @@ class TestRunRouting:
         opt.run()
         mock_run.assert_called_once()
 
+    @patch.object(PromptOptimization, "_run_gepa_without_split")
+    def test_gepa_stopping_condition_warns(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="gepa", stopping_condition=lambda _: True)
+        with patch("ddtrace.llmobs._prompt_optimization.log") as mock_log:
+            opt.run()
+            warning_messages = [str(call) for call in mock_log.warning.call_args_list]
+            assert any("stopping_condition" in m for m in warning_messages)
+
+    @patch.object(PromptOptimization, "_run_gepa_without_split")
+    def test_gepa_max_iterations_warns(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="gepa", max_iterations=10)
+        with patch("ddtrace.llmobs._prompt_optimization.log") as mock_log:
+            opt.run()
+            warning_messages = [str(call) for call in mock_log.warning.call_args_list]
+            assert any("max_iterations" in m for m in warning_messages)
+
+    @patch.object(PromptOptimization, "_run_gepa_without_split")
+    def test_gepa_no_warn_when_defaults(self, mock_run):
+        mock_run.return_value = MagicMock()
+        opt = _make_prompt_optimization(method="gepa")
+        with patch("ddtrace.llmobs._prompt_optimization.log") as mock_log:
+            opt.run()
+            warning_messages = [str(call) for call in mock_log.warning.call_args_list]
+            assert not any("stopping_condition" in m or "max_iterations" in m for m in warning_messages)
+
 
 # ===========================================================================
 # 7. _run_without_split (metaprompting)
@@ -912,6 +939,48 @@ class TestGEPAAdapterHelpers:
         records = LLMObsGEPAAdapter._dataset_to_gepa_format(ds)
         assert records == []
 
+    def test_make_reflective_dataset_schema(self):
+        """make_reflective_dataset must return Mapping[str, list[dict]] with required keys."""
+        adapter = self._make_adapter()
+        candidate = {"system_prompt": "current"}
+        eval_batch = MagicMock()
+        eval_batch.trajectories = [
+            {
+                "input_data": {"q": "hello"},
+                "expected_output": "world",
+                "output": "wrong",
+                "evaluations": {"acc": 0.0},
+                "score": 0.0,
+            }
+        ]
+        result = adapter.make_reflective_dataset(candidate, eval_batch, ["system_prompt"])
+        assert isinstance(result, dict)
+        assert "system_prompt" in result
+        assert len(result["system_prompt"]) == 1
+        entry = result["system_prompt"][0]
+        assert "Inputs" in entry
+        assert "Generated Outputs" in entry
+        assert "Feedback" in entry
+
+    def test_make_reflective_dataset_empty_trajectories_warns(self):
+        """make_reflective_dataset warns and returns empty list when trajectories is None."""
+        adapter = self._make_adapter()
+        eval_batch = MagicMock()
+        eval_batch.trajectories = None
+        with patch("ddtrace.llmobs._optimizers.gepa_strategy.log") as mock_log:
+            result = adapter.make_reflective_dataset({}, eval_batch, ["system_prompt"])
+            mock_log.warning.assert_called_once()
+            assert "capture_traces" in str(mock_log.warning.call_args)
+        assert result == {"system_prompt": []}
+
+    def test_propose_new_texts_is_callable_field(self):
+        """propose_new_texts must be a callable field (not just a method) for GEPA protocol."""
+        adapter = self._make_adapter()
+        # GEPA checks `adapter.propose_new_texts is not None` then calls it directly
+        assert callable(adapter.propose_new_texts)
+        # Must not be None (GEPA skips proposal if None)
+        assert adapter.propose_new_texts is not None
+
 
 # ===========================================================================
 # 12. GEPA Adapter evaluate
@@ -1098,6 +1167,20 @@ class TestRunGEPACore:
             assert call_kwargs["max_metric_calls"] == 200
             assert call_kwargs["seed"] == 99
             assert call_kwargs["candidate_selection_strategy"] == "elite"
+
+    def test_max_metric_calls_default(self):
+        """max_metric_calls defaults to 150 when not specified in config."""
+        mock_gepa = MagicMock()
+        mock_result = MagicMock()
+        mock_result.best_candidate = {"system_prompt": "optimized"}
+        mock_gepa.optimize.return_value = mock_result
+
+        with patch.dict(sys.modules, {"gepa": mock_gepa}):
+            opt = _make_prompt_optimization(method="gepa")
+            ds = _make_dataset()
+            opt._run_gepa_core(ds, ds)
+            call_kwargs = mock_gepa.optimize.call_args[1]
+            assert call_kwargs["max_metric_calls"] == 150
 
 
 # ===========================================================================


### PR DESCRIPTION
## Description

Adds GEPA (Generative Evolutionary Prompt Algorithm) as an alternative optimization backend for `LLMObs._prompt_optimization()`, alongside the existing metaprompting approach. Also refactors `load_optimization_system_prompt` into a module-level function shared by both backends, adds train/valid/test dataset splitting, and applies a full round of Codex-suggested enhancements.

### Core feature
- `_prompt_optimization.py`: new `method="gepa"` parameter, `load_optimization_system_prompt` module-level helper, dataset split support (`dataset_split`, `test_dataset`)
- `_optimizers/gepa_strategy.py`: `LLMObsGEPAAdapter` bridging dd-trace-py task/evaluators/optimization_task to GEPA's `GEPAAdapter` protocol
- `pyproject.toml`: `gepa` optional extra (`pip install ddtrace[gepa]`), constrained to Python ≥3.10

### Code review fixes (Codex review round 1)
- Fixed `load_optimization_system_prompt` to use `_prompt_optimization_prompt.py` (Python module) — not a non-existent `.md` file
- Added `from __future__ import annotations` to `gepa_strategy.py` for Python 3.9 compatibility
- Fixed per-record scoring: average across all evaluators instead of "first non-zero" logic
- Pass record `metadata` to tasks and `BaseEvaluator` contexts inside GEPA
- Guard `compute_score` result against `None` before comparison
- Constrain `gepa` optional dep to `python_version >= '3.10'`

### Implementation review fixes (Codex review round 2)
- `propose_new_texts` assigned as instance field (protocol-correct) vs method
- `log.warning` when `stopping_condition` or `max_iterations` are passed with `method='gepa'` (both are silently ignored — GEPA owns its own loop)
- Updated docstrings for both params
- `log.warning` in `make_reflective_dataset` when trajectories is None/empty

### Enhancements (Codex review round 3)
**Score alignment**: `LLMObsGEPAAdapter.evaluate()` now runs summary evaluators + `compute_score` on each mini-batch and distributes the result as a uniform per-record score — GEPA's evolutionary pressure now aligns with the user's actual metric. *Measured impact: valid score 0.875 → 1.0 on goal-completeness dataset; test recall 0.444 → 0.667.*

**Separate optimizer config**: `gepa_config` param added to `LLMObs._prompt_optimization()` and `PromptOptimization.__init__()`; passed directly to `gepa.optimize()` taking precedence over `config` keys.

**Configurable split seed**: `dataset_split_seed=42` param replaces hard-coded constant; exposed in the public API.

**Experiment tags**: every sub-experiment now tagged `prompt_optimization_method`, `prompt_optimization_phase`, `prompt_optimization_iteration`, `prompt_optimization_split_seed` for filtering in Datadog.

**Structured GEPA metadata**: `GEPAOptimizerMetadata` dataclass capturing `num_candidates`, `best_valset_score`, `total_metric_calls`, `num_full_val_evals`, `seed` attached to `OptimizationResult.gepa_metadata` and shown in `summary()`.

**Better failure UX**: Python version in `ImportError` for missing `gepa` on <3.10; `optimizer_error` field on `OptimizationResult`; duplicate final experiment skipped when GEPA falls back to initial prompt unchanged.

## Testing

Unit tests in `tests/llmobs/test_prompt_optimization.py` (125 tests total). Covers:
- GEPA path with and without dataset splitting
- Score alignment via `compute_score` in `LLMObsGEPAAdapter.evaluate()`
- `GEPAOptimizerMetadata` populated on result
- `optimizer_error` on failure / skip duplicate experiment on no-op fallback
- Warning logs for `stopping_condition`/`max_iterations` ignored with GEPA
- `make_reflective_dataset` protocol schema and empty-trajectory warning
- `propose_new_texts` callable-field check
- `max_metric_calls` default (150) forwarded to `gepa.optimize()`
- Validation of `dataset_split` parameters
- Metaprompting path (existing tests preserved)

End-to-end run on `goal_completeness` dataset (41 records, 60/20/20 split, 150 metric calls):
- Valid accuracy: **1.000** (was 0.875 before score alignment fix)
- Test accuracy: **0.667** (was 0.444; matches metaprompting baseline)
- Precision: 1.0 / FPR: 0.0 on both valid and test sets

## Risks

- `method="gepa"` requires `pip install ddtrace[gepa]`; missing package raises `ImportError` with install instructions including Python version
- GEPA requires Python ≥3.10; on 3.9 the extra installs nothing and `method="gepa"` raises `ImportError`
- `stopping_condition` and `max_iterations` are ignored for `method="gepa"` (GEPA manages its own stopping budget via `max_metric_calls`); both emit a warning
- `LLMObs._prompt_optimization()` remains a private API (underscore prefix)

## Additional Notes

The score alignment fix (enhancement #1) had the largest measurable impact: by running `compute_score` inside each GEPA mini-batch evaluation, GEPA's evolutionary selection aligns with the metric users actually care about rather than a proxy average of raw evaluator values.