### PR TITLE
feat(ai_guard): support DD_APM_TRACING_ENABLED=false (standalone)

### DIFF
--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -320,8 +320,15 @@ class ASMConfig(DDConfig):
 
     @property
     def _apm_opt_out(self) -> bool:
+        # AI Guard standalone: when AI Guard is enabled and APM tracing is disabled, opt out of APM
+        # billing while still letting AI Guard traces (USER_KEEP'd via _aiguard_manual_keep) reach the
+        # backend. ``ai_guard_config`` is a module global defined below; this property is only evaluated
+        # at runtime (after module import), so the reference resolves fine.
         return (
-            self._asm_enabled or self._iast_enabled or tracer_config._sca_enabled is True
+            self._asm_enabled
+            or self._iast_enabled
+            or tracer_config._sca_enabled is True
+            or ai_guard_config._ai_guard_enabled
         ) and not self._apm_tracing_enabled
 
     @property

--- a/releasenotes/notes/ai-guard-standalone-0297fbdbf4721f13.yaml
+++ b/releasenotes/notes/ai-guard-standalone-0297fbdbf4721f13.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    ai_guard: This introduces AI Guard standalone mode. When APM tracing is disabled
+    (``DD_APM_TRACING_ENABLED=false``), traces produced by AI Guard are still sent to
+    Datadog, kept with ``USER_KEEP`` sampling priority and the AI Guard decision maker
+    so that they can be attributed to AI Guard, while APM host billing is not triggered.

--- a/tests/appsec/ai_guard/api/test_ai_guard_standalone.py
+++ b/tests/appsec/ai_guard/api/test_ai_guard_standalone.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+import pytest
+
+import ddtrace
+from ddtrace.constants import USER_KEEP
+from ddtrace.contrib.internal.trace_utils import set_http_meta
+from ddtrace.ext import SpanTypes
+from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
+from ddtrace.internal.constants import SamplingMechanism
+from ddtrace.internal.settings.asm import ai_guard_config
+from ddtrace.internal.settings.asm import config as asm_config
+from tests.appsec.ai_guard.utils import mock_evaluate_response
+from tests.appsec.ai_guard.utils import override_ai_guard_config
+
+
+MESSAGES = [
+    {"role": "user", "content": "What is the meaning of life?"},
+]
+
+
+_STANDALONE_AI_GUARD_CONFIG = dict(
+    _ai_guard_enabled="True",
+    _ai_guard_endpoint="https://api.example.com/ai-guard",
+    _dd_api_key="test-api-key",
+    _dd_app_key="test-app-key",
+)
+
+
+@pytest.fixture
+def ai_guard_standalone_tracer(tracer):
+    """Enable AI Guard with APM tracing disabled (standalone mode) and restore afterwards."""
+    with override_ai_guard_config(_STANDALONE_AI_GUARD_CONFIG):
+        # compute_stats_enabled is passed to force tracer._recreate so the sampling processor
+        # picks up apm_opt_out (which is now True because AI Guard is enabled + APM disabled).
+        tracer.configure(apm_tracing_disabled=True, compute_stats_enabled=False)
+        try:
+            yield tracer
+        finally:
+            tracer.configure(apm_tracing_disabled=False, compute_stats_enabled=False)
+            ddtrace.config._reset()
+
+
+class TestAIGuardStandalone:
+    """AI Guard standalone mode: DD_AI_GUARD_ENABLED=true + DD_APM_TRACING_ENABLED=false.
+
+    AI Guard traces must still reach the backend (kept with USER_KEEP and the AI_GUARD decision
+    maker) while APM host billing is opted out (``_dd.apm.enabled=0``).
+    """
+
+    def test_apm_opt_out_enabled_when_ai_guard_enabled_and_apm_disabled(self):
+        """AI Guard alone (no AppSec/IAST/SCA) with APM disabled triggers _apm_opt_out."""
+        with override_ai_guard_config(_STANDALONE_AI_GUARD_CONFIG):
+            original = asm_config._apm_tracing_enabled
+            try:
+                asm_config._apm_tracing_enabled = False
+                assert ai_guard_config._ai_guard_enabled
+                assert asm_config._apm_opt_out is True
+            finally:
+                asm_config._apm_tracing_enabled = original
+
+    def test_apm_opt_out_disabled_when_apm_tracing_enabled(self):
+        """AI Guard enabled but APM tracing enabled must NOT opt out of APM billing."""
+        with override_ai_guard_config(_STANDALONE_AI_GUARD_CONFIG):
+            original = asm_config._apm_tracing_enabled
+            try:
+                asm_config._apm_tracing_enabled = True
+                assert ai_guard_config._ai_guard_enabled
+                assert asm_config._apm_opt_out is False
+            finally:
+                asm_config._apm_tracing_enabled = original
+
+    def test_standalone_sets_apm_enabled_metric(self, ai_guard_standalone_tracer):
+        """In standalone mode every span gets the _dd.apm.enabled=0 metric (no APM billing)."""
+        tracer = ai_guard_standalone_tracer
+        assert asm_config._apm_opt_out is True
+
+        with tracer.trace("test", span_type=SpanTypes.WEB) as span:
+            set_http_meta(span, {}, raw_uri="http://example.com/", status_code="200")
+
+        assert span.get_metric("_dd.apm.enabled") == 0.0
+
+    @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
+    def test_standalone_keeps_ai_guard_trace(self, mock_execute_request, ai_guard_standalone_tracer):
+        """After evaluate(), the service-entry span is kept (USER_KEEP) with the AI_GUARD decision maker."""
+        mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+        tracer = ai_guard_standalone_tracer
+        assert asm_config._apm_opt_out is True
+
+        from ddtrace.appsec.ai_guard import new_ai_guard_client
+
+        client = new_ai_guard_client()
+        with tracer.trace("root_span", span_type=SpanTypes.WEB) as root_span:
+            client.evaluate(MESSAGES)
+
+        assert root_span.context.sampling_priority == USER_KEEP
+        assert root_span.get_tag(SAMPLING_DECISION_TRACE_TAG_KEY) == "-%d" % SamplingMechanism.AI_GUARD
+        assert root_span.get_metric("_dd.apm.enabled") == 0.0


