### PR TITLE
fix(ci_visibility): close thread-local socket on writer shutdown

### DIFF
--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -269,7 +269,13 @@ class BackendConnector(threading.local):
             self.default_headers["Accept-Encoding"] = "gzip"
 
     def close(self) -> None:
-        self.conn.close()
+        # http.client.HTTPConnection.close() raises AttributeError when
+        # sock is None (never connected). Guard against that so callers can
+        # always call close() safely, including thread-teardown code.
+        try:
+            self.conn.close()
+        except AttributeError:
+            pass
 
     def _make_connection(self, parsed_url: ParseResult, timeout_seconds: float) -> http.client.HTTPConnection:
         if parsed_url.scheme == "http":

--- a/ddtrace/testing/internal/logs.py
+++ b/ddtrace/testing/internal/logs.py
@@ -48,6 +48,9 @@ class LogsWriter(BaseWriter):
         self.service = service
         self.hostname = socket.gethostname()
 
+    def _task_teardown(self) -> None:
+        self.connector.close()
+
     def _encode_events(self, events: list[Event]) -> bytes:
         return json.dumps(events).encode("utf-8")
 

--- a/ddtrace/testing/internal/logs.py
+++ b/ddtrace/testing/internal/logs.py
@@ -45,11 +45,9 @@ class LogsWriter(BaseWriter):
         super().__init__(max_buffer_events=self._MAX_BUFFER_EVENTS)
         self.flush_interval_seconds = self._FLUSH_INTERVAL_SECONDS
         self.connector = connector_setup.get_connector_for_subdomain(Subdomain.LOGS)
+        self._connectors = [self.connector]
         self.service = service
         self.hostname = socket.gethostname()
-
-    def _task_teardown(self) -> None:
-        self.connector.close()
 
     def _encode_events(self, events: list[Event]) -> bytes:
         return json.dumps(events).encode("utf-8")

--- a/ddtrace/testing/internal/writer.py
+++ b/ddtrace/testing/internal/writer.py
@@ -142,6 +142,15 @@ class BaseWriter(ABC):
                 "%s: %d events were dropped during this session.", self.__class__.__name__, self._dropped_events
             )
 
+    def _task_teardown(self) -> None:
+        """Called once from the background task thread after the flush loop exits.
+
+        Override in subclasses to release per-thread resources (e.g., close a
+        :class:`~ddtrace.testing.internal.http.BackendConnector` whose
+        underlying HTTP connection was created on the background thread via
+        ``threading.local``).
+        """
+
     def _periodic_task(self) -> None:
         while True:
             self._flush_now.wait(timeout=self.flush_interval_seconds)
@@ -155,6 +164,7 @@ class BaseWriter(ABC):
             if self.should_finish.is_set():
                 break
 
+        self._task_teardown()
         log.debug("Exiting %s background task", self.__class__.__name__)
 
     def flush(self) -> None:
@@ -280,6 +290,9 @@ class TestOptWriter(BaseWriter):
             TestSession: serialize_session,
         }
 
+    def _task_teardown(self) -> None:
+        self.connector.close()
+
     def add_metadata(self, event_type: str, metadata: dict[str, str]) -> None:
         self.metadata[event_type].update(metadata)
 
@@ -355,6 +368,9 @@ class TestCoverageWriter(BaseWriter):
         super().__init__(min_flush_events=_get_min_flush_events())
 
         self.connector = connector_setup.get_connector_for_subdomain(Subdomain.CITESTCOV)
+
+    def _task_teardown(self) -> None:
+        self.connector.close()
 
     def put_coverage(self, test_run: TestRun, coverage_bitmaps: t.Iterable[tuple[str, bytes]]) -> None:
         files = [{"filename": pathname, "bitmap": bitmap} for pathname, bitmap in coverage_bitmaps]

--- a/ddtrace/testing/internal/writer.py
+++ b/ddtrace/testing/internal/writer.py
@@ -86,6 +86,10 @@ class BaseWriter(ABC):
         self._dropped_events = 0
         # 4.5MB max uncompressed payload size, following <https://github.com/DataDog/datadog-ci-rb/pull/272>.
         self.max_payload_size = int(4.5 * 1024 * 1024)
+        # Connectors registered here are closed from both the background thread
+        # (via _task_teardown) and the caller thread (via wait_finish), covering
+        # all thread-local HTTPConnections opened via BackendConnector.
+        self._connectors: list[t.Any] = []
 
     def put_event(self, event: Event) -> None:
         with self.lock:
@@ -141,15 +145,17 @@ class BaseWriter(ABC):
             log.warning(
                 "%s: %d events were dropped during this session.", self.__class__.__name__, self._dropped_events
             )
+        # Close the caller thread's thread-local connection for each registered
+        # connector (BackendConnector is threading.local, so this closes the
+        # connection opened by any sync flush that ran on the caller thread).
+        for connector in self._connectors:
+            connector.close()
 
     def _task_teardown(self) -> None:
