### PR TITLE
chore: annotation for `ddtrace.internal.telemetry.writer.TelemetryWriter`

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -160,7 +160,7 @@ class TelemetryWriter(PeriodicService):
         self._is_periodic = is_periodic
         self._integrations_queue: dict[str, dict] = dict()
         self._namespace = MetricNamespace()
-        self._logs: set[dict[str, Any]] = set()
+        self._logs: set[LogData] = set()
         self._events_queue: list[dict[str, Any]] = []
         self._queued_configs: list[dict] = []
         self._sent_configs: list[dict] = []

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -44,7 +44,7 @@ from .metrics_namespaces import MetricType
 log = get_logger(__name__)
 
 
-class LogData(dict):
+class LogData(dict[str, Any]):
     def __hash__(self):
         return hash((self["message"], self["level"], self.get("tags"), self.get("stack_trace")))
 
@@ -588,7 +588,7 @@ class TelemetryWriter(PeriodicService):
                 tags,
             )
 
-    def _report_logs(self) -> set[dict[str, Any]]:
+    def _report_logs(self) -> set[LogData]:
         with self._service_lock:
             logs = self._logs
             self._logs = set()


### PR DESCRIPTION
## Description

The `_logs` attribute of the above is a set of instances of `LogData`, which subclasses `dict` and adds a `__hash__` method. However, it is annotated as `set[dict[str, Any]]`. This is incorrect, because `dict`'s are not necessarily hashable and cannot be used as items in a container such as `set`. This PR changes it to `set[LogData]`.

## Additional Notes

#18043 again.
