### PR TITLE
fix(graphql): derive execute() middleware arg position from signature

### DIFF
--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from collections.abc import Iterable
+import inspect
 from io import StringIO
 import re
 import sys
@@ -46,6 +47,37 @@ if _graphql_version < (3, 0):
     from graphql.language.ast import Document
 else:
     from graphql.language.ast import DocumentNode as Document
+
+
+def _get_middleware_arg_position(execute_fn: Optional[Callable] = None) -> int:
+    """Positional index of ``middleware`` in ``graphql.execute()``.
+
+    graphql-core has moved this parameter between releases (3.2.10 inserted
+    ``max_coercion_errors`` ahead of it, shifting it from index 9 to 10), so the
+    index is read from the live ``execute`` signature rather than hardcoded
+    against the graphql-core version. ``execute_fn`` is only passed by tests; in
+    normal use the wrapped ``graphql.execute`` is introspected. Falls back to the
+    documented positions for stable releases when the signature can't be read.
+    """
+    if execute_fn is None and _graphql_version >= (3, 0):
+        try:
+            from graphql.execution.execute import execute as execute_fn
+        except ImportError:
+            execute_fn = None
+    if execute_fn is not None:
+        try:
+            return list(inspect.signature(execute_fn).parameters).index("middleware")
+        except (ValueError, TypeError):
+            pass
+    # Signature introspection failed: fall back to the documented positions.
+    if _graphql_version >= (3, 2, 10):
+        return 10
+    if _graphql_version >= (3, 2):
+        return 9
+    return 8
+
+
+_middleware_arg_position = _get_middleware_arg_position()
 
 
 def get_version() -> str:
@@ -250,10 +282,7 @@ def _inject_trace_middleware_to_args(trace_middleware: Callable, args: tuple, kw
     """
     Adds a trace middleware to graphql.execute(..., middleware, ...)
     """
-    middlewares_arg = 8
-    if _graphql_version >= (3, 2):
-        # middleware is the 10th argument graphql.execute(..) version 3.2+
-        middlewares_arg = 9
+    middlewares_arg = _middleware_arg_position
 
     # get middlewares from args or kwargs
     try:

--- a/releasenotes/notes/fix-graphql-middleware-arg-index-8a1bb5b72713609b.yaml
+++ b/releasenotes/notes/fix-graphql-middleware-arg-index-8a1bb5b72713609b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    graphql: Resolves a ``TypeError: 'int' object is not iterable`` raised for every
+    operation when resolver tracing (``DD_TRACE_GRAPHQL_RESOLVERS_ENABLED=true``) was
+    used with graphql-core 3.2.10 or later. graphql-core moved the ``middleware``
+    parameter of ``execute()``, so the integration now reads its position from the
+    function signature instead of a hardcoded index.

--- a/tests/contrib/graphql/test_graphql.py
+++ b/tests/contrib/graphql/test_graphql.py
@@ -75,6 +75,62 @@ async def test_graphql_with_traced_resolver(test_schema, test_source_str, snapsh
         assert result.data == {"hello": "friend"}
 
 
+def test_middleware_arg_position_tracks_execute_signature():
+    # Regression test for https://github.com/DataDog/dd-trace-py/issues/18723.
+    # graphql-core>=3.2.10 inserted ``max_coercion_errors`` before ``middleware``
+    # in execute()'s signature, shifting it from index 9 to 10. The tracer used a
+    # hardcoded index and raised "TypeError: 'int' object is not iterable" for
+    # every operation. The position must now follow the live signature. This is
+    # asserted against synthetic signatures so it holds regardless of the
+    # graphql-core version installed in the test environment.
+    from ddtrace.contrib.internal.graphql.patch import _get_middleware_arg_position
+
+    def execute_pre_3_2_10(
+        schema,
+        document,
+        root_value,
+        context_value,
+        variable_values,
+        operation_name,
+        field_resolver,
+        type_resolver,
+        subscribe_field_resolver,
+        middleware,
+        execution_context_class,
+        is_awaitable,
+    ): ...
+
+    def execute_3_2_10(
+        schema,
+        document,
+        root_value,
+        context_value,
+        variable_values,
+        operation_name,
+        field_resolver,
+        type_resolver,
+        subscribe_field_resolver,
+        max_coercion_errors,
+        middleware,
+        execution_context_class,
+        is_awaitable,
+    ): ...
+
+    assert _get_middleware_arg_position(execute_pre_3_2_10) == 9
+    assert _get_middleware_arg_position(execute_3_2_10) == 10
+
+
+@pytest.mark.skipif(graphql_version < (3, 1), reason="graphql.graphql_sync is not supported in graphql<3.1")
+def test_graphql_sync_with_traced_resolver_regression(test_schema, test_source_str, enable_graphql_resolvers):
+    # End-to-end companion to test_middleware_arg_position_tracks_execute_signature:
+    # exercises the full graphql_sync -> execute middleware-injection path with
+    # resolver tracing enabled (issue #18723). On graphql-core>=3.2.10 this raised
+    # before the fix; on earlier versions it is a harmless smoke test.
+    result = graphql_sync(test_schema, test_source_str)
+    assert result.errors is None
+    assert result.data == {"hello": "friend"}
+
+
 def resolve_fail(root, info):
     undefined_var = None
     return undefined_var.property


### PR DESCRIPTION
## Description

With `DD_TRACE_GRAPHQL_RESOLVERS_ENABLED=true`, every GraphQL operation fails on graphql-core 3.2.10/3.2.11 with `TypeError: 'int' object is not iterable` while the tracer injects its resolver middleware.

graphql-core 3.2.10 added a `max_coercion_errors` parameter to `execute()` *before* `middleware`, shifting `middleware` from positional index 9 to 10. `_inject_trace_middleware_to_args` hardcoded index 9 for graphql-core `>=3.2`, so it read `max_coercion_errors` (the int `50`, passed positionally by `graphql_impl`) as `middleware` and ran `list(50)`. `set_argument_value` used the same stale index, so both the read and the write were wrong.

The position isn't a clean version cutoff — it's 9 in 3.2.0–3.2.9, 10 in 3.2.10+, and it moves again in the 3.3 line. Rather than chase versions, this reads `middleware`'s index from `execute()`'s live signature, with the documented positions kept only as a fallback when the signature can't be introspected.

Fixes #18723

## Testing

- `test_middleware_arg_position_tracks_execute_signature`: a version-independent unit test that asserts the derived index against synthetic pre-3.2.10 (index 9) and 3.2.10+ (index 10) signatures, so it guards the logic regardless of the graphql-core pinned in the test env.
- `test_graphql_sync_with_traced_resolver_regression`: end-to-end check that `graphql_sync` with resolver tracing enabled returns data instead of raising.

Verified manually with the issue's repro against `graphql-core==3.2.11` (raised before, returns `{'hello': 'world'}` after) and `3.2.9` (still index 9, unaffected).

Note: the `graphql` suite's locked requirements currently pin graphql-core ≤3.2.8, so the end-to-end test only exercises the new signature once those locks are regenerated (the `~=3.2.0` spec already allows it); the unit test covers the affected layout in the meantime.

## Risks

Low. The change is confined to the graphql integration's middleware-injection helper. The signature lookup runs once at import; if it ever fails, the version-keyed fallback now returns the correct index for stable releases (10 for ≥3.2.10, 9 for ≥3.2, else 8).

## Additional Notes

<!-- oss-radar:idempotency=auto-20260624-101015.w3.DataDog_dd-trace-py.18723 -->
