### PR TITLE
chore(asm): clarify appsec_enabled docstring in Tracer.configure

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -331,7 +331,11 @@ class Tracer(object):
         :param object context_provider: The ``ContextProvider`` that will be used to retrieve
             automatically the current call context. This is an advanced option that usually
             doesn't need to be changed from the default value.
-        :param bool appsec_enabled: Enables Application Security Monitoring (ASM) for the tracer.
+        :param bool appsec_enabled: Reflects the AppSec (ASM) state on the tracer: it updates
+            ``asm_config._asm_enabled`` and forces the trace writer to a payload format compatible
+            with ASM metadata. It does NOT start the WAF span processor on its own. AppSec is
+            activated via ``DD_APPSEC_ENABLED`` (product startup) or remote configuration, both of
+            which register the processor through ``load_appsec()`` before reconfiguring the tracer.
         :param bool iast_enabled: Enables IAST support for the tracer
         :param bool apm_tracing_disabled: When APM tracing is disabled ensures ASM support is still enabled.
         :param list[TraceProcessor] trace_processors: This parameter sets TraceProcessor (ex: TraceFilters).


### PR DESCRIPTION
APPSEC-68524

Clarify the `appsec_enabled` parameter docstring in `Tracer.configure()`.

Since #14244, this parameter only reflects the ASM state (`asm_config._asm_enabled`) and forces the trace writer to an ASM-compatible payload format — it does **not** start the WAF span processor. AppSec is activated via `DD_APPSEC_ENABLED` or remote config, both of which register the processor through `load_appsec()`. The old docstring ("Enables Application Security Monitoring") implied the opposite and triggered a false-positive Codex security finding (APPSEC-68524). This is a docs-only clarification; behavior is unchanged.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the library release note guidelines
- The change includes or references documentation updates if necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
