### PR TITLE
fix(asm): enforce user blocking when appsec trace_utils is not imported

### DIFF
--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -380,3 +380,7 @@ def block_request_if_user_blocked(userid: str, mode: str = "sdk", session_id: Op
             entry_span._set_attribute(user.ID, str(userid))
     if should_block_user(None, userid, session_id):
         _asm_request_context.block_request()
+
+
+# Registered here (always imported on AppSec startup) so set_user enforces user blocking.
+core.on("set_user_for_asm", block_request_if_user_blocked, "block_user")

--- a/ddtrace/appsec/trace_utils/__init__.py
+++ b/ddtrace/appsec/trace_utils/__init__.py
@@ -14,10 +14,7 @@ from ddtrace.appsec._trace_utils import track_custom_event
 from ddtrace.appsec._trace_utils import track_user_login_failure_event
 from ddtrace.appsec._trace_utils import track_user_login_success_event
 from ddtrace.appsec._trace_utils import track_user_signup_event
-import ddtrace.internal.core
 
-
-ddtrace.internal.core.on("set_user_for_asm", block_request_if_user_blocked, "block_user")
 
 F = TypeVar("F", bound=Callable[..., Any])
 

--- a/releasenotes/notes/asm-user-blocking-listener-registration-6b1f0d2a9c3e4f87.yaml
+++ b/releasenotes/notes/asm-user-blocking-listener-registration-6b1f0d2a9c3e4f87.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where user blocking could be bypassed when calling
+    ``ddtrace.contrib.trace_utils.set_user`` if neither ``ddtrace.appsec.trace_utils`` nor the
+    user tracking SDK had been imported. The user blocking decision is now always enforced when
+    AppSec is enabled.

--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -349,3 +349,25 @@ class EventsSDKTestCase(TracerTestCase):
 
             assert any("No root span" in record.message for record in self._caplog.records)
             assert any(record.levelno == logging.WARNING for record in self._caplog.records)
+
+
+@pytest.mark.subprocess(env=dict(DD_APPSEC_ENABLED="true"))
+def test_user_blocking_listener_registered_without_appsec_trace_utils():
+    """Regression test for APPSEC-68564.
+
+    ``ddtrace.contrib.trace_utils.set_user`` enforces user blocking by dispatching the
+    ``set_user_for_asm`` event. The ``block_user`` listener must be registered during AppSec
+    startup even when ``ddtrace.appsec.trace_utils`` (and the user-tracking SDK) are never
+    imported, otherwise a blocked user can bypass blocking.
+    """
+    import sys
+
+    from ddtrace.appsec._listeners import load_appsec
+    from ddtrace.internal import core
+
+    # Enabling AppSec must not require importing the public user-tracking modules.
+    load_appsec()
+
+    assert "ddtrace.appsec.trace_utils" not in sys.modules
+    assert "ddtrace.appsec.track_user_sdk" not in sys.modules
+    assert core.event_hub.has_listeners("set_user_for_asm"), "block_user listener was not registered"


### PR DESCRIPTION
APPSEC-68564

`ddtrace.contrib.trace_utils.set_user(may_block=True)` enforces user blocking by dispatching the `set_user_for_asm` event. The `block_user` listener was only registered in `ddtrace.appsec.trace_utils`, which is not imported during AppSec startup — so if an app used `set_user` without importing that module (or the user-tracking SDK), the WAF blocking decision was silently skipped and a blocked user could keep making requests.

This moves the listener registration into `ddtrace.appsec._trace_utils`, which is always imported when AppSec is enabled.

## Testing
Added a subprocess regression test that enables AppSec without importing `ddtrace.appsec.trace_utils` and asserts the listener is registered (fails before the fix, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)