### PR TITLE
chore(iast): pin abseil build dependency to immutable commit

### DIFF
--- a/cmake/AbseilDep.cmake
+++ b/cmake/AbseilDep.cmake
@@ -40,6 +40,12 @@ else()
     set(_absl_src_dir "${FETCHCONTENT_BASE_DIR}/absl-src")
     set(_absl_bin_dir "${FETCHCONTENT_BASE_DIR}/absl-build")
 
+    # Immutable commit SHA backing tag 20250127.1. We clone by tag (shallow clones by tag are resilient to GitHub
+    # transient failures) but then verify the checked-out commit matches this SHA, so a retagged or compromised upstream
+    # tag fails the build instead of injecting code.
+    set(_absl_tag "20250127.1")
+    set(_absl_expected_sha "d9e4955c65cd4367dd6bf46f4ccb8cd3d100540b")
+
     # Only clone if the source directory is not already present (disconnected / cached build support — equivalent to
     # FETCHCONTENT_UPDATES_DISCONNECTED).
     if(NOT EXISTS "${_absl_src_dir}/.git")
@@ -50,7 +56,7 @@ else()
             math(EXPR _absl_attempt "${_absl_attempt} + 1")
             message(STATUS "Cloning abseil (attempt ${_absl_attempt}/${_absl_max_attempts})...")
             execute_process(
-                COMMAND git clone --depth 1 --branch 20250127.1 --progress https://github.com/abseil/abseil-cpp.git
+                COMMAND git clone --depth 1 --branch ${_absl_tag} --progress https://github.com/abseil/abseil-cpp.git
                         "${_absl_src_dir}" RESULT_VARIABLE _absl_result)
             if(_absl_result EQUAL 0)
                 set(_absl_success TRUE)
@@ -63,6 +69,21 @@ else()
         endwhile()
     else()
         message(STATUS "Using cached abseil source at ${_absl_src_dir}")
+    endif()
+
+    # Verify the resolved source matches the expected immutable commit (covers both a fresh clone by tag and a
+    # cached/tampered source tree) before building it.
+    execute_process(
+        COMMAND git -C "${_absl_src_dir}" rev-parse HEAD
+        OUTPUT_VARIABLE _absl_actual_sha
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _absl_revparse_result)
+    if(NOT _absl_revparse_result EQUAL 0)
+        message(FATAL_ERROR "Unable to determine abseil commit at ${_absl_src_dir} for integrity verification.")
+    endif()
+    if(NOT _absl_actual_sha STREQUAL _absl_expected_sha)
+        message(FATAL_ERROR "Abseil integrity check failed: expected commit ${_absl_expected_sha} (tag ${_absl_tag}) "
+                            "but found ${_absl_actual_sha}. Refusing to build a potentially tampered dependency.")
     endif()
 
     add_subdirectory("${_absl_src_dir}" "${_absl_bin_dir}" EXCLUDE_FROM_ALL)

--- a/cmake/abseil/CMakeLists.txt
+++ b/cmake/abseil/CMakeLists.txt
@@ -43,10 +43,12 @@ set(ABSL_ENABLE_INSTALL
 set(FETCHCONTENT_UPDATES_DISCONNECTED
     ON
     CACHE BOOL "" FORCE)
+# Pin to the immutable commit SHA backing tag 20250127.1 rather than the tag name, so a retagged or compromised upstream
+# tag cannot silently inject different build code during a source/wheel build (supply-chain hardening).
 FetchContent_Declare(
     absl
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-    GIT_TAG 20250127.1
+    GIT_TAG d9e4955c65cd4367dd6bf46f4ccb8cd3d100540b # tag 20250127.1
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE)
 FetchContent_MakeAvailable(absl)


### PR DESCRIPTION
## Description

Supply-chain hardening for the IAST native-extension build.

`abseil-cpp` was fetched by the **mutable git tag** `20250127.1` in two places:
- `cmake/abseil/CMakeLists.txt` — `FetchContent_Declare(... GIT_TAG 20250127.1 ...)` (pre-build invoked by `setup.py`)
- `cmake/AbseilDep.cmake` — `git clone --depth 1 --branch 20250127.1 ...` (fallback build path)

A git tag is mutable, so a retagged or compromised upstream tag could inject different CMake/C++ build code during a source/wheel build.

**Fix:** pin both paths to the immutable commit `d9e4955c65cd4367dd6bf46f4ccb8cd3d100540b` (the commit backing tag `20250127.1`):
- FetchContent path now checks out the commit SHA directly.
- The clone fallback keeps the resilient shallow clone-by-tag, then verifies `git rev-parse HEAD` equals the expected SHA and aborts the build (`FATAL_ERROR`) on mismatch — covering both a retagged tag and a tampered/cached source tree.

## Testing

- `cmake-format` lint passes (also confirms both files parse cleanly).
- No runtime/library behavior change; only the build-time dependency fetch is affected. The native build is exercised by the wheel-build jobs in CI.

## Risks

Low. Only affects building ddtrace from source; published wheels (which already bundle compiled abseil) are unaffected. If GitHub were to drop the tag, the build would fail loudly rather than silently building something else — which is the intended behavior.

## Additional Notes

No release note: this does not affect customers (build-only change). `changelog/no-changelog` label applied.

JIRA: [APPSEC-68575](https://datadoghq.atlassian.net/browse/APPSEC-68575)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-68575]: https://datadoghq.atlassian.net/browse/APPSEC-68575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-68575]: https://datadoghq.atlassian.net/browse/APPSEC-68575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