### PR TITLE
perf(appsec): cache negative SQLi RASP evaluations

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -21,6 +21,8 @@ from ddtrace.appsec._metrics import UNKNOWN_VERSION
 from ddtrace.appsec._metrics import report_waf_run_error
 from ddtrace.appsec._metrics import report_waf_truncation
 from ddtrace.appsec._metrics import set_waf_request_metrics
+from ddtrace.appsec._rasp_sqli_cache import RaspSqliCache
+from ddtrace.appsec._rasp_sqli_cache import _CacheKey as _SqliCacheKey
 from ddtrace.appsec._utils import Block_config
 from ddtrace.appsec._utils import Telemetry_result
 from ddtrace.appsec._utils import get_triggers
@@ -120,6 +122,7 @@ class ASM_Environment:
         self.block_callable: Optional[Callable[[], None]] = None
         self.telemetry: Telemetry_result = Telemetry_result()
         self.addresses_sent: set[str] = set()
+        self.rasp_sqli_cache: RaspSqliCache = RaspSqliCache()
         self.waf_triggers: "list[WafEvent]" = []
         self.blocked: Optional[Block_config] = None
         self.finalized: bool = False
@@ -211,6 +214,29 @@ class _RaspSubcontextHolder:
 
     def __init__(self) -> None:
         self.subctx: Optional[Any] = None
+
+
+def check_rasp_sqli_cache(data: dict[str, Any]) -> tuple[Optional[_SqliCacheKey], bool]:
+    """Return (cache_key, is_cached) for a SQLi RASP evaluation."""
+    env = _get_asm_context()
+    if env is None:
+        return None, False
+    cache_key, is_cached = env.rasp_sqli_cache.check(data)
+    return cache_key, is_cached
+
+
+def update_rasp_sqli_cache(cache_key: _SqliCacheKey, waf_results: "DDWaf_result") -> None:
+    """Store a clean SQLi RASP result in the request-local negative cache."""
+    env = _get_asm_context()
+    if env is not None:
+        env.rasp_sqli_cache.store(cache_key, waf_results)
+
+
+def clear_rasp_sqli_cache() -> None:
+    """Invalidate the SQLi RASP cache. Called before each main-context WAF run."""
+    env = _get_asm_context()
+    if env is not None:
+        env.rasp_sqli_cache.clear()
 
 
 def open_rasp_subcontext_scope() -> None:

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -321,8 +321,15 @@ class AppSecSpanProcessor(SpanProcessor):
             if not data:
                 return None
 
+            sqli_cache_key: Optional[tuple[int, Optional[str]]] = None
+            if rule_type == EXPLOIT_PREVENTION.TYPE.SQLI:
+                sqli_cache_key, is_cached = _asm_request_context.check_rasp_sqli_cache(data)
+                if is_cached:
+                    return None
+
             try:
                 if rule_type is None:
+                    _asm_request_context.clear_rasp_sqli_cache()
                     # Request-related data -> main per-request context.
                     waf_results = self._ddwaf.run(ctx, data, timeout_ms=asm_config._waf_timeout)
                 else:
@@ -334,6 +341,8 @@ class AppSecSpanProcessor(SpanProcessor):
                         log.debug("appsec::processor::waf::rasp_subcontext_unavailable")
                         return None
                     waf_results = self._ddwaf.run(subctx, data, timeout_ms=asm_config._waf_timeout)
+                    if sqli_cache_key is not None:
+                        _asm_request_context.update_rasp_sqli_cache(sqli_cache_key, waf_results)
             except Exception:
                 log.debug("appsec::processor::waf::run", exc_info=True)
                 waf_results = Binding_error

