### PR TITLE
feat(botocore): add per-service distributed tracing configuration

### DIFF
--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -193,8 +193,13 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
         # botocore.patched_api_call: distributed_tracing off -> suppress (opt-out,
         # no headers anywhere); on + handler registered -> suppress; on +
         # registration failed -> do NOT suppress, fall back to aiohttp injection.
+        # Mirror the sync path: combine the global flag with the per-service override
+        # so DD_BOTOCORE_{SERVICE}_DISTRIBUTED_TRACING=false is respected here too.
+        effective_distributed_tracing = config.botocore["distributed_tracing"] and config.botocore[
+            "service_distributed_tracing"
+        ].get(endpoint_name, True)
         token = None
-        if not config.botocore["distributed_tracing"]:
+        if not effective_distributed_tracing:
             token = _http_propagation_suppressed.set(True)
         elif _ensure_before_sign_handler(instance, _aiobotocore_before_sign_handler):
             token = _http_propagation_suppressed.set(True)

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -4,6 +4,7 @@ Trace queries to aws api done via botocore client
 
 import collections
 import json
+import os
 from typing import Union  # noqa:F401
 
 from botocore import __version__
@@ -53,6 +54,21 @@ from .utils import update_eventbridge_detail
 
 
 _PATCHED_SUBMODULES: set[str] = set()
+
+
+def _load_service_distributed_tracing_overrides() -> dict[str, bool]:
+    """Scans env at startup for DD_BOTOCORE_{SERVICE}_DISTRIBUTED_TRACING vars.
+    E.g. DD_BOTOCORE_BEDROCK_RUNTIME_DISTRIBUTED_TRACING=false → {"bedrock-runtime": False}
+    """
+    prefix = "DD_BOTOCORE_"
+    suffix = "_DISTRIBUTED_TRACING"
+    result = {}
+    for key, value in os.environ.items():
+        if key.startswith(prefix) and key.endswith(suffix):
+            service = key[len(prefix) : -len(suffix)].lower().replace("_", "-")
+            result[service] = asbool(value)
+    return result
+
 
 # Original botocore client class
 _Botocore_client = botocore.client.BaseClient
@@ -209,6 +225,7 @@ config._add(
         "propagation_enabled": asbool(env.get("DD_BOTOCORE_PROPAGATION_ENABLED", default=False)),
         "empty_poll_enabled": asbool(env.get("DD_BOTOCORE_EMPTY_POLL_ENABLED", default=True)),
         "dynamodb_primary_key_names_for_tables": _load_dynamodb_primary_key_names_for_tables(),
+        "service_distributed_tracing": _load_service_distributed_tracing_overrides(),
         "add_span_pointers": asbool(env.get("DD_BOTOCORE_ADD_SPAN_POINTERS", default=True)),
         "payload_tagging_request": env.get("DD_TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING", default=None),
         "payload_tagging_response": env.get("DD_TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING", default=None),
@@ -302,6 +319,14 @@ def patched_api_call(botocore, pin, original_func, instance, args, kwargs):
     operation = get_argument_value(args, kwargs, 0, "operation_name", True)
     params = get_argument_value(args, kwargs, 1, "api_params", True)
 
+    # Effective distributed tracing flag for this call: global setting AND per-service override.
+    # Service patchers read this from function_vars rather than config directly so that
+    # DD_BOTOCORE_{SERVICE}_DISTRIBUTED_TRACING=false suppresses body/payload injection
+    # while still generating spans.
+    effective_distributed_tracing = config.botocore["distributed_tracing"] and config.botocore[
+        "service_distributed_tracing"
+    ].get(endpoint_name, True)
+
     function_vars = {
         "endpoint_name": endpoint_name,
         "operation": operation,
@@ -309,6 +334,7 @@ def patched_api_call(botocore, pin, original_func, instance, args, kwargs):
         "pin": pin,
         "trace_operation": trace_operation,
         "integration": botocore._datadog_integration,
+        "distributed_tracing": effective_distributed_tracing,
     }
 
     patching_fn = patched_api_call_fallback
@@ -329,7 +355,7 @@ def patched_api_call(botocore, pin, original_func, instance, args, kwargs):
     # Suppression is set/reset only on this path, so the contextvar stays owned
     # here and early-return paths can't leak it.
     token = None
-    if not config.botocore["distributed_tracing"]:
+    if not effective_distributed_tracing:
         token = _http_propagation_suppressed.set(True)
     elif _ensure_before_sign_handler(instance, _botocore_before_sign_handler):
         token = _http_propagation_suppressed.set(True)
@@ -398,7 +424,7 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
         ctx.span,
     ):
         core.dispatch("botocore.patched_api_call.started", (ctx,))
