### PR TITLE
chore(llmobs): inline-experiments local-regression POC + design doc

### DIFF
--- a/ddtrace/llmobs/_local_regression_experiments_design.md
+++ b/ddtrace/llmobs/_local_regression_experiments_design.md
@@ -1,0 +1,166 @@
+# Design: Trace-Seeded Local Regression Experiments
+
+**Status:** Draft / brainstorm — not yet implemented.
+**Author:** mehul
+**Last updated:** 2026-06-04
+
+## 1. Motivation
+
+Today, running an LLMObs experiment requires the user to curate a `Dataset` and
+author an `Experiment` harness. That's great for deliberate evaluation, but it
+does not serve the *inner dev loop*: a developer who has just changed a prompt,
+model, or piece of application logic and wants to answer one question quickly —
+
+> "Did my local change alter what my app produces, compared to what it did in
+> production, on real historical inputs?"
+
+This is **snapshot / golden-master regression testing, seeded from production
+traces** — the LLM analogue of unit tests. The developer's already-instrumented
+app *is* the system under test; production traces *are* the fixtures.
+
+## 2. Paradigm
+
+After a user has instrumented their app with the LLMObs decorators
+(`@workflow`, `@task`, `@agent`, `@llm`), they:
+
+1. Mark a **top-level `@workflow`** as an experiment subject with a new,
+   inert-by-default decorator.
+2. (Optionally) author a small **YAML config** describing *where to pull data
+   from* and how to run.
+3. Run an **explicit command** — `ddtrace-experiment run [--config experiment.yaml]` —
+   which pulls matching production traces, synthesizes an ephemeral dataset,
+   re-executes the *current local code* against those inputs, compares against
+   the historical output, and reports results both in the terminal and in the
+   LLMObs UI.
+
+Crucially, none of this fires during normal app execution — see §4.
+
+## 3. Decisions (converged)
+
+| Area | Decision |
+|------|----------|
+| **Subject scope** | Top-level `@workflow` only. Keeps replay inputs JSON-serializable and the capture boundary clean. |
+| **Baseline** | Regression by default (`expected_output` = recorded prod output), but fully configurable — the user may pass their own `evaluators=[...]`. |
+| **Default comparator** | LLM-judge equivalence (overridable + stackable). Handles non-deterministic text far better than string diff. *(Open: cheaper embedding-similarity default — see §8.)* |
+| **Dataset lifetime** | Ephemeral, in-memory, synthesized from traces each run. Never persisted to the backend. |
+| **Result surface** | Both — a terminal per-row diff table for the fast loop, and a streamed Experiment visible in the LLMObs UI with full history. |
+| **Trigger** | Explicit command (hard gate) + optional YAML config (soft refinement). |
+| **Config format** | Standalone YAML, passed via `--config`. |
+| **Config requirement** | Optional. Missing config → run with sane defaults. |
+
+## 4. Safety / gating — the crux
+
+The new decorator lives on code that *also runs in production*. Replaying
+traffic and re-executing live code in a prod process would be a severe footgun,
+so the activation must be **structurally impossible in prod**, not merely
+discouraged.
+
+### Principle: positive, explicit activation — never environment detection
+
+We do **not** try to auto-detect "local vs. prod." Every available signal
+(`DD_ENV`, TTY presence, source-checkout, hostname) is a heuristic that
+eventually *fails open* in production. A safety gate must never fail open.
+
+Instead, activation requires a **deliberate signal that prod never produces**:
+
+- **Primary gate (required):** the user invoked the `ddtrace-experiment`
+  command. This flips an **in-process sentinel** *before* importing the user's
+  module. Prod imports the module the normal way → sentinel never set → the
+  decorator is completely inert (no trace queries, no network, no flag checks
+  beyond the sentinel).
+- **Secondary signal (optional):** a user-authored config file passed to the
+  command. When present, it's a second independent signal prod never carries.
+- **One-way fail-safe (backstop):** even if the sentinel were somehow set,
+  additionally refuse to run when it smells like prod
+  (`not sys.stdout.isatty()` **and** `DD_ENV == "prod"`). This can only ever
+  make the gate *more* restrictive, never less.
+
+The `pytest` plugin variant (§7) gets the same property for free: running under
+pytest is both an explicit entrypoint and a context prod genuinely never enters.
+
+### Why this is robust
+
+All active behavior lives in the **launcher**, which only runs when the command
+is invoked. The decorator shipped into production is a pure no-op marker. The
+command is sufficient on its own; the optional config and the env fail-safe are
+defense-in-depth.
+
+## 5. Responsibility split
+
+| Lives in… | Holds | Rationale |
+|-----------|-------|-----------|
+| **Decorator** (app code) | "this `@workflow` is an experiment subject" — a marker, nothing else | Stable, rarely changes, safe in prod because inert. |
+| **Config file** (user-authored YAML) | *where to pull data* (ml_app, env, time window, sample size, dedup, include-errors), comparator + threshold, jobs/runs, project name, push-to-UI toggle | The volatile knobs — tune trace selection without editing instrumented code. |
+| **Code** (optional) | custom `evaluators=[...]`, custom comparator | Evaluators are logic; they belong in Python. |
+
+## 6. Execution flow
+
+```
+$ ddtrace-experiment run --config experiment.yaml
+   1. Parse config (or fall back to defaults).
+   2. Flip in-process experiment sentinel.
+   3. Run prod fail-safe check; abort if it smells like prod.
+   4. Import the user's module → @experiment decorators register (no longer no-op).
+   5. Discover marked top-level workflow(s).
+   6. Query production traces per config (ml_app / env / window / filters).
+   7. Synthesize an ephemeral Dataset:
+        input_data       = recorded workflow input
+        expected_output  = recorded workflow output (regression baseline)
+   8. Run the existing Experiment.run() engine:
+        task       = the user's current local workflow
+        evaluators = [default comparator] + any user-supplied evaluators
+   9. Report:
+        - terminal: per-row diff table (input, prod output, new output, verdict)
+        - LLMObs UI: streamed as a normal Experiment with history
+```
+
+The heavy lifting (concurrency, retries, metric streaming, summary evaluators)
+is **reused from the existing `Experiment.run()` engine** — this feature is
+mostly *dataset synthesis from traces* + *a default comparator* + *the launcher
+and gate*.
+
+## 7. Trigger implementations (shared core)
+
+Both ride a shared sentinel/registry core; the second can be added later.
+
+- **CLI launcher** — `ddtrace-experiment`, a console-script sibling of the
+  existing `ddtrace-run` (`pyproject.toml` → `ddtrace/commands/`). Max control,
+  no pytest dependency.
+- **pytest plugin** — decorated workflows collected as test items; pytest's
+  collection is the gate. Purest "unit test" feel, free CI/reporting; reports a
+  score/diff rather than a hard pass/fail (semantic equivalence is fuzzy).
+
+## 8. Example config (illustrative)
+
+```yaml
+# experiment.yaml — all fields optional; shown with example defaults
+data:
+  ml_app: my-llm-app          # default: inferred from DD_LLMOBS_ML_APP
+  env: prod                   # which traces to pull from
+  time_window: 24h            # last 24h
+  sample_size: 50             # cap number of seeded records
+  include_errors: false       # skip traces that errored in prod
+  dedup_by_input: true        # collapse duplicate inputs
+comparator:
+  type: llm_judge             # llm_judge | embedding_similarity | exact
+  threshold: 0.8              # for similarity-based comparators
+run:
+  jobs: 10                    # concurrency
+  runs: 1                     # passes (for non-deterministic tasks)
+  project: local-regressions  # LLMObs project name
+  push_to_ui: true
+```
+
+## 9. Open questions
+
+1. **Zero-config default comparator** — LLM-judge (accurate, costs tokens) vs.
+   embedding-similarity (cheaper, needs an embedding model). Currently leaning
+   LLM-judge; revisit on cost.
+2. **Trace-selection defaults** — exact defaults for window / sample size /
+   error inclusion / dedup when no config is supplied.
+3. **Multiple marked workflows** — run all discovered subjects, or require the
+   command to name one?
+4. **Input replayability** — guardrails for top-level workflows whose recorded
+   input isn't cleanly JSON-serializable.
+5. **Which trigger first** — CLI launcher vs. pytest plugin.
+```

--- a/poc_experiments/.gitignore
+++ b/poc_experiments/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+experiment_cases.jsonl

--- a/poc_experiments/README.md
+++ b/poc_experiments/README.md
@@ -1,0 +1,43 @@
+# Trace-seeded local regression experiments — POC
+
+Stdlib-only, self-contained prototype. **Not wired into ddtrace yet** — it
+exists to validate the `@experiment_start` / `@experiment_end` decorator +
+stop-point mechanics before integrating with the LLMObs SDK.
+
+See the design doc: `ddtrace/llmobs/_local_regression_experiments_design.md`
+and RFC-002 in the Obsidian vault.
+
+## Run it
+
+```bash
+cd poc_experiments
+
+# 1) Capture a baseline from a real run (emit side-effects fire, cases recorded)
+python experiment_poc.py capture example_app:generate_traffic
+
+# 2) Replay with no code change -> all MATCH, and NO emit side-effects
+#    (the @experiment_end stop-point unwinds before emit runs)
+python experiment_poc.py replay example_app
+
+# 3) Simulate a local change and replay -> CHANGED rows with a before/after diff
+PROMPT_SUFFIX='!' python experiment_poc.py replay example_app
+```
+
+`experiment_cases.jsonl` is the local "span dump" (the ephemeral dataset stand-in).
+
+## What this proves
+
+| Property | Where you see it |
+|---|---|
+| Input-in / output-out in **different functions**, replayed as **one unit** | `ingest` (start) vs `emit` (end); replay invokes only `ingest` |
+| `@experiment_end` is a real **stop point** | replay shows no `[emit side-effect]` lines |
+| Decorators are **inert in prod** (gated) | `import example_app` runs normally, nothing recorded |
+| **Regression detection** | step 3 reports `CHANGED` baseline→new |
+
+## Known POC shortcuts (to address on the path to real)
+
+- Sync only (real workflows are async — `ContextVar` already propagates across `await`).
+- Comparator is exact-match (`_default_comparator`); swap for LLM-judge equivalence.
+- Span source is a local JSONL capture; later swap for a Datadog trace pull.
+- Trigger is `python experiment_poc.py`; later a `ddtrace-experiment` console script.
+- One end-hit per unit assumed; loops/retries (multiple `emit`s) not yet handled.

--- a/poc_experiments/demo.sh
+++ b/poc_experiments/demo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Inline Experiments — end-to-end replay demo.
+# Tells the dev-loop story: capture a known-good baseline, then replay the
+# current code against it to tell a SAFE change apart from a REGRESSION.
+#
+# Uses the deterministic example so it runs with zero external deps. Point it at
+# a real app by passing a different module:  ./demo.sh example_lux_shaped
+set -e
+cd "$(dirname "$0")"
+PY="${PY:-python}"
+APP="${1:-example_briefing_shaped}"
+
+line() { printf '%s\n' "────────────────────────────────────────────────────────"; }
+
+line; echo "  INLINE EXPERIMENTS — replay demo   (app: $APP)"; line; echo
+
+echo "STEP 1 ▸ capture a baseline from the current, known-good code"
+rm -f experiment_cases.jsonl
+RUN_TS=t1 $PY experiment_poc.py capture "$APP:generate_traffic" >/dev/null
+echo "  baseline recorded:"
+sed 's/^/      /' experiment_cases.jsonl
+echo
+
+echo "STEP 2 ▸ developer reworks the summary wording — a SAFE refactor"
+echo "         replay current code vs baseline (structural comparator)"
+RUN_TS=t2 DRIFT=text $PY experiment_poc.py replay "$APP" --comparator structural
+echo "  → MATCH: output shape preserved despite reworded text. Safe to ship. ✅"
+echo
+
+echo "STEP 3 ▸ a change accidentally DROPS a ticker — a REGRESSION"
+echo "         replay current code vs baseline (structural comparator)"
+RUN_TS=t2 DRIFT=drop $PY experiment_poc.py replay "$APP" --comparator structural
+echo "  → CHANGED: output structure regressed. Caught before shipping. ❌"
+echo
+line; echo "  done — capture once, replay on every change."; line

--- a/poc_experiments/example_app.py
+++ b/poc_experiments/example_app.py
@@ -1,0 +1,57 @@
+"""
+A stand-in for an instrumented LLM app.
+
+The thing under test is the flow from `ingest` (where input ENTERS) to `emit`
+(where output EXITS). They are deliberately *different functions* connected by
+ordinary orchestration — one call tree — which is the case the start/end
+decorators are designed for.
+
+`PROMPT_SUFFIX` simulates a local code change: set it, replay, and watch the
+outputs diverge from the captured baseline.
+"""
+
+import os
+
+from experiment_poc import experiment_end
+from experiment_poc import experiment_start
+
+
+# Flip this (via env) to simulate "I changed my prompt/model locally".
+PROMPT_SUFFIX = os.environ.get("PROMPT_SUFFIX", "")
+
+
+@experiment_start
+def ingest(query: str):
+    """Input enters here."""
+    cleaned = query.strip().lower()
+    return orchestrate(cleaned)
+
+
+def orchestrate(q: str):
+    """Imagine retrieval + LLM calls etc."""
+    answer = fake_model(q)
+    return emit(answer)
+
+
+def fake_model(q: str) -> str:
+    """Deterministic stand-in for an LLM call."""
+    base = {
+        "capital of france": "Paris",
+        "2+2": "4",
+        "meaning of life": "42",
+    }.get(q, "I don't know")
+    return base + PROMPT_SUFFIX
+
+
+@experiment_end
+def emit(result: str):
+    """Output exits here. In prod this would publish to the user / a queue —
+    a real side effect we do NOT want to fire during replay."""
+    print(f"  [emit side-effect] {result}")
+    return result
+
+
+def generate_traffic():
+    """Drives a few inputs so `capture` has something to record."""
+    for q in ["Capital of France", "2+2", "Meaning of life"]:
+        ingest(q)

--- a/poc_experiments/example_briefing_shaped.py
+++ b/poc_experiments/example_briefing_shaped.py
@@ -1,0 +1,42 @@
+"""
+Deterministic, dict-output example that mirrors the stock app's PortfolioBriefing
+shape — so we can demo the comparators without paid LLM calls.
+
+Output: {generated_at, analyses: [{ticker, sentiment}], summary}
+
+Env knobs simulate the drift you'd see between a capture and a later replay:
+    RUN_TS=<str>   value of generated_at (differs per run, like a timestamp)
+    DRIFT=text     same structure, different summary wording (LLM non-determinism)
+    DRIFT=drop     drop the last ticker (a real structural regression)
+"""
+
+import asyncio
+import os
+
+from experiment_poc import experiment_start
+
+
+@experiment_start(name="briefing", inputs=["tickers"], output=lambda ret: ret)
+async def analyze(tickers):
+    await asyncio.sleep(0)
+    drift = os.environ.get("DRIFT", "")
+
+    analyses = [{"ticker": t, "sentiment": "bullish" if t == "NVDA" else "neutral"} for t in tickers]
+    if drift == "drop" and len(analyses) > 1:
+        analyses = analyses[:-1]  # a regression: a ticker silently dropped
+
+    summary = (
+        "AI demand keeps semis strong; NVDA out front."
+        if drift == "text"
+        else "Tech momentum led by NVDA."
+    )
+
+    return {
+        "generated_at": os.environ.get("RUN_TS", "T0"),
+        "analyses": analyses,
+        "summary": summary,
+    }
+
+
+async def generate_traffic():
+    await analyze(["NVDA", "AMD"])

--- a/poc_experiments/example_lux_shaped.py
+++ b/poc_experiments/example_lux_shaped.py
@@ -1,0 +1,69 @@
+"""
+Mirrors lux's REAL boundary shape so we can validate the mechanics without
+lux's infra:
+
+    @llmobs_agent(name="lux_agent")
+    async def _run_lux_agent(agent, deps, message, user_handle=""):
+        return await agent.handle_message(deps, message)   # -> (response, deps)
+
+Here `infra` stands in for the non-serializable agent/deps. We capture only
+`message`/`user_handle` and extract the response from the returned tuple.
+
+`PROMPT_SUFFIX` simulates a local agent code change.
+"""
+
+import asyncio
+import os
+
+from experiment_poc import experiment_start
+
+
+PROMPT_SUFFIX = os.environ.get("PROMPT_SUFFIX", "")
+
+
+class FakeInfra:
+    """Stands in for the live agent + deps (MCP, Postgres, etc.) — NOT serializable."""
+
+    def __init__(self):
+        self.calls = 0
+
+
+async def _build_fixtures() -> dict:
+    """Rebuild the live infra at replay time. In real lux this is:
+        refresher = JwtRefresher(...); refresher.start()
+        runtime = await create_lux_runtime(org_id=..., jwt_getter=refresher.get_token)
+        deps = LuxAgentDependencies(... openai_provider, services, time_budget ...)
+        return {"agent": runtime.agent, "deps": deps}
+    """
+    await asyncio.sleep(0)
+    return {"infra": FakeInfra(), "deps": {"conversation_id": "c-replay"}}
+
+
+@experiment_start(
+    name="lux_agent",
+    inputs=["message", "user_handle"],
+    output=lambda ret: ret[0],
+    fixtures=_build_fixtures,
+)
+async def run_agent(infra: "FakeInfra", deps: dict, message: str, user_handle: str = ""):
+    """Single-function unit: message in, (response, deps) out — exactly lux's shape."""
+    infra.calls += 1
+    await asyncio.sleep(0)  # simulate I/O
+    response = await _model(message)
+    return (response, deps)  # like `agent_response, deps = await _run_lux_agent(...)`
+
+
+async def _model(message: str) -> str:
+    await asyncio.sleep(0)
+    base = {
+        "why is my app slow": "N+1 queries in the retrieval span",
+        "explain trace abc123": "It errored at the tool-call span",
+    }.get(message.strip().lower(), "I could not determine the cause")
+    return base + PROMPT_SUFFIX
+
+
+async def generate_traffic():
+    infra = FakeInfra()
+    deps = {"conversation_id": "c-1"}
+    for msg in ["Why is my app slow", "Explain trace abc123", "What changed yesterday"]:
+        await run_agent(infra, deps, msg, user_handle="mehul")

--- a/poc_experiments/experiment_poc.py
+++ b/poc_experiments/experiment_poc.py
@@ -1,0 +1,416 @@
+"""
+Trace-seeded local regression experiments — runnable POC.
+
+Self-contained, stdlib-only. NOT wired into ddtrace yet — this exists to feel
+the decorator + stop-point mechanics before integrating with the real LLMObs
+SDK or a real service like lux.
+
+Two boundary shapes are supported:
+
+  1. Single-function unit (lux's `_run_lux_agent` shape): input enters and the
+     result is RETURNED by the same function.
+        @experiment_start(inputs=["message"], output=lambda ret: ret[0])
+        async def run_agent(agent, deps, message, user_handle=""): ...
+     Capture records (selected inputs -> extracted return). Replay re-invokes
+     the function and compares the new return.
+
+  2. Across-functions emit shape (input at one fn, output handed to another):
+        @experiment_start(inputs=["query"])
+        def ingest(query): ...
+        @experiment_end
+        def emit(result): ...
+     Capture records (inputs -> what emit received). Replay re-invokes the start
+     and UNWINDS at emit, so emit's real side effects do NOT run.
+
+Mode gating: decorators are an inert passthrough unless a mode is set by the CLI
+(never read from an ambient OS env var), so they are safe in app code.
+
+Usage:
+    python experiment_poc.py capture example_app:generate_traffic
+    python experiment_poc.py replay  example_app
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import functools
+import importlib
+import inspect
+import json
+import sys
+from enum import Enum
+
+
+class Mode(Enum):
+    OFF = "off"
+    CAPTURE = "capture"
+    REPLAY = "replay"
+
+
+_mode: Mode = Mode.OFF  # the single gate; only the CLI flips it
+_REGISTRY: dict[str, dict] = {}  # name -> {start, inputs, start_output, end, end_output}
+_current_case: contextvars.ContextVar = contextvars.ContextVar("experiment_case", default=None)
+CAPTURE_PATH = "experiment_cases.jsonl"
+
+
+class _ExperimentStop(BaseException):
+    """Raised at the end marker during REPLAY to unwind to the harness.
+    BaseException (not Exception) so a broad ``except Exception:`` between start
+    and end cannot swallow it."""
+
+    def __init__(self, output):
+        self.output = output
+
+
+# --------------------------------------------------------------------------- #
+# (de)serialization
+# --------------------------------------------------------------------------- #
+def _encode(obj):
+    return json.loads(json.dumps(obj, default=repr))
+
+
+def _bind_inputs(fn, args, kwargs, inputs):
+    """Entry args as a {param_name: value} dict, optionally restricted to
+    `inputs` (so live infra like agent/deps is excluded)."""
+    try:
+        bound = inspect.signature(fn).bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        named = dict(bound.arguments)
+    except Exception:
+        named = {"args": list(args), "kwargs": dict(kwargs)}
+    if inputs is not None:
+        named = {k: v for k, v in named.items() if k in inputs}
+    return _encode(named)
+
+
+def _start_output(output_fn, ret):
+    """Single-function unit: output is the entry's RETURN value."""
+    return _encode(output_fn(ret)) if output_fn is not None else _encode(ret)
+
+
+def _end_output(output_fn, args, kwargs):
+    """Emit shape: output is what was passed INTO the end function."""
+    if output_fn is not None:
+        return _encode(output_fn(args, kwargs))
+    if len(args) == 1 and not kwargs:
+        return _encode(args[0])
+    return _encode({"args": list(args), "kwargs": dict(kwargs)})
+
+
+# --------------------------------------------------------------------------- #
+# Decorators
+# --------------------------------------------------------------------------- #
+def experiment_start(_fn=None, *, name: str = "default", inputs: list | None = None, output=None, fixtures=None):
+    """Mark the ENTRY point.
+
+    inputs   : restrict which args are captured/replayed (others are live infra).
+    output   : (ret) -> value, extracts the semantic output from the return when
+               this is a single-function unit (no separate @experiment_end).
+    fixtures : callable (sync or async) returning a dict of the NON-captured args
+               (the live infra) to supply at replay time. For lux this is where
+               create_lux_runtime() + LuxAgentDependencies(...) get built.
+    """
+
+    def deco(fn):
+        _REGISTRY.setdefault(name, {}).update(start=fn, inputs=inputs, start_output=output, fixtures=fixtures)
+
+        def _finish_capture(case, result):
+            if case["reached_end"]:  # an @experiment_end set the output
+                _append_case(case)
+            elif "end" not in _REGISTRY.get(name, {}):  # single-function unit
+                case["output"] = _start_output(output, result)
+                _append_case(case)
+
+        if asyncio.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def awrapper(*args, **kwargs):
+                if _mode is Mode.OFF:
+                    return await fn(*args, **kwargs)
+                case = {"name": name, "input": _bind_inputs(fn, args, kwargs, inputs), "output": None, "reached_end": False}
+                token = _current_case.set(case)
+                try:
+                    result = await fn(*args, **kwargs)
+                    if _mode is Mode.CAPTURE:
+                        _finish_capture(case, result)
+                    return result
+                finally:
+                    _current_case.reset(token)
+
+            return awrapper
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            if _mode is Mode.OFF:
+                return fn(*args, **kwargs)
+            case = {"name": name, "input": _bind_inputs(fn, args, kwargs, inputs), "output": None, "reached_end": False}
+            token = _current_case.set(case)
+            try:
+                result = fn(*args, **kwargs)
+                if _mode is Mode.CAPTURE:
+                    _finish_capture(case, result)
+                return result
+            finally:
+                _current_case.reset(token)
+
+        return wrapper
+
+    return deco(_fn) if _fn is not None else deco
+
+
+def experiment_end(_fn=None, *, name: str = "default", output=None):
+    """Mark the STOP point (emit shape). output : (args, kwargs) -> value."""
+
+    def deco(fn):
+        _REGISTRY.setdefault(name, {}).update(end=fn, end_output=output)
+
+        def _handle(args, kwargs):
+            out = _end_output(output, args, kwargs)
+            if _mode is Mode.REPLAY:
+                raise _ExperimentStop(out)  # capture + unwind before side effects
+            case = _current_case.get()  # CAPTURE
+            if case is not None:
+                case["output"] = out
+                case["reached_end"] = True
+
+        if asyncio.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def awrapper(*args, **kwargs):
+                if _mode is Mode.OFF:
+                    return await fn(*args, **kwargs)
+                _handle(args, kwargs)  # raises in REPLAY
+                return await fn(*args, **kwargs)
+
+            return awrapper
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            if _mode is Mode.OFF:
+                return fn(*args, **kwargs)
+            _handle(args, kwargs)  # raises in REPLAY
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return deco(_fn) if _fn is not None else deco
+
+
+# --------------------------------------------------------------------------- #
+# Persistence
+# --------------------------------------------------------------------------- #
+def _append_case(case):
+    with open(CAPTURE_PATH, "a") as f:
+        f.write(json.dumps({"name": case["name"], "input": case["input"], "output": case["output"]}) + "\n")
+
+
+def _load_cases():
+    cases = []
+    try:
+        with open(CAPTURE_PATH) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    cases.append(json.loads(line))
+    except FileNotFoundError:
+        pass
+    return cases
+
+
+# --- Comparators -------------------------------------------------------------
+# A comparator answers "is the new output equivalent to the recorded baseline?".
+# Real LLM apps are non-deterministic (free text, timestamps), so `exact` reports
+# CHANGED on every replay. `ignoring`/`structural` make replay meaningful by
+# comparing what actually matters.
+
+
+def exact_comparator(recorded, new):
+    """Strict equality. Useful for deterministic outputs only."""
+    return recorded == new
+
+
+def _deep_drop(value, keys):
+    if isinstance(value, dict):
+        return {k: _deep_drop(v, keys) for k, v in value.items() if k not in keys}
+    if isinstance(value, list):
+        return [_deep_drop(v, keys) for v in value]
+    return value
+
+
+def ignoring(*keys):
+    """Equality after recursively dropping volatile keys (e.g. 'generated_at')."""
+    keyset = set(keys)
+
+    def cmp(recorded, new):
+        return _deep_drop(recorded, keyset) == _deep_drop(new, keyset)
+
+    return cmp
+
+
+def _shape(value):
+    """Reduce a value to its structure: dict keys, list lengths, and leaf *types*
+    (not leaf values). So free-text/number drift is ignored, but a missing field,
+    a changed type, or a dropped list element shows up."""
+    if isinstance(value, dict):
+        return {k: _shape(v) for k, v in sorted(value.items())}
+    if isinstance(value, list):
+        return [_shape(v) for v in value]
+    return type(value).__name__
+
+
+def structural_comparator(recorded, new):
+    """Equivalent if the output *shape* matches (keys/types/list-lengths)."""
+    return _shape(recorded) == _shape(new)
+
+
+def llm_judge(judge_fn):
+    """Comparator backed by a caller-supplied judge: ``judge_fn(recorded, new) -> bool``
+    (typically an LLM 'are these semantically equivalent?' call). Kept dependency-free
+    — the caller supplies the model call, so the POC stays stdlib-only. For semantic
+    equivalence on free-text outputs that `structural` can't judge."""
+
+    def cmp(recorded, new):
+        return bool(judge_fn(recorded, new))
+
+    return cmp
+
+
+_default_comparator = exact_comparator
+
+
+def _comparator_from_args(rest):
+    """Build a comparator from CLI flags: --comparator exact|structural|ignoring
+    and --ignore key1,key2 (implies ignoring)."""
+    kind = "exact"
+    ignore: list = []
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--comparator" and i + 1 < len(rest):
+            kind = rest[i + 1]
+            i += 2
+            continue
+        if rest[i] == "--ignore" and i + 1 < len(rest):
+            ignore = [k for k in rest[i + 1].split(",") if k]
+            i += 2
+            continue
+        i += 1
+    if kind == "structural":
+        return structural_comparator
+    if kind == "ignoring" or ignore:
+        return ignoring(*ignore)
+    return exact_comparator
+
+
+# --------------------------------------------------------------------------- #
+# Replay
+# --------------------------------------------------------------------------- #
+def _invoke(spec, input_kwargs):
+    """Call the entry with captured inputs + freshly-built live fixtures."""
+    entry = spec["start"]
+    fixtures = spec.get("fixtures")
+    if asyncio.iscoroutinefunction(entry):
+
+        async def _run():
+            fx = fixtures() if fixtures else {}
+            if inspect.iscoroutine(fx):
+                fx = await fx
+            return await entry(**fx, **input_kwargs)
+
+        return asyncio.run(_run())
+
+    fx = fixtures() if fixtures else {}
+    if inspect.iscoroutine(fx):
+        raise RuntimeError("async `fixtures` requires an async entry function")
+    return entry(**fx, **input_kwargs)
+
+
+def replay(name: str = "default", comparator=None):
+    comparator = comparator or _default_comparator
+    spec = _REGISTRY.get(name, {})
+    entry = spec.get("start")
+    if entry is None:
+        raise RuntimeError(f"No @experiment_start registered for '{name}'. Did you import the app module?")
+    has_end = "end" in spec
+    start_output_fn = spec.get("start_output")
+
+    results = []
+    for case in _load_cases():
+        if case.get("name") != name:
+            continue
+        row = {"input": case["input"], "recorded": case["output"], "new": None, "status": "NO_END"}
+        try:
+            ret = _invoke(spec, case["input"])
+            if not has_end:  # single-function unit: the return IS the output
+                row["new"] = _start_output(start_output_fn, ret)
+                row["status"] = "MATCH" if comparator(row["recorded"], row["new"]) else "CHANGED"
+        except _ExperimentStop as stop:  # emit shape: end unwound with the output
+            row["new"] = stop.output
+            row["status"] = "MATCH" if comparator(row["recorded"], row["new"]) else "CHANGED"
+        except Exception as e:  # noqa: BLE001 - POC: surface task errors as a row
+            row["new"] = f"<error: {e!r}>"
+            row["status"] = "ERROR"
+        results.append(row)
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def _trunc(v, n=40):
+    s = v if isinstance(v, str) else json.dumps(v)
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _print_report(name, results):
+    counts: dict = {}
+    print(f"\n  experiment: {name}   ({len(results)} cases)")
+    print("  " + "-" * 86)
+    print(f"  {'status':<8} {'input':<30} {'recorded':<22} {'new':<22}")
+    print("  " + "-" * 86)
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+        print(f"  {r['status']:<8} {_trunc(r['input'], 30):<30} {_trunc(r['recorded'], 22):<22} {_trunc(r['new'], 22):<22}")
+    print("  " + "-" * 86)
+    print("  " + "  ".join(f"{k}={v}" for k, v in counts.items()) + "\n")
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# CLI — the explicit, prod-impossible trigger
+# --------------------------------------------------------------------------- #
+def _import_target(target):
+    mod_name, _, attr = target.partition(":")
+    mod = importlib.import_module(mod_name)
+    return mod, (getattr(mod, attr) if attr else None)
+
+
+def cli(argv=None):
+    global _mode
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) < 2 or argv[0] not in {"capture", "replay"}:
+        print(__doc__)
+        raise SystemExit(1)
+
+    cmd, target = argv[0], argv[1]
+    if cmd == "capture":
+        _mode = Mode.CAPTURE
+        _, entry = _import_target(target)
+        if entry is None:
+            raise SystemExit("capture needs 'module:entrypoint', e.g. example_app:generate_traffic")
+        result = entry()
+        if inspect.iscoroutine(result):
+            asyncio.run(result)
+        print(f"captured cases -> {CAPTURE_PATH}")
+    else:
+        _mode = Mode.REPLAY
+        _import_target(target)
+        comparator = _comparator_from_args(argv[2:])
+        for name in sorted(_REGISTRY):
+            _print_report(name, replay(name, comparator))
+
+
+if __name__ == "__main__":
+    import experiment_poc  # single module identity (see README)
+
+    experiment_poc.cli()


### PR DESCRIPTION
## Description

**Tracking / reference PR — not intended for merge as-is.** Captures the proof-of-concept for **trace-seeded local regression experiments** (a "unit test for LLM apps" paradigm): an inert-by-default `@experiment_start`/`@experiment_end` decorator marks an input→output boundary; an explicit trigger captures a baseline and replays the *current local code* against it, reporting MATCH/CHANGED per case.

Adds (all under `poc_experiments/`, plus a design doc):
- `experiment_poc.py` — sync+async decorators, mode-gated capture/replay, stop-point unwind, selective-arg capture, `fixtures` for live-infra rebuild, and `exact` / `ignoring` / `structural` / `llm_judge` comparators.
- `example_app.py`, `example_lux_shaped.py`, `example_briefing_shaped.py` — runnable examples (emit-style, async single-function, dict output with drift scenarios).
- `demo.sh` — narrated end-to-end replay demo.
- `ddtrace/llmobs/_local_regression_experiments_design.md` — design doc (see also RFC-002).

The eventual goal is folding this into `ddtrace.llmobs` with a `ddtrace-experiment` entrypoint.

## Testing

Stdlib-only POC; validated locally via `demo.sh` and 5 comparator drift scenarios (deterministic, no infra). No ddtrace runtime code is touched.

## Risks

None — adds only `poc_experiments/` scratch and a design `.md`; nothing is imported by ddtrace at runtime.

## Additional Notes

Reference branch so the work is tracked while the design is iterated. Separate from the pydantic_ai `Omit` fix (#18487).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