--- a/ddtrace/appsec/_rasp_sqli_cache.py
+++ b/ddtrace/appsec/_rasp_sqli_cache.py
@@ -1,0 +1,65 @@
+"""Per-request negative cache for SQLi RASP evaluations.
+
+Repeated identical queries within one request skip WAF subcontext allocation
+on cache hit. Only clean results are cached (no match, no timeout, no actions).
+
+Key: (hash(sql), db_system). hash() avoids holding (potentially long) query strings in memory for
+the request lifetime.
+
+Invalidation: the cache is cleared before each main-context WAF run
+(rule_type is None), since the WAF subcontext inherits main-context data and
+previously-cached results may no longer hold after new request data arrives.
+"""
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Optional
+
+from ddtrace.appsec._constants import WAF_DATA_NAMES
+
+
+if TYPE_CHECKING:
+    from ddtrace.appsec._utils import DDWaf_result
+
+
+_MAX_SIZE = 128
+
+_CacheKey = tuple[int, Optional[str]]  # (hash(sql), db_system)
+
+
+class RaspSqliCache:
+    __slots__ = ("_cache",)
+
+    def __init__(self) -> None:
+        self._cache: set[_CacheKey] = set()
+
+    def check(self, data: dict[str, Any]) -> tuple[Optional[_CacheKey], bool]:
+        """Return (cache_key, is_cached).
+
+        cache_key is None when the SQL value is unhashable (caching skipped for this call).
+        """
+        sql = data.get(WAF_DATA_NAMES.SQLI_ADDRESS)
+        db_system = data.get(WAF_DATA_NAMES.SQLI_SYSTEM_ADDRESS)
+        try:
+            key: _CacheKey = (hash(sql), db_system)
+            return key, key in self._cache
+        except TypeError:
+            return None, False
+
+    def store(self, cache_key: _CacheKey, waf_results: "DDWaf_result") -> None:
+        """Add a clean WAF result to the cache."""
+        if (
+            waf_results.return_code == 0
+            and not waf_results.data
+            and not waf_results.actions
+            and not waf_results.timeout
+            and not waf_results.meta_tags
+            and not waf_results.metrics
+            and not waf_results.api_security
+            and not waf_results.keep
+            and len(self._cache) < _MAX_SIZE
+        ):
+            self._cache.add(cache_key)
+
+    def clear(self) -> None:
+        self._cache.clear()

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -1066,6 +1066,101 @@ def test_rasp_subcontext_fresh_per_non_ssrf_call():
     assert waf.created == 2
 
 