-        if args and config.botocore["distributed_tracing"]:
+        if args and function_vars.get("distributed_tracing"):
             prep_context_injection(ctx, endpoint_name, operation, trace_operation, params)
 
         try:

--- a/ddtrace/contrib/internal/botocore/services/kinesis.py
+++ b/ddtrace/contrib/internal/botocore/services/kinesis.py
@@ -161,7 +161,9 @@ def _patched_kinesis_api_call(parent_ctx, original_func, instance, args, kwargs,
             core.dispatch("botocore.patched_kinesis_api_call.started", (ctx,))
 
             if is_kinesis_put_operation:
-                records_to_process = select_records_for_injection(params, bool(config.botocore["distributed_tracing"]))
+                records_to_process = select_records_for_injection(
+                    params, bool(function_vars.get("distributed_tracing"))
+                )
                 for record, should_inject_trace_context in records_to_process:
                     update_record(ctx, record, stream_arn, inject_trace_context=should_inject_trace_context)
 

--- a/ddtrace/contrib/internal/botocore/services/sqs.py
+++ b/ddtrace/contrib/internal/botocore/services/sqs.py
@@ -122,7 +122,7 @@ def _patched_sqs_api_call(parent_ctx, original_func, instance, args, kwargs, fun
     )
     should_update_messages = (
         args
-        and config.botocore["distributed_tracing"]
+        and function_vars.get("distributed_tracing")
         and endpoint_name == "sqs"
         and operation in ("SendMessage", "SendMessageBatch")
     )

--- a/ddtrace/contrib/internal/botocore/services/stepfunctions.py
+++ b/ddtrace/contrib/internal/botocore/services/stepfunctions.py
@@ -49,7 +49,7 @@ def patched_stepfunction_api_call(original_func, instance, args, kwargs: dict, f
     operation = function_vars.get("operation")
 
     is_start_execution_call = endpoint_name == "states" and operation in {"StartExecution", "StartSyncExecution"}
-    should_update_input = args and config.botocore["distributed_tracing"] and is_start_execution_call
+    should_update_input = args and function_vars.get("distributed_tracing") and is_start_execution_call
     if should_update_input:
         call_name = schematize_cloud_messaging_operation(
             trace_operation,

--- a/releasenotes/notes/botocore-per-service-tracing-toggle-d8cf602618d34cb5.yaml
+++ b/releasenotes/notes/botocore-per-service-tracing-toggle-d8cf602618d34cb5.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    botocore: Adds ``DD_BOTOCORE_{SERVICE}_DISTRIBUTED_TRACING`` environment variables to
+    disable distributed tracing injection for individual AWS services while still generating
+    spans. This mirrors the existing global ``DD_BOTOCORE_DISTRIBUTED_TRACING`` flag but
+    scoped to a single service. The service name corresponds to the botocore endpoint prefix,
+    with hyphens replaced by underscores and the name uppercased (e.g.
+    ``DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING=false`` prevents trace context from being
+    injected into Kinesis record bodies, avoiding payload size overflows).

--- a/releasenotes/notes/botocore-per-service-tracing-toggle-d8cf602618d34cb5.yaml
+++ b/releasenotes/notes/botocore-per-service-tracing-toggle-d8cf602618d34cb5.yaml
@@ -2,9 +2,4 @@
 features:
   - |
     botocore: Adds ``DD_BOTOCORE_{SERVICE}_DISTRIBUTED_TRACING`` environment variables to
-    disable distributed tracing injection for individual AWS services while still generating
-    spans. This mirrors the existing global ``DD_BOTOCORE_DISTRIBUTED_TRACING`` flag but
-    scoped to a single service. The service name corresponds to the botocore endpoint prefix,
-    with hyphens replaced by underscores and the name uppercased (e.g.
-    ``DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING=false`` prevents trace context from being
-    injected into Kinesis record bodies, avoiding payload size overflows).
+    disable distributed tracing injection for individual AWS services while still generating spans.

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -1930,6 +1930,46 @@ class BotocoreTest(TracerTestCase):
     def test_invoke_legacy_context_env_override(self):
         assert config.botocore.invoke_with_legacy_context is True
 
+    @mock_kinesis
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING="false"))
+    def test_kinesis_distributed_tracing_disabled_per_service(self):
+        client = self.session.create_client("kinesis", region_name="us-east-1")
+        client.create_stream(StreamName="test", ShardCount=1)
+        data = json.dumps({"Hello": "World"})
+        client.put_records(StreamName="test", Records=[{"Data": data, "PartitionKey": "1"}])
+
+        spans = self.get_spans()
+        # spans are still generated; only injection into record bodies is suppressed
+        assert spans, "Expected spans even when DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING=false"
+        put_span = next(s for s in spans if s.get_tag("aws.operation") == "PutRecords")
+        # confirm the record body was NOT modified with _datadog injection
+        records = client.get_records(
+            ShardIterator=client.get_shard_iterator(
+                StreamName="test",
+                ShardId="shardId-000000000000",
+                ShardIteratorType="TRIM_HORIZON",
+            )["ShardIterator"]
+        )["Records"]
+        assert records, "Expected at least one record"
+        record_data = json.loads(records[0]["Data"])
+        assert "_datadog" not in record_data, "Expected no _datadog injection in record body"
+        assert put_span is not None
+
+    @mock_kinesis
+    @mock_s3
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING="false"))
+    def test_per_service_distributed_tracing_does_not_affect_other_services(self):
+        s3 = self.session.create_client("s3", region_name="us-east-1")
+        s3.list_buckets()
+
+        kinesis = self.session.create_client("kinesis", region_name="us-east-1")
+        kinesis.list_streams()
+
+        spans = self.get_spans()
+        operations = {s.get_tag("aws.operation") for s in spans}
+        assert "ListBuckets" in operations, "S3 span should still be present"
+        assert "ListStreams" in operations, "Kinesis span should still be present (only injection disabled)"
+
     def _test_sns(self, use_default_tracer=False):
         sns = self.session.create_client("sns", region_name="us-east-1", endpoint_url="http://localhost:4566")
 


