### PR TITLE
fix(iast): make re.finditer aspect taint matches lazily

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -2,7 +2,6 @@ import _io
 from builtins import bytearray as builtin_bytearray
 from builtins import bytes as builtin_bytes
 import codecs
-import itertools
 import json
 import os
 from re import Match
@@ -1119,6 +1118,16 @@ def re_findall_aspect(
     return result
 
 
+def _taint_finditer_lazily(matches: Iterator, ranges: Any) -> Iterator:
+    # Taint each Match object as it is yielded, keeping the underlying finditer iterator lazy.
+    for match in matches:
+        try:
+            taint_pyobject_with_ranges(match, ranges)
+        except Exception as e:
+            iast_propagation_error_log("IAST propagation error. re_finditer_aspect", e)
+        yield match
+
+
 def re_finditer_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Iterator:
     if orig_function is not None and (not flag_added_args or not args):
         # This patch is unexpected, so we fallback
@@ -1148,9 +1157,10 @@ def re_finditer_aspect(orig_function: Optional[Callable], flag_added_args: int, 
             string = args[0]
             if is_pyobject_tainted(string):
                 ranges = get_ranges(string)
-                result, result_backup = itertools.tee(result)
-                for elem in result_backup:
-                    taint_pyobject_with_ranges(elem, ranges)
+                # Wrap the iterator in a lazy generator so each Match is tainted as the
+                # application consumes it, preserving finditer's laziness and avoiding
+                # buffering every match in memory (memory DoS on request-controlled input).
+                return _taint_finditer_lazily(result, ranges)
     except Exception as e:
         iast_propagation_error_log("IAST propagation error. re_finditer_aspect", e)
     return result

--- a/releasenotes/notes/iast-finditer-lazy-memory-dos-5fdf5acfad35cddc.yaml
+++ b/releasenotes/notes/iast-finditer-lazy-memory-dos-5fdf5acfad35cddc.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Code Security (IAST): This fix resolves an issue where instrumenting ``re.finditer`` eagerly
+    consumed the entire match iterator to taint every match, which removed the laziness of
+    ``re.finditer`` and allowed a request-controlled input with many matches to allocate excess
+    memory. Matches are now tainted lazily as the application iterates over them.

--- a/tests/appsec/iast/aspects/test_re_aspects.py
+++ b/tests/appsec/iast/aspects/test_re_aspects.py
@@ -645,6 +645,34 @@ def test_re_finditer_aspect_not_tainted():
         assert not is_pyobject_tainted(i)
 
 
+def test_re_finditer_aspect_is_lazy():
+    # The aspect must not eagerly drain the underlying finditer iterator: consuming a
+    # single match should not force the whole input to be scanned (memory DoS guard).
+    tainted = taint_pyobject(
+        pyobject="a a a a a a",
+        source_name="test_re_finditer_aspect_is_lazy",
+        source_value="a a a a a a",
+        source_origin=OriginType.PARAMETER,
+    )
+
+    consumed = []
+    pattern = re.compile(r"a")
+
+    def spy_finditer(string):
+        # Records how many matches are pulled from the underlying lazy iterator.
+        for match in pattern.finditer(string):
+            consumed.append(match)
+            yield match
+
+    # self (args[0]) is a real Pattern so the aspect instruments it; spy_finditer is
+    # the injected original function whose consumption we observe.
+    res_iterator = re_finditer_aspect(spy_finditer, 1, pattern, tainted)
+    first = next(res_iterator)
+    # Only the first match should have been pulled from the underlying iterator so far.
+    assert len(consumed) == 1
+    assert is_pyobject_tainted(first)
+
+
 def test_re_match_getitem_aspect_tainted_string_re_object():
     tainted_isaac_newton = taint_pyobject(
         pyobject="Isaac Newton, physicist",


### PR DESCRIPTION
## Description

Fixes a memory-DoS in the IAST `re_finditer_aspect` ([APPSEC-68533](https://datadoghq.atlassian.net/browse/APPSEC-68533)).

On the tainted-input path the aspect used `itertools.tee(result)` and then drained one clone to completion to taint every `Match`. Because `itertools.tee` buffers every item consumed by one clone until the other advances, this forced the entire `re.finditer` scan eagerly and held every `Match` object in memory until the returned iterator was consumed/GC'd — defeating `re.finditer`'s laziness. A request-controlled string matching many times could therefore allocate memory proportional to the total match count even when the application only needs the first match or breaks early.

The fix replaces the `tee` + eager drain with a lazy generator that taints each `Match` as the application yields it, bounding memory to what is actually consumed. Per-match `try/except` keeps propagation errors from breaking application iteration. The now-unused `itertools` import was removed.

## Testing

- Added `test_re_finditer_aspect_is_lazy`, which asserts only one match is pulled from the underlying iterator after a single `next()`.
- Existing `test_re_finditer_aspect_tainted_string` / `_tainted_bytes` / `_not_tainted` continue to pass (tainting still applied to every consumed match).
- Full `appsec_iast_default` suite green: 19591 passed (the 16 `test_telemetry.py` collection errors are pre-existing and unrelated to this change).

## Risks

Low. The change preserves the tainting behavior for consumed matches and only alters *when* tainting happens (lazily, per-yield) and *how* the iterator is returned. Behavior for the non-tainted path is unchanged.

## Additional Notes

Jira: [APPSEC-68533](https://datadoghq.atlassian.net/browse/APPSEC-68533)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-68533]: https://datadoghq.atlassian.net/browse/APPSEC-68533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-68533]: https://datadoghq.atlassian.net/browse/APPSEC-68533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