### PR TITLE
fix(ai_guard): prevent litellm callers from disabling guardrail blocking

### DIFF
--- a/ddtrace/appsec/ai_guard/integrations/litellm.py
+++ b/ddtrace/appsec/ai_guard/integrations/litellm.py
@@ -192,6 +192,9 @@ class DatadogAIGuardGuardrail(CustomGuardrail):
         raw = dynamic_params.get("block")
         if raw is None:
             return server_block
+        # AIDEV-NOTE: intentionally fail-secure — only the literal "false" is treated as
+        # "don't add block"; any other value errs toward blocking. The `or server_block`
+        # below means dynamic params can never weaken server policy regardless.
         dynamic_block = raw if isinstance(raw, bool) else str(raw).lower() != "false"
         return server_block or dynamic_block
 

--- a/ddtrace/appsec/ai_guard/integrations/litellm.py
+++ b/ddtrace/appsec/ai_guard/integrations/litellm.py
@@ -185,12 +185,15 @@ class DatadogAIGuardGuardrail(CustomGuardrail):
         return result
 
     def _resolve_block(self, dynamic_params: dict[str, Any]) -> bool:
+        # Blocking is a trusted server-side policy (litellm config / DD_AI_GUARD_BLOCK).
+        # Request-body dynamic params may only strengthen it (monitor -> block), never weaken
+        # it, so a proxy caller cannot disable enforcement on its own request.
+        server_block = ai_guard_config._ai_guard_block if self._block is None else bool(self._block)
         raw = dynamic_params.get("block")
         if raw is None:
