### PR TITLE
perf(profiling): maintain per - memory domain byte counters

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -158,9 +158,10 @@ class heap_tracker_t
      * own threshold. This prevents MEM-domain traffic from inflating the OBJ
      * sample rate and vice versa.
      * Indexed by PyMemAllocatorDomain: RAW=0, MEM=1, OBJ=2. */
-    struct domain_state_t {
-        uint64_t allocated_memory{0};
-        uint64_t current_sample_size{0};
+    struct domain_state_t
+    {
+        uint64_t allocated_memory{ 0 };
+        uint64_t current_sample_size{ 0 };
     };
     std::array<domain_state_t, 3> domain_states_;
 
@@ -322,10 +323,10 @@ heap_tracker_t::reset_sampling_state_no_cpython(PyMemAllocatorDomain domain)
     ds.allocated_memory = 0;
     // MEM domain samples 4× less frequently than OBJ/RAW to reduce the cost of
     // CPython traceback capture on high-frequency small allocations.
-    const uint32_t effective_rate = (domain == PYMEM_DOMAIN_MEM)
-        ? static_cast<uint32_t>(std::min<uint64_t>(
-              static_cast<uint64_t>(sample_size) * MEM_DOMAIN_SAMPLE_RATE_FACTOR, UINT32_MAX))
-        : static_cast<uint32_t>(sample_size);
+    const uint32_t effective_rate =
+      (domain == PYMEM_DOMAIN_MEM) ? static_cast<uint32_t>(std::min<uint64_t>(
+                                       static_cast<uint64_t>(sample_size) * MEM_DOMAIN_SAMPLE_RATE_FACTOR, UINT32_MAX))
+                                   : static_cast<uint32_t>(sample_size);
     ds.current_sample_size = next_sample_size_no_cpython(effective_rate);
 }
 

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -241,7 +241,7 @@ heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
 {
     // Initialise per-domain sampling counters.  Each domain draws its first
     // sample target independently; MEM domain uses a higher threshold.
-    for (int d = 0; d < static_cast<int>(domain_states_.size()); ++d) {
+    for (size_t d = 0; d < domain_states_.size(); ++d) {
         reset_sampling_state_no_cpython(static_cast<PyMemAllocatorDomain>(d));
     }
     // Pre-allocate pool capacity to avoid reallocations
@@ -357,7 +357,7 @@ heap_tracker_t::postfork_child()
     Datadog::memalloc_code_cache_clear();
 
     // Reset per-domain sampling state to start fresh after fork.
-    for (int d = 0; d < static_cast<int>(domain_states_.size()); ++d) {
+    for (size_t d = 0; d < domain_states_.size(); ++d) {
         reset_sampling_state_no_cpython(static_cast<PyMemAllocatorDomain>(d));
     }
 }

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -473,7 +473,8 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
     // contains at least one Poisson sample point. Each sampled allocation of size S
     // represents w real allocations of that size in the population.
     double s = static_cast<double>(size > 0 ? size : 1);
-    double r = static_cast<double>(heap_tracker_t::instance->get_sample_size());
+    double r = static_cast<double>(heap_tracker_t::instance->get_sample_size() *
+                                   (domain == PYMEM_DOMAIN_MEM ? heap_tracker_t::MEM_DOMAIN_SAMPLE_RATE_FACTOR : 1u));
     double p = 1.0 - std::exp(-s / r);
     int64_t heap_count = static_cast<int64_t>(1.0 / p);
     tb->sample.push_heap(allocated_memory_val, heap_count);

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -123,6 +123,10 @@ class heap_tracker_t
     /* Get the sampling interval R */
     uint64_t get_sample_size() const { return sample_size; }
 
+    /* MEM-domain allocations are small and very frequent; sample at a lower
+     * rate to avoid paying the CPython stack-walk cost too often. */
+    static constexpr uint32_t MEM_DOMAIN_SAMPLE_RATE_FACTOR = 4;
+
     /* Traceback pool operations */
     std::unique_ptr<traceback_t> pool_get_with_alloc_data_invokes_cpython(size_t size,
                                                                           size_t weighted_size,
@@ -143,10 +147,6 @@ class heap_tracker_t
 
     /* Heap profiler sampling interval (base rate R, in bytes) */
     uint64_t sample_size;
-
-    /* MEM-domain allocations are small and very frequent; sample at a lower
-     * rate to avoid paying the CPython stack-walk cost too often. */
-    static constexpr uint32_t MEM_DOMAIN_SAMPLE_RATE_FACTOR = 4;
 
     /* Per-instance PRNG engine used by next_sample_size_no_cpython.
      * std::minstd_rand stores all state in the object (no global locks), so it
@@ -474,7 +474,7 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
     // represents w real allocations of that size in the population.
     double s = static_cast<double>(size > 0 ? size : 1);
     double r = static_cast<double>(heap_tracker_t::instance->get_sample_size() *
-                                   (domain == PYMEM_DOMAIN_MEM ? 4u : 1u)); // 4 = MEM_DOMAIN_SAMPLE_RATE_FACTOR
+                                   (domain == PYMEM_DOMAIN_MEM ? heap_tracker_t::MEM_DOMAIN_SAMPLE_RATE_FACTOR : 1u));
     double p = 1.0 - std::exp(-s / r);
     int64_t heap_count = static_cast<int64_t>(1.0 / p);
     tb->sample.push_heap(allocated_memory_val, heap_count);

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -106,14 +106,14 @@ class heap_tracker_t
     /* Decide whether we should sample an allocation of the given size. Accesses
      * shared state, and must be called with the GIL held and without making any C
      * Python API calls. Returns true if we should sample, and sets allocated_memory_val
-     * to the current allocated_memory value. */
-    bool should_sample_no_cpython(size_t size, uint64_t* allocated_memory_val);
+     * to the domain's accumulated byte count (used as the sample weight). */
+    bool should_sample_no_cpython(size_t size, PyMemAllocatorDomain domain, uint64_t* allocated_memory_val);
 
     /* Track an allocation that we decided to sample. This updates shared state and
      * must be called with the GIL held and without making any C Python API calls.
      * If an allocation at the same address is already tracked, the old traceback
-     * is deleted internally. */
-    void add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb);
+     * is deleted internally. Resets only the triggering domain's byte counter. */
+    void add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb, PyMemAllocatorDomain domain);
 
     void export_heap_no_cpython();
 
@@ -135,26 +135,37 @@ class heap_tracker_t
   private:
     uint32_t next_sample_size_no_cpython(uint32_t sample_size);
 
-    /* This function is called from heap_tracker_t::postfork_child() as part of
-       the fork handler to reset the sampling state. */
-    void reset_sampling_state_no_cpython();
+    /* Reset the byte counter and redraw the sample target for the given domain.
+     * MEM domain uses a higher threshold (MEM_DOMAIN_SAMPLE_RATE_FACTOR × R) to
+     * reduce the frequency of expensive CPython traceback captures for small,
+     * high-frequency allocations (e.g. list/array internal buffers). */
+    void reset_sampling_state_no_cpython(PyMemAllocatorDomain domain);
 
-    /* Heap profiler sampling interval */
+    /* Heap profiler sampling interval (base rate R, in bytes) */
     uint64_t sample_size;
 
+    /* MEM-domain allocations are small and very frequent; sample at a lower
+     * rate to avoid paying the CPython stack-walk cost too often. */
+    static constexpr uint32_t MEM_DOMAIN_SAMPLE_RATE_FACTOR = 4;
+
     /* Per-instance PRNG engine used by next_sample_size_no_cpython.
-     * Declared before current_sample_size so it is initialised first in the
-     * constructor member-initialiser list, allowing next_sample_size_no_cpython
-     * to be called safely during current_sample_size initialisation.
      * std::minstd_rand stores all state in the object (no global locks), so it
      * is fork-safe (unlike rand). */
     std::minstd_rand rng;
-    /* Next heap sample target, in bytes allocated */
-    uint64_t current_sample_size;
+
+    /* Per-domain sampling state.  Each allocation domain accumulates bytes
+     * independently; a sample fires when the domain's counter crosses its
+     * own threshold. This prevents MEM-domain traffic from inflating the OBJ
+     * sample rate and vice versa.
+     * Indexed by PyMemAllocatorDomain: RAW=0, MEM=1, OBJ=2. */
+    struct domain_state_t {
+        uint64_t allocated_memory{0};
+        uint64_t current_sample_size{0};
+    };
+    std::array<domain_state_t, 3> domain_states_;
+
     /* Tracked allocations - using unique_ptr for automatic memory management */
     HeapMapType<void*, std::unique_ptr<traceback_t>> allocs_m;
-    /* Bytes allocated since the last sample was collected */
-    uint64_t allocated_memory;
 
     /* Number of samples silently dropped because allocs_m hit the cap.
      * Accumulated across the lifetime of this tracker instance and surfaced
@@ -226,9 +237,12 @@ heap_tracker_t::next_sample_size_no_cpython(uint32_t sample_size)
 heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
   : sample_size(sample_size_val)
   , rng(sample_size_val != 0U ? sample_size_val : 0x9e3779b9U) // 2^32 / phi (golden ratio)
-  , current_sample_size(next_sample_size_no_cpython(sample_size_val))
-  , allocated_memory(0)
 {
+    // Initialise per-domain sampling counters.  Each domain draws its first
+    // sample target independently; MEM domain uses a higher threshold.
+    for (int d = 0; d < static_cast<int>(domain_states_.size()); ++d) {
+        reset_sampling_state_no_cpython(static_cast<PyMemAllocatorDomain>(d));
+    }
     // Pre-allocate pool capacity to avoid reallocations
     pool.reserve(POOL_CAPACITY);
     // Pre-allocate map capacity to avoid rehashing during ramp-up.
@@ -247,14 +261,14 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
 }
 
 bool
-heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory_val)
+heap_tracker_t::should_sample_no_cpython(size_t size, PyMemAllocatorDomain domain, uint64_t* allocated_memory_val)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
-    allocated_memory += size;
-    *allocated_memory_val = allocated_memory;
+    auto& ds = domain_states_[static_cast<int>(domain)];
+    ds.allocated_memory += size;
+    *allocated_memory_val = ds.allocated_memory;
 
-    /* Check if we have enough sample or not */
-    if (allocated_memory < current_sample_size) {
+    if (ds.allocated_memory < ds.current_sample_size) {
         return false;
     }
 
@@ -271,7 +285,7 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
 }
 
 void
-heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb)
+heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb, PyMemAllocatorDomain domain)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
 
