### PR TITLE
fix(tracing): forward throw/close/send when wrapping async generators

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -8,6 +8,8 @@ import logging
 import os
 from os import getpid
 from threading import Lock
+from typing import Any
+from typing import AsyncGenerator
 from typing import Callable
 from typing import Optional
 from typing import TypeVar
@@ -805,34 +807,26 @@ class Tracer(object):
         @functools.wraps(f)
         async def func_wrapper(*args, **kwargs):
             with self.trace(span_name, service=service, resource=resource, span_type=span_type):
-                # Delegate to the wrapped async generator, forwarding sent values,
-                # thrown exceptions, and close requests. This is the async analogue of
-                # ``yield from`` (which has no async equivalent) and is required so that
-                # ``try/finally`` cleanup inside the generator runs and so that the wrapper
-                # composes correctly with ``contextlib.asynccontextmanager``. A plain
-                # ``async for value in f(...): yield value`` only forwards ``__anext__`` and
-                # would skip the inner generator's cleanup on ``athrow``/``aclose``.
-                agen = f(*args, **kwargs)
-                try:
-                    item = await agen.__anext__()
-                except StopAsyncIteration:
-                    return
+                # Delegate to the wrapped async generator: forward sent values,
+                # thrown exceptions, and close requests. This is required so that
+                # `try/finally` cleanup inside the generator runs; otherwise, the wrapper
+                # can fail when used with `contextlib.asynccontextmanager`.
+                agen: AsyncGenerator[Any, Any] = f(*args, **kwargs)
+                to_send: Any = None
+                to_throw: Optional[BaseException] = None
                 while True:
+                    item: Any
                     try:
-                        sent = yield item
+                        item = await (agen.athrow(to_throw) if to_throw is not None else agen.asend(to_send))
+                    except StopAsyncIteration:
+                        return
+                    try:
+                        to_send, to_throw = (yield item), None
                     except GeneratorExit:
                         await agen.aclose()
                         raise
                     except BaseException as exc:
-                        try:
-                            item = await agen.athrow(exc)
-                        except StopAsyncIteration:
-                            return
-                    else:
-                        try:
-                            item = await agen.asend(sent)
-                        except StopAsyncIteration:
-                            return
+                        to_throw = exc
 
         return cast(AnyCallable, func_wrapper)
 

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -800,13 +800,39 @@ class Tracer(object):
         resource: Optional[str] = None,
         span_type: Optional[str] = None,
     ) -> AnyCallable:
-        """Wrap a generator function with tracing."""
+        """Wrap an async generator function with tracing."""
 
         @functools.wraps(f)
         async def func_wrapper(*args, **kwargs):
             with self.trace(span_name, service=service, resource=resource, span_type=span_type):
-                async for value in f(*args, **kwargs):
-                    yield value
+                # Delegate to the wrapped async generator, forwarding sent values,
+                # thrown exceptions, and close requests. This is the async analogue of
+                # ``yield from`` (which has no async equivalent) and is required so that
+                # ``try/finally`` cleanup inside the generator runs and so that the wrapper
+                # composes correctly with ``contextlib.asynccontextmanager``. A plain
+                # ``async for value in f(...): yield value`` only forwards ``__anext__`` and
+                # would skip the inner generator's cleanup on ``athrow``/``aclose``.
+                agen = f(*args, **kwargs)
+                try:
+                    item = await agen.__anext__()
+                except StopAsyncIteration:
+                    return
+                while True:
+                    try:
+                        sent = yield item
+                    except GeneratorExit:
+                        await agen.aclose()
+                        raise
+                    except BaseException as exc:
+                        try:
+                            item = await agen.athrow(exc)
+                        except StopAsyncIteration:
+                            return
+                    else:
+                        try:
+                            item = await agen.asend(sent)
+                        except StopAsyncIteration:
+                            return
 
         return cast(AnyCallable, func_wrapper)
 

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -815,9 +815,8 @@ class Tracer(object):
                 to_send: Any = None
                 to_throw: Optional[BaseException] = None
                 while True:
-                    item: Any
                     try:
-                        item = await (agen.athrow(to_throw) if to_throw is not None else agen.asend(to_send))
+                        item: Any = await (agen.athrow(to_throw) if to_throw is not None else agen.asend(to_send))
                     except StopAsyncIteration:
                         return
                     try:

