### PR TITLE
feat(profiling): add off-cpu cause label to stack profiler samples

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
@@ -59,7 +59,8 @@ intern_string(std::string_view s);
     X(trace_type, "trace type")                                                                                        \
     X(class_name, "class name")                                                                                        \
     X(lock_name, "lock name")                                                                                          \
-    X(gpu_device_name, "gpu device name")
+    X(gpu_device_name, "gpu device name")                                                                              \
+    X(off_cpu_cause, "off cpu cause")
 
 #define X_ENUM(a, b) a,
 #define X_STR(a, b) b,

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -60,6 +60,8 @@ struct ThreadState
     int64_t now_time_ns = 0;
     bool has_cpu_time = false;
     bool task_on_cpu = true;
+    // Leaf frame name (first frame rendered), used to classify off-CPU cause.
+    std::string top_frame_name;
 };
 
 class StackRenderer

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -123,10 +123,14 @@ StackRenderer::render_frame(Frame& frame)
 
     const auto& string_table = Sampler::get().get_echion().string_table();
 
+    // For the leaf frame, capture the name for off-CPU cause classification.  Reuse the lookup
+    // result below to avoid a second string-table lookup on the same key.
+    std::optional<std::string_view> leaf_name_str;
     if (thread_state.top_frame_name.empty()) {
         auto maybe_top_name = string_table.lookup(frame.name);
         if (maybe_top_name) {
-            thread_state.top_frame_name = std::string(maybe_top_name->get());
+            leaf_name_str = maybe_top_name->get();
+            thread_state.top_frame_name = std::string(*leaf_name_str);
         }
     }
 
@@ -136,11 +140,11 @@ StackRenderer::render_frame(Frame& frame)
     auto maybe_name_id = string_id_cache.find(frame.name);
     if (maybe_name_id == string_id_cache.end()) {
         std::string_view name_str;
-        auto maybe_name_str = string_table.lookup(frame.name);
-        if (maybe_name_str) {
-            name_str = maybe_name_str->get();
+        if (leaf_name_str) {
+            name_str = *leaf_name_str; // reuse the lookup result from the top-frame capture above
         } else {
-            name_str = missing_name;
+            auto maybe_name_str = string_table.lookup(frame.name);
+            name_str = maybe_name_str ? maybe_name_str->get() : missing_name;
         }
 
         auto maybe_interned_name_id = Datadog::intern_string(name_str);

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -45,6 +45,7 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
     thread_state.cpu_time_ns = 0;
     thread_state.has_cpu_time = false;
     thread_state.task_on_cpu = true;
+    thread_state.top_frame_name.clear();
 
     // Finalize the thread information we have
     sample->push_threadinfo(static_cast<int64_t>(thread_id), static_cast<int64_t>(native_id), name);
@@ -101,6 +102,7 @@ StackRenderer::render_task_begin(std::string_view task_name, bool on_cpu)
 
     sample->push_task_name(task_name);
     thread_state.task_on_cpu = on_cpu;
+    thread_state.top_frame_name.clear();
 }
 
 void
@@ -120,6 +122,13 @@ StackRenderer::render_frame(Frame& frame)
     static constexpr std::string_view missing_name = "<unknown function>";
 
     const auto& string_table = Sampler::get().get_echion().string_table();
+
+    if (thread_state.top_frame_name.empty()) {
+        auto maybe_top_name = string_table.lookup(frame.name);
+        if (maybe_top_name) {
+            thread_state.top_frame_name = std::string(maybe_top_name->get());
+        }
+    }
 
     auto line = frame.line;
 
@@ -188,6 +197,10 @@ StackRenderer::render_native_frame(const std::string& name, const std::string& m
         return;
     }
 
+    if (thread_state.top_frame_name.empty()) {
+        thread_state.top_frame_name = name;
+    }
+
     auto maybe_name_id = Datadog::intern_string(name);
     if (!maybe_name_id) {
         return;
@@ -233,6 +246,24 @@ StackRenderer::render_cpu_time(microsecond_t cpu_time_us)
     sample->push_cputime(thread_state.cpu_time_ns, 1);
 }
 
+// Classify the off-CPU cause from the leaf Python or native frame name.
+// Matches Python-level blocking patterns only; OS-level causes (preemption,
+// page faults) are indistinguishable here and fall through to "other".
+static std::string_view
+classify_offcpu_cause(std::string_view frame_name)
+{
+    if (frame_name.find("sleep") != std::string_view::npos) {
+        return "sleep";
+    }
+    if (frame_name.find("acquire") != std::string_view::npos || frame_name.find("wait") != std::string_view::npos) {
+        return "lock";
+    }
+    if (frame_name.find("recv") != std::string_view::npos || frame_name.find("send") != std::string_view::npos) {
+        return "io";
+    }
+    return "other";
+}
+
 void
 StackRenderer::render_stack_end()
 {
@@ -249,12 +280,16 @@ StackRenderer::render_stack_end()
             const int64_t off_cpu_ns = thread_state.wall_time_ns > thread_state.cpu_time_ns
                                          ? thread_state.wall_time_ns - thread_state.cpu_time_ns
                                          : 0; // clamp to 0 for clock skew between the two clocks
-            sample->push_offcputime(off_cpu_ns, 1);
+            if (sample->push_offcputime(off_cpu_ns, 1) && off_cpu_ns > 0) {
+                sample->push_label(ExportLabelKey::off_cpu_cause, classify_offcpu_cause(thread_state.top_frame_name));
+            }
         }
     } else {
         // Suspended task (asyncio/greenlet not currently scheduled): was off-CPU for the full
         // sampling interval.  This is exact — no CPU time measurement required.
-        sample->push_offcputime(thread_state.wall_time_ns, 1);
+        if (sample->push_offcputime(thread_state.wall_time_ns, 1)) {
+            sample->push_label(ExportLabelKey::off_cpu_cause, classify_offcpu_cause(thread_state.top_frame_name));
+        }
     }
 
     sample->flush_sample();

