### PR TITLE
chore(pyproject): exclude wrapt 2.2.1

### DIFF
--- a/lib-injection/sources/requirements.csv
+++ b/lib-injection/sources/requirements.csv
@@ -6,6 +6,6 @@ bytecode,">=0.14.0,<1",python_version~='3.11.0'
 bytecode,">=0.13.0,<1",python_version<'3.11'
 envier,~=0.6.1,
 opentelemetry-api,">=1,<2",
-wrapt,">=1,!=2.2.0,<3",
+wrapt,">=1,!=2.2.0,!=2.2.1,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,14 +40,16 @@ dependencies = [
     "bytecode>=0.13.0,<1; python_version<'3.11'",
     "envier~=0.6.1",
     "opentelemetry-api>=1,<2",
-    # TODO: lift the `!=2.2.0` exclusion once wrapt ships a release that
-    # reverts/fixes the descriptor regression introduced in
+    # TODO: lift the `!=2.2.0,!=2.2.1` exclusions once wrapt ships a release
+    # that reverts/fixes the descriptor regression introduced in
     # https://github.com/GrahamDumpleton/wrapt/commit/ae93dd71c378161ff3643c9a1f708f66f97f3b5d
     # wrapt 2.2.0's `FunctionWrapper.__get__(None, owner)` calls `tp_descr_get`
     # with `Py_None` instead of `NULL`, which breaks class-level access to any
     # C method_descriptor we wrap (e.g. `_pickle.Unpickler.load`,
     # `asyncpg.protocol.protocol.BaseProtocol.execute`). See incident 53643.
-    "wrapt>=1,!=2.2.0,<3",
+    # wrapt 2.2.1 imports asyncio from wrapt.synchronization at import time,
+    # which breaks ddtrace.auto's lazy-import guarantee for asyncio.
+    "wrapt>=1,!=2.2.0,!=2.2.1,<3",
 ]
 
 [project.optional-dependencies]

--- a/requirements.csv
+++ b/requirements.csv
@@ -6,6 +6,6 @@ bytecode,">=0.14.0,<1",python_version~='3.11.0'
 bytecode,">=0.13.0,<1",python_version<'3.11'
 envier,~=0.6.1,
 opentelemetry-api,">=1,<2",
-wrapt,">=1,!=2.2.0,<3",
+wrapt,">=1,!=2.2.0,!=2.2.1,<3",
 opentracing,">=2,<3",
 opentelemetry-exporter-otlp,">=1,<2",


### PR DESCRIPTION
  ## Description

  Exclude `wrapt==2.2.1` from the supported dependency range.

  `wrapt 2.2.1` imports `asyncio` at `import wrapt` time via `wrapt.synchronization`. Since `ddtrace.auto` imports `wrapt` through startup modules such as `ddtrace.internal.forksafe`, this causes `asyncio` to be
  present in `sys.modules` during auto instrumentation and breaks the lazy-import guarantee checked by `tests/contrib/asyncio/test_lazyimport.py`.

  ## Risks

  Low. This only excludes a specific `wrapt` release that violates ddtrace startup import assumptions. Other supported `wrapt` versions remain allowed.

