### PR TITLE
chore(profiling): track heap traceback counts

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -37,6 +37,12 @@ class ProfilerStats
     // Number of currently tracked allocations in the heap tracker
     std::optional<size_t> heap_tracker_size;
 
+    // Configured cap on tracked allocations (TRACEBACK_ARRAY_MAX_COUNT)
+    std::optional<size_t> heap_tracker_cap;
+
+    // Samples dropped because the cap was reached (cumulative over tracker lifetime)
+    std::optional<size_t> heap_tracker_cap_drops;
+
     // Number of asyncio tasks seen across sampled threads in the last sampling cycle
     std::optional<size_t> asyncio_task_count;
 
@@ -70,6 +76,12 @@ class ProfilerStats
 
     void set_heap_tracker_size(size_t count);
     std::optional<size_t> get_heap_tracker_size() const;
+
+    void set_heap_tracker_cap(size_t cap);
+    std::optional<size_t> get_heap_tracker_cap() const;
+
+    void set_heap_tracker_cap_drops(size_t count);
+    std::optional<size_t> get_heap_tracker_cap_drops() const;
 
     void set_asyncio_task_count(size_t count);
     std::optional<size_t> get_asyncio_task_count() const;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -37,9 +37,6 @@ class ProfilerStats
     // Number of currently tracked allocations in the heap tracker
     std::optional<size_t> heap_tracker_size;
 
-    // Configured cap on tracked allocations (TRACEBACK_ARRAY_MAX_COUNT)
-    std::optional<size_t> heap_tracker_cap;
-
     // Samples dropped because the cap was reached (cumulative over tracker lifetime)
     std::optional<size_t> heap_tracker_cap_drops;
 
@@ -76,9 +73,6 @@ class ProfilerStats
 
     void set_heap_tracker_size(size_t count);
     std::optional<size_t> get_heap_tracker_size() const;
-
-    void set_heap_tracker_cap(size_t cap);
-    std::optional<size_t> get_heap_tracker_cap() const;
 
     void set_heap_tracker_cap_drops(size_t count);
     std::optional<size_t> get_heap_tracker_cap_drops() const;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -47,6 +47,8 @@ Datadog::ProfilerStats::reset_state()
     string_table_count = std::nullopt;
     copy_memory_error_count = 0;
     heap_tracker_size = std::nullopt;
+    heap_tracker_cap = std::nullopt;
+    heap_tracker_cap_drops = std::nullopt;
     asyncio_task_count = std::nullopt;
     greenlet_count = std::nullopt;
     sample_capture_cpu_time_us = 0;
