### PR TITLE
fix(django): preserve process_exception on async function-based middleware

### DIFF
--- a/ddtrace/contrib/internal/django/middleware.py
+++ b/ddtrace/contrib/internal/django/middleware.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 from inspect import iscoroutinefunction
 from inspect import isfunction
 from types import FunctionType
@@ -158,6 +159,13 @@ def traced_middleware_factory(func: FunctionType, args: tuple[Any], kwargs: dict
                 # Don't flag the span as errored on routine ASGI cancellation (#17728).
                 ctx.span._ignore_exception(asyncio.CancelledError)
                 return await middleware(*args, **kwargs)
+
+        # Preserve __dict__ (which holds process_exception, process_view,
+        # etc.) so Django's load_middleware can discover middleware hooks on
+        # the wrapper.  The sync branch uses wrapt's wrap() which does this
+        # automatically; the async branch uses functools.wraps because
+        # bytecode wrappers cannot be used for coroutine functions (#17728).
+        functools.update_wrapper(traced_async_middleware_func, middleware)
 
         return traced_async_middleware_func
     else:

--- a/tests/contrib/django/middleware.py
+++ b/tests/contrib/django/middleware.py
@@ -119,6 +119,38 @@ class AsyncCallMiddleware:
 
 
 try:
+    from django.utils.decorators import sync_and_async_middleware
+
+    @sync_and_async_middleware
+    def fn_middleware_with_process_exception(get_response):
+        """Function-based middleware with process_exception attribute.
+
+        Mimics allauth's AccountMiddleware pattern: the factory attaches
+        process_exception to the inner function so Django can discover it
+        via hasattr() in load_middleware.
+        """
+        from asgiref.sync import iscoroutinefunction as _iscoro
+
+        if _iscoro(get_response):
+
+            async def middleware(request):
+                return await get_response(request)
+        else:
+
+            def middleware(request):
+                return get_response(request)
+
+        def process_exception(request, exception):
+            return HttpResponse("caught", status=200)
+
+        middleware.process_exception = process_exception
+        return middleware
+
+except ImportError:
+    pass
+
+
+try:
     from django.utils.decorators import async_only_middleware
 
     @async_only_middleware

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -2876,6 +2876,37 @@ async def test_async_function_middleware_cancellation_does_not_tag_span_errored(
     )
 
 
+@pytest.mark.skipif(django.VERSION < (3, 1, 0), reason="async middleware require Django 3.1+")
+def test_traced_middleware_factory_preserves_process_exception_on_async():
+    """traced_middleware_factory must preserve process_exception on async
+    function-based middleware so Django's load_middleware can register it
+    in _exception_middleware.
+
+    Regression test for #18696: allauth's AccountMiddleware (and any
+    @sync_and_async_middleware that attaches process_exception) had its
+    exception handler silently dropped under ASGI.
+    """
+    from ddtrace.contrib.internal.django.middleware import traced_middleware_factory
+
+    def process_exception(request, exception):
+        pass
+
+    async def async_inner(request):
+        pass
+
+    def factory(get_response):
+        async_inner.process_exception = process_exception
+        return async_inner
+
+    wrapped = traced_middleware_factory(factory, (lambda r: r,), {})
+
+    assert hasattr(wrapped, "process_exception"), (
+        "traced_middleware_factory dropped process_exception from async middleware; "
+        "Django will not register the exception handler under ASGI (#18696)"
+    )
+    assert wrapped.process_exception is process_exception
+
+
 @pytest.mark.skipif(django.VERSION < (4, 1, 0), reason="async middleware require Django 4.1+")
 def test_wrap_middleware_class_async_hooks():
     """wrap_middleware_class should use wrapt wrapping (not bytecode wrapping)


### PR DESCRIPTION
## Description

`traced_middleware_factory` creates a new `async def` wrapper for async function-based middleware but does not copy attributes like `process_exception` from the original function. Django's `load_middleware` uses `hasattr(mw_instance, 'process_exception')` to discover exception handlers, so the handler is silently dropped under ASGI.

The **sync** branch already handles this correctly — it uses `wrap()` (wrapt) which preserves attributes. The **async** branch cannot use bytecode wrappers (#17728), so this PR copies the relevant hook attributes explicitly.

## Motivation

Affects any Django middleware that:
1. Is function-based (not class-based)
2. Uses `@sync_and_async_middleware`
3. Attaches `process_exception` as a function attribute

**Confirmed affected:** [allauth's `AccountMiddleware`](https://github.com/pennersr/django-allauth/blob/main/allauth/account/middleware.py) — its `process_exception` handles `ReauthenticationRequired` (reauthentication redirect). With ddtrace under ASGI, this becomes a 500 instead of a redirect.

Fixes #18696

## Changes

- **`ddtrace/contrib/internal/django/middleware.py`**: Copy `process_exception`, `process_view`, and `process_template_response` from the original middleware function onto the async wrapper
- **`tests/contrib/django/test_django.py`**: Regression test that `traced_middleware_factory` preserves `process_exception` on async middleware
- **`tests/contrib/django/middleware.py`**: Add `fn_middleware_with_process_exception` test fixture (allauth-style pattern)

## Testing

```python
from ddtrace.contrib.internal.django.middleware import traced_middleware_factory

def process_exception(request, exception):
    pass

async def async_inner(request):
    pass

def factory(get_response):
    async_inner.process_exception = process_exception
    return async_inner

wrapped = traced_middleware_factory(factory, (lambda r: r,), {})

# Before fix: AssertionError
# After fix: passes
assert hasattr(wrapped, "process_exception")
assert wrapped.process_exception is process_exception
```