### PR TITLE
chore(appsec): suppress IAST taint source generation during request analysis

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+import contextlib
 import json
 import re
 from types import TracebackType
@@ -791,3 +792,11 @@ def _set_headers(span: Span, headers: Any, kind: str, only_asm_enabled: bool = F
 def asm_listen() -> None:
     core.on("asm.set_blocked", set_blocked_dict)
     core.on("asm.get_blocked", get_blocked, "block_config")
+
+
+def iast_disabled_taint_sources() -> "contextlib.AbstractContextManager[None]":
+    if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._iast_request_context_base import iast_suppress_context
+
+        return iast_suppress_context()
+    return contextlib.nullcontext()

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -10,6 +10,7 @@ from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _on_context_ended
 from ddtrace.appsec._asm_request_context import _set_headers_and_response
 from ddtrace.appsec._asm_request_context import get_blocked
+from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
 from ddtrace.contrib.internal.trace_utils_base import _set_url_tag
@@ -57,18 +58,19 @@ async def _on_asgi_request_parse_body(receive: _ASGIReceive, headers: Mapping[st
             return await receive()
 
         try:
-            content_type = headers.get("content-type") or headers.get("Content-Type")
-            if content_type in ("application/json", "text/json"):
-                if body is None or body == b"":
+            with iast_disabled_taint_sources():
+                content_type = headers.get("content-type") or headers.get("Content-Type")
+                if content_type in ("application/json", "text/json"):
+                    if body is None or body == b"":
+                        req_body = None
+                    else:
+                        req_body = json.loads(body.decode())
+                elif content_type in ("application/xml", "text/xml"):
+                    req_body = xmltodict.parse(body)
+                elif content_type == "text/plain":
                     req_body = None
                 else:
-                    req_body = json.loads(body.decode())
-            elif content_type in ("application/xml", "text/xml"):
-                req_body = xmltodict.parse(body)
-            elif content_type == "text/plain":
-                req_body = None
-            else:
-                req_body = parse_form_multipart(body.decode(), headers) or None
+                    req_body = parse_form_multipart(body.decode(), headers) or None
             return receive_wrapped, req_body
         except Exception:
             return receive_wrapped, None

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -12,6 +12,7 @@ from ddtrace.appsec._asm_request_context import _set_headers_and_response
 from ddtrace.appsec._asm_request_context import block_request
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
+from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._asm_request_context import in_asm_context
 from ddtrace.appsec._asm_request_context import is_blocked
 from ddtrace.appsec._asm_request_context import set_block_request_callable
@@ -89,20 +90,21 @@ def _on_request_span_modifier(
                 environ["wsgi.input"] = io.BytesIO(body)
 
         try:
-            if content_type in ("application/json", "text/json"):
-                if _HAS_JSON_MIXIN and hasattr(request, "json") and request.json:
-                    req_body = request.json
-                elif request.data is None or request.data == b"":
-                    req_body = None
+            with iast_disabled_taint_sources():
+                if content_type in ("application/json", "text/json"):
+                    if _HAS_JSON_MIXIN and hasattr(request, "json") and request.json:
+                        req_body = request.json
+                    elif request.data is None or request.data == b"":
+                        req_body = None
+                    else:
+                        req_body = json.loads(request.data.decode("UTF-8"))
+                elif content_type in ("application/xml", "text/xml"):
+                    req_body = xmltodict.parse(request.get_data())
+                elif hasattr(request, "form"):
+                    req_body = {k: vs if len(vs) > 1 else vs[0] for k, vs in request.form.to_dict(flat=False).items()}
                 else:
-                    req_body = json.loads(request.data.decode("UTF-8"))
-            elif content_type in ("application/xml", "text/xml"):
-                req_body = xmltodict.parse(request.get_data())
-            elif hasattr(request, "form"):
-                req_body = {k: vs if len(vs) > 1 else vs[0] for k, vs in request.form.to_dict(flat=False).items()}
-            else:
-                # no raw body
-                req_body = None
+                    # no raw body
+                    req_body = None
         except Exception:
             logger.debug("Failed to parse request body", exc_info=True)
         finally:

--- a/ddtrace/appsec/_contrib/tornado/__init__.py
+++ b/ddtrace/appsec/_contrib/tornado/__init__.py
@@ -7,6 +7,7 @@ from ddtrace.appsec._asm_request_context import _use_html
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import get_headers
+from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._asm_request_context import set_waf_address
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._utils import Block_config
@@ -47,26 +48,26 @@ def tornado_call_waf_first(integration: str, handler: Any) -> None:
     if block := get_blocked():
         tornado_block(integration, handler, block)
         return
-    # adding body request support
-    handler.request._parse_body()
-    request_headers = get_headers() or {}
-    parsed_body = handler.request.body_arguments
-    if parsed_body:
-        parsed_body = {k: v[0] if len(v) == 1 else list(v) for k, v in parsed_body.items()}
-    else:
-        _body: bytes = handler.request.body
-        try:
-            if "json" in request_headers.get("content-type", ""):
-                parsed_body = json.loads(_body)
-        except BaseException:
-            pass  # nosec
-        try:
-            if not parsed_body and "xml" in request_headers.get("content-type", ""):
-                import ddtrace.vendor.xmltodict as xmltodict
+    with iast_disabled_taint_sources():
+        handler.request._parse_body()
+        request_headers = get_headers() or {}
+        parsed_body = handler.request.body_arguments
+        if parsed_body:
+            parsed_body = {k: v[0] if len(v) == 1 else list(v) for k, v in parsed_body.items()}
+        else:
+            _body: bytes = handler.request.body
+            try:
+                if "json" in request_headers.get("content-type", ""):
+                    parsed_body = json.loads(_body)
+            except BaseException:
+                pass  # nosec
+            try:
+                if not parsed_body and "xml" in request_headers.get("content-type", ""):
+                    import ddtrace.vendor.xmltodict as xmltodict
 
-                parsed_body = xmltodict.parse(_body)
-        except BaseException:
-            pass  # nosec
+                    parsed_body = xmltodict.parse(_body)
+            except BaseException:
+                pass  # nosec
     if parsed_body:
         set_waf_address(SPAN_DATA_NAMES.REQUEST_BODY, parsed_body)
         call_waf_callback()

--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -1,3 +1,4 @@
+import contextlib
 import contextvars
 from typing import Optional
 
@@ -20,6 +21,16 @@ log = get_logger(__name__)
 # Stopgap module for providing ASM context for the blocking features wrapping some contextvars.
 
 IAST_CONTEXT: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar("iast_var", default=None)
+
+
+@contextlib.contextmanager
+def iast_suppress_context():
+    """Temporarily disable IAST taint *source* generation for the current context."""
+    token = IAST_CONTEXT.set(None)
+    try:
+        yield
+    finally:
+        IAST_CONTEXT.reset(token)
 
 
 def _set_span_tag_iast_request_tainted(span):

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -291,48 +291,52 @@ class AppSecSpanProcessor(SpanProcessor):
         # persistent addresses must be sent if api security is used
         force_keys = custom_data.get("PROCESSOR_SETTINGS", {}).get("extract-schema", False) if custom_data else False
 
-        for key, waf_name in iter_data:
-            if key in data_already_sent and not force_sent:
-                continue
-            # non-persistent addresses are sent as-is (even when value is None) and never tracked
-            # in data_already_sent, so they are re-sent on each call.
-            if waf_name not in WAF_DATA_NAMES.PERSISTENT_ADDRESSES and custom_data:
-                if key in custom_data:
-                    data[waf_name] = _serialize_address_values(waf_name, custom_data.get(key))
+        # The address values gathered and serialized below only feed the WAF; suppress IAST taint source
+        # generation so we don't create throwaway tainted objects (e.g. materializing lazy-tainted header /
+        # query / body structures during serialization and WAF encoding). Customer reads re-taint independently.
+        with _asm_request_context.iast_disabled_taint_sources():
+            for key, waf_name in iter_data:
+                if key in data_already_sent and not force_sent:
+                    continue
+                # non-persistent addresses are sent as-is (even when value is None) and never tracked
+                # in data_already_sent, so they are re-sent on each call.
+                if waf_name not in WAF_DATA_NAMES.PERSISTENT_ADDRESSES and custom_data:
+                    if key in custom_data:
+                        data[waf_name] = _serialize_address_values(waf_name, custom_data.get(key))
 
-            elif self._is_needed(waf_name) or force_keys:
-                value = None
-                if custom_data is not None and custom_data.get(key) is not None:
-                    value = custom_data.get(key)
-                elif key in SPAN_DATA_NAMES:
-                    value = _asm_request_context.get_value("waf_addresses", SPAN_DATA_NAMES[key])
-                # if value is a callable, it's a lazy value for api security that should not be sent now
-                if value is not None and not hasattr(value, "__call__"):
-                    data[waf_name] = _serialize_address_values(waf_name, value)
-                    if waf_name in WAF_DATA_NAMES.PERSISTENT_ADDRESSES:
-                        data_already_sent.add(key)
-                    log.debug("[action] WAF got value %s", WAF_DATA_NAMES.get(key, key))
+                elif self._is_needed(waf_name) or force_keys:
+                    value = None
+                    if custom_data is not None and custom_data.get(key) is not None:
+                        value = custom_data.get(key)
+                    elif key in SPAN_DATA_NAMES:
+                        value = _asm_request_context.get_value("waf_addresses", SPAN_DATA_NAMES[key])
+                    # if value is a callable, it's a lazy value for api security that should not be sent now
+                    if value is not None and not hasattr(value, "__call__"):
+                        data[waf_name] = _serialize_address_values(waf_name, value)
+                        if waf_name in WAF_DATA_NAMES.PERSISTENT_ADDRESSES:
+                            data_already_sent.add(key)
+                        log.debug("[action] WAF got value %s", WAF_DATA_NAMES.get(key, key))
 
-        # small optimization to avoid running the waf if there is no data to check
-        if not data:
-            return None
+            # small optimization to avoid running the waf if there is no data to check
+            if not data:
+                return None
 
-        try:
-            if rule_type is None:
-                # Request-related data -> main per-request context.
-                waf_results = self._ddwaf.run(ctx, data, timeout_ms=asm_config._waf_timeout)
-            else:
-                # RASP data is non-persisting -> subcontext (per guarded operation; shared across
-                # an SSRF request's req + res). If the subcontext can't be created, bypass the RASP
-                # check rather than running the data on the main context (which would persist it).
-                subctx = _asm_request_context.get_or_create_rasp_subcontext(self._ddwaf, ctx, rule_type)
-                if subctx is None:
-                    log.debug("appsec::processor::waf::rasp_subcontext_unavailable")
-                    return None
-                waf_results = self._ddwaf.run(subctx, data, timeout_ms=asm_config._waf_timeout)
-        except Exception:
-            log.debug("appsec::processor::waf::run", exc_info=True)
-            waf_results = Binding_error
+            try:
+                if rule_type is None:
+                    # Request-related data -> main per-request context.
+                    waf_results = self._ddwaf.run(ctx, data, timeout_ms=asm_config._waf_timeout)
+                else:
+                    # RASP data is non-persisting -> subcontext (per guarded operation; shared across
+                    # an SSRF request's req + res). If the subcontext can't be created, bypass the RASP
+                    # check rather than running the data on the main context (which would persist it).
+                    subctx = _asm_request_context.get_or_create_rasp_subcontext(self._ddwaf, ctx, rule_type)
+                    if subctx is None:
+                        log.debug("appsec::processor::waf::rasp_subcontext_unavailable")
+                        return None
+                    waf_results = self._ddwaf.run(subctx, data, timeout_ms=asm_config._waf_timeout)
+            except Exception:
+                log.debug("appsec::processor::waf::run", exc_info=True)
+                waf_results = Binding_error
         _asm_request_context.set_waf_info(lambda: self._ddwaf.info)  # type: ignore
         if waf_results.return_code < 0:
             error_tag = APPSEC.RASP_ERROR if rule_type else APPSEC.WAF_ERROR

--- a/tests/appsec/iast/taint_tracking/test_disable_taint_sources.py
+++ b/tests/appsec/iast/taint_tracking/test_disable_taint_sources.py
@@ -1,0 +1,60 @@
+"""Tests for ``iast_suppress_context``: suppressing IAST taint *source* generation.
+
+The context manager is used by the AppSec machinery to avoid creating throwaway tainted objects while
+analysing request data that never reaches the customer's business logic. It works by clearing the active
+IAST request context id (which gates source generation) and restoring it on exit, so it must:
+- suppress ``taint_pyobject`` while active and restore behaviour afterwards,
+- restore the previous context id (not hard-reset),
+- leave taint *propagation* (aspects) untouched,
+- be harmless when there is no active IAST request context.
+"""
+
+from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
+from ddtrace.appsec._iast._iast_request_context_base import iast_suppress_context
+from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
+
+
+def _taint(value):
+    return taint_pyobject(
+        pyobject=value,
+        source_name="test",
+        source_value=value,
+        source_origin=OriginType.PARAMETER,
+    )
+
+
+def test_taint_sources_suppressed_inside_context(iast_context_defaults):
+    # Sanity: tainting works normally.
+    assert is_pyobject_tainted(_taint("normal_value"))
+
+    with iast_suppress_context():
+        assert not is_pyobject_tainted(_taint("suppressed_value"))
+
+    # Behaviour is restored after the block.
+    assert is_pyobject_tainted(_taint("restored_value"))
+
+
+def test_context_id_is_saved_and_restored(iast_context_defaults):
+    context_id = _get_iast_context_id()
+    assert context_id is not None
+
+    with iast_suppress_context():
+        # The active context id is cleared while suppressed.
+        assert _get_iast_context_id() is None
+
+    # The original context id is restored on exit.
+    assert _get_iast_context_id() == context_id
+
+
+def test_propagation_is_not_suppressed(iast_context_defaults):
+    from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
+
+    tainted = _taint("tainted")
+    assert is_pyobject_tainted(tainted)
+
+    # Source generation is disabled, but propagation through aspects must still work on already-tainted input.
+    with iast_suppress_context():
+        result = add_aspect(tainted, "_suffix")
+        assert is_pyobject_tainted(result)


### PR DESCRIPTION
## Motivation

Taint collision can occur when a clean string is allocated with the same value during the same request at the same location as a previously tainted string.

While preventing all collisions is hard, we can at least ensure that there is no collision between iast strings in the appsec instrumentation and in the client code by disabling IAST source tainting in AAP.

This fixes the flaky tests `tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect::test_secure`.

## Description

When IAST is enabled, AppSec request analysis (request body parsing and WAF address gathering) reads request data through IAST-instrumented framework getters, which taint a fresh copy of the value on each call. The copies AppSec builds only flow into the WAF and are then discarded, so the taint metadata attached to them is unnecessary overhead.

Add `iast_suppress_context`, a context manager that temporarily clears the active IAST request context id — which gates taint source generation — and restores it on exit. It is applied around:

- the per-framework request body parsing handlers (Flask, FastAPI, Tornado)
- the WAF address serialization and run path in the processor.

Taint propagation is unaffected (aspects resolve their taint map from the object, not from the request context id), and the customer's own request reads still taint independently, since the framework getters taint a fresh copy on each call rather than mutating their cached object. 

## Testing

- New unit tests covering suppression while active, context id save/restore, and that taint propagation is not suppressed.
- Existing IAST integration suites for Flask, FastAPI and Tornado pass, confirming customer-facing tainting is preserved.
- Ensure that system-tests flakiness has disappeared using a pipeline that runs 100 times the scenario without failure: https://github.com/DataDog/system-tests/actions/runs/28028487659

## Risks

Low. Suppression is scoped to AppSec-only request analysis paths whose results never reach customer business logic.

## Additional Notes

Django is intentionally not modified: it taints the request body via a one-time assignment rather than per-call getters, and its body parsing runs in non-instrumented tracer code, so no throwaway taint sources are generated there. Django's WAF address analysis is already covered by the framework-agnostic processor path.
