### PR TITLE
ci: bump `fuzz_infra` timeout

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -10,7 +10,7 @@ fuzz_infra:
   image: registry.ddbuild.io/images/docker:27.3.1
   tags: ["arch:amd64"]
   stage: fuzz
-  timeout: 30m
+  timeout: 45m
   allow_failure: true
   id_tokens:
     DDSIGN_ID_TOKEN:


### PR DESCRIPTION
## Description

The jobs seem to keep failing (timing out) for random reasons. Since I don't currently have neither the time (nor the desire, really) to dig deeper into why, I'll start with bumping the timeout. 