### PR TITLE
fix(otel): avoid tracing otlp http metrics export to the collector

### DIFF
--- a/ddtrace/contrib/internal/requests/connection.py
+++ b/ddtrace/contrib/internal/requests/connection.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from typing import Optional  # noqa:F401
 from urllib import parse
 
@@ -14,6 +13,8 @@ from ddtrace.internal.constants import USER_AGENT_HEADER
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.opentelemetry.constants import OTLP_EXPORTER_HEADER_IDENTIFIER
 from ddtrace.internal.settings import env
+from ddtrace.internal.settings._opentelemetry import ExporterConfig
+from ddtrace.internal.settings._opentelemetry import _is_otlp_traces_exporter_enabled
 from ddtrace.internal.settings._opentelemetry import otel_config
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils import get_argument_value
@@ -30,30 +31,52 @@ def is_otlp_export(request: requests.models.Request) -> bool:
     normalized_user_agent = user_agent.lower().replace(" ", "-")
     if OTLP_EXPORTER_HEADER_IDENTIFIER in normalized_user_agent:
         return True
-    # The upstream OTLP HTTP metrics exporter omits the OTLP user-agent header that the
-    # trace and log exporters set, so user-agent detection alone misses it. Fall back to
-    # matching the request host against the configured OTLP collector.
-    parsed = parse.urlparse(request.url)
-    return (parsed.hostname, parsed.port) in _otlp_collector_hosts()
+    # The OTLP HTTP metrics exporter omits the OTLP user-agent header that the trace and
+    # log exporters set, so fall back to matching the enabled OTLP export URLs.
+    return _normalize_otlp_url(request.url) in _OTLP_EXPORT_URLS
 
 
-@lru_cache(maxsize=1)
-def _otlp_collector_hosts() -> frozenset:
-    """``(hostname, port)`` pairs of the configured OTLP traces, metrics, and logs endpoints."""
-    endpoints = (
-        otel_config.exporter.TRACES_ENDPOINT,
-        otel_config.exporter.METRICS_ENDPOINT,
-        otel_config.exporter.LOGS_ENDPOINT,
-        env.get("OTEL_EXPORTER_OTLP_ENDPOINT"),
-    )
-    hosts = set()
-    for endpoint in endpoints:
-        if not endpoint:
+def _normalize_otlp_url(url: str) -> "Optional[tuple]":
+    parsed = parse.urlparse(url)
+    if not parsed.hostname:
+        return None
+    return (parsed.scheme, parsed.hostname, parsed.port, parsed.path.rstrip("/"))
+
+
+def _otlp_export_urls() -> frozenset:
+    """Full export URLs for the enabled OTLP signals, resolved as the OpenTelemetry SDK does."""
+    base = env.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    urls = set()
+    for enabled, signal_endpoint_var, endpoint, path in (
+        (
+            config._otel_metrics_enabled,
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            otel_config.exporter.METRICS_ENDPOINT,
+            ExporterConfig.METRICS_PATH,
+        ),
+        (
+            config._otel_logs_enabled,
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+            otel_config.exporter.LOGS_ENDPOINT,
+            ExporterConfig.LOGS_PATH,
+        ),
+        (
+            _is_otlp_traces_exporter_enabled(otel_config.exporter),
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            otel_config.exporter.TRACES_ENDPOINT,
+            ExporterConfig.TRACES_PATH,
+        ),
+    ):
+        if not enabled:
             continue
-        parsed = parse.urlparse(endpoint)
-        if parsed.hostname:
-            hosts.add((parsed.hostname, parsed.port))
-    return frozenset(hosts)
+        url = base.rstrip("/") + path if base and not env.get(signal_endpoint_var) else endpoint
+        normalized = _normalize_otlp_url(url)
+        if normalized is not None:
+            urls.add(normalized)
+    return frozenset(urls)
+
+
+_OTLP_EXPORT_URLS = _otlp_export_urls()
 
 
 def _extract_hostname_and_path(uri: str) -> tuple[Optional[str], str]:

--- a/ddtrace/contrib/internal/requests/connection.py
+++ b/ddtrace/contrib/internal/requests/connection.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Optional  # noqa:F401
 from urllib import parse
 
@@ -12,6 +13,8 @@ from ddtrace.internal import core
 from ddtrace.internal.constants import USER_AGENT_HEADER
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.opentelemetry.constants import OTLP_EXPORTER_HEADER_IDENTIFIER
+from ddtrace.internal.settings import env
+from ddtrace.internal.settings._opentelemetry import otel_config
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils import get_argument_value
 
@@ -21,13 +24,36 @@ log = get_logger(__name__)
 
 def is_otlp_export(request: requests.models.Request) -> bool:
     """Determine if a request is submitting data to the OpenTelemetry OTLP exporter."""
