### PR TITLE
fix(tracing): update wrapping bytecode assembly target for jump_backw…

### DIFF
--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -83,7 +83,7 @@ elif PY >= (3, 14):
         try                                 @genexit lasti
             yield_value                     0
             resume                          3
-            jump_backward_no_interrupt      @loop
+            jump_backward_no_interrupt      @presend0
         send0:
             end_send
 
@@ -208,7 +208,7 @@ elif PY >= (3, 13):
         try                                 @genexit lasti
             yield_value                     0
             resume                          3
-            jump_backward_no_interrupt      @loop
+            jump_backward_no_interrupt      @presend0
         send0:
             end_send
 
@@ -332,7 +332,7 @@ elif PY >= (3, 12):
         try                                 @genexit lasti
             yield_value                     3
             resume                          3
-            jump_backward_no_interrupt      @loop
+            jump_backward_no_interrupt      @presend0
         send0:
             end_send
 
@@ -456,7 +456,7 @@ elif PY >= (3, 11):
         try                                 @genexit lasti
             yield_value
             resume                          3
-            jump_backward_no_interrupt      @loop
+            jump_backward_no_interrupt      @presend0
         send0:
 
         yield:

--- a/releasenotes/notes/fix-async-generator-wrapping-await-loop-9a799f7c1f22d142.yaml
+++ b/releasenotes/notes/fix-async-generator-wrapping-await-loop-9a799f7c1f22d142.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    tracing: Resolves an issue where wrapping an async generator on Python 3.11 through 3.14 raises a
+    ``TypeError: object NoneType can't be used in 'await' expression`` error. 
+    This occurs when the generator body awaits a coroutine that suspends to the event loop before its first ``yield``.
+    Python 3.9 and 3.10 are not affected.

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -526,6 +526,36 @@ async def test_double_async_for_with_exception():
 
 
 @pytest.mark.asyncio
+async def test_wrap_async_generator_awaits_suspending_coroutine():
+    # Regression test for the async-generator trampoline await loop.
+    # The body awaits a coroutine that suspends to the event loop multiple
+    # times before the first yield. This drives the SEND/YIELD/RESUME cycle
+    # more than once; the loop previously jumped back to GET_AWAITABLE
+    # instead of SEND, which eventually awaited None and raised
+    # "object NoneType can't be used in 'await' expression".
+    def wrapper(f, args, kwargs):
+        return f(*args, **kwargs)
+
+    async def suspends():
+        for _ in range(3):
+            await asyncio.sleep(0)
+        return "ready"
+
+    async def g():
+        value = await suspends()
+        yield value
+        yield value + "!"
+
+    wrap(g, wrapper)
+
+    out = []
+    async for item in g():
+        out.append(item)
+
+    assert out == ["ready", "ready!"]
+
+
+@pytest.mark.asyncio
 async def test_wrap_async_generator_throw_close():
     channel = []
 


### PR DESCRIPTION
## Description

Fixes a `TypeError: object NoneType can't be used in 'await' expression` that occurs when an
async generator is bytecode-wrapped by ddtrace and its body `await`s a coroutine that suspends 
to the event loop more than once before the first `yield`. 

This commonly manifests with `contextlib.asynccontextmanager`-decorated async
generators that open a connection (`await`) before yielding, surfacing as HTTP 500s.

### Bug

* async-generator trampoline assembly in
`ddtrace/internal/wrapping/asyncs.py`. The inner await-driving loop that pumps
`__anext__()`/`asend()` jumped back to `@loop` (`GET_AWAITABLE`) instead of `@presend0`
(`SEND`). 
* After `RESUME`, the stack holds `[iterator, sent_value]`, so re-running
`GET_AWAITABLE` operated on the sent value and corrupted the await machinery, eventually
feeding `None` into an `await`. 
* The interrupted generator could then no longer be closed,
producing the secondary `aclose()` `RuntimeError`.

### Fix

The fix changes the inner `jump_backward_no_interrupt @loop` → `@presend0` in `ASYNC_GEN_ASSEMBLY` blocks
for Python v3.11 - 3.14.

## Testing

- Added a regression test; passes across v3.11–3.14
- Verified the real `asyncs.py` wrapping against fresh CPython 3.12, 3.13, and 3.14
  interpreters

## Risks

Low. It only affects ddtrace-wrapped async generators; coroutine and sync-generator wrapping paths are unchanged.

## Additional Notes

_bug fix status across runtime versions_
| Python | Await mechanism | Pre-fix | Post-fix |
|--------|-----------------|---------|----------|
| 3.9  | `YIELD_FROM`       | OK (immune) | OK |
| 3.10 | `YIELD_FROM`       | OK (immune) | OK |
| 3.11 | `SEND`/`presend0`  | FAILED      | OK |
| 3.12 | `SEND`/`presend0`  | FAILED      | OK |
| 3.13 | `SEND`/`presend0`  | FAILED      | OK |
| 3.14 | `SEND`/`presend0`  | FAILED      | OK |