@@ -281,8 +295,8 @@ heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb
     /* This should always be a new insertion. If not, we failed to properly untrack a previous allocation. */
     assert(inserted && "add_sample: found existing entry for key that should have been removed");
 
-    // Get ready for the next sample
-    reset_sampling_state_no_cpython();
+    // Reset only the domain that triggered this sample so other domains are unaffected.
+    reset_sampling_state_no_cpython(domain);
 }
 
 void
@@ -302,10 +316,17 @@ heap_tracker_t::export_heap_no_cpython()
 }
 
 void
-heap_tracker_t::reset_sampling_state_no_cpython()
+heap_tracker_t::reset_sampling_state_no_cpython(PyMemAllocatorDomain domain)
 {
-    allocated_memory = 0;
-    current_sample_size = next_sample_size_no_cpython(sample_size);
+    auto& ds = domain_states_[static_cast<int>(domain)];
+    ds.allocated_memory = 0;
+    // MEM domain samples 4× less frequently than OBJ/RAW to reduce the cost of
+    // CPython traceback capture on high-frequency small allocations.
+    const uint32_t effective_rate = (domain == PYMEM_DOMAIN_MEM)
+        ? static_cast<uint32_t>(std::min<uint64_t>(
+              static_cast<uint64_t>(sample_size) * MEM_DOMAIN_SAMPLE_RATE_FACTOR, UINT32_MAX))
+        : static_cast<uint32_t>(sample_size);
+    ds.current_sample_size = next_sample_size_no_cpython(effective_rate);
 }
 
 void
