### PR TITLE
fix(openfeature): map invalid FFE config parse errors

### DIFF
--- a/releasenotes/notes/fix-openfeature-ffe-invalid-config-error-code-18713ffe.yaml
+++ b/releasenotes/notes/fix-openfeature-ffe-invalid-config-error-code-18713ffe.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    openfeature: Fixes the error code returned for invalid Feature Flagging and Experimentation
+    flag configurations. Invalid flag configuration now returns ``PARSE_ERROR`` instead of a
+    generic error code, preserving the expected OpenFeature error type.

--- a/src/native/ffe.rs
+++ b/src/native/ffe.rs
@@ -188,7 +188,8 @@ pub mod ffe {
                     ErrorCode::TypeMismatch,
                     format!("type mismatch, expected={expected:?}, found={found:?}"),
                 ),
-                EvaluationError::ConfigurationParseError => {
+                EvaluationError::ConfigurationParseError
+                | EvaluationError::FlagConfigurationInvalid => {
                     ResolutionDetails::error(ErrorCode::ParseError, "configuration error")
                 }
                 EvaluationError::ConfigurationMissing => ResolutionDetails::error(

--- a/tests/openfeature/test_provider.py
+++ b/tests/openfeature/test_provider.py
@@ -127,6 +127,19 @@ class TestBooleanFlagResolution:
         assert result.error_code == ErrorCode.TYPE_MISMATCH
         assert "expected" in result.error_message.lower()
 
+    def test_resolve_boolean_flag_invalid_configuration(self, provider):
+        """Should return parse error when a flag has invalid configuration."""
+        flag = create_boolean_flag("invalid-config-flag", enabled=True, default_value=True)
+        flag["variations"]["true"]["value"] = "not-a-boolean"
+        config = create_config(flag)
+        process_ffe_configuration(config)
+
+        result = provider.resolve_boolean_details("invalid-config-flag", False)
+
+        assert result.value is False
+        assert result.reason == Reason.ERROR
+        assert result.error_code == ErrorCode.PARSE_ERROR
+
 
 class TestStringFlagResolution:
     """Test string flag resolution."""


### PR DESCRIPTION
## Motivation

PR #18713 bumps libdatadog to v36. System Tests fail because invalid Feature Flagging and Experimentation flag configuration now comes through libdatadog as `FlagConfigurationInvalid`; dd-trace-py previously fell through to OpenFeature `GENERAL`, causing metrics to emit `error.type:general` instead of the expected `error.type:parse_error`.

## Changes

This maps `EvaluationError::FlagConfigurationInvalid` to the existing native `ParseError` wrapper path alongside `ConfigurationParseError`. It also adds an OpenFeature provider regression test for invalid per-flag configuration and a release note for the preserved error-code behavior.

## Decisions

The fix stays in the Rust/PyO3 wrapper rather than changing Python metrics code or system-test expectations, because the upstream native error still represents an invalid flag configuration parse/compile failure. This PR is stacked on `vianney/bump-libdatadog-36` so the libdatadog upgrade can absorb the compatibility shim directly.

## Testing

- `scripts/lint fmt tests/openfeature/test_provider.py`
- `cargo fmt --manifest-path src/native/Cargo.toml -- src/native/ffe.rs`
- `scripts/lint style tests/openfeature/test_provider.py`
- `scripts/run-tests --venv 13c4b39 tests/openfeature/test_provider.py -- -- -k invalid_configuration -vv`
- `uvx --from reno reno lint`

## Risks

Low. The change only maps a newly introduced libdatadog v36 FFE error variant to the same OpenFeature parse error already used for configuration parse failures.