### PR TITLE
fix(django): preserve process_exception on async function-based middleware

### DIFF
--- a/ddtrace/contrib/internal/django/middleware.py
+++ b/ddtrace/contrib/internal/django/middleware.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 from inspect import iscoroutinefunction
 from inspect import isfunction
 from types import FunctionType
@@ -140,10 +141,9 @@ def traced_middleware_factory(func: FunctionType, args: tuple[Any], kwargs: dict
 
     if iscoroutinefunction(middleware):
         # Handle async middleware - create async wrapper
+        @functools.wraps(middleware)
         async def traced_async_middleware_func(*args, **kwargs):
             # The first argument for all middleware is the request object
-            # DEV: Do `optional=true` to avoid raising an error for middleware that don't follow the convention
-            # DEV: This is a function, so no `self` argument, so request is at position 0
             request = get_argument_value(args, kwargs, 0, "request", optional=True)
 
             with core.context_with_data(

--- a/releasenotes/notes/fix-django-now-preserves-middleware-attributes-535c70935bf3a07e.yaml
+++ b/releasenotes/notes/fix-django-now-preserves-middleware-attributes-535c70935bf3a07e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Django: This fix resolves an issue where async function-based middleware attributes,
+    such as ``process_exception``, were not preserved, causing Django to skip
+    exception handlers under ASGI.

--- a/tests/contrib/django/middleware.py
+++ b/tests/contrib/django/middleware.py
@@ -52,6 +52,34 @@ def fn2_middleware(get_response):
     return mw
 
 
+try:
+    from asgiref.sync import iscoroutinefunction as is_asgi_coroutine_function
+    from django.utils.decorators import sync_and_async_middleware
+
+    @sync_and_async_middleware
+    def fn_middleware_with_process_exception(get_response):
+        """Function middleware that exposes a Django process_exception hook."""
+
+        if is_asgi_coroutine_function(get_response):
+
+            async def mw(request):
+                return await get_response(request)
+
+        else:
+
+            def mw(request):
+                return get_response(request)
+
+        def process_exception(request, exception):
+            return HttpResponse("caught", status=200)
+
+        mw.process_exception = process_exception
+        return mw
+
+except ImportError:
+    pass
+
+
 def empty_middleware(get_response):
     """Empty function middleware for regression testing."""
 

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -460,6 +460,17 @@ def test_multiple_fn_middleware_resource_names(client, test_spans):
     assert test_spans.find_span(name="django.middleware", resource="tests.contrib.django.middleware.fn2_middleware")
 
 
+@pytest.mark.skipif(django.VERSION < (4, 1, 0), reason="async middleware require Django 4.1+")
+def test_async_function_middleware_preserves_process_exception():
+    from django.core.handlers.base import BaseHandler
+
+    with override_settings(MIDDLEWARE=["tests.contrib.django.middleware.fn_middleware_with_process_exception"]):
+        handler = BaseHandler()
+        handler.load_middleware(is_async=True)
+
+    assert len(handler._exception_middleware) == 1
+
+
 """
 View tests
 """


### PR DESCRIPTION
Superseeds https://github.com/DataDog/dd-trace-py/pull/18697 made by @fabrice-toussaint.
Thank you for your contribution !

## Description

`traced_middleware_factory` creates a new `async def` wrapper for async function-based middleware but does not copy attributes like `process_exception` from the original function. Django's `load_middleware` uses `hasattr(mw_instance, 'process_exception')` to discover exception handlers, so the handler is silently dropped under ASGI.

The **sync** branch already handles this correctly — it uses `wrap()` (wrapt) which preserves attributes. The **async** branch cannot use bytecode wrappers (#17728), so this PR copies the relevant hook attributes explicitly.

## Motivation

Affects any Django middleware that:
1. Is function-based (not class-based)
2. Uses `@sync_and_async_middleware`
3. Attaches `process_exception` as a function attribute

**Confirmed affected:** [allauth's `AccountMiddleware`](https://github.com/pennersr/django-allauth/blob/main/allauth/account/middleware.py) — its `process_exception` handles `ReauthenticationRequired` (reauthentication redirect). With ddtrace under ASGI, this becomes a 500 instead of a redirect.

Fixes #18696

## Changes

We now are using @functools.wraps() on the async middleware which preserves `process_exception`

## Testing

Adds a test that check that `process_exception` is still here on an async middleware