### PR TITLE
perf(botocore): compile and cache JSONPath redaction expressions

### DIFF
--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ddtrace import config
 from ddtrace._trace.span import Span
-from ddtrace.vendor.jsonpath_ng import parse
+from ddtrace.vendor.jsonpath_ng.parser import JsonPathParser
 
 
 _MAX_TAG_VALUE_LENGTH = 5000
@@ -77,8 +77,9 @@ class AWSPayloadTagging:
         Expands the JSON payload from various AWS services into tags and sets them on the Span.
         """
         if not self.validated:
-            self.request_redaction_paths = self._get_redaction_paths_request()
-            self.response_redaction_paths = self._get_redaction_paths_response()
+            parser = JsonPathParser()  # build LALR parser just once
+            self.request_redaction_paths = [parser.parse(p) for p in self._get_redaction_paths_request(parser)]
+            self.response_redaction_paths = [parser.parse(p) for p in self._get_redaction_paths_response(parser)]
             self.validated = True
 
         if not self.request_redaction_paths and not self.response_redaction_paths:
@@ -107,7 +108,7 @@ class AWSPayloadTagging:
             return True
         return False
 
-    def _validate_json_paths(self, paths: Optional[str]) -> bool:
+    def _validate_json_paths(self, paths: Optional[str], parser: JsonPathParser) -> bool:
         """
         Checks whether paths is "all" or all valid JSONPaths
         """
@@ -124,7 +125,7 @@ class AWSPayloadTagging:
                 if not path.startswith("$"):
                     return False
                 try:
-                    parse(path)
+                    parser.parse(path)
                 except Exception:
                     return False
             else:
@@ -132,16 +133,15 @@ class AWSPayloadTagging:
 
         return True
 
-    def _redact_json(self, data: dict[str, Any], span: Span, paths: list) -> None:
+    def _redact_json(self, data: dict[str, Any], span: Span, expressions: list) -> None:
         """
         Redact sensitive data in the JSON payload based on default and user-provided JSONPath expressions
         """
-        for path in paths:
-            expression = parse(path)
+        for expression in expressions:
             for match in expression.find(data):
                 match.context.value[match.path.fields[0]] = "redacted"
 
-    def _get_redaction_paths_response(self) -> list:
+    def _get_redaction_paths_response(self, parser: JsonPathParser) -> list:
         """
         Get the list of redaction paths, combining defaults with any user-provided JSONPaths.
         """
@@ -149,7 +149,7 @@ class AWSPayloadTagging:
             return []
 
         response_redaction = config.botocore.get("payload_tagging_response")
-        if self._validate_json_paths(response_redaction):
+        if self._validate_json_paths(response_redaction, parser):
             if response_redaction == "all":
                 return self._RESPONSE_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS
             return (
@@ -158,7 +158,7 @@ class AWSPayloadTagging:
 
         return []
 
-    def _get_redaction_paths_request(self) -> list:
+    def _get_redaction_paths_request(self, parser: JsonPathParser) -> list:
         """
         Get the list of redaction paths, combining defaults with any user-provided JSONPaths.
         """
@@ -166,7 +166,7 @@ class AWSPayloadTagging:
             return []
 
         request_redaction = config.botocore.get("payload_tagging_request")
-        if self._validate_json_paths(request_redaction):
+        if self._validate_json_paths(request_redaction, parser):
             if request_redaction == "all":
                 return self._REQUEST_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS
             return (

--- a/releasenotes/notes/botocore-perf-cache-payload-tagging-jsonpath-9837d40fdaa008a6.yaml
+++ b/releasenotes/notes/botocore-perf-cache-payload-tagging-jsonpath-9837d40fdaa008a6.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    botocore: Improves the performance of AWS payload tagging by compiling each
+    JSONPath redaction expression once and reusing it, instead of rebuilding the
+    JSONPath parser and re-parsing every redaction path on each instrumented AWS
+    API call. This reduces CPU overhead when ``DD_TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING``
+    or ``DD_TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING`` is enabled.


### PR DESCRIPTION
## Description

When AWS payload tagging is enabled, the botocore integration recompiled its JSONPath redaction expressions on every instrumented API call. `_redact_json` called `parse(path)` per redaction path, and each `parse()` [constructed a new `jsonpath_ng` `JsonPathParser`](https://github.com/h2non/jsonpath-ng/blob/v1.8.0/jsonpath_ng/parser.py#L15), which [rebuilds the PLY LALR parse table from scratch](https://github.com/h2non/jsonpath-ng/blob/v1.8.0/jsonpath_ng/parser.py#L47-L54) (~5ms of CPU per construction). With the default redaction paths that meant 96 parser builds (and ~0.5s) per S3 operation.

This change compiles each redaction path into a JSONPath expression once, reusing a single parser for all paths. The compiled expressions now get cached on the `AWSPayloadTagging` singleton, behind the existing `validated` guard. Subsequent calls reuse the cached expressions instead of re-parsing. This reduces the cost of building the JsonPathParser for each of the parse calls that do need to happen, and it eliminates the need to re-parse each of the paths on every instrumented call.

## Testing

The existing botocore payload-tagging snapshot tests (`tests/contrib/botocore/test.py::BotocoreTest::test_aws_payload_tagging_*`) pass unchanged: 8 passed, 2 skipped on the `botocore==1.34.49` venv.

### Performance measurement

<details>
<summary>Before/after cProfile output</summary>

Profiled 10 `get_object` calls against a public bucket with payload tagging on:

```python
import cProfile, pstats
import boto3
from botocore import UNSIGNED
from botocore.config import Config

s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
with cProfile.Profile() as pr:
    for _ in range(10):
        s3.get_object(Bucket="elevation-tiles-prod", Key="index.html")
pstats.Stats(pr).sort_stats(pstats.SortKey.CUMULATIVE).print_stats("jsonpath_ng/parser.py")
```

Run with `DD_TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING=all DD_TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING=all ddtrace-run python s3_perf_test.py`.

**Before** (parser rebuilt per path, per call):
```
         18513797 function calls (18319760 primitive calls) in 12.003 seconds

   Ordered by: cumulative time
   List reduced from 1443 to 16 due to restriction <'jsonpath_ng/parser.py'>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      960    0.001    0.000    4.931    0.005 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:14(parse)
      960    0.018    0.000    4.566    0.005 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:25(__init__)
      960    0.001    0.000    0.363    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:56(parse)
      960    0.001    0.000    0.362    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:60(parse_token_stream)
     8320    0.002    0.000    0.319    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:188(token)
     2600    0.002    0.000    0.005    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:80(p_jsonpath_binop)
     2600    0.001    0.000    0.003    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:146(p_fields_or_any)
     2600    0.002    0.000    0.003    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:99(p_jsonpath_fields)
     2520    0.001    0.000    0.002    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:154(p_fields_id)
        1    0.000    0.000    0.002    0.002 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:1(<module>)
      960    0.000    0.000    0.001    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:113(p_jsonpath_root)
      400    0.000    0.000    0.001    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:137(p_jsonpath_child_slicebrackets)
      400    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:166(p_slice_any)
      960    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:185(__init__)
        1    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:18(JsonPathParser)
        1    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:184(IteratorToTokenStream)
```

**After** (parser built once, expressions cached):
```
         330577 function calls (312032 primitive calls) in 7.313 seconds

   Ordered by: cumulative time
   List reduced from 1457 to 15 due to restriction <'jsonpath_ng/parser.py'>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       48    0.000    0.000    0.017    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:56(parse)
       48    0.000    0.000    0.017    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:60(parse_token_stream)
      416    0.000    0.000    0.015    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:188(token)
        1    0.000    0.000    0.005    0.005 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:25(__init__)
        1    0.000    0.000    0.001    0.001 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:1(<module>)
      130    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:80(p_jsonpath_binop)
      130    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:146(p_fields_or_any)
      130    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:99(p_jsonpath_fields)
      126    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:154(p_fields_id)
       20    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:137(p_jsonpath_child_slicebrackets)
       48    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:113(p_jsonpath_root)
       20    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:166(p_slice_any)
       48    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:185(__init__)
        1    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:18(JsonPathParser)
        1    0.000    0.000    0.000    0.000 /.../dd-trace-py/ddtrace/vendor/jsonpath_ng/parser.py:184(IteratorToTokenStream)
```
Note the reduction in:
- Total function calls (from 18,513,797 to 330,577)
- `JsonPathParser.__init__`
  - Number of calls down from 960 to 1
  - Cumulative time down from 4.566s to 0.005s
- `JsonPathParser.parse`
  - Number of calls down from 960 to 48
  - Cumulative time down from 0.363s to 0.017s

</details>

## Risks

Preserves behavior. Only removes redundant work.

Thread-safety: PLY's `LRParser` is stateful and not thread-safe. To avoid problems with this, the parser is a local built under the existing `validated` guard, not a shared/persisted instance. Concurrent first-calls each get their own parser rather than sharing, meaning the worst-case scenario is redundant one-time work. The cached expression objects are read-only during `.find()`, so they're safe to share across threads thereafter.

## Additional Notes

Note that this performance enhancement should also improve other instrumented AWS calls, but I noticed it because of and tested it with `S3.getObject`.