--- a/releasenotes/notes/profiling-offcpu-cause-label-a3b2c1d4e5f6a7b8.yaml
+++ b/releasenotes/notes/profiling-offcpu-cause-label-a3b2c1d4e5f6a7b8.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Profiling: When off-CPU time collection is enabled
+    (``_DD_PROFILING_STACK_OFFCPU_TIME_ENABLED=true``), each stack sample with
+    non-zero off-CPU time now carries an ``off cpu cause`` pprof label classifying
+    the likely reason the thread was blocked:
+
+    - ``sleep`` — explicit sleep call (``time.sleep``, ``asyncio.sleep``)
+    - ``lock``  — lock or event wait (``threading.Lock.acquire``,
+      ``asyncio.Lock.acquire``, ``threading.Event.wait``, etc.)
+    - ``io``    — blocking socket I/O (``socket.recv``, ``socket.send``)
+    - ``other`` — off-CPU time observed but cause not identifiable from the
+      Python frame (includes OS preemption and C-extension blocking)
+
+    The label is inferred from the leaf Python or native frame name and is
+    intended for backend aggregation and filtering, not as a precise kernel-level
+    attribution.

--- a/scripts/demo_offcpu_approximation.py
+++ b/scripts/demo_offcpu_approximation.py
@@ -15,7 +15,7 @@ Writes a pprof profile, then prints:
 Usage:
     python scripts/demo_offcpu_approximation.py [--duration SECS]
 
