### PR TITLE
fix(llmobs): respect configured writer timeout in _send_payload

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -304,7 +304,7 @@ class BaseLLMObsWriter(PeriodicService):
             )
 
     def _send_payload(self, payload: bytes, num_events: int):
-        conn = get_connection(self._intake)
+        conn = get_connection(self._intake, timeout=self._timeout)
         try:
             conn.request("POST", self._endpoint, payload, self._headers)
             resp = conn.getresponse()

--- a/releasenotes/notes/fix-llmobs-writer-respect-timeout-cd84c70e0d69e371.yaml
+++ b/releasenotes/notes/fix-llmobs-writer-respect-timeout-cd84c70e0d69e371.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    LLM Observability: Resolves an issue where the writer ignored its configured request
+    LLM Observability: Fixes an issue where the writer ignored its configured request
     timeout (``_DD_LLMOBS_WRITER_TIMEOUT``, default 5 seconds) and instead used the 2 second
     connection default, causing intermittent ``TimeoutError`` and dropped span and evaluation
     metric events on high-latency connections to the agent or intake.

--- a/releasenotes/notes/fix-llmobs-writer-respect-timeout-cd84c70e0d69e371.yaml
+++ b/releasenotes/notes/fix-llmobs-writer-respect-timeout-cd84c70e0d69e371.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where the writer ignored its configured request
+    timeout (``_DD_LLMOBS_WRITER_TIMEOUT``, default 5 seconds) and instead used the 2 second
+    connection default, causing intermittent ``TimeoutError`` and dropped span and evaluation
+    metric events on high-latency connections to the agent or intake.

--- a/releasenotes/notes/fix-llmobs-writer-respect-timeout-cd84c70e0d69e371.yaml
+++ b/releasenotes/notes/fix-llmobs-writer-respect-timeout-cd84c70e0d69e371.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes an issue where the writer ignored its configured request
+    LLM Observability: Fixes an issue where the span writer ignored its configured request
     timeout (``_DD_LLMOBS_WRITER_TIMEOUT``, default 5 seconds) and instead used the 2 second
-    connection default, causing intermittent ``TimeoutError`` and dropped span and evaluation
-    metric events on high-latency connections to the agent or intake.
+    connection default, causing intermittent ``TimeoutError`` and dropped span events on
+    high-latency connections to the agent or intake.

--- a/tests/llmobs/test_llmobs_span_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_span_agentless_writer.py
@@ -136,6 +136,18 @@ def test_send_completion_bad_api_key(mock_writer_logs):
     )
 
 
+@mock.patch("ddtrace.llmobs._writer.get_connection")
+def test_send_payload_uses_configured_timeout(mock_get_connection, mock_writer_logs):
+    """Regression: _send_payload must open the connection with the writer's configured
+    timeout (self._timeout), not get_connection's DEFAULT_TIMEOUT (2.0s).
+    """
+    mock_get_connection.return_value.getresponse.return_value.status = 200
+    llmobs_span_writer = LLMObsSpanWriter(1, 5.0, is_agentless=True, _site=DD_SITE, _api_key=DD_API_KEY)
+    llmobs_span_writer.enqueue(_completion_event())
+    llmobs_span_writer.periodic()
+    mock_get_connection.assert_called_once_with(llmobs_span_writer._intake, timeout=5.0)
+
+
 def test_send_completion_no_api_key(mock_writer_logs):
     with override_global_config(dict(_dd_api_key="")):
         llmobs_span_writer = LLMObsSpanWriter(interval=1, timeout=1, is_agentless=True, _site=DD_SITE, _api_key="")


### PR DESCRIPTION
## Description

Cherry-picked from #18575 by @jeong-hasang. Added one commit scoping the release note to span events — the path reported and tested. 

`BaseLLMObsWriter._send_payload` opened its connection with `get_connection(self._intake)`, passing no timeout. As a result it ignores the writer's configured `self._timeout` (`_DD_LLMOBS_WRITER_TIMEOUT`, default 5s) and falls back to `get_connection`'s `DEFAULT_TIMEOUT` of 2s. On high-latency connections to the agent/intake, the 2s socket timeout was exceeded at the tail; all retries hit the same ceiling, so the batch was dropped (`failed to send N LLMObs span events` + `TimeoutError`).

Every other `get_connection` call in the module already passes `timeout=` explicitly — this was the only one that didn't.

```diff
-        conn = get_connection(self._intake)
+        conn = get_connection(self._intake, timeout=self._timeout)
```

## Testing

- Regression test `tests/llmobs/test_llmobs_span_agentless_writer.py::test_send_payload_uses_configured_timeout` mocks `get_connection` and asserts `_send_payload` opens the connection with the configured timeout (5s), not `DEFAULT_TIMEOUT`. Fails without the fix, passes with it.
- Reproduced independently against a stand-in slow agent: at a 3s agent delay, 4.10.3 drops the batch with `TimeoutError`; with this fix the same 3s batch is delivered.

## Notes for reviewers

- The socket timeout is per-operation, so with retries the worst-case wall time before a batch is declared dropped rises from ~2s to ~5s per attempt. This runs on the background writer thread and never blocks the request path.
- This is a tolerance bump (2s→5s), not a cure for agent slowness: a >5s round-trip will still drop. The upside is that `_DD_LLMOBS_WRITER_TIMEOUT` now actually takes effect on this path, giving operators a working knob.

## Risks

Low. One-line behavior change in a background flush thread; no public API change.