### PR TITLE
fix(botocore): read SQS DSM context from top-level MessageAttributes

### DIFF
--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -137,26 +137,26 @@ def handle_sqs_prepare(params):
 def get_datastreams_context(message):
     """
     Formats we're aware of:
-        - message.Body.MessageAttributes._datadog.Value.decode() (SQS)
-        - message.MessageAttributes._datadog.StringValue (SNS -> SQS)
+        - message.MessageAttributes._datadog.StringValue (SQS)
+        - message.Body.MessageAttributes._datadog.Value.decode() (SNS -> SQS)
         - message.MessageAttributes._datadog.BinaryValue.decode() (SNS -> SQS, raw)
         - message.messageAttributes._datadog.stringValue (SQS -> lambda)
     """
     context_json = None
     message_body = message
-    try:
-        body = message.get("Body")
-        if body:
-            message_body = json.loads(body)
-    except (ValueError, TypeError):
-        log.debug("Unable to parse message body as JSON, treat as non-json")
+    message_attributes = message.get("MessageAttributes") or message.get("messageAttributes")
 
-    message_attributes = message_body.get("MessageAttributes") or message_body.get("messageAttributes")
-    if not message_attributes:
-        log.debug("DataStreams skipped message: %r", message)
-        return None
+    # Fall back to the body for SNS -> SQS notifications, which carry their attributes there.
+    if not (message_attributes and "_datadog" in message_attributes):
+        try:
+            body = message.get("Body")
+            if body:
+                message_body = json.loads(body)
+        except (ValueError, TypeError):
+            log.debug("Unable to parse message body as JSON, treat as non-json")
+        message_attributes = message_body.get("MessageAttributes") or message_body.get("messageAttributes")
 
-    if "_datadog" not in message_attributes:
+    if not message_attributes or "_datadog" not in message_attributes:
         log.debug("DataStreams skipped message: %r", message)
         return None
 

--- a/releasenotes/notes/fix-botocore-sqs-dsm-json-body-41ad5469f34fa3a1.yaml
+++ b/releasenotes/notes/fix-botocore-sqs-dsm-json-body-41ad5469f34fa3a1.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    botocore: Fixes a bug in Data Streams Monitoring where the pathway context of an
+    SQS message was not extracted when the message body was valid JSON, silently
+    breaking the data stream for non-SNS messages with a JSON payload. The ``_datadog``
+    message attribute is now read from the top-level SQS ``MessageAttributes`` first,
+    and the message body is only parsed for SNS-to-SQS notifications.

