### PR TITLE
chore(llmobs): treat root parent ID sentinel as missing on header extraction [backport 4.11]

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -3108,7 +3108,7 @@ class LLMObs(Service):
                     return
                 raise LLMObsActivateDistributedHeadersError("Failed to extract trace/span ID from request headers.")
             _parent_id = context._meta.get(PROPAGATED_PARENT_ID_KEY)
-            if _parent_id is None:
+            if _parent_id is None or _parent_id == ROOT_PARENT_ID:
                 error = "missing_parent_id"
                 log.debug("Failed to extract LLMObs parent ID from request headers.")
                 return

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 import pytest
@@ -602,6 +603,24 @@ def test_activate_distributed_context_without_sample_rate(llmobs):
     llmobs._instance._activate_llmobs_distributed_context({}, ctx)
     active_ctx = llmobs._instance._llmobs_context_provider.active()
     assert PROPAGATED_SAMPLE_RATE not in active_ctx._meta
+
+
+def test_activate_distributed_context_root_sentinel_no_warning(llmobs, caplog):
+    ctx = Context(trace_id=123456789, span_id=987654321)
+    ctx._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = _DECIMAL_TRACE_ID
+    ctx._meta[PROPAGATED_PARENT_ID_KEY] = ROOT_PARENT_ID
+    with caplog.at_level(logging.DEBUG, logger="ddtrace.llmobs._llmobs"):
+        llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    assert "Failed to parse LLMObs parent ID from request headers." not in caplog.text
+
+
+def test_activate_distributed_context_garbage_parent_id_still_warns(llmobs, caplog):
+    ctx = Context(trace_id=123456789, span_id=987654321)
+    ctx._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = _DECIMAL_TRACE_ID
+    ctx._meta[PROPAGATED_PARENT_ID_KEY] = "not-a-number"
+    with caplog.at_level(logging.WARNING, logger="ddtrace.llmobs._llmobs"):
+        llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    assert "Failed to parse LLMObs parent ID from request headers." in caplog.text
 
 
 def test_propagated_sample_rate_stored_in_meta_struct(llmobs):


### PR DESCRIPTION
Backport of #18699 to the `4.11` release branch.

## Description

When no LLMObs span is active, the inject side writes the `ROOT_PARENT_ID` sentinel (`"undefined"`) into the `_dd.p.llmobs_parent_id` propagation tag. When the parent id is set to `ROOT_PARENT_ID`, the extract path (`LLMObs._activate_llmobs_distributed_context`) ran `int("undefined")`, which raises `ValueError` and left a spurious `WARNING` — `Failed to parse LLMObs parent ID from request headers.`

This was the only consumer that integer-parses the tag. Every other `ROOT_PARENT_ID` reader either compares it or uses it as a fallback default. The fix treats the sentinel exactly like a missing parent id (the existing `_parent_id is None` branch → silent `DEBUG`), restoring inject/extract symmetry.

## Risks

Low. No change to span parenting behavior. The only observable changes are the removed warning (now `DEBUG`) and the telemetry tag for this path (`invalid_parent_id` → `missing_parent_id`).

Clean cherry-pick of `d9cc717b2eadffcb023ae035a7af755181275d43` (`-x` recorded in the commit).