-    if not (config._otel_logs_enabled or config._otel_metrics_enabled):
+    if not config._otel_enabled:
         return False
     user_agent = request.headers.get(USER_AGENT_HEADER, "")
     normalized_user_agent = user_agent.lower().replace(" ", "-")
     if OTLP_EXPORTER_HEADER_IDENTIFIER in normalized_user_agent:
         return True
-    return False
+    # The upstream OTLP HTTP metrics exporter omits the OTLP user-agent header that the
+    # trace and log exporters set, so user-agent detection alone misses it. Fall back to
+    # matching the request host against the configured OTLP collector.
+    parsed = parse.urlparse(request.url)
+    return (parsed.hostname, parsed.port) in _otlp_collector_hosts()
+
+
+@lru_cache(maxsize=1)
+def _otlp_collector_hosts() -> frozenset:
+    """``(hostname, port)`` pairs of the configured OTLP traces, metrics, and logs endpoints."""
+    endpoints = (
+        otel_config.exporter.TRACES_ENDPOINT,
+        otel_config.exporter.METRICS_ENDPOINT,
+        otel_config.exporter.LOGS_ENDPOINT,
+        env.get("OTEL_EXPORTER_OTLP_ENDPOINT"),
+    )
+    hosts = set()
+    for endpoint in endpoints:
+        if not endpoint:
+            continue
+        parsed = parse.urlparse(endpoint)
+        if parsed.hostname:
+            hosts.add((parsed.hostname, parsed.port))
+    return frozenset(hosts)
 
 
 def _extract_hostname_and_path(uri: str) -> tuple[Optional[str], str]:

--- a/releasenotes/notes/otel-metrics-export-not-traced-057e8878c3b66779.yaml
+++ b/releasenotes/notes/otel-metrics-export-not-traced-057e8878c3b66779.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    otel: Prevents the OpenTelemetry OTLP HTTP metrics exporter connection from being traced by ``requests``.
+    Unlike the trace and log exporters, the metrics exporter does not set the OTLP user-agent header, so the
+    export request to the collector was incorrectly traced. Exporter requests are now also matched against the
+    configured OTLP collector host so traces, metrics, and logs exports are all excluded from tracing.

--- a/releasenotes/notes/otel-metrics-export-not-traced-057e8878c3b66779.yaml
+++ b/releasenotes/notes/otel-metrics-export-not-traced-057e8878c3b66779.yaml
@@ -4,4 +4,5 @@ fixes:
     otel: Prevents the OpenTelemetry OTLP HTTP metrics exporter connection from being traced by ``requests``.
     Unlike the trace and log exporters, the metrics exporter does not set the OTLP user-agent header, so the
     export request to the collector was incorrectly traced. Exporter requests are now also matched against the
-    configured OTLP collector host so traces, metrics, and logs exports are all excluded from tracing.
+    full export URL of each enabled OTLP signal so traces, metrics, and logs exports are excluded from tracing
+    without affecting application requests to the same host.

--- a/releasenotes/notes/otel-metrics-export-not-traced-057e8878c3b66779.yaml
+++ b/releasenotes/notes/otel-metrics-export-not-traced-057e8878c3b66779.yaml
@@ -1,8 +1,4 @@
 ---
 fixes:
   - |
-    otel: Prevents the OpenTelemetry OTLP HTTP metrics exporter connection from being traced by ``requests``.
-    Unlike the trace and log exporters, the metrics exporter does not set the OTLP user-agent header, so the
-    export request to the collector was incorrectly traced. Exporter requests are now also matched against the
-    full export URL of each enabled OTLP signal so traces, metrics, and logs exports are excluded from tracing
-    without affecting application requests to the same host.
+    otel: Resolves an issue where OpenTelemetry OTLP metrics export requests to the collector were incorrectly traced as spans.

--- a/tests/opentelemetry/test_metrics.py
+++ b/tests/opentelemetry/test_metrics.py
@@ -96,3 +96,32 @@ def test_otel_metrics_disabled_and_unset():
     assert (meter_provider is None) or (type(meter_provider).__name__ == "_ProxyMeterProvider"), (
         "OpenTelemetry mterics exporter should not be configured automatically."
     )
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env={
+        "DD_TRACE_OTEL_ENABLED": "true",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example:4318",
+    },
+)
+def test_otlp_export_request_to_collector_is_not_traced():
+    """OTLP exporter requests to the collector must not be traced.
+
+    The upstream OTLP HTTP metrics exporter omits the OTLP user-agent header that the trace
+    and log exporters set, so detection falls back to matching the configured collector host.
+    """
+    import requests
+
+    from ddtrace.contrib.internal.requests.connection import is_otlp_export
+
+    def prepared(url):
+        return requests.Request("POST", url, headers={"User-Agent": "python-requests/2.34.2"}).prepare()
+
+    # Export to the configured collector (any signal path) is detected and skipped.
+    assert is_otlp_export(prepared("http://collector.example:4318/v1/metrics")) is True
+    assert is_otlp_export(prepared("http://collector.example:4318/v1/traces")) is True
+    assert is_otlp_export(prepared("http://collector.example:4318/v1/logs")) is True
+    # Requests to a different host or port remain traced.
+    assert is_otlp_export(prepared("http://api.example:8080/v1/metrics")) is False
+    assert is_otlp_export(prepared("http://collector.example:9999/v1/metrics")) is False

