### PR TITLE
feat(ci): automate libdatadog main bump for pre-bump benchmarking

### DIFF
--- a/.github/chainguard/gitlab.libdatadog-update.create-pr.sts.yaml
+++ b/.github/chainguard/gitlab.libdatadog-update.create-pr.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-py:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,7 @@ src/native/target*
 
 # file created when running scripts/lint
 uv.lock
+
+# scripts/update-libdatadog.py ephemeral outputs (artifacts dir + local auth binary)
+/libdatadog-update/
+/authanywhere

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ include:
   - local: ".gitlab/multi-os-tests.yml"
   - local: ".gitlab/benchmarks/serverless.yml"
   - local: ".gitlab/native.yml"
+  - local: ".gitlab/check-libdatadog-version.yml"
   - local: ".gitlab/system-tests.yml"
   - local: ".gitlab/fuzz.yml"
   - local: ".gitlab/config-registry.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ include:
   - local: ".gitlab/multi-os-tests.yml"
   - local: ".gitlab/benchmarks/serverless.yml"
   - local: ".gitlab/native.yml"
+  - local: ".gitlab/update-libdatadog.yml"
   - local: ".gitlab/check-libdatadog-version.yml"
   - local: ".gitlab/system-tests.yml"
   - local: ".gitlab/fuzz.yml"

--- a/.gitlab/check-libdatadog-version.yml
+++ b/.gitlab/check-libdatadog-version.yml
@@ -33,12 +33,15 @@
     # Install Node LTS + the Claude Code CLI.
     - |
       curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+      # nvm refuses to run when NPM_CONFIG_PREFIX is set (some images set it).
+      unset NPM_CONFIG_PREFIX
       export NVM_DIR="$HOME/.nvm"
       . "$NVM_DIR/nvm.sh"
       nvm install --lts
       npm install -g @anthropic-ai/claude-code
     # Mint the AI Gateway token immediately before use (short expiry window).
     - |
+      unset NPM_CONFIG_PREFIX
       export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
       raw_token="$(./authanywhere --audience rapid-ai-platform)"
       export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"

--- a/.gitlab/check-libdatadog-version.yml
+++ b/.gitlab/check-libdatadog-version.yml
@@ -45,7 +45,7 @@
       export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
       # x-dd-tag-* are attribution tags; adjust ml_app/dd.team to taste.
       export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-check\nx-dd-tag-dd.team: apm-python'
-      claude --bare -p 'Find the latest released version of DataDog/libdatadog by running `git ls-remote --tags https://github.com/DataDog/libdatadog` and picking the highest semantic-version tag (format vX.Y.Z). Then read src/native/Cargo.toml to find the libdatadog rev currently pinned in this repo. Report the latest version, the current pin, and whether an upgrade is available, in one short paragraph.' \
+      claude --bare -p 'Determine whether the libdatadog dependency in this repo is out of date. Steps: (1) Read src/native/Cargo.toml and find the libdatadog rev currently pinned (the `rev = "..."` on the github.com/DataDog/libdatadog deps); it may be a release tag like v35.0.0 or a 40-character commit SHA. (2) Run `curl -s https://api.github.com/repos/DataDog/libdatadog/compare/<rev>...main`, substituting the pinned rev for <rev>. In the JSON, `ahead_by` is how many commits main is ahead of the current pin (i.e. how many commits behind the pin is), and `base_commit.sha` is the commit the pin resolves to. (3) Report in one short paragraph: the current pinned rev, the commit SHA it resolves to, and how many commits behind main it is. (4) If the pin is MORE THAN 5 commits behind main, end with the exact line: "UPDATE NEEDED: libdatadog is N commits behind main." (substitute N). Otherwise end with: "OK: libdatadog is within 5 commits of main."' \
         --model anthropic/claude-sonnet-4-6 \
-        --allowedTools 'Read' 'Bash(git ls-remote:*)' \
+        --allowedTools 'Read' 'Bash(git ls-remote:*)' 'Bash(curl:*)' \
         --permission-mode bypassPermissions

--- a/.gitlab/check-libdatadog-version.yml
+++ b/.gitlab/check-libdatadog-version.yml
@@ -1,0 +1,48 @@
+# Manually-triggered job that asks Claude (via the Datadog AI Gateway) to report
+# the latest libdatadog version and compare it to the rev pinned in this repo.
+# It doubles as the AI-gateway smoke test: if this is green, the auth + gateway
+# plumbing works and we can build the claude-agent-sdk repair loop (Phase 5) on
+# top of it.
+#
+# Auth mirrors .gitlab/scripts/summarize_failures.py: authanywhere mints a
+# short-lived AI Gateway token (--audience rapid-ai-platform), and Claude talks
+# to the gateway via ANTHROPIC_BASE_URL + ANTHROPIC_CUSTOM_HEADERS.
+
+"check libdatadog version":
+  stage: tests
+  tags: [ "arch:amd64" ]
+  # Depend on nothing: needs:[] lets it start immediately, ignoring stage order;
+  # interruptible:false keeps it alive even if a new commit auto-cancels the rest.
+  needs: []
+  interruptible: false
+  image:
+    name: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+  timeout: 15m
+  rules:
+    - when: manual
+      allow_failure: true
+  script:
+    # Download authanywhere (used to mint the AI Gateway token).
+    - |
+      if [ "$(uname -m)" = "x86_64" ]; then ARCH="amd64"; else ARCH="arm64"; fi
+      curl -fsSL -o authanywhere "https://binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-${ARCH}"
+      chmod +x ./authanywhere
+    # Install Node LTS + the Claude Code CLI.
+    - |
+      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+      export NVM_DIR="$HOME/.nvm"
+      . "$NVM_DIR/nvm.sh"
+      nvm install --lts
+      npm install -g @anthropic-ai/claude-code
+    # Mint the AI Gateway token immediately before use (short expiry window).
+    - |
+      export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
+      raw_token="$(./authanywhere --audience rapid-ai-platform)"
+      export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"
+      export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
+      # x-dd-tag-* are attribution tags; adjust ml_app/dd.team to taste.
+      export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-check\nx-dd-tag-dd.team: apm-python'
+      claude --bare -p 'Find the latest released version of DataDog/libdatadog by running `git ls-remote --tags https://github.com/DataDog/libdatadog` and picking the highest semantic-version tag (format vX.Y.Z). Then read src/native/Cargo.toml to find the libdatadog rev currently pinned in this repo. Report the latest version, the current pin, and whether an upgrade is available, in one short paragraph.' \
+        --model anthropic/claude-sonnet-4-6 \
+        --allowedTools 'Read' 'Bash(git ls-remote:*)' \
+        --permission-mode bypassPermissions

--- a/.gitlab/check-libdatadog-version.yml
+++ b/.gitlab/check-libdatadog-version.yml
@@ -19,6 +19,9 @@
     name: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
   timeout: 15m
   rules:
+    # Auto-run when an upstream pipeline (e.g. libdatadog) triggers us with this
+    # variable set; otherwise stays a manual ▶ button.
+    - if: '$UPDATE_LIBDATADOG_VERSION == "true"'
     - when: manual
       allow_failure: true
   script:

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -39,10 +39,12 @@ include:
   script:
     # Download authanywhere + install Node LTS and the Claude CLI (for the repair
     # loop). Slow steps first so the short-lived AI token is minted last.
+    # auth artifacts live in $HOME (OUTSIDE the repo working tree) so they can
+    # never appear in `git status` and thus never be committed.
     - |
       if [ "$(uname -m)" = "x86_64" ]; then ARCH="amd64"; else ARCH="arm64"; fi
-      curl -fsSL -o authanywhere "https://binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-${ARCH}"
-      chmod +x ./authanywhere
+      curl -fsSL -o "$HOME/authanywhere" "https://binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-${ARCH}"
+      chmod +x "$HOME/authanywhere"
       curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
       # The testrunner image sets NPM_CONFIG_PREFIX, which nvm refuses to run with.
       unset NPM_CONFIG_PREFIX
@@ -52,14 +54,14 @@ include:
     # GitHub token for the PR (used only by the script's GitHub API calls — never
     # placed in a git remote URL). Best-effort: if unavailable, the script still
     # bumps + validates and just lists the changes instead of opening a PR.
-    # The token is written to tmp/github_token.txt (NOT an uploaded artifact) so the
-    # after_script can revoke it; do not rm it here.
+    # Written to $HOME (outside the repo, not an artifact) so after_script can revoke it.
     - |
-      mkdir -p tmp
       if command -v dd-octo-sts >/dev/null 2>&1; then
-        dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.libdatadog-update.create-pr > tmp/github_token.txt || true
-        if [ -s tmp/github_token.txt ]; then
-          export GH_TOKEN="$(cat tmp/github_token.txt)"
+        dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.libdatadog-update.create-pr > "$HOME/.dd_octo_sts_token" || true
+        if [ -s "$HOME/.dd_octo_sts_token" ]; then
+          export GH_TOKEN="$(cat "$HOME/.dd_octo_sts_token")"
+        else
+          echo "dd-octo-sts produced no token (is gitlab.libdatadog-update.create-pr merged to main?); PR creation will be skipped."
         fi
       else
         echo "dd-octo-sts not found in image; PR creation will be skipped (changes listed only)."
@@ -69,7 +71,7 @@ include:
     - |
       unset NPM_CONFIG_PREFIX
       export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
-      raw_token="$(./authanywhere --audience rapid-ai-platform)"
+      raw_token="$("$HOME/authanywhere" --audience rapid-ai-platform)"
       export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"
       export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
       export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-update\nx-dd-tag-dd.team: apm-python'
@@ -84,8 +86,8 @@ include:
     # immediately via the broker (rather than waiting out its short lifetime).
     # after_script runs in a fresh shell, so the token is read from the file.
     - !reference [.testrunner, after_script]
-    - if [[ -f tmp/github_token.txt ]]; then dd-octo-sts revoke -t "$(cat tmp/github_token.txt)" || true; fi
-    - rm -f tmp/github_token.txt
+    - if [[ -s "$HOME/.dd_octo_sts_token" ]]; then dd-octo-sts revoke -t "$(cat "$HOME/.dd_octo_sts_token")" || true; fi
+    - rm -f "$HOME/.dd_octo_sts_token"
   artifacts:
     when: always
     paths:

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -31,6 +31,14 @@ include:
       aud: dd-octo-sts
   variables:
     ARTIFACTS_DIR: "${CI_PROJECT_DIR}/libdatadog-update"