### PR DESCRIPTION
Adds DD_BOTOCORE_{SERVICE}_DISTRIBUTED_TRACING env vars to disable trace context injection for individual AWS services (e.g. Kinesis record bodies, SQS message attributes, Step Functions input) while still generating spans. Env vars are read once at module load into config.botocore["service_distributed_tracing"].

Closes #18615

## Description

The service name is the botocore endpoint prefix, uppercased with hyphens replaced
by underscores — e.g. `DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING=false` prevents
`_datadog` injection into Kinesis record bodies (useful when record size approaches
the 1 MB limit). Env vars are read once at module load, consistent with other
botocore settings.

## Testing

- `test_kinesis_distributed_tracing_disabled_per_service`: verifies that spans are
  still generated when `DD_BOTOCORE_KINESIS_DISTRIBUTED_TRACING=false`, and that
  `_datadog` is absent from Kinesis record bodies.
- `test_per_service_distributed_tracing_does_not_affect_other_services`: verifies
  that setting the Kinesis flag does not suppress spans for other services (S3).

## Risks

The flag defaults to enabled, so existing behaviour is unchanged.

One known ambiguity: a hypothetical endpoint named `foo_bar` (underscore) would
be indistinguishable from `foo-bar` (hyphen) at the env var level. No existing
botocore endpoints collide under this mapping — all endpoint prefixes are
kebab-case by convention.

## Additional Notes

The HTTP-layer propagation suppression (`_http_propagation_suppressed` contextvar)
is also gated on the effective per-service flag, so trace headers are not injected
at the urllib3 layer either when per-service distributed tracing is disabled.