@@ -111,6 +113,30 @@ std::optional<size_t>
 Datadog::ProfilerStats::get_heap_tracker_size() const
 {
     return heap_tracker_size;
+}
+
+void
+Datadog::ProfilerStats::set_heap_tracker_cap(size_t cap)
+{
+    heap_tracker_cap = cap;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_heap_tracker_cap() const
+{
+    return heap_tracker_cap;
+}
+
+void
+Datadog::ProfilerStats::set_heap_tracker_cap_drops(size_t count)
+{
+    heap_tracker_cap_drops = count;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_heap_tracker_cap_drops() const
+{
+    return heap_tracker_cap_drops;
 }
 
 void
@@ -190,6 +216,20 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_heap_tracker_count) {
         internal_metadata_json += R"("heap_tracker_count": )";
         append_to_string(internal_metadata_json, *maybe_heap_tracker_count);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_heap_cap = get_heap_tracker_cap();
+    if (maybe_heap_cap) {
+        internal_metadata_json += R"("heap_tracker_cap": )";
+        append_to_string(internal_metadata_json, *maybe_heap_cap);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_heap_cap_drops = get_heap_tracker_cap_drops();
+    if (maybe_heap_cap_drops) {
+        internal_metadata_json += R"("heap_tracker_cap_drops": )";
+        append_to_string(internal_metadata_json, *maybe_heap_cap_drops);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -47,7 +47,6 @@ Datadog::ProfilerStats::reset_state()
     string_table_count = std::nullopt;
     copy_memory_error_count = 0;
     heap_tracker_size = std::nullopt;
-    heap_tracker_cap = std::nullopt;
     heap_tracker_cap_drops = std::nullopt;
     asyncio_task_count = std::nullopt;
     greenlet_count = std::nullopt;
@@ -113,18 +112,6 @@ std::optional<size_t>
 Datadog::ProfilerStats::get_heap_tracker_size() const
 {
     return heap_tracker_size;
-}
-
-void
-Datadog::ProfilerStats::set_heap_tracker_cap(size_t cap)
-{
-    heap_tracker_cap = cap;
-}
-
-std::optional<size_t>
-Datadog::ProfilerStats::get_heap_tracker_cap() const
-{
-    return heap_tracker_cap;
 }
 
 void
@@ -216,13 +203,6 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_heap_tracker_count) {
         internal_metadata_json += R"("heap_tracker_count": )";
         append_to_string(internal_metadata_json, *maybe_heap_tracker_count);
-        internal_metadata_json += ",";
-    }
-
-    auto maybe_heap_cap = get_heap_tracker_cap();
-    if (maybe_heap_cap) {
-        internal_metadata_json += R"("heap_tracker_cap": )";
-        append_to_string(internal_metadata_json, *maybe_heap_cap);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -155,6 +155,11 @@ class heap_tracker_t
     /* Bytes allocated since the last sample was collected */
     uint64_t allocated_memory;
 
+    /* Number of samples silently dropped because allocs_m hit the cap.
+     * Accumulated across the lifetime of this tracker instance and surfaced
+     * via ProfilerStats so the backend / user can detect data loss. */
+    size_t cap_drops{ 0 };
+
     /* Debug guard to assert that GIL-protected critical sections are maintained
      * while accessing the profiler's state */
     memalloc_gil_debug_check_t gil_guard;
@@ -252,12 +257,9 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
         return false;
     }
 
-    if (allocs_m.size() > TRACEBACK_ARRAY_MAX_COUNT) {
-        /* TODO(nick) this is vestigial from the original array-based
-         * implementation. Do we actually want this? It gives us bounded memory
-         * use, but the size limit is arbitrary and once we hit the arbitrary
-         * limit our reported numbers will be inaccurate.
-         */
+    if (allocs_m.size() >= TRACEBACK_ARRAY_MAX_COUNT) {
+        ++cap_drops;
+        reset_sampling_state_no_cpython();
         return false;
     }
 
@@ -290,7 +292,12 @@ heap_tracker_t::export_heap_no_cpython()
         tb->sample.export_sample();
     }
 
-    Datadog::Sample::profile_borrow().stats().set_heap_tracker_size(allocs_m.size());
+    auto& stats = Datadog::Sample::profile_borrow().stats();
+    stats.set_heap_tracker_size(allocs_m.size());
+    stats.set_heap_tracker_cap(TRACEBACK_ARRAY_MAX_COUNT);
+    if (cap_drops > 0) {
+        stats.set_heap_tracker_cap_drops(cap_drops);
+    }
 }
 
 void
@@ -317,6 +324,8 @@ heap_tracker_t::postfork_child()
     // Allocations map may contain data from the parent process, and also
     // traceback_t objects may reference invalid Profile state.
     allocs_m.clear();
+
+    cap_drops = 0;
 
     // Reset the sampling state to start fresh after fork.
     reset_sampling_state_no_cpython();

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -295,9 +295,7 @@ heap_tracker_t::export_heap_no_cpython()
     auto& stats = Datadog::Sample::profile_borrow().stats();
     stats.set_heap_tracker_size(allocs_m.size());
     stats.set_heap_tracker_cap(TRACEBACK_ARRAY_MAX_COUNT);
-    if (cap_drops > 0) {
-        stats.set_heap_tracker_cap_drops(cap_drops);
-    }
+    stats.set_heap_tracker_cap_drops(cap_drops);
 }
 
 void

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -257,6 +257,9 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
         return false;
     }
 
+    /* This cap bounds memory use but creates blind spots: once allocs_m is full,
+     * new allocations are not sampled. cap_drops tracks how often this happens
+     * so we can observe whether the limit is ever reached in practice. */
     if (allocs_m.size() >= TRACEBACK_ARRAY_MAX_COUNT) {
         ++cap_drops;
         reset_sampling_state_no_cpython();
@@ -294,7 +297,6 @@ heap_tracker_t::export_heap_no_cpython()
 
     auto& stats = Datadog::Sample::profile_borrow().stats();
     stats.set_heap_tracker_size(allocs_m.size());
-    stats.set_heap_tracker_cap(TRACEBACK_ARRAY_MAX_COUNT);
     stats.set_heap_tracker_cap_drops(cap_drops);
 }
 

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -42,9 +42,5 @@ class traceback_t
  * backend frame limit while still keeping allocator-hook traversal finite. */
 #define TRACEBACK_MAX_WALKED_NFRAME 1024
 