### PR DESCRIPTION
## Description

[APPSEC-68486](https://datadoghq.atlassian.net/browse/APPSEC-68486) (epic [APPSEC-61460](https://datadoghq.atlassian.net/browse/APPSEC-61460)) Support `DD_APM_TRACING_ENABLED=false` for AI Guard 

When a customer runs **only** AI Guard (`DD_AI_GUARD_ENABLED=true`, without AppSec/IAST/SCA) and sets `DD_APM_TRACING_ENABLED=false` to avoid APM host billing, the tracer did **not** enter the APM opt-out path. The decision lives in `ASMConfig._apm_opt_out`, which only considered AppSec, IAST and SCA — so AI-Guard-only deployments still triggered APM host billing and did not get the `_dd.apm.enabled=0` billing flag.

This change includes AI Guard in `_apm_opt_out`. All the standalone machinery already keys off that property (tracer disabling, `_dd.apm.enabled=0` on spans, writer stats opt-out, integration "tracing active" gates). AI Guard's existing `_aiguard_manual_keep()` already stamps the service-entry span with `USER_KEEP` + `_dd.p.dm=-13` (AI Guard decision maker), so kept traces still reach the backend and can be attributed to AI Guard, while APM host billing is opted out.

Unlike AAP standalone, AI Guard does not require the 1-trace-per-minute keep-alive; the reused rate limiter is harmless because AI Guard traces are explicitly `USER_KEEP`'d and bypass the sampler.

Scope is single-service (matching the system-test scenario `AI_GUARD_STANDALONE` in DataDog/system-tests#7177). Distributed downstream propagation in standalone is gated by the `_dd.p.ts` tag, which AI Guard does not set, and is out of scope.

[APPSEC-68486]: https://datadoghq.atlassian.net/browse/APPSEC-68486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-61460]: https://datadoghq.atlassian.net/browse/APPSEC-61460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