### PR TITLE
chore: refactor valkey integration for separation of concerns

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -516,9 +516,6 @@ class Tracer(object):
                 service = parent.service
                 service_source = parent.get_tag(_SERVICE_SOURCE) or ""
             else:
-                import pdb
-
-                # pdb.set_trace()
                 service = config.service
         else:
             if service in config._integration_default_services:

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -516,6 +516,9 @@ class Tracer(object):
                 service = parent.service
                 service_source = parent.get_tag(_SERVICE_SOURCE) or ""
             else:
+                import pdb
+
+                # pdb.set_trace()
                 service = config.service
         else:
             if service in config._integration_default_services:

--- a/ddtrace/_trace/utils_valkey.py
+++ b/ddtrace/_trace/utils_valkey.py
@@ -1,26 +1,17 @@
-"""
-Some utils used by the dogtrace valkey integration
-"""
-
-from contextlib import contextmanager
 from typing import Any
 from typing import Optional
 from typing import Union
 
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
-from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.valkey_utils import _extract_conn_tags
 from ddtrace.ext import SpanKind
-from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
 from ddtrace.ext import valkey as valkeyx
-from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_cache_operation
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.trace import Span
-from ddtrace.trace import tracer
 
 
 format_command_args = stringify_cache_args
@@ -50,52 +41,3 @@ def _set_span_tags(
         for attr in ("command_stack", "_command_stack"):
             if hasattr(instance, attr):
                 span._set_attribute(valkeyx.PIPELINE_LEN, len(getattr(instance, attr)))
-
-
-@contextmanager
-def _instrument_valkey_cmd(config_integration, instance, args):
-    query = stringify_cache_args(args, cmd_max_len=config_integration.cmd_max_length)
-    with (
-        core.context_with_data(
-            "valkey.command",
-            span_name=schematize_cache_operation(valkeyx.CMD, cache_provider=valkeyx.APP),
-            service=trace_utils.ext_service(None, config_integration),
-            span_type=SpanTypes.VALKEY,
-            resource=query.split(" ")[0] if config_integration.resource_only_command else query,
-        ) as ctx,
-        ctx.span as span,
-    ):
-        _set_span_tags(span, config_integration, args, instance, query)
-        yield ctx
-
-
-@contextmanager
-def _instrument_valkey_execute_pipeline(config_integration, cmds, instance, is_cluster=False):
-    cmd_string = resource = "\n".join(cmds)
-    if config_integration.resource_only_command:
-        resource = "\n".join([cmd.split(" ")[0] for cmd in cmds])
-
-    with tracer.trace(
-        schematize_cache_operation(valkeyx.CMD, cache_provider=valkeyx.APP),
-        resource=resource,
-        service=trace_utils.ext_service(None, config_integration),
-        span_type=SpanTypes.VALKEY,
-    ) as span:
-        _set_span_tags(span, config_integration, None, instance, cmd_string)
-        yield span
-
-
-@contextmanager
-def _instrument_valkey_execute_async_cluster_pipeline(config_integration, cmds, instance):
-    cmd_string = resource = "\n".join(cmds)
-    if config_integration.resource_only_command:
-        resource = "\n".join([cmd.split(" ")[0] for cmd in cmds])
-
-    with tracer.trace(
-        schematize_cache_operation(valkeyx.CMD, cache_provider=valkeyx.APP),
-        resource=resource,
-        service=trace_utils.ext_service(None, config_integration),
-        span_type=SpanTypes.VALKEY,
-    ) as span:
-        _set_span_tags(span, config_integration, None, instance, cmd_string)
-        yield span

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -393,12 +393,16 @@ def set_service_and_source(
     int_config: Union["IntegrationConfig", dict],
     default_service_key: str = "_default_service",
 ) -> None:
+    service_source = ""
     mapped_service = config.service_mapping.get(service, service)
+    import pdb
+
+    # pdb.set_trace()
     if service != mapped_service:
-        span.set_tag(_SERVICE_SOURCE, "opt.service_mapping")
+        service_source = "opt.service_mapping"
         service = mapped_service
     elif int_config.get("split_by_domain", False):
-        span.set_tag(_SERVICE_SOURCE, "opt.split_by_domain")
+        service_source = "opt.split_by_domain"
     # NB "not service" here makes svc_src make sense in cases of service inheritance
     elif not service or service == int_config.get(default_service_key):
         service_source = getattr(
@@ -406,8 +410,10 @@ def set_service_and_source(
             "integration_name",
             int_config.get("integration_name", "") if hasattr(int_config, "get") else "",
         )
-        if service_source:
-            span.set_tag(_SERVICE_SOURCE, service_source)
+    else:
+        service_source = "m"
+    if service_source:
+        span.set_tag(_SERVICE_SOURCE, service_source)
     if service:
         span.service = service
 

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -395,9 +395,6 @@ def set_service_and_source(
 ) -> None:
     service_source = ""
     mapped_service = config.service_mapping.get(service, service)
-    import pdb
-
-    # pdb.set_trace()
     if service != mapped_service:
         service_source = "opt.service_mapping"
         service = mapped_service

--- a/ddtrace/contrib/internal/valkey/asyncio_patch.py
+++ b/ddtrace/contrib/internal/valkey/asyncio_patch.py
@@ -1,7 +1,7 @@
 from ddtrace import config
-from ddtrace._trace.utils_valkey import _instrument_valkey_cmd
-from ddtrace._trace.utils_valkey import _instrument_valkey_execute_async_cluster_pipeline
-from ddtrace._trace.utils_valkey import _instrument_valkey_execute_pipeline
+from ddtrace.contrib.internal.valkey.patch import _instrument_valkey_cmd
+from ddtrace.contrib.internal.valkey.patch import _instrument_valkey_execute_async_cluster_pipeline
+from ddtrace.contrib.internal.valkey.patch import _instrument_valkey_execute_pipeline
 from ddtrace.contrib.internal.valkey_utils import _run_valkey_command_async
 from ddtrace.internal.utils.formats import stringify_cache_args
 

--- a/ddtrace/contrib/internal/valkey/patch.py
+++ b/ddtrace/contrib/internal/valkey/patch.py
@@ -1,18 +1,25 @@
+from contextlib import contextmanager
+
 import valkey
 import wrapt
 
 from ddtrace import config
-from ddtrace._trace.utils_valkey import _instrument_valkey_cmd
-from ddtrace._trace.utils_valkey import _instrument_valkey_execute_pipeline
+from ddtrace._trace.utils_valkey import _set_span_tags
+from ddtrace.contrib import trace_utils
+from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.contrib.internal.valkey_utils import ROW_RETURNING_COMMANDS
 from ddtrace.contrib.internal.valkey_utils import determine_row_count
 from ddtrace.contrib.trace_utils import unwrap
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import valkey as valkeyx
 from ddtrace.internal import core
+from ddtrace.internal.schema import schematize_cache_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.settings import env
 from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
+from ddtrace.trace import tracer
 
 
 config._add(
@@ -25,8 +32,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(valkey, "__version__", "")
 
 
@@ -126,3 +132,54 @@ def instrumented_execute_pipeline(integration_config, is_cluster=False):
             return func(*args, **kwargs)
 
     return _instrumented_execute_pipeline
+
+
+@contextmanager
+def _instrument_valkey_cmd(config_integration, instance, args):
+    query = stringify_cache_args(args, cmd_max_len=config_integration.cmd_max_length)
+    with (
+        core.context_with_data(
+            "valkey.command",
+            span_name=schematize_cache_operation(valkeyx.CMD, cache_provider=valkeyx.APP),
+            span_type=SpanTypes.VALKEY,
+            resource=query.split(" ")[0] if config_integration.resource_only_command else query,
+        ) as ctx,
+        ctx.span as span,
+    ):
+        set_service_and_source(span, trace_utils.ext_service(None, config_integration), config_integration)
+        _set_span_tags(span, config_integration, args, instance, query)
+        yield ctx
+
+
+@contextmanager
+def _instrument_valkey_execute_pipeline(config_integration, cmds, instance, is_cluster=False):
+    cmd_string = resource = "\n".join(cmds)
+    if config_integration.resource_only_command:
+        resource = "\n".join([cmd.split(" ")[0] for cmd in cmds])
+
+    with tracer.trace(
+        schematize_cache_operation(valkeyx.CMD, cache_provider=valkeyx.APP),
+        resource=resource,
+        span_type=SpanTypes.VALKEY,
+    ) as span:
+        set_service_and_source(span, trace_utils.ext_service(None, config_integration), config_integration)
+        _set_span_tags(span, config_integration, None, instance, cmd_string)
+        yield span
+
+
+@contextmanager
+def _instrument_valkey_execute_async_cluster_pipeline(config_integration, cmds, instance):
+    cmd_string = resource = "\n".join(cmds)
+    if config_integration.resource_only_command:
+        resource = "\n".join([cmd.split(" ")[0] for cmd in cmds])
+
+    with tracer.trace(
+        schematize_cache_operation(valkeyx.CMD, cache_provider=valkeyx.APP),
+        resource=resource,
+        span_type=SpanTypes.VALKEY,
+    ) as span:
+        set_service_and_source(
+            span, schematize_service_name(trace_utils.ext_service(None, config_integration)), config_integration
+        )
+        _set_span_tags(span, config_integration, None, instance, cmd_string)
+        yield span


### PR DESCRIPTION
This change reorganizes some code in the valkey integration and trace utils according to the principle of separation of concerns. It also handles a bug in `set_service_and_source` that was exposed by this refactor, namely that the `svc_src: m` fallback is not applied in cases where service name is not provided on creation of a root span that later has its service name set.