-/* The maximum number of traceback samples we can store in the heap profiler.
- * This was historically UINT16_MAX to match a uint16_t index type that no
- * longer exists (we now use a hash map). 262144 is 4x the old limit and
- * covers model-serving / data-pipeline workloads with many long-lived
- * allocations. */
-#define TRACEBACK_ARRAY_MAX_COUNT (1U << 18) /* 262 144 */
+/* The maximum number of traceback samples we can store in the heap profiler */
+#define TRACEBACK_ARRAY_MAX_COUNT UINT16_MAX

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -42,5 +42,9 @@ class traceback_t
  * backend frame limit while still keeping allocator-hook traversal finite. */
 #define TRACEBACK_MAX_WALKED_NFRAME 1024
 
-/* The maximum number of traceback samples we can store in the heap profiler */
-#define TRACEBACK_ARRAY_MAX_COUNT UINT16_MAX
+/* The maximum number of traceback samples we can store in the heap profiler.
+ * This was historically UINT16_MAX to match a uint16_t index type that no
+ * longer exists (we now use a hash map). 262144 is 4x the old limit and
+ * covers model-serving / data-pipeline workloads with many long-lived
+ * allocations. */
+#define TRACEBACK_ARRAY_MAX_COUNT (1U << 18) /* 262 144 */

--- a/tests/profiling/collector/test_heap_tracker_count.py
+++ b/tests/profiling/collector/test_heap_tracker_count.py
@@ -42,6 +42,13 @@ def test_heap_tracker_count_present():
         assert "heap_tracker_count" in metadata, f"Missing heap_tracker_count in {f}: {metadata}"
         assert isinstance(metadata["heap_tracker_count"], int), f"heap_tracker_count must be an integer: {metadata}"
         assert metadata["heap_tracker_count"] >= 0, f"heap_tracker_count must be non-negative: {metadata}"
+        assert "heap_tracker_cap" in metadata, f"Missing heap_tracker_cap in {f}: {metadata}"
+        assert isinstance(metadata["heap_tracker_cap"], int), f"heap_tracker_cap must be an integer: {metadata}"
+        assert metadata["heap_tracker_cap"] > 0, f"heap_tracker_cap must be positive: {metadata}"
+        assert "heap_tracker_cap_drops" in metadata, f"Missing heap_tracker_cap_drops in {f}: {metadata}"
+        assert isinstance(metadata["heap_tracker_cap_drops"], int), (
+            f"heap_tracker_cap_drops must be an integer: {metadata}"
+        )
 
     # The last file may be a partial flush, so check the penultimate one has tracked allocations
     if len(files) >= 2:

--- a/tests/profiling/collector/test_heap_tracker_count.py
+++ b/tests/profiling/collector/test_heap_tracker_count.py
@@ -42,9 +42,6 @@ def test_heap_tracker_count_present():
         assert "heap_tracker_count" in metadata, f"Missing heap_tracker_count in {f}: {metadata}"
         assert isinstance(metadata["heap_tracker_count"], int), f"heap_tracker_count must be an integer: {metadata}"
         assert metadata["heap_tracker_count"] >= 0, f"heap_tracker_count must be non-negative: {metadata}"
-        assert "heap_tracker_cap" in metadata, f"Missing heap_tracker_cap in {f}: {metadata}"
-        assert isinstance(metadata["heap_tracker_cap"], int), f"heap_tracker_cap must be an integer: {metadata}"
-        assert metadata["heap_tracker_cap"] > 0, f"heap_tracker_cap must be positive: {metadata}"
         assert "heap_tracker_cap_drops" in metadata, f"Missing heap_tracker_cap_drops in {f}: {metadata}"
         assert isinstance(metadata["heap_tracker_cap_drops"], int), (
             f"heap_tracker_cap_drops must be an integer: {metadata}"


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-14718

## Description

The heap profiler silently stops recording new allocation samples once the
live-allocation map (`allocs_m`) hits `TRACEBACK_ARRAY_MAX_COUNT`. There is currently no way to know if this indeed happens in any of the prod services.

If this indeed happens, then we'd like to know about it. If not, and we are way below the limit, then we'd also like to know it that we could potentially update the limit.

### Changes
1. Track sample drops by adding a `cap_drops` counter
2. Reset the sampling clock on a cap hit, which currently if hit, will prevent further sample accumulation
3. Reset `cap_drops` on fork, so the child doesn't inherit the parent's drop count
4. _Bonus_: Fix an off-by-one error in the current cap check
`allocs_m.size() == TRACEBACK_ARRAY_MAX_COUNT + 1` 

## Testing
* CI