+    # Attribute the commit to the dd-octo-sts bot — the identity behind the token
+    # we mint (it already authors commits in this repo, e.g. 1a5569de). git reads
+    # these natively for both author and committer. NB: unlike the GitHub-API path
+    # peter-evans uses, a local commit won't carry GitHub's "Verified" badge.
+    GIT_AUTHOR_NAME: "dd-octo-sts[bot]"
+    GIT_AUTHOR_EMAIL: "200755185+dd-octo-sts[bot]@users.noreply.github.com"
+    GIT_COMMITTER_NAME: "dd-octo-sts[bot]"
+    GIT_COMMITTER_EMAIL: "200755185+dd-octo-sts[bot]@users.noreply.github.com"
   before_script:
     - !reference [.testrunner, before_script]
   script:
@@ -48,17 +56,19 @@ include:
       npm install -g @anthropic-ai/claude-code
     # GitHub token for the PR. Best-effort: if unavailable, the script still bumps +
     # validates and prints the `gh pr create` command instead of opening the PR.
+    # The token is written to tmp/github_token.txt (NOT an uploaded artifact) so the
+    # after_script can revoke it; do not rm it here.
     - |
+      mkdir -p tmp
       if command -v dd-octo-sts >/dev/null 2>&1; then
-        dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.libdatadog-update.create-pr > gh_token || true
-        if [ -s gh_token ]; then
-          export GH_TOKEN="$(cat gh_token)"
+        dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.libdatadog-update.create-pr > tmp/github_token.txt || true
+        if [ -s tmp/github_token.txt ]; then
+          export GH_TOKEN="$(cat tmp/github_token.txt)"
           # origin is the GitLab mirror; add a GitHub remote for the branch push.
           git remote remove gh-origin 2>/dev/null || true
           git remote add gh-origin "https://x-access-token:${GH_TOKEN}@github.com/DataDog/dd-trace-py.git"
           export GIT_PUSH_REMOTE="gh-origin"
         fi
-        rm -f gh_token
       else
         echo "dd-octo-sts not found in image; PR creation will be skipped (branch push + command print only)."
       fi
@@ -77,6 +87,13 @@ include:
       #   runs in PR CI (and `pip install -e .` isn't viable from this uv env).
       # Drop these flags to go live.
       scripts/update-libdatadog.py --no-push --skip-python
+  after_script:
+    # Preserve the testrunner's core-backtrace step, then revoke the GitHub token
+    # immediately via the broker (rather than waiting out its short lifetime).
+    # after_script runs in a fresh shell, so the token is read from the file.
+    - !reference [.testrunner, after_script]
+    - if [[ -f tmp/github_token.txt ]]; then dd-octo-sts revoke -t "$(cat tmp/github_token.txt)" || true; fi
+    - rm -f tmp/github_token.txt
   artifacts:
     when: always
     paths:

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -1,0 +1,76 @@
+# Bump libdatadog to its latest `main` commit, validate the native build, let
+# Claude attempt a bounded repair if it breaks, and open a PR. The brain is
+# scripts/update-libdatadog.py — this job only provides auth + a clean env.
+#
+# Runs on the testrunner image because it carries the Rust toolchain the
+# `rust ci` job relies on (cargo build/clippy/test). Two credentials are wired:
+#   - AI Gateway (authanywhere --audience rapid-ai-platform) for the repair loop
+#   - GitHub (dd-octo-sts, gitlab.libdatadog-update.create-pr policy) for the PR
+# The octo-sts policy must be merged to `main` first (octo-sts reads policies
+# from the default branch).
+#
+# Triggered manually, or automatically when an upstream pipeline (e.g.
+# libdatadog) passes UPDATE_LIBDATADOG_VERSION=true.
+
+include:
+  - local: ".gitlab/testrunner.yml"
+
+"update libdatadog":
+  stage: tests
+  extends: .testrunner
+  timeout: 40m
+  needs: []
+  interruptible: false
+  rules:
+    # Auto-run when an upstream pipeline triggers us; otherwise a manual button.
+    - if: '$UPDATE_LIBDATADOG_VERSION == "true"'
+    - when: manual
+      allow_failure: true
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  variables:
+    ARTIFACTS_DIR: "${CI_PROJECT_DIR}/libdatadog-update"
+  before_script:
+    - !reference [.testrunner, before_script]
+  script:
+    # Download authanywhere + install Node LTS and the Claude CLI (for the repair
+    # loop). Slow steps first so the short-lived AI token is minted last.
+    - |
+      if [ "$(uname -m)" = "x86_64" ]; then ARCH="amd64"; else ARCH="arm64"; fi
+      curl -fsSL -o authanywhere "https://binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-${ARCH}"
+      chmod +x ./authanywhere
+      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+      export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
+      nvm install --lts
+      npm install -g @anthropic-ai/claude-code
+    # GitHub token for the PR. Best-effort: if unavailable, the script still bumps +
+    # validates and prints the `gh pr create` command instead of opening the PR.
+    - |
+      if command -v dd-octo-sts >/dev/null 2>&1; then
+        dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.libdatadog-update.create-pr > gh_token || true
+        if [ -s gh_token ]; then
+          export GH_TOKEN="$(cat gh_token)"
+          # origin is the GitLab mirror; add a GitHub remote for the branch push.
+          git remote remove gh-origin 2>/dev/null || true
+          git remote add gh-origin "https://x-access-token:${GH_TOKEN}@github.com/DataDog/dd-trace-py.git"
+          export GIT_PUSH_REMOTE="gh-origin"
+        fi
+        rm -f gh_token
+      else
+        echo "dd-octo-sts not found in image; PR creation will be skipped (branch push + command print only)."
+      fi
+    # Mint the AI Gateway token immediately before use (short expiry), re-source
+    # nvm so the claude CLI is on PATH, then run the update.
+    - |
+      export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
+      raw_token="$(./authanywhere --audience rapid-ai-platform)"
+      export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"
+      export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
+      export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-update\nx-dd-tag-dd.team: apm-python'
+      scripts/update-libdatadog.py
+  artifacts:
+    when: always
+    paths:
+      - libdatadog-update/
+    expire_in: 1 month

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -41,6 +41,8 @@ include:
       curl -fsSL -o authanywhere "https://binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-${ARCH}"
       chmod +x ./authanywhere
       curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+      # The testrunner image sets NPM_CONFIG_PREFIX, which nvm refuses to run with.
+      unset NPM_CONFIG_PREFIX
       export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
       nvm install --lts
       npm install -g @anthropic-ai/claude-code
@@ -63,6 +65,7 @@ include:
     # Mint the AI Gateway token immediately before use (short expiry), re-source
     # nvm so the claude CLI is on PATH, then run the update.
     - |
+      unset NPM_CONFIG_PREFIX
       export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
       raw_token="$(./authanywhere --audience rapid-ai-platform)"
       export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -71,10 +71,12 @@ include:
       export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"
       export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
       export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-update\nx-dd-tag-dd.team: apm-python'
-      # PR creation disabled while we validate the rest of the flow. --no-push runs
-      # the full bump -> validate -> repair -> commit, but skips `git push` and
-      # `gh pr create` (it prints the command instead). Drop --no-push to go live.
-      scripts/update-libdatadog.py --no-push
+      # --no-push: PR creation disabled while we validate the rest of the flow
+      #   (runs the full bump -> validate -> repair -> commit; prints the gh command).
+      # --skip-python: cargo is the real native signal here; the full Python suite
+      #   runs in PR CI (and `pip install -e .` isn't viable from this uv env).
+      # Drop these flags to go live.
+      scripts/update-libdatadog.py --no-push --skip-python
   artifacts:
     when: always
     paths:

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -31,14 +31,9 @@ include:
       aud: dd-octo-sts
   variables:
     ARTIFACTS_DIR: "${CI_PROJECT_DIR}/libdatadog-update"
-    # Attribute the commit to the dd-octo-sts bot — the identity behind the token
-    # we mint (it already authors commits in this repo, e.g. 1a5569de). git reads
-    # these natively for both author and committer. NB: unlike the GitHub-API path
-    # peter-evans uses, a local commit won't carry GitHub's "Verified" badge.
-    GIT_AUTHOR_NAME: "dd-octo-sts[bot]"
-    GIT_AUTHOR_EMAIL: "200755185+dd-octo-sts[bot]@users.noreply.github.com"
-    GIT_COMMITTER_NAME: "dd-octo-sts[bot]"
-    GIT_COMMITTER_EMAIL: "200755185+dd-octo-sts[bot]@users.noreply.github.com"
+    # The PR commit is created server-side via the GitHub API (see the script),
+    # so GitHub attributes it to the dd-octo-sts bot and signs it ("Verified") —
+    # no local git author/committer, push remote, or token-in-URL needed.
   before_script:
     - !reference [.testrunner, before_script]
   script:
@@ -54,8 +49,9 @@ include:
       export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
       nvm install --lts
       npm install -g @anthropic-ai/claude-code
-    # GitHub token for the PR. Best-effort: if unavailable, the script still bumps +
-    # validates and prints the `gh pr create` command instead of opening the PR.
+    # GitHub token for the PR (used only by the script's GitHub API calls — never
+    # placed in a git remote URL). Best-effort: if unavailable, the script still
+    # bumps + validates and just lists the changes instead of opening a PR.
     # The token is written to tmp/github_token.txt (NOT an uploaded artifact) so the
     # after_script can revoke it; do not rm it here.
     - |
@@ -64,13 +60,9 @@ include:
         dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.libdatadog-update.create-pr > tmp/github_token.txt || true
         if [ -s tmp/github_token.txt ]; then
           export GH_TOKEN="$(cat tmp/github_token.txt)"
-          # origin is the GitLab mirror; add a GitHub remote for the branch push.
-          git remote remove gh-origin 2>/dev/null || true
-          git remote add gh-origin "https://x-access-token:${GH_TOKEN}@github.com/DataDog/dd-trace-py.git"
-          export GIT_PUSH_REMOTE="gh-origin"
         fi
       else
-        echo "dd-octo-sts not found in image; PR creation will be skipped (branch push + command print only)."
+        echo "dd-octo-sts not found in image; PR creation will be skipped (changes listed only)."
       fi
     # Mint the AI Gateway token immediately before use (short expiry), re-source
     # nvm so the claude CLI is on PATH, then run the update.

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -75,12 +75,11 @@ include:
       export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"
       export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
       export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-update\nx-dd-tag-dd.team: apm-python'
-      # --no-push: PR creation disabled while we validate the rest of the flow
-      #   (runs the full bump -> validate -> repair -> commit; prints the gh command).
+      # Live: a green run opens a verified PR via the GitHub API (no-op if already
+      # on latest main, or skipped if no token was minted).
       # --skip-python: cargo is the real native signal here; the full Python suite
       #   runs in PR CI (and `pip install -e .` isn't viable from this uv env).
