### PR TITLE
feat(appsec): upgrade libddwaf to 2.0.0

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -13,6 +13,7 @@ from urllib import parse
 
 from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import APPSEC
+from ddtrace.appsec._constants import EXPLOIT_PREVENTION
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._constants import Constant_Class
 from ddtrace.appsec._metrics import UNKNOWN_VERSION
@@ -186,6 +187,61 @@ def should_analyze_body_response(env: ASM_Environment) -> bool:
         env.downstream_requests < asm_config._dr_body_limit_per_request
         and (DownstreamRequests.counter * KNUTH_FACTOR) % UINT64_MAX <= DownstreamRequests.sampling_rate
     )
+
+
+# SSRF shares one subcontext across an outgoing request's SSRF_REQ + SSRF_RES calls, which may run
+# in different core contexts (e.g. httpx: request on the inner send context, final response on the
+# outer). A mutable holder is stored on the owning context; both calls resolve it via find_item
+# (which walks up the context tree), and it is released when that scope ends.
+
+_RASP_SUBCONTEXT = "asm::rasp_subcontext"
+
+_SSRF_RULE_TYPES = frozenset(
+    (
+        EXPLOIT_PREVENTION.TYPE.SSRF,
+        EXPLOIT_PREVENTION.TYPE.SSRF_REQ,
+        EXPLOIT_PREVENTION.TYPE.SSRF_RES,
+    )
+)
+
+
+class _RaspSubcontextHolder:
+    __slots__ = ("subctx",)
+
+    def __init__(self) -> None:
+        self.subctx: Optional[Any] = None
+
+
+def open_rasp_subcontext_scope() -> None:
+    """Establish the current core context as the owner of an SSRF subcontext.
+
+    Called by SSRF integrations from the per-outgoing-request core context (``url_open_analysis``,
+    httpx's request context, or urllib3's own ``context_with_data``) so the request's SSRF_REQ and
+    SSRF_RES WAF calls share one subcontext, created lazily on the first RASP call within the scope.
+    Because the holder lives on that per-request context, concurrent outgoing requests (each in its
+    own context) get distinct subcontexts, and dropping the context releases the holder.
+
+    Reentrant: if an enclosing scope already owns a holder (e.g. ``requests`` driving ``urllib3``),
+    this is a no-op and the inner operation shares the outer subcontext.
+    """
+    if core.find_item(_RASP_SUBCONTEXT) is None:
+        core.set_item(_RASP_SUBCONTEXT, _RaspSubcontextHolder())
+
+
+def get_or_create_rasp_subcontext(ddwaf: Any, ctx: Any, rule_type: Optional[str]) -> Optional[Any]:
+    """Return the subcontext to use for a RASP WAF call.
+
+    SSRF calls reuse the subcontext stored on the owning scope (created lazily on first use);
+    other RASP types (LFI/CMDI/SHI/SQLI) get a fresh subcontext per call. Returns None when no
+    subcontext could be created, in which case the caller bypasses the RASP check.
+    """
+    if rule_type in _SSRF_RULE_TYPES:
+        holder = core.find_item(_RASP_SUBCONTEXT)
+        if holder is not None:
+            if holder.subctx is None:
+                holder.subctx = ddwaf.new_subcontext(ctx)
+            return holder.subctx
+    return ddwaf.new_subcontext(ctx)
 
 
 def get_framework() -> str:

--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -7,6 +7,7 @@ from typing import Union
 from ddtrace.appsec._asm_request_context import _get_asm_context
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
+from ddtrace.appsec._asm_request_context import open_rasp_subcontext_scope
 from ddtrace.appsec._constants import EXPLOIT_PREVENTION
 from ddtrace.appsec._constants import WAF_ACTIONS
 from ddtrace.appsec._contrib.stripe.patch import patch as patch_stripe_for_appsec
