### PR TITLE
fix(asm): match Content-Type case-insensitively for request body analysis

### DIFF
--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -21,9 +21,8 @@ from ddtrace.internal.core import ExecutionContext
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils import http as http_utils
-from ddtrace.internal.utils.http import is_json_media_type
-from ddtrace.internal.utils.http import is_xml_media_type
-from ddtrace.internal.utils.http import normalize_media_type
+from ddtrace.internal.utils.http import MediaType
+from ddtrace.internal.utils.http import classify_media_type
 from ddtrace.internal.utils.http import parse_form_multipart
 import ddtrace.vendor.xmltodict as xmltodict
 
@@ -62,15 +61,15 @@ async def _on_asgi_request_parse_body(receive: _ASGIReceive, headers: Mapping[st
 
         try:
             with iast_disabled_taint_sources():
-                content_type = normalize_media_type(headers.get("content-type") or headers.get("Content-Type"))
-                if is_json_media_type(content_type):
+                media_type = classify_media_type(headers.get("content-type") or headers.get("Content-Type"))
+                if media_type is MediaType.JSON:
                     if body is None or body == b"":
                         req_body = None
                     else:
                         req_body = json.loads(body.decode())
-                elif is_xml_media_type(content_type):
+                elif media_type is MediaType.XML:
                     req_body = xmltodict.parse(body)
-                elif content_type == "text/plain":
+                elif media_type is MediaType.PLAIN:
                     req_body = None
                 else:
                     req_body = parse_form_multipart(body.decode(), headers) or None

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -59,7 +59,9 @@ async def _on_asgi_request_parse_body(receive: _ASGIReceive, headers: Mapping[st
 
         try:
             with iast_disabled_taint_sources():
-                content_type = headers.get("content-type") or headers.get("Content-Type")
+                # Match the bare media type, case-insensitively (RFC 9110), ignoring params like charset.
+                raw_content_type = headers.get("content-type") or headers.get("Content-Type") or ""
+                content_type = raw_content_type.split(";", 1)[0].strip().lower()
                 if content_type in ("application/json", "text/json"):
                     if body is None or body == b"":
                         req_body = None

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -21,6 +21,9 @@ from ddtrace.internal.core import ExecutionContext
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils import http as http_utils
+from ddtrace.internal.utils.http import is_json_media_type
+from ddtrace.internal.utils.http import is_xml_media_type
+from ddtrace.internal.utils.http import normalize_media_type
 from ddtrace.internal.utils.http import parse_form_multipart
 import ddtrace.vendor.xmltodict as xmltodict
 
@@ -59,15 +62,13 @@ async def _on_asgi_request_parse_body(receive: _ASGIReceive, headers: Mapping[st
 
         try:
             with iast_disabled_taint_sources():
-                # Match the bare media type, case-insensitively (RFC 9110), ignoring params like charset.
-                raw_content_type = headers.get("content-type") or headers.get("Content-Type") or ""
-                content_type = raw_content_type.split(";", 1)[0].strip().lower()
-                if content_type in ("application/json", "text/json"):
+                content_type = normalize_media_type(headers.get("content-type") or headers.get("Content-Type"))
+                if is_json_media_type(content_type):
                     if body is None or body == b"":
                         req_body = None
                     else:
                         req_body = json.loads(body.decode())
-                elif content_type in ("application/xml", "text/xml"):
+                elif is_xml_media_type(content_type):
                     req_body = xmltodict.parse(body)
                 elif content_type == "text/plain":
                     req_body = None

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -64,7 +64,8 @@ def _on_request_span_modifier(
 ) -> Optional[Any]:
     req_body = None
     if asm_config._asm_enabled and request.method in _BODY_METHODS:
-        content_type = request.content_type
+        # Match the bare media type, case-insensitively (RFC 9110), ignoring params like charset.
+        content_type = (request.content_type or "").split(";", 1)[0].strip().lower()
         wsgi_input = environ.get("wsgi.input", "")
 
         # Copy wsgi input if not seekable

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -30,9 +30,8 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.utils import http as http_utils
-from ddtrace.internal.utils.http import is_json_media_type
-from ddtrace.internal.utils.http import is_xml_media_type
-from ddtrace.internal.utils.http import normalize_media_type
+from ddtrace.internal.utils.http import MediaType
+from ddtrace.internal.utils.http import classify_media_type
 from ddtrace.trace import Span
 import ddtrace.vendor.xmltodict as xmltodict
 
@@ -67,7 +66,7 @@ def _on_request_span_modifier(
 ) -> Optional[Any]:
     req_body = None
     if asm_config._asm_enabled and request.method in _BODY_METHODS:
-        content_type = normalize_media_type(request.content_type)
+        media_type = classify_media_type(request.content_type)
         wsgi_input = environ.get("wsgi.input", "")
 
         # Copy wsgi input if not seekable
@@ -94,14 +93,14 @@ def _on_request_span_modifier(
 
         try:
             with iast_disabled_taint_sources():
-                if is_json_media_type(content_type):
+                if media_type is MediaType.JSON:
                     if _HAS_JSON_MIXIN and hasattr(request, "json") and request.json:
                         req_body = request.json
                     elif request.data is None or request.data == b"":
                         req_body = None
                     else:
                         req_body = json.loads(request.data.decode("UTF-8"))
-                elif is_xml_media_type(content_type):
+                elif media_type is MediaType.XML:
                     req_body = xmltodict.parse(request.get_data())
                 elif hasattr(request, "form"):
                     req_body = {k: vs if len(vs) > 1 else vs[0] for k, vs in request.form.to_dict(flat=False).items()}

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -30,6 +30,9 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.utils import http as http_utils
+from ddtrace.internal.utils.http import is_json_media_type
+from ddtrace.internal.utils.http import is_xml_media_type
+from ddtrace.internal.utils.http import normalize_media_type
 from ddtrace.trace import Span
 import ddtrace.vendor.xmltodict as xmltodict
 
@@ -64,8 +67,7 @@ def _on_request_span_modifier(
 ) -> Optional[Any]:
     req_body = None
     if asm_config._asm_enabled and request.method in _BODY_METHODS:
-        # Match the bare media type, case-insensitively (RFC 9110), ignoring params like charset.
-        content_type = (request.content_type or "").split(";", 1)[0].strip().lower()
+        content_type = normalize_media_type(request.content_type)
         wsgi_input = environ.get("wsgi.input", "")
 
         # Copy wsgi input if not seekable
@@ -92,14 +94,14 @@ def _on_request_span_modifier(
 
         try:
             with iast_disabled_taint_sources():
-                if content_type in ("application/json", "text/json"):
+                if is_json_media_type(content_type):
                     if _HAS_JSON_MIXIN and hasattr(request, "json") and request.json:
                         req_body = request.json
                     elif request.data is None or request.data == b"":
                         req_body = None
                     else:
                         req_body = json.loads(request.data.decode("UTF-8"))
-                elif content_type in ("application/xml", "text/xml"):
+                elif is_xml_media_type(content_type):
                     req_body = xmltodict.parse(request.get_data())
                 elif hasattr(request, "form"):
                     req_body = {k: vs if len(vs) > 1 else vs[0] for k, vs in request.form.to_dict(flat=False).items()}

--- a/ddtrace/appsec/_contrib/tornado/__init__.py
+++ b/ddtrace/appsec/_contrib/tornado/__init__.py
@@ -15,6 +15,9 @@ from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
+from ddtrace.internal.utils.http import is_json_media_type
+from ddtrace.internal.utils.http import is_xml_media_type
+from ddtrace.internal.utils.http import normalize_media_type
 
 
 logger = get_logger(__name__)
@@ -55,16 +58,15 @@ def tornado_call_waf_first(integration: str, handler: Any) -> None:
         if parsed_body:
             parsed_body = {k: v[0] if len(v) == 1 else list(v) for k, v in parsed_body.items()}
         else:
-            # HTTP media types are case-insensitive (RFC 9110): normalize before matching.
-            content_type = request_headers.get("content-type", "").lower()
+            content_type = normalize_media_type(request_headers.get("content-type"))
             _body: bytes = handler.request.body
             try:
-                if "json" in content_type:
+                if is_json_media_type(content_type):
                     parsed_body = json.loads(_body)
             except BaseException:
                 pass  # nosec
             try:
-                if not parsed_body and "xml" in content_type:
+                if not parsed_body and is_xml_media_type(content_type):
                     import ddtrace.vendor.xmltodict as xmltodict
 
                     parsed_body = xmltodict.parse(_body)

--- a/ddtrace/appsec/_contrib/tornado/__init__.py
+++ b/ddtrace/appsec/_contrib/tornado/__init__.py
@@ -15,9 +15,8 @@ from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
-from ddtrace.internal.utils.http import is_json_media_type
-from ddtrace.internal.utils.http import is_xml_media_type
-from ddtrace.internal.utils.http import normalize_media_type
+from ddtrace.internal.utils.http import MediaType
+from ddtrace.internal.utils.http import classify_media_type
 
 
 logger = get_logger(__name__)
@@ -58,15 +57,15 @@ def tornado_call_waf_first(integration: str, handler: Any) -> None:
         if parsed_body:
             parsed_body = {k: v[0] if len(v) == 1 else list(v) for k, v in parsed_body.items()}
         else:
-            content_type = normalize_media_type(request_headers.get("content-type"))
+            media_type = classify_media_type(request_headers.get("content-type"))
             _body: bytes = handler.request.body
             try:
-                if is_json_media_type(content_type):
+                if media_type is MediaType.JSON:
                     parsed_body = json.loads(_body)
             except BaseException:
                 pass  # nosec
             try:
-                if not parsed_body and is_xml_media_type(content_type):
+                if not parsed_body and media_type is MediaType.XML:
                     import ddtrace.vendor.xmltodict as xmltodict
 
                     parsed_body = xmltodict.parse(_body)

--- a/ddtrace/appsec/_contrib/tornado/__init__.py
+++ b/ddtrace/appsec/_contrib/tornado/__init__.py
@@ -55,14 +55,16 @@ def tornado_call_waf_first(integration: str, handler: Any) -> None:
         if parsed_body:
             parsed_body = {k: v[0] if len(v) == 1 else list(v) for k, v in parsed_body.items()}
         else:
+            # HTTP media types are case-insensitive (RFC 9110): normalize before matching.
+            content_type = request_headers.get("content-type", "").lower()
             _body: bytes = handler.request.body
             try:
-                if "json" in request_headers.get("content-type", ""):
+                if "json" in content_type:
                     parsed_body = json.loads(_body)
             except BaseException:
                 pass  # nosec
             try:
-                if not parsed_body and "xml" in request_headers.get("content-type", ""):
+                if not parsed_body and "xml" in content_type:
                     import ddtrace.vendor.xmltodict as xmltodict
 
                     parsed_body = xmltodict.parse(_body)

--- a/ddtrace/appsec/_http_utils.py
+++ b/ddtrace/appsec/_http_utils.py
@@ -9,6 +9,9 @@ from typing import Union
 from urllib.parse import parse_qs
 
 from ddtrace.internal.utils import http as http_utils
+from ddtrace.internal.utils.http import is_json_media_type
+from ddtrace.internal.utils.http import is_xml_media_type
+from ddtrace.internal.utils.http import normalize_media_type
 import ddtrace.vendor.xmltodict as xmltodict
 
 
@@ -41,22 +44,15 @@ def parse_http_body(
             return None
 
     try:
-        content_type = normalized_headers.get("content-type")
-        if not content_type:
+        base_content_type = normalize_media_type(normalized_headers.get("content-type"))
+        if not base_content_type:
             return None
 
-        # Content-Type legally carries parameters (charset, boundary, ...),
-        # e.g. application/json; charset=utf-8 — many HTTP clients always
-        # add a charset. Match against the bare media type so a charset
-        # suffix doesn't silently skip body inspection.
-        # HTTP media types are case-insensitive (RFC 9110): normalize before matching.
-        base_content_type = content_type.split(";", 1)[0].strip().lower()
-
-        if base_content_type in ("application/json", "application/vnd.api+json", "text/json"):
+        if is_json_media_type(base_content_type):
             return json.loads(body)
         elif base_content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
             return parse_qs(body)
-        elif base_content_type in ("application/xml", "text/xml"):
+        elif is_xml_media_type(base_content_type):
             return xmltodict.parse(body)
         elif base_content_type == "multipart/form-data":
             return http_utils.parse_form_multipart(body, normalized_headers)

--- a/ddtrace/appsec/_http_utils.py
+++ b/ddtrace/appsec/_http_utils.py
@@ -49,7 +49,8 @@ def parse_http_body(
         # e.g. application/json; charset=utf-8 — many HTTP clients always
         # add a charset. Match against the bare media type so a charset
         # suffix doesn't silently skip body inspection.
-        base_content_type = content_type.split(";", 1)[0].strip()
+        # HTTP media types are case-insensitive (RFC 9110): normalize before matching.
+        base_content_type = content_type.split(";", 1)[0].strip().lower()
 
         if base_content_type in ("application/json", "application/vnd.api+json", "text/json"):
             return json.loads(body)

--- a/ddtrace/appsec/_http_utils.py
+++ b/ddtrace/appsec/_http_utils.py
@@ -9,9 +9,8 @@ from typing import Union
 from urllib.parse import parse_qs
 
 from ddtrace.internal.utils import http as http_utils
-from ddtrace.internal.utils.http import is_json_media_type
-from ddtrace.internal.utils.http import is_xml_media_type
-from ddtrace.internal.utils.http import normalize_media_type
+from ddtrace.internal.utils.http import MediaType
+from ddtrace.internal.utils.http import classify_media_type
 import ddtrace.vendor.xmltodict as xmltodict
 
 
@@ -44,20 +43,15 @@ def parse_http_body(
             return None
 
     try:
-        base_content_type = normalize_media_type(normalized_headers.get("content-type"))
-        if not base_content_type:
-            return None
-
-        if is_json_media_type(base_content_type):
+        category = classify_media_type(normalized_headers.get("content-type"))
+        if category is MediaType.JSON:
             return json.loads(body)
-        elif base_content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
+        elif category is MediaType.FORM_URLENCODED:
             return parse_qs(body)
-        elif is_xml_media_type(base_content_type):
+        elif category is MediaType.XML:
             return xmltodict.parse(body)
-        elif base_content_type == "multipart/form-data":
+        elif category is MediaType.MULTIPART:
             return http_utils.parse_form_multipart(body, normalized_headers)
-        elif base_content_type == "text/plain":
-            return None
         else:
             return None
 

--- a/ddtrace/contrib/internal/django/utils.py
+++ b/ddtrace/contrib/internal/django/utils.py
@@ -21,6 +21,9 @@ from ddtrace.internal import compat
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import stringify_cache_args
+from ddtrace.internal.utils.http import is_json_media_type
+from ddtrace.internal.utils.http import is_xml_media_type
+from ddtrace.internal.utils.http import normalize_media_type
 from ddtrace.internal.utils.http import parse_form_multipart
 from ddtrace.internal.utils.http import parse_form_params
 from ddtrace.internal.utils.importlib import func_name
@@ -255,8 +258,7 @@ def _extract_body(request):
     if request.method in _BODY_METHODS:
         req_body = None
         content_type = request.content_type if hasattr(request, "content_type") else request.META.get("CONTENT_TYPE")
-        # Match the bare media type, case-insensitively (RFC 9110), ignoring params like charset.
-        content_type = (content_type or "").split(";", 1)[0].strip().lower()
+        content_type = normalize_media_type(content_type)
         headers = core.dispatch_with_results(  # ast-grep-ignore: core-dispatch-with-results
             "django.extract_body"
         ).headers.value
@@ -265,9 +267,9 @@ def _extract_body(request):
                 req_body = parse_form_params(request.body.decode("UTF-8", errors="ignore"))
             elif content_type == "multipart/form-data":
                 req_body = parse_form_multipart(request.body.decode("UTF-8", errors="ignore"), headers)
-            elif content_type in ("application/json", "text/json"):
+            elif is_json_media_type(content_type):
                 req_body = json.loads(request.body.decode("UTF-8", errors="ignore"))
-            elif content_type in ("application/xml", "text/xml"):
+            elif is_xml_media_type(content_type):
                 req_body = xmltodict.parse(request.body.decode("UTF-8", errors="ignore"))
             else:  # text/plain, others: don't use them
                 req_body = None

--- a/ddtrace/contrib/internal/django/utils.py
+++ b/ddtrace/contrib/internal/django/utils.py
@@ -21,9 +21,8 @@ from ddtrace.internal import compat
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import stringify_cache_args
-from ddtrace.internal.utils.http import is_json_media_type
-from ddtrace.internal.utils.http import is_xml_media_type
-from ddtrace.internal.utils.http import normalize_media_type
+from ddtrace.internal.utils.http import MediaType
+from ddtrace.internal.utils.http import classify_media_type
 from ddtrace.internal.utils.http import parse_form_multipart
 from ddtrace.internal.utils.http import parse_form_params
 from ddtrace.internal.utils.importlib import func_name
@@ -258,18 +257,18 @@ def _extract_body(request):
     if request.method in _BODY_METHODS:
         req_body = None
         content_type = request.content_type if hasattr(request, "content_type") else request.META.get("CONTENT_TYPE")
-        content_type = normalize_media_type(content_type)
+        media_type = classify_media_type(content_type)
         headers = core.dispatch_with_results(  # ast-grep-ignore: core-dispatch-with-results
             "django.extract_body"
         ).headers.value
         try:
-            if content_type == "application/x-www-form-urlencoded":
+            if media_type is MediaType.FORM_URLENCODED:
                 req_body = parse_form_params(request.body.decode("UTF-8", errors="ignore"))
-            elif content_type == "multipart/form-data":
+            elif media_type is MediaType.MULTIPART:
                 req_body = parse_form_multipart(request.body.decode("UTF-8", errors="ignore"), headers)
-            elif is_json_media_type(content_type):
+            elif media_type is MediaType.JSON:
                 req_body = json.loads(request.body.decode("UTF-8", errors="ignore"))
-            elif is_xml_media_type(content_type):
+            elif media_type is MediaType.XML:
                 req_body = xmltodict.parse(request.body.decode("UTF-8", errors="ignore"))
             else:  # text/plain, others: don't use them
                 req_body = None

--- a/ddtrace/contrib/internal/django/utils.py
+++ b/ddtrace/contrib/internal/django/utils.py
@@ -255,6 +255,8 @@ def _extract_body(request):
     if request.method in _BODY_METHODS:
         req_body = None
         content_type = request.content_type if hasattr(request, "content_type") else request.META.get("CONTENT_TYPE")
+        # Match the bare media type, case-insensitively (RFC 9110), ignoring params like charset.
+        content_type = (content_type or "").split(";", 1)[0].strip().lower()
         headers = core.dispatch_with_results(  # ast-grep-ignore: core-dispatch-with-results
             "django.extract_body"
         ).headers.value

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from email.encoders import encode_noop
+from enum import Enum
 from json import loads
 import logging
 import re
@@ -33,8 +34,18 @@ _W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE = re.compile(r",|;|~|[^\x20-\x7E]+")
 _W3C_TRACESTATE_INVALID_CHARS_REGEX_KEY = re.compile(r",| |=|[^\x20-\x7E]+")
 
 
-def normalize_media_type(content_type):
-    # type: (Optional[str]) -> str
+class MediaType(Enum):
+    """Body-parsing category for an HTTP ``Content-Type``."""
+
+    JSON = "json"
+    XML = "xml"
+    FORM_URLENCODED = "form_urlencoded"
+    MULTIPART = "multipart"
+    PLAIN = "plain"
+    UNKNOWN = "unknown"
+
+
+def normalize_media_type(content_type: Optional[str]) -> str:
     """Return the bare media type without parameters, lowercased.
 
     HTTP media types are case-insensitive and may carry parameters such as
@@ -47,16 +58,25 @@ def normalize_media_type(content_type):
     return content_type.split(";", 1)[0].strip().lower()
 
 
-def is_json_media_type(media_type):
-    # type: (str) -> bool
-    """Whether a normalized media type denotes JSON, including ``application/*+json`` suffixes."""
-    return media_type in ("application/json", "text/json") or media_type.endswith("+json")
+def classify_media_type(content_type: Optional[str]) -> MediaType:
+    """Classify a ``Content-Type`` value into a :class:`MediaType` body-parsing category.
 
-
-def is_xml_media_type(media_type):
-    # type: (str) -> bool
-    """Whether a normalized media type denotes XML, including ``application/*+xml`` suffixes."""
-    return media_type in ("application/xml", "text/xml") or media_type.endswith("+xml")
+    The value is normalized first (case-insensitive, parameters ignored), and
+    structured-suffix types are recognized: ``application/*+json`` maps to JSON and
+    ``application/*+xml`` maps to XML.
+    """
+    media_type = normalize_media_type(content_type)
+    if media_type in ("application/json", "text/json") or media_type.endswith("+json"):
+        return MediaType.JSON
+    if media_type in ("application/xml", "text/xml") or media_type.endswith("+xml"):
+        return MediaType.XML
+    if media_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
+        return MediaType.FORM_URLENCODED
+    if media_type == "multipart/form-data":
+        return MediaType.MULTIPART
+    if media_type == "text/plain":
+        return MediaType.PLAIN
+    return MediaType.UNKNOWN
 
 
 if TYPE_CHECKING:
@@ -423,16 +443,17 @@ def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None)
                 res.setdefault(key, []).append(value)
             res = {k: v[0] if len(v) == 1 else v for k, v in res.items()}
         else:
-            base_content_type = normalize_media_type(msg.get("Content-Type"))
-            if is_json_media_type(base_content_type):
+            # msg.get_content_type() defaults a part with no Content-Type to text/plain (RFC 2046).
+            category = classify_media_type(msg.get_content_type())
+            if category is MediaType.JSON:
                 res = json.loads(msg.get_payload())
-            elif is_xml_media_type(base_content_type):
+            elif category is MediaType.XML:
                 import ddtrace.vendor.xmltodict as xmltodict
 
                 res = xmltodict.parse(msg.get_payload())
-            elif base_content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
+            elif category is MediaType.FORM_URLENCODED:
                 res = parse_qs(msg.get_payload())
-            elif base_content_type in ("text/plain", ""):
+            elif category is MediaType.PLAIN:
                 res = msg.get_payload()
             else:
                 res = ""

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -45,27 +45,18 @@ class MediaType(Enum):
     UNKNOWN = "unknown"
 
 
-def normalize_media_type(content_type: Optional[str]) -> str:
-    """Return the bare media type without parameters, lowercased.
-
-    HTTP media types are case-insensitive and may carry parameters such as
-    ``charset`` or ``boundary`` (RFC 9110), e.g. ``Application/JSON; charset=utf-8``.
-    Matching against the normalized bare media type avoids those variants silently
-    skipping body inspection.
-    """
-    if not content_type:
-        return ""
-    return content_type.split(";", 1)[0].strip().lower()
-
-
 def classify_media_type(content_type: Optional[str]) -> MediaType:
     """Classify a ``Content-Type`` value into a :class:`MediaType` body-parsing category.
 
-    The value is normalized first (case-insensitive, parameters ignored), and
-    structured-suffix types are recognized: ``application/*+json`` maps to JSON and
-    ``application/*+xml`` maps to XML.
+    HTTP media types are case-insensitive and may carry parameters such as ``charset``
+    or ``boundary`` (RFC 9110), e.g. ``Application/JSON; charset=utf-8``; the value is
+    normalized to its bare, lowercased media type before matching. Any subtype carrying
+    a ``+json`` structured suffix (e.g. ``application/vnd.api+json``) maps to JSON, and
+    any ``+xml`` suffix maps to XML. An empty or unrecognized value maps to UNKNOWN.
     """
-    media_type = normalize_media_type(content_type)
+    if not content_type:
+        return MediaType.UNKNOWN
+    media_type = content_type.split(";", 1)[0].strip().lower()
     if media_type in ("application/json", "text/json") or media_type.endswith("+json"):
         return MediaType.JSON
     if media_type in ("application/xml", "text/xml") or media_type.endswith("+xml"):
@@ -443,8 +434,10 @@ def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None)
                 res.setdefault(key, []).append(value)
             res = {k: v[0] if len(v) == 1 else v for k, v in res.items()}
         else:
-            # msg.get_content_type() defaults a part with no Content-Type to text/plain (RFC 2046).
-            category = classify_media_type(msg.get_content_type())
+            content_type = msg.get("Content-Type")
+            # A part with no Content-Type header defaults to text/plain (RFC 2046); a present
+            # but unrecognized value (UNKNOWN) is left unparsed, as before.
+            category = MediaType.PLAIN if content_type is None else classify_media_type(content_type)
             if category is MediaType.JSON:
                 res = json.loads(msg.get_payload())
             elif category is MediaType.XML:

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -33,6 +33,32 @@ _W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE = re.compile(r",|;|~|[^\x20-\x7E]+")
 _W3C_TRACESTATE_INVALID_CHARS_REGEX_KEY = re.compile(r",| |=|[^\x20-\x7E]+")
 
 
+def normalize_media_type(content_type):
+    # type: (Optional[str]) -> str
+    """Return the bare media type without parameters, lowercased.
+
+    HTTP media types are case-insensitive and may carry parameters such as
+    ``charset`` or ``boundary`` (RFC 9110), e.g. ``Application/JSON; charset=utf-8``.
+    Matching against the normalized bare media type avoids those variants silently
+    skipping body inspection.
+    """
+    if not content_type:
+        return ""
+    return content_type.split(";", 1)[0].strip().lower()
+
+
+def is_json_media_type(media_type):
+    # type: (str) -> bool
+    """Whether a normalized media type denotes JSON, including ``application/*+json`` suffixes."""
+    return media_type in ("application/json", "text/json") or media_type.endswith("+json")
+
+
+def is_xml_media_type(media_type):
+    # type: (str) -> bool
+    """Whether a normalized media type denotes XML, including ``application/*+xml`` suffixes."""
+    return media_type in ("application/xml", "text/xml") or media_type.endswith("+xml")
+
+
 if TYPE_CHECKING:
     import http.client as httplib
 
@@ -397,17 +423,16 @@ def parse_form_multipart(body: str, headers: Optional[Mapping[str, str]] = None)
                 res.setdefault(key, []).append(value)
             res = {k: v[0] if len(v) == 1 else v for k, v in res.items()}
         else:
-            content_type = msg.get("Content-Type")
-            base_content_type = content_type.split(";", 1)[0].strip() if content_type else content_type
-            if base_content_type in ("application/json", "text/json"):
+            base_content_type = normalize_media_type(msg.get("Content-Type"))
+            if is_json_media_type(base_content_type):
                 res = json.loads(msg.get_payload())
-            elif base_content_type in ("application/xml", "text/xml"):
+            elif is_xml_media_type(base_content_type):
                 import ddtrace.vendor.xmltodict as xmltodict
 
                 res = xmltodict.parse(msg.get_payload())
             elif base_content_type in ("application/x-url-encoded", "application/x-www-form-urlencoded"):
                 res = parse_qs(msg.get_payload())
-            elif base_content_type in ("text/plain", None):
+            elif base_content_type in ("text/plain", ""):
                 res = msg.get_payload()
             else:
                 res = ""

--- a/releasenotes/notes/appsec-content-type-case-insensitive-body-parsing-3462222b0129b2dc.yaml
+++ b/releasenotes/notes/appsec-content-type-case-insensitive-body-parsing-3462222b0129b2dc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    AAP: Resolve an issue where some request bodies could be skipped during analysis
+    depending on the ``Content-Type`` header for the Tornado, Flask, and FastAPI integrations.

--- a/releasenotes/notes/appsec-content-type-case-insensitive-body-parsing-3462222b0129b2dc.yaml
+++ b/releasenotes/notes/appsec-content-type-case-insensitive-body-parsing-3462222b0129b2dc.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     AAP: Resolve an issue where some request bodies could be skipped during analysis
-    depending on the ``Content-Type`` header for the Tornado, Flask, and FastAPI integrations.
+    depending on the ``Content-Type`` header for the Django, Tornado, Flask, and FastAPI integrations.

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1110,6 +1110,8 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "Application/JSON", "tst-037-003"),
             # Content-Type parameters (e.g. charset) must not skip body inspection
             ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "application/json; charset=utf-8", "tst-037-003"),
+            # structured-suffix JSON types (application/*+json, e.g. RFC 7807) must be parsed
+            ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "application/vnd.api+json", "tst-037-003"),
             # xml body must be blocked
             (
                 '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
@@ -1120,6 +1122,12 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             (
                 '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
                 "Text/XML",
+                "tst-037-003",
+            ),
+            # structured-suffix XML types (application/*+xml) must be parsed
+            (
+                '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
+                "application/atom+xml",
                 "tst-037-003",
             ),
             # form body must be blocked
@@ -1154,8 +1162,10 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             "json_large",
             "json_mixed_case_content_type",
             "json_charset_param_content_type",
+            "json_structured_suffix_content_type",
             "xml",
             "xml_mixed_case_content_type",
+            "xml_structured_suffix_content_type",
             "form",
             "form_multipart",
             "form_multipart_duplicate_keys",

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1106,10 +1106,20 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "application/json", "tst-037-003"),
             ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "application/json", "tst-037-003"),
             (json.dumps(LARGE_BODY), "application/json", "tst-037-003"),
+            # HTTP media types are case-insensitive (RFC 9110): mixed-case must still be parsed/blocked
+            ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "Application/JSON", "tst-037-003"),
+            # Content-Type parameters (e.g. charset) must not skip body inspection
+            ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "application/json; charset=utf-8", "tst-037-003"),
             # xml body must be blocked
             (
                 '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
                 "text/xml",
+                "tst-037-003",
+            ),
+            # mixed-case xml must still be parsed/blocked
+            (
+                '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
+                "Text/XML",
                 "tst-037-003",
             ),
             # form body must be blocked
@@ -1142,7 +1152,10 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             "json",
             "text_json",
             "json_large",
+            "json_mixed_case_content_type",
+            "json_charset_param_content_type",
             "xml",
+            "xml_mixed_case_content_type",
             "form",
             "form_multipart",
             "form_multipart_duplicate_keys",

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1130,11 +1130,25 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
                 "application/atom+xml",
                 "tst-037-003",
             ),
+            # xml Content-Type parameters (e.g. charset) must not skip body inspection
+            (
+                '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
+                "text/xml; charset=utf-8",
+                "tst-037-003",
+            ),
             # form body must be blocked
             ("attack=yqrweytqwreasldhkuqwgervflnmlnli", "application/x-www-form-urlencoded", "tst-037-003"),
             (
                 '--52d1fb4eb9c021e53ac2846190e4ac72\r\nContent-Disposition: form-data; name="attack"\r\n'
                 'Content-Type: application/json\r\n\r\n{"test": "yqrweytqwreasldhkuqwgervflnmlnli"}\r\n'
+                "--52d1fb4eb9c021e53ac2846190e4ac72--\r\n",
+                "multipart/form-data; boundary=52d1fb4eb9c021e53ac2846190e4ac72",
+                "tst-037-003",
+            ),
+            # mixed-case Content-Type on a multipart inner part must still be parsed
+            (
+                '--52d1fb4eb9c021e53ac2846190e4ac72\r\nContent-Disposition: form-data; name="attack"\r\n'
+                'Content-Type: Application/JSON\r\n\r\n{"test": "yqrweytqwreasldhkuqwgervflnmlnli"}\r\n'
                 "--52d1fb4eb9c021e53ac2846190e4ac72--\r\n",
                 "multipart/form-data; boundary=52d1fb4eb9c021e53ac2846190e4ac72",
                 "tst-037-003",
@@ -1166,8 +1180,10 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             "xml",
             "xml_mixed_case_content_type",
             "xml_structured_suffix_content_type",
+            "xml_charset_param_content_type",
             "form",
             "form_multipart",
+            "form_multipart_mixed_case_part",
             "form_multipart_duplicate_keys",
             "text",
             "no_attack",


### PR DESCRIPTION
APPSEC-68557: AAP request bodies could be skipped during analysis depending on the `Content-Type` header. This normalizes the header before matching in the Tornado, Flask, and FastAPI integrations so those bodies are still analyzed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)