--- a/tests/opentelemetry/test_metrics.py
+++ b/tests/opentelemetry/test_metrics.py
@@ -101,15 +101,16 @@ def test_otel_metrics_disabled_and_unset():
 @pytest.mark.subprocess(
     ddtrace_run=True,
     env={
-        "DD_TRACE_OTEL_ENABLED": "true",
+        "DD_LOGS_OTEL_ENABLED": "true",
+        "OTEL_TRACES_EXPORTER": "otlp",
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example:4318",
     },
 )
-def test_otlp_export_request_to_collector_is_not_traced():
-    """OTLP exporter requests to the collector must not be traced.
+def test_otlp_export_requests_are_not_traced():
+    """OTLP exporter requests must not be traced.
 
-    The upstream OTLP HTTP metrics exporter omits the OTLP user-agent header that the trace
-    and log exporters set, so detection falls back to matching the configured collector host.
+    The OTLP HTTP metrics exporter omits the OTLP user-agent header that the trace and log
+    exporters set, so detection falls back to matching the enabled export URLs by full path.
     """
     import requests
 
@@ -118,10 +119,11 @@ def test_otlp_export_request_to_collector_is_not_traced():
     def prepared(url):
         return requests.Request("POST", url, headers={"User-Agent": "python-requests/2.34.2"}).prepare()
 
-    # Export to the configured collector (any signal path) is detected and skipped.
-    assert is_otlp_export(prepared("http://collector.example:4318/v1/metrics")) is True
-    assert is_otlp_export(prepared("http://collector.example:4318/v1/traces")) is True
+    # Exports for enabled signals are matched by their full URL.
     assert is_otlp_export(prepared("http://collector.example:4318/v1/logs")) is True
-    # Requests to a different host or port remain traced.
-    assert is_otlp_export(prepared("http://api.example:8080/v1/metrics")) is False
-    assert is_otlp_export(prepared("http://collector.example:9999/v1/metrics")) is False
+    assert is_otlp_export(prepared("http://collector.example:4318/v1/traces")) is True
+    # A disabled signal's endpoint, a different path or scheme, and other hosts are user traffic.
+    assert is_otlp_export(prepared("http://collector.example:4318/v1/metrics")) is False
+    assert is_otlp_export(prepared("http://collector.example:4318/api/data")) is False
+    assert is_otlp_export(prepared("https://collector.example:4318/v1/logs")) is False
+    assert is_otlp_export(prepared("http://api.example:8080/v1/logs")) is False


### PR DESCRIPTION
## Description

The OpenTelemetry OTLP **HTTP metrics** exporter does not set the OTLP user-agent header (`OTel-OTLP-Exporter-Python/...`) that the **trace** and **log** exporters set on their session. Because `is_otlp_export` detected exporter traffic *only* by substring-matching that user-agent, the metrics export `POST /v1/metrics` to the collector went out with the default `python-requests/<v>` user-agent and was traced as a `requests.request` span.

Upstream reference — the user-agent header (`_OTLP_HTTP_HEADERS`) is applied to the session in the trace exporter and log exporter, but **not** the metric exporter:
- `opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py` → `self._session.headers.update(_OTLP_HTTP_HEADERS)`
- `opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py` → `self._session.headers.update(_OTLP_HTTP_HEADERS)`
- `.../metric_exporter/__init__.py` → only updates `self._headers` + `Content-Type` (no `_OTLP_HTTP_HEADERS`)

### Example of the unwanted span

```
name: requests.request
resource: POST /v1/metrics
http.url: http://otel-collector:4318/v1/metrics
http.request.headers.user-agent: python-requests/2.34.2   <-- not the OTLP UA
component: requests
```

## Solution

Keep the cheap user-agent fast path, then fall back to matching the request `host:port` against the configured OTLP collector (traces, metrics, and logs endpoints, plus `OTEL_EXPORTER_OTLP_ENDPOINT`). This excludes exporter connections from tracing regardless of the user-agent they send, and now covers all three signals. The host set is memoized (`lru_cache`) so the hot path only does a `urlparse` + `frozenset` lookup. The gate is broadened from logs/metrics to `config._otel_enabled` so traces are covered too.

## Testing

- Added `test_otlp_export_request_to_collector_is_not_traced` verifying collector-bound requests are detected (any signal path) while requests to other hosts/ports remain traced.
- Verified end-to-end against the OTLP dogfood stack (`opentelemetry-exporter-otlp` 1.30.0): with the upstream metrics http exporter, the pre-fix code emitted a `requests.request POST /v1/metrics` span to the collector; the fix emits zero such spans while leaving user request spans intact.

Follow-up to #14984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)