@@ -289,6 +290,8 @@ def wrapped_open_ED4CF71136E15EBF(original_open_callable, instance, args, kwargs
         if valid_url and url and (ctx := _get_asm_context()):
             use_body = should_analyze_body_response(ctx)
             with core.context_with_data("url_open_analysis", full_url=url, use_body=use_body):
+                # This outgoing request's SSRF_REQ + SSRF_RES WAF calls share one subcontext.
+                open_rasp_subcontext_scope()
                 # API10, doing all request calls in HTTPConnection.request
                 try:
                     response = original_open_callable(*args, **kwargs)
@@ -335,7 +338,15 @@ def wrapped_urllib3_make_request_6D4E8B2A1F095C73(original_request_callable, ins
     full_url = core.find_item("full_url")
     env = _get_asm_context()
     do_rasp = _get_rasp_capability("ssrf") and full_url is not None and env is not None
-    if do_rasp:
+    if not do_rasp:
+        return original_request_callable(*args, **kwargs)
+    core.discard_item("full_url")
+    # Run this outgoing request in its own core context so concurrent urllib3 requests each get a
+    # distinct subcontext (shared only by this request's SSRF_REQ + SSRF_RES). When an outer client
+    # (e.g. requests) already owns a scope, open_rasp_subcontext_scope finds it (walks up) and
+    # reuses it. Dropping this context releases the holder, so no explicit close is needed.
+    with core.context_with_data("rasp.ssrf.urllib3"):
+        open_rasp_subcontext_scope()
         use_body = core.find_item("use_body", False)
         method = args[1] if len(args) > 1 else kwargs.get("method", None)
         body = args[3] if len(args) > 3 else kwargs.get("body", None)
@@ -353,21 +364,20 @@ def wrapped_urllib3_make_request_6D4E8B2A1F095C73(original_request_callable, ins
             rule_type=EXPLOIT_PREVENTION.TYPE.SSRF_REQ,
         )
         env.downstream_requests += 1
-        core.discard_item("full_url")
         if res and _must_block(res.actions):
             raise BlockingException(get_blocked(), EXPLOIT_PREVENTION.BLOCKING, EXPLOIT_PREVENTION.TYPE.SSRF, full_url)
-    response = original_request_callable(*args, **kwargs)
-    try:
-        if do_rasp and response.__class__.__name__ == "BaseHTTPResponse" and 300 <= response.status < 400:
-            # api10 for redirected response status and headers in urllib3
-            addresses = {
-                "DOWN_RES_STATUS": str(response.status),
-                "DOWN_RES_HEADERS": response.headers,
-            }
-            call_waf_callback(addresses, rule_type=EXPLOIT_PREVENTION.TYPE.SSRF_RES)
-    except Exception:
-        pass  # nosec
-    return response
+        response = original_request_callable(*args, **kwargs)
+        try:
+            if response.__class__.__name__ == "BaseHTTPResponse" and 300 <= response.status < 400:
+                # api10 for redirected response status and headers in urllib3
+                addresses = {
+                    "DOWN_RES_STATUS": str(response.status),
+                    "DOWN_RES_HEADERS": response.headers,
+                }
+                call_waf_callback(addresses, rule_type=EXPLOIT_PREVENTION.TYPE.SSRF_RES)
+        except Exception:
+            pass  # nosec
+        return response
 
 
 def wrapped_urllib3_urlopen(original_open_callable, instance, args, kwargs):
@@ -401,6 +411,8 @@ def wrapped_request_D8CB81E472AF98A2(original_request_callable, instance, args, 
         if valid_url and url and (ctx := _get_asm_context()):
             use_body = should_analyze_body_response(ctx)
             with core.context_with_data("url_open_analysis", full_url=url, use_body=use_body):
+                # This outgoing request's SSRF_REQ + SSRF_RES WAF calls share one subcontext.
+                open_rasp_subcontext_scope()
                 # API10, doing all request calls in HTTPConnection.request
                 try:
                     response = original_request_callable(*args, **kwargs)

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -257,7 +257,8 @@ class WAF_DATA_NAMES(metaclass=Constant_Class):
         )
     )
 
-    # EPHEMERAL ADDRESSES
+    # Non-persistent addresses: RASP addresses run in a subcontext; the others (extract-schema,
+    # login/payment business logic) run on the main context with rule_type=None.
     PROCESSOR_SETTINGS: Literal["waf.context.processor"] = "waf.context.processor"
     CMDI_ADDRESS: Literal["server.sys.exec.cmd"] = "server.sys.exec.cmd"
     SHI_ADDRESS: Literal["server.sys.shell.cmd"] = "server.sys.shell.cmd"

--- a/ddtrace/appsec/_contrib/httpx/subscribers.py
+++ b/ddtrace/appsec/_contrib/httpx/subscribers.py
@@ -7,6 +7,7 @@ from typing import Optional
 from ddtrace.appsec._asm_request_context import _get_asm_context
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
+from ddtrace.appsec._asm_request_context import open_rasp_subcontext_scope
 from ddtrace.appsec._asm_request_context import should_analyze_body_response
 from ddtrace.appsec._common_module_patches import _get_rasp_capability
 from ddtrace.appsec._constants import EXPLOIT_PREVENTION
@@ -31,6 +32,10 @@ class AppSecHttpxRequestContextSubscriber(ContextSubscriber[HttpClientRequestEve
         asm_context = _get_asm_context()
         if asm_context is None:
             return
+
+        # Own the SSRF subcontext on this outer request context so the inner send's SSRF_REQ and
+        # the final SSRF_RES (dispatched on this context in on_ended) share one subcontext.
+        open_rasp_subcontext_scope()
 
         analyze_body = should_analyze_body_response(asm_context)
         ctx.set_item(APPSEC_SSRF_ANALYZE_BODY_KEY, analyze_body)

--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -505,9 +505,7 @@ ddwaf_subcontext_init = ctypes.CFUNCTYPE(ddwaf_subcontext, ddwaf_context)(
 
 
 def py_ddwaf_subcontext_init(ctx: ddwaf_context_capsule) -> ddwaf_subcontext_capsule:
-    # Pass the parent context capsule so the subcontext keeps it alive: ddwaf_subcontext_destroy
-    # requires the parent ddwaf_context to still exist, and capsule destruction is GC-ordered.
-    return ddwaf_subcontext_capsule(ddwaf_subcontext_init(ctx.ctx), ddwaf_subcontext_destroy, parent=ctx)
+    return ddwaf_subcontext_capsule(ddwaf_subcontext_init(ctx.ctx), ddwaf_subcontext_destroy)
 
 
 ddwaf_subcontext_eval = ctypes.CFUNCTYPE(

--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
 import ctypes
@@ -12,6 +11,7 @@ from ddtrace.appsec._ddwaf.waf_stubs import DDWafRulesType
 from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_builder_capsule
 from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_context_capsule
 from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_handle_capsule
+from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_subcontext_capsule
 from ddtrace.appsec._utils import _observator
 from ddtrace.appsec._utils import unpatching_popen
 from ddtrace.internal.logger import get_logger
@@ -43,25 +43,43 @@ DDWAF_MAX_CONTAINER_SIZE = 256
 DDWAF_NO_LIMIT = 1 << 31
 DDWAF_DEPTH_NO_LIMIT = 1000
 
+# Containers store their size/capacity in a uint16, so they cannot hold more than this.
+DDWAF_OBJ_MAX_CAPACITY = 0xFFFF
 
+
+# Type tags are not a bitfield: UNSIGNED (0x06) overlaps BOOL (0x02) | SIGNED (0x04), so compare
+# with exact equality, never bitmasks. Strings have 3 variants (heap, literal, inline "small").
 class DDWAF_OBJ_TYPE(IntEnum):
     DDWAF_OBJ_INVALID = 0
-    # Value shall be decoded as a int64_t (or int32_t on 32bits platforms).
-    DDWAF_OBJ_SIGNED = 1 << 0
-    # Value shall be decoded as a uint64_t (or uint32_t on 32bits platforms).
-    DDWAF_OBJ_UNSIGNED = 1 << 1
-    # Value shall be decoded as a UTF-8 string of length nbEntries.
-    DDWAF_OBJ_STRING = 1 << 2
-    # Value shall be decoded as an array of ddwaf_object of length nbEntries, each item having no parameterName.
-    DDWAF_OBJ_ARRAY = 1 << 3
-    # Value shall be decoded as an array of ddwaf_object of length nbEntries, each item having a parameterName.
-    DDWAF_OBJ_MAP = 1 << 4
-    # Value shall be decode as bool
-    DDWAF_OBJ_BOOL = 1 << 5
-    # 64-bit float (or double) type
-    DDWAF_OBJ_FLOAT = 1 << 6
     # Null type, only used for its semantical value
-    DDWAF_OBJ_NULL = 1 << 7
+    DDWAF_OBJ_NULL = 0x01
+    # Value shall be decoded as a bool
+    DDWAF_OBJ_BOOL = 0x02
+    # Value shall be decoded as an int64_t
+    DDWAF_OBJ_SIGNED = 0x04
+    # Value shall be decoded as a uint64_t
+    DDWAF_OBJ_UNSIGNED = 0x06
+    # 64-bit float (or double) type
+    DDWAF_OBJ_FLOAT = 0x08
+    # Value shall be decoded as a UTF-8 string of length size, stored on the heap
+    DDWAF_OBJ_STRING = 0x10
+    # Read-only C string that is never freed on destruction
+    DDWAF_OBJ_LITERAL_STRING = 0x12
+    # UTF-8 string of at most 14 bytes stored inline in the object (no allocation)
+    DDWAF_OBJ_SMALL_STRING = 0x14
+    # Array of ddwaf_object of length size
+    DDWAF_OBJ_ARRAY = 0x20
+    # Map: array of ddwaf_object_kv of length size
+    DDWAF_OBJ_MAP = 0x40
+
+
+# Set of all the string variants for quick membership tests
+_STRING_TYPES = frozenset(
+    (
+        DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING,
+        DDWAF_OBJ_TYPE.DDWAF_OBJ_LITERAL_STRING,
+    )
+)
 
 
 class DDWAF_RET_CODE(IntEnum):
@@ -81,13 +99,186 @@ class DDWAF_LOG_LEVEL(IntEnum):
     DDWAF_LOG_OFF = 5
 
 
+# An allocator is an opaque pointer (`typedef struct _ddwaf_allocator *ddwaf_allocator;`)
+ddwaf_allocator = ctypes.c_void_p
+ddwaf_handle = ctypes.c_void_p  # mainly an abstract type in the interface
+ddwaf_context = ctypes.c_void_p  # mainly an abstract type in the interface
+ddwaf_subcontext = ctypes.c_void_p  # mainly an abstract type in the interface
+ddwaf_builder = ctypes.c_void_p  # mainly an abstract type in the interface
+
+
 #
 # Objects Definitions
 #
 
 
+# The ddwaf_object is a 16-byte tagged union. Field definitions are wired up after the
+# class bodies to allow the cyclic references (array -> object, map -> object_kv -> object).
+class ddwaf_object(ctypes.Union):
+    """ctypes view of the libddwaf 2.0 ``ddwaf_object`` 16-byte tagged union."""
+
+    def __init__(
+        self,
+        struct: Optional[DDWafRulesType] = None,
+        observator: Optional[_observator] = None,
+        max_objects: int = DDWAF_MAX_CONTAINER_SIZE,
+        max_depth: int = DDWAF_MAX_CONTAINER_DEPTH,
+        max_string_length: int = DDWAF_MAX_STRING_LENGTH,
+    ) -> None:
+        if observator is None:
+            observator = _observator()
+        # Build through a pointer (uniform with the slots returned by insert/insert_key).
+        _build_ddwaf_object(ctypes.pointer(self), struct, observator, max_objects, max_depth, max_string_length)
+
+    @classmethod
+    def create_without_limits(cls, struct: DDWafRulesType) -> "ddwaf_object":
+        return cls(struct, max_objects=DDWAF_NO_LIMIT, max_depth=DDWAF_DEPTH_NO_LIMIT, max_string_length=DDWAF_NO_LIMIT)
+
+    @classmethod
+    def from_json_bytes(cls, data: bytes) -> Optional["ddwaf_object"]:
+        """Create a ddwaf_object from a JSON string as bytes."""
+        obj = cls.__new__(cls)
+        if not ddwaf_object_from_json(obj, data, len(data), DEFAULT_ALLOCATOR):
+            log.debug("Failed to create ddwaf_object from JSON: %s", data)
+            # Free any partial allocation (no-op on the zero-initialised INVALID object).
+            ddwaf_object_destroy(obj, DEFAULT_ALLOCATOR)
+            return None
+        return obj
+
+    @property
+    def struct(self) -> DDWafRulesType:
+        """Generate a python structure from ddwaf_object"""
+        t = self.type
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_SMALL_STRING:
+            sstr = self.value.sstr
+            if not sstr.size:
+                return ""
+            # Length-based read: slicing the c_char array would truncate at an embedded NUL.
+            return ctypes.string_at(ctypes.addressof(sstr) + _SMALL_STRING_DATA_OFFSET, sstr.size).decode(
+                "UTF-8", errors="ignore"
+            )
+        if t in _STRING_TYPES:
+            s = self.value.str
+            if not s.ptr or not s.size:
+                return ""
+            return ctypes.string_at(s.ptr, s.size).decode("UTF-8", errors="ignore")
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP:
+            m = self.value.map
+            return {m.ptr[i].key.struct: m.ptr[i].val.struct for i in range(m.size)}
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_ARRAY:
+            a = self.value.array
+            return [a.ptr[i].struct for i in range(a.size)]
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED:
+            return self.value.i64.val
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED:
+            return self.value.u64.val
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_BOOL:
+            return self.value.b8.val
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_FLOAT:
+            return self.value.f64.val
+        if t == DDWAF_OBJ_TYPE.DDWAF_OBJ_NULL or t == DDWAF_OBJ_TYPE.DDWAF_OBJ_INVALID:
+            return None
+        log.debug("ddwaf_object struct: unknown object type: %s", repr(t))
+        return None
+
+    def __repr__(self) -> str:
+        return repr(self.struct)
+
+
+ddwaf_object_p = ctypes.POINTER(ddwaf_object)
+
+
+class ddwaf_object_kv(ctypes.Structure):
+    """A key/value pair stored in a ddwaf_object map. Fields are wired up below."""
+
+
+ddwaf_object_kv_p = ctypes.POINTER(ddwaf_object_kv)
+
+
+class _ddwaf_object_bool(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_uint8), ("val", ctypes.c_bool)]
+
+
+class _ddwaf_object_signed(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_uint8), ("val", ctypes.c_int64)]
+
+
+class _ddwaf_object_unsigned(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_uint8), ("val", ctypes.c_uint64)]
+
+
+class _ddwaf_object_float(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_uint8), ("val", ctypes.c_double)]
+
+
+class _ddwaf_object_string(ctypes.Structure):
+    # ``ptr`` is a raw pointer read with ctypes.string_at using the explicit size
+    # (the buffer is not necessarily NUL-terminated in libddwaf 2.0).
+    _fields_ = [("type", ctypes.c_uint8), ("size", ctypes.c_uint32), ("ptr", ctypes.c_void_p)]
+
+
+class _ddwaf_object_small_string(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_uint8), ("size", ctypes.c_uint8), ("data", ctypes.c_char * 14)]
+
+
+# Byte offset of the inline data buffer within a small string, used for length-based reads.
+_SMALL_STRING_DATA_OFFSET = _ddwaf_object_small_string.data.offset
+
+
+class _ddwaf_object_array(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_uint8),
+        ("size", ctypes.c_uint16),
+        ("capacity", ctypes.c_uint16),
+        ("ptr", ddwaf_object_p),
+    ]
+
+
+class _ddwaf_object_map(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_uint8),
+        ("size", ctypes.c_uint16),
+        ("capacity", ctypes.c_uint16),
+        ("ptr", ddwaf_object_kv_p),
+    ]
+
+
+class _ddwaf_object_value(ctypes.Union):
+    _fields_ = [
+        ("b8", _ddwaf_object_bool),
+        ("i64", _ddwaf_object_signed),
+        ("u64", _ddwaf_object_unsigned),
+        ("f64", _ddwaf_object_float),
+        ("str", _ddwaf_object_string),
+        ("sstr", _ddwaf_object_small_string),
+        ("array", _ddwaf_object_array),
+        ("map", _ddwaf_object_map),
+    ]
+
+
+ddwaf_object._fields_ = [
+    ("type", ctypes.c_uint8),
+    ("value", _ddwaf_object_value),
+]
+
+ddwaf_object_kv._fields_ = [
+    ("key", ddwaf_object),
+    ("val", ddwaf_object),
+]
+
+
+#
+# Recursive builder for ddwaf_object (serialization of python structures).
+#
+# Each ``self`` is either a freshly allocated ``ddwaf_object`` (top level) or a pointer to a
+# slot inside a parent container (returned by ddwaf_object_insert / ddwaf_object_insert_key).
+# ``self`` is always a pointer to the ddwaf_object being filled (ctypes.pointer(top_level) or a
+# slot from ddwaf_object_insert/insert_key); it is only forwarded to the set_*/insert C functions.
+#
+
+
 def _build_sequence(
-    self: "ddwaf_object",
+    self: "ctypes._Pointer[ddwaf_object]",
     struct: Any,
     observator: _observator,
     max_objects: int,
@@ -97,18 +288,21 @@ def _build_sequence(
     if max_depth <= 0:
         observator.set_container_depth(DDWAF_MAX_CONTAINER_DEPTH)
         max_objects = 0
-    array = ddwaf_object_array(self)
+    elif max_objects > DDWAF_OBJ_MAX_CAPACITY:
+        # Container size is a uint16; cap inserts (even on the no-limit path) so it can't wrap.
+        max_objects = DDWAF_OBJ_MAX_CAPACITY
+    # Reserve only what we will actually insert (bounded by max_objects, always <= uint16 max).
+    ddwaf_object_set_array(self, min(len(struct), max_objects), DEFAULT_ALLOCATOR)
     for counter_object, elt in enumerate(struct):
         if counter_object >= max_objects:
             observator.set_container_size(len(struct))
             break
-        obj = ddwaf_object.__new__(ddwaf_object)
-        _build_ddwaf_object(obj, elt, observator, max_objects, max_depth - 1, max_string_length)
-        ddwaf_object_array_add(array, obj)
+        slot = ddwaf_object_insert(self, DEFAULT_ALLOCATOR)
+        _build_ddwaf_object(slot, elt, observator, max_objects, max_depth - 1, max_string_length)
 
 
 def _build_mapping(
-    self: "ddwaf_object",
+    self: "ctypes._Pointer[ddwaf_object]",
     struct: Any,
     observator: _observator,
     max_objects: int,
@@ -118,7 +312,11 @@ def _build_mapping(
     if max_depth <= 0:
         observator.set_container_depth(DDWAF_MAX_CONTAINER_DEPTH)
         max_objects = 0
-    map_o = ddwaf_object_map(self)
+    elif max_objects > DDWAF_OBJ_MAX_CAPACITY:
+        # Container size is a uint16; cap inserts (even on the no-limit path) so it can't wrap.
+        max_objects = DDWAF_OBJ_MAX_CAPACITY
+    # Reserve only what we will actually insert (bounded by max_objects, always <= uint16 max).
+    ddwaf_object_set_map(self, min(len(struct), max_objects), DEFAULT_ALLOCATOR)
     # order is unspecified and could lead to problems if max_objects is reached
     counter_object = 0
     for key, val in struct.items():
@@ -135,14 +333,13 @@ def _build_mapping(
         if len(res_key) > max_string_length:
             observator.set_string_length(len(res_key))
             res_key = res_key[:max_string_length]
-        obj = ddwaf_object.__new__(ddwaf_object)
-        _build_ddwaf_object(obj, val, observator, max_objects, max_depth - 1, max_string_length)
-        ddwaf_object_map_add(map_o, res_key, obj)
+        slot = ddwaf_object_insert_key(self, res_key, len(res_key), DEFAULT_ALLOCATOR)
+        _build_ddwaf_object(slot, val, observator, max_objects, max_depth - 1, max_string_length)
         counter_object += 1
 
 
 def _build_ddwaf_object(
-    self: "ddwaf_object",
+    self: "ctypes._Pointer[ddwaf_object]",
     struct: Any,
     observator: _observator,
     max_objects: int,
@@ -164,22 +361,22 @@ def _build_ddwaf_object(
         if len(encoded) > max_string_length:
             observator.set_string_length(len(encoded))
             encoded = encoded[:max_string_length]
-        ddwaf_object_string(self, encoded)
+        ddwaf_object_set_string(self, encoded, len(encoded), DEFAULT_ALLOCATOR)
     elif t is list:
         _build_sequence(self, struct, observator, max_objects, max_depth, max_string_length)
     elif t is int:
-        ddwaf_object_signed(self, struct)
+        ddwaf_object_set_signed(self, struct)
     elif t is bool:
-        ddwaf_object_bool(self, struct)
+        ddwaf_object_set_bool(self, struct)
     elif t is float:
-        ddwaf_object_float(self, struct)
+        ddwaf_object_set_float(self, struct)
     elif t is bytes:
         if len(struct) > max_string_length:
             observator.set_string_length(len(struct))
             struct = struct[:max_string_length]
-        ddwaf_object_string(self, struct)
+        ddwaf_object_set_string(self, struct, len(struct), DEFAULT_ALLOCATOR)
     elif struct is None:
-        ddwaf_object_null(self)
+        ddwaf_object_set_null(self)
     elif isinstance(struct, Sequence):
         _build_sequence(self, struct, observator, max_objects, max_depth, max_string_length)
     elif isinstance(struct, Mapping):
@@ -189,149 +386,7 @@ def _build_ddwaf_object(
         if len(encoded) > max_string_length:
             observator.set_string_length(len(encoded))
             encoded = encoded[:max_string_length]
-        ddwaf_object_string(self, encoded)
-
-
-# to allow cyclic references, ddwaf_object fields are defined later
-class ddwaf_object(ctypes.Structure):
-    # "type" define how to read the "value" union field
-    # defined in ddwaf.h
-    #  1 is intValue
-    #  2 is uintValue
-    #  4 is stringValue as UTF-8 encoded
-    #  8 is array of length "nbEntries" without parameterName
-    # 16 is a map : array of length "nbEntries" with parameterName
-    # 32 is boolean
-
-    def __init__(
-        self,
-        struct: Optional[DDWafRulesType] = None,
-        observator: Optional[_observator] = None,
-        max_objects: int = DDWAF_MAX_CONTAINER_SIZE,
-        max_depth: int = DDWAF_MAX_CONTAINER_DEPTH,
-        max_string_length: int = DDWAF_MAX_STRING_LENGTH,
-    ) -> None:
-        if observator is None:
-            observator = _observator()
-        _build_ddwaf_object(self, struct, observator, max_objects, max_depth, max_string_length)
-
-    @classmethod
-    def create_without_limits(cls, struct: DDWafRulesType) -> "ddwaf_object":
-        return cls(struct, max_objects=DDWAF_NO_LIMIT, max_depth=DDWAF_DEPTH_NO_LIMIT, max_string_length=DDWAF_NO_LIMIT)
-
-    @classmethod
-    def from_json_bytes(cls, data: bytes) -> Optional["ddwaf_object"]:
-        """Create a ddwaf_object from a JSON string as bytes."""
-        obj = cls.__new__(cls)
-        if not ddwaf_object_from_json(obj, data, len(data)):
-            log.debug("Failed to create ddwaf_object from JSON: %s", data)
-            return None
-        return obj
-
-    @property
-    def struct(self) -> DDWafRulesType:
-        """Generate a python structure from ddwaf_object"""
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING:
-            return self.value.stringValue[: self.nbEntries].decode("UTF-8", errors="ignore")
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP:
-            return {
-                obj.parameterName[: obj.parameterNameLength].decode("UTF-8", errors="ignore"): obj.struct
-                for obj in self.value.array[: self.nbEntries]
-            }
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_ARRAY:
-            return [self.value.array[i].struct for i in range(self.nbEntries)]
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED:
-            return self.value.intValue
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED:
-            return self.value.uintValue
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_BOOL:
-            return self.value.boolean
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_FLOAT:
-            return self.value.f64
-        if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_NULL or self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_INVALID:
-            return None
-        log.debug("ddwaf_object struct: unknown object type: %s", repr(type(self.type)))
-        return None
-
-    def __repr__(self) -> str:
-        return repr(self.struct)
-
-
-ddwaf_object_p = ctypes.POINTER(ddwaf_object)
-
-
-class ddwaf_value(ctypes.Union):
-    _fields_ = [
-        ("stringValue", ctypes.POINTER(ctypes.c_char)),
-        ("uintValue", ctypes.c_ulonglong),
-        ("intValue", ctypes.c_longlong),
-        ("array", ddwaf_object_p),
-        ("boolean", ctypes.c_bool),
-        ("f64", ctypes.c_double),
-    ]
-
-
-ddwaf_object._fields_ = [
-    ("parameterName", ctypes.POINTER(ctypes.c_char)),
-    ("parameterNameLength", ctypes.c_uint64),
-    ("value", ddwaf_value),
-    ("nbEntries", ctypes.c_uint64),
-    ("type", ctypes.c_int),
-]
-
-
-ddwaf_object_free_fn = ctypes.CFUNCTYPE(None, ddwaf_object_p)
-ddwaf_object_free = ddwaf_object_free_fn(
-    ("ddwaf_object_free", ddwaf),
-    ((1, "object"),),
-)
-
-
-class ddwaf_config_limits(ctypes.Structure):
-    _fields_ = [
-        ("max_container_size", ctypes.c_uint32),
-        ("max_container_depth", ctypes.c_uint32),
-        ("max_string_length", ctypes.c_uint32),
-    ]
-
-
-class ddwaf_config_obfuscator(ctypes.Structure):
-    _fields_ = [
-        ("key_regex", ctypes.c_char_p),
-        ("value_regex", ctypes.c_char_p),
-    ]
-
-
-class ddwaf_config(ctypes.Structure):
-    _fields_ = [
-        ("limits", ddwaf_config_limits),
-        ("obfuscator", ddwaf_config_obfuscator),
-        ("free_fn", ddwaf_object_free_fn),
-    ]
-    # TODO : initial value of free_fn
-
-    def __init__(
-        self,
-        max_container_size: int = 0,
-        max_container_depth: int = 0,
-        max_string_length: int = 0,
-        key_regex: bytes = b"",
-        value_regex: bytes = b"",
-        free_fn: Callable[[ddwaf_object], None] = ddwaf_object_free,
-    ) -> None:
-        self.limits.max_container_size = max_container_size
-        self.limits.max_container_depth = max_container_depth
-        self.limits.max_string_length = max_string_length
-        self.obfuscator.key_regex = key_regex
-        self.obfuscator.value_regex = value_regex
-        self.free_fn = free_fn
-
-
-ddwaf_config_p = ctypes.POINTER(ddwaf_config)
-
-ddwaf_handle = ctypes.c_void_p  # may stay as this because it's mainly an abstract type in the interface
-ddwaf_context = ctypes.c_void_p  # may stay as this because it's mainly an abstract type in the interface
-ddwaf_builder = ctypes.c_void_p  # may stay as this because it's mainly an abstract type in the interface
+        ddwaf_object_set_string(self, encoded, len(encoded), DEFAULT_ALLOCATOR)
 
 
 ddwaf_log_cb = ctypes.POINTER(
@@ -342,21 +397,48 @@ ddwaf_log_cb = ctypes.POINTER(
 
 
 #
-# Functions Prototypes (creating python counterpart function from C function with )
+# Allocators
 #
 
-ddwaf_init = ctypes.CFUNCTYPE(ddwaf_handle, ddwaf_object_p, ddwaf_config_p, ddwaf_object_p)(
+
+ddwaf_get_default_allocator = ctypes.CFUNCTYPE(ddwaf_allocator)(
+    ("ddwaf_get_default_allocator", ddwaf),
+    (),
+)
+
+# The default allocator is a process-wide singleton, always valid and never destroyed.
+DEFAULT_ALLOCATOR = ddwaf_get_default_allocator()
+
+
+ddwaf_object_destroy = ctypes.CFUNCTYPE(None, ddwaf_object_p, ddwaf_allocator)(
+    ("ddwaf_object_destroy", ddwaf),
+    (
+        (1, "object"),
+        (1, "alloc"),
+    ),
+)
+
+
+def ddwaf_object_free(obj: ddwaf_object) -> None:
+    """Compatibility helper: destroy an object using the default allocator."""
+    ddwaf_object_destroy(obj, DEFAULT_ALLOCATOR)
+
+
+#
+# Functions Prototypes (creating python counterpart function from C function)
+#
+
+ddwaf_init = ctypes.CFUNCTYPE(ddwaf_handle, ddwaf_object_p, ddwaf_object_p)(
     ("ddwaf_init", ddwaf),
     (
         (1, "ruleset_map"),
-        (1, "config", None),
         (1, "diagnostics", None),
     ),
 )
 
 
-def py_ddwaf_init(ruleset_map: ddwaf_object, config: ddwaf_config, info: ddwaf_object) -> ddwaf_handle_capsule:
-    return ddwaf_handle_capsule(ddwaf_init(ruleset_map, config, info), ddwaf_destroy)
+def py_ddwaf_init(ruleset_map: ddwaf_object, info: ddwaf_object) -> ddwaf_handle_capsule:
+    return ddwaf_handle_capsule(ddwaf_init(ruleset_map, info), ddwaf_destroy)
 
 
 ddwaf_destroy = ctypes.CFUNCTYPE(None, ddwaf_handle)(
@@ -381,19 +463,31 @@ def py_ddwaf_known_addresses(handle: ddwaf_handle_capsule) -> list[str]:
     return [obj[i].decode("UTF-8") for i in range(size.value)]
 
 
-ddwaf_context_init = ctypes.CFUNCTYPE(ddwaf_context, ddwaf_handle)(
+ddwaf_context_init = ctypes.CFUNCTYPE(ddwaf_context, ddwaf_handle, ddwaf_allocator)(
     ("ddwaf_context_init", ddwaf),
-    ((1, "handle"),),
+    (
+        (1, "handle"),
+        (1, "output_alloc"),
+    ),
 )
 
 
 def py_ddwaf_context_init(handle: ddwaf_handle_capsule) -> ddwaf_context_capsule:
-    return ddwaf_context_capsule(ddwaf_context_init(handle.handle), ddwaf_context_destroy)
+    return ddwaf_context_capsule(ddwaf_context_init(handle.handle, DEFAULT_ALLOCATOR), ddwaf_context_destroy)
 
 
-ddwaf_run = ctypes.CFUNCTYPE(
-    ctypes.c_int, ddwaf_context, ddwaf_object_p, ddwaf_object_p, ddwaf_object_p, ctypes.c_uint64
-)(("ddwaf_run", ddwaf), ((1, "context"), (1, "persistent_data"), (1, "ephemeral_data"), (1, "result"), (1, "timeout")))
+ddwaf_context_eval = ctypes.CFUNCTYPE(
+    ctypes.c_int, ddwaf_context, ddwaf_object_p, ddwaf_allocator, ddwaf_object_p, ctypes.c_uint64
+)(
+    ("ddwaf_context_eval", ddwaf),
+    (
+        (1, "context"),
+        (1, "data"),
+        (1, "alloc"),
+        (1, "result"),
+        (1, "timeout"),
+    ),
+)
 
 ddwaf_context_destroy = ctypes.CFUNCTYPE(None, ddwaf_context)(
     ("ddwaf_context_destroy", ddwaf),
@@ -401,17 +495,51 @@ ddwaf_context_destroy = ctypes.CFUNCTYPE(None, ddwaf_context)(
 )
 
 
-# ddwaf_builder
+# ddwaf_subcontext (libddwaf 2.0 replacement for ephemeral data)
 
 
-ddwaf_builder_init = ctypes.CFUNCTYPE(ddwaf_builder, ddwaf_config_p)(
-    ("ddwaf_builder_init", ddwaf),
-    ((1, "config"),),
+ddwaf_subcontext_init = ctypes.CFUNCTYPE(ddwaf_subcontext, ddwaf_context)(
+    ("ddwaf_subcontext_init", ddwaf),
+    ((1, "context"),),
 )
 
 
-def py_ddwaf_builder_init(config: ddwaf_config) -> ddwaf_builder_capsule:
-    return ddwaf_builder_capsule(ddwaf_builder_init(config), ddwaf_builder_destroy)
+def py_ddwaf_subcontext_init(ctx: ddwaf_context_capsule) -> ddwaf_subcontext_capsule:
+    # Pass the parent context capsule so the subcontext keeps it alive: ddwaf_subcontext_destroy
+    # requires the parent ddwaf_context to still exist, and capsule destruction is GC-ordered.
+    return ddwaf_subcontext_capsule(ddwaf_subcontext_init(ctx.ctx), ddwaf_subcontext_destroy, parent=ctx)
+
+
+ddwaf_subcontext_eval = ctypes.CFUNCTYPE(
+    ctypes.c_int, ddwaf_subcontext, ddwaf_object_p, ddwaf_allocator, ddwaf_object_p, ctypes.c_uint64
+)(
+    ("ddwaf_subcontext_eval", ddwaf),
+    (
+        (1, "subcontext"),
+        (1, "data"),
+        (1, "alloc"),
+        (1, "result"),
+        (1, "timeout"),
+    ),
+)
+
+ddwaf_subcontext_destroy = ctypes.CFUNCTYPE(None, ddwaf_subcontext)(
+    ("ddwaf_subcontext_destroy", ddwaf),
+    ((1, "subcontext"),),
+)
+
+
+# ddwaf_builder
+
+
+ddwaf_builder_init = ctypes.CFUNCTYPE(ddwaf_builder)(
+    ("ddwaf_builder_init", ddwaf),
+    (),
+)
+
+
+def py_ddwaf_builder_init() -> ddwaf_builder_capsule:
+    return ddwaf_builder_capsule(ddwaf_builder_init(), ddwaf_builder_destroy)
 
 
 ddwaf_builder_add_or_update_config = ctypes.CFUNCTYPE(
@@ -483,126 +611,106 @@ ddwaf_builder_destroy = ctypes.CFUNCTYPE(None, ddwaf_builder)(
 )
 
 
-# ddwaf_object
-
-# Not used in Python code but kept for completeness with the libddwaf API
-ddwaf_object_invalid = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p)(
-    ("ddwaf_object_invalid", ddwaf),
-    ((3, "object"),),
-)
+# ddwaf_object creation / serialization (libddwaf 2.0 set_* and insert API)
 
 
-ddwaf_object_string = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_char_p)(
-    ("ddwaf_object_string", ddwaf),
+ddwaf_object_set_string = ctypes.CFUNCTYPE(
+    ddwaf_object_p, ddwaf_object_p, ctypes.c_char_p, ctypes.c_uint32, ddwaf_allocator
+)(
+    ("ddwaf_object_set_string", ddwaf),
     (
-        (3, "object"),
+        (1, "object"),
         (1, "string"),
+        (1, "length"),
+        (1, "alloc"),
     ),
 )
 
-# Not used in Python code but kept for completeness with the libddwaf API
-ddwaf_object_string_from_unsigned = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_uint64)(
-    ("ddwaf_object_string_from_unsigned", ddwaf),
+ddwaf_object_set_signed = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_int64)(
+    ("ddwaf_object_set_signed", ddwaf),
     (
-        (3, "object"),
+        (1, "object"),
         (1, "value"),
     ),
 )
 
-ddwaf_object_string_from_signed = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_int64)(
-    ("ddwaf_object_string_from_signed", ddwaf),
+ddwaf_object_set_unsigned = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_uint64)(
+    ("ddwaf_object_set_unsigned", ddwaf),
     (
-        (3, "object"),
+        (1, "object"),
         (1, "value"),
     ),
 )
 
-# Not used in Python code but kept for completeness with the libddwaf API
-ddwaf_object_unsigned = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_uint64)(
-    ("ddwaf_object_unsigned", ddwaf),
+ddwaf_object_set_bool = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_bool)(
+    ("ddwaf_object_set_bool", ddwaf),
     (
-        (3, "object"),
+        (1, "object"),
         (1, "value"),
     ),
 )
 
-ddwaf_object_signed = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_int64)(
-    ("ddwaf_object_signed", ddwaf),
+ddwaf_object_set_float = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_double)(
+    ("ddwaf_object_set_float", ddwaf),
     (
-        (3, "object"),
+        (1, "object"),
         (1, "value"),
     ),
 )
 
-# object_(un)signed_forced : not used ?
+ddwaf_object_set_null = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p)(
+    ("ddwaf_object_set_null", ddwaf),
+    ((1, "object"),),
+)
 
-ddwaf_object_bool = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_bool)(
-    ("ddwaf_object_bool", ddwaf),
+ddwaf_object_set_array = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_uint16, ddwaf_allocator)(
+    ("ddwaf_object_set_array", ddwaf),
     (
-        (3, "object"),
-        (1, "value"),
+        (1, "object"),
+        (1, "capacity"),
+        (1, "alloc"),
     ),
 )
 
-
-ddwaf_object_float = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_double)(
-    ("ddwaf_object_float", ddwaf),
+ddwaf_object_set_map = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ctypes.c_uint16, ddwaf_allocator)(
+    ("ddwaf_object_set_map", ddwaf),
     (
-        (3, "object"),
-        (1, "value"),
+        (1, "object"),
+        (1, "capacity"),
+        (1, "alloc"),
     ),
 )
 
-ddwaf_object_null = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p)(
-    ("ddwaf_object_null", ddwaf),
-    ((3, "object"),),
-)
-
-ddwaf_object_array = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p)(
-    ("ddwaf_object_array", ddwaf),
-    ((3, "object"),),
-)
-
-ddwaf_object_map = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p)(
-    ("ddwaf_object_map", ddwaf),
-    ((3, "object"),),
-)
-
-ddwaf_object_array_add = ctypes.CFUNCTYPE(ctypes.c_bool, ddwaf_object_p, ddwaf_object_p)(
-    ("ddwaf_object_array_add", ddwaf),
+# Returns a pointer to the newly inserted (uninitialized) element to be built into.
+ddwaf_object_insert = ctypes.CFUNCTYPE(ddwaf_object_p, ddwaf_object_p, ddwaf_allocator)(
+    ("ddwaf_object_insert", ddwaf),
     (
         (1, "array"),
-        (1, "object"),
+        (1, "alloc"),
     ),
 )
 
-ddwaf_object_map_add = ctypes.CFUNCTYPE(ctypes.c_bool, ddwaf_object_p, ctypes.c_char_p, ddwaf_object_p)(
-    ("ddwaf_object_map_add", ddwaf),
+ddwaf_object_insert_key = ctypes.CFUNCTYPE(
+    ddwaf_object_p, ddwaf_object_p, ctypes.c_char_p, ctypes.c_uint32, ddwaf_allocator
+)(
+    ("ddwaf_object_insert_key", ddwaf),
     (
         (1, "map"),
         (1, "key"),
-        (1, "object"),
+        (1, "length"),
+        (1, "alloc"),
     ),
 )
 
-# unused because accessible from python part
-# ddwaf_object_type
-# ddwaf_object_size
-# ddwaf_object_length
-# ddwaf_object_get_key
-# ddwaf_object_get_string
-# ddwaf_object_get_unsigned
-# ddwaf_object_get_signed
-# ddwaf_object_get_index
-# ddwaf_object_get_bool https://github.com/DataDog/libddwaf/commit/7dc68dacd972ae2e2a3c03a69116909c98dbd9cb
-# ddwaf_object_get_float
-
-ddwaf_object_from_json = ctypes.CFUNCTYPE(ctypes.c_bool, ddwaf_object_p, ctypes.c_char_p, ctypes.c_uint32)(
+ddwaf_object_from_json = ctypes.CFUNCTYPE(
+    ctypes.c_bool, ddwaf_object_p, ctypes.c_char_p, ctypes.c_uint32, ddwaf_allocator
+)(
     ("ddwaf_object_from_json", ddwaf),
     (
-        (3, "output"),
+        (1, "output"),
         (1, "json_str"),
         (1, "length"),
+        (1, "alloc"),
     ),
 )
 

--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -3,20 +3,24 @@ import time
 from typing import Any
 from typing import Optional
 from typing import Sequence
+from typing import Union
 
 from ddtrace.appsec._constants import DEFAULT
-from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_config
+from ddtrace.appsec._ddwaf.ddwaf_types import DEFAULT_ALLOCATOR
+from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_context_eval
 from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_object
 from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_object_free
-from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_run
+from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_subcontext_eval
 from ddtrace.appsec._ddwaf.ddwaf_types import py_add_or_update_config
 from ddtrace.appsec._ddwaf.ddwaf_types import py_ddwaf_builder_build_instance
 from ddtrace.appsec._ddwaf.ddwaf_types import py_ddwaf_builder_init
 from ddtrace.appsec._ddwaf.ddwaf_types import py_ddwaf_context_init
 from ddtrace.appsec._ddwaf.ddwaf_types import py_ddwaf_known_addresses
+from ddtrace.appsec._ddwaf.ddwaf_types import py_ddwaf_subcontext_init
 from ddtrace.appsec._ddwaf.ddwaf_types import py_remove_config
 from ddtrace.appsec._ddwaf.waf_stubs import DDWafRulesType
 from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_context_capsule
+from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_subcontext_capsule
 from ddtrace.appsec._metrics import report_error
 from ddtrace.appsec._utils import DDWaf_info
 from ddtrace.appsec._utils import DDWaf_result
@@ -35,6 +39,7 @@ DDWAF_OK = 0
 DDWAF_MATCH = 1
 
 ASM_DD_DEFAULT = "ASM_DD/default"
+OBFUSCATOR_CONFIG = "obfuscator/config"
 
 
 class DDWaf:
@@ -46,14 +51,25 @@ class DDWaf:
         obfuscation_parameter_key_regexp: bytes,
         obfuscation_parameter_value_regexp: bytes,
     ) -> None:
-        config = ddwaf_config(
-            key_regex=obfuscation_parameter_key_regexp, value_regex=obfuscation_parameter_value_regexp
-        )
         diagnostics = ddwaf_object()
         ruleset_map_object = ddwaf_object.from_json_bytes(ruleset_json_str)
         if not ruleset_map_object:
             raise ValueError("Invalid ruleset provided to DDWaf constructor")
-        self._builder = py_ddwaf_builder_init(config)
+        self._builder = py_ddwaf_builder_init()
+        # libddwaf 2.0 has no ddwaf_config: obfuscator regexes are a builder config. Both keys are
+        # optional (defaults apply when omitted), so only add it when a regex is set. The builder
+        # copies the config, so the source can be freed right after.
+        obfuscator = {}
+        if obfuscation_parameter_key_regexp:
+            obfuscator["key_regex"] = obfuscation_parameter_key_regexp
+        if obfuscation_parameter_value_regexp:
+            obfuscator["value_regex"] = obfuscation_parameter_value_regexp
+        if obfuscator:
+            obfuscator_config = ddwaf_object.create_without_limits({"obfuscator": obfuscator})
+            obfuscator_diagnostics = ddwaf_object()
+            py_add_or_update_config(self._builder, OBFUSCATOR_CONFIG, obfuscator_config, obfuscator_diagnostics)
+            ddwaf_object_free(obfuscator_diagnostics)
+            ddwaf_object_free(obfuscator_config)
         py_add_or_update_config(self._builder, ASM_DD_DEFAULT, ruleset_map_object, diagnostics)
         self._handle = py_ddwaf_builder_build_instance(self._builder)
         self._cached_version = ""
@@ -158,26 +174,54 @@ class DDWaf:
             LOGGER.debug("DDWaf._at_request_start: failure to create the context.")
         return ctx
 
+    def new_subcontext(self, ctx: ddwaf_context_capsule) -> Optional[ddwaf_subcontext_capsule]:
+        """Create a fresh subcontext from the per-request main context.
+
+        Subcontexts are libddwaf 2.0's replacement for ephemeral data: they inherit the
+        context's persistent data but evaluate non-persisting data (used for RASP, one
+        subcontext per guarded operation). Subcontexts may then be evaluated concurrently with
+        each other and with the parent context (each capsule has its own lock), but creating one
+        derives from the parent, so we serialize init under the parent context lock.
+        """
+        if not ctx:
+            return None
+        with ctx._lock:
+            subctx = py_ddwaf_subcontext_init(ctx)
+        if not subctx:
+            LOGGER.debug("DDWaf.new_subcontext: failure to create the subcontext.")
+            return None
+        return subctx
+
     def run(
         self,
-        ctx: ddwaf_context_capsule,
+        target: Union[ddwaf_context_capsule, ddwaf_subcontext_capsule],
         data: DDWafRulesType,
-        ephemeral_data: Optional[DDWafRulesType] = None,
         timeout_ms: float = DEFAULT.WAF_TIMEOUT,
     ) -> DDWaf_result:
+        # Single data object per call; persistence depends on the eval target chosen by the caller
+        # (main context for request data, subcontext for non-persisting RASP data).
         start = time.monotonic()
-        if not ctx:
+        if not target:
             LOGGER.debug("DDWaf.run: dry run. no context created.")
-            return DDWaf_result(0, [], {}, 0, (time.time() - start) * 1e6, False, self.empty_observator, {})
+            return DDWaf_result(0, [], {}, 0, (time.monotonic() - start) * 1e6, False, self.empty_observator, {})
 
         result_obj = ddwaf_object()
         observator = _observator()
         wrapper = ddwaf_object(data, observator=observator)
-        wrapper_ephemeral = ddwaf_object(ephemeral_data, observator=observator) if ephemeral_data else None
-        with ctx._lock:
-            error = ddwaf_run(ctx.ctx, wrapper, wrapper_ephemeral, result_obj, int(timeout_ms * 1000))
+        if isinstance(target, ddwaf_subcontext_capsule):
+            handle, eval_fn = target.subctx, ddwaf_subcontext_eval
+        else:
+            handle, eval_fn = target.ctx, ddwaf_context_eval
+        with target._lock:
+            error = eval_fn(handle, wrapper, DEFAULT_ALLOCATOR, result_obj, int(timeout_ms * 1000))
+        # Input ownership after eval (ddwaf.h): OK/MATCH -> context owns it (freed on context
+        # destroy); INVALID_OBJECT(-2) -> libddwaf already freed it (don't read/free);
+        # INVALID_ARGUMENT(-1) -> not taken, free here; INTERNAL(-3) -> undefined, leave alone.
         if error < 0:
-            LOGGER.debug("run DDWAF error: %d\ninput %s\nerror %s", error, wrapper.struct, self.info.errors)
+            # Log the source dict, never wrapper.struct (the wrapper may already be freed).
+            LOGGER.debug("run DDWAF error: %d\ninput %s\nerror %s", error, data, self.info.errors)
+            if error == DDWAF_ERR_INVALID_ARGUMENT:
+                ddwaf_object_free(wrapper)
         result = result_obj.struct
         if error == DDWAF_ERR_INTERNAL or not isinstance(result, dict):
             # result is not valid

--- a/ddtrace/appsec/_ddwaf/waf_stubs.py
+++ b/ddtrace/appsec/_ddwaf/waf_stubs.py
@@ -59,14 +59,12 @@ class ddwaf_context_capsule(Generic[T]):
 
 class ddwaf_subcontext_capsule(Generic[T]):
     # Subcontexts (libddwaf 2.0) evaluate non-persisting RASP data, inheriting the parent
-    # context's persistent data. Own lock to serialize eval/destroy on the same subcontext.
-    def __init__(self, subctx: type[T], free_fn: Callable[[type[T]], None], parent: Any = None) -> None:
+    # context's persistent data. In v2.0 a subcontext is independent of its parent context (the
+    # context may be destroyed first; shared objects are reference counted), so we don't need to
+    # keep a reference to the parent. Own lock to serialize eval/destroy on the same subcontext.
+    def __init__(self, subctx: type[T], free_fn: Callable[[type[T]], None]) -> None:
         self.subctx: Optional[type[T]] = subctx
         self.free_fn = free_fn
-        # Keep a strong reference to the parent context capsule: ddwaf_subcontext_destroy needs
-        # the parent ddwaf_context alive, and capsule __del__ order is GC-driven. Holding the
-        # parent here guarantees it outlives this subcontext capsule.
-        self._parent = parent
         self._lock: threading_Lock = threading_Lock()
 
     def __del__(self) -> None:

--- a/ddtrace/appsec/_ddwaf/waf_stubs.py
+++ b/ddtrace/appsec/_ddwaf/waf_stubs.py
@@ -40,11 +40,9 @@ class ddwaf_context_capsule(Generic[T]):
         self.ctx: Optional[type[T]] = ctx
         self.free_fn = free_fn
         self.rc_products: str = ""
-        # AIDEV-NOTE: This lock serializes concurrent ddwaf_run calls on the same context.
-        # ctypes foreign function calls release the Python GIL, allowing thread pool workers
-        # (run_in_executor) to call the WAF simultaneously with the event loop thread when both
-        # inherit the same ddwaf_context via contextvars propagation. libddwaf's ddwaf_context
-        # is not thread-safe for concurrent runs, so we must serialize them here.
+        # Serializes concurrent ddwaf_context_eval calls on the same context: ctypes releases the
+        # GIL, so thread-pool workers and the event loop can hit a shared context at once, which
+        # libddwaf does not allow.
         self._lock: threading_Lock = threading_Lock()
 
     def __del__(self) -> None:
@@ -57,6 +55,30 @@ class ddwaf_context_capsule(Generic[T]):
 
     def __bool__(self) -> bool:
         return bool(self.ctx)
+
+
+class ddwaf_subcontext_capsule(Generic[T]):
+    # Subcontexts (libddwaf 2.0) evaluate non-persisting RASP data, inheriting the parent
+    # context's persistent data. Own lock to serialize eval/destroy on the same subcontext.
+    def __init__(self, subctx: type[T], free_fn: Callable[[type[T]], None], parent: Any = None) -> None:
+        self.subctx: Optional[type[T]] = subctx
+        self.free_fn = free_fn
+        # Keep a strong reference to the parent context capsule: ddwaf_subcontext_destroy needs
+        # the parent ddwaf_context alive, and capsule __del__ order is GC-driven. Holding the
+        # parent here guarantees it outlives this subcontext capsule.
+        self._parent = parent
+        self._lock: threading_Lock = threading_Lock()
+
+    def __del__(self) -> None:
+        if self.subctx:
+            try:
+                self.free_fn(self.subctx)
+            except TypeError:
+                LOGGER.debug("Failed to free subcontext", exc_info=True)
+            self.subctx = None
+
+    def __bool__(self) -> bool:
+        return bool(self.subctx)
 
 
 class ddwaf_builder_capsule(Generic[T]):

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -282,12 +282,11 @@ class AppSecSpanProcessor(SpanProcessor):
             if not custom_data or not custom_data.get("PROCESSOR_SETTINGS", {}).get("extract-schema", False):
                 return None
 
-        data = {}
-        ephemeral_data = {}
+        # Single data object per eval (persistence is decided by the target). Persistent addresses
+        # are tracked in data_already_sent so they are not re-sent on later calls in this request.
+        data: dict[str, Any] = {}
         iter_data = [(key, WAF_DATA_NAMES[key]) for key in custom_data] if custom_data is not None else WAF_DATA_NAMES
         data_already_sent = _asm_request_context.get_data_sent()
-        if data_already_sent is None:
-            data_already_sent = set()
 
         # persistent addresses must be sent if api security is used
         force_keys = custom_data.get("PROCESSOR_SETTINGS", {}).get("extract-schema", False) if custom_data else False
@@ -295,10 +294,11 @@ class AppSecSpanProcessor(SpanProcessor):
         for key, waf_name in iter_data:
             if key in data_already_sent and not force_sent:
                 continue
-            # ensure ephemeral addresses are sent, event when value is None
+            # non-persistent addresses are sent as-is (even when value is None) and never tracked
+            # in data_already_sent, so they are re-sent on each call.
             if waf_name not in WAF_DATA_NAMES.PERSISTENT_ADDRESSES and custom_data:
                 if key in custom_data:
-                    ephemeral_data[waf_name] = _serialize_address_values(waf_name, custom_data.get(key))
+                    data[waf_name] = _serialize_address_values(waf_name, custom_data.get(key))
 
             elif self._is_needed(waf_name) or force_keys:
                 value = None
@@ -314,13 +314,22 @@ class AppSecSpanProcessor(SpanProcessor):
                     log.debug("[action] WAF got value %s", WAF_DATA_NAMES.get(key, key))
 
         # small optimization to avoid running the waf if there is no data to check
-        if not data and not ephemeral_data:
+        if not data:
             return None
 
         try:
-            waf_results = self._ddwaf.run(
-                ctx, data, ephemeral_data=ephemeral_data or None, timeout_ms=asm_config._waf_timeout
-            )
+            if rule_type is None:
+                # Request-related data -> main per-request context.
+                waf_results = self._ddwaf.run(ctx, data, timeout_ms=asm_config._waf_timeout)
+            else:
+                # RASP data is non-persisting -> subcontext (per guarded operation; shared across
+                # an SSRF request's req + res). If the subcontext can't be created, bypass the RASP
+                # check rather than running the data on the main context (which would persist it).
+                subctx = _asm_request_context.get_or_create_rasp_subcontext(self._ddwaf, ctx, rule_type)
+                if subctx is None:
+                    log.debug("appsec::processor::waf::rasp_subcontext_unavailable")
+                    return None
+                waf_results = self._ddwaf.run(subctx, data, timeout_ms=asm_config._waf_timeout)
         except Exception:
             log.debug("appsec::processor::waf::run", exc_info=True)
             waf_results = Binding_error

--- a/releasenotes/notes/waf-upgrade-to-2.0.0-7614fb6a23c1f05a.yaml
+++ b/releasenotes/notes/waf-upgrade-to-2.0.0-7614fb6a23c1f05a.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    ASM: This upgrades libddwaf to 2.0.0.

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ CURRENT_OS = platform.system()
 SERVERLESS_BUILD = os.getenv("DD_SERVERLESS_BUILD", "0").lower() in ("1", "yes", "on", "true")
 WHEEL_FLAVOR = "-serverless" if SERVERLESS_BUILD else ""
 
-LIBDDWAF_VERSION = "1.30.1"
+LIBDDWAF_VERSION = "2.0.0"
 
 # DEV: update this accordingly when src/native upgrades libdatadog dependency.
 # libdatadog v35.0.0 requires rust 1.87.0.

--- a/tests/appsec/appsec/test_ddwaf_fuzz.py
+++ b/tests/appsec/appsec/test_ddwaf_fuzz.py
@@ -5,6 +5,9 @@ from hypothesis import strategies as st
 import pytest
 from requests.structures import CaseInsensitiveDict
 
+from ddtrace.appsec._ddwaf.ddwaf_types import DDWAF_DEPTH_NO_LIMIT
+from ddtrace.appsec._ddwaf.ddwaf_types import DDWAF_NO_LIMIT
+from ddtrace.appsec._ddwaf.ddwaf_types import DDWAF_OBJ_MAX_CAPACITY
 from ddtrace.appsec._ddwaf.ddwaf_types import _observator
 from ddtrace.appsec._ddwaf.ddwaf_types import ddwaf_object
 
@@ -92,6 +95,46 @@ def test_limits(obj, res, trunc):
     dd_obj = ddwaf_object(obj, observator=obs, max_objects=1, max_depth=1, max_string_length=2)
     assert dd_obj.struct == res
     assert (obs.string_length, obs.container_size, obs.container_depth) == trunc
+
+
+@pytest.mark.parametrize(
+    "obj, res",
+    [
+        ("a\x00b", "a\x00b"),  # embedded NUL, small (inline) string
+        (b"x\x00y\x00z", "x\x00y\x00z"),  # embedded NULs in bytes
+        ("\x00" * 14, "\x00" * 14),  # all NULs, exactly the 14-byte inline boundary
+        ("", ""),  # empty small string
+        ("a\x00" + "b" * 20, "a\x00" + "b" * 20),  # embedded NUL, heap (>14 bytes) string
+    ],
+)
+def test_string_with_embedded_nul(obj, res):
+    # libddwaf 2.0 strings are length-delimited (not NUL-terminated). Reading must preserve
+    # embedded NUL bytes for both the inline "small string" and heap string representations.
+    dd_obj = ddwaf_object(obj)
+    assert dd_obj.struct == res
+
+
+@pytest.mark.parametrize("container", ["list", "dict"])
+def test_large_container_capped_at_uint16(container):
+    # libddwaf 2.0 stores a container's size in a uint16. The builder must cap the number of
+    # elements at DDWAF_OBJ_MAX_CAPACITY (65535) even on the create_without_limits path, and
+    # record the truncation, rather than letting the native size field silently wrap.
+    n = DDWAF_OBJ_MAX_CAPACITY + 2000
+    if container == "list":
+        value = list(range(n))
+    else:
+        value = {str(i): i for i in range(n)}
+    obs = _observator()
+    obj = ddwaf_object(
+        value,
+        observator=obs,
+        max_objects=DDWAF_NO_LIMIT,
+        max_depth=DDWAF_DEPTH_NO_LIMIT,
+        max_string_length=DDWAF_NO_LIMIT,
+    )
+    result = obj.struct
+    assert len(result) == DDWAF_OBJ_MAX_CAPACITY  # capped, not wrapped
+    assert obs.container_size == n  # original size recorded as a truncation
 
 
 def test_vendorized_xmltodict():

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -630,7 +630,10 @@ def test_ddwaf_run_contained_typeerror(tracer, caplog):
 
     with (
         caplog.at_level(logging.DEBUG),
-        mock.patch("ddtrace.appsec._ddwaf.waf.ddwaf_run", side_effect=TypeError("expected c_long instead of int")),
+        mock.patch(
+            "ddtrace.appsec._ddwaf.waf.ddwaf_context_eval",
+            side_effect=TypeError("expected c_long instead of int"),
+        ),
     ):
         with asm_context(tracer=tracer, config=config_asm) as span:
             set_http_meta(
@@ -667,7 +670,7 @@ def test_ddwaf_run_contained_oserror(tracer, caplog):
 
     with (
         caplog.at_level(logging.DEBUG),
-        mock.patch("ddtrace.appsec._ddwaf.waf.ddwaf_run", side_effect=OSError("ddwaf run failed")),
+        mock.patch("ddtrace.appsec._ddwaf.waf.ddwaf_context_eval", side_effect=OSError("ddwaf run failed")),
     ):
         with asm_context(tracer=tracer, config=config_asm) as span:
             set_http_meta(
@@ -821,9 +824,12 @@ def test_required_addresses():
 @pytest.mark.parametrize(
     "persistent", [key for key, value in WAF_DATA_NAMES if value in WAF_DATA_NAMES.PERSISTENT_ADDRESSES]
 )
-@pytest.mark.parametrize("ephemeral", ["LFI_ADDRESS", "PROCESSOR_SETTINGS"])
+@pytest.mark.parametrize("non_persistent", ["LFI_ADDRESS", "PROCESSOR_SETTINGS"])
 @mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
-def test_ephemeral_addresses(mock_run, persistent, ephemeral):
+def test_persistent_dedup_and_non_persistent_resend(mock_run, persistent, non_persistent):
+    # dd-trace-py only sends each persistent address to the WAF once per request (it persists in
+    # the context), while non-persistent addresses are re-sent on every call. This dedup policy is
+    # independent of the libddwaf version. call_args[0][1] is the single `data` argument of DDWaf.run.
     from ddtrace.appsec._utils import DDWaf_result
     from ddtrace.appsec._utils import _observator
     from ddtrace.trace import tracer
@@ -833,27 +839,24 @@ def test_ephemeral_addresses(mock_run, persistent, ephemeral):
     with asm_context(tracer=tracer, config=config_asm, rc_payload=CUSTOM_RULE_METHOD) as span:
         processor = AppSecSpanProcessor._instance
         assert processor
-        # first call must send all data to the waf
-        processor._waf_action(span, None, {persistent: {"key_1": "value_1"}, ephemeral: {"key_2": "value_2"}})
+        # first call sends both the persistent and the non-persistent address to the waf
+        processor._waf_action(span, None, {persistent: {"key_1": "value_1"}, non_persistent: {"key_2": "value_2"}})
         assert mock_run.call_args
         assert mock_run.call_args[0]
-        assert mock_run.call_args[0][1] == {WAF_DATA_NAMES[persistent]: {"key_1": "value_1"}}
-        assert mock_run.call_args[1]
-        assert mock_run.call_args[1]["ephemeral_data"] == {WAF_DATA_NAMES[ephemeral]: {"key_2": "value_2"}}
-        # second call must only send ephemeral data to the waf, not persistent data again
-        processor._waf_action(span, None, {persistent: {"key_1": "value_1"}, ephemeral: {"key_2": "value_3"}})
-        assert mock_run.call_args
-        assert mock_run.call_args[0]
-        assert mock_run.call_args[0][1] == {}
-        assert mock_run.call_args[1]
-        assert mock_run.call_args[1]["ephemeral_data"] == {
-            WAF_DATA_NAMES[ephemeral]: {"key_2": "value_3"},
+        assert mock_run.call_args[0][1] == {
+            WAF_DATA_NAMES[persistent]: {"key_1": "value_1"},
+            WAF_DATA_NAMES[non_persistent]: {"key_2": "value_2"},
         }
+        # second call must not re-send the persistent address, but must re-send the non-persistent one
+        processor._waf_action(span, None, {persistent: {"key_1": "value_1"}, non_persistent: {"key_2": "value_3"}})
+        assert mock_run.call_args
+        assert mock_run.call_args[0]
+        assert mock_run.call_args[0][1] == {WAF_DATA_NAMES[non_persistent]: {"key_2": "value_3"}}
     assert (span._local_root or span).get_tag(APPSEC.RC_PRODUCTS) == "[ASM:1] u:1 r:1"
 
 
 @mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
-def test_waf_action_null_ephemeral_addresses(mock_run):
+def test_waf_action_none_value_non_persistent_address(mock_run):
     from ddtrace.appsec._utils import DDWaf_result
     from ddtrace.appsec._utils import _observator
     from ddtrace.trace import tracer
@@ -863,13 +866,12 @@ def test_waf_action_null_ephemeral_addresses(mock_run):
     with asm_context(tracer=tracer, config=config_asm) as span:
         processor = AppSecSpanProcessor._instance
         assert processor
-        # None value for ephemeral addresses should not be discarded
+        # A None value for a non-persistent address must still be sent (it signals the address is
+        # present, e.g. a login failure with no known user), not discarded.
         processor._waf_action(span, None, {"LOGIN_FAILURE": None})
         assert mock_run.call_args
         assert mock_run.call_args[0]
-        assert mock_run.call_args[0][1] == {}
-        assert mock_run.call_args[1]
-        assert mock_run.call_args[1]["ephemeral_data"] == {WAF_DATA_NAMES.LOGIN_FAILURE: None}
+        assert mock_run.call_args[0][1] == {WAF_DATA_NAMES.LOGIN_FAILURE: None}
 
 
 @pytest.mark.parametrize("skip_event", [True, False])
@@ -919,3 +921,118 @@ def test_lambda_inferred_span(tracer, inferred_span_name):
     assert gateway_span.get_metric(APPSEC.ENABLED) == 1.0
     assert get_triggers(lambda_span)
     assert get_triggers(gateway_span)
+
+
+def test_rasp_subcontext_scope_shared_for_ssrf():
+    """A nested SSRF operation (e.g. requests driving urllib3) must share ONE subcontext.
+
+    The reentrant open must not let an inner scope clobber the outer holder, and SSRF_REQ +
+    SSRF_RES of the same outgoing request must resolve the same subcontext.
+    """
+    from ddtrace.appsec import _asm_request_context as arc
+    from ddtrace.internal import core
+
+    class _FakeSubctx:
+        pass
+
+    class _FakeWaf:
+        def __init__(self):
+            self.created = 0
+
+        def new_subcontext(self, ctx):
+            self.created += 1
+            return _FakeSubctx()
+
+    waf = _FakeWaf()
+    main_ctx = object()
+    with core.context_with_data("outer_request"):
+        arc.open_rasp_subcontext_scope()
+        s_req = arc.get_or_create_rasp_subcontext(waf, main_ctx, "ssrf_req")
+        # Inner client opens a nested scope: it must detect the parent holder and not create one.
+        with core.context_with_data("inner_send"):
+            arc.open_rasp_subcontext_scope()  # reentrant: reuses the outer holder
+            s_inner = arc.get_or_create_rasp_subcontext(waf, main_ctx, "ssrf_req")
+            assert s_inner is s_req
+        # Final response on the outer scope still shares the same subcontext.
+        s_res = arc.get_or_create_rasp_subcontext(waf, main_ctx, "ssrf_res")
+        assert s_res is s_req
+    assert waf.created == 1
+
+
+def test_rasp_subcontext_distinct_per_concurrent_outgoing_request():
+    """Concurrent outgoing requests each run in their own per-request core context, so they must
+    get DISTINCT subcontexts (the holder is rooted per request, never shared via a common parent).
+    """
+    from ddtrace.appsec import _asm_request_context as arc
+    from ddtrace.internal import core
+
+    class _FakeSubctx:
+        pass
+
+    class _FakeWaf:
+        def __init__(self):
+            self.created = 0
+
+        def new_subcontext(self, ctx):
+            self.created += 1
+            return _FakeSubctx()
+
+    waf = _FakeWaf()
+    main_ctx = object()
+    with core.context_with_data("inbound_request"):  # shared parent (the inbound request)
+        with core.context_with_data("outgoing_a"):
+            arc.open_rasp_subcontext_scope()
+            a = arc.get_or_create_rasp_subcontext(waf, main_ctx, "ssrf_req")
+        with core.context_with_data("outgoing_b"):  # sibling, not nested under A
+            arc.open_rasp_subcontext_scope()
+            b = arc.get_or_create_rasp_subcontext(waf, main_ctx, "ssrf_req")
+        assert a is not b
+    assert waf.created == 2
+
+
+def test_rasp_subcontext_fresh_per_non_ssrf_call():
+    """LFI/CMDI/SHI/SQLI must get a fresh subcontext on every call (one per guarded operation)."""
+    from ddtrace.appsec import _asm_request_context as arc
+    from ddtrace.internal import core
+
+    class _FakeSubctx:
+        pass
+
+    class _FakeWaf:
+        def __init__(self):
+            self.created = 0
+
+        def new_subcontext(self, ctx):
+            self.created += 1
+            return _FakeSubctx()
+
+    waf = _FakeWaf()
+    main_ctx = object()
+    with core.context_with_data("request"):
+        arc.open_rasp_subcontext_scope()
+        a = arc.get_or_create_rasp_subcontext(waf, main_ctx, "lfi")
+        b = arc.get_or_create_rasp_subcontext(waf, main_ctx, "lfi")
+        assert a is not b
+    assert waf.created == 2
+
+
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
+def test_rasp_bypassed_when_subcontext_unavailable(mock_run):
+    """If a RASP subcontext can't be created, the WAF call is bypassed entirely (not run on the
+    main context, which would persist the non-persisting RASP data).
+    """
+    from ddtrace.appsec._constants import EXPLOIT_PREVENTION
+    from ddtrace.trace import tracer
+
+    with asm_context(tracer=tracer, config=config_asm) as span:
+        processor = AppSecSpanProcessor._instance
+        assert processor
+        with mock.patch.object(_asm_request_context, "get_or_create_rasp_subcontext", return_value=None):
+            res = processor._waf_action(
+                span,
+                None,
+                {EXPLOIT_PREVENTION.ADDRESS.LFI: "/etc/passwd"},
+                rule_type=EXPLOIT_PREVENTION.TYPE.LFI,
+            )
+        assert res is None
+        mock_run.assert_not_called()

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -296,7 +296,7 @@ def test_log_metric_error_ddwaf_update(telemetry_writer):
         assert "waf_version:{}".format(asm_config._ddwaf_version) in list_metrics_logs[0]["tags"]
 
 
-unpatched_run = ddtrace.appsec._ddwaf.ddwaf_types.ddwaf_run
+unpatched_run = ddtrace.appsec._ddwaf.ddwaf_types.ddwaf_context_eval
 
 
 def _wrapped_run(*args, **kwargs):
@@ -304,7 +304,7 @@ def _wrapped_run(*args, **kwargs):
     return -3
 
 
-@mock.patch.object(ddtrace.appsec._ddwaf.waf, "ddwaf_run", new=_wrapped_run)
+@mock.patch.object(ddtrace.appsec._ddwaf.waf, "ddwaf_context_eval", new=_wrapped_run)
 def test_log_metric_error_ddwaf_internal_error(telemetry_writer):
     """Test that an internal error is logged when the WAF returns an internal error."""
 

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -13,7 +13,7 @@
       "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.rc_products": "[] u:0 r:1",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "699dd65400000000",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -14,7 +14,7 @@
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.fp.session": "ssn--3fd6b904-1f57cef4-",
       "_dd.appsec.rc_products": "[] u:0 r:1",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "699dd65400000000",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -13,7 +13,7 @@
       "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.rc_products": "[] u:0 r:1",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "tests.appsec.appsec",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.errors": "{\"missing key 'conditions'\": [\"crs-913-110\"], \"missing key 'tags'\": [\"crs-942-100\"]}",
       "_dd.appsec.event_rules.version": "5.5.5",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "tests.appsec.appsec",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -15,7 +15,7 @@
       "_dd.appsec.fp.session": "ssn----",
       "_dd.appsec.normalized_route": "/",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de754900000000",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -14,7 +14,7 @@
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.fp.session": "ssn----",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de754a00000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -10,7 +10,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/osspawn",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2d5a00000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/osspawn",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2bae00000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/ossystem",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2d5800000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/ossystem",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2ba600000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/subcommunicatenoshell",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2d5d00000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/subcommunicatenoshell",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2bad00000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/subcommunicateshell",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2d5e00000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
@@ -11,7 +11,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.normalized_route": "/executions/subcommunicateshell",
       "_dd.appsec.rc_products": "[] u:0 r:2",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2ba900000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -12,7 +12,7 @@
       "_dd.appsec.normalized_route": "/checkuser/{user_id}",
       "_dd.appsec.rc_products": "[] u:0 r:2",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2d5900000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -12,7 +12,7 @@
       "_dd.appsec.normalized_route": "/checkuser/{user_id}",
       "_dd.appsec.rc_products": "[] u:0 r:2",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69dd2ba700000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -12,7 +12,7 @@
       "_dd.appsec.normalized_route": "/checkuser/{user_id}",
       "_dd.appsec.rc_products": "[] u:0 r:2",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -12,7 +12,7 @@
       "_dd.appsec.normalized_route": "/checkuser/{user_id}",
       "_dd.appsec.rc_products": "[] u:0 r:2",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.waf.version": "1.30.1",
+      "_dd.appsec.waf.version": "2.0.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",


### PR DESCRIPTION
APPSEC-61170

Upgrade the bundled libddwaf native library from 1.30.1 to 2.0.0 (major ABI break): the ctypes binding is rewritten for the new 16-byte `ddwaf_object` tagged union and allocator-based API, and ephemeral data is replaced by subcontexts — request data is evaluated on the main per-request context while RASP runs on a subcontext (one per guarded operation, shared across an outgoing request's SSRF_REQ + SSRF_RES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)