### PR TITLE
chore(native): upgrade libdatadog to v36.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ WHEEL_FLAVOR = "-serverless" if SERVERLESS_BUILD else ""
 LIBDDWAF_VERSION = "2.0.0"
 
 # DEV: update this accordingly when src/native upgrades libdatadog dependency.
-# libdatadog v35.0.0 requires rust 1.87.0.
+# libdatadog v36.0.0 requires rust 1.87.0.
 RUST_MINIMUM_VERSION = "1.87.0"
 
 

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -187,8 +187,8 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "35.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "36.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "cbindgen",
  "serde",
@@ -483,12 +483,13 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "chrono",
  "derive_more",
  "faststr",
  "libdd-common",
+ "libdd-remote-config",
  "log",
  "md5",
  "pyo3",
@@ -502,30 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "datadog-remote-config"
-version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
-dependencies = [
- "anyhow",
- "base64",
- "futures-util",
- "http",
- "http-body-util",
- "libdd-common",
- "libdd-trace-protobuf",
- "manual_future",
- "serde",
- "serde_json",
- "serde_with",
- "sha2",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "ddtrace-native"
 version = "0.1.0"
 dependencies = [
@@ -533,7 +510,6 @@ dependencies = [
  "build_common",
  "bytes",
  "datadog-ffe",
- "datadog-remote-config",
  "libc",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -544,6 +520,7 @@ dependencies = [
  "libdd-library-config",
  "libdd-log",
  "libdd-profiling-ffi",
+ "libdd-remote-config",
  "libdd-shared-runtime",
  "libdd-trace-utils",
  "libdd-tracer-flare",
@@ -1083,7 +1060,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1411,7 +1387,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1421,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1432,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "bytes",
  "http",
@@ -1445,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1472,6 +1448,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-native-certs",
+ "rustls-platform-verifier",
  "serde",
  "static_assertions",
  "thiserror 1.0.69",
@@ -1483,8 +1460,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "35.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "36.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1498,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1530,8 +1507,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "6.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1549,6 +1526,7 @@ dependencies = [
  "libdd-shared-runtime",
  "libdd-telemetry",
  "libdd-tinybytes",
+ "libdd-trace-normalization",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf",
  "libdd-trace-stats",
@@ -1566,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "prost",
 ]
@@ -1574,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1586,8 +1564,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "35.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "36.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "bytes",
  "fastrand",
@@ -1600,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "libc",
@@ -1628,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "chrono",
  "tracing",
@@ -1639,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1678,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1691,6 +1669,7 @@ dependencies = [
  "libdd-common",
  "libdd-common-ffi",
  "libdd-profiling",
+ "libdd-shared-runtime-ffi",
  "serde_json",
  "thiserror 2.0.18",
  "tokio-util",
@@ -1699,15 +1678,43 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "prost",
 ]
 
 [[package]]
+name = "libdd-remote-config"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
+dependencies = [
+ "anyhow",
+ "base64",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "http",
+ "http-body-util",
+ "libdd-common",
+ "libdd-trace-protobuf",
+ "manual_future",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "async-trait",
  "futures",
@@ -1722,9 +1729,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-shared-runtime-ffi"
+version = "36.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
+dependencies = [
+ "build_common",
+ "libdd-shared-runtime",
+ "tracing",
+]
+
+[[package]]
 name = "libdd-telemetry"
-version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "5.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1751,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "serde",
 ]
@@ -1759,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1767,8 +1784,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1784,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "prost",
  "serde",
@@ -1793,8 +1810,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1818,8 +1835,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "6.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+version = "8.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "base64",
@@ -1841,8 +1858,10 @@ dependencies = [
  "rmp",
  "rmp-serde",
  "rmpv",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "thin-vec",
  "tokio",
  "tracing",
 ]
@@ -1850,13 +1869,13 @@ dependencies = [
 [[package]]
 name = "libdd-tracer-flare"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v36.0.0#b2a83ff19a2f4760d180bd9eb9e91f41566ba5b9"
 dependencies = [
  "anyhow",
  "bytes",
- "datadog-remote-config",
  "http",
  "libdd-common",
+ "libdd-remote-config",
  "libdd-trace-utils",
  "serde_json",
  "tempfile",
@@ -3165,6 +3184,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3381,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -26,32 +26,32 @@ libc = { version = "0.2", optional = true }
 rand = "0.9"
 rustc-hash = "1.1"
 serde = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
 serde_json = "1.0"
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", features = [
+libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", features = [
   "stats-obfuscation"
 ] }
-libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true, features = [
+libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", optional = true }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", optional = true }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0" }
 pyo3 = { version = "0.28", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v35.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v36.0.0", features = [
     "cbindgen",
 ] }
 

--- a/src/native/ffe.rs
+++ b/src/native/ffe.rs
@@ -231,6 +231,7 @@ pub mod ffe {
                 AssignmentReason::TargetingMatch => Reason::TargetingMatch,
                 AssignmentReason::Split => Reason::Split,
                 AssignmentReason::Static => Reason::Static,
+                AssignmentReason::Default => Reason::Default,
             }
         }
     }

