### PR TITLE
fix(llmobs): coerce non-string metadata keys to strings

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -4,6 +4,7 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import is_dataclass
 import json
+import math
 import re
 from typing import TYPE_CHECKING
 from typing import Any
@@ -248,9 +249,39 @@ def _unserializable_default_repr(obj):
 _MAX_NESTED_META_DEPTH = 12
 
 
+def _coerce_meta_key(key: Any) -> str:
+    """Coerce a mapping key to a string using the same rules as JSON object keys.
+
+    Non-string keys (int/float/bool/None) are encoded verbatim by the msgpack meta_struct
+    intake path used by APM convergence, which the llmobs_spans trace-indexer cannot decode
+    into a string-keyed map, so the whole span is dropped (MLOB-7618). The direct LLMObs
+    intake never hit this because json.dumps stringifies these keys at encode time; coercing
+    here gives both intake paths identical semantics. Already-string keys pass through unchanged.
+    """
+    if isinstance(key, str):
+        return key
+    if isinstance(key, bool):  # check before int: bool is a subclass of int
+        return "true" if key else "false"
+    if isinstance(key, int):
+        return str(key)
+    if isinstance(key, float):
+        if math.isnan(key):
+            return "NaN"
+        if key == math.inf:
+            return "Infinity"
+        if key == -math.inf:
+            return "-Infinity"
+        return float.__repr__(key)
+    if key is None:
+        return "null"
+    # Non-scalar key (json.dumps would raise TypeError). Stringify rather than drop the span.
+    return safe_json(key)
+
+
 def _sanitize_span_event_depth(obj: Any) -> Any:
     """Return a sanitized copy of obj with any container value that exceeds
-    _MAX_NESTED_META_DEPTH levels from the root replaced by its JSON string representation.
+    _MAX_NESTED_META_DEPTH levels from the root replaced by its JSON string representation,
+    and every mapping key coerced to a string (see _coerce_meta_key).
     The original structure is never mutated.
     A warning is logged for each stringified field, including its dotted path.
     """
@@ -267,7 +298,10 @@ def _sanitize_span_event_depth(obj: Any) -> Any:
             )
             return safe_json(node)
         if isinstance(node, dict):
-            return {k: _walk(v, depth + 1, f"{path}.{k}" if path else str(k)) for k, v in node.items()}
+            return {
+                _coerce_meta_key(k): _walk(v, depth + 1, f"{path}.{k}" if path else str(k))
+                for k, v in node.items()
+            }
         return [_walk(v, depth + 1, f"{path}[{i}]" if path else str(i)) for i, v in enumerate(node)]
 
     return _walk(obj, 0, "")

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -4,7 +4,6 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import is_dataclass
 import json
-import math
 import re
 from typing import TYPE_CHECKING
 from typing import Any
@@ -249,40 +248,11 @@ def _unserializable_default_repr(obj):
 _MAX_NESTED_META_DEPTH = 12
 
 
-def _coerce_meta_key(key: Any) -> str:
-    """Coerce a mapping key to a string using the same rules as JSON object keys.
-
-    Non-string keys (int/float/bool/None) are encoded verbatim by the msgpack meta_struct
-    intake path used by APM convergence, which the llmobs_spans trace-indexer cannot decode
-    into a string-keyed map, so the whole span is dropped (MLOB-7618). The direct LLMObs
-    intake never hit this because json.dumps stringifies these keys at encode time; coercing
-    here gives both intake paths identical semantics. Already-string keys pass through unchanged.
-    """
-    if isinstance(key, str):
-        return key
-    if isinstance(key, bool):  # check before int: bool is a subclass of int
-        return "true" if key else "false"
-    if isinstance(key, int):
-        return str(key)
-    if isinstance(key, float):
-        if math.isnan(key):
-            return "NaN"
-        if key == math.inf:
-            return "Infinity"
-        if key == -math.inf:
-            return "-Infinity"
-        return float.__repr__(key)
-    if key is None:
-        return "null"
-    # Non-scalar key (json.dumps would raise TypeError). Stringify rather than drop the span.
-    return safe_json(key)
-
-
 def _sanitize_span_event_depth(obj: Any) -> Any:
     """Return a sanitized copy of obj with any container value that exceeds
     _MAX_NESTED_META_DEPTH levels from the root replaced by its JSON string representation,
-    and every mapping key coerced to a string (see _coerce_meta_key).
-    The original structure is never mutated.
+    and every mapping key stringified (non-string keys break the msgpack meta_struct intake
+    path, MLOB-7618). The original structure is never mutated.
     A warning is logged for each stringified field, including its dotted path.
     """
 
