### PR TITLE
chore(AAP): remove dead urllib3 redirect response WAF branch

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -366,18 +366,11 @@ def wrapped_urllib3_make_request_6D4E8B2A1F095C73(original_request_callable, ins
         env.downstream_requests += 1
         if res and _must_block(res.actions):
             raise BlockingException(get_blocked(), EXPLOIT_PREVENTION.BLOCKING, EXPLOIT_PREVENTION.TYPE.SSRF, full_url)
-        response = original_request_callable(*args, **kwargs)
-        try:
-            if response.__class__.__name__ == "BaseHTTPResponse" and 300 <= response.status < 400:
-                # api10 for redirected response status and headers in urllib3
-                addresses = {
-                    "DOWN_RES_STATUS": str(response.status),
-                    "DOWN_RES_HEADERS": response.headers,
-                }
-                call_waf_callback(addresses, rule_type=EXPLOIT_PREVENTION.TYPE.SSRF_RES)
-        except Exception:
-            pass  # nosec
-        return response
+        # api10 redirect (3xx) response analysis is intentionally NOT done here: urllib3 bottoms
+        # out in http.client.HTTPConnection.getresponse (wrapped by `wrapped_response`), which
+        # already sends DOWN_RES_STATUS/DOWN_RES_HEADERS for 3xx responses within this same SSRF
+        # subcontext. Re-inspecting here would double-call the WAF.
+        return original_request_callable(*args, **kwargs)
 
 
 def wrapped_urllib3_urlopen(original_open_callable, instance, args, kwargs):

--- a/tests/appsec/contrib_appsec/flask_app/app.py
+++ b/tests/appsec/contrib_appsec/flask_app/app.py
@@ -323,6 +323,34 @@ def redirect_httpx_async(route: str, port: int):
     return payload
 
 
+@app.route("/redirect_urllib3/<string:route>/<int:port>", methods=["GET", "POST"])
+def redirect_urllib3(route: str, port: int):
+    import urllib3
+
+    full_url = f"http://127.0.0.1:{port}/{route}"
+    body_str = request.data.decode()
+    body = body_str if body_str else None
+    method = "POST" if body is not None else "GET"
+    headers = {"TagRoute": route}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    try:
+        http = urllib3.PoolManager()
+        response = http.request(
+            method,
+            full_url,
+            body=body.encode() if body is not None else None,
+            headers=headers,
+            timeout=DOWNSTREAM_HTTP_TIMEOUT,
+        )
+        payload = {"payload": response.data.decode(errors="ignore")}
+    except Exception as e:
+        import traceback
+
+        payload = {"error": repr(e), "trace": traceback.format_exc()}
+    return payload
+
+
 # Auto user event manual instrumentation
 
 

--- a/tests/appsec/contrib_appsec/flask_app/app_subapps.py
+++ b/tests/appsec/contrib_appsec/flask_app/app_subapps.py
@@ -20,6 +20,7 @@ from tests.appsec.contrib_appsec.flask_app.app import redirect
 from tests.appsec.contrib_appsec.flask_app.app import redirect_httpx
 from tests.appsec.contrib_appsec.flask_app.app import redirect_httpx_async
 from tests.appsec.contrib_appsec.flask_app.app import redirect_requests
+from tests.appsec.contrib_appsec.flask_app.app import redirect_urllib3
 from tests.appsec.contrib_appsec.flask_app.app import service_renaming
 
 
@@ -86,6 +87,7 @@ redirect_subapp = _make_redirect_subapp(redirect, "redirect_sub")
 redirect_requests_subapp = _make_redirect_subapp(redirect_requests, "redirect_requests_sub")
 redirect_httpx_subapp = _make_redirect_subapp(redirect_httpx, "redirect_httpx_sub")
 redirect_httpx_async_subapp = _make_redirect_subapp(redirect_httpx_async, "redirect_httpx_async_sub")
+redirect_urllib3_subapp = _make_redirect_subapp(redirect_urllib3, "redirect_urllib3_sub")
 
 
 # Assign DM back onto root.wsgi_app so root.test_client() still drives the dispatcher.
@@ -99,6 +101,7 @@ root.wsgi_app = DispatcherMiddleware(
         "/redirect_requests": redirect_requests_subapp,
         "/redirect_httpx": redirect_httpx_subapp,
         "/redirect_httpx_async": redirect_httpx_async_subapp,
+        "/redirect_urllib3": redirect_urllib3_subapp,
     },
 )
 

