### PR TITLE
chore: set a default service name for cherrypy

### DIFF
--- a/ddtrace/contrib/internal/cherrypy/patch.py
+++ b/ddtrace/contrib/internal/cherrypy/patch.py
@@ -12,13 +12,13 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib import trace_utils
+from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal.schema import SpanDirection
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.settings import env
-from ddtrace.internal.trace_utils import set_service_and_source
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.vendor.debtcollector import deprecate
@@ -50,6 +50,7 @@ SPAN_NAME = schematize_url_operation("cherrypy.request", protocol="http", direct
 class TraceTool(cherrypy.Tool):
     def __init__(self, app, service, use_distributed_tracing=None):
         self.app = app
+        config.cherrypy["service"] = schematize_service_name(service)
         if use_distributed_tracing is not None:
             self.use_distributed_tracing = use_distributed_tracing
 
@@ -82,12 +83,10 @@ class TraceTool(cherrypy.Tool):
             headers_case_sensitive=True,
         ) as ctx:
             req_span = ctx.span
-            (
-                set_service_and_source(
-                    req_span,
-                    schematize_service_name(trace_utils.int_service(None, config.cherrypy, default="cherrypy")),
-                    config.cherrypy,
-                ),
+            set_service_and_source(
+                req_span,
+                trace_utils.int_service(None, config.cherrypy, default="cherrypy"),
+                config.cherrypy,
             )
 
             ctx.set_item("req_span", req_span)

--- a/ddtrace/contrib/internal/cherrypy/patch.py
+++ b/ddtrace/contrib/internal/cherrypy/patch.py
@@ -18,6 +18,7 @@ from ddtrace.internal.schema import SpanDirection
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.settings import env
+from ddtrace.internal.trace_utils import set_service_and_source
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.vendor.debtcollector import deprecate
@@ -30,6 +31,7 @@ config._add(
     "cherrypy",
     dict(
         distributed_tracing=asbool(env.get("DD_CHERRYPY_DISTRIBUTED_TRACING", default=True)),
+        _default_service="cherrypy",
     ),
 )
 
@@ -48,7 +50,6 @@ SPAN_NAME = schematize_url_operation("cherrypy.request", protocol="http", direct
 class TraceTool(cherrypy.Tool):
     def __init__(self, app, service, use_distributed_tracing=None):
         self.app = app
-        self.service = service
         if use_distributed_tracing is not None:
             self.use_distributed_tracing = use_distributed_tracing
 
@@ -64,14 +65,6 @@ class TraceTool(cherrypy.Tool):
     def use_distributed_tracing(self, use_distributed_tracing):
         config.cherrypy["distributed_tracing"] = asbool(use_distributed_tracing)
 
-    @property
-    def service(self):
-        return config.cherrypy.get("service", "cherrypy")
-
-    @service.setter
-    def service(self, service):
-        config.cherrypy["service"] = schematize_service_name(service)
-
     def _setup(self):
         cherrypy.Tool._setup(self)
         cherrypy.request.hooks.attach("on_end_request", self._on_end_request, priority=5)
@@ -82,7 +75,6 @@ class TraceTool(cherrypy.Tool):
             "cherrypy.request",
             span_name=SPAN_NAME,
             span_type=SpanTypes.WEB,
-            service=trace_utils.int_service(None, config.cherrypy, default="cherrypy"),
             tags={},
             distributed_headers=cherrypy.request.headers,
             integration_config=config.cherrypy,
@@ -90,6 +82,13 @@ class TraceTool(cherrypy.Tool):
             headers_case_sensitive=True,
         ) as ctx:
             req_span = ctx.span
+            (
+                set_service_and_source(
+                    req_span,
+                    schematize_service_name(trace_utils.int_service(None, config.cherrypy, default="cherrypy")),
+                    config.cherrypy,
+                ),
+            )
 
             ctx.set_item("req_span", req_span)
             core.dispatch("web.request.start", (ctx, config.cherrypy))

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -82,7 +82,7 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         # ensure CherryPy uses the last set configuration to be sure
         # there are no breaking changes for who uses `ddtrace-run`
         # with the `TraceMiddleware`
-        assert cherrypy.tools.tracer.service == "test.cherrypy.service"
+        assert config.cherrypy["service"] == "test.cherrypy.service"
         TraceMiddleware(
             cherrypy,
             service="new-intake",
@@ -95,7 +95,7 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         spans = self.pop_spans()
         assert len(spans) == 1
 
-        assert cherrypy.tools.tracer.service == "new-intake"
+        assert config.cherrypy["service"] == "new-intake"
 
     def test_child(self):
         self.getPage("/child")
@@ -458,8 +458,8 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         config.cherrypy["service"] = previous_service
 
     def test_service_configuration_middleware(self):
-        previous_service = cherrypy.tools.tracer.service
-        cherrypy.tools.tracer.service = "my_cherrypy_service2"
+        previous_service = config.cherrypy.get("service", "test.cherrypy.service")
+        config.cherrypy["service"] = "my_cherrypy_service2"
         self.getPage("/")
         time.sleep(0.1)
         self.assertStatus("200 OK")
@@ -477,7 +477,7 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         assert_span_http_status_code(s, 200)
         assert s.get_tag(http.METHOD) == "GET"
 
-        cherrypy.tools.tracer.service = previous_service
+        config.cherrypy["service"] = previous_service
 
     def test_inferred_spans_api_gateway_default(self):
         default_headers = [

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
@@ -12,7 +12,7 @@
       "_dd.base_service": "pytest",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de46ee00000000",
-      "_dd.svc_src": "m",
+      "_dd.svc_src": "cherrypy",
       "_dd.tags.process": "entrypoint.basedir:pytest,entrypoint.name:main,entrypoint.type:script,entrypoint.workdir:project,svc.auto:pytest",
       "component": "cherrypy",
       "http.method": "GET",
@@ -44,7 +44,7 @@
        "error": 0,
        "meta": {
          "_dd.base_service": "pytest",
-         "_dd.svc_src": "m",
+         "_dd.svc_src": "cherrypy",
          "a": "b"
        },
        "duration": 189167,

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.json
@@ -12,7 +12,7 @@
       "_dd.base_service": "pytest",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de46ee00000000",
-      "_dd.svc_src": "m",
+      "_dd.svc_src": "cherrypy",
       "_dd.tags.process": "entrypoint.basedir:pytest,entrypoint.name:main,entrypoint.type:script,entrypoint.workdir:project,svc.auto:pytest",
       "component": "cherrypy",
       "error.message": "",

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.json
@@ -12,7 +12,7 @@
       "_dd.base_service": "pytest",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de46ee00000000",
-      "_dd.svc_src": "m",
+      "_dd.svc_src": "cherrypy",
       "_dd.tags.process": "entrypoint.basedir:pytest,entrypoint.name:main,entrypoint.type:script,entrypoint.workdir:project,svc.auto:pytest",
       "component": "cherrypy",
       "error.message": "division by zero",

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
@@ -12,7 +12,7 @@
       "_dd.base_service": "pytest",
       "_dd.p.dm": "-0",
       "_dd.p.tid": "69de46ee00000000",
-      "_dd.svc_src": "m",
+      "_dd.svc_src": "cherrypy",
       "_dd.tags.process": "entrypoint.basedir:pytest,entrypoint.name:main,entrypoint.type:script,entrypoint.workdir:project,svc.auto:pytest",
       "component": "cherrypy",
       "http.method": "GET",


### PR DESCRIPTION
This change sets a default service name for the cherrypy integration, which reduces the occurrence of `m` svc_src tags on spans generated by that integration.