--- a/tests/contrib/botocore/test_dsm.py
+++ b/tests/contrib/botocore/test_dsm.py
@@ -216,6 +216,42 @@ class BotocoreDSMTest(TracerTestCase):
 
     @mock_sqs
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_DATA_STREAMS_ENABLED="True"))
+    def test_data_streams_sqs_json_body(self):
+        # A JSON message body must still link the consumer pathway to the producer.
+        with (
+            mock.patch("time.time") as mt,
+        ):
+            mt.return_value = 1642544540
+
+            json_body = json.dumps(
+                {"tax_document_id": "5b51a91c", "process_type": "STANDARD_SOURCE", "job_type": "TAX"}
+            )
+
+            self.sqs_client.send_message(QueueUrl=self.sqs_test_queue["QueueUrl"], MessageBody=json_body)
+
+            self.sqs_client.receive_message(
+                QueueUrl=self.sqs_test_queue["QueueUrl"],
+                MessageAttributeNames=["_datadog"],
+                WaitTimeSeconds=2,
+            )
+
+            processor = data_streams_processor()
+            assert processor is not None, "Datastream Monitoring is not enabled"
+            first = pathway_stats_merged(processor)
+
+            out_tags = "direction:out,topic:Test,type:sqs"
+            in_tags = "direction:in,topic:Test,type:sqs"
+
+            out_hash, out_parent_hash, out_stats = self._entry_for_tags(first, out_tags, expected_parent_hash=0)
+            assert out_parent_hash == 0
+            self._assert_dsm_counts(out_stats, min_latency_count=1, payload_count=1)
+
+            _in_hash, in_parent_hash, in_stats = self._entry_for_tags(first, in_tags, expected_parent_hash=out_hash)
+            assert in_parent_hash == out_hash
+            self._assert_dsm_counts(in_stats, min_latency_count=1, payload_count=1)
+
+    @mock_sqs
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_DATA_STREAMS_ENABLED="True"))
     def test_data_streams_sqs_batch(self):
         # DEV: We want to mock time to ensure we only create a single bucket
         with (

--- a/tests/datastreams/test_botocore.py
+++ b/tests/datastreams/test_botocore.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 from ddtrace.internal.datastreams.botocore import get_datastreams_context
@@ -49,3 +50,91 @@ class TestGetDatastreamsContext:
         assert result["x-datadog-trace-id"] == "123456789"
         assert result["x-datadog-parent-id"] == "987654321"
         assert result["x-datadog-sampling-priority"] == "1"
+
+    def test_sqs_json_body_reads_top_level_message_attributes(self):
+        """SQS message with a JSON body resolves _datadog from the top-level attributes."""
+        trace_context = {"dd-pathway-ctx-base64": "leP46s4u2yD00vLN0Gf00vLN0Gc="}
+
+        message = {
+            "Body": json.dumps({"tax_document_id": "5b51a91c", "process_type": "STANDARD_SOURCE", "job_type": "TAX"}),
+            "MessageAttributes": {"_datadog": {"StringValue": json.dumps(trace_context), "DataType": "String"}},
+        }
+
+        assert get_datastreams_context(message) == trace_context
+
+    def test_sqs_plain_body_reads_top_level_message_attributes(self):
+        """SQS message with a non-JSON body resolves the context."""
+        trace_context = {"dd-pathway-ctx-base64": "leP46s4u2yD00vLN0Gf00vLN0Gc="}
+
+        message = {
+            "Body": "Message No.0",
+            "MessageAttributes": {"_datadog": {"StringValue": json.dumps(trace_context), "DataType": "String"}},
+        }
+
+        assert get_datastreams_context(message) == trace_context
+
+    def test_sns_to_sqs_notification_reads_body_message_attributes(self):
+        """SNS -> SQS (non-raw): the context lives in the JSON body's MessageAttributes."""
+        trace_context = {"dd-pathway-ctx-base64": "leP46s4u2yD00vLN0Gf00vLN0Gc="}
+
+        message = {
+            "Body": json.dumps(
+                {
+                    "Type": "Notification",
+                    "Message": "hello",
+                    "MessageAttributes": {
+                        "_datadog": {
+                            "Type": "Binary",
+                            "Value": base64.b64encode(json.dumps(trace_context).encode()).decode(),
+                        }
+                    },
+                }
+            )
+        }
+
+        assert get_datastreams_context(message) == trace_context
+
+    def test_sns_to_sqs_notification_falls_back_when_top_level_attributes_lack_datadog(self):
+        """Top-level attributes present but without _datadog still falls back to the body."""
+        trace_context = {"dd-pathway-ctx-base64": "leP46s4u2yD00vLN0Gf00vLN0Gc="}
+
+        message = {
+            "MessageAttributes": {"other": {"StringValue": "value", "DataType": "String"}},
+            "Body": json.dumps(
+                {
+                    "Type": "Notification",
+                    "MessageAttributes": {
+                        "_datadog": {
+                            "Type": "Binary",
+                            "Value": base64.b64encode(json.dumps(trace_context).encode()).decode(),
+                        }
+                    },
+                }
+            ),
+        }
+
+        assert get_datastreams_context(message) == trace_context
+
+    def test_sns_to_sqs_raw_delivery_reads_top_level_binary_value(self):
+        """SNS -> SQS raw delivery carries _datadog as a top-level BinaryValue."""
+        trace_context = {"dd-pathway-ctx-base64": "leP46s4u2yD00vLN0Gf00vLN0Gc="}
+
+        message = {
+            "Body": "raw delivered body",
+            "MessageAttributes": {
+                "_datadog": {"BinaryValue": json.dumps(trace_context).encode(), "DataType": "Binary"}
+            },
+        }
+
+        assert get_datastreams_context(message) == trace_context
+
+    def test_no_datadog_attribute_returns_none(self):
+        message = {
+            "Body": json.dumps({"job_type": "TAX"}),
+            "MessageAttributes": {"other": {"StringValue": "value", "DataType": "String"}},
+        }
+
+        assert get_datastreams_context(message) is None
+
+    def test_no_message_attributes_returns_none(self):
+        assert get_datastreams_context({"Body": json.dumps({"job_type": "TAX"})}) is None


### PR DESCRIPTION
## Description

`get_datastreams_context` always parsed the SQS `Body` as JSON and read `MessageAttributes` from it. For a non-SNS SQS message with a JSON body, the real `_datadog` attribute on the top-level `MessageAttributes` was missed, silently dropping the DSM pathway context. Now we read the top-level `MessageAttributes` first and only parse the body for SNS-to-SQS notifications. All four message formats remain supported.

## Testing

Unit + moto integration tests for the JSON-body case (and existing formats). Also verified end-to-end on the DSM map: `main` vs this branch side by side — `main` dead-ends at the queue, this branch links.

## Risks

Low — backward compatible, no public API change.

## Additional Notes

Backport to the active 3.x branch requested (bug is identical there; affected customer is on 3.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