-            if self._block is None:
-                return ai_guard_config._ai_guard_block
-            return bool(self._block)
-        return raw if isinstance(raw, bool) else str(raw).lower() != "false"
+            return server_block
+        dynamic_block = raw if isinstance(raw, bool) else str(raw).lower() != "false"
+        return server_block or dynamic_block
 
     async def _run_ai_guard_check(
         self,

--- a/releasenotes/notes/ai-guard-litellm-block-bypass-1ce7c561bc87182b.yaml
+++ b/releasenotes/notes/ai-guard-litellm-block-bypass-1ce7c561bc87182b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    AI Guard: This fix resolves an issue where the LiteLLM proxy guardrail allowed a
+    per-request ``block`` dynamic parameter, supplied in the incoming request body, to
+    disable the operator-configured blocking policy and let a denied request proceed in
+    monitor mode. Request-supplied parameters can now only strengthen blocking (turning
+    monitor mode into blocking); they can no longer weaken an enabled blocking policy.

--- a/tests/appsec/ai_guard/litellm_guardrail/test_litellm_guardrail.py
+++ b/tests/appsec/ai_guard/litellm_guardrail/test_litellm_guardrail.py
@@ -264,19 +264,29 @@ class TestResolveBlock:
             g = DatadogAIGuardGuardrail(block=True)
             assert g._resolve_block({}) is True
 
-    def test_bool_true_overrides_default(self, guardrail_monitor):
+    def test_dynamic_true_strengthens_monitor_mode(self, guardrail_monitor):
+        """A request param may upgrade monitor mode to blocking."""
         assert guardrail_monitor._resolve_block({"block": True}) is True
 
-    def test_bool_false_overrides_default(self, guardrail):
-        assert guardrail._resolve_block({"block": False}) is False
+    def test_dynamic_false_cannot_weaken_blocking(self, guardrail):
+        """A request param must not be able to disable an enabled blocking policy."""
+        assert guardrail._resolve_block({"block": False}) is True
+
+    def test_dynamic_false_keeps_monitor_mode(self, guardrail_monitor):
+        """block=False in a request param leaves monitor mode unchanged (no weakening)."""
+        assert guardrail_monitor._resolve_block({"block": False}) is False
 
     @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes"])
-    def test_truthy_strings(self, guardrail, value):
+    def test_truthy_strings_strengthen(self, guardrail_monitor, value):
+        assert guardrail_monitor._resolve_block({"block": value}) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE"])
+    def test_false_string_cannot_weaken_blocking(self, guardrail, value):
         assert guardrail._resolve_block({"block": value}) is True
 
     @pytest.mark.parametrize("value", ["false", "False", "FALSE"])
-    def test_false_string(self, guardrail, value):
-        assert guardrail._resolve_block({"block": value}) is False
+    def test_false_string_keeps_monitor_mode(self, guardrail_monitor, value):
+        assert guardrail_monitor._resolve_block({"block": value}) is False
 
 
 class TestRunAIGuardCheck:
@@ -327,11 +337,12 @@ class TestRunAIGuardCheck:
         assert exc_info.value.action == "ABORT"
 
     @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
-    def test_dynamic_param_false_overrides_instance_blocking(self, mock_req, guardrail):
-        """block='false' in dynamic params disables blocking even when instance default is True."""
-        mock_req.return_value = mock_evaluate_response("DENY", reason="injection", block=False)
-        # Must not raise — dynamic param disables blocking
-        asyncio.run(guardrail._run_ai_guard_check(self.MSGS, {"block": "false"}))
+    def test_dynamic_param_false_cannot_disable_instance_blocking(self, mock_req, guardrail):
+        """block='false' in dynamic params must not disable an enabled server-side blocking policy."""
+        mock_req.return_value = mock_evaluate_response("DENY", reason="injection", block=True)
+        # Must raise — a request param cannot weaken blocking
+        with pytest.raises(DatadogAIGuardGuardrailException):
+            asyncio.run(guardrail._run_ai_guard_check(self.MSGS, {"block": "false"}))
 
     @patch("ddtrace.appsec.ai_guard._api_client.AIGuardClient._execute_request")
     def test_dynamic_param_true_overrides_monitor_mode(self, mock_req, guardrail_monitor):


### PR DESCRIPTION
## Description

Fixes a security issue in the LiteLLM proxy guardrail (`ddtrace/appsec/ai_guard/integrations/litellm.py`) 
`get_guardrail_dynamic_request_body_params()` resolves to LiteLLM's `get_guardrail_from_metadata`, which reads `data["guardrails"]` directly from the **incoming request body** — controllable by any caller of the proxy. A caller could send:

```json
{"model": "...", "messages": [...],
 "guardrails": [{"datadog_ai_guard": {"extra_body": {"block": false}}}]}
```

`_resolve_block()` previously let that request-supplied `block` value override the operator's `self._block` / `DD_AI_GUARD_BLOCK`, so a `DENY`/`ABORT` verdict no longer raised `AIGuardAbortError` and the request proceeded in monitor mode. This let the guarded party silently downgrade the operator's blocking policy on its own request.

**Fix:** blocking is now trusted server-side state. Request-supplied dynamic params may only **strengthen** blocking (monitor → block) and can no longer **weaken** an enabled blocking policy (`return server_block or dynamic_block`).

| Operator config | Request param | Result (before) | Result (after) |
|---|---|---|---|
| `block=True` | `block=false` | monitor ❌ | **block** ✅ |
| monitor | `block=true` | block | block |
| monitor | `block=false` | monitor | monitor |

## Testing

- Updated the dynamic-param unit tests in `tests/appsec/ai_guard/litellm_guardrail/test_litellm_guardrail.py` to assert the monotonic semantics (request params cannot disable an enabled blocking policy; can still upgrade monitor mode).
- `scripts/lint fmt` passes; the `_resolve_block` truth table was verified in isolation. The full litellm suite runs in CI.

## Risks

Low. Behavior change is limited to the LiteLLM guardrail's handling of the per-request `block` dynamic param: it can no longer disable blocking. Operators relying on per-request *disabling* of blocking via the request body (an insecure pattern) would be affected; strengthening still works.

## Additional Notes

JIRA: [APPSEC-68512](https://datadoghq.atlassian.net/browse/APPSEC-68512)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-68512]: https://datadoghq.atlassian.net/browse/APPSEC-68512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-68512]: https://datadoghq.atlassian.net/browse/APPSEC-68512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