### PR TITLE
chore(appsec): remove double-free of diagnostics in DDWaf.update_rules

### DIFF
--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -149,13 +149,11 @@ class DDWaf:
             ok &= py_add_or_update_config(self._builder, path, ruleset_object, diagnostics)
             self._set_info(diagnostics, "update")
             ddwaf_object_free(ruleset_object)
-            ddwaf_object_free(diagnostics)
         if not self._asm_dd_cache:
             # we need to add the default ruleset back
             diagnostics = ddwaf_object()
             ok &= py_add_or_update_config(self._builder, ASM_DD_DEFAULT, self._default_ruleset, diagnostics)
             self._set_info(diagnostics, "update")
-            ddwaf_object_free(diagnostics)
             self._asm_dd_cache.add(ASM_DD_DEFAULT)
         new_handle = py_ddwaf_builder_build_instance(self._builder)
         self._rc_products_str = ",".join(f"{p}:{len(v)}" for p, v in sorted(self._rc_products.items()) if v)


### PR DESCRIPTION
`_set_info()` already frees `diagnostics` internally; the two explicit `ddwaf_object_free(diagnostics)` calls in `update_rules` after `_set_info()` were redundant double-frees.