+def _sqli_run_calls(mock_run):
+    return [
+        call
+        for call in mock_run.call_args_list
+        if len(call.args) > 1 and isinstance(call.args[1], dict) and WAF_DATA_NAMES.SQLI_ADDRESS in call.args[1]
+    ]
+
+
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.new_subcontext")
+def test_rasp_sqli_negative_result_cached(mock_new_subcontext, mock_run):
+    """Repeated safe SQLi evaluations in one request should not create new subcontexts."""
+    from ddtrace.appsec._constants import EXPLOIT_PREVENTION
+    from ddtrace.appsec._utils import DDWaf_result
+    from ddtrace.appsec._utils import _observator
+    from ddtrace.trace import tracer
+
+    mock_new_subcontext.return_value = object()
+    mock_run.return_value = DDWaf_result(0, [], {}, 1.0, 2.0, False, _observator(), {})
+
+    with asm_context(tracer=tracer, config=config_asm) as span:
+        processor = AppSecSpanProcessor._instance
+        assert processor
+        custom_data = {
+            EXPLOIT_PREVENTION.ADDRESS.SQLI: "SELECT 1",
+            EXPLOIT_PREVENTION.ADDRESS.SQLI_TYPE: "sqlite",
+        }
+
+        result = processor._waf_action(span, None, custom_data, rule_type=EXPLOIT_PREVENTION.TYPE.SQLI)
+        cached_result = processor._waf_action(span, None, custom_data, rule_type=EXPLOIT_PREVENTION.TYPE.SQLI)
+
+    assert result is mock_run.return_value
+    assert cached_result is None
+    assert mock_new_subcontext.call_count == 1
+    assert len(_sqli_run_calls(mock_run)) == 1
+
+
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.new_subcontext")
+def test_rasp_sqli_cache_cleared_when_addresses_sent_grows(mock_new_subcontext, mock_run):
+    """If the parent WAF context gains request data, the cache is invalidated and the same SQL must be evaluated again."""
+    from ddtrace.appsec._constants import EXPLOIT_PREVENTION
+    from ddtrace.appsec._utils import DDWaf_result
+    from ddtrace.appsec._utils import _observator
+    from ddtrace.trace import tracer
+
+    mock_new_subcontext.return_value = object()
+    mock_run.return_value = DDWaf_result(0, [], {}, 1.0, 2.0, False, _observator(), {})
+
+    with asm_context(tracer=tracer, config=config_asm) as span:
+        processor = AppSecSpanProcessor._instance
+        assert processor
+        custom_data = {
+            EXPLOIT_PREVENTION.ADDRESS.SQLI: "SELECT 1",
+            EXPLOIT_PREVENTION.ADDRESS.SQLI_TYPE: "sqlite",
+        }
+
+        processor._waf_action(span, None, custom_data, rule_type=EXPLOIT_PREVENTION.TYPE.SQLI)
+        _asm_request_context.clear_rasp_sqli_cache()
+        processor._waf_action(span, None, custom_data, rule_type=EXPLOIT_PREVENTION.TYPE.SQLI)
+
+    assert mock_new_subcontext.call_count == 2
+    assert len(_sqli_run_calls(mock_run)) == 2
+
+
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
+@mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.new_subcontext")
+def test_rasp_sqli_positive_result_not_cached(mock_new_subcontext, mock_run):
+    """Positive SQLi results must keep reporting normally rather than becoming cache hits."""
+    from ddtrace.appsec._constants import EXPLOIT_PREVENTION
+    from ddtrace.appsec._utils import DDWaf_result
+    from ddtrace.appsec._utils import _observator
+    from ddtrace.trace import tracer
+
+    mock_new_subcontext.return_value = object()
+    mock_run.side_effect = [
+        DDWaf_result(1, [{}], {}, 1.0, 2.0, False, _observator(), {}),
+        DDWaf_result(1, [{}], {}, 1.0, 2.0, False, _observator(), {}),
+    ]
+
+    with asm_context(tracer=tracer, config=config_asm) as span:
+        processor = AppSecSpanProcessor._instance
+        assert processor
+        custom_data = {
+            EXPLOIT_PREVENTION.ADDRESS.SQLI: "SELECT 1",
+            EXPLOIT_PREVENTION.ADDRESS.SQLI_TYPE: "sqlite",
+        }
+
+        processor._waf_action(span, None, custom_data, rule_type=EXPLOIT_PREVENTION.TYPE.SQLI)
+        processor._waf_action(span, None, custom_data, rule_type=EXPLOIT_PREVENTION.TYPE.SQLI)
+
+    assert mock_new_subcontext.call_count == 2
+    assert len(_sqli_run_calls(mock_run)) == 2
+
+
 @mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
 def test_rasp_bypassed_when_subcontext_unavailable(mock_run):
     """If a RASP subcontext can't be created, the WAF call is bypassed entirely (not run on the

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -1106,7 +1106,7 @@ def test_rasp_sqli_negative_result_cached(mock_new_subcontext, mock_run):
 @mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.run")
 @mock.patch("ddtrace.appsec._ddwaf.waf.DDWaf.new_subcontext")
 def test_rasp_sqli_cache_cleared_when_addresses_sent_grows(mock_new_subcontext, mock_run):
-    """If the parent WAF context gains request data, the cache is invalidated and the same SQL must be evaluated again."""
+    """If the parent WAF context gains request data, cache is invalidated and the same SQL must be evaluated again."""
     from ddtrace.appsec._constants import EXPLOIT_PREVENTION
     from ddtrace.appsec._utils import DDWaf_result
     from ddtrace.appsec._utils import _observator


### PR DESCRIPTION
## Description

SQLi RASP checks run on every instrumented DB call. ORM-heavy endpoints trigger many identical queries per request (N+1 patterns, repeated lookups) — each previously ran a full libddwaf subcontext evaluation.

This PR adds a **request-local negative-result cache** for SQLi RASP. When the WAF returns a clean result for a \`(sql_statement, db_system, persistent_addresses_snapshot)\` triple, subsequent identical evaluations within the same request skip subcontext creation and WAF execution.

**Cache safety:**
- Only caches \`return_code == 0\` results with no matches, actions, or timeout — any positive result is always re-evaluated.
- The key includes a snapshot of \`addresses_sent\` (the set of persistent request-level addresses inherited by subcontexts), so the same SQL is re-evaluated if new request data arrives mid-request (e.g. body parsed after headers).
- Request-scoped (\`ASM_Environment\`), discarded with the request — no cross-request sharing.
- Max 128 entries per request to bound memory overhead.

SQLi-only for now; other RASP types lack the same high-frequency repeated-call pattern.

## Testing

Three new unit tests in \`tests/appsec/appsec/test_processor.py\`:
- A clean result is cached; the second identical call skips subcontext creation and WAF execution entirely.
- The cache key invalidates when new persistent addresses arrive mid-request, forcing a fresh WAF evaluation.
- Positive results are never cached; both calls run the full WAF.

## Risks

Cache correctness depends on WAF determinism for a given \`(sql, db_system, inherited_addresses)\` triple, which holds for current SQLi rules. The cache is conservative: any non-trivially-clean result skips caching. False negatives (unnecessary re-evaluation) are possible; false positives (skipping a real attack) are not.