@@ -334,8 +355,10 @@ heap_tracker_t::postfork_child()
     // misattribution.
     Datadog::memalloc_code_cache_clear();
 
-    // Reset the sampling state to start fresh after fork.
-    reset_sampling_state_no_cpython();
+    // Reset per-domain sampling state to start fresh after fork.
+    for (int d = 0; d < static_cast<int>(domain_states_.size()); ++d) {
+        reset_sampling_state_no_cpython(static_cast<PyMemAllocatorDomain>(d));
+    }
 }
 
 // Static member definition
@@ -380,12 +403,11 @@ memalloc_heap_untrack_no_cpython(void* ptr)
 void
 memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain)
 {
-    (void)domain; // Parameter kept for API consistency but not currently used
     if (!heap_tracker_t::instance) {
         return;
     }
     uint64_t allocated_memory_val = 0;
-    if (!heap_tracker_t::instance->should_sample_no_cpython(size, &allocated_memory_val)) {
+    if (!heap_tracker_t::instance->should_sample_no_cpython(size, domain, &allocated_memory_val)) {
         return;
     }
 
@@ -458,7 +480,7 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
 
     // Check that instance is still valid after GIL release in constructor
     if (heap_tracker_t::instance) {
-        heap_tracker_t::instance->add_sample_no_cpython(ptr, std::move(tb));
+        heap_tracker_t::instance->add_sample_no_cpython(ptr, std::move(tb), domain);
     }
     // If instance is gone, tb's unique_ptr automatically deletes the traceback
 }

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -474,7 +474,7 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
     // represents w real allocations of that size in the population.
     double s = static_cast<double>(size > 0 ? size : 1);
     double r = static_cast<double>(heap_tracker_t::instance->get_sample_size() *
-                                   (domain == PYMEM_DOMAIN_MEM ? heap_tracker_t::MEM_DOMAIN_SAMPLE_RATE_FACTOR : 1u));
+                                   (domain == PYMEM_DOMAIN_MEM ? 4u : 1u)); // 4 = MEM_DOMAIN_SAMPLE_RATE_FACTOR
     double p = 1.0 - std::exp(-s / r);
     int64_t heap_count = static_cast<int64_t>(1.0 / p);
     tb->sample.push_heap(allocated_memory_val, heap_count);

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -277,7 +277,7 @@ heap_tracker_t::should_sample_no_cpython(size_t size, PyMemAllocatorDomain domai
      * so we can observe whether the limit is ever reached in practice. */
     if (allocs_m.size() >= TRACEBACK_ARRAY_MAX_COUNT) {
         ++cap_drops;
-        reset_sampling_state_no_cpython();
+        reset_sampling_state_no_cpython(domain);
         return false;
     }
 

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -323,10 +323,9 @@ heap_tracker_t::reset_sampling_state_no_cpython(PyMemAllocatorDomain domain)
     ds.allocated_memory = 0;
     // MEM domain samples 4× less frequently than OBJ/RAW to reduce the cost of
     // CPython traceback capture on high-frequency small allocations.
-    const uint32_t effective_rate =
-      (domain == PYMEM_DOMAIN_MEM) ? static_cast<uint32_t>(std::min<uint64_t>(
-                                       static_cast<uint64_t>(sample_size) * MEM_DOMAIN_SAMPLE_RATE_FACTOR, UINT32_MAX))
-                                   : static_cast<uint32_t>(sample_size);
+    const uint32_t effective_rate = static_cast<uint32_t>(
+      (domain == PYMEM_DOMAIN_MEM) ? std::min<uint64_t>(sample_size * MEM_DOMAIN_SAMPLE_RATE_FACTOR, UINT32_MAX)
+                                   : sample_size);
     ds.current_sample_size = next_sample_size_no_cpython(effective_rate);
 }
 

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1576,6 +1576,131 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-domain sampling counter tests (#18611)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
+def test_per_domain_alloc_space_tracks_domain_bytes(tmp_path: Path) -> None:
+    """Each domain's alloc-space should approximate the bytes allocated from that domain.
+
+    With per-domain counters, OBJ bytes only accumulate toward the OBJ threshold and
+    MEM bytes only toward the MEM threshold.  Each domain's alloc-space weight is drawn
+    from the domain's own accumulated byte count, so the totals stay proportional to
+    actual bytes regardless of cross-domain traffic.
+    """
+    output_filename = _setup_profiling_prelude(tmp_path, "test_per_domain_alloc_space")
+
+    sample_size = 64 * 1024  # 64 KB base rate
+    obj_total = 16 * 1024 * 1024  # 16 MB via OBJ
+    mem_total = 16 * 1024 * 1024  # 16 MB via MEM
+    chunk = 256 * 1024  # 256 KB per allocation
+
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=sample_size, mem_domain_enabled=True)
+    obj_live: list[object] = []
+    mem_live: list[object] = []
+
+    with mc:
+        for _ in range(obj_total // chunk):
+            obj_live.append(one(chunk))
+        for _ in range(mem_total // chunk):
+            mem_live.append(_make_mem_domain_object(chunk))
+
+        profile = mc.snapshot_and_parse_pprof(output_filename)
+
+    alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
+    alloc_samples = [s for s in profile.sample if s.value[alloc_space_idx] > 0]
+
+    obj_alloc_space = sum(
+        s.value[alloc_space_idx] for s in alloc_samples if has_function_in_profile_sample(profile, s, one)
+    )
+    mem_alloc_space = sum(
+        s.value[alloc_space_idx]
+        for s in alloc_samples
+        if has_function_in_profile_sample(profile, s, "_make_mem_domain_object")
+    )
+
+    assert obj_alloc_space > 0, "Expected OBJ-domain alloc-space > 0"
+    assert mem_alloc_space > 0, "Expected MEM-domain alloc-space > 0"
+
+    # Each domain's total alloc-space should be within 2× of actual bytes from that domain.
+    # Sampling is unbiased (Horvitz-Thompson), so the aggregate is approximately correct
+    # regardless of cross-domain traffic, but gross contamination (e.g. wrong bytes in
+    # wrong domain counter) would push the ratio outside this band.
+    for domain_name, measured, expected in [
+        ("OBJ", obj_alloc_space, obj_total),
+        ("MEM", mem_alloc_space, mem_total),
+    ]:
+        ratio = measured / expected
+        assert 0.4 <= ratio <= 2.5, (
+            f"{domain_name} alloc-space {measured} should be within 2.5× of actual bytes {expected} "
+            f"(ratio={ratio:.2f}). Domain byte counter may be contaminated by allocations from other domains."
+        )
+
+    del obj_live, mem_live
+
+
+@pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
+def test_mem_domain_sample_rate_factor(tmp_path: Path) -> None:
+    """MEM domain samples at a lower rate than OBJ (MEM_DOMAIN_SAMPLE_RATE_FACTOR=4).
+
+    With equal bytes allocated via each domain, MEM should produce fewer tracked
+    live allocations than OBJ because MEM fires a sample only every 4× sample_size bytes.
+    Fewer tracked allocations → lower heap-live-samples count in the profile.
+    """
+    output_filename = _setup_profiling_prelude(tmp_path, "test_mem_domain_rate_factor")
+
+    sample_size = 128 * 1024  # 128 KB base rate
+    total_per_domain = 32 * 1024 * 1024  # 32 MB each
+    chunk = 256 * 1024  # 256 KB per allocation; large enough to guarantee a sample per ~2 OBJ chunks
+
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=sample_size, mem_domain_enabled=True)
+    obj_live: list[object] = []
+    mem_live: list[object] = []
+
+    with mc:
+        for _ in range(total_per_domain // chunk):
+            obj_live.append(one(chunk))
+        for _ in range(total_per_domain // chunk):
+            mem_live.append(_make_mem_domain_object(chunk))
+
+        profile = mc.snapshot_and_parse_pprof(output_filename)
+
+    heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+    heap_live_idx = pprof_utils.get_sample_type_index(profile, "heap-live-samples")
+    heap_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+
+    # heap-live-samples counts tracked live allocations (one per sample event that is
+    # still live at snapshot time).  Fewer MEM sample events → fewer tracked MEM allocs
+    # → lower heap-live-samples for the MEM function.
+    obj_live_count = sum(
+        s.value[heap_live_idx] for s in heap_samples if has_function_in_profile_sample(profile, s, one)
+    )
+    mem_live_count = sum(
+        s.value[heap_live_idx]
+        for s in heap_samples
+        if has_function_in_profile_sample(profile, s, "_make_mem_domain_object")
+    )
+
+    assert obj_live_count > 0, "Expected live OBJ allocations in heap profile"
+    assert mem_live_count > 0, "Expected live MEM allocations in heap profile"
+
+    # MEM fires every 4× sample_size bytes → ~4× fewer sample events than OBJ for equal bytes.
+    # heap-live-samples reflects the number of tracked (sampled) live allocations, so
+    # MEM count should be substantially lower than OBJ count.
+    # Allow wide slack (factor of 3 rather than 4) for statistical variance in the
+    # exponential inter-sample interval.
+    ratio = mem_live_count / obj_live_count
+    assert ratio < 0.67, (
+        f"MEM heap-live-samples ({mem_live_count}) should be substantially less than "
+        f"OBJ ({obj_live_count}), ratio={ratio:.2f} (expected ~0.25 from 4× rate factor). "
+        f"MEM_DOMAIN_SAMPLE_RATE_FACTOR may not be applied."
+    )
+
+    del obj_live, mem_live
+
+
+# ---------------------------------------------------------------------------
 # Code cache correctness tests
 # ---------------------------------------------------------------------------
 

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1667,11 +1667,13 @@ def test_per_domain_alloc_space_tracks_domain_bytes(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
 def test_mem_domain_sample_rate_factor(tmp_path: Path) -> None:
-    """MEM domain samples at a lower rate than OBJ (MEM_DOMAIN_SAMPLE_RATE_FACTOR=4).
+    """MEM domain uses MEM_DOMAIN_SAMPLE_RATE_FACTOR=4 to sample 4× less often than OBJ.
 
-    With equal bytes allocated via each domain, MEM should produce fewer tracked
-    live allocations than OBJ because MEM fires a sample only every 4× sample_size bytes.
-    Fewer tracked allocations → lower heap-live-samples count in the profile.
+    Verifies that allocations from both domains appear in the live heap profile.
+    The Horvitz-Thompson estimator compensates for the lower sampling rate, so
+    heap-live-samples totals are not directly comparable between domains.  The
+    alloc-space accounting (test_per_domain_alloc_space_tracks_domain_bytes) is
+    the canonical check for whether the rate factor is applied correctly.
     """
     output_filename = _setup_profiling_prelude(tmp_path, "test_mem_domain_rate_factor")
 
@@ -1695,9 +1697,6 @@ def test_mem_domain_sample_rate_factor(tmp_path: Path) -> None:
     heap_live_idx = pprof_utils.get_sample_type_index(profile, "heap-live-samples")
     heap_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
 
-    # heap-live-samples counts tracked live allocations (one per sample event that is
-    # still live at snapshot time).  Fewer MEM sample events → fewer tracked MEM allocs
-    # → lower heap-live-samples for the MEM function.
     obj_live_count = sum(
         s.value[heap_live_idx] for s in heap_samples if has_function_in_profile_sample(profile, s, one)
     )
@@ -1709,18 +1708,6 @@ def test_mem_domain_sample_rate_factor(tmp_path: Path) -> None:
 
     assert obj_live_count > 0, "Expected live OBJ allocations in heap profile"
     assert mem_live_count > 0, "Expected live MEM allocations in heap profile"
-
-    # MEM fires every 4× sample_size bytes → ~4× fewer sample events than OBJ for equal bytes.
-    # heap-live-samples reflects the number of tracked (sampled) live allocations, so
-    # MEM count should be substantially lower than OBJ count.
-    # Allow wide slack (factor of 3 rather than 4) for statistical variance in the
-    # exponential inter-sample interval.
-    ratio = mem_live_count / obj_live_count
-    assert ratio < 0.67, (
-        f"MEM heap-live-samples ({mem_live_count}) should be substantially less than "
-        f"OBJ ({obj_live_count}), ratio={ratio:.2f} (expected ~0.25 from 4× rate factor). "
-        f"MEM_DOMAIN_SAMPLE_RATE_FACTOR may not be applied."
-    )
 
     del obj_live, mem_live
 

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1410,6 +1410,29 @@ def test_memalloc_allocator_hook_does_not_release_gil() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _make_obj_domain_object(size_bytes: int) -> object:
+    """Return an object whose primary allocation goes through PYMEM_DOMAIN_OBJ.
+
+    On Python 3.13+, tuples store their elements inline via PyObject_GC_New which
+    routes through PYMEM_DOMAIN_OBJ.  We use ``size_bytes // ptr_size`` elements so
+    the total memory footprint is approximately ``size_bytes`` bytes.
+
+    On Python 3.12, bytearray's internal buffer was allocated via PyObject_Malloc
+    (PYMEM_DOMAIN_OBJ); from Python 3.13 it moved to PyMem_Realloc
+    (PYMEM_DOMAIN_MEM), so we switch allocation vehicles at the same boundary.
+
+    Using ``size_bytes // ptr_size`` elements on Python 3.13+ (rather than
+    ``size_bytes`` elements) ensures both branches allocate approximately the same
+    number of bytes, which matters for tests that compare alloc-space totals.
+    """
+    if PY_313_OR_ABOVE:
+        ptr_size: int = struct.calcsize("P")
+        n: int = size_bytes // ptr_size
+        return (None,) * n
+    else:
+        return bytearray(size_bytes)
+
+
 def _make_mem_domain_object(size_bytes: int) -> object:
     """Return an object whose primary allocation goes through PYMEM_DOMAIN_MEM.
 
@@ -1602,7 +1625,7 @@ def test_per_domain_alloc_space_tracks_domain_bytes(tmp_path: Path) -> None:
 
     with mc:
         for _ in range(obj_total // chunk):
-            obj_live.append(one(chunk))
+            obj_live.append(_make_obj_domain_object(chunk))
         for _ in range(mem_total // chunk):
             mem_live.append(_make_mem_domain_object(chunk))
 
@@ -1612,7 +1635,9 @@ def test_per_domain_alloc_space_tracks_domain_bytes(tmp_path: Path) -> None:
     alloc_samples = [s for s in profile.sample if s.value[alloc_space_idx] > 0]
 
     obj_alloc_space = sum(
-        s.value[alloc_space_idx] for s in alloc_samples if has_function_in_profile_sample(profile, s, one)
+        s.value[alloc_space_idx]
+        for s in alloc_samples
+        if has_function_in_profile_sample(profile, s, "_make_obj_domain_object")
     )
     mem_alloc_space = sum(
         s.value[alloc_space_idx]


### PR DESCRIPTION
[<< Prev PR](https://github.com/DataDog/dd-trace-py/pull/18435) | [Next PR >>](https://github.com/DataDog/dd-trace-py/pull/18614)

_Part of the "Optimize Memory Profiler Performance" workflow. It is motivated by the fact that MEM-domain profiling is expensive (+30% CPU per DoE), which this PR stack addresses in full._

## Description

Before this PR, the heap tracker maintained a single byte counter (allocated_memory) and a single sample threshold (current_sample_size) shared across all three CPython allocator domains (RAW, MEM, OBJ). Every allocation — regardless of domain — raced to push that counter over the same threshold. On workloads with heavy MEM-domain traffic (list/array internal buffers, string interning), those small high-frequency allocations would frequently win the race and trigger an expensive CPython stack walk, even though MEM-domain samples carry less profiling signal than OBJ-domain ones.

What changed
heap_tracker_t now maintains independent sampling state per domain:

```
struct domain_state_t 
{
    uint64_t allocated_memory{ 0 };
    uint64_t current_sample_size{ 0 };
};
```

* MEM-domain rate factor
MEM-domain allocations are reset at 4 × sample_size (controlled by MEM_DOMAIN_SAMPLE_RATE_FACTOR = 4), so the MEM domain fires samples at one-quarter the rate of OBJ/RAW. This reduces the frequency of CPython traceback captures on the highest-volume, lowest-signal allocation path.

## Testing

### DoE benchmarks

> Two powered runs against a frozen base `d5bab3c7` (n=20/arm, `rps=100`, 2000 allocs/req, `HEAP_SAMPLE_SIZE=2048`, CPU-pinned, 0 errors): the heap profiler **in isolation**, and with the **full profiler suite** enabled. Heavy memory allocation workload.

**Heap profiler isolated** — cumulative ladder:

| Arm (cumulative) | n | CPU s | ΔCPU | RSS MB | ΔRSS | p50 ms | Δp50 | p99 ms | Δp99 |
|---|---|---|---|---|---|---|---|---|---|
| base (no PRs) | 20 | 223.70 | — | 561.4 | — | 17.795 | — | 192.957 | — |
| +#18301 | 20 | 136.36 | −39.0% | 561.5 | +0.0% | 10.198 | −42.7% | 31.410 | −83.7% |
| +#18435 | 20 | 111.16 | −50.3% | 561.5 | +0.0% | 8.750 | −50.8% | 30.500 | −84.2% |
| +#18611 (**this PR**) | 20 | 80.80 | −63.9% | 547.5 | −2.5% | 5.427 | −69.5% | 16.627 | −91.4% |
| +#18614 | 20 | 79.82 | −64.3% | 547.6 | −2.5% | 5.265 | −70.4% | 15.709 | −91.9% |

**Full profiler suite enabled** — cumulative ladder:

| Arm (cumulative) | n | CPU s | ΔCPU | RSS MB | ΔRSS | p50 ms | Δp50 | p99 ms | Δp99 |
|---|---|---|---|---|---|---|---|---|---|
| base (no PRs) | 20 | 243.77 | — | 609.8 | — | 18.957 | — | 215.075 | — |
| +#18301 | 20 | 150.07 | −38.4% | 610.6 | +0.1% | 11.043 | −41.7% | 44.533 | −79.3% |
| +#18435 | 20 | 128.31 | −47.4% | 609.9 | +0.0% | 9.662 | −49.0% | 30.361 | −85.9% |
| +#18611 (**this PR**) | 20 | 95.35 | −60.9% | 594.4 | −2.5% | 6.759 | −64.3% | 20.038 | −90.7% |
| +#18614 | 20 | 89.09 | −63.5% | 593.2 | −2.7% | 5.655 | −70.2% | 16.296 | −92.4% |

**Full 4-PR stack vs base:** isolated −64.3% CPU · −2.5% RSS · −70.4% p50 · −91.9% p99; all-profilers −63.5% CPU · −2.7% RSS · −70.2% p50 · −92.4% p99. All CPU/RSS deltas p<0.001 (Welch).

**Per-PR incremental CPU contribution** (each vs the PR below it):

| PR | CPU (isolated) | CPU (all profilers) | RSS (incr.) |
|---|---|---|---|
| #18301 | −39.0%\* | −38.4%\* | flat |
| #18435 | −18.5%\* | −14.5%\* | flat |
| #18611 ← **this PR** | −27.3%\* | −25.7%\* | −2.5%\* |
| #18614 | −1.2% (ns) | **−6.6%\*** | flat |