--- a/src/native/tracer_flare.rs
+++ b/src/native/tracer_flare.rs
@@ -1,4 +1,7 @@
-use datadog_remote_config::{RemoteConfigData, RemoteConfigProduct};
+use libdd_remote_config::{
+    config::{agent_config::AgentConfigFile, agent_task::AgentTaskFile},
+    RemoteConfigContent,
+};
 use libdd_tracer_flare::{error::FlareError, FlareAction, TracerFlareManager};
 use pyo3::{create_exception, exceptions::PyException, prelude::*, Bound, PyErr};
 
@@ -157,36 +160,39 @@ impl TracerFlareManagerPy {
     fn handle_remote_config_data(&self, data: &[u8], product: &str) -> PyResult<FlareActionPy> {
         let manager = &self.manager;
 
-        let product: RemoteConfigProduct = match product {
-            "AGENT_CONFIG" => RemoteConfigProduct::AgentConfig,
-            "AGENT_TASK" => RemoteConfigProduct::AgentTask,
-            _ => {
-                return Err(ParsingError::new_err(format!(
-                    "Received unexpected tracer flare product type: {}",
-                    product
-                )));
-            }
-        };
-
-        let config_data: RemoteConfigData = match RemoteConfigData::try_parse(product, data) {
-            Ok(data) => data,
-            Err(e) => {
-                // AGENT_CONFIG has multiple payload shapes; e.g. configuration_order
-                // is valid JSON but not our schema. Valid-JSON parse failures return none_action()
-                // silently; truly malformed JSON propagates as ParsingError.
-                if product == RemoteConfigProduct::AgentConfig
-                    && serde_json::from_slice::<serde_json::Value>(data).is_ok()
-                {
-                    return Ok(FlareActionPy::none_action());
+        match product {
+            "AGENT_CONFIG" => match AgentConfigFile::parse(data) {
+                Ok(config) => Ok(manager
+                    .handle_remote_config_data(&config)
+                    .map_err(|e| {
+                        ParsingError::new_err(format!("Parsing error for AGENT_CONFIG: {}", e))
+                    })?
+                    .into()),
+                Err(e) => {
+                    // AGENT_CONFIG has multiple payload shapes; e.g. configuration_order
+                    // is valid JSON but not our schema. Valid-JSON parse failures return none_action()
+                    // silently; truly malformed JSON propagates as ParsingError.
+                    if serde_json::from_slice::<serde_json::Value>(data).is_ok() {
+                        Ok(FlareActionPy::none_action())
+                    } else {
+                        Err(ParsingError::new_err(format!("Parsing error: {}", e)))
+                    }
                 }
-                return Err(ParsingError::new_err(format!("Parsing error: {}", e)));
-            }
-        };
-
-        Ok(manager
-            .handle_remote_config_data(&config_data)
-            .map_err(|e| ParsingError::new_err(format!("Parsing error for AGENT_CONFIG: {}", e)))?
-            .into())
+            },
+            "AGENT_TASK" => match AgentTaskFile::parse(data) {
+                Ok(task) => Ok(manager
+                    .handle_remote_config_data(&task)
+                    .map_err(|e| {
+                        ParsingError::new_err(format!("Parsing error for AGENT_TASK: {}", e))
+                    })?
+                    .into()),
+                Err(e) => Err(ParsingError::new_err(format!("Parsing error: {}", e))),
+            },
+            _ => Err(ParsingError::new_err(format!(
+                "Received unexpected tracer flare product type: {}",
+                product
+            ))),
+        }
     }
 
     /// Zips files from a directory and sends them to the agent.


### PR DESCRIPTION
## Description

Updates to libdatadog v36.0.0

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

Minimal. Only the libdatadog dependencies have been updated, not other crates

## Additional Notes

Claude was responsible for updating `src/native/tracer_flare.rs` to align with the updated `agent_config::AgentConfigFile` and `agent_task::AgentTaskFile` concepts. I'm not familiar with the RC changes, but at a high-level the updated branching appears correct.