--- a/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
+++ b/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where applying ``@tracer.wrap()`` to an
+    async generator function skipped the generator's ``try``/``finally`` cleanup
+    when an exception was raised or the generator was closed early, and broke
+    composition with ``contextlib.asynccontextmanager`` (raising errors such as
+    ``object NoneType can't be used in 'await' expression``). The wrapper now
+    forwards ``athrow``, ``aclose``, and ``asend`` to the wrapped async generator.

--- a/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
+++ b/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
@@ -1,7 +1,9 @@
 ---
 fixes:
   - |
-    tracing: an issue where applying ``@tracer.wrap()`` to an
-    async generator function skipped the generator's ``try``/``finally`` cleanup
-    when an exception was raised / generator closed early, breaking
-    composition with ``contextlib.asynccontextmanager``.
+tracing: Applying ``@tracer.wrap()`` to an async generator now forwards
+    sent values, thrown exceptions, and close requests to the underlying
+    generator, so it behaves like the unwrapped generator in all cases. Previously the
+    wrapper only relayed values during forward iteration, so sent values were
+    dropped and ``try``/``finally`` cleanup was skipped whenever the generator
+     was closed early or received a thrown exception.

--- a/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
+++ b/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
@@ -1,9 +1,7 @@
 ---
 fixes:
   - |
-    tracing: This fix resolves an issue where applying ``@tracer.wrap()`` to an
+    tracing: an issue where applying ``@tracer.wrap()`` to an
     async generator function skipped the generator's ``try``/``finally`` cleanup
-    when an exception was raised or the generator was closed early, and broke
-    composition with ``contextlib.asynccontextmanager`` (raising errors such as
-    ``object NoneType can't be used in 'await' expression``). The wrapper now
-    forwards ``athrow``, ``aclose``, and ``asend`` to the wrapped async generator.
+    when an exception was raised / generator closed early, breaking
+    composition with ``contextlib.asynccontextmanager``.

--- a/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
+++ b/releasenotes/notes/fix-tracer-wrap-async-generator-delegation-83529d8d52a0a7c4.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-tracing: Applying ``@tracer.wrap()`` to an async generator now forwards
+    tracing: Applying ``@tracer.wrap()`` to an async generator now forwards
     sent values, thrown exceptions, and close requests to the underlying
     generator, so it behaves like the unwrapped generator in all cases. Previously the
     wrapper only relayed values during forward iteration, so sent values were
     dropped and ``try``/``finally`` cleanup was skipped whenever the generator
-     was closed early or received a thrown exception.
+    was closed early or received a thrown exception.

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -352,3 +352,74 @@ async def test_wrapped_async_gen_send(tracer, test_spans):
     await gen.aclose()
 
     assert received == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_classmethod_asynccontextmanager(tracer, test_spans):
+    # The exact shape that triggered the original bug: a classmethod async
+    # context manager whose body raises must propagate the exception AND run
+    # the wrapped generator's ``finally``.
+    events = []
+
+    class Model:
+        @classmethod
+        @asynccontextmanager
+        @tracer.wrap("model.conn")
+        async def get_conn(cls):
+            events.append("enter")
+            try:
+                yield "conn"
+            finally:
+                events.append("cleanup")
+
+    with pytest.raises(ValueError):
+        async with Model.get_conn() as conn:
+            assert conn == "conn"
+            events.append("body")
+            raise ValueError("boom")
+
+    assert events == ["enter", "body", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_cancelled_error(tracer, test_spans):
+    # asyncio.CancelledError (a BaseException, not Exception) must still
+    # propagate and run the wrapped generator's ``finally``.
+    events = []
+
+    @asynccontextmanager
+    @tracer.wrap("managed")
+    async def managed():
+        try:
+            yield "resource"
+        finally:
+            events.append("cleanup")
+
+    with pytest.raises(asyncio.CancelledError):
+        async with managed():
+            raise asyncio.CancelledError()
+
+    assert events == ["cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_athrow_yields(tracer, test_spans):
+    """Inner gen catches the thrown exception and yields a recovery value."""
+
+    @tracer.wrap("resilient")
+    async def resilient():
+        value = 0
+        while True:
+            try:
+                yield value
+            except ValueError:
+                yield -1  # recovery yield, then loop continues
+            value += 1
+
+    gen = resilient()
+    assert await gen.asend(None) == 0
+    assert await gen.asend(None) == 1
+    recovery = await gen.athrow(ValueError("oops"))  # should yield -1, not raise
+    assert recovery == -1
+    assert await gen.asend(None) == 2  # resumes normally after recovery
+    await gen.aclose()

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -1,6 +1,7 @@
 """Ensure that the tracer works with asynchronous executions within the same ``IOLoop``."""
 
 import asyncio
+from contextlib import asynccontextmanager
 import os
 import re
 
@@ -252,3 +253,102 @@ async def test_wrapped_generator(tracer, test_spans):
     assert span.resource == "r"
     assert span.span_type == "t"
     assert span.get_tag("a") == "b"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_asynccontextmanager(tracer, test_spans):
+    # @tracer.wrap() on an async generator must compose with
+    # contextlib.asynccontextmanager so it can be driven via ``async with``.
+    events = []
+
+    @asynccontextmanager
+    @tracer.wrap("managed")
+    async def managed():
+        events.append("enter")
+        try:
+            yield "resource"
+        finally:
+            events.append("cleanup")
+
+    async with managed() as resource:
+        assert resource == "resource"
+        events.append("body")
+
+    assert events == ["enter", "body", "cleanup"]
+
+    traces = test_spans.pop_traces()
+    assert 1 == len(traces)
+    assert 1 == len(traces[0])
+    assert traces[0][0].name == "managed"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_cleanup_on_exception(tracer, test_spans):
+    # When the consumer raises, the exception must propagate AND the wrapped
+    # generator's ``finally`` block must still run (regression: the old
+    # ``async for ... yield`` wrapper skipped the inner cleanup).
+    events = []
+
+    @asynccontextmanager
+    @tracer.wrap("managed")
+    async def managed():
+        events.append("enter")
+        try:
+            yield "resource"
+        finally:
+            events.append("cleanup")
+
+    with pytest.raises(ValueError, match="boom"):
+        async with managed():
+            events.append("body")
+            raise ValueError("boom")
+
+    assert events == ["enter", "body", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_early_close(tracer, test_spans):
+    # Closing the wrapped generator before it is exhausted must forward
+    # ``aclose`` to the inner generator so its ``finally`` runs, without raising
+    # "aclose(): asynchronous generator is already running".
+    events = []
+
+    @tracer.wrap("counter")
+    async def counter():
+        try:
+            for i in range(10):
+                yield i
+        finally:
+            events.append("cleanup")
+
+    gen = counter()
+    seen = [await gen.__anext__(), await gen.__anext__()]
+    await gen.aclose()
+
+    assert seen == [0, 1]
+    assert events == ["cleanup"]
+
+    traces = test_spans.pop_traces()
+    assert 1 == len(traces)
+    assert traces[0][0].name == "counter"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_async_gen_send(tracer, test_spans):
+    # Values sent into the wrapped generator via ``asend`` must be forwarded
+    # to the inner generator.
+    received = []
+
+    @tracer.wrap("echo")
+    async def echo():
+        while True:
+            value = yield
+            received.append(value)
+
+    gen = echo()
+    await gen.asend(None)  # prime
+    await gen.asend("a")
+    await gen.asend("b")
+    await gen.aclose()
+
+    assert received == ["a", "b"]


### PR DESCRIPTION
## Description

`tracer.wrap()` on async generator functions currently re-yields through a manual `async for value in ...` loop. This only forwards `__anext__` — it does **not** forward `athrow()`, `aclose()`, or `asend()` to the wrapped async generator. When the wrapped generator was driven by something that throws or closes it, its own `try/finally` cleanup is being skipped and its lifecycle could become corrupted.

This was hit in AB-experiments on staging on an `@asynccontextmanager` + `@tracer.wrap()` async generator. When the `async with` body raised, `asynccontextmanager.__aexit__` called `athrow()` on the wrapper, which never reached the user's `yield`, so the `finally` was skipped, As a result, the half-finalized async-gen state became HTTP 500s errors:
* `RuntimeError: aclose(): asynchronous generator is already running`
* `TypeError: object NoneType can't be used in 'await' expression`.

This PR rewrites `_wrap_generator_async` to manually delegate `asend`/`athrow`/`aclose` to the wrapped generator.

Minimal repro:
```python
@asynccontextmanager
@tracer.wrap()
async def managed():
    try:
        yield "resource"
    finally:
        cleanup()  # skipped on the exception path before this fix

async with managed():
    raise ValueError("boom")  # cleanup() never ran
```

## Testing

- New unit / regression tests
- CI

## Additional Notes

- The sync version of `_wrap_generator` is already correct via `yield from`
