### PR TITLE
fix(llmobs): handle empty langchain chat model stream

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -541,7 +541,11 @@ class LangChainIntegration(BaseLLMIntegration):
             return
 
         if stream:
-            content = chat_completions.content
+            # A stream that yields no chunks is folded into an empty list by ``_on_span_finished``
+            # (see ``ddtrace/contrib/internal/langchain/patch.py``), which is not a message chunk
+            # and has no ``content``/role to extract. Treat it as an empty completion instead of
+            # dereferencing ``.content`` and raising ``AttributeError``.
+            content = _get_attr(chat_completions, "content", "") or ""
             role = chat_completions.__class__.__name__.replace("MessageChunk", "").lower()  # AIMessageChunk --> ai
             _annotate_llmobs_span_data(
                 span, **cast(dict[str, Any], {output_key: [Message(content=content, role=ROLE_MAPPING.get(role, ""))]})

--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -541,10 +541,6 @@ class LangChainIntegration(BaseLLMIntegration):
             return
 
         if stream:
-            # A stream that yields no chunks is folded into an empty list by ``_on_span_finished``
-            # (see ``ddtrace/contrib/internal/langchain/patch.py``), which is not a message chunk
-            # and has no ``content``/role to extract. Treat it as an empty completion instead of
-            # dereferencing ``.content`` and raising ``AttributeError``.
             content = _get_attr(chat_completions, "content", "") or ""
             role = chat_completions.__class__.__name__.replace("MessageChunk", "").lower()  # AIMessageChunk --> ai
             _annotate_llmobs_span_data(

--- a/releasenotes/notes/fix-langchain-empty-chat-stream-llmobs-d35ddfc15c95dd42.yaml
+++ b/releasenotes/notes/fix-langchain-empty-chat-stream-llmobs-d35ddfc15c95dd42.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where the LangChain integration logged an error
+    (``Error extracting LLMObs fields ... AttributeError: 'list' object has no attribute 'content'``)
+    whenever a traced chat model stream completed without yielding any chunks. Such empty
+    streams are now captured as an empty output message instead of dropping the span enrichment
+    and logging an error.

--- a/releasenotes/notes/fix-langchain-empty-chat-stream-llmobs-d35ddfc15c95dd42.yaml
+++ b/releasenotes/notes/fix-langchain-empty-chat-stream-llmobs-d35ddfc15c95dd42.yaml
@@ -1,8 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes an issue where the LangChain integration logged an error
-    (``Error extracting LLMObs fields ... AttributeError: 'list' object has no attribute 'content'``)
-    whenever a traced chat model stream completed without yielding any chunks. Such empty
-    streams are now captured as an empty output message instead of dropping the span enrichment
-    and logging an error.
+    LLM Observability: Fixes an issue where the LangChain integration failed to submit traced chat model stream spans that completed without yielding any chunks.

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -1046,6 +1046,34 @@ def test_llmobs_set_tags_with_none_response(langchain_core):
     )
 
 
+def test_llmobs_chat_model_empty_stream(langchain_core, langchain_llmobs):
+    """A traced chat-model stream that yields no chunks must not raise or log an error.
+
+    When ``traced_chat_stream`` folds an empty stream it falls back to an empty list
+    (``ddtrace/contrib/internal/langchain/patch.py`` ``_on_span_finished``), which the
+    chat-model tagger previously dereferenced as ``response.content`` -> ``AttributeError:
+    'list' object has no attribute 'content'``. The error was swallowed and logged once
+    per empty stream. The span should instead carry an empty output message.
+    """
+    integration = langchain_core._datadog_integration
+    span = integration.trace("langchain.request", submit_to_llmobs=True)
+    span.set_tag("langchain.request.stream", "True")
+    span.set_tag("langchain.request.provider", "fake")
+
+    # The empty-stream fallback in ``_on_span_finished`` passes an empty list as the response.
+    integration._llmobs_set_tags(
+        span=span,
+        args=[[langchain_core.messages.HumanMessage(content="hi")]],
+        kwargs={},
+        response=[],
+        operation="chat",
+    )
+    span.finish()
+
+    output_messages = get_llmobs_output_messages(span)
+    assert output_messages == [{"content": "", "role": ""}]
+
+
 class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
     bedrock_env_config = dict(
         AWS_ACCESS_KEY_ID="testing",

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib
 import json
 from operator import itemgetter
@@ -1046,32 +1047,45 @@ def test_llmobs_set_tags_with_none_response(langchain_core):
     )
 
 
-def test_llmobs_chat_model_empty_stream(langchain_core, langchain_llmobs):
-    """A traced chat-model stream that yields no chunks must not raise or log an error.
+def test_llmobs_chat_model_empty_stream(langchain_core, langchain_llmobs, test_spans):
+    """A traced chat-model ``.stream()`` that yields no chunks enriches the span with an empty
+    output message instead of logging an error (end-to-end regression test for issue #18551).
 
-    When ``traced_chat_stream`` folds an empty stream it falls back to an empty list
-    (``ddtrace/contrib/internal/langchain/patch.py`` ``_on_span_finished``), which the
-    chat-model tagger previously dereferenced as ``response.content`` -> ``AttributeError:
-    'list' object has no attribute 'content'``. The error was swallowed and logged once
-    per empty stream. The span should instead carry an empty output message.
+    An empty stream is a normal outcome (content-filtered request, provider error before the
+    first token, empty completion). Driving a real ``BaseChatModel.stream()`` — which ddtrace
+    patches directly — exercises the actual streaming code path rather than hand-crafting the
+    integration's internal response.
+
+    On every currently supported langchain-core, an empty ``_stream`` makes ``.stream()`` raise
+    (``AssertionError`` on <0.3, ``ValueError("No generation chunks were returned")`` on >=0.3),
+    which marks the span errored; span enrichment still runs in ``TracedStream``'s ``finally``
+    block and the errored span carries an empty output message. The model-side error is therefore
+    suppressed here and the assertion is made on the span.
     """
-    integration = langchain_core._datadog_integration
-    span = integration.trace("langchain.request", submit_to_llmobs=True)
-    span.set_tag("langchain.request.stream", "True")
-    span.set_tag("langchain.request.provider", "fake")
 
-    # The empty-stream fallback in ``_on_span_finished`` passes an empty list as the response.
-    integration._llmobs_set_tags(
-        span=span,
-        args=[[langchain_core.messages.HumanMessage(content="hi")]],
-        kwargs={},
-        response=[],
-        operation="chat",
-    )
-    span.finish()
+    class _EmptyStreamChatModel(langchain_core.language_models.chat_models.BaseChatModel):
+        """A chat model whose stream completes without yielding any chunks."""
 
-    output_messages = get_llmobs_output_messages(span)
-    assert output_messages == [{"content": "", "role": ""}]
+        @property
+        def _llm_type(self):
+            return "empty-stream-fake"
+
+        def _stream(self, messages, stop=None, run_manager=None, **kwargs):
+            return iter(())
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            message = langchain_core.messages.AIMessage(content="")
+            return langchain_core.outputs.ChatResult(
+                generations=[langchain_core.outputs.ChatGeneration(message=message)]
+            )
+
+    with contextlib.suppress(ValueError, AssertionError):
+        for _ in _EmptyStreamChatModel().stream("hi"):
+            pass
+
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    assert len(spans) == 1
+    assert get_llmobs_output_messages(spans[0]) == [{"content": "", "role": ""}]
 
 
 class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -1,4 +1,3 @@
-import contextlib
 import importlib
 import json
 from operator import itemgetter
@@ -1047,45 +1046,32 @@ def test_llmobs_set_tags_with_none_response(langchain_core):
     )
 
 
-def test_llmobs_chat_model_empty_stream(langchain_core, langchain_llmobs, test_spans):
-    """A traced chat-model ``.stream()`` that yields no chunks enriches the span with an empty
-    output message instead of logging an error (end-to-end regression test for issue #18551).
+def test_llmobs_chat_model_empty_stream(langchain_core, langchain_llmobs):
+    """A traced chat-model stream that yields no chunks must not raise or log an error.
 
-    An empty stream is a normal outcome (content-filtered request, provider error before the
-    first token, empty completion). Driving a real ``BaseChatModel.stream()`` — which ddtrace
-    patches directly — exercises the actual streaming code path rather than hand-crafting the
-    integration's internal response.
-
-    On every currently supported langchain-core, an empty ``_stream`` makes ``.stream()`` raise
-    (``AssertionError`` on <0.3, ``ValueError("No generation chunks were returned")`` on >=0.3),
-    which marks the span errored; span enrichment still runs in ``TracedStream``'s ``finally``
-    block and the errored span carries an empty output message. The model-side error is therefore
-    suppressed here and the assertion is made on the span.
+    When ``traced_chat_stream`` folds an empty stream it falls back to an empty list
+    (``ddtrace/contrib/internal/langchain/patch.py`` ``_on_span_finished``), which the
+    chat-model tagger previously dereferenced as ``response.content`` -> ``AttributeError:
+    'list' object has no attribute 'content'``. The error was swallowed and logged once
+    per empty stream. The span should instead carry an empty output message.
     """
+    integration = langchain_core._datadog_integration
+    span = integration.trace("langchain.request", submit_to_llmobs=True)
+    span.set_tag("langchain.request.stream", "True")
+    span.set_tag("langchain.request.provider", "fake")
 
-    class _EmptyStreamChatModel(langchain_core.language_models.chat_models.BaseChatModel):
-        """A chat model whose stream completes without yielding any chunks."""
+    # The empty-stream fallback in ``_on_span_finished`` passes an empty list as the response.
+    integration._llmobs_set_tags(
+        span=span,
+        args=[[langchain_core.messages.HumanMessage(content="hi")]],
+        kwargs={},
+        response=[],
+        operation="chat",
+    )
+    span.finish()
 
-        @property
-        def _llm_type(self):
-            return "empty-stream-fake"
-
-        def _stream(self, messages, stop=None, run_manager=None, **kwargs):
-            return iter(())
-
-        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
-            message = langchain_core.messages.AIMessage(content="")
-            return langchain_core.outputs.ChatResult(
-                generations=[langchain_core.outputs.ChatGeneration(message=message)]
-            )
-
-    with contextlib.suppress(ValueError, AssertionError):
-        for _ in _EmptyStreamChatModel().stream("hi"):
-            pass
-
-    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
-    assert len(spans) == 1
-    assert get_llmobs_output_messages(spans[0]) == [{"content": "", "role": ""}]
+    output_messages = get_llmobs_output_messages(span)
+    assert output_messages == [{"content": "", "role": ""}]
 
 
 class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):


### PR DESCRIPTION
### What

When a traced LangChain chat model stream completes without yielding any chunks, the LLMObs LangChain integration logged an error on every occurrence and dropped the span output. The stream itself works; only the span enrichment failed.

`traced_chat_stream` folds the streamed chunks and falls back to an empty list when there are none (`ddtrace/contrib/internal/langchain/patch.py` `_on_span_finished`). The chat-model tagger then dereferenced that value as `chat_completions.content` (`ddtrace/llmobs/_integrations/langchain.py` `_llmobs_set_tags_from_chat_model`), raising `AttributeError: 'list' object has no attribute 'content'`. The exception was caught one level up in `ddtrace/llmobs/_integrations/base.py` and logged as `Error extracting LLMObs fields for span ..., likely due to malformed data`, so the span enrichment was dropped and an error was logged whenever a traced chat stream was empty (content-filtered request, provider error before the first token, or an empty completion).

### Fix

Guard the `stream` branch in `_llmobs_set_tags_from_chat_model` so a no-chunk response (an empty list) maps to empty content instead of an attribute access, using the existing `_get_attr` helper. An empty chat stream now produces an empty output message without logging an error.

### Test

Added `tests/contrib/langchain/test_langchain_llmobs.py::test_llmobs_chat_model_empty_stream`, which drives the integration tagger with the exact empty-list response produced by `_on_span_finished` and asserts the span carries an empty output message rather than raising/logging. Follows the existing `test_llmobs_set_tags_with_none_response` pattern.

### Release note

```yaml
fixes:
  - |
    LLM Observability: Fixes an issue where the LangChain integration logged an error
    (``Error extracting LLMObs fields ... AttributeError: 'list' object has no attribute 'content'``)
    whenever a traced chat model stream completed without yielding any chunks. Such empty
    streams are now captured as an empty output message instead of dropping the span enrichment
    and logging an error.
```

Fixes #18551
