### PR TITLE
test(grpc): wait for server shutdown to fix flaky gRPC IAST tests

### DIFF
--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -47,5 +47,12 @@ class GrpcBaseTestCase(TracerTestCase):
         self._server.start()
 
     def _stop_server(self):
-        self._server.stop(None)
+        # ``Server.stop`` is asynchronous: it returns a ``threading.Event`` that is set once the
+        # gRPC core has finished shutting down and released the listening socket. We must wait on
+        # it before returning, otherwise the next test's ``add_insecure_port`` (same fixed port)
+        # can race the still-closing socket. Under SO_REUSEPORT both servers briefly bind the port
+        # and the kernel may route the new client to the dying server, causing flaky failures.
+        # This became visible once pytest-xdist was enabled for the appsec_iast_default suite.
+        shutdown_complete = self._server.stop(None)
+        shutdown_complete.wait()
         self._server_pool.shutdown(wait=True)

--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -47,12 +47,8 @@ class GrpcBaseTestCase(TracerTestCase):
         self._server.start()
 
     def _stop_server(self):
-        # ``Server.stop`` is asynchronous: it returns a ``threading.Event`` that is set once the
-        # gRPC core has finished shutting down and released the listening socket. We must wait on
-        # it before returning, otherwise the next test's ``add_insecure_port`` (same fixed port)
-        # can race the still-closing socket. Under SO_REUSEPORT both servers briefly bind the port
-        # and the kernel may route the new client to the dying server, causing flaky failures.
-        # This became visible once pytest-xdist was enabled for the appsec_iast_default suite.
+        # Wait for shutdown so the port is released before the next test rebinds it (avoids a
+        # SO_REUSEPORT race where the new client hits the dying server, causing flaky failures).
         shutdown_complete = self._server.stop(None)
         shutdown_complete.wait()
         self._server_pool.shutdown(wait=True)


### PR DESCRIPTION
## Description

The gRPC IAST tests (`tests/appsec/iast/test_grpc_iast.py`) are intermittently flaky. They share `GrpcBaseTestCase` (`tests/contrib/grpc/common.py`), which rebinds the **same fixed port** in every `setUp`. `_stop_server` called `self._server.stop(None)` — which is **asynchronous** — and only waited on the thread pool, never on the gRPC core releasing the listening socket.

`grpc.Server.stop(grace)` returns a `threading.Event` that is set once shutdown completes. By discarding it, the next test's `add_insecure_port` could race the previous server's still-closing socket. Under Linux `SO_REUSEPORT`, both servers briefly bind the same port and the kernel can route the new client's request to the dying server → intermittent `RpcError` / IAST taint-range assertion failures.

This was latent until **#17317 enabled `pytest-xdist` for `appsec_iast_default`**, which tightened timing and surfaced the race.

## Fix

Wait on the shutdown `Event` before returning, so the port is released deterministically before the next test binds. The change lives in shared infra, so it also hardens the `tests/contrib/grpc/test_grpc.py` cases that stop/restart the server mid-test.

## Testing

Ran the gRPC IAST tests on the `appsec_iast_default` py3.13 venv **5×** (`riot run -s <hash> -- -k GrpcTestIASTCase`): **9 passed, 2 skipped** every iteration, ~13.5s, with no hang/deadlock from the added `.wait()`.

## Risks

Low. Test-infrastructure-only change. `Server.stop(None)` cancels in-flight RPCs immediately and sets the event promptly, so there is no deadlock risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)