@@ -298,10 +268,7 @@ def _sanitize_span_event_depth(obj: Any) -> Any:
             )
             return safe_json(node)
         if isinstance(node, dict):
-            return {
-                _coerce_meta_key(k): _walk(v, depth + 1, f"{path}.{k}" if path else str(k))
-                for k, v in node.items()
-            }
+            return {str(k): _walk(v, depth + 1, f"{path}.{k}" if path else str(k)) for k, v in node.items()}
         return [_walk(v, depth + 1, f"{path}[{i}]" if path else str(i)) for i, v in enumerate(node)]
 
     return _walk(obj, 0, "")

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -251,8 +251,7 @@ _MAX_NESTED_META_DEPTH = 12
 def _sanitize_span_event_depth(obj: Any) -> Any:
     """Return a sanitized copy of obj with any container value that exceeds
     _MAX_NESTED_META_DEPTH levels from the root replaced by its JSON string representation,
-    and every mapping key stringified (non-string keys break the msgpack meta_struct intake
-    path, MLOB-7618). The original structure is never mutated.
+    and every mapping key stringified. The original structure is never mutated.
     A warning is logged for each stringified field, including its dotted path.
     """
 

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -612,7 +612,8 @@ def _annotate_llmobs_span_data(
         if model_provider is not None:
             meta[LLMOBS_STRUCT.MODEL_PROVIDER] = model_provider
         if metadata is not None:
-            meta[LLMOBS_STRUCT.METADATA].update(metadata)
+            # Metadata keys are serialized as strings, so coerce non-string keys here.
+            meta[LLMOBS_STRUCT.METADATA].update({str(k): v for k, v in metadata.items()})
         if agent_manifest is not None or cost_tags is not None:
             # Initialize metadata_dd here to avoid unnecessary empty dict allocations in the top-level metadata dict.
             metadata_dd = meta[LLMOBS_STRUCT.METADATA].setdefault(LLMOBS_STRUCT.METADATA_DD, {})

--- a/releasenotes/notes/llmobs-coerce-metadata-keys-3b9f1c2a7d4e6f80.yaml
+++ b/releasenotes/notes/llmobs-coerce-metadata-keys-3b9f1c2a7d4e6f80.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where spans annotated with ``metadata``
+    containing non-string keys (for example ``int``, ``float``, or ``bool`` keys) could be
+    dropped during ingestion on the APM meta_struct intake path. Metadata keys are now
+    coerced to strings before encoding, matching the behavior of the direct intake path.

--- a/releasenotes/notes/llmobs-coerce-metadata-keys-3b9f1c2a7d4e6f80.yaml
+++ b/releasenotes/notes/llmobs-coerce-metadata-keys-3b9f1c2a7d4e6f80.yaml
@@ -1,7 +1,6 @@
 ---
 fixes:
   - |
-    LLM Observability: This fix resolves an issue where spans annotated with ``metadata``
-    containing non-string keys (for example ``int``, ``float``, or ``bool`` keys) could be
-    dropped during ingestion on the APM meta_struct intake path. Metadata keys are now
-    coerced to strings before encoding, matching the behavior of the direct intake path.
+    LLM Observability: Resolves an issue where spans annotated with ``metadata`` containing
+    non-string keys (e.g. ``int``/``float``/``bool``) could be dropped during ingestion.
+    Metadata keys are now stringified before encoding.

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -377,6 +377,13 @@ class TestAnnotateLLMObsSpanData:
             assert meta[LLMOBS_STRUCT.METADATA] == {"temperature": 0.5}
             assert meta[LLMOBS_STRUCT.TOOL_DEFINITIONS] == tools
 
+    def test_metadata_keys_are_stringified(self, llmobs):
+        """Non-string metadata keys are coerced to strings (MLOB-7618)."""
+        with llmobs.task(name="test_span") as span:
+            _annotate_llmobs_span_data(span, metadata={42: "a", 2.5: "b", True: "c", None: "d"})
+            metadata = span._get_struct_tag(LLMOBS_STRUCT.KEY)[LLMOBS_STRUCT.META][LLMOBS_STRUCT.METADATA]
+            assert metadata == {"42": "a", "2.5": "b", "True": "c", "None": "d"}
+
     def test_merges_metadata_metrics_tags_across_calls(self, llmobs):
         """metadata, metrics, and tags accumulate rather than overwrite across multiple annotate calls."""
         with llmobs.task(name="test_span") as span:

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -394,11 +394,10 @@ class TestAnnotateLLMObsSpanData:
 
 class TestSanitizeSpanEventDepth:
     """Non-string mapping keys are stringified so the msgpack meta_struct intake path
-    does not drop the span (MLOB-7618)."""
+    does not drop the span (MLOB-7618).
+    """
 
     def test_stringifies_top_level_non_string_keys(self):
-        # Note: bool/int and float keys are tested in separate dicts to avoid Python
-        # collapsing equal keys (1 == True, 2 == 2.0) before the sanitizer runs.
         assert _sanitize_span_event_depth({"metadata": {5: "a", 2.5: "b", None: "c"}}) == {
             "metadata": {"5": "a", "2.5": "b", "None": "c"}
         }

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -4,7 +4,6 @@ import pytest
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
-from ddtrace.llmobs._utils import _coerce_meta_key
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
 from ddtrace.llmobs._utils import _sanitize_span_event_depth
 from ddtrace.llmobs._utils import _trace_id_to_wire
@@ -394,37 +393,20 @@ class TestAnnotateLLMObsSpanData:
 
 
 class TestSanitizeSpanEventDepth:
-    """Non-string mapping keys must be coerced to strings so the msgpack meta_struct intake
-    path (APM convergence) round-trips identically to the JSON intake path (MLOB-7618)."""
+    """Non-string mapping keys are stringified so the msgpack meta_struct intake path
+    does not drop the span (MLOB-7618)."""
 
-    @pytest.mark.parametrize(
-        "key,expected",
-        [
-            ("already_str", "already_str"),
-            (1, "1"),
-            (-42, "-42"),
-            (True, "true"),
-            (False, "false"),
-            (1.5, "1.5"),
-            (None, "null"),
-            (float("inf"), "Infinity"),
-            (float("-inf"), "-Infinity"),
-            (float("nan"), "NaN"),
-        ],
-    )
-    def test_coerce_meta_key_scalars(self, key, expected):
-        assert _coerce_meta_key(key) == expected
+    def test_stringifies_top_level_non_string_keys(self):
+        # Note: bool/int and float keys are tested in separate dicts to avoid Python
+        # collapsing equal keys (1 == True, 2 == 2.0) before the sanitizer runs.
+        assert _sanitize_span_event_depth({"metadata": {5: "a", 2.5: "b", None: "c"}}) == {
+            "metadata": {"5": "a", "2.5": "b", "None": "c"}
+        }
+        assert _sanitize_span_event_depth({"metadata": {True: "x", False: "y"}}) == {
+            "metadata": {"True": "x", "False": "y"}
+        }
 
-    def test_bool_keys_are_not_treated_as_ints(self):
-        """bool is a subclass of int; True/1 and False/0 must not collapse to the same int form."""
-        assert _coerce_meta_key(True) == "true"
-        assert _coerce_meta_key(1) == "1"
-
-    def test_sanitizes_top_level_non_string_keys(self):
-        sanitized = _sanitize_span_event_depth({"metadata": {1: "a", 2.0: "b", True: "c", None: "d"}})
-        assert sanitized == {"metadata": {"1": "a", "2.0": "b", "true": "c", "null": "d"}}
-
-    def test_sanitizes_nested_non_string_keys(self):
+    def test_stringifies_nested_non_string_keys(self):
         sanitized = _sanitize_span_event_depth({"metadata": {"outer": {3: {"4": [{5: "v"}]}}}})
         assert sanitized == {"metadata": {"outer": {"3": {"4": [{"5": "v"}]}}}}
 

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -4,7 +4,9 @@ import pytest
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
+from ddtrace.llmobs._utils import _coerce_meta_key
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
+from ddtrace.llmobs._utils import _sanitize_span_event_depth
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.utils import Documents
@@ -389,6 +391,51 @@ class TestAnnotateLLMObsSpanData:
             assert data[LLMOBS_STRUCT.META][LLMOBS_STRUCT.METADATA] == {"key1": "val1", "key2": "val2"}
             assert data[LLMOBS_STRUCT.METRICS] == {"input_tokens": 10, "output_tokens": 5}
             assert {"env": "prod", "version": "1.0"}.items() <= data[LLMOBS_STRUCT.TAGS].items()
+
+
+class TestSanitizeSpanEventDepth:
+    """Non-string mapping keys must be coerced to strings so the msgpack meta_struct intake
+    path (APM convergence) round-trips identically to the JSON intake path (MLOB-7618)."""
+
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("already_str", "already_str"),
+            (1, "1"),
+            (-42, "-42"),
+            (True, "true"),
+            (False, "false"),
+            (1.5, "1.5"),
+            (None, "null"),
+            (float("inf"), "Infinity"),
+            (float("-inf"), "-Infinity"),
+            (float("nan"), "NaN"),
+        ],
+    )
+    def test_coerce_meta_key_scalars(self, key, expected):
+        assert _coerce_meta_key(key) == expected
+
+    def test_bool_keys_are_not_treated_as_ints(self):
+        """bool is a subclass of int; True/1 and False/0 must not collapse to the same int form."""
+        assert _coerce_meta_key(True) == "true"
+        assert _coerce_meta_key(1) == "1"
+
+    def test_sanitizes_top_level_non_string_keys(self):
+        sanitized = _sanitize_span_event_depth({"metadata": {1: "a", 2.0: "b", True: "c", None: "d"}})
+        assert sanitized == {"metadata": {"1": "a", "2.0": "b", "true": "c", "null": "d"}}
+
+    def test_sanitizes_nested_non_string_keys(self):
+        sanitized = _sanitize_span_event_depth({"metadata": {"outer": {3: {"4": [{5: "v"}]}}}})
+        assert sanitized == {"metadata": {"outer": {"3": {"4": [{"5": "v"}]}}}}
+
+    def test_string_keyed_structures_pass_through_unchanged(self):
+        original = {"metadata": {"temperature": 0.5, "nested": {"k": [1, 2, 3]}}}
+        assert _sanitize_span_event_depth(original) == original
+
+    def test_does_not_mutate_input(self):
+        original = {"metadata": {1: "a"}}
+        _sanitize_span_event_depth(original)
+        assert original == {"metadata": {1: "a"}}  # original keys untouched
 
 
 class TestTraceIdNormalization:


### PR DESCRIPTION
## Summary

Spans annotated with `metadata` containing non-string keys (`int`/`float`/`bool`) could be dropped during ingestion (MLOB-7618). Such keys are preserved by-type on the msgpack meta_struct intake path; the `llmobs_spans` trace-indexer decodes into a string-keyed map and drops the whole span. The direct LLMObs intake never hit this because `json.dumps` stringifies object keys at encode time.

## Fix

Stringify mapping keys in `_sanitize_span_event_depth`, the choke point applied to the full `_llmobs` META before encoding. It already walks the structure recursively, so keys are stringified at every depth.

## Test plan

`TestSanitizeSpanEventDepth` in `tests/llmobs/test_utils.py`: top-level + nested non-string keys, string-key pass-through, non-mutation.

Fixes MLOB-7618.

Claude session: `682fcd7f-700d-4430-9e63-a8080ebc39e6`
Resume: `claude --resume 682fcd7f-700d-4430-9e63-a8080ebc39e6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
