### PR TITLE
fix: native rust fix for HAMT/ContextVar crash [backport 4.11]

### DIFF
--- a/ddtrace/_trace/provider.py
+++ b/ddtrace/_trace/provider.py
@@ -1,5 +1,6 @@
 import abc
 import contextvars
+import sys
 from typing import Any
 from typing import Optional
 from typing import Union
@@ -17,6 +18,21 @@ ActiveTrace = Union[Span, Context]
 _DD_CONTEXTVAR: contextvars.ContextVar[Optional[ActiveTrace]] = contextvars.ContextVar(
     "datadog_contextvar", default=None
 )
+
+
+# PyContextVar_Set is not atomic before CPython 3.12: an allocation during
+# the HAMT rebuild can trigger a cyclic GC pass that frees a node still in use,
+# crashing with SEGV_MAPERR. On affected versions we route the set through a
+# native helper that secures the context's storage during the call.
+# CPython 3.12+ is unaffected, so use the plain (and faster) set there.
+if sys.version_info < (3, 12):
+    from ddtrace.internal.native._native import safe_contextvar_set
+
+    def _activate_contextvar(ctx: Optional[ActiveTrace]) -> None:
+        safe_contextvar_set(_DD_CONTEXTVAR, ctx)
+
+else:
+    _activate_contextvar = _DD_CONTEXTVAR.set  # type: ignore[assignment]
 
 
 class BaseContextProvider(metaclass=abc.ABCMeta):
@@ -65,7 +81,7 @@ class DefaultContextProvider(BaseContextProvider):
 
     def activate(self, ctx: Optional[ActiveTrace]) -> None:
         """Makes the given context active in the current execution."""
-        _DD_CONTEXTVAR.set(ctx)
+        _activate_contextvar(ctx)
         super(DefaultContextProvider, self).activate(ctx)
 
     def active(self) -> Optional[ActiveTrace]:

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -1,3 +1,4 @@
+import contextvars
 from enum import Enum
 from typing import Any
 from typing import Iterator
@@ -765,3 +766,5 @@ class config:
     def set_raise(val: bool) -> None:
         """Set whether errors in event listeners should be re-raised (DD_TESTING_RAISE)."""
         ...
+
+def safe_contextvar_set(var: contextvars.ContextVar[Any], value: Any) -> None: ...

--- a/releasenotes/notes/internal-add-contextvar-helper-d73542f1c6cfceac.yaml
+++ b/releasenotes/notes/internal-add-contextvar-helper-d73542f1c6cfceac.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    tracing: A rare crash happening on versions of CPython prior to 3.12 has been fixed.
+

--- a/src/native/contextvar.rs
+++ b/src/native/contextvar.rs
@@ -1,0 +1,61 @@
+use pyo3::ffi;
+use pyo3::prelude::*;
+
+/// Set a `ContextVar` while protecting against a CPython crash.
+///
+/// `PyContextVar_Set` rebuilds the thread state's context HAMT and is not
+/// atomic: the allocations it performs while building the new trie can trigger
+/// a cyclic GC pass, and it then Py_DECREF's the previous HAMT root, which can
+/// start a dealloc cascade. If a node still referenced by the in-flight rebuild
+/// is collected during that window, the next access to it faults with
+/// `SEGV_MAPERR`.
+///
+/// PyContext_CopyCurrent returns a fresh context object that shares -- and
+/// holds a strong reference to -- the current context's variable storage. Keeping
+/// that snapshot alive across the set pins the whole storage graph as
+/// GC-reachable, so neither the Py_DECREF cascade nor a concurrent GC pass can
+/// free a node that is still in use. The snapshot (and the discarded token) are
+/// released once the set has completed and the context is consistent again.
+#[pyfunction]
+pub fn safe_contextvar_set(
+    py: Python<'_>,
+    var: &Bound<'_, PyAny>,
+    value: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    // SAFETY: the GIL (`py`) is held for every call below and is never released,
+    // so the thread state and its context cannot change underneath us.
+    unsafe {
+        let snapshot = ffi::PyContext_CopyCurrent();
+        if snapshot.is_null() {
+            // Snapshotting the current context failed (e.g. out of memory); an
+            // exception is already set. Propagate it rather than crashing.
+            return Err(PyErr::take(py).unwrap_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("PyContext_CopyCurrent failed")
+            }));
+        }
+
+        let token = ffi::PyContextVar_Set(var.as_ptr(), value.as_ptr());
+
+        // Capture any error before the decrefs below can perturb interpreter state.
+        let err = if token.is_null() {
+            PyErr::take(py)
+        } else {
+            None
+        };
+
+        // The returned token is never used (we don't support reset here), so drop
+        // it. Then release the snapshot now that the context is consistent again.
+        ffi::Py_XDECREF(token);
+        ffi::Py_DECREF(snapshot);
+
+        if let Some(err) = err {
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+pub fn register_contextvar(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(safe_contextvar_set, m)?)?;
+    Ok(())
+}

--- a/src/native/lib.rs
+++ b/src/native/lib.rs
@@ -3,6 +3,7 @@ mod crashtracker;
 #[cfg(feature = "profiling")]
 pub use datadog_profiling_ffi::*;
 mod config;
+mod contextvar;
 mod data_pipeline;
 #[cfg(feature = "stats")]
 mod ddsketch;
@@ -53,6 +54,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     data_pipeline::register_data_pipeline(m)?;
     span::register_native_span(m)?;
     event_hub::register_event_hub(m)?;
+    contextvar::register_contextvar(m)?;
     rand::register_rand(m)?;
     m.add_function(wrap_pyfunction!(ddtrace_utils::flatten_key_value, m)?)?;
     m.add_function(wrap_pyfunction!(ddtrace_utils::is_sequence, m)?)?;


### PR DESCRIPTION
Backport of PR #18599 (branch `kowalski/fix-fancy-rust-fix-for-hamt-crash`) to branch 4.11.

## Description

This is an attempt to fix a customer-reported crash ([Jira](https://datadoghq.atlassian.net/browse/SCP-1205)).
- The customer is using a version that already includes this `ContextVar`-related crash: https://github.com/DataDog/dd-trace-py/pull/17407
- It's likely https://github.com/python/cpython/pull/148928 would fix the crash as well but (1) it would only land in recent versions of CPython -- the customer is using 3.11 -- and (2) I don't have a review/approval yet.

This fix addresses the issue in a sort of makeshift way like the CPython upstream fix would. Since we can't bump reference counts directly from CPython, the PR adds a Rust helper which takes care of it. Not great, not terrible.

**Note** the bug only happens in versions prior to 3.12 (which made significant changes to the GC and doesn't trigger that HAMT crash anymore), so the fix is gated to them.

## Notes on conflict resolution

Applied manually to the release branch. `contextvar::register_contextvar` is wired into each branch's `src/native/lib.rs` layout (4.8 uses `utils` instead of `ddtrace_utils`; 4.11 registers after `event_hub`).