-      # Drop these flags to go live.
-      scripts/update-libdatadog.py --no-push --skip-python
+      scripts/update-libdatadog.py --skip-python
   after_script:
     # Preserve the testrunner's core-backtrace step, then revoke the GitHub token
     # immediately via the broker (rather than waiting out its short lifetime).

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -22,8 +22,11 @@ include:
   needs: []
   interruptible: false
   rules:
-    # Auto-run when an upstream pipeline triggers us; otherwise a manual button.
+    # Runs automatically on every main commit and on upstream triggers; the script's
+    # drift gate decides whether to actually proceed (default: >= 5 commits behind
+    # libdatadog main). No allow_failure: a non-convergent repair fails the job red.
     - if: '$UPDATE_LIBDATADOG_VERSION == "true"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
     - when: manual
       allow_failure: true
   id_tokens:
@@ -31,12 +34,25 @@ include:
       aud: dd-octo-sts
   variables:
     ARTIFACTS_DIR: "${CI_PROJECT_DIR}/libdatadog-update"
+    # Commits of libdatadog drift required before a bump proceeds. Configurable;
+    # an upstream trigger can set 0 to force a bump regardless of drift.
+    LIBDATADOG_MIN_DRIFT: "5"
     # The PR commit is created server-side via the GitHub API (see the script),
     # so GitHub attributes it to the dd-octo-sts bot and signs it ("Verified") —
     # no local git author/committer, push remote, or token-in-URL needed.
   before_script:
     - !reference [.testrunner, before_script]
   script:
+    # Cheap drift gate FIRST, before any expensive setup: only proceed when
+    # libdatadog main is >= LIBDATADOG_MIN_DRIFT commits ahead of our pin.
+    # Exit 100 (from --check-drift) means "skip" -> finish the job green as a no-op.
+    - |
+      set +e
+      scripts/update-libdatadog.py --check-drift
+      rc=$?
+      set -e
+      if [ "$rc" -eq 100 ]; then echo "Below drift threshold — nothing to do."; exit 0; fi
+      if [ "$rc" -ne 0 ]; then echo "Drift check errored (rc=$rc)"; exit "$rc"; fi
     # Download authanywhere + install Node LTS and the Claude CLI (for the repair
     # loop). Slow steps first so the short-lived AI token is minted last.
     # auth artifacts live in $HOME (OUTSIDE the repo working tree) so they can

--- a/.gitlab/update-libdatadog.yml
+++ b/.gitlab/update-libdatadog.yml
@@ -68,7 +68,10 @@ include:
       export ANTHROPIC_AUTH_TOKEN="${raw_token#Authorization: Bearer }"
       export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
       export ANTHROPIC_CUSTOM_HEADERS=$'source: claude\norg-id: 2\nprovider: anthropic\nx-dd-tag-ml_app: dd-trace-py-libdatadog-update\nx-dd-tag-dd.team: apm-python'