-Requires: DD_PROFILING_STACK_V2_OFFCPU_TIME_ENABLED=true OR the script sets
+Requires: _DD_PROFILING_STACK_OFFCPU_TIME_ENABLED=true OR the script sets
 it internally via ddup.config(offcpu_time_enabled=True).
 """
 

--- a/scripts/demo_offcpu_approximation.py
+++ b/scripts/demo_offcpu_approximation.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+Demo: off-CPU time approximation in dd-trace-py stack v2 profiler.
+
+Three threads run for ~2 seconds, each with a distinct blocking pattern:
+  - sleeper-thread:       time.sleep loops          → cause: sleep
+  - lock-waiter-thread:   blocked on a held lock    → cause: lock
+  - spinner-thread:       busy loop                 → mostly on-CPU
+
+Writes a pprof profile, then prints:
+  1. Per-thread wall / cpu / off-cpu totals
+  2. Off-cpu cause breakdown (sleep / lock / io / other)
+  3. Top off-CPU call stacks per thread
+
+Usage:
+    python scripts/demo_offcpu_approximation.py [--duration SECS]
+
+Requires: DD_PROFILING_STACK_V2_OFFCPU_TIME_ENABLED=true OR the script sets
+it internally via ddup.config(offcpu_time_enabled=True).
+"""
+
+import argparse
+from collections import defaultdict
+import os
+import queue
+import socket
+import sys
+import tempfile
+import threading
+import time
+from typing import Any
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.profiling.collector import stack
+
+
+WALL_TYPE = "wall-time"
+CPU_TYPE = "cpu-time"
+OFF_CPU_TYPE = "off-cpu-time"
+OFF_CPU_CAUSE_LABEL = "off cpu cause"
+THREAD_NAME_LABEL = "thread name"
+
+CAUSES = ["sleep", "lock", "io", "other"]
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_CYAN = "\033[36m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_DIM = "\033[2m"
+
+
+def _h(text: str) -> str:
+    return f"{_BOLD}{_CYAN}{text}{_RESET}"
+
+
+def _g(text: str) -> str:
+    return f"{_GREEN}{text}{_RESET}"
+
+
+def _y(text: str) -> str:
+    return f"{_YELLOW}{text}{_RESET}"
+
+
+def _ns_to_ms(ns: int) -> float:
+    return ns / 1_000_000
+
+
+def _rule(width: int = 80) -> str:
+    return "─" * width
+
+
+def _section(title: str, width: int = 80) -> None:
+    print()
+    print(_h(f"{'─── ' + title + ' ':─<{width}}"))
+
+
+# ---------------------------------------------------------------------------
+# Workloads
+# ---------------------------------------------------------------------------
+
+
+def sleeper(duration: float) -> None:
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        time.sleep(0.05)
+
+
+def lock_waiter(lock: threading.Lock, duration: float) -> None:
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        lock.acquire()
+        lock.release()
+
+
+def event_waiter(duration: float) -> None:
+    event = threading.Event()
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        remaining = end - time.monotonic()
+        event.wait(timeout=min(0.05, max(0.0, remaining)))
+
+
+def queue_waiter(duration: float) -> None:
+    q: queue.Queue[object] = queue.Queue()
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        remaining = end - time.monotonic()
+        try:
+            q.get(timeout=min(0.05, max(0.0, remaining)))
+        except queue.Empty:
+            pass
+
+
+def io_waiter(duration: float) -> None:
+    r, w = socket.socketpair()
+    try:
+        end = time.monotonic() + duration
+        while time.monotonic() < end:
+            remaining = end - time.monotonic()
+            if remaining <= 0:
+                break
+            r.settimeout(min(0.05, remaining))
+            try:
+                r.recv(1024)
+            except (TimeoutError, OSError):
+                pass
+    finally:
+        r.close()
+        w.close()
+
+
+def spinner(duration: float) -> None:
+    end = time.monotonic() + duration
+    x = 0
+    while time.monotonic() < end:
+        x = (x + 1) & 0xFFFF
+
+
+def cpu_fibonacci(duration: float) -> None:
+    """Pure-Python Fibonacci accumulation — fully on-CPU, visible Python frames."""
+    end = time.monotonic() + duration
+    a, b = 0, 1
+    while time.monotonic() < end:
+        a, b = b, (a + b) % (2**31)
+
+
+def cpu_hash(duration: float) -> None:
+    """SHA-256 in a tight loop — on-CPU via C extension, shows hashlib frame."""
+    import hashlib  # noqa: PLC0415
+
+    data = b"offcpu-demo-payload" * 64
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        hashlib.sha256(data).digest()
+
+
+# ---------------------------------------------------------------------------
+# pprof helpers
+# ---------------------------------------------------------------------------
+
+
+def _label(string_table: Any, sample: Any, key: str) -> Any:
+    for lbl in sample.label:
+        if string_table[lbl.key] == key:
+            return lbl
+    return None
+
+
+def _stack_frames(profile: Any, sample: Any, max_frames: int = 5) -> list[tuple[str, str]]:
+    """Return [(function_name, filename), ...] leaf-first, up to max_frames."""
+    frames: list[tuple[str, str]] = []
+    func_by_id = {f.id: f for f in profile.function}
+    for loc_id in sample.location_id:
+        loc = next((loc_ for loc_ in profile.location if loc_.id == loc_id), None)
+        if loc is None:
+            continue
+        for line in loc.line:
+            func = func_by_id.get(line.function_id)
+            if func is None:
+                continue
+            name = profile.string_table[func.name]
+            filename = os.path.basename(profile.string_table[func.filename])
+            frames.append((name, filename))
+            if len(frames) >= max_frames:
+                return frames
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration", type=float, default=2.0, metavar="SECS")
+    args = parser.parse_args()
+    duration = args.duration
+
+    if not ddup.is_available:
+        raise SystemExit("ddup native extension not available — build first")
+
+    pprof_prefix = os.path.join(tempfile.gettempdir(), "offcpu_demo")
+
+    ddup.config(
+        env="demo",
+        service="offcpu-demo",
+        version="rnd-week",
+        output_filename=pprof_prefix,
+        offcpu_time_enabled=True,
+    )
+    ddup.start()
+    ddup.upload()
+
+    held_lock = threading.Lock()
+    held_lock.acquire()  # keep held so lock_waiter blocks
+
+    t_sleep = threading.Thread(target=sleeper, args=(duration,), name="sleeper-thread")
+    t_lock = threading.Thread(target=lock_waiter, args=(held_lock, duration), name="lock-waiter-thread")
+    t_event = threading.Thread(target=event_waiter, args=(duration,), name="event-waiter-thread")
+    t_queue = threading.Thread(target=queue_waiter, args=(duration,), name="queue-waiter-thread")
+    t_io = threading.Thread(target=io_waiter, args=(duration,), name="io-waiter-thread")
+    t_spin = threading.Thread(target=spinner, args=(duration,), name="spinner-thread")
+    t_fib = threading.Thread(target=cpu_fibonacci, args=(duration,), name="cpu-fibonacci-thread")
+    t_hash = threading.Thread(target=cpu_hash, args=(duration,), name="cpu-hash-thread")
+
+    print(
+        f"Profiling {duration:.1f}s  •  8 threads: "
+        "sleeper / lock-waiter / event-waiter / queue-waiter / io-waiter / "
+        "spinner / cpu-fibonacci / cpu-hash"
+    )
+    with stack.StackCollector():
+        t_sleep.start()
+        t_lock.start()
+        t_event.start()
+        t_queue.start()
+        t_io.start()
+        t_spin.start()
+        t_fib.start()
+        t_hash.start()
+        time.sleep(duration)
+        held_lock.release()
+        t_sleep.join()
+        t_lock.join()
+        t_event.join()
+        t_queue.join()
+        t_io.join()
+        t_spin.join()
+        t_fib.join()
+        t_hash.join()
+
+    ddup.upload()
+
+    # --- parse ---
+    output_filename = pprof_prefix + "." + str(os.getpid())
+    tests_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tests")
+    sys.path.insert(0, tests_dir)
+    from profiling.collector import pprof_utils  # noqa: PLC0415
+
+    profile = pprof_utils.parse_newest_profile(output_filename, assert_samples=False)
+    st = profile.string_table
+
+    def type_idx(name: str) -> int | None:
+        try:
+            return int(pprof_utils.get_sample_type_index(profile, name))
+        except StopIteration:
+            return None
+
+    wall_idx = type_idx(WALL_TYPE)
+    cpu_idx = type_idx(CPU_TYPE)
+    off_cpu_idx = type_idx(OFF_CPU_TYPE)
+
+    has_offcpu = off_cpu_idx is not None
+    has_cause = has_offcpu and any(_label(st, s, OFF_CPU_CAUSE_LABEL) for s in profile.sample)
+
+    # accumulate per-thread totals and cause breakdown
+    totals: dict[str, dict[str, int]] = {}
+    cause_totals: dict[str, dict[str, int]] = {}
+    # heaviest off-CPU sample per thread (for stack display)
+    heaviest: dict[str, tuple[int, object]] = {}  # thread_name → (off_cpu_ns, sample)
+
+    for sample in profile.sample:
+        lbl = _label(st, sample, THREAD_NAME_LABEL)
+        if lbl is None:
+            continue
+        tname = st[lbl.str]
+
+        if tname not in totals:
+            totals[tname] = {"wall": 0, "cpu": 0, "off_cpu": 0}
+            cause_totals[tname] = defaultdict(int)
+
+        if wall_idx is not None:
+            totals[tname]["wall"] += sample.value[wall_idx]
+        if cpu_idx is not None:
+            totals[tname]["cpu"] += sample.value[cpu_idx]
+
+        off_ns = sample.value[off_cpu_idx] if has_offcpu else 0
+        totals[tname]["off_cpu"] += off_ns
+
+        if has_cause and off_ns > 0:
+            cause_lbl = _label(st, sample, OFF_CPU_CAUSE_LABEL)
+            cause = st[cause_lbl.str] if cause_lbl else "other"
+            cause_totals[tname][cause] += off_ns
+            cur_best, _ = heaviest.get(tname, (0, None))
+            if off_ns > cur_best:
+                heaviest[tname] = (off_ns, sample)
+
+    # ── 1. Time summary ─────────────────────────────────────────────────────
+    _section("Time summary")
+    col = 22
+    print(f"{'Thread':<{col}}  {'wall (ms)':>12}  {'cpu (ms)':>12}  {'off-cpu (ms)':>14}  {'off-cpu %':>10}")
+    print(_rule())
+    for tname in sorted(totals):
+        d = totals[tname]
+        wall_ms = _ns_to_ms(d["wall"])
+        cpu_ms = _ns_to_ms(d["cpu"])
+        off_ms = _ns_to_ms(d["off_cpu"])
+        pct = (off_ms / wall_ms * 100) if wall_ms > 0 else 0.0
+        pct_str = _g(f"{pct:>9.1f}%") if pct > 80 else f"{pct:>9.1f}%"
+        print(f"{tname:<{col}}  {wall_ms:>12.1f}  {cpu_ms:>12.1f}  {off_ms:>14.1f}  {pct_str}")
+
+    if not has_offcpu:
+        print()
+        print(_y("  Off-CPU collection disabled — rebuild with offcpu_time_enabled=True"))
+        return
+
+    # ── 2. Cause breakdown ──────────────────────────────────────────────────
+    if has_cause:
+        _section("Off-CPU cause breakdown")
+        header = f"{'Thread':<{col}}" + "".join(f"  {c:>14}" for c in CAUSES)
+        print(header)
+        print(_rule())
+        for tname in sorted(cause_totals):
+            row = f"{tname:<{col}}"
+            for cause in CAUSES:
+                ms = _ns_to_ms(cause_totals[tname].get(cause, 0))
+                cell = f"{ms:>13.1f}ms"
+                row += "  " + (_g(cell) if ms > 100 else _DIM + cell + _RESET)
+            print(row)
+    else:
+        print()
+        print(_y("  'off cpu cause' label not present — rebuild from vlad/profiling-offcpu-cause-label"))
+
+    # ── 3. Top off-CPU stacks ───────────────────────────────────────────────
+    _section("Top off-CPU stacks  (heaviest single sample per thread)")
+    for tname in sorted(heaviest):
+        off_ns, sample = heaviest[tname]
+        cause_lbl = _label(st, sample, OFF_CPU_CAUSE_LABEL)
+        cause = st[cause_lbl.str] if cause_lbl else "?"
+        frames = _stack_frames(profile, sample, max_frames=6)
+        print()
+        print(f"  {_bold_thread(tname)}  cause={_g(cause)}  {_ns_to_ms(off_ns):.1f} ms")
+        if frames:
+            for i, (fname, ffile) in enumerate(frames):
+                prefix = "  └─ " if i == len(frames) - 1 else "  ├─ "
+                print(f"    {prefix}{fname:<40} {_DIM}{ffile}{_RESET}")
+        else:
+            print("    (no frames captured)")
+    print()
+
+
+def _bold_thread(name: str) -> str:
+    return f"{_BOLD}[{name}]{_RESET}"
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1392,13 +1392,24 @@ def test_off_cpu_lower_for_cpu_bound_thread() -> None:
     )
 
 
