### PR TITLE
fix(asm): hash django session id in anonymization mode

### DIFF
--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -169,6 +169,9 @@ def _on_django_process(
         return
     user_id, user_extra = get_user_info(info_retriever, django_config, kwargs)
     user_login = user_extra.get("login")
+    real_mode = mode if mode != LOGIN_EVENTS_MODE.AUTO else asm_config._user_event_mode
+    if session_key and real_mode == LOGIN_EVENTS_MODE.ANON:
+        session_key = _hash_user_id(session_key)
     res = None
     if result_user and result_user.is_authenticated:
         if _metrics._is_user_auth_value_missing(user_id):
@@ -203,7 +206,6 @@ def _on_django_process(
                 span=span,
             )
         if in_asm_context():
-            real_mode = mode if mode != LOGIN_EVENTS_MODE.AUTO else asm_config._user_event_mode
             custom_data = {
                 "REQUEST_USER_ID": str(user_id) if user_id else None,
                 "REQUEST_USERNAME": user_login,

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -175,6 +175,7 @@ def track_user_login_success_event(
     if not span:
         return
     user_id = _maybe_hash(user_id, real_mode)
+    session_id = _maybe_hash(session_id, real_mode)
     span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, real_mode)
     if user_id:
         if login_events_mode != LOGIN_EVENTS_MODE.SDK:

--- a/releasenotes/notes/django-anon-session-id-442be8562292534e.yaml
+++ b/releasenotes/notes/django-anon-session-id-442be8562292534e.yaml
@@ -1,9 +1,6 @@
 ---
 fixes:
   - |
-    ASM: This fix resolves an issue where the Django session id, automatically collected by user
-    activity tracking, was exported in clear text as the ``usr.session_id`` span tag even when
-    automatic user instrumentation was running in ``anonymization`` mode. For Django's default
-    server-side session backends the session id is the session cookie value, so it is now hashed
-    in ``anonymization`` mode, consistently with the user id and login, to preserve the expected
-    anonymization boundary.
+    ASM: This fix resolves an issue where the Django session id collected by automatic user
+    activity tracking was not hashed in ``anonymization`` mode. It is now hashed, consistently
+    with the user id and login.

--- a/releasenotes/notes/django-anon-session-id-442be8562292534e.yaml
+++ b/releasenotes/notes/django-anon-session-id-442be8562292534e.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where the Django session id, automatically collected by user
+    activity tracking, was exported in clear text as the ``usr.session_id`` span tag even when
+    automatic user instrumentation was running in ``anonymization`` mode. For Django's default
+    server-side session backends the session id is the session cookie value, so it is now hashed
+    in ``anonymization`` mode, consistently with the user id and login, to preserve the expected
+    anonymization boundary.

--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -7,6 +7,7 @@ import pytest
 from ddtrace import constants
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
+from ddtrace.appsec._utils import _hash_user_id
 from ddtrace.appsec.trace_utils import block_request_if_user_blocked
 from ddtrace.appsec.trace_utils import should_block_user
 from ddtrace.appsec.trace_utils import track_custom_event
@@ -122,6 +123,9 @@ class EventsSDKTestCase(TracerTestCase):
             assert entry_span.get_tag("%s.track" % success_prefix) == "true"
             assert not entry_span.get_tag("_dd.appsec.events.users.login.success.sdk")
             assert entry_span.get_tag(APPSEC.AUTO_LOGIN_EVENTS_SUCCESS_MODE) == str(LOGIN_EVENTS_MODE.ANON)
+            # the session id must be anonymized in anonymization mode, never exported in clear text
+            assert entry_span.get_tag(user.SESSION_ID) == _hash_user_id("test_session_id")
+            assert entry_span.get_tag(user.SESSION_ID) != "test_session_id"
 
     def test_track_user_login_event_success_auto_mode_extended(self):
         with asm_context(tracer=self.tracer, span_name="test_success1", config=config_asm) as span:
@@ -142,6 +146,8 @@ class EventsSDKTestCase(TracerTestCase):
             assert entry_span.get_tag("%s.track" % success_prefix) == "true"
             assert not entry_span.get_tag("_dd.appsec.events.users.login.success.sdk")
             assert entry_span.get_tag(APPSEC.AUTO_LOGIN_EVENTS_SUCCESS_MODE) == str(LOGIN_EVENTS_MODE.IDENT)
+            # the session id is kept as is in identification mode
+            assert entry_span.get_tag(user.SESSION_ID) == "test_session_id"
 
     def test_track_user_login_event_success_with_metadata(self):
         with (

--- a/tests/appsec/integrations/django_tests/test_appsec_django.py
+++ b/tests/appsec/integrations/django_tests/test_appsec_django.py
@@ -10,6 +10,7 @@ from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._processor import AppSecSpanProcessor  # noqa: F401
+from ddtrace.appsec._utils import _hash_user_id
 from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import constants
@@ -330,9 +331,14 @@ def test_django_authenticated_request_tags_session_id(client, test_spans, tracer
         assert response.status_code == 200
 
         request_span = test_spans.find_span(name="django.request")
-        assert request_span.get_tag(user.SESSION_ID) == session_key
         if mode == LOGIN_EVENTS_MODE.IDENT:
+            assert request_span.get_tag(user.SESSION_ID) == session_key
             assert request_span.get_tag(user.ID)
+        else:
+            # in anonymization mode the session id (a session cookie token for default backends)
+            # must be hashed before being exported as a tag
+            assert request_span.get_tag(user.SESSION_ID) == _hash_user_id(session_key)
+            assert request_span.get_tag(user.SESSION_ID) != session_key
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
APPSEC-68548

Django's auto user-activity tracking exported `request.session.session_key` as the `usr.session_id` span tag in clear text even in `anonymization` mode. For default server-side session backends this key is the session cookie value, so it disclosed live session tokens and bypassed the anonymization boundary.

This hashes the session id (consistently with user id and login) in `anonymization` mode, for both the `usr.session_id` tag and the WAF `REQUEST_SESSION_ID` address. `identification` mode is unchanged.

## Testing
- Updated unit tests (`test_appsec_trace_utils.py`) assert the session id is hashed in anon mode and clear in ident mode.
- Updated Django integration test (`test_appsec_django.py`) asserts the per-request tag is hashed in anon mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)