-      scripts/update-libdatadog.py
+      # PR creation disabled while we validate the rest of the flow. --no-push runs
+      # the full bump -> validate -> repair -> commit, but skips `git push` and
+      # `gh pr create` (it prints the command instead). Drop --no-push to go live.
+      scripts/update-libdatadog.py --no-push
   artifacts:
     when: always
     paths:

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env scripts/uv-run-script
+# -*- mode: python -*-
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+r"""Update the pinned libdatadog dependency in src/native to the latest commit on
+libdatadog's `main` branch, validate the build, and (when green) open a PR.
+
+Phases:
+  1. Resolve target — `git ls-remote` libdatadog main → SHA. No-op if already pinned.
+  2. Apply bump — rewrite every libdatadog `rev = "..."` in src/native/Cargo.toml,
+     regenerate Cargo.lock, and sync setup.py's RUST_MINIMUM_VERSION if needed.
+  3. Validate — cargo build / fmt / clippy / test (+ optional python smoke).
+  4. Outcome — green: write release note, push branch, open PR (or print the
+     command if no GH token).
+  5. Repair — if validation is red, Claude (via the AI gateway) attempts a
+     bounded set of fixes constrained to src/native + setup.py, with the build
+     re-validated by code the agent can't influence. Converges → normal PR;
+     gives up → draft PR with the diagnosis.
+
+The script is intentionally runnable locally: with no GH token it stops after
+pushing/printing, and `--dry-run` makes no changes at all.
+
+Usage:
+  scripts/update-libdatadog.py                 # bump to latest main, validate, PR
+  scripts/update-libdatadog.py --dry-run       # show what would change, touch nothing
+  scripts/update-libdatadog.py --target-rev SHA  # bump to a specific rev
+  scripts/update-libdatadog.py --skip-python   # cargo-only validation (fast local loop)
+
+Environment:
+  GH_TOKEN              if set (and `gh` present), used to open the PR; otherwise
+                        the branch is pushed and the create-PR command is printed.
+  GIT_PUSH_REMOTE       git remote to push to (default: origin). CI sets this to a
+                        GitHub remote since `origin` is the GitLab mirror.
+  ANTHROPIC_AUTH_TOKEN  AI-gateway bearer token; required for the Phase 5 repair
+  ANTHROPIC_BASE_URL    loop. If unset, repair is skipped and red builds draft-PR.
+  ARTIFACTS_DIR         where to write logs and the summary (default: ./libdatadog-update)
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+import urllib.request
+
+
+LIBDATADOG_REPO = "https://github.com/DataDog/libdatadog"
+GH_REPO_SLUG = "DataDog/dd-trace-py"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NATIVE_DIR = REPO_ROOT / "src" / "native"
+CARGO_TOML = NATIVE_DIR / "Cargo.toml"
+SETUP_PY = REPO_ROOT / "setup.py"
+RELEASENOTES_DIR = REPO_ROOT / "releasenotes" / "notes"
+
+# The only paths the AI repair loop is allowed to touch. Anything it changes
+# outside these is reverted before re-validation, so it can't "fix" a red build
+# by weakening tests or loosening lints.
+ALLOWED_REPAIR_PREFIXES = ("src/native/", "setup.py")
+
+# Claude model + tools for the repair loop, mirroring .gitlab/check-libdatadog-version.yml.
+CLAUDE_MODEL = "anthropic/claude-sonnet-4-6"
+CLAUDE_REPAIR_TOOLS = ["Read", "Edit", "Write", "Grep", "Glob", "Bash(cargo:*)"]
+
+# Matches the `rev = "..."` on any Cargo.toml line that pins the libdatadog git
+# source. Every git dependency in src/native/Cargo.toml is libdatadog, but we
+# anchor on the URL anyway so this stays correct if other git deps are added.
+_LIBDD_REV_RE = re.compile(r'(git\s*=\s*"https://github\.com/DataDog/libdatadog"[^\n]*?\brev\s*=\s*")([^"]+)(")')
+
+
+class StepError(RuntimeError):
+    """A validation/build step failed; carries the captured output for diagnosis."""
+
+    def __init__(self, label: str, returncode: int, output: str) -> None:
+        super().__init__(f"step {label!r} failed (exit {returncode})")
+        self.label = label
+        self.returncode = returncode
+        self.output = output
+
+
+@dataclasses.dataclass
+class RunResult:
+    label: str
+    returncode: int
+    output: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+def run(label: str, cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> RunResult:
+    """Run a command, streaming a header, capturing combined output."""
+    print(f"\n$ {' '.join(cmd)}", flush=True)
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if proc.stdout:
+        print(proc.stdout, end="", flush=True)
+    result = RunResult(label=label, returncode=proc.returncode, output=proc.stdout or "")
+    if check and not result.ok:
+        raise StepError(label, proc.returncode, result.output)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Phase 1 — resolve target
+# --------------------------------------------------------------------------- #
+def resolve_latest_main_sha() -> str:
+    """Return the current commit SHA of libdatadog's main branch."""
+    out = run(
+        "ls-remote",
+        ["git", "ls-remote", LIBDATADOG_REPO, "refs/heads/main"],
+    ).output.strip()
+    if not out:
+        raise RuntimeError(f"git ls-remote returned nothing for {LIBDATADOG_REPO} main")
+    sha = out.split()[0]
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise RuntimeError(f"unexpected SHA from ls-remote: {sha!r}")
+    return sha
+
+
+def current_pinned_revs() -> set[str]:
+    text = CARGO_TOML.read_text()
+    return {m.group(2) for m in _LIBDD_REV_RE.finditer(text)}
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2 — apply the bump
+# --------------------------------------------------------------------------- #
+def rewrite_cargo_toml(target_rev: str) -> int:
+    """Point every libdatadog rev at target_rev. Returns the number of lines changed."""
+    text = CARGO_TOML.read_text()
+    new_text, n = _LIBDD_REV_RE.subn(rf"\g<1>{target_rev}\g<3>", text)
+    if n:
+        CARGO_TOML.write_text(new_text)
+    return n
+
+
+def regenerate_lockfile() -> None:
+    """Refresh Cargo.lock for the changed git revs.
+
+    Running `cargo update` against each libdatadog package re-resolves only the
+    libdatadog git source; registry deps are left untouched. A plain `cargo
+    check` would also update the lock, but doing it explicitly keeps the diff
+    minimal and makes the subsequent `cargo test --locked` meaningful.
+    """
+    pkgs = _libdatadog_package_names()
+    cmd = ["cargo", "update", "--manifest-path", str(CARGO_TOML)]
+    for pkg in pkgs:
+        cmd += ["-p", pkg]
+    run("cargo-update", cmd, cwd=NATIVE_DIR)
+
+
+def _libdatadog_package_names() -> list[str]:
+    """Crate names of the libdatadog git deps declared in Cargo.toml."""
+    text = CARGO_TOML.read_text()
+    names = []
+    for line in text.splitlines():
+        # Each libdatadog dep declares `git = "...libdatadog"` on the same line as
+        # its name (even the multi-line ones like data-pipeline/build_common), so a
+        # single-line match captures all 15.
+        m = re.match(r"\s*([A-Za-z0-9_-]+)\s*=\s*\{[^}]*github\.com/DataDog/libdatadog", line)
+        if m:
+            names.append(m.group(1))
+    return sorted(set(names))
+
+
+def _fetch_libdatadog_rust_channel(target_rev: str) -> str | None:
+    """Read libdatadog's pinned Rust channel at target_rev, or None if unavailable.
+
+    libdatadog uses a `rust-toolchain.toml` with `channel = "X.Y.Z"`; older revs
+    may use a bare `rust-toolchain` file. Best-effort over the network.
+    """
+    for fname in ("rust-toolchain.toml", "rust-toolchain"):
+        url = f"https://raw.githubusercontent.com/DataDog/libdatadog/{target_rev}/{fname}"
+        try:
+            with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310 (trusted host)
+                text = resp.read().decode("utf-8")
+        except Exception:
+            continue
+        m = re.search(r'channel\s*=\s*"([^"]+)"', text)  # toml form
+        if m:
+            return m.group(1).strip()
+        bare = text.strip()  # plain `rust-toolchain` file: just the version
+        if re.fullmatch(r"\d+\.\d+(\.\d+)?", bare):
+            return bare
+    return None
+
+
+def sync_rust_minimum_version(target_rev: str) -> str | None:
+    """Update setup.py's RUST_MINIMUM_VERSION to libdatadog's pinned channel.
+
+    Returns the new version if it changed, else None. Best-effort: if the
+    toolchain file can't be fetched or only specifies a partial version, leave
+    setup.py untouched and let the build step surface any real mismatch.
+    """
+    channel = _fetch_libdatadog_rust_channel(target_rev)
+    if not channel or not re.fullmatch(r"\d+\.\d+\.\d+", channel):
+        # Only act on a full X.Y.Z; "stable"/"1.87" aren't safe to pin verbatim.
+        print(
+            f"\n[rust-version] no actionable channel from libdatadog@{short(target_rev)} "
+            f"({channel!r}); leaving setup.py."
+        )
+        return None
+
+    text = SETUP_PY.read_text()
+    m = re.search(r'(RUST_MINIMUM_VERSION\s*=\s*")([^"]+)(")', text)
+    if not m:
+        print("\n[rust-version] RUST_MINIMUM_VERSION not found in setup.py; skipping.")
+        return None
+    if m.group(2) == channel:
+        return None
+
+    new_text = text[: m.start(2)] + channel + text[m.end(2) :]
+    # Refresh the explanatory comment if it names a specific version.
+    new_text = re.sub(
+        r"(# libdatadog\s+\S+\s+requires rust\s+)\d+\.\d+\.\d+\.?",
+        rf"\g<1>{channel}.",
+        new_text,
+    )
+    SETUP_PY.write_text(new_text)
+    print(f"\n[rust-version] RUST_MINIMUM_VERSION {m.group(2)} -> {channel} (from libdatadog rust-toolchain).")
+    return channel
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3 — validate
+# --------------------------------------------------------------------------- #
+def validate(skip_python: bool) -> list[RunResult]:
+    """Run the cargo (and optionally python) validation suite.
+
+    Raises StepError on the first failing step so the caller can route to the
+    repair loop with the failing command's output.
+    """
+    results: list[RunResult] = []
+    cargo_steps = [
+        ("cargo-build", ["cargo", "build", "--all-features"]),
+        ("cargo-fmt", ["cargo", "fmt", "--all", "--", "--check"]),
+        ("cargo-clippy", ["cargo", "clippy", "--all-features", "--", "-D", "warnings"]),
+        ("cargo-test", ["cargo", "test", "--no-fail-fast", "--locked"]),
+    ]
+    for label, cmd in cargo_steps:
+        results.append(run(label, cmd, cwd=NATIVE_DIR))
+
+    if not skip_python:
+        # Build + import smoke. Heavier suites run in CI once the PR exists.
+        results.append(run("pip-install", [sys.executable, "-m", "pip", "install", "-e", "."], cwd=REPO_ROOT))
+        results.append(
+            run(
+                "native-import-smoke",
+                [sys.executable, "-c", "import ddtrace.internal.native; print('native import OK')"],
+                cwd=REPO_ROOT,
+            )
+        )
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Phase 4 — outcome (release note + PR / fallback)
+# --------------------------------------------------------------------------- #
+def short(sha: str) -> str:
+    return sha[:12]
+
+
+def write_release_note(target_rev: str) -> Path:
+    """Write a reno-style upgrade note. Filename suffix is derived from the SHA
+    (deterministic, avoids the random hash reno would otherwise generate).
+    """
+    path = RELEASENOTES_DIR / f"upgrade-libdatadog-{short(target_rev)}.yaml"
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            upgrade:
+              - |
+                Bumps libdatadog dependency to {LIBDATADOG_REPO}@{short(target_rev)} (main).
+            """
+        )
+    )
+    return path
+
+
+def git_branch_name(target_rev: str) -> str:
+    return f"chore/update-libdatadog-{short(target_rev)}"
+
+
+def open_pr_or_fallback(
+    target_rev: str, branch: str, summary: str, *, push: bool, dry_run: bool, draft: bool = False
+) -> None:
+    flavor = "DRAFT " if draft else ""
+    title = f"chore(native): update libdatadog to {short(target_rev)} (main)"
+    body = summary
+
+    if dry_run:
+        print(f"\n[dry-run] would create branch, commit, and open {flavor}PR:")
+        print(f"  branch: {branch}\n  title:  {title}")
+        return
+
+    run("git-checkout", ["git", "checkout", "-B", branch], cwd=REPO_ROOT)
+    run(
+        "git-add",
+        ["git", "add", "src/native/Cargo.toml", "src/native/Cargo.lock", "setup.py", "releasenotes/notes/"],
+        cwd=REPO_ROOT,
+    )
+    run("git-commit", ["git", "commit", "-m", title], cwd=REPO_ROOT)
+
+    # In GitLab CI `origin` is the GitLab mirror, not GitHub; the job sets
+    # GIT_PUSH_REMOTE to a GitHub remote it configures with the octo-sts token.
+    remote = os.environ.get("GIT_PUSH_REMOTE", "origin")
+
+    if not push:
+        print("\n[--no-push] branch committed locally; not pushing. To open the PR:")
+        print(f"  git push -u {remote} {branch} && gh pr create --repo {GH_REPO_SLUG} --fill")
+        return
+
+    run("git-push", ["git", "push", "-u", remote, branch, "--force-with-lease"], cwd=REPO_ROOT)
+
+    if os.environ.get("GH_TOKEN") and shutil.which("gh"):
+        # --repo is required: `origin` here is the GitLab mirror, so gh can't infer
+        # the GitHub repo from the remotes.
+        cmd = [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            GH_REPO_SLUG,
+            "--base",
+            "main",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+        ]
+        if draft:
+            cmd.append("--draft")
+        run("gh-pr-create", cmd, cwd=REPO_ROOT)
+    else:
+        print(f"\n[no GH_TOKEN/gh] branch pushed. To open the {flavor}PR:")
+        draft_flag = " --draft" if draft else ""
+        print(
+            f"  gh pr create --repo {GH_REPO_SLUG} --base main --head {branch}{draft_flag} --title {title!r} --body ..."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Phase 5 — bounded AI repair loop
+# --------------------------------------------------------------------------- #
+def _claude_available() -> bool:
+    """True if the `claude` CLI and AI-gateway credentials are present."""
+    if not shutil.which("claude"):
+        print("\n[repair] `claude` CLI not found in PATH — skipping auto-repair.")
+        return False
+    if not (os.environ.get("ANTHROPIC_AUTH_TOKEN") and os.environ.get("ANTHROPIC_BASE_URL")):
+        print("\n[repair] AI-gateway env (ANTHROPIC_AUTH_TOKEN/ANTHROPIC_BASE_URL) not set — skipping.")
+        return False
+    return True
+
+
+def _revert_changes_outside_allowed() -> list[str]:
+    """Revert tracked files the agent modified outside ALLOWED_REPAIR_PREFIXES.
+
+    This is the integrity gate: the agent can edit src/native and setup.py to
+    adapt to API changes, but it cannot make a red build pass by touching tests,
+    CI, or anything else — those edits are thrown away before we re-validate.
+    Returns the list of reverted paths.
+    """
+    changed = run("git-changed", ["git", "diff", "--name-only", "HEAD"], cwd=REPO_ROOT, check=False).output
+    reverted = []
+    for path in (line.strip() for line in changed.splitlines() if line.strip()):
+        if not path.startswith(ALLOWED_REPAIR_PREFIXES):
+            run("git-revert-file", ["git", "checkout", "HEAD", "--", path], cwd=REPO_ROOT, check=False)
+            reverted.append(path)
+    if reverted:
+        print(f"\n[repair] reverted out-of-scope edits: {', '.join(reverted)}")
+    return reverted
+
+
+def _repair_prompt(failure: StepError, target_rev: str, log_path: Path) -> str:
+    return (
+        f"The libdatadog Rust dependency in src/native was just bumped to {short(target_rev)} (main) "
+        f"and the build no longer passes. The failing step was `{failure.label}`. "
+        f"Its full output is in {log_path} — read it first.\n\n"
+        "Your job: make the native build compile and pass again by adapting our code to libdatadog's "
+        "changed API. Constraints:\n"
+        "- Edit ONLY files under src/native/ and setup.py. Do NOT modify tests, CI config, or anything else.\n"
+        "- Do NOT weaken or delete assertions, lints, or tests to force a pass.\n"
+        "- Verify your fix by running `cargo build --all-features` (and `cargo clippy --all-features -- -D warnings`) "
+        "in src/native before finishing.\n"
+        "- If the breakage is NOT a small, mechanical API adaptation (e.g. it needs a design decision or a large "
+        "rewrite), stop and explain why rather than forcing a change.\n"
+        "When done, briefly summarize what changed and why."
+    )
+
+
+def repair_loop(
+    failure: StepError, target_rev: str, max_iterations: int, artifacts: Path, *, skip_python: bool
+) -> bool:
+    """Attempt to fix build/test breakage from libdatadog API changes.
+
+    Each iteration: invoke Claude (constrained to src/native + setup.py), revert
+    any out-of-scope edits, then re-run validate() — the deterministic gate the
+    agent cannot influence. Returns True once validate() passes, else False after
+    max_iterations.
+    """
+    if not _claude_available():
+        return False
+
+    for i in range(1, max_iterations + 1):
+        log_path = artifacts / f"repair-input-{i}.log"
+        log_path.write_text(f"step: {failure.label} (exit {failure.returncode})\n\n{failure.output}")
+        print(f"\n[repair] iteration {i}/{max_iterations} — invoking Claude…")
+
+        # Single --allowedTools followed by all values, matching the proven form
+        # in .gitlab/check-libdatadog-version.yml.
+        cmd = [
+            "claude",
+            "--bare",
+            "-p",
+            _repair_prompt(failure, target_rev, log_path),
+            "--model",
+            CLAUDE_MODEL,
+            "--allowedTools",
+            *CLAUDE_REPAIR_TOOLS,
+            "--permission-mode",
+            "bypassPermissions",
+        ]
+        transcript = run(f"claude-repair-{i}", cmd, cwd=REPO_ROOT, check=False)
+        (artifacts / f"repair-transcript-{i}.log").write_text(transcript.output)
+
+        _revert_changes_outside_allowed()
+
+        try:
+            validate(skip_python=skip_python)
+            print(f"\n[repair] converged after {i} iteration(s).")
+            return True
+        except StepError as exc:
+            failure = exc
+            (artifacts / f"{exc.label}-after-repair-{i}.log").write_text(exc.output)
+            print(f"[repair] still failing at {exc.label!r} after iteration {i}.")
+
+    print(f"\n[repair] did not converge after {max_iterations} iteration(s).")
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--target-rev", help="bump to this rev instead of latest main")
+    parser.add_argument("--dry-run", action="store_true", help="show changes, modify nothing")
+    parser.add_argument("--skip-python", action="store_true", help="cargo-only validation")
+    parser.add_argument("--no-push", dest="push", action="store_false", help="commit but do not push/PR")
+    parser.add_argument("--max-repair-iterations", type=int, default=3)
+    args = parser.parse_args()
+
+    artifacts = Path(os.environ.get("ARTIFACTS_DIR", REPO_ROOT / "libdatadog-update"))
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    # Phase 1 -------------------------------------------------------------- #
+    target_rev = args.target_rev or resolve_latest_main_sha()
+    pinned = current_pinned_revs()
+    print(f"\nTarget rev : {target_rev}")
+    print(f"Current pin: {', '.join(sorted(pinned)) or '(none found)'}")
+
+    if pinned == {target_rev}:
+        print("Already pinned to target — nothing to do.")
+        return 0
+
+    # Phase 2 -------------------------------------------------------------- #
+    if args.dry_run:
+        n = len(_LIBDD_REV_RE.findall(CARGO_TOML.read_text()))
+        print(
+            f"\n[dry-run] would rewrite {n} libdatadog rev(s) → {short(target_rev)}, "
+            "regenerate Cargo.lock, and validate."
+        )
+        return 0
+
+    n = rewrite_cargo_toml(target_rev)
+    print(f"\nRewrote {n} libdatadog rev(s) in {CARGO_TOML.relative_to(REPO_ROOT)}.")
+    regenerate_lockfile()
+    rust_version = sync_rust_minimum_version(target_rev)
+
+    # Phase 3 -------------------------------------------------------------- #
+    summary_lines = [
+        f"Bumps libdatadog to `{short(target_rev)}` (main).",
+        "",
+        f"- Source: {LIBDATADOG_REPO}/commit/{target_rev}",
+        f"- Rewrote {n} `rev` pin(s) in `src/native/Cargo.toml` and regenerated `Cargo.lock`.",
+    ]
+    if rust_version:
+        summary_lines.append(f"- Bumped `RUST_MINIMUM_VERSION` to `{rust_version}` (from libdatadog's toolchain).")
+
+    converged = True
+    repaired = False
+    try:
+        validate(skip_python=args.skip_python)
+    except StepError as exc:
+        (artifacts / f"{exc.label}.log").write_text(exc.output)
+        print(f"\nValidation failed at {exc.label!r}; entering repair loop.")
+        # Phase 5 ---------------------------------------------------------- #
+        converged = repair_loop(exc, target_rev, args.max_repair_iterations, artifacts, skip_python=args.skip_python)
+        repaired = converged
+        if not converged:
+            summary_lines += [
+                "",
+                f"> ⚠️ **Validation FAILED** at `{exc.label}` and automated repair did not converge "
+                f"after {args.max_repair_iterations} attempt(s). Opened as a **draft** for a human to finish. "
+                "See the `repair-*` / `*-after-repair-*` logs in the job artifacts.",
+            ]
+    if repaired:
+        summary_lines.append(
+            f"- Build initially broke and was auto-repaired by Claude "
+            f"({args.max_repair_iterations}-attempt cap). **Scrutinize the src/native diff.**"
+        )
+
+    # Phase 4 -------------------------------------------------------------- #
+    note = write_release_note(target_rev)
+    summary_lines.append(f"- Added release note `{note.relative_to(REPO_ROOT)}`.")
+    summary = "\n".join(summary_lines)
+    (artifacts / "summary.md").write_text(summary)
+
+    open_pr_or_fallback(
+        target_rev, git_branch_name(target_rev), summary, push=args.push, dry_run=args.dry_run, draft=not converged
+    )
+    print("\nDone." if converged else "\nDone (draft PR — validation did not pass).")
+    return 0 if converged else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -8,7 +8,8 @@ r"""Update the pinned libdatadog dependency in src/native to the latest commit o
 libdatadog's `main` branch, validate the build, and (when green) open a PR.
 
 Phases:
-  1. Resolve target — `git ls-remote` libdatadog main → SHA. No-op if already pinned.
+  1. Resolve target — `git ls-remote` libdatadog main → SHA. No-op if already
+     pinned or if the pin is fewer than --min-commits behind main (drift gate).
   2. Apply bump — rewrite every libdatadog `rev = "..."` in src/native/Cargo.toml,
      regenerate Cargo.lock, and sync setup.py's RUST_MINIMUM_VERSION if needed.
   3. Validate — cargo build / fmt / clippy / test (+ optional python smoke).
@@ -27,8 +28,12 @@ Usage:
   scripts/update-libdatadog.py --dry-run       # show what would change, touch nothing
   scripts/update-libdatadog.py --target-rev SHA  # bump to a specific rev
   scripts/update-libdatadog.py --skip-python   # cargo-only validation (fast local loop)
+  scripts/update-libdatadog.py --min-commits 0 # bump regardless of drift
+  scripts/update-libdatadog.py --check-drift   # only evaluate the gate (exit 0 proceed / 100 skip)
 
 Environment:
+  LIBDATADOG_MIN_DRIFT  default for --min-commits (commits of libdatadog drift
+                        required before a bump proceeds; default 5).
   GH_TOKEN              GitHub token (from octo-sts). When set, the bump is
                         committed and the PR opened via the GitHub API as a
                         verified, bot-attributed commit. Without it, the changes
@@ -209,6 +214,26 @@ def resolve_latest_main_sha() -> str:
 def current_pinned_revs() -> set[str]:
     text = CARGO_TOML.read_text()
     return {m.group(2) for m in _LIBDD_REV_RE.finditer(text)}
+
+
+def libdatadog_commits_behind(pin: str) -> int | None:
+    """How many commits libdatadog `main` is ahead of `pin` (tag or SHA), via the
+    GitHub compare API. None if it can't be determined (network/api error).
+    """
+    owner_repo = LIBDATADOG_REPO.removeprefix("https://github.com/")
+    url = f"{GH_API_BASE}/repos/{owner_repo}/compare/{pin}...main"
+    try:
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        # Authenticate if a token is around (higher rate limit); libdatadog is
+        # public so this also works unauthenticated.
+        if os.environ.get("GH_TOKEN"):
+            req.add_header("Authorization", f"Bearer {os.environ['GH_TOKEN']}")
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (fixed host)
+            return int(json.loads(resp.read().decode()).get("ahead_by", 0))
+    except Exception as exc:  # noqa: BLE001 — best-effort gate; caller decides
+        print(f"[drift] could not compute commits-behind for {pin!r}: {exc}")
+        return None
 
 
 # --------------------------------------------------------------------------- #