-_OFF_CPU_CAUSE_LABEL = "off cpu cause"
-
-
-def test_off_cpu_cause_sleep(tmp_path: Path) -> None:
+# Use subprocess as ddup config persists across tests.
+@pytest.mark.subprocess
+def test_off_cpu_cause_sleep() -> None:
     """Samples from a sleeping thread should be tagged with cause='sleep'."""
+    import os
+    import time
+
+    import pytest
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+
+    _OFF_CPU_TYPE = "off-cpu-time"
+    _OFF_CPU_CAUSE_LABEL = "off cpu cause"
+
     test_name = "test_off_cpu_cause_sleep"
-    pprof_prefix = str(tmp_path / test_name)
+    pprof_prefix = "/tmp/" + test_name
     output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
@@ -1416,9 +1427,8 @@ def test_off_cpu_cause_sleep(tmp_path: Path) -> None:
     ddup.upload()
 
     profile = pprof_utils.parse_newest_profile(output_filename)
-    assert _OFF_CPU_TYPE in _available_sample_types(profile), (
-        f"off-cpu sample type '{_OFF_CPU_TYPE}' not found; available: {_available_sample_types(profile)}"
-    )
+    available = [profile.string_table[st.type] for st in profile.sample_type]
+    assert _OFF_CPU_TYPE in available, f"off-cpu sample type not found; available: {available}"
 
     off_cpu_samples = pprof_utils.get_samples_with_value_type(profile, _OFF_CPU_TYPE)
     if len(off_cpu_samples) == 0:
@@ -1437,10 +1447,25 @@ def test_off_cpu_cause_sleep(tmp_path: Path) -> None:
     assert "sleep" in causes, f"expected 'sleep' cause for sleeping thread, got: {causes}"
 
 
-def test_off_cpu_cause_lock(tmp_path: Path) -> None:
+# Use subprocess as ddup config persists across tests.
+@pytest.mark.subprocess
+def test_off_cpu_cause_lock() -> None:
     """Samples from a thread blocked on a lock should be tagged with cause='lock'."""
+    import os
+    import threading
+    import time
+
+    import pytest
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+
+    _OFF_CPU_TYPE = "off-cpu-time"
+    _OFF_CPU_CAUSE_LABEL = "off cpu cause"
+
     test_name = "test_off_cpu_cause_lock"
-    pprof_prefix = str(tmp_path / test_name)
+    pprof_prefix = "/tmp/" + test_name
     output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
@@ -1467,22 +1492,106 @@ def test_off_cpu_cause_lock(tmp_path: Path) -> None:
     ddup.upload()
 
     profile = pprof_utils.parse_newest_profile(output_filename)
-    assert _OFF_CPU_TYPE in _available_sample_types(profile), (
-        f"off-cpu sample type '{_OFF_CPU_TYPE}' not found; available: {_available_sample_types(profile)}"
-    )
+    available = [profile.string_table[st.type] for st in profile.sample_type]
+    assert _OFF_CPU_TYPE in available, f"off-cpu sample type not found; available: {available}"
 
     off_cpu_samples = pprof_utils.get_samples_with_value_type(profile, _OFF_CPU_TYPE)
-    if len(off_cpu_samples) == 0:
-        pytest.skip("No off-cpu samples collected; CPU time measurement may be unavailable on this platform")
-
     labeled = pprof_utils.get_samples_with_label_key(profile, _OFF_CPU_CAUSE_LABEL)
     labeled_offcpu = [s for s in labeled if s in off_cpu_samples]