--- a/tests/appsec/contrib_appsec/test_flask.py
+++ b/tests/appsec/contrib_appsec/test_flask.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 
 from flask.testing import FlaskClient
 import pytest
@@ -7,6 +8,7 @@ from ddtrace.internal.endpoints import endpoint_collection
 from ddtrace.internal.packages import get_version_for_package
 from tests.appsec.contrib_appsec import utils
 from tests.utils import TracerTestCase
+from tests.utils import override_global_config
 from tests.utils import scoped_tracer
 
 
@@ -355,6 +357,36 @@ class Test_Flask(_Test_Flask_Base, utils.Contrib_TestClass_For_Threats):
             assert span.get_tag(FLASK_URL_RULE) == "/asm/<int:param_int>/<string:param_str>"
             assert span.resource == "GET /asm/<int:param_int>/<string:param_str>"
             assert get_tag(FLASK_RESOURCE_FULL) is None
+
+    def test_api10_redirect_urllib3(self, interface, api10_http_server_port, entry_span):
+        # Direct urllib3 (PoolManager) redirect analysis. The downstream call follows a 3xx
+        # redirect; the intermediate redirect response must still be inspected by the SSRF
+        # response WAF. urllib3 bottoms out in http.client.HTTPConnection.getresponse, so the
+        # redirect status + headers rules fire from there (not from the urllib3 _make_request
+        # wrapper). This guards the removal of the dead urllib3 redirect branch (APPSEC-68563).
+        INSPECTED_REDIRECT_RESP_HEADERS = "apiA-100-006"
+        INSPECTED_REDIRECT_RESP_STATUS = "apiA-100-007"
+
+        url = f"/redirect_urllib3/redirect-source/{api10_http_server_port}"
+        with override_global_config(
+            dict(
+                _asm_enabled=True,
+                _api_security_enabled=True,
+                _ep_enabled=True,
+                _asm_static_rule_file=utils.rules.RULES_EXPLOIT_PREVENTION,
+                _dr_sample_rate=1.0,
+            )
+        ):
+            self.update_tracer(interface)
+            response = interface.client.get(url)
+            assert self.status(response) == 200, f"{self.status(response)} is not 200 {self.body(response)}"
+            redirect_response_payload = json.loads(self.body(response)).get("payload")
+            api_response_payload = json.loads(redirect_response_payload).get("payload")
+            assert api_response_payload == "api10-response-body", api_response_payload
+
+            self.check_rules_triggered(
+                sorted([INSPECTED_REDIRECT_RESP_HEADERS, INSPECTED_REDIRECT_RESP_STATUS]), entry_span
+            )
 
 
 class Test_Flask_RC(_Test_Flask_Base, utils.Contrib_TestClass_For_Threats_RC):


### PR DESCRIPTION
APPSEC-68563

The urllib3 `_make_request` redirect branch checked `response.__class__.__name__ == "BaseHTTPResponse"`, which never matches (urllib3 1.x/2.x return objects named `HTTPResponse`), so it was dead code. Redirect (3xx) responses are already inspected one layer lower by the `http.client.HTTPConnection.getresponse` wrapper (`wrapped_response`), within the same SSRF subcontext — so there is no security gap. Removing the branch also prevents a future class-name "fix" from double-calling the WAF.

Flagged by a codex scan as a false negative; verified to be a false positive (see Jira). No functional change.

## Tests

Added coverage for the **direct urllib3** path (no `requests`/`httpx` wrapper involved), which the existing redirect tests did not exercise:

- New `redirect_urllib3` endpoint in the Flask test app (registered in both the flat app and the subapp `DispatcherMiddleware`) that drives the downstream call with `urllib3.PoolManager().request(...)` directly.
- New `Test_Flask::test_api10_redirect_urllib3` — follows a 3xx redirect and asserts the redirect response **headers** (`apiA-100-006`) and **status** (`apiA-100-007`) SSRF rules still trigger, confirming redirect inspection comes from the `http.client.getresponse` wrapper and that removing the dead urllib3 branch loses no coverage. Runs in both flat and subapp Flask configurations.

`test_api10` suite: 56 → 58 passing.

Note: the bare-urllib3 path only inspects the redirect (3xx) response, not the final non-3xx response body/headers (those are wired for `requests` and `urllib` only). That is a pre-existing gap, not a regression from this change, so the new test is scoped to the redirect behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)