@@ -505,13 +530,22 @@ def create_verified_pr(branch: str, title: str, body: str, changes: list[tuple[s
             body={"sha": commit["sha"], "force": True},
         )
 
-    pr = _gh_api(
-        "POST",
-        f"/repos/{owner}/{repo}/pulls",
-        token=token,
-        body={"title": title, "head": branch, "base": "main", "body": body, "draft": draft},
-    )
-    return pr["html_url"]
+    try:
+        pr = _gh_api(
+            "POST",
+            f"/repos/{owner}/{repo}/pulls",
+            token=token,
+            body={"title": title, "head": branch, "base": "main", "body": body, "draft": draft},
+        )
+        return pr["html_url"]
+    except urllib.error.HTTPError as exc:
+        if exc.code != 422:  # 422 == a PR already exists for this head (re-run on same rev)
+            raise
+        existing = _gh_api("GET", f"/repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open", token=token)
+        if existing:
+            print("[pr] a PR already exists for this branch; the commit was updated on it.")
+            return existing[0]["html_url"]
+        raise
 
 
 def open_pr_or_fallback(
@@ -651,6 +685,19 @@ def main() -> int:
     parser.add_argument("--skip-python", action="store_true", help="cargo-only validation")
     parser.add_argument("--no-push", dest="push", action="store_false", help="commit but do not push/PR")
     parser.add_argument("--max-repair-iterations", type=int, default=3)
+    parser.add_argument(
+        "--min-commits",
+        type=int,
+        default=int(os.environ.get("LIBDATADOG_MIN_DRIFT", "5")),
+        help="only proceed when libdatadog main is at least this many commits ahead of the pin "
+        "(default 5 or $LIBDATADOG_MIN_DRIFT). --target-rev bypasses the gate.",
+    )
+    parser.add_argument(
+        "--check-drift",
+        action="store_true",
+        help="only evaluate the drift gate: exit 0 to proceed, 100 to skip. Lets CI avoid "
+        "expensive setup on no-op runs.",
+    )
     args = parser.parse_args()
 
     artifacts = Path(os.environ.get("ARTIFACTS_DIR", REPO_ROOT / "libdatadog-update"))
@@ -662,8 +709,28 @@ def main() -> int:
     print(f"\nTarget rev : {target_rev}")
     print(f"Current pin: {', '.join(sorted(pinned)) or '(none found)'}")
 
-    if pinned == {target_rev}:
-        print("Already pinned to target — nothing to do.")
+    already_current = pinned == {target_rev}
+
+    # Drift gate — proceed only when libdatadog main is far enough ahead of the
+    # pin (configurable; --target-rev forces a bump regardless).
+    behind = None if already_current else (libdatadog_commits_behind(sorted(pinned)[0]) if pinned else None)
+    if behind is not None:
+        print(f"Drift      : {behind} commit(s) behind libdatadog main (threshold {args.min_commits})")
+    if args.target_rev:
+        proceed = not already_current
+    else:
+        # If drift is unknown (API error), proceed rather than silently miss updates.
+        proceed = (not already_current) and (behind is None or behind >= args.min_commits)
+
+    if args.check_drift:
+        print("Decision   :", "proceed" if proceed else "skip")
+        return 0 if proceed else 100
+
+    if not proceed:
+        reason = (
+            "already pinned to target" if already_current else f"only {behind} commit(s) behind (< {args.min_commits})"
+        )
+        print(f"Nothing to do — {reason}.")
         return 0
 
     # Phase 2 -------------------------------------------------------------- #

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -49,6 +49,7 @@ import shutil
 import subprocess
 import sys
 import textwrap
+import threading
 import urllib.request
 
 
@@ -70,6 +71,9 @@ ALLOWED_REPAIR_PREFIXES = ("src/native/", "setup.py")
 # The read-only shell tools let the agent locate and inspect libdatadog's fetched
 # source under $CARGO_HOME/git/checkouts (outside the repo tree) so it can discover
 # e.g. a crate's new name when one was renamed at the target rev.
+# Hard cap per repair iteration so a hung/slow agent can't block the job; the
+# job's own timeout is the outer backstop.
+CLAUDE_REPAIR_TIMEOUT_S = 600
 CLAUDE_MODEL = "anthropic/claude-sonnet-4-6"
 CLAUDE_REPAIR_TOOLS = [
     "Read",
@@ -111,21 +115,60 @@ class RunResult:
         return self.returncode == 0
 
 
-def run(label: str, cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> RunResult:
-    """Run a command, streaming a header, capturing combined output."""
+def run(
+    label: str, cmd: list[str], *, cwd: Path | None = None, check: bool = True, timeout: float | None = None
+) -> RunResult:
+    """Run a command, streaming its output live and capturing it for the caller.
+
+    Output is streamed line-by-line (so long-running steps don't look frozen in CI)
+    while also being captured into the result. If `timeout` is set, the process is
+    killed after that many seconds and the step is reported as failed (rc 124) —
+    this is what stops a hung subprocess (e.g. Claude) from blocking the job
+    indefinitely.
+    """
     print(f"\n$ {' '.join(cmd)}", flush=True)
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         cmd,
         cwd=str(cwd) if cwd else None,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        bufsize=1,
     )
-    if proc.stdout:
-        print(proc.stdout, end="", flush=True)
-    result = RunResult(label=label, returncode=proc.returncode, output=proc.stdout or "")
+    timed_out = False
+    timer: threading.Timer | None = None
+    if timeout:
+
+        def _kill() -> None:
+            nonlocal timed_out
+            timed_out = True
+            proc.kill()
+
+        timer = threading.Timer(timeout, _kill)
+        timer.start()
+
+    lines: list[str] = []
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            print(line, end="", flush=True)
+            lines.append(line)
+    finally:
+        proc.wait()
+        if timer:
+            timer.cancel()
+
+    output = "".join(lines)
+    returncode = proc.returncode
+    if timed_out:
+        msg = f"\n[timeout] '{label}' exceeded {timeout:.0f}s and was killed."
+        print(msg, flush=True)
+        output += msg + "\n"
+        returncode = 124
+
+    result = RunResult(label=label, returncode=returncode, output=output)
     if check and not result.ok:
-        raise StepError(label, proc.returncode, result.output)
+        raise StepError(label, returncode, output)
     return result
 
 
@@ -490,8 +533,10 @@ def repair_loop(failure: StepError, target_rev: str, max_iterations: int, artifa
             "--permission-mode",
             "bypassPermissions",
         ]
-        transcript = run(f"claude-repair-{i}", cmd, cwd=REPO_ROOT, check=False)
+        transcript = run(f"claude-repair-{i}", cmd, cwd=REPO_ROOT, check=False, timeout=CLAUDE_REPAIR_TIMEOUT_S)
         (artifacts / f"repair-transcript-{i}.log").write_text(transcript.output)
+        if transcript.returncode == 124:
+            print(f"[repair] iteration {i} timed out after {CLAUDE_REPAIR_TIMEOUT_S}s; moving on.")
 
         _revert_changes_outside_allowed()
 

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -12,8 +12,8 @@ Phases:
   2. Apply bump — rewrite every libdatadog `rev = "..."` in src/native/Cargo.toml,
      regenerate Cargo.lock, and sync setup.py's RUST_MINIMUM_VERSION if needed.
   3. Validate — cargo build / fmt / clippy / test (+ optional python smoke).
-  4. Outcome — green: write release note, push branch, open PR (or print the
-     command if no GH token).
+  4. Outcome — green: write release note, then commit + open the PR via the
+     GitHub API as a verified, bot-attributed commit (no local commit / push).
   5. Repair — if validation is red, Claude (via the AI gateway) attempts a
      bounded set of fixes constrained to src/native + setup.py, with the build
      re-validated by code the agent can't influence. Converges → normal PR;
@@ -29,12 +29,10 @@ Usage:
   scripts/update-libdatadog.py --skip-python   # cargo-only validation (fast local loop)
 
 Environment:
-  GH_TOKEN              if set (and `gh` present), used to open the PR; otherwise
-                        the branch is pushed and the create-PR command is printed.
-  GIT_PUSH_REMOTE       git remote to push to (default: origin). CI sets this to a
-                        GitHub remote since `origin` is the GitLab mirror.
-  GIT_AUTHOR_*/         commit identity, read natively by git. CI sets these to
-  GIT_COMMITTER_*       dd-octo-sts[bot]; locally git falls back to your config.
+  GH_TOKEN              GitHub token (from octo-sts). When set, the bump is
+                        committed and the PR opened via the GitHub API as a
+                        verified, bot-attributed commit. Without it, the changes
+                        are listed and PR creation is skipped.
   ANTHROPIC_AUTH_TOKEN  AI-gateway bearer token; required for the Phase 5 repair
   ANTHROPIC_BASE_URL    loop. If unset, repair is skipped and red builds draft-PR.
   ARTIFACTS_DIR         where to write logs and the summary (default: ./libdatadog-update)
@@ -43,7 +41,9 @@ Environment:
 from __future__ import annotations
 
 import argparse
+import base64
 import dataclasses
+import json
 import os
 from pathlib import Path
 import re
@@ -52,11 +52,18 @@ import subprocess
 import sys
 import textwrap
 import threading
+import urllib.error
 import urllib.request
 
 
 LIBDATADOG_REPO = "https://github.com/DataDog/libdatadog"
 GH_REPO_SLUG = "DataDog/dd-trace-py"
+GH_API_BASE = "https://api.github.com"
+
+# Paths the PR commit is allowed to include. Bounds the commit to the bump's real
+# changes and keeps CI junk (the authanywhere binary, libdatadog-update/, tmp/)
+# out of the tree we send to GitHub.
+COMMIT_PATH_PREFIXES = ("src/native/", "setup.py", "releasenotes/notes/")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 NATIVE_DIR = REPO_ROOT / "src" / "native"
@@ -392,66 +399,129 @@ def git_branch_name(target_rev: str) -> str:
     return f"chore/update-libdatadog-{short(target_rev)}"
 
 
+def _gh_api(method: str, path: str, *, token: str, body: dict | None = None) -> dict:
+    """Call the GitHub REST API and return the parsed JSON (or {} for empty 2xx)."""
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{GH_API_BASE}{path}", data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310 (fixed api.github.com host)
+        raw = resp.read().decode()
+    return json.loads(raw) if raw else {}
+
+
+def _commit_changes() -> list[tuple[str, bool]]:
+    """(path, is_deleted) for in-scope working-tree changes vs HEAD, incl. untracked.
+
+    Restricted to COMMIT_PATH_PREFIXES so CI artifacts/binaries never enter the commit.
+    """
+    out = run(
+        "git-status", ["git", "status", "--porcelain", "--untracked-files=all"], cwd=REPO_ROOT, check=False
+    ).output
+    changes = []
+    for line in out.splitlines():
+        if len(line) < 4:
+            continue
+        status, path = line[:2], line[3:]
+        if " -> " in path:  # rename → take the new path
+            path = path.split(" -> ", 1)[1]
+        path = path.strip().strip('"')
+        if path.startswith(COMMIT_PATH_PREFIXES):
+            changes.append((path, "D" in status))
+    return changes
+
+
+def create_verified_pr(branch: str, title: str, body: str, changes: list[tuple[str, bool]], *, draft: bool) -> str:
+    """Create a GitHub-signed (Verified) commit via the API, point a branch at it,
+    and open a PR. Returns the PR URL.
+
+    The commit is built server-side from the current tip of main, so GitHub
+    attributes it to the token's app bot (dd-octo-sts[bot]) and signs it — no
+    local commit, no git author config, and no token-in-remote-URL needed.
+    """
+    token = os.environ["GH_TOKEN"]
+    owner, repo = GH_REPO_SLUG.split("/")
+
+    base_sha = _gh_api("GET", f"/repos/{owner}/{repo}/git/ref/heads/main", token=token)["object"]["sha"]
+    base_tree = _gh_api("GET", f"/repos/{owner}/{repo}/git/commits/{base_sha}", token=token)["tree"]["sha"]
+
+    tree: list[dict] = []
+    for path, deleted in changes:
+        full = REPO_ROOT / path
+        if deleted or not full.exists():
+            tree.append({"path": path, "mode": "100644", "type": "blob", "sha": None})
+            continue
+        blob = _gh_api(
+            "POST",
+            f"/repos/{owner}/{repo}/git/blobs",
+            token=token,
+            body={"content": base64.b64encode(full.read_bytes()).decode(), "encoding": "base64"},
+        )
+        mode = "100755" if os.access(full, os.X_OK) else "100644"
+        tree.append({"path": path, "mode": mode, "type": "blob", "sha": blob["sha"]})
+
+    new_tree = _gh_api(
+        "POST", f"/repos/{owner}/{repo}/git/trees", token=token, body={"base_tree": base_tree, "tree": tree}
+    )
+    # Omit author/committer: GitHub attributes the commit to the app bot and signs it.
+    commit = _gh_api(
+        "POST",
+        f"/repos/{owner}/{repo}/git/commits",
+        token=token,
+        body={"message": f"{title}\n\n{body}", "tree": new_tree["sha"], "parents": [base_sha]},
+    )
+
+    try:
+        _gh_api(
+            "POST",
+            f"/repos/{owner}/{repo}/git/refs",
+            token=token,
+            body={"ref": f"refs/heads/{branch}", "sha": commit["sha"]},
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code != 422:  # 422 == ref already exists
+            raise
+        _gh_api(
+            "PATCH",
+            f"/repos/{owner}/{repo}/git/refs/heads/{branch}",
+            token=token,
+            body={"sha": commit["sha"], "force": True},
+        )
+
+    pr = _gh_api(
+        "POST",
+        f"/repos/{owner}/{repo}/pulls",
+        token=token,
+        body={"title": title, "head": branch, "base": "main", "body": body, "draft": draft},
+    )
+    return pr["html_url"]
+
+
 def open_pr_or_fallback(
     target_rev: str, branch: str, summary: str, *, push: bool, dry_run: bool, draft: bool = False
 ) -> None:
     flavor = "DRAFT " if draft else ""
     title = f"chore(native): update libdatadog to {short(target_rev)} (main)"
-    body = summary
+    changes = _commit_changes()
 
-    if dry_run:
-        print(f"\n[dry-run] would create branch, commit, and open {flavor}PR:")
-        print(f"  branch: {branch}\n  title:  {title}")
+    print(f"\nChanges to commit ({len(changes)}):")
+    for path, deleted in changes:
+        print(f"  {'D' if deleted else 'M'} {path}")
+
+    if dry_run or not push:
+        why = "dry-run" if dry_run else "--no-push"
+        print(f"\n[{why}] skipping PR creation; would open {flavor}PR '{title}' on branch {branch}.")
         return
 
-    run("git-checkout", ["git", "checkout", "-B", branch], cwd=REPO_ROOT)
-    run(
-        "git-add",
-        ["git", "add", "src/native/Cargo.toml", "src/native/Cargo.lock", "setup.py", "releasenotes/notes/"],
-        cwd=REPO_ROOT,
-    )
-    # git reads the author/committer from GIT_AUTHOR_*/GIT_COMMITTER_* (the CI job
-    # sets these to dd-octo-sts[bot]) or, locally, from the developer's git config.
-    run("git-commit", ["git", "commit", "-m", title], cwd=REPO_ROOT)
-
-    # In GitLab CI `origin` is the GitLab mirror, not GitHub; the job sets
-    # GIT_PUSH_REMOTE to a GitHub remote it configures with the octo-sts token.
-    remote = os.environ.get("GIT_PUSH_REMOTE", "origin")
-
-    if not push:
-        print("\n[--no-push] branch committed locally; not pushing. To open the PR:")
-        print(f"  git push -u {remote} {branch} && gh pr create --repo {GH_REPO_SLUG} --fill")
+    if not os.environ.get("GH_TOKEN"):
+        print(f"\n[no GH_TOKEN] cannot create the {flavor}PR via the GitHub API; skipping (changes listed above).")
         return
 
-    run("git-push", ["git", "push", "-u", remote, branch, "--force-with-lease"], cwd=REPO_ROOT)
-
-    if os.environ.get("GH_TOKEN") and shutil.which("gh"):
-        # --repo is required: `origin` here is the GitLab mirror, so gh can't infer
-        # the GitHub repo from the remotes.
-        cmd = [
-            "gh",
-            "pr",
-            "create",
-            "--repo",
-            GH_REPO_SLUG,
-            "--base",
-            "main",
-            "--head",
-            branch,
-            "--title",
-            title,
-            "--body",
-            body,
-        ]
-        if draft:
-            cmd.append("--draft")
-        run("gh-pr-create", cmd, cwd=REPO_ROOT)
-    else:
-        print(f"\n[no GH_TOKEN/gh] branch pushed. To open the {flavor}PR:")
-        draft_flag = " --draft" if draft else ""
-        print(
-            f"  gh pr create --repo {GH_REPO_SLUG} --base main --head {branch}{draft_flag} --title {title!r} --body ..."
-        )
+    url = create_verified_pr(branch, title, summary, changes, draft=draft)
+    print(f"\nOpened {flavor}PR (GitHub-signed commit): {url}")
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -67,8 +67,22 @@ RELEASENOTES_DIR = REPO_ROOT / "releasenotes" / "notes"
 ALLOWED_REPAIR_PREFIXES = ("src/native/", "setup.py")
 
 # Claude model + tools for the repair loop, mirroring .gitlab/check-libdatadog-version.yml.
+# The read-only shell tools let the agent locate and inspect libdatadog's fetched
+# source under $CARGO_HOME/git/checkouts (outside the repo tree) so it can discover
+# e.g. a crate's new name when one was renamed at the target rev.
 CLAUDE_MODEL = "anthropic/claude-sonnet-4-6"
-CLAUDE_REPAIR_TOOLS = ["Read", "Edit", "Write", "Grep", "Glob", "Bash(cargo:*)"]
+CLAUDE_REPAIR_TOOLS = [
+    "Read",
+    "Edit",
+    "Write",
+    "Grep",
+    "Glob",
+    "Bash(cargo:*)",
+    "Bash(find:*)",
+    "Bash(ls:*)",
+    "Bash(cat:*)",
+    "Bash(grep:*)",
+]
 
 # Matches the `rev = "..."` on any Cargo.toml line that pins the libdatadog git
 # source. Every git dependency in src/native/Cargo.toml is libdatadog, but we
@@ -150,18 +164,27 @@ def rewrite_cargo_toml(target_rev: str) -> int:
 
 
 def regenerate_lockfile() -> None:
-    """Refresh Cargo.lock for the changed git revs.
+    """Best-effort refresh of Cargo.lock for the changed git revs.
 
     Running `cargo update` against each libdatadog package re-resolves only the
-    libdatadog git source; registry deps are left untouched. A plain `cargo
-    check` would also update the lock, but doing it explicitly keeps the diff
-    minimal and makes the subsequent `cargo test --locked` meaningful.
+    libdatadog git source; registry deps are left untouched, keeping the lock
+    diff minimal in the happy path.
+
+    Tolerant by design: if the new rev renamed/removed a crate we depend on,
+    this `cargo update` fails to resolve. We do NOT crash here — the same
+    resolution error resurfaces in `cargo build` during validate(), which IS
+    routed to the repair loop so the agent can fix src/native/Cargo.toml.
     """
     pkgs = _libdatadog_package_names()
     cmd = ["cargo", "update", "--manifest-path", str(CARGO_TOML)]
     for pkg in pkgs:
         cmd += ["-p", pkg]
-    run("cargo-update", cmd, cwd=NATIVE_DIR)
+    res = run("cargo-update", cmd, cwd=NATIVE_DIR, check=False)
+    if not res.ok:
+        print(
+            "\n[cargo-update] lock refresh failed (likely a renamed/removed crate at the new rev); "
+            "deferring to `cargo build` in validation, which routes failures to the repair loop."
+        )
 
 
 def _libdatadog_package_names() -> list[str]:
@@ -396,7 +419,9 @@ def _repair_prompt(failure: StepError, target_rev: str, log_path: Path) -> str:
         f"and the build no longer passes. The failing step was `{failure.label}`. "
         f"Its full output is in {log_path} — read it first.\n\n"
         "Your job: make the native build compile and pass again by adapting our code to libdatadog's "
-        "changed API. Constraints:\n"
+        "changed API. The breakage may be a renamed/removed/moved crate (fix the dependency entries in "
+        "src/native/Cargo.toml — e.g. a `datadog-*` crate renamed to `libdd-*`), a changed function/type "
+        "signature, or a moved import. Constraints:\n"
         "- Edit ONLY files under src/native/ and setup.py. Do NOT modify tests, CI config, or anything else.\n"
         "- Do NOT weaken or delete assertions, lints, or tests to force a pass.\n"
         "- Verify your fix by running `cargo build --all-features` (and `cargo clippy --all-features -- -D warnings`) "

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -172,8 +172,8 @@ def regenerate_lockfile() -> None:
 
     Tolerant by design: if the new rev renamed/removed a crate we depend on,
     this `cargo update` fails to resolve. We do NOT crash here — the same
-    resolution error resurfaces in `cargo build` during validate(), which IS
-    routed to the repair loop so the agent can fix src/native/Cargo.toml.
+    resolution error resurfaces in `cargo build` during validate_native(), which
+    IS routed to the repair loop so the agent can fix src/native/Cargo.toml.
     """
     pkgs = _libdatadog_package_names()
     cmd = ["cargo", "update", "--manifest-path", str(CARGO_TOML)]
@@ -262,33 +262,60 @@ def sync_rust_minimum_version(target_rev: str) -> str | None:
 # --------------------------------------------------------------------------- #
 # Phase 3 — validate
 # --------------------------------------------------------------------------- #
-def validate(skip_python: bool) -> list[RunResult]:
-    """Run the cargo (and optionally python) validation suite.
+def validate_native() -> None:
+    """Run the cargo validation suite — the repairable signal.
 
-    Raises StepError on the first failing step so the caller can route to the
-    repair loop with the failing command's output.
+    Raises StepError on the first failing step so the caller can route it to the
+    repair loop. This is native-code only: every failure here is something the
+    agent can plausibly fix by editing src/native.
     """
-    results: list[RunResult] = []
-    cargo_steps = [
+    for label, cmd in (
         ("cargo-build", ["cargo", "build", "--all-features"]),
         ("cargo-fmt", ["cargo", "fmt", "--all", "--", "--check"]),
         ("cargo-clippy", ["cargo", "clippy", "--all-features", "--", "-D", "warnings"]),
         ("cargo-test", ["cargo", "test", "--no-fail-fast", "--locked"]),
-    ]
-    for label, cmd in cargo_steps:
-        results.append(run(label, cmd, cwd=NATIVE_DIR))
+    ):
+        run(label, cmd, cwd=NATIVE_DIR)
 
-    if not skip_python:
-        # Build + import smoke. Heavier suites run in CI once the PR exists.
-        results.append(run("pip-install", [sys.executable, "-m", "pip", "install", "-e", "."], cwd=REPO_ROOT))
-        results.append(
-            run(
-                "native-import-smoke",
-                [sys.executable, "-c", "import ddtrace.internal.native; print('native import OK')"],
-                cwd=REPO_ROOT,
-            )
-        )
-    return results
+
+def _python_with_pip() -> str | None:
+    """A real interpreter that has pip, or None.
+
+    NOT sys.executable: under `uv run --script` that's an ephemeral env without
+    pip, so installing the project with it fails spuriously.
+    """
+    self_py = Path(sys.executable).resolve()
+    for cand in ("python3", "python", "python3.12", "python3.11"):
+        path = shutil.which(cand)
+        if not path or Path(path).resolve() == self_py:
+            continue
+        if run("python-pip-check", [path, "-m", "pip", "--version"], check=False).ok:
+            return path
+    return None
+
+
+def validate_python() -> bool:
+    """Best-effort build + import smoke. Returns False on a real failure.
+
+    Deliberately NOT routed to the repair loop: a pip/venv problem is an
+    environment issue, not a libdatadog API change. The comprehensive Python
+    suite runs in PR CI anyway; this is just an early ABI smoke. Skips (returns
+    True) when no pip-capable interpreter is available.
+    """
+    py = _python_with_pip()
+    if not py:
+        print("\n[python-smoke] no pip-capable interpreter found; skipping (full suite runs in PR CI).")
+        return True
+    if not run("pip-install", [py, "-m", "pip", "install", "-e", "."], cwd=REPO_ROOT, check=False).ok:
+        print("\n[python-smoke] `pip install -e .` failed — see log; not treated as a native-build failure.")
+        return False
+    smoke = run(
+        "native-import-smoke",
+        [py, "-c", "import ddtrace.internal.native; print('native import OK')"],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    return smoke.ok
 
 
 # --------------------------------------------------------------------------- #
@@ -432,15 +459,14 @@ def _repair_prompt(failure: StepError, target_rev: str, log_path: Path) -> str:
     )
 
 
-def repair_loop(
-    failure: StepError, target_rev: str, max_iterations: int, artifacts: Path, *, skip_python: bool
-) -> bool:
-    """Attempt to fix build/test breakage from libdatadog API changes.
+def repair_loop(failure: StepError, target_rev: str, max_iterations: int, artifacts: Path) -> bool:
+    """Attempt to fix native build breakage from libdatadog API changes.
 
     Each iteration: invoke Claude (constrained to src/native + setup.py), revert
-    any out-of-scope edits, then re-run validate() — the deterministic gate the
-    agent cannot influence. Returns True once validate() passes, else False after
-    max_iterations.
+    any out-of-scope edits, then re-run validate_native() — the deterministic
+    gate the agent cannot influence. Returns True once it passes, else False
+    after max_iterations. Only native (cargo) failures are repaired; environment
+    issues (e.g. pip) are never routed here.
     """
     if not _claude_available():
         return False
@@ -470,7 +496,7 @@ def repair_loop(
         _revert_changes_outside_allowed()
 
         try:
-            validate(skip_python=skip_python)
+            validate_native()
             print(f"\n[repair] converged after {i} iteration(s).")
             return True
         except StepError as exc:
@@ -531,20 +557,22 @@ def main() -> int:
     if rust_version:
         summary_lines.append(f"- Bumped `RUST_MINIMUM_VERSION` to `{rust_version}` (from libdatadog's toolchain).")
 
+    # Native (cargo) validation — the repairable signal. Only failures here are
+    # routed to the AI repair loop.
     converged = True
     repaired = False
     try:
-        validate(skip_python=args.skip_python)
+        validate_native()
     except StepError as exc:
         (artifacts / f"{exc.label}.log").write_text(exc.output)
         print(f"\nValidation failed at {exc.label!r}; entering repair loop.")
         # Phase 5 ---------------------------------------------------------- #
-        converged = repair_loop(exc, target_rev, args.max_repair_iterations, artifacts, skip_python=args.skip_python)
+        converged = repair_loop(exc, target_rev, args.max_repair_iterations, artifacts)
         repaired = converged
         if not converged:
             summary_lines += [
                 "",
-                f"> ⚠️ **Validation FAILED** at `{exc.label}` and automated repair did not converge "
+                f"> ⚠️ **Native build FAILED** at `{exc.label}` and automated repair did not converge "
                 f"after {args.max_repair_iterations} attempt(s). Opened as a **draft** for a human to finish. "
                 "See the `repair-*` / `*-after-repair-*` logs in the job artifacts.",
             ]
@@ -553,6 +581,11 @@ def main() -> int:
             f"- Build initially broke and was auto-repaired by Claude "
             f"({args.max_repair_iterations}-attempt cap). **Scrutinize the src/native diff.**"
         )
+
+    # Python smoke — best-effort, NOT routed to repair (env issue ≠ API change).
+    # The comprehensive Python suite runs in PR CI.
+    if converged and not args.skip_python and not validate_python():
+        summary_lines.append("- ⚠️ Python import smoke did not pass — verify the native ABI in PR CI.")
 
     # Phase 4 -------------------------------------------------------------- #
     note = write_release_note(target_rev)

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -65,6 +65,14 @@ GH_API_BASE = "https://api.github.com"
 # out of the tree we send to GitHub.
 COMMIT_PATH_PREFIXES = ("src/native/", "setup.py", "releasenotes/notes/")
 
+# Second line of defense: even within the allowlist above, refuse to commit a
+# path that looks like a secret/credential/binary. If this ever fires it means
+# the allowlist was loosened or something unexpected landed under it.
+SENSITIVE_PATH_RE = re.compile(
+    r"(token|secret|credential|authanywhere|password|\.pem$|\.key$|id_rsa|\.env$|\.netrc)",
+    re.IGNORECASE,
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 NATIVE_DIR = REPO_ROOT / "src" / "native"
 CARGO_TOML = NATIVE_DIR / "Cargo.toml"
@@ -442,6 +450,12 @@ def create_verified_pr(branch: str, title: str, body: str, changes: list[tuple[s
     attributes it to the token's app bot (dd-octo-sts[bot]) and signs it — no
     local commit, no git author config, and no token-in-remote-URL needed.
     """
+    # Safety net: never commit a secret/credential-looking path, even if it
+    # somehow passed the COMMIT_PATH_PREFIXES allowlist.
+    sensitive = [p for p, _ in changes if SENSITIVE_PATH_RE.search(p)]
+    if sensitive:
+        raise RuntimeError(f"refusing to create commit: sensitive-looking path(s) in change set: {sensitive}")
+
     token = os.environ["GH_TOKEN"]
     owner, repo = GH_REPO_SLUG.split("/")
 

--- a/scripts/update-libdatadog.py
+++ b/scripts/update-libdatadog.py
@@ -33,6 +33,8 @@ Environment:
                         the branch is pushed and the create-PR command is printed.
   GIT_PUSH_REMOTE       git remote to push to (default: origin). CI sets this to a
                         GitHub remote since `origin` is the GitLab mirror.
+  GIT_AUTHOR_*/         commit identity, read natively by git. CI sets these to
+  GIT_COMMITTER_*       dd-octo-sts[bot]; locally git falls back to your config.
   ANTHROPIC_AUTH_TOKEN  AI-gateway bearer token; required for the Phase 5 repair
   ANTHROPIC_BASE_URL    loop. If unset, repair is skipped and red builds draft-PR.
   ARTIFACTS_DIR         where to write logs and the summary (default: ./libdatadog-update)
@@ -408,6 +410,8 @@ def open_pr_or_fallback(
         ["git", "add", "src/native/Cargo.toml", "src/native/Cargo.lock", "setup.py", "releasenotes/notes/"],
         cwd=REPO_ROOT,
     )
+    # git reads the author/committer from GIT_AUTHOR_*/GIT_COMMITTER_* (the CI job
+    # sets these to dd-octo-sts[bot]) or, locally, from the developer's git config.
     run("git-commit", ["git", "commit", "-m", title], cwd=REPO_ROOT)
 
     # In GitLab CI `origin` is the GitLab mirror, not GitHub; the job sets


### PR DESCRIPTION
## Description

Adds an automated workflow that pulls the **latest `main` of [libdatadog](https://github.com/DataDog/libdatadog)** into dd-trace-py, validates the native build, and opens a PR — so we can **benchmark the newest libdatadog against dd-trace-py *before* officially bumping the pinned version**. A libdatadog bump is otherwise a manual chore where breakage and perf impact only surface at bump time; this surfaces both ahead of the official, tagged bump.

### How it works
- **`.gitlab/update-libdatadog.yml`** runs **automatically on every `main` commit** (plus manual + upstream trigger), but a **drift gate** means it only *proceeds* when libdatadog `main` is at least **`LIBDATADOG_MIN_DRIFT` commits ahead** of our pin (default **5**, configurable; an upstream trigger can set `0` to force). A cheap `--check-drift` pre-step skips no-op runs before any heavy setup.
- **`scripts/update-libdatadog.py`** then repoints every libdatadog `rev` in `src/native/Cargo.toml` to the latest `main` SHA, regenerates `Cargo.lock`, syncs `setup.py`'s `RUST_MINIMUM_VERSION`, and validates with `cargo build`/`fmt`/`clippy`/`test`.
  - On API breakage it runs a **bounded Claude repair loop** (via the Datadog AI Gateway) constrained to `src/native` + `setup.py`; out-of-scope edits are reverted before a **deterministic re-validation** the agent can't influence. Avoids large migrations/refactors (it's told to stop and report if the fix isn't mechanical).
  - On success it opens the PR as a **verified commit via the GitHub API**, attributed to `dd-octo-sts[bot]` and GitHub-signed (same mechanism as our `generate-package-versions` PRs) — no local commit, no token in any git remote URL. If repair can't converge, it opens a **draft PR with the diagnosis and fails the job red**.
- **`.gitlab/check-libdatadog-version.yml`** — a lightweight job that reports how many commits behind `main` the current pin is.
- **`.github/chainguard/gitlab.libdatadog-update.create-pr.sts.yaml`** — GitLab-issued octo-sts policy granting the PR-creation token.

### Benchmarks run automatically on the opened PR
The PR this tooling opens goes through dd-trace-py's **normal CI**, which runs the **micro- and macro-benchmarks on every branch** (candidate = the update branch, baseline = `main`). Because `main` still carries the old libdatadog pin and the branch carries the new one (native extension rebuilt), that comparison **is** the perf delta of the libdatadog change — exactly what we want to see before committing to the bump. No extra wiring: opening the PR is sufficient to get it benchmarked.

## Testing

- Ran the `update libdatadog` job end-to-end in CI: latest-`main` resolution, drift gate, `Cargo.toml`/`Cargo.lock` bump, `RUST_MINIMUM_VERSION` sync, and full cargo validation all succeed.
- A real libdatadog `main` API change (a renamed crate + signature changes in `ffe.rs`/`tracer_flare.rs`) was **auto-repaired by the Claude loop and converged**.
- Verified the commit change-set is restricted to `src/native` / `setup.py` / `releasenotes` — CI artifacts and auth files are excluded (allowlist + sensitive-path assertion + auth files kept outside the repo).
- Drift gate verified (proceeds when ≥ threshold behind, skips otherwise); script linted, dry-run, YAML validated.

## Risks

- **Low / opt-in.** Proceeds only past the drift threshold; most `main` commits are a fast no-op. Doesn't touch production code paths.
- PR creation is gated by the new octo-sts policy, which **must be merged to `main` first** (octo-sts reads policies from the default branch); until then the job degrades gracefully and simply skips PR creation.
- AI repair is bounded, scoped to `src/native`+`setup.py`, and every fix is re-validated by deterministic cargo runs the agent can't alter. Any resulting PR is a normal PR that still goes through full CR + CI (incl. benchmarks) before merge.
- Auth hardening: GitHub token + `authanywhere` live outside the repo working tree, the token is never placed in a git remote URL, and it's revoked via the broker at job end.

## Additional Notes

- **Prerequisite:** merge `.github/chainguard/gitlab.libdatadog-update.create-pr.sts.yaml` to `main` before the `update libdatadog` job can mint a token (CODEOWNERS: `@DataDog/python-guild` / `@DataDog/apm-core-python`).
- Tracks libdatadog **`main` HEAD** (a moving target) by design — the goal is to benchmark the bleeding edge ahead of an official, tagged bump.
- Deliberate (deferrable) divergences from the original spec: PRs are **normal (verified) per-rev PRs**, not a single rolling draft PR off a persistent `libdatadog-latest` branch (re-runs on the same rev reuse the existing PR). Can be revisited.
- `changelog/no-changelog`: CI tooling only, no user-facing change.