-    assert len(labeled_offcpu) > 0, "off-cpu samples should have an 'off cpu cause' label"
+
+    # Filter to lock-thread only: samples from other threads (e.g. main thread sleeping) have
+    # unrelated causes and would hide a missing lock-thread signal.
+    lock_thread_samples = [
+        s
+        for s in labeled_offcpu
+        if any(
+            profile.string_table[lbl.key] == "thread name" and profile.string_table[lbl.str] == "lock-thread"
+            for lbl in s.label
+        )
+    ]
+    if len(lock_thread_samples) == 0:
+        pytest.skip("No off-cpu samples collected for lock-thread; CPU time measurement may be unavailable")
 
     causes = {
         profile.string_table[
             pprof_utils.get_label_with_key(profile.string_table, s, _OFF_CPU_CAUSE_LABEL).str  # type: ignore[union-attr]  # noqa: E501
         ]
-        for s in labeled_offcpu
+        for s in lock_thread_samples
     }
     assert "lock" in causes, f"expected 'lock' cause for lock-waiting thread, got: {causes}"
+
+
+# Use subprocess as ddup config persists across tests.
+@pytest.mark.subprocess
+def test_off_cpu_cause_io() -> None:
+    """Samples from a thread blocked on socket recv should be tagged with cause='io'."""
+    import os
+    import socket
+    import threading
+    import time
+
+    import pytest
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+
+    _OFF_CPU_TYPE = "off-cpu-time"
+    _OFF_CPU_CAUSE_LABEL = "off cpu cause"
+
+    test_name = "test_off_cpu_cause_io"
+    pprof_prefix = "/tmp/" + test_name
+    output_filename = pprof_prefix + "." + str(os.getpid())
+
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="test", output_filename=pprof_prefix, offcpu_time_enabled=True)
+    ddup.start()
+    ddup.upload()
+
+    r, w = socket.socketpair()
+
+    def io_waiter() -> None:
+        r.settimeout(0.5)
+        try:
+            r.recv(1024)
+        except (TimeoutError, OSError):
+            pass
+
+    io_thread = threading.Thread(target=io_waiter, name="io-thread")
+
+    with stack.StackCollector():
+        io_thread.start()
+        time.sleep(0.3)
+        io_thread.join()
+
+    ddup.upload()
+    r.close()
+    w.close()
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    available = [profile.string_table[st.type] for st in profile.sample_type]
+    assert _OFF_CPU_TYPE in available, f"off-cpu sample type not found; available: {available}"
+
+    off_cpu_samples = pprof_utils.get_samples_with_value_type(profile, _OFF_CPU_TYPE)
+    labeled = pprof_utils.get_samples_with_label_key(profile, _OFF_CPU_CAUSE_LABEL)
+    labeled_offcpu = [s for s in labeled if s in off_cpu_samples]
+
+    # Filter to io-thread only to avoid interference from other threads.
+    io_thread_samples = [
+        s
+        for s in labeled_offcpu
+        if any(
+            profile.string_table[lbl.key] == "thread name" and profile.string_table[lbl.str] == "io-thread"
+            for lbl in s.label
+        )
+    ]
+    if len(io_thread_samples) == 0:
+        pytest.skip("No off-cpu samples collected for io-thread; CPU time measurement may be unavailable")
+
+    causes = {
+        profile.string_table[
+            pprof_utils.get_label_with_key(profile.string_table, s, _OFF_CPU_CAUSE_LABEL).str  # type: ignore[union-attr]  # noqa: E501
+        ]
+        for s in io_thread_samples
+    }
+    assert "io" in causes, f"expected 'io' cause for socket recv thread, got: {causes}"

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1390,3 +1390,99 @@ def test_off_cpu_lower_for_cpu_bound_thread() -> None:
     assert sleeping_off_cpu > cpu_bound_off_cpu * 2, (
         f"sleeper off-cpu ({sleeping_off_cpu}ns) should greatly exceed cpu-bound off-cpu ({cpu_bound_off_cpu}ns)"
     )
+
+
+_OFF_CPU_CAUSE_LABEL = "off cpu cause"
+
+
+def test_off_cpu_cause_sleep(tmp_path: Path) -> None:
+    """Samples from a sleeping thread should be tagged with cause='sleep'."""
+    test_name = "test_off_cpu_cause_sleep"
+    pprof_prefix = str(tmp_path / test_name)
+    output_filename = pprof_prefix + "." + str(os.getpid())
+
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="test", output_filename=pprof_prefix, offcpu_time_enabled=True)
+    ddup.start()
+    ddup.upload()
+
+    def sleeper() -> None:
+        for _ in range(10):
+            time.sleep(0.05)
+
+    with stack.StackCollector():
+        sleeper()
+
+    ddup.upload()
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    assert _OFF_CPU_TYPE in _available_sample_types(profile), (
+        f"off-cpu sample type '{_OFF_CPU_TYPE}' not found; available: {_available_sample_types(profile)}"
+    )
+
+    off_cpu_samples = pprof_utils.get_samples_with_value_type(profile, _OFF_CPU_TYPE)
+    if len(off_cpu_samples) == 0:
+        pytest.skip("No off-cpu samples collected; CPU time measurement may be unavailable on this platform")
+
+    labeled = pprof_utils.get_samples_with_label_key(profile, _OFF_CPU_CAUSE_LABEL)
+    labeled_offcpu = [s for s in labeled if s in off_cpu_samples]
+    assert len(labeled_offcpu) > 0, "off-cpu samples should have an 'off cpu cause' label"
+
+    causes = {
+        profile.string_table[
+            pprof_utils.get_label_with_key(profile.string_table, s, _OFF_CPU_CAUSE_LABEL).str  # type: ignore[union-attr]  # noqa: E501
+        ]
+        for s in labeled_offcpu
+    }
+    assert "sleep" in causes, f"expected 'sleep' cause for sleeping thread, got: {causes}"
+
+
+def test_off_cpu_cause_lock(tmp_path: Path) -> None:
+    """Samples from a thread blocked on a lock should be tagged with cause='lock'."""
+    test_name = "test_off_cpu_cause_lock"
+    pprof_prefix = str(tmp_path / test_name)
+    output_filename = pprof_prefix + "." + str(os.getpid())
+
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="test", output_filename=pprof_prefix, offcpu_time_enabled=True)
+    ddup.start()
+    ddup.upload()
+
+    lock = threading.Lock()
+    lock.acquire()
+
+    def lock_waiter() -> None:
+        for _ in range(5):
+            lock.acquire()
+            lock.release()
+
+    lock_thread = threading.Thread(target=lock_waiter, name="lock-thread")
+
+    with stack.StackCollector():
+        lock_thread.start()
+        time.sleep(0.3)
+        lock.release()
+        lock_thread.join()
+
+    ddup.upload()
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    assert _OFF_CPU_TYPE in _available_sample_types(profile), (
+        f"off-cpu sample type '{_OFF_CPU_TYPE}' not found; available: {_available_sample_types(profile)}"
+    )
+
+    off_cpu_samples = pprof_utils.get_samples_with_value_type(profile, _OFF_CPU_TYPE)
+    if len(off_cpu_samples) == 0:
+        pytest.skip("No off-cpu samples collected; CPU time measurement may be unavailable on this platform")
+
+    labeled = pprof_utils.get_samples_with_label_key(profile, _OFF_CPU_CAUSE_LABEL)
+    labeled_offcpu = [s for s in labeled if s in off_cpu_samples]
+    assert len(labeled_offcpu) > 0, "off-cpu samples should have an 'off cpu cause' label"
+
+    causes = {
+        profile.string_table[
+            pprof_utils.get_label_with_key(profile.string_table, s, _OFF_CPU_CAUSE_LABEL).str  # type: ignore[union-attr]  # noqa: E501
+        ]
+        for s in labeled_offcpu
+    }
+    assert "lock" in causes, f"expected 'lock' cause for lock-waiting thread, got: {causes}"


### PR DESCRIPTION
[<< Prev PR](https://github.com/DataDog/dd-trace-py/pull/18623)

## Summary

Follow-up to #18623 (off-CPU time approximation). Adds an `off cpu cause` pprof label to each stack sample that has non-zero off-CPU time, classifying the likely reason a thread was blocked.

- `sleep` — explicit sleep (`time.sleep`, `asyncio.sleep`)
- `lock` — lock/semaphore/event wait (`threading.Lock.acquire`, `asyncio.Lock.acquire`, `threading.Event.wait`, etc.)
- `io` — blocking socket I/O (`socket.recv`, `socket.send`)
- `other` — off-CPU observed but cause not identifiable from the Python frame (OS preemption, C-extension blocking)

### How it works

The leaf frame (first frame rendered by echion, which is the frame where the thread is currently blocked) is captured in `ThreadState.top_frame_name` during `render_frame()` / `render_native_frame()`. At `render_stack_end()`, the name is matched against keyword patterns to produce the cause string, then emitted as a pprof label alongside the off-CPU value.

The label is only emitted when:
1. Off-CPU collection is enabled (`_DD_PROFILING_STACK_OFFCPU_TIME_ENABLED=true`)
2. `off_cpu_ns > 0` for the sample

### Limitations (documented in release note)

OS-level causes (involuntary preemption, page faults, futex contention) are indistinguishable from Python frame inspection alone — those fall through to `"other"`. True kernel-level attribution requires eBPF (`sched_switch`). The label is a Python-semantic approximation intended for backend aggregation and UI filtering.

## Testing
* `demo_offcpu_approximation.py` [demo script](https://github.com/DataDog/dd-trace-py/compare/vlad/profiling-offcpu-cause-label...vlad/profiling-offcpu-demo?expand=1)

```
$ .riot/venv_py31211_deps/bin/python scripts/demo_offcpu_approximation.py --duration 5
Profiling 5.0s  •  8 threads: sleeper / lock-waiter / event-waiter / queue-waiter / io-waiter / spinner / cpu-fibonacci / cpu-hash

─── Time summary ───────────────────────────────────────────────────────────────
Thread                     wall (ms)      cpu (ms)    off-cpu (ms)   off-cpu %
────────────────────────────────────────────────────────────────────────────────
MainThread                    5030.6           0.3          5030.4      100.0%
cpu-fibonacci-thread          5003.5        1618.4          3899.4       77.9%
cpu-hash-thread               5004.4        1655.6          3843.5       76.8%
event-waiter-thread           5000.8           2.0          4998.8      100.0%
io-waiter-thread              5019.7           2.6          5017.1       99.9%
lock-waiter-thread            5030.6           0.0          5030.6      100.0%
queue-waiter-thread           5011.5           2.4          5009.1      100.0%
sleeper-thread                5011.5           1.3          5010.1      100.0%
spinner-thread                5011.5        1739.6          3805.9       75.9%

─── Off-CPU cause breakdown ────────────────────────────────────────────────────
Thread                           sleep            lock              io           other
────────────────────────────────────────────────────────────────────────────────
MainThread                     5005.8ms           24.6ms            0.0ms            0.0ms
cpu-fibonacci-thread              0.0ms            0.0ms            0.0ms         3899.4ms
cpu-hash-thread                   0.0ms            0.0ms            0.0ms         3843.5ms
event-waiter-thread               0.0ms         4998.8ms            0.0ms            0.0ms
io-waiter-thread                  0.0ms            0.0ms         4650.7ms          366.3ms
lock-waiter-thread                0.0ms         5030.6ms            0.0ms            0.0ms
queue-waiter-thread               0.0ms         5003.8ms            0.0ms            5.2ms
sleeper-thread                 5010.1ms            0.0ms            0.0ms            0.0ms
spinner-thread                    0.0ms            0.0ms            0.0ms         3805.9ms

─── Top off-CPU stacks  (heaviest single sample per thread) ────────────────────

  [MainThread]  cause=sleep  5005.8 ms
      ├─ sleep                                    time
      ├─ main                                     demo_offcpu_approximation.py
      └─ <module>                                 demo_offcpu_approximation.py

  [cpu-fibonacci-thread]  cause=other  2930.9 ms
      ├─ monotonic                                time
      ├─ cpu_fibonacci                            demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      ├─ Thread._bootstrap_inner                  threading.py
      ├─ init_stack.<locals>.thread_bootstrap_inner threading.py
      └─ Thread._bootstrap                        threading.py

  [cpu-hash-thread]  cause=other  2875.5 ms
      ├─ openssl_sha256                           _hashlib
      ├─ cpu_hash                                 demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      ├─ Thread._bootstrap_inner                  threading.py
      ├─ init_stack.<locals>.thread_bootstrap_inner threading.py
      └─ Thread._bootstrap                        threading.py

  [event-waiter-thread]  cause=lock  4988.8 ms
      ├─ lock.acquire                             
      ├─ Condition.wait                           threading.py
      ├─ Event.wait                               threading.py
      ├─ event_waiter                             demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      └─ Thread._bootstrap_inner                  threading.py

  [io-waiter-thread]  cause=io  4650.7 ms
      ├─ socket.recv                              
      ├─ io_waiter                                demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      ├─ Thread._bootstrap_inner                  threading.py
      ├─ init_stack.<locals>.thread_bootstrap_inner threading.py
      └─ Thread._bootstrap                        threading.py

  [lock-waiter-thread]  cause=lock  5030.6 ms
      ├─ lock.acquire                             
      ├─ lock_waiter                              demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      ├─ Thread._bootstrap_inner                  threading.py
      ├─ init_stack.<locals>.thread_bootstrap_inner threading.py
      └─ Thread._bootstrap                        threading.py

  [queue-waiter-thread]  cause=lock  4993.3 ms
      ├─ lock.acquire                             
      ├─ Condition.wait                           threading.py
      ├─ Queue.get                                queue.py
      ├─ queue_waiter                             demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      └─ Thread._bootstrap_inner                  threading.py

  [sleeper-thread]  cause=sleep  5010.1 ms
      ├─ sleep                                    time
      ├─ sleeper                                  demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      ├─ Thread._bootstrap_inner                  threading.py
      ├─ init_stack.<locals>.thread_bootstrap_inner threading.py
      └─ Thread._bootstrap                        threading.py

  [spinner-thread]  cause=other  3011.7 ms
      ├─ monotonic                                time
      ├─ spinner                                  demo_offcpu_approximation.py
      ├─ Thread.run                               threading.py
      ├─ Thread._bootstrap_inner                  threading.py
      ├─ init_stack.<locals>.thread_bootstrap_inner threading.py
      └─ Thread._bootstrap                        threading.py

```