-        """Called once from the background task thread after the flush loop exits.
-
-        Override in subclasses to release per-thread resources (e.g., close a
-        :class:`~ddtrace.testing.internal.http.BackendConnector` whose
-        underlying HTTP connection was created on the background thread via
-        ``threading.local``).
-        """
+        # Close the background thread's thread-local connection for each
+        # registered connector.
+        for connector in self._connectors:
+            connector.close()
 
     def _periodic_task(self) -> None:
         while True:
@@ -282,6 +288,7 @@ class TestOptWriter(BaseWriter):
         }
 
         self.connector = connector_setup.get_connector_for_subdomain(Subdomain.CITESTCYCLE)
+        self._connectors = [self.connector]
 
         self.serializers: dict[type[TestItem[t.Any, t.Any]], EventSerializer[t.Any]] = {
             TestRun: serialize_test_run,
@@ -289,9 +296,6 @@ class TestOptWriter(BaseWriter):
             TestModule: serialize_module,
             TestSession: serialize_session,
         }
-
-    def _task_teardown(self) -> None:
-        self.connector.close()
 
     def add_metadata(self, event_type: str, metadata: dict[str, str]) -> None:
         self.metadata[event_type].update(metadata)
@@ -368,9 +372,7 @@ class TestCoverageWriter(BaseWriter):
         super().__init__(min_flush_events=_get_min_flush_events())
 
         self.connector = connector_setup.get_connector_for_subdomain(Subdomain.CITESTCOV)
-
-    def _task_teardown(self) -> None:
-        self.connector.close()
+        self._connectors = [self.connector]
 
     def put_coverage(self, test_run: TestRun, coverage_bitmaps: t.Iterable[tuple[str, bytes]]) -> None:
         files = [{"filename": pathname, "bitmap": bitmap} for pathname, bitmap in coverage_bitmaps]

--- a/releasenotes/notes/fix-unclosed-socket-ci-visibility-writer-12615029218b6e6f.yaml
+++ b/releasenotes/notes/fix-unclosed-socket-ci-visibility-writer-12615029218b6e6f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixes a ``ResourceWarning: unclosed socket`` that occurred when
+    using the pytest plugin. The background writer thread's thread-local
+    HTTP connection was not closed on thread exit.

--- a/tests/testing/internal/test_writer.py
+++ b/tests/testing/internal/test_writer.py
@@ -156,11 +156,15 @@ class TestWaitFinishTimeout:
             def __init__(self) -> None:
                 super().__init__()
                 self.started_flushing = threading.Event()
+                # Use a *separate* event to block the send so that signal_finish()
+                # (which sets should_finish) does not inadvertently unblock _send_events
+                # and let the thread exit before the timeout fires.
+                self._unblock_send = threading.Event()
 
             def _send_events(self, events: list[Event]) -> bool:
                 self.started_flushing.set()
-                # Block until finish is signalled (simulates slow network).
-                self.should_finish.wait()
+                # Block until explicitly unblocked (simulates a slow network call).
+                self._unblock_send.wait()
                 return True
 
             def _encode_events(self, events: list[Event]) -> bytes:
@@ -173,12 +177,17 @@ class TestWaitFinishTimeout:
         writer._flush_now.set()
         writer.started_flushing.wait(timeout=5)
 
-        # With a short timeout, wait_finish should return even though the thread is stuck.
+        # Thread is stuck in _send_events.  Signal finish so the thread knows it
+        # should stop after the current send, but the send itself is still blocked.
         writer.signal_finish()
         writer.wait_finish(timeout=0.1)
-        # Thread may still be alive because we timed out.
-        # Clean up: signal the thread to finish.
-        writer.should_finish.set()
+
+        # The timeout must have fired: the thread is still alive because _send_events
+        # has not returned yet.
+        assert writer.task.is_alive(), "thread should still be running while _send_events is blocked"
+
+        # Unblock the send so the thread can finish cleanly.
+        writer._unblock_send.set()
         writer.task.join(timeout=5)
 
 
@@ -401,6 +410,44 @@ class TestTestOptWriter:
                 send_gzip=True,
             ),
         ]
+
+    @patch("ddtrace.testing.internal.http.BackendConnector")
+    def test_connector_closed_after_writer_finishes(self, mock_bc: Mock) -> None:
+        """Regression: background task must close its thread-local connector.
+
+        ``BackendConnector`` subclasses ``threading.local`` so each thread
+        gets its own HTTP connection via ``__init__``.  Without an explicit
+        ``close()`` call from the background task the underlying socket is
+        left open until the GC eventually closes it, producing a
+        ``ResourceWarning: unclosed socket``.
+        """
+        close_caller_threads: list[str] = []
+
+        original_connector = Mock()
+        original_connector.request.return_value = BackendResult(
+            response=Mock(status=200), response_length=0, elapsed_seconds=0.0
+        )
+
+        def _close_tracking() -> None:
+            close_caller_threads.append(threading.current_thread().name)
+
+        original_connector.close.side_effect = _close_tracking
+        mock_bc.return_value = original_connector
+
+        writer = TestOptWriter(BackendConnectorAgentlessSetup(site="test", api_key="key"))
+        writer.start()
+        writer.put_event(Event(type="test"))
+        writer.signal_finish()
+        writer.wait_finish()
+
+        # close() must be called from the background task thread (not the main thread)
+        # so that the thread-local HTTP connection is properly closed.
+        assert close_caller_threads, "connector.close() was never called"
+        main_thread_name = threading.main_thread().name
+        assert all(t != main_thread_name for t in close_caller_threads), (
+            "connector.close() was called from the main thread, not the background task thread; "
+            "the thread-local socket would not be closed"
+        )
 
 
 class TestTestCoverageWriter:
@@ -893,6 +940,7 @@ class TestCircuitBreaker:
             writer = TestOptWriter(BackendConnectorAgentlessSetup(site="test", api_key="key"))
             result = writer._send_events([Event(type="test")])
             assert result is True
+
 
 
 class TestOversizedEventWarning:

--- a/tests/testing/internal/test_writer.py
+++ b/tests/testing/internal/test_writer.py
@@ -942,7 +942,6 @@ class TestCircuitBreaker:
             assert result is True
 
 
-
 class TestOversizedEventWarning:
     """Regression test: a single event exceeding max_payload_size must log a warning."""
 

--- a/tests/testing/internal/test_writer.py
+++ b/tests/testing/internal/test_writer.py
@@ -413,13 +413,18 @@ class TestTestOptWriter:
 
     @patch("ddtrace.testing.internal.http.BackendConnector")
     def test_connector_closed_after_writer_finishes(self, mock_bc: Mock) -> None:
-        """Regression: background task must close its thread-local connector.
+        """Regression: both the background task and the caller thread must close their
+        thread-local connectors.
 
-        ``BackendConnector`` subclasses ``threading.local`` so each thread
-        gets its own HTTP connection via ``__init__``.  Without an explicit
-        ``close()`` call from the background task the underlying socket is
-        left open until the GC eventually closes it, producing a
-        ``ResourceWarning: unclosed socket``.
+        ``BackendConnector`` subclasses ``threading.local`` so each thread gets its own
+        HTTP connection via ``__init__``.  Two connections can exist:
+
+        * **background thread** — opened when the periodic task calls ``_send_events``
+        * **caller thread** — opened when ``min_flush_events`` triggers a sync flush via
+          ``put_event`` → ``flush`` on the test/caller thread
+
+        Without explicit ``close()`` calls on both threads the underlying sockets are
+        left open, producing ``ResourceWarning: unclosed socket``.
         """
         close_caller_threads: list[str] = []
 
@@ -440,14 +445,13 @@ class TestTestOptWriter:
         writer.signal_finish()
         writer.wait_finish()
 
-        # close() must be called from the background task thread (not the main thread)
-        # so that the thread-local HTTP connection is properly closed.
-        assert close_caller_threads, "connector.close() was never called"
+        # close() must be called at least twice: once from the background task thread
+        # and once from the caller (main) thread via wait_finish().
         main_thread_name = threading.main_thread().name
-        assert all(t != main_thread_name for t in close_caller_threads), (
-            "connector.close() was called from the main thread, not the background task thread; "
-            "the thread-local socket would not be closed"
-        )
+        bg_closes = [t for t in close_caller_threads if t != main_thread_name]
+        caller_closes = [t for t in close_caller_threads if t == main_thread_name]
+        assert bg_closes, "connector.close() was never called from the background task thread"
+        assert caller_closes, "connector.close() was never called from the caller thread (via wait_finish)"
 
 
 class TestTestCoverageWriter:


### PR DESCRIPTION
## Description

`BackendConnector` subclasses `threading.local`, so every thread that calls `connector.request()` gets its own `HTTPConnection`. Two threads can open connections:

- **Background task thread** — via the periodic flush loop
- **Caller/test thread** — when `min_flush_events` triggers a sync flush from `put_event()`

Without explicit `close()` calls from each thread, both sockets stay open until GC collects them, causing `ResourceWarning: unclosed socket`.

### Changes

- Add `self._connectors` registry to `BaseWriter.__init__`
- `BaseWriter._task_teardown()` iterates `_connectors` and calls `close()` from the background thread
- `BaseWriter.wait_finish()` iterates `_connectors` and calls `close()` from the caller thread
- Subclasses (`TestOptWriter`, `TestCoverageWriter`, `LogsWriter`) simply set `self._connectors = [self.connector]` in `__init__` — no per-class teardown overrides needed
- Guard `BackendConnector.close()` against `AttributeError` when `sock=None` (never-connected socket)
- Fix `test_wait_finish_respects_timeout` (was inadvertently unblocking the send via the `should_finish` event before the timeout fired)

## Testing

- Added `test_connector_closed_after_writer_finishes`: asserts `connector.close()` is called from both the background thread (`_task_teardown`) and the caller thread (`wait_finish`)