### PR TITLE
test(grpc): retry port bind to fix flaky gRPC IAST tests

### DIFF
--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import grpc
 from grpc._grpcio_metadata import __version__ as _GRPC_VERSION
@@ -42,7 +43,15 @@ class GrpcBaseTestCase(TracerTestCase):
     def _start_server(self):
         self._server_pool = logging_pool.pool(1)
         self._server = grpc.server(self._server_pool)
-        self._server.add_insecure_port("[::]:%d" % (_GRPC_PORT))
+        # gRPC core releases the listening socket asynchronously after a previous server's shutdown
+        # Event fires, so rebinding the worker's fixed port can transiently fail. Retry the bind to
+        # avoid a flaky "Failed to bind to address" RuntimeError between tests.
+        for _ in range(10):
+            if self._server.add_insecure_port("[::]:%d" % (_GRPC_PORT)) != 0:
+                break
+            time.sleep(0.1)
+        else:
+            raise RuntimeError("Failed to bind to address [::]:%d after multiple attempts" % (_GRPC_PORT))
         add_HelloServicer_to_server(_HelloServicer(), self._server)
         self._server.start()
 

--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -43,10 +43,8 @@ class GrpcBaseTestCase(TracerTestCase):
     def _start_server(self):
         self._server_pool = logging_pool.pool(1)
         self._server = grpc.server(self._server_pool)
-        # gRPC core releases the listening socket asynchronously after a previous server's shutdown
-        # Event fires, so rebinding the worker's fixed port can transiently fail. add_insecure_port
-        # raises RuntimeError (port 0 from Core) on failure, so retry with a short backoff to avoid
-        # a flaky "Failed to bind to address" between tests.
+        # gRPC core releases the listening socket asynchronously, so a rebind can transiently fail:
+        # add_insecure_port raises RuntimeError (Core port 0), not returns 0. Retry with a backoff.
         last_exc = None
         for _ in range(10):
             try:

--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -46,13 +46,13 @@ class GrpcBaseTestCase(TracerTestCase):
         # gRPC core releases the listening socket asynchronously, so a rebind can transiently fail:
         # add_insecure_port raises RuntimeError (Core port 0), not returns 0. Retry with a backoff.
         last_exc = None
-        for _ in range(10):
+        for i in range(10):
             try:
                 self._server.add_insecure_port("[::]:%d" % (_GRPC_PORT))
                 break
             except RuntimeError as exc:
                 last_exc = exc
-                time.sleep(0.1)
+                time.sleep(0.1 * (i + 1))
         else:
             raise RuntimeError("Failed to bind to address [::]:%d after multiple attempts" % (_GRPC_PORT)) from last_exc
         add_HelloServicer_to_server(_HelloServicer(), self._server)

--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -44,14 +44,19 @@ class GrpcBaseTestCase(TracerTestCase):
         self._server_pool = logging_pool.pool(1)
         self._server = grpc.server(self._server_pool)
         # gRPC core releases the listening socket asynchronously after a previous server's shutdown
-        # Event fires, so rebinding the worker's fixed port can transiently fail. Retry the bind to
-        # avoid a flaky "Failed to bind to address" RuntimeError between tests.
+        # Event fires, so rebinding the worker's fixed port can transiently fail. add_insecure_port
+        # raises RuntimeError (port 0 from Core) on failure, so retry with a short backoff to avoid
+        # a flaky "Failed to bind to address" between tests.
+        last_exc = None
         for _ in range(10):
-            if self._server.add_insecure_port("[::]:%d" % (_GRPC_PORT)) != 0:
+            try:
+                self._server.add_insecure_port("[::]:%d" % (_GRPC_PORT))
                 break
-            time.sleep(0.1)
+            except RuntimeError as exc:
+                last_exc = exc
+                time.sleep(0.1)
         else:
-            raise RuntimeError("Failed to bind to address [::]:%d after multiple attempts" % (_GRPC_PORT))
+            raise RuntimeError("Failed to bind to address [::]:%d after multiple attempts" % (_GRPC_PORT)) from last_exc
         add_HelloServicer_to_server(_HelloServicer(), self._server)
         self._server.start()
 

--- a/tests/contrib/grpc/test_grpc_utils.py
+++ b/tests/contrib/grpc/test_grpc_utils.py
@@ -4,6 +4,8 @@ import pytest
 from ddtrace._trace.span import Span
 from ddtrace.contrib.internal.grpc import utils
 
+from .common import GrpcBaseTestCase
+
 
 def test_parse_method_path_with_package():
     method_path = "/package.service/method"
@@ -129,3 +131,36 @@ def test_set_grpc_method_meta(method, method_kind, expected_tags):
     utils.set_grpc_method_meta(span, method, method_kind)
     for key, value in expected_tags.items():
         assert span._get_attribute(key) == value, f"Expected tag {key}={value!r}, got {span._get_attribute(key)!r}"
+
+
+@mock.patch("tests.contrib.grpc.common.time.sleep")
+@mock.patch("tests.contrib.grpc.common.add_HelloServicer_to_server")
+@mock.patch("tests.contrib.grpc.common.logging_pool.pool")
+@mock.patch("tests.contrib.grpc.common.grpc.server")
+def test_start_server_retries_on_bind_runtime_error(mock_server, mock_pool, mock_add_servicer, mock_sleep):
+    # A failed bind raises RuntimeError (gRPC core returns port 0); the retry must catch it and rebind.
+    fake_server = mock_server.return_value
+    fake_server.add_insecure_port.side_effect = [RuntimeError("Failed to bind"), RuntimeError("Failed to bind"), 50531]
+
+    instance = GrpcBaseTestCase.__new__(GrpcBaseTestCase)
+    instance._start_server()
+
+    assert fake_server.add_insecure_port.call_count == 3
+    fake_server.start.assert_called_once()
+
+
+@mock.patch("tests.contrib.grpc.common.time.sleep")
+@mock.patch("tests.contrib.grpc.common.add_HelloServicer_to_server")
+@mock.patch("tests.contrib.grpc.common.logging_pool.pool")
+@mock.patch("tests.contrib.grpc.common.grpc.server")
+def test_start_server_raises_after_exhausting_retries(mock_server, mock_pool, mock_add_servicer, mock_sleep):
+    # When every attempt keeps failing, give up after 10 tries and never start the server.
+    fake_server = mock_server.return_value
+    fake_server.add_insecure_port.side_effect = RuntimeError("Failed to bind")
+
+    instance = GrpcBaseTestCase.__new__(GrpcBaseTestCase)
+    with pytest.raises(RuntimeError, match="after multiple attempts"):
+        instance._start_server()
+
+    assert fake_server.add_insecure_port.call_count == 10
+    fake_server.start.assert_not_called()

--- a/tests/contrib/grpc/test_grpc_utils.py
+++ b/tests/contrib/grpc/test_grpc_utils.py
@@ -140,7 +140,7 @@ def test_set_grpc_method_meta(method, method_kind, expected_tags):
 def test_start_server_retries_on_bind_runtime_error(mock_server, mock_pool, mock_add_servicer, mock_sleep):
     # A failed bind raises RuntimeError (gRPC core returns port 0); the retry must catch it and rebind.
     fake_server = mock_server.return_value
-    fake_server.add_insecure_port.side_effect = [RuntimeError("Failed to bind"), RuntimeError("Failed to bind"), 50531]
+    fake_server.add_insecure_port.side_effect = [RuntimeError("Failed to bind")] * 2 + [50531]
 
     instance = GrpcBaseTestCase.__new__(GrpcBaseTestCase)
     instance._start_server()


### PR DESCRIPTION
## Description

The gRPC IAST tests (`tests/appsec/iast/test_grpc_iast.py`) and the shared gRPC contrib tests are still intermittently flaky after #18726, failing in `setUp` with:

```
RuntimeError: Failed to bind to address [::]:50534; set GRPC_VERBOSITY=debug ...
```

#18726 made `_stop_server` wait on the shutdown `Event` returned by `grpc.Server.stop(None)`. That fixed the *client-hits-dying-server* race, but a second race remains: gRPC core releases the **listening socket asynchronously, after** the shutdown `Event` is set. Each `pytest-xdist` worker rebinds the **same fixed port** (`50531 + worker_num`, e.g. `50534` for `gw3`) on every `setUp`, so the next test's `add_insecure_port` can still hit a socket the OS hasn't fully released.

## Fix

Retry `add_insecure_port` with a short backoff in `_start_server` (shared infra in `tests/contrib/grpc/common.py`), giving the OS time to release the port.

Key detail: when the bind fails, gRPC core returns port `0` and `grpc.Server.add_insecure_port` **raises** `RuntimeError("Failed to bind to address ...")` via `validate_port_binding_result` — it does **not** return `0` to the caller. So the retry must wrap the call in `try/except RuntimeError`, not check the return value. We retry up to 10× with a 0.1s sleep and, if it never succeeds, re-raise a clear error chained from the last failure. Both per-test `setUp` and the mid-test server restart in `test_grpc.py` route through `_start_server`, so all affected cases are covered.

## Tests

Added two mock-based regression tests in `tests/contrib/grpc/test_grpc_utils.py` so the retry cannot silently regress to checking the return value:

- `test_start_server_retries_on_bind_runtime_error` — `add_insecure_port` raises `RuntimeError` twice then succeeds; asserts the bind is retried (3 attempts) and the server starts. This test fails against the previous return-value-based implementation.
- `test_start_server_raises_after_exhausting_retries` — `add_insecure_port` always raises; asserts it gives up after exactly 10 attempts and never starts the server.
