### PR TITLE
fix(llmobs): handle Bedrock Agent knowledge base references

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock_agents.py
+++ b/ddtrace/llmobs/_integrations/bedrock_agents.py
@@ -451,6 +451,22 @@ def _invocation_input_span(
     return span_event
 
 
+def _extract_retrieved_reference_text(retrieved_references: Any) -> str:
+    if isinstance(retrieved_references, list):
+        if not retrieved_references:
+            return ""
+        retrieved_references = retrieved_references[0]
+    if not isinstance(retrieved_references, dict):
+        return ""
+    text = retrieved_references.get("text")
+    if text is not None:
+        return str(text)
+    content = retrieved_references.get("content", {})
+    if isinstance(content, dict):
+        return str(content.get("text", ""))
+    return ""
+
+
 def _observation_span(
     observation: dict[str, Any], root_span: Span, current_active_span: Optional[LLMObsSpanEvent]
 ) -> Optional[LLMObsSpanEvent]:
@@ -475,7 +491,7 @@ def _observation_span(
     elif observation_type == "KNOWLEDGE_BASE":
         output_chunk = observation.get("knowledgeBaseLookupOutput", {})
         bedrock_metadata = output_chunk.get("metadata", {})
-        output_value = output_chunk.get("retrievedReferences", {}).get("text", "")
+        output_value = _extract_retrieved_reference_text(output_chunk.get("retrievedReferences", {}))
     elif observation_type == "ACTION_GROUP_CODE_INTERPRETER":
         output_chunk = observation.get("codeInterpreterInvocationOutput", {})
         bedrock_metadata = output_chunk.get("metadata", {})

--- a/releasenotes/notes/fix-bedrock-agent-knowledge-base-references-94dfd051efaa8c77.yaml
+++ b/releasenotes/notes/fix-bedrock-agent-knowledge-base-references-94dfd051efaa8c77.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    botocore: This fix resolves an issue where Bedrock Agent tracing failed to translate knowledge base observations when Bedrock returned retrieved references as a list.

--- a/tests/contrib/botocore/test_bedrock_agents_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_agents_llmobs.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ddtrace import config
+from ddtrace.llmobs._integrations.bedrock import BedrockIntegration
 from tests.contrib.botocore.bedrock_utils import AGENT_ALIAS_ID
 from tests.contrib.botocore.bedrock_utils import AGENT_ID
 from tests.contrib.botocore.bedrock_utils import AGENT_INPUT
@@ -173,3 +175,46 @@ def test_agent_invoke_stream_trace_disabled(bedrock_agent_client, request_vcr, l
             pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["name"] == "Bedrock Agent {}".format(AGENT_ID)
+
+
+def test_agent_knowledge_base_observation_accepts_retrieved_references_list(tracer, bedrock_llmobs, llmobs_events):
+    integration = BedrockIntegration(integration_config=config.botocore)
+    trace_step_id = "knowledge-base-step"
+    retrieved_text = "Knowledge base retrieved reference text."
+    traces = [
+        {
+            "trace": {
+                "orchestrationTrace": {
+                    "invocationInput": {
+                        "traceId": trace_step_id,
+                        "invocationType": "KNOWLEDGE_BASE",
+                        "knowledgeBaseLookupInput": {
+                            "knowledgeBaseId": "knowledge-base-id",
+                            "text": "lookup request",
+                        },
+                    }
+                }
+            }
+        },
+        {
+            "trace": {
+                "orchestrationTrace": {
+                    "observation": {
+                        "traceId": trace_step_id,
+                        "type": "KNOWLEDGE_BASE",
+                        "knowledgeBaseLookupOutput": {
+                            "metadata": {"totalTimeMs": 1},
+                            "retrievedReferences": [{"content": {"text": retrieved_text}}],
+                        },
+                    }
+                }
+            }
+        },
+    ]
+
+    with tracer.trace("Bedrock Agent {}".format(AGENT_ID)) as root_span:
+        integration.translate_bedrock_traces(traces, root_span)
+
+    knowledge_base_spans = [event for event in llmobs_events if event["name"] == "knowledge-base-id"]
+    assert len(knowledge_base_spans) == 1
+    assert knowledge_base_spans[0]["meta"]["output"]["value"] == retrieved_text


### PR DESCRIPTION
Generated with [APM Instrumentation Toolkit](https://github.com/DataDog/apm-instrumentation-toolkit)

## Description

Fixes #17153.

This updates Bedrock Agent LLMObs trace translation to handle knowledge-base observation `retrievedReferences` values returned as a list of reference objects. The previous code assumed a dict-shaped value and raised `AttributeError: 'list' object has no attribute 'get'`.

Changes:
- Extract retrieved reference text from either the legacy dict shape or the AWS list shape.
- Add a focused regression test covering list-shaped `retrievedReferences`.
- Add a release note for the user-facing botocore/Bedrock Agent tracing fix.

## Testing

Compiled kit PR gate: passed.

Toolkit evidence summary:

| Phase/Gate | Status | Evidence |
| --- | --- | --- |
| Reproduction | pass | Focused regression reproduced the reported `AttributeError` before implementation. |
| Implement | pass | Focused regression and full Bedrock Agent LLMObs test file passed after the fix. |
| Final test gate | pass | `test_bedrock_agents_llmobs.py` passed: 5 passed, 1 warning. |
| Final lint gate | pass | `hatch run lint:style` and release-note spelling passed. |
| Evidence review | pass | Reviewer accepted the red/green evidence and scope advisory. |

Commands run by the final PR gate:

```bash
scripts/run-tests --venv 160bd16 -- -- -vv tests/contrib/botocore/test_bedrock_agents_llmobs.py
hatch run lint:style -- ddtrace/llmobs/_integrations/bedrock_agents.py tests/contrib/botocore/test_bedrock_agents_llmobs.py
hatch run lint:spelling -- releasenotes/notes/fix-bedrock-agent-knowledge-base-references-94dfd051efaa8c77.yaml
```

Reproduction evidence:
- Before implementation, the focused regression reproduced the reported `AttributeError`.
- After implementation, the focused regression passed.
- Final PR gate reran the full `test_bedrock_agents_llmobs.py` file and lint/spelling checks.

## Risks

Low. The change is defensive parsing for a known Bedrock Agent response shape and preserves the existing dict-shaped handling.

## Try it out

```bash
gh repo clone DataDog/dd-trace-py
cd dd-trace-py
git fetch origin apm-ai-toolkit/execute/botocore/20260625-220557
git checkout apm-ai-toolkit/execute/botocore/20260625-220557
scripts/run-tests --venv 160bd16 -- -- -vv tests/contrib/botocore/test_bedrock_agents_llmobs.py
```

## Additional Notes

The compiled kit scope advisory flagged `ddtrace/llmobs/_integrations/bedrock_agents.py` as outside the botocore adapter's default path guesses. The PR gate accepted it because the issue traceback and reproduction evidence identify that file as the failing implementation path.

Generated with [APM Instrumentation Toolkit](https://github.com/DataDog/apm-instrumentation-toolkit)
