### PR TITLE
fix(botocore): set serverless peer.service to AWS resource name

### DIFF
--- a/ddtrace/_trace/utils_botocore/span_tags.py
+++ b/ddtrace/_trace/utils_botocore/span_tags.py
@@ -58,6 +58,43 @@ def _derive_peer_hostname(service: str, region: str, params: Optional[dict[str, 
     return f"{mapped}.{region}.amazonaws.com" if mapped else None
 
 
+# Maps an AWS endpoint to the span tag (populated by
+# ``aws._add_api_param_span_tags``) that holds the targeted resource name.
+# This lets peer.service identify the downstream managed service by its
+# resource (queue/stream/table/topic/bucket name) rather than the AWS
+# endpoint hostname.
+_PEER_SERVICE_RESOURCE_TAGS = {
+    "sqs": "queuename",
+    "sns": "topicname",
+    "kinesis": "streamname",
+    "dynamodb": "tablename",
+    "dynamodbdocument": "tablename",
+    "s3": "bucketname",
+    "eventbridge": "rulename",
+    "events": "rulename",
+}
+
+
+def _derive_peer_service(span: Span, endpoint_name: str) -> Optional[str]:
+    """Return the AWS resource name to use as peer.service for the given service.
+
+    Reads the resource-name span tags already set by
+    ``aws._add_api_param_span_tags`` (queue/stream/table/topic/bucket name) so
+    that the inferred downstream service is identified by the specific resource
+    being accessed instead of the generic AWS endpoint hostname.
+
+    Returns ``None`` when no resource name is available (e.g. service-level
+    operations such as ``ListQueues``), in which case the caller falls back to
+    the endpoint hostname.
+    """
+
+    tag_name = _PEER_SERVICE_RESOURCE_TAGS.get(endpoint_name.lower())
+    if not tag_name:
+        return None
+
+    return span.get_tag(tag_name) or None
+
+
 def set_botocore_patched_api_call_span_tags(span: Span, instance, args, params, endpoint_name, operation):
     span._set_attribute(COMPONENT, config.botocore.integration_name)
     # set span.kind to the type of request being performed
@@ -92,12 +129,16 @@ def set_botocore_patched_api_call_span_tags(span: Span, instance, args, params, 
         span._set_attribute("region", region_name)
         span._set_attribute("aws.partition", aws.get_aws_partition(region_name))
 
-        # Derive peer hostname only in serverless environments to avoid
-        # unnecessary tag noise in traditional hosts/containers.
+        # Derive peer.service only in serverless environments to avoid
+        # unnecessary tag noise in traditional hosts/containers. Prefer the
+        # targeted resource name (queue/stream/table/topic/bucket); fall back
+        # to the AWS endpoint hostname when no resource name is available.
         if in_aws_lambda():
-            hostname = _derive_peer_hostname(endpoint_name, region_name, params)
-            if hostname:
-                span._set_attribute("peer.service", hostname)
+            peer_service = _derive_peer_service(span, endpoint_name)
+            if not peer_service:
+                peer_service = _derive_peer_hostname(endpoint_name, region_name, params)
+            if peer_service:
+                span._set_attribute("peer.service", peer_service)
 
 
 def set_botocore_response_metadata_tags(

--- a/releasenotes/notes/botocore-peer-service-resource-name-7c0f1a2b3d4e5f60.yaml
+++ b/releasenotes/notes/botocore-peer-service-resource-name-7c0f1a2b3d4e5f60.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    botocore: This fix changes the ``peer.service`` tag set on AWS SDK spans in
+    serverless (AWS Lambda) environments to use the targeted resource name
+    (queue, stream, table, topic, or bucket name) instead of the AWS endpoint
+    hostname. When no resource name is available (for example, service-level
+    operations such as ``ListQueues``), ``peer.service`` falls back to the
+    endpoint hostname as before.

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -3473,7 +3473,7 @@ class BotocoreTest(TracerTestCase):
     @mock_s3
     @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
     def test_s3_client_peer_service_in_lambda(self):
-        """Test that peer.service tag is set for S3 when running in AWS Lambda"""
+        """Test that peer.service is set to the bucket name when running in AWS Lambda"""
         s3 = self.session.create_client("s3", region_name="us-east-1")
 
         # Test with bucket parameter
@@ -3482,8 +3482,8 @@ class BotocoreTest(TracerTestCase):
         assert spans
         assert len(spans) == 1
         span = spans[0]
-        # Should have peer.service set to bucket-specific hostname
-        assert span.get_tag("peer.service") == "test-bucket.s3.us-east-1.amazonaws.com"
+        # Should have peer.service set to the bucket name (the resource)
+        assert span.get_tag("peer.service") == "test-bucket"
 
     @mock_dynamodb
     @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
@@ -3530,7 +3530,7 @@ class BotocoreTest(TracerTestCase):
     @mock_events
     @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
     def test_eventbridge_client_peer_service_in_lambda(self):
-        """Test that peer.service tag is set for EventBridge when running in AWS Lambda"""
+        """Test that peer.service falls back to the events hostname when no rule is targeted"""
         events = self.session.create_client("events", region_name="us-east-1")
 
         events.list_rules()
@@ -3538,5 +3538,63 @@ class BotocoreTest(TracerTestCase):
         assert spans
         assert len(spans) == 1
         span = spans[0]
-        # Should have peer.service set to events hostname
+        # No resource name available -> fall back to the events hostname
         assert span.get_tag("peer.service") == "events.us-east-1.amazonaws.com"
+
+    # peer.service should resolve to the targeted resource name (queue/stream/
+    # table/topic/rule) rather than the AWS endpoint hostname.
+    @mock_sqs
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
+    def test_sqs_client_peer_service_resource_name_in_lambda(self):
+        """peer.service is set to the queue name when an SQS queue is targeted"""
+        sqs = self.session.create_client("sqs", region_name="us-east-1")
+
+        sqs.create_queue(QueueName="my-queue")
+        spans = self.get_spans()
+        assert spans
+        span = spans[0]
+        assert span.get_tag("peer.service") == "my-queue"
+
+    @mock_kinesis
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
+    def test_kinesis_client_peer_service_resource_name_in_lambda(self):
+        """peer.service is set to the stream name when a Kinesis stream is targeted"""
+        kinesis = self.session.create_client("kinesis", region_name="us-east-1")
+
+        kinesis.create_stream(StreamName="my-stream", ShardCount=1)
+        spans = self.get_spans()
+        assert spans
+        span = spans[0]
+        assert span.get_tag("peer.service") == "my-stream"
+
+    @mock_dynamodb
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
+    def test_dynamodb_client_peer_service_resource_name_in_lambda(self):
+        """peer.service is set to the table name when a DynamoDB table is targeted"""
+        dynamodb = self.session.create_client("dynamodb", region_name="us-west-2")
+
+        dynamodb.create_table(
+            TableName="my-table",
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        spans = self.get_spans()
+        assert spans
+        span = spans[0]
+        assert span.get_tag("peer.service") == "my-table"
+
+    @mock_sns
+    @mock_sqs
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(AWS_LAMBDA_FUNCTION_NAME="my-func"))
+    def test_sns_client_peer_service_resource_name_in_lambda(self):
+        """peer.service is set to the topic name when an SNS topic is targeted"""
+        sns = self.session.create_client("sns", region_name="us-west-2")
+
+        topic_arn = sns.create_topic(Name="my-topic")["TopicArn"]
+        self.get_spans()  # flush create_topic span
+        sns.publish(TopicArn=topic_arn, Message="hello")
+        spans = self.get_spans()
+        assert spans
+        publish_span = [s for s in spans if s.get_tag("aws.operation") == "Publish"][0]
+        assert publish_span.get_tag("peer.service") == "my-topic"


### PR DESCRIPTION
## Summary

- In AWS Lambda environments, set `peer.service` on AWS SDK (botocore) spans to the targeted resource name (queue / stream / table / topic / bucket name) instead of the AWS endpoint hostname.
- The resource name is resolved from the param span tags already populated by `aws._add_api_param_span_tags` (`queuename`, `streamname`, `tablename`, `topicname`, `bucketname`, `rulename`).
- Falls back to the endpoint hostname when no resource name is available (e.g. service-level operations such as `ListQueues`).

## Motivation

Part of the Serverless Service Representation (SSR) work. `peer.service` should identify the downstream managed service by its specific resource rather than the generic AWS endpoint hostname, so that the trace/service map can group by the resource.

## Test plan

- [ ] `tests/contrib/botocore/test.py` peer.service tests pass in CI (hostname fallback + resource-name resolution for sqs/sns/kinesis/dynamodb/s3)