### PR TITLE
feat(llmobs): agent attribution on spans

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -45,8 +45,9 @@ PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
 PROPAGATED_SESSION_ID_KEY = "_dd.p.llmobs_sid"
 # Agent attribution: nearest-agent identity propagated across process boundaries.
-# The id is always str(span_id) (digit-safe); the name is an arbitrary user string and
-# must pass _agent_name_wire_safe before being written to the tagset (see _utils.py).
+# The id is always str(span_id) (digit-safe); the name is an arbitrary user string. Both are
+# written via _stamp_agent_attribution, which drops the name (or both) rather than overflow
+# the x-datadog-tags budget (see _utils.py).
 PROPAGATED_PARENT_AGENT_ID_KEY = "_dd.p.llmobs_parent_agent_id"
 PROPAGATED_PARENT_AGENT_NAME_KEY = "_dd.p.llmobs_parent_agent_name"
 LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -44,6 +44,11 @@ LLMOBS_SUBMITTED_TAG_KEY = "_dd.llmobs.submitted"
 PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
 PROPAGATED_SESSION_ID_KEY = "_dd.p.llmobs_sid"
+# Agent attribution: nearest-agent identity propagated across process boundaries.
+# The id is always str(span_id) (digit-safe); the name is an arbitrary user string and
+# must pass _agent_name_wire_safe before being written to the tagset (see _utils.py).
+PROPAGATED_PARENT_AGENT_ID_KEY = "_dd.p.llmobs_parent_agent_id"
+PROPAGATED_PARENT_AGENT_NAME_KEY = "_dd.p.llmobs_parent_agent_name"
 LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils
 
 UNKNOWN_MODEL_PROVIDER = "unknown"
@@ -181,6 +186,8 @@ class LLMOBS_STRUCT:
     KEY: Final = "_llmobs"
     NAME: Final = "name"
     PARENT_ID: Final = "parent_id"
+    PARENT_AGENT_NAME: Final = "parent_agent_name"
+    PARENT_AGENT_SPAN_ID: Final = "parent_agent_span_id"
     TRACE_ID: Final = "trace_id"
     ML_APP: Final = "ml_app"
     SESSION_ID: Final = "session_id"

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -48,8 +48,8 @@ PROPAGATED_SESSION_ID_KEY = "_dd.p.llmobs_sid"
 # The id is always str(span_id) (digit-safe); the name is an arbitrary user string. Both are
 # written via _stamp_agent_attribution, which drops the name (or both) rather than overflow
 # the x-datadog-tags budget (see _utils.py).
-PROPAGATED_PARENT_AGENT_ID_KEY = "_dd.p.llmobs_parent_agent_id"
-PROPAGATED_PARENT_AGENT_NAME_KEY = "_dd.p.llmobs_parent_agent_name"
+PROPAGATED_PARENT_AGENT_ID_KEY = "_dd.p.llmobs_pagent_span_id"
+PROPAGATED_PARENT_AGENT_NAME_KEY = "_dd.p.llmobs_pagent_name"
 LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils
 
 UNKNOWN_MODEL_PROVIDER = "unknown"
@@ -187,8 +187,8 @@ class LLMOBS_STRUCT:
     KEY: Final = "_llmobs"
     NAME: Final = "name"
     PARENT_ID: Final = "parent_id"
-    PARENT_AGENT_NAME: Final = "parent_agent_name"
-    PARENT_AGENT_SPAN_ID: Final = "parent_agent_span_id"
+    PARENT_AGENT_NAME: Final = "pagent_name"
+    PARENT_AGENT_SPAN_ID: Final = "pagent_span_id"
     TRACE_ID: Final = "trace_id"
     ML_APP: Final = "ml_app"
     SESSION_ID: Final = "session_id"

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -82,6 +82,8 @@ from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import PROMPT_TRACKING_INSTRUMENTATION_METHOD
 from ddtrace.llmobs._constants import PROPAGATED_LLMOBS_TRACE_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
+from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_ID_KEY
+from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_NAME_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLE_RATE
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLING_DECISION
@@ -140,12 +142,14 @@ from ddtrace.llmobs._prompts.cache import WarmCache
 from ddtrace.llmobs._prompts.manager import PromptManager
 from ddtrace.llmobs._utils import AnnotationContext
 from ddtrace.llmobs._utils import LinkTracker
+from ddtrace.llmobs._utils import _agent_name_wire_safe
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _batched
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_parent_prompt
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
+from ddtrace.llmobs._utils import _resolve_parent_agent
 from ddtrace.llmobs._utils import _sanitize_span_event_depth
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
@@ -746,6 +750,18 @@ class LLMObs(Service):
             raise ValueError("Failed to extract LLMObs trace ID from span context.")
 
         meta = llmobs_data.get(LLMOBS_STRUCT.META) or _Meta()
+        # Surface the agent attribution resolved at activation. The block is always present:
+        # the resolved parent agent when there is one, else an `attempted` sentinel that lets
+        # the backend distinguish "no agent parent" from "older SDK that never resolved".
+        agent_name = llmobs_data.get(LLMOBS_STRUCT.PARENT_AGENT_NAME)
+        agent_span_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_AGENT_SPAN_ID)
+        if agent_name is not None or agent_span_id is not None:
+            meta["agent_attribution"] = {
+                "parent_agent_name": agent_name,
+                "parent_agent_span_id": agent_span_id,
+            }
+        else:
+            meta["agent_attribution"] = {"attempted": "true"}
         metrics = llmobs_data.get(LLMOBS_STRUCT.METRICS) or {}
         tags = self._llmobs_tags(span)
         _dd_attrs = {
@@ -2349,6 +2365,9 @@ class LLMObs(Service):
         session_id is optional and propagated from the parent span._store or the distributed context.
         """
         llmobs_parent = self._llmobs_context_provider.active()
+        # Resolve the nearest agent ancestor once, at activation: O(1) one-level lookup
+        # (the parent already resolved its own attribution when it activated).
+        parent_agent_name, parent_agent_span_id = _resolve_parent_agent(llmobs_parent)
         if llmobs_parent:
             parent_id = str(llmobs_parent.span_id)
             if isinstance(llmobs_parent, Span):
@@ -2419,6 +2438,8 @@ class LLMObs(Service):
             span,
             name=resolved_name,
             parent_id=parent_id,
+            parent_agent_name=parent_agent_name,
+            parent_agent_span_id=parent_agent_span_id,
             trace_id=llmobs_trace_id,
             ml_app=ml_app,
             session_id=session_id,

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -750,9 +750,8 @@ class LLMObs(Service):
             raise ValueError("Failed to extract LLMObs trace ID from span context.")
 
         meta = llmobs_data.get(LLMOBS_STRUCT.META) or _Meta()
-        # Surface the agent attribution resolved at activation. The block is always present:
-        # the resolved parent agent when there is one, else an `attempted` sentinel that lets
-        # the backend distinguish "no agent parent" from "older SDK that never resolved".
+        # Surface the agent attribution resolved at activation, but only on spans that
+        # actually have a resolved agent parent. Spans without one are left untouched.
         agent_name = llmobs_data.get(LLMOBS_STRUCT.PARENT_AGENT_NAME)
         agent_span_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_AGENT_SPAN_ID)
         if agent_name is not None or agent_span_id is not None:
@@ -760,8 +759,6 @@ class LLMObs(Service):
                 "parent_agent_name": agent_name,
                 "parent_agent_span_id": agent_span_id,
             }
-        else:
-            meta["agent_attribution"] = {"attempted": "true"}
         metrics = llmobs_data.get(LLMOBS_STRUCT.METRICS) or {}
         tags = self._llmobs_tags(span)
         _dd_attrs = {

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -142,7 +142,6 @@ from ddtrace.llmobs._prompts.cache import WarmCache
 from ddtrace.llmobs._prompts.manager import PromptManager
 from ddtrace.llmobs._utils import AnnotationContext
 from ddtrace.llmobs._utils import LinkTracker
-from ddtrace.llmobs._utils import _agent_name_wire_safe
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _batched
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
@@ -151,6 +150,7 @@ from ddtrace.llmobs._utils import _get_parent_prompt
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
 from ddtrace.llmobs._utils import _resolve_parent_agent
 from ddtrace.llmobs._utils import _sanitize_span_event_depth
+from ddtrace.llmobs._utils import _stamp_agent_attribution
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
 from ddtrace.llmobs._utils import add_span_link
@@ -2348,6 +2348,11 @@ class LLMObs(Service):
                 context._meta[PROPAGATED_SAMPLE_RATE] = sr
             if sd is not None:
                 context._meta[PROPAGATED_SAMPLING_DECISION] = sd
+            # Carry the nearest agent onto the context so spans created in in-process task
+            # boundaries (asyncio tasks, thread-pool executors) still attribute to it.
+            # Stamped last so the budget check sees the full tagset.
+            parent_agent_name, parent_agent_span_id = _resolve_parent_agent(active)
+            _stamp_agent_attribution(context._meta, parent_agent_name, parent_agent_span_id)
             return context
         return None
 
@@ -3409,13 +3414,10 @@ class LLMObs(Service):
             )
 
         # Propagate the nearest agent so spans in the downstream process attribute correctly.
-        # The id is always digit-safe; the name is arbitrary user text, so skip it (id-only)
-        # when it would raise in the tagset encoder rather than drop the whole header.
+        # Stamped last so the budget check sees the full tagset; degrades to id-only (or drops)
+        # rather than overflowing x-datadog-tags.
         parent_agent_name, parent_agent_span_id = _resolve_parent_agent(active_span)
-        if parent_agent_span_id is not None:
-            span_context._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = parent_agent_span_id
-        if parent_agent_name is not None and _agent_name_wire_safe(parent_agent_name):
-            span_context._meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = parent_agent_name
+        _stamp_agent_attribution(span_context._meta, parent_agent_name, parent_agent_span_id)
 
     @classmethod
     def inject_distributed_headers(cls, request_headers: dict[str, str], span: Optional[Span] = None) -> dict[str, str]:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -3411,6 +3411,15 @@ class LLMObs(Service):
                 sampling_decision.value if hasattr(sampling_decision, "value") else sampling_decision
             )
 
+        # Propagate the nearest agent so spans in the downstream process attribute correctly.
+        # The id is always digit-safe; the name is arbitrary user text, so skip it (id-only)
+        # when it would raise in the tagset encoder rather than drop the whole header.
+        parent_agent_name, parent_agent_span_id = _resolve_parent_agent(active_span)
+        if parent_agent_span_id is not None:
+            span_context._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = parent_agent_span_id
+        if parent_agent_name is not None and _agent_name_wire_safe(parent_agent_name):
+            span_context._meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = parent_agent_name
+
     @classmethod
     def inject_distributed_headers(cls, request_headers: dict[str, str], span: Optional[Span] = None) -> dict[str, str]:
         """Injects the span's distributed context into the given request headers."""
@@ -3473,7 +3482,11 @@ class LLMObs(Service):
             parent_llmobs_trace_id = context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
             propagated_sample_rate = context._meta.get(PROPAGATED_SAMPLE_RATE)
             propagated_sampling_decision = context._meta.get(PROPAGATED_SAMPLING_DECISION)
-            propagated_session_id = context._meta.get(PROPAGATED_SESSION_ID_KEY)
+propagated_session_id = context._meta.get(PROPAGATED_SESSION_ID_KEY)
+            # The hand-built llmobs_context below does not inherit inbound _dd.p.* tags, so
+            # the agent attribution keys must be copied onto it explicitly (mirrors trace_id).
+            propagated_agent_id = context._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY)
+            propagated_agent_name = context._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY)
             # `PROPAGATED_LLMOBS_TRACE_ID_KEY` on `Context._meta` is wire-format (decimal).
             # Store the inbound value as-is and defer normalization to the reader
             # (`_activate_llmobs_span`, Context-parent branch) so we never apply
@@ -3489,8 +3502,12 @@ class LLMObs(Service):
                     llmobs_context._meta[PROPAGATED_SAMPLE_RATE] = propagated_sample_rate
                 if propagated_sampling_decision is not None:
                     llmobs_context._meta[PROPAGATED_SAMPLING_DECISION] = propagated_sampling_decision
-                if propagated_session_id is not None:
+if propagated_session_id is not None:
                     llmobs_context._meta[PROPAGATED_SESSION_ID_KEY] = propagated_session_id
+                if propagated_agent_id is not None:
+                    llmobs_context._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = propagated_agent_id
+                if propagated_agent_name is not None:
+                    llmobs_context._meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = propagated_agent_name
                 cls._instance._llmobs_context_provider.activate(llmobs_context)
                 error = "missing_parent_llmobs_trace_id"
                 return
@@ -3500,8 +3517,12 @@ class LLMObs(Service):
                 llmobs_context._meta[PROPAGATED_SAMPLE_RATE] = propagated_sample_rate
             if propagated_sampling_decision is not None:
                 llmobs_context._meta[PROPAGATED_SAMPLING_DECISION] = propagated_sampling_decision
-            if propagated_session_id is not None:
+if propagated_session_id is not None:
                 llmobs_context._meta[PROPAGATED_SESSION_ID_KEY] = propagated_session_id
+            if propagated_agent_id is not None:
+                llmobs_context._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = propagated_agent_id
+            if propagated_agent_name is not None:
+                llmobs_context._meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = propagated_agent_name
             cls._instance._llmobs_context_provider.activate(llmobs_context)
         finally:
             telemetry.record_activate_distributed_headers(error)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -3481,7 +3481,7 @@ class LLMObs(Service):
             parent_llmobs_trace_id = context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
             propagated_sample_rate = context._meta.get(PROPAGATED_SAMPLE_RATE)
             propagated_sampling_decision = context._meta.get(PROPAGATED_SAMPLING_DECISION)
-propagated_session_id = context._meta.get(PROPAGATED_SESSION_ID_KEY)
+            propagated_session_id = context._meta.get(PROPAGATED_SESSION_ID_KEY)
             # The hand-built llmobs_context below does not inherit inbound _dd.p.* tags, so
             # the agent attribution keys must be copied onto it explicitly (mirrors trace_id).
             propagated_agent_id = context._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY)
@@ -3501,7 +3501,7 @@ propagated_session_id = context._meta.get(PROPAGATED_SESSION_ID_KEY)
                     llmobs_context._meta[PROPAGATED_SAMPLE_RATE] = propagated_sample_rate
                 if propagated_sampling_decision is not None:
                     llmobs_context._meta[PROPAGATED_SAMPLING_DECISION] = propagated_sampling_decision
-if propagated_session_id is not None:
+                if propagated_session_id is not None:
                     llmobs_context._meta[PROPAGATED_SESSION_ID_KEY] = propagated_session_id
                 if propagated_agent_id is not None:
                     llmobs_context._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = propagated_agent_id
@@ -3516,7 +3516,7 @@ if propagated_session_id is not None:
                 llmobs_context._meta[PROPAGATED_SAMPLE_RATE] = propagated_sample_rate
             if propagated_sampling_decision is not None:
                 llmobs_context._meta[PROPAGATED_SAMPLING_DECISION] = propagated_sampling_decision
-if propagated_session_id is not None:
+            if propagated_session_id is not None:
                 llmobs_context._meta[PROPAGATED_SESSION_ID_KEY] = propagated_session_id
             if propagated_agent_id is not None:
                 llmobs_context._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = propagated_agent_id

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -756,8 +756,8 @@ class LLMObs(Service):
         agent_span_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_AGENT_SPAN_ID)
         if agent_name is not None or agent_span_id is not None:
             meta["agent_attribution"] = {
-                "parent_agent_name": agent_name,
-                "parent_agent_span_id": agent_span_id,
+                "pagent_name": agent_name,
+                "pagent_span_id": agent_span_id,
             }
         metrics = llmobs_data.get(LLMOBS_STRUCT.METRICS) or {}
         tags = self._llmobs_tags(span)

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -444,9 +444,10 @@ def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
         )
 
     # Context parent (distributed). Keys land on context._meta via _dd.p.* propagation.
+    ctx = active
     return (
-        active._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY),
-        active._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY),
+        ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY),
+        ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY),
     )
 
 

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -27,6 +27,8 @@ from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import ML_APP_DEFAULT
+from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_ID_KEY
+from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_NAME_KEY
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import Message
@@ -414,6 +416,52 @@ def get_llmobs_span_kind(span: Span) -> Optional[str]:
     return kind
 
 
+def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
+    """Resolve (parent_agent_name, parent_agent_span_id) from the active LLMObs parent.
+
+    ``active`` is the result of ``_llmobs_context_provider.active()``:
+      - a ``Span`` whose kind is ``"agent"``: the parent IS the agent, so attribute to it.
+      - any other ``Span``: it already resolved its own attribution when it activated, so
+        inherit its stored ``PARENT_AGENT_*`` values (one level of lookup, no walk).
+      - a ``Context`` (distributed parent): read the propagated ``_dd.p.*`` keys off
+        ``context._meta``. The name may be absent if an upstream hop ran an older SDK.
+      - ``None``: no parent, so there is no agent to attribute to.
+
+    An agent span never attributes itself: resolution always looks at the parent.
+    """
+    if active is None:
+        return None, None
+
+    if isinstance(active, Span):
+        if get_llmobs_span_kind(active) == "agent":
+            return (get_llmobs_span_name(active) or active.name, str(active.span_id))
+        data = _get_llmobs_data_metastruct(active)
+        return (
+            data.get(LLMOBS_STRUCT.PARENT_AGENT_NAME),
+            data.get(LLMOBS_STRUCT.PARENT_AGENT_SPAN_ID),
+        )
+
+    # Context parent (distributed). Keys land on context._meta via _dd.p.* propagation.
+    return (
+        active._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY),
+        active._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY),
+    )
+
+
+def _agent_name_wire_safe(name: str) -> bool:
+    """Return True if ``name`` can be written to the x-datadog-tags tagset without raising.
+
+    ``encode_tagset_values`` raises on commas, ``=``, or any byte outside 0x20-0x7E, and on
+    the shared 512B budget being exceeded. A raise drops the ENTIRE header (taking ml_app,
+    llmobs_trace_id, parent_id, sample rate with it), so an unsafe agent name must be skipped
+    rather than sanitized. When the name is skipped only the id propagates and the backend
+    resolves the real name by span_id (the documented fallback).
+    """
+    if len(name.encode("utf-8")) > 256:  # conservative slice of the 512B shared tagset budget
+        return False
+    return all(0x20 <= ord(c) <= 0x7E and c not in (",", "=") for c in name)
+
+
 def get_llmobs_parent_id(span: Span) -> Optional[str]:
     llmobs_data = _get_llmobs_data_metastruct(span)
     parent_id = llmobs_data.get(LLMOBS_STRUCT.PARENT_ID)
@@ -615,6 +663,8 @@ def _annotate_llmobs_span_data(
     experiment_output: Optional[str] = None,
     intent: Optional[str] = None,
     parent_id: Optional[str] = None,
+    parent_agent_name: Optional[str] = None,
+    parent_agent_span_id: Optional[str] = None,
     trace_id: Optional[str] = None,
     dd_scope: Optional[str] = None,
     dd_sample_rate: Optional[str] = None,
@@ -649,6 +699,10 @@ def _annotate_llmobs_span_data(
             span._set_ctx_item(ML_APP, ml_app)
         if parent_id is not None:
             llmobs_span_data[LLMOBS_STRUCT.PARENT_ID] = parent_id
+        if parent_agent_name is not None:
+            llmobs_span_data[LLMOBS_STRUCT.PARENT_AGENT_NAME] = parent_agent_name
+        if parent_agent_span_id is not None:
+            llmobs_span_data[LLMOBS_STRUCT.PARENT_AGENT_SPAN_ID] = parent_agent_span_id
         if trace_id is not None:
             llmobs_span_data[LLMOBS_STRUCT.TRACE_ID] = trace_id
         if kind is not None:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -18,6 +18,8 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import git as _git
 from ddtrace.ext.ci import _filter_sensitive_info
 from ddtrace.internal import gitmetadata
+from ddtrace.internal._tagset import TagsetEncodeError
+from ddtrace.internal._tagset import encode_tagset_values
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import DEFAULT_PROMPT_NAME
@@ -451,19 +453,51 @@ def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
     )
 
 
-def _agent_name_wire_safe(name: str) -> bool:
-    """Return True if ``name`` can be written to the x-datadog-tags tagset without raising.
+# Headroom under the 512B x-datadog-tags budget for propagation tags the core tracer may
+# append after us (e.g. _dd.p.tid, _dd.p.dm).
+_AGENT_ATTRIBUTION_TAGSET_BUDGET = 500
 
-    ``encode_tagset_values`` raises on commas or any byte outside 0x20-0x7E, and on the shared
-    512B budget being exceeded (``=`` is legal in tagset *values*, only illegal in keys). A
-    raise drops the ENTIRE header (taking ml_app, llmobs_trace_id, parent_id, sample rate with
-    it), so an unsafe agent name must be skipped rather than sanitized. When the name is
-    skipped only the id propagates and the backend resolves the real name by span_id (the
-    documented fallback).
+
+def _propagation_tags_within_budget(meta: dict) -> bool:
+    """Return True if the ``_dd.p.*`` propagation tags in ``meta`` encode within budget.
+
+    Mirrors the propagator's own key filter (``key.startswith("_dd.p.")``) and encoder, so the
+    check matches what ``HTTPPropagator.inject()`` will later attempt. ``encode_tagset_values``
+    raises ``TagsetMaxSizeEncodeError`` past the budget and ``TagsetEncodeError`` on commas or
+    bytes outside 0x20-0x7E; both mean "does not fit" here.
     """
-    if len(name.encode("utf-8")) > 256:  # conservative slice of the 512B shared tagset budget
+    tags = {k: v for k, v in meta.items() if k.startswith("_dd.p.")}
+    try:
+        encode_tagset_values(tags, max_size=_AGENT_ATTRIBUTION_TAGSET_BUDGET)
+        return True
+    except TagsetEncodeError:
         return False
-    return all(0x20 <= ord(c) <= 0x7E and c != "," for c in name)
+
+
+def _stamp_agent_attribution(meta: dict, agent_name: Optional[str], agent_span_id: Optional[str]) -> None:
+    """Write the agent id/name ``_dd.p.*`` tags onto ``meta`` without overflowing x-datadog-tags.
+
+    A ``TagsetMaxSizeEncodeError`` at inject time drops the ENTIRE header (taking ml_app,
+    llmobs_trace_id, parent_id with it), so attribution degrades gracefully instead:
+      1. both id and name when they fit within the budget;
+      2. id only when adding the name would exceed it (the backend resolves the name from
+         span_id -- the documented fallback), which also covers unsafe names (comma / non-printable);
+      3. neither when even the id would exceed the budget.
+
+    ``meta`` must already carry the other ``_dd.p.*`` tags so the budget check sees the full tagset.
+    """
+    if agent_span_id is None:
+        return
+    meta[PROPAGATED_PARENT_AGENT_ID_KEY] = agent_span_id
+    if agent_name is not None:
+        meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = agent_name
+        if _propagation_tags_within_budget(meta):
+            return
+        # Name pushed the tagset over budget (size or unsafe chars): keep id-only.
+        del meta[PROPAGATED_PARENT_AGENT_NAME_KEY]
+    if not _propagation_tags_within_budget(meta):
+        # Even id-only overflows: drop attribution entirely rather than risk the whole header.
+        meta.pop(PROPAGATED_PARENT_AGENT_ID_KEY, None)
 
 
 def get_llmobs_parent_id(span: Span) -> Optional[str]:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -421,13 +421,13 @@ def get_llmobs_span_kind(span: Span) -> Optional[str]:
 def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
     """Resolve (parent_agent_name, parent_agent_span_id) from the active LLMObs parent.
 
-    ``active`` is the result of ``_llmobs_context_provider.active()``:
-      - a ``Span`` whose kind is ``"agent"``: the parent IS the agent, so attribute to it.
-      - any other ``Span``: it already resolved its own attribution when it activated, so
-        inherit its stored ``PARENT_AGENT_*`` values (one level of lookup, no walk).
-      - a ``Context`` (distributed parent): read the propagated ``_dd.p.*`` keys off
-        ``context._meta``. The name may be absent if an upstream hop ran an older SDK.
-      - ``None``: no parent, so there is no agent to attribute to.
+    active is the result of _llmobs_context_provider.active():
+      - a Span whose kind is "agent": the parent IS the agent, so attribute to it.
+      - any other Span: it already resolved its own attribution when it activated, so
+        inherit its stored PARENT_AGENT_* values (one level of lookup, no walk).
+      - a Context (distributed parent): read the propagated _dd.p.* keys off
+        context._meta. The name may be absent if an upstream hop ran an older SDK.
+      - None: no parent, so there is no agent to attribute to.
 
     An agent span never attributes itself: resolution always looks at the parent.
     """

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -453,12 +453,13 @@ def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
     )
 
 
-# Headroom under the 512B x-datadog-tags budget for propagation tags the core tracer may
-# append after us (e.g. _dd.p.tid, _dd.p.dm).
-_AGENT_ATTRIBUTION_TAGSET_BUDGET = 500
+# Budget for the entire _dd.p.* tagset when stamping agent attribution.
+# `_dd.p.tid=<16-hex>` (27 chars including the comma separator) is added by HTTPPropagator
+# at inject time, after this check runs, so we leave that headroom here.
+_AGENT_ATTRIBUTION_TAGSET_BUDGET = 485
 
 
-def _propagation_tags_within_budget(meta: dict) -> bool:
+def _is_propagation_tags_within_budget(meta: dict) -> bool:
     """Return True if the ``_dd.p.*`` propagation tags in ``meta`` encode within budget.
 
     Mirrors the propagator's own key filter (``key.startswith("_dd.p.")``) and encoder, so the
@@ -480,9 +481,9 @@ def _stamp_agent_attribution(meta: dict, agent_name: Optional[str], agent_span_i
     A ``TagsetMaxSizeEncodeError`` at inject time drops the ENTIRE header (taking ml_app,
     llmobs_trace_id, parent_id with it), so attribution degrades gracefully instead:
       1. both id and name when they fit within the budget;
-      2. id only when adding the name would exceed it (the backend resolves the name from
-         span_id -- the documented fallback), which also covers unsafe names (comma / non-printable);
-      3. neither when even the id would exceed the budget.
+      2. id + truncated name when the full name exceeds the budget;
+      3. id only when even a truncated name cannot fit (e.g. the name is entirely invalid chars);
+      4. neither when even the id would exceed the budget.
 
     ``meta`` must already carry the other ``_dd.p.*`` tags so the budget check sees the full tagset.
     """
@@ -491,13 +492,32 @@ def _stamp_agent_attribution(meta: dict, agent_name: Optional[str], agent_span_i
     meta[PROPAGATED_PARENT_AGENT_ID_KEY] = agent_span_id
     if agent_name is not None:
         meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = agent_name
-        if _propagation_tags_within_budget(meta):
+        if _is_propagation_tags_within_budget(meta):
             return
-        # Name pushed the tagset over budget (size or unsafe chars): keep id-only.
+        # Full name doesn't fit (too long or invalid chars); try truncation.
         del meta[PROPAGATED_PARENT_AGENT_NAME_KEY]
-    if not _propagation_tags_within_budget(meta):
+        tags_id_only = {k: v for k, v in meta.items() if k.startswith("_dd.p.")}
+        try:
+            encoded_id_only = encode_tagset_values(tags_id_only, max_size=_AGENT_ATTRIBUTION_TAGSET_BUDGET)
+        except TagsetEncodeError:
+            pass  # Id-only also overflows; fall through to the drop-id path below.
+        else:
+            # Overhead for `,name_key=` (comma is safe: other tags are already encoded before us).
+            name_entry_overhead = 1 + len(PROPAGATED_PARENT_AGENT_NAME_KEY) + 1
+            available_for_value = _AGENT_ATTRIBUTION_TAGSET_BUDGET - len(encoded_id_only) - name_entry_overhead
+            if available_for_value > 0:
+                meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = agent_name[:available_for_value]
+                if not _is_propagation_tags_within_budget(meta):
+                    # Truncated name is still invalid (e.g. contains commas): drop name.
+                    del meta[PROPAGATED_PARENT_AGENT_NAME_KEY]
+    if not _is_propagation_tags_within_budget(meta):
         # Even id-only overflows: drop attribution entirely rather than risk the whole header.
         meta.pop(PROPAGATED_PARENT_AGENT_ID_KEY, None)
+        log.debug(
+            "LLMObs: agent attribution dropped — x-datadog-tags budget exhausted. agent_name=%r agent_span_id=%r",
+            agent_name,
+            agent_span_id,
+        )
 
 
 def get_llmobs_parent_id(span: Span) -> Optional[str]:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -433,9 +433,11 @@ def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
         return None, None
 
     if isinstance(active, Span):
-        if get_llmobs_span_kind(active) == "agent":
-            return (get_llmobs_span_name(active) or active.name, str(active.span_id))
+        # Read the meta_struct once: this runs on every span activation (hot path).
         data = _get_llmobs_data_metastruct(active)
+        kind = data.get(LLMOBS_STRUCT.META, {}).get(LLMOBS_STRUCT.SPAN, {}).get(LLMOBS_STRUCT.KIND)
+        if kind == "agent":
+            return (data.get(LLMOBS_STRUCT.NAME) or active.name, str(active.span_id))
         return (
             data.get(LLMOBS_STRUCT.PARENT_AGENT_NAME),
             data.get(LLMOBS_STRUCT.PARENT_AGENT_SPAN_ID),
@@ -451,15 +453,16 @@ def _resolve_parent_agent(active) -> tuple[Optional[str], Optional[str]]:
 def _agent_name_wire_safe(name: str) -> bool:
     """Return True if ``name`` can be written to the x-datadog-tags tagset without raising.
 
-    ``encode_tagset_values`` raises on commas, ``=``, or any byte outside 0x20-0x7E, and on
-    the shared 512B budget being exceeded. A raise drops the ENTIRE header (taking ml_app,
-    llmobs_trace_id, parent_id, sample rate with it), so an unsafe agent name must be skipped
-    rather than sanitized. When the name is skipped only the id propagates and the backend
-    resolves the real name by span_id (the documented fallback).
+    ``encode_tagset_values`` raises on commas or any byte outside 0x20-0x7E, and on the shared
+    512B budget being exceeded (``=`` is legal in tagset *values*, only illegal in keys). A
+    raise drops the ENTIRE header (taking ml_app, llmobs_trace_id, parent_id, sample rate with
+    it), so an unsafe agent name must be skipped rather than sanitized. When the name is
+    skipped only the id propagates and the backend resolves the real name by span_id (the
+    documented fallback).
     """
     if len(name.encode("utf-8")) > 256:  # conservative slice of the 512B shared tagset budget
         return False
-    return all(0x20 <= ord(c) <= 0x7E and c not in (",", "=") for c in name)
+    return all(0x20 <= ord(c) <= 0x7E and c != "," for c in name)
 
 
 def get_llmobs_parent_id(span: Span) -> Optional[str]:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -64,6 +64,8 @@ class LLMObsSpanData(TypedDict, total=False):
 
     name: str
     parent_id: str
+    parent_agent_name: str
+    parent_agent_span_id: str
     trace_id: str
     ml_app: str
     session_id: str

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -64,8 +64,8 @@ class LLMObsSpanData(TypedDict, total=False):
 
     name: str
     parent_id: str
-    parent_agent_name: str
-    parent_agent_span_id: str
+    pagent_name: str
+    pagent_span_id: str
     trace_id: str
     ml_app: str
     session_id: str

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -188,6 +188,7 @@ class _Meta(TypedDict, total=False):
     tool: _ToolField
     tool_definitions: list[ToolDefinition]
     intent: str
+    agent_attribution: dict[str, Optional[str]]
 
 
 class _SpanLink(TypedDict):

--- a/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
+++ b/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    LLM Observability: every span generated under an agent now carries a
+    ``meta.agent_attribution`` block identifying its nearest agent ancestor
+    (``parent_agent_name`` and ``parent_agent_span_id``). The nearest agent is
+    resolved in-process at span start, and propagated across service boundaries
+    via the ``_dd.p.llmobs_parent_agent_id`` / ``_dd.p.llmobs_parent_agent_name``
+    distributed tags. Spans with no agent ancestor emit ``{"attempted": "true"}``
+    so attribution coverage can be distinguished from spans created by older SDK
+    versions. This lets the backend attribute spans to their agents without an
+    extra lookup.

--- a/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
+++ b/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
@@ -1,10 +1,7 @@
 ---
 features:
   - |
-    LLM Observability: every span generated under an agent now carries a
-    ``meta.agent_attribution`` block identifying its nearest agent ancestor
-    (``pagent_name`` and ``pagent_span_id``). The nearest agent is
-    resolved in-process at span start, and propagated across service boundaries
-    via the ``_dd.p.llmobs_pagent_span_id`` / ``_dd.p.llmobs_pagent_name``
-    distributed tags. Spans with no agent ancestor omit the block entirely. This
-    lets the backend attribute spans to their agents without an extra lookup.
+    LLM Observability: spans generated under an agent are now automatically
+    attributed to their nearest agent ancestor, both within a single process and
+    across service boundaries. This enables the Datadog backend to group and
+    display spans by the agent that produced them.

--- a/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
+++ b/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
@@ -3,8 +3,8 @@ features:
   - |
     LLM Observability: every span generated under an agent now carries a
     ``meta.agent_attribution`` block identifying its nearest agent ancestor
-    (``parent_agent_name`` and ``parent_agent_span_id``). The nearest agent is
+    (``pagent_name`` and ``pagent_span_id``). The nearest agent is
     resolved in-process at span start, and propagated across service boundaries
-    via the ``_dd.p.llmobs_parent_agent_id`` / ``_dd.p.llmobs_parent_agent_name``
+    via the ``_dd.p.llmobs_pagent_span_id`` / ``_dd.p.llmobs_pagent_name``
     distributed tags. Spans with no agent ancestor omit the block entirely. This
     lets the backend attribute spans to their agents without an extra lookup.

--- a/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
+++ b/releasenotes/notes/llmobs-agent-attribution-97bec4750413d613.yaml
@@ -6,7 +6,5 @@ features:
     (``parent_agent_name`` and ``parent_agent_span_id``). The nearest agent is
     resolved in-process at span start, and propagated across service boundaries
     via the ``_dd.p.llmobs_parent_agent_id`` / ``_dd.p.llmobs_parent_agent_name``
-    distributed tags. Spans with no agent ancestor emit ``{"attempted": "true"}``
-    so attribution coverage can be distinguished from spans created by older SDK
-    versions. This lets the backend attribute spans to their agents without an
-    extra lookup.
+    distributed tags. Spans with no agent ancestor omit the block entirely. This
+    lets the backend attribute spans to their agents without an extra lookup.

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -341,8 +341,8 @@ def _expected_agent_attribution(span):
     while ancestor is not None:
         if get_llmobs_span_kind(ancestor) == "agent":
             return {
-                "parent_agent_name": get_llmobs_span_name(ancestor) or ancestor.name,
-                "parent_agent_span_id": str(ancestor.span_id),
+                "pagent_name": get_llmobs_span_name(ancestor) or ancestor.name,
+                "pagent_span_id": str(ancestor.span_id),
             }
         ancestor = _get_nearest_llmobs_ancestor(ancestor)
     return None

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -334,8 +334,8 @@ def _expected_agent_attribution(span):
 
     Walks the LLMObs ancestor chain to the nearest "agent" span (full walk) — this must
     match the implementation, which achieves the same result via one-level inheritance at
-    activation. Returns the resolved block, or the `attempted` sentinel when no agent
-    ancestor exists.
+    activation. Returns the resolved block, or ``None`` when no agent ancestor exists (the
+    span event omits the block entirely in that case).
     """
     ancestor = _get_nearest_llmobs_ancestor(span)
     while ancestor is not None:
@@ -345,7 +345,7 @@ def _expected_agent_attribution(span):
                 "parent_agent_span_id": str(ancestor.span_id),
             }
         ancestor = _get_nearest_llmobs_ancestor(ancestor)
-    return {"attempted": "true"}
+    return None
 
 
 def _llmobs_base_span_event(
@@ -396,7 +396,9 @@ def _llmobs_base_span_event(
             "sampling_decision": mock.ANY,
         },
     }
-    span_event["meta"]["agent_attribution"] = _expected_agent_attribution(span)
+    expected_agent_attribution = _expected_agent_attribution(span)
+    if expected_agent_attribution is not None:
+        span_event["meta"]["agent_attribution"] = expected_agent_attribution
     if session_id:
         span_event["session_id"] = session_id
     if error:

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -20,7 +20,9 @@ from ddtrace.llmobs._constants import UNKNOWN_MODEL_NAME
 from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._llmobs import _STANDARD_INTEGRATION_SPAN_NAMES
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
+from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.llmobs._utils import get_llmobs_span_links
+from ddtrace.llmobs._utils import get_llmobs_span_name
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
 from ddtrace.llmobs._writer import LLMObsSpanWriter
 from ddtrace.trace import Span
@@ -327,6 +329,25 @@ def _expected_llmobs_non_llm_span_event(
     return span_event
 
 
+def _expected_agent_attribution(span):
+    """Independently compute the agent_attribution block expected on a span event.
+
+    Walks the LLMObs ancestor chain to the nearest "agent" span (full walk) — this must
+    match the implementation, which achieves the same result via one-level inheritance at
+    activation. Returns the resolved block, or the `attempted` sentinel when no agent
+    ancestor exists.
+    """
+    ancestor = _get_nearest_llmobs_ancestor(span)
+    while ancestor is not None:
+        if get_llmobs_span_kind(ancestor) == "agent":
+            return {
+                "parent_agent_name": get_llmobs_span_name(ancestor) or ancestor.name,
+                "parent_agent_span_id": str(ancestor.span_id),
+            }
+        ancestor = _get_nearest_llmobs_ancestor(ancestor)
+    return {"attempted": "true"}
+
+
 def _llmobs_base_span_event(
     span,
     span_kind,
@@ -375,6 +396,7 @@ def _llmobs_base_span_event(
             "sampling_decision": mock.ANY,
         },
     }
+    span_event["meta"]["agent_attribution"] = _expected_agent_attribution(span)
     if session_id:
         span_event["session_id"] = session_id
     if error:

--- a/tests/llmobs/test_llmobs_agent_attribution.py
+++ b/tests/llmobs/test_llmobs_agent_attribution.py
@@ -19,8 +19,8 @@ def test_tool_under_agent_attributes_to_agent(llmobs, llmobs_events):
             pass
     tool_event = _event_by_name(llmobs_events, "my_tool")
     assert tool_event["meta"]["agent_attribution"] == {
-        "parent_agent_name": "my_agent",
-        "parent_agent_span_id": str(agent_span.span_id),
+        "pagent_name": "my_agent",
+        "pagent_span_id": str(agent_span.span_id),
     }
 
 
@@ -30,7 +30,7 @@ def test_indirect_nesting_attributes_to_agent(llmobs, llmobs_events):
         with llmobs.workflow(name="my_workflow"):
             with llmobs.tool(name="my_tool"):
                 pass
-    expected = {"parent_agent_name": "my_agent", "parent_agent_span_id": str(agent_span.span_id)}
+    expected = {"pagent_name": "my_agent", "pagent_span_id": str(agent_span.span_id)}
     assert _event_by_name(llmobs_events, "my_workflow")["meta"]["agent_attribution"] == expected
     assert _event_by_name(llmobs_events, "my_tool")["meta"]["agent_attribution"] == expected
 
@@ -42,13 +42,13 @@ def test_sub_agent_attributes_to_enclosing_agent(llmobs, llmobs_events):
             with llmobs.tool(name="inner_tool"):
                 pass
     assert _event_by_name(llmobs_events, "inner_agent")["meta"]["agent_attribution"] == {
-        "parent_agent_name": "outer_agent",
-        "parent_agent_span_id": str(outer.span_id),
+        "pagent_name": "outer_agent",
+        "pagent_span_id": str(outer.span_id),
     }
     # The tool's nearest agent ancestor is the inner agent.
     assert _event_by_name(llmobs_events, "inner_tool")["meta"]["agent_attribution"] == {
-        "parent_agent_name": "inner_agent",
-        "parent_agent_span_id": str(inner.span_id),
+        "pagent_name": "inner_agent",
+        "pagent_span_id": str(inner.span_id),
     }
 
 

--- a/tests/llmobs/test_llmobs_agent_attribution.py
+++ b/tests/llmobs/test_llmobs_agent_attribution.py
@@ -1,0 +1,73 @@
+"""Tests for LLMObs agent attribution: meta.agent_attribution stamped at span finish.
+
+The SDK resolves the nearest agent ancestor at span activation (O(1) one-level lookup,
+inheriting the parent's already-resolved attribution) and surfaces it as
+``meta.agent_attribution`` on every emitted span event. Spans with no agent ancestor emit
+an ``{"attempted": "true"}`` sentinel.
+"""
+
+
+def _event_by_name(llmobs_events, name):
+    matches = [e for e in llmobs_events if e["name"] == name]
+    assert len(matches) == 1, f"expected exactly one event named {name!r}, got {len(matches)}"
+    return matches[0]
+
+
+def test_tool_under_agent_attributes_to_agent(llmobs, llmobs_events):
+    with llmobs.agent(name="my_agent") as agent_span:
+        with llmobs.tool(name="my_tool"):
+            pass
+    tool_event = _event_by_name(llmobs_events, "my_tool")
+    assert tool_event["meta"]["agent_attribution"] == {
+        "parent_agent_name": "my_agent",
+        "parent_agent_span_id": str(agent_span.span_id),
+    }
+
+
+def test_indirect_nesting_attributes_to_agent(llmobs, llmobs_events):
+    """agent -> workflow -> tool: the workflow and the tool both attribute to the agent."""
+    with llmobs.agent(name="my_agent") as agent_span:
+        with llmobs.workflow(name="my_workflow"):
+            with llmobs.tool(name="my_tool"):
+                pass
+    expected = {"parent_agent_name": "my_agent", "parent_agent_span_id": str(agent_span.span_id)}
+    assert _event_by_name(llmobs_events, "my_workflow")["meta"]["agent_attribution"] == expected
+    assert _event_by_name(llmobs_events, "my_tool")["meta"]["agent_attribution"] == expected
+
+
+def test_sub_agent_attributes_to_enclosing_agent(llmobs, llmobs_events):
+    """An agent nested under an agent attributes to the enclosing agent, never itself."""
+    with llmobs.agent(name="outer_agent") as outer:
+        with llmobs.agent(name="inner_agent") as inner:
+            with llmobs.tool(name="inner_tool"):
+                pass
+    assert _event_by_name(llmobs_events, "inner_agent")["meta"]["agent_attribution"] == {
+        "parent_agent_name": "outer_agent",
+        "parent_agent_span_id": str(outer.span_id),
+    }
+    # The tool's nearest agent ancestor is the inner agent.
+    assert _event_by_name(llmobs_events, "inner_tool")["meta"]["agent_attribution"] == {
+        "parent_agent_name": "inner_agent",
+        "parent_agent_span_id": str(inner.span_id),
+    }
+
+
+def test_top_level_agent_emits_sentinel(llmobs, llmobs_events):
+    with llmobs.agent(name="root_agent"):
+        pass
+    assert _event_by_name(llmobs_events, "root_agent")["meta"]["agent_attribution"] == {"attempted": "true"}
+
+
+def test_top_level_llm_emits_sentinel(llmobs, llmobs_events):
+    with llmobs.llm(name="root_llm", model_name="test-model"):
+        pass
+    assert _event_by_name(llmobs_events, "root_llm")["meta"]["agent_attribution"] == {"attempted": "true"}
+
+
+def test_tool_outside_agent_emits_sentinel(llmobs, llmobs_events):
+    """A workflow with a tool but no agent anywhere in the chain: both get the sentinel."""
+    with llmobs.workflow(name="lonely_workflow"):
+        with llmobs.tool(name="lonely_tool"):
+            pass
+    assert _event_by_name(llmobs_events, "lonely_workflow")["meta"]["agent_attribution"] == {"attempted": "true"}
+    assert _event_by_name(llmobs_events, "lonely_tool")["meta"]["agent_attribution"] == {"attempted": "true"}

--- a/tests/llmobs/test_llmobs_agent_attribution.py
+++ b/tests/llmobs/test_llmobs_agent_attribution.py
@@ -2,8 +2,8 @@
 
 The SDK resolves the nearest agent ancestor at span activation (O(1) one-level lookup,
 inheriting the parent's already-resolved attribution) and surfaces it as
-``meta.agent_attribution`` on every emitted span event. Spans with no agent ancestor emit
-an ``{"attempted": "true"}`` sentinel.
+``meta.agent_attribution`` only on spans that have an agent ancestor. Spans with no agent
+ancestor omit the block entirely.
 """
 
 
@@ -52,22 +52,22 @@ def test_sub_agent_attributes_to_enclosing_agent(llmobs, llmobs_events):
     }
 
 
-def test_top_level_agent_emits_sentinel(llmobs, llmobs_events):
+def test_top_level_agent_omits_block(llmobs, llmobs_events):
     with llmobs.agent(name="root_agent"):
         pass
-    assert _event_by_name(llmobs_events, "root_agent")["meta"]["agent_attribution"] == {"attempted": "true"}
+    assert "agent_attribution" not in _event_by_name(llmobs_events, "root_agent")["meta"]
 
 
-def test_top_level_llm_emits_sentinel(llmobs, llmobs_events):
+def test_top_level_llm_omits_block(llmobs, llmobs_events):
     with llmobs.llm(name="root_llm", model_name="test-model"):
         pass
-    assert _event_by_name(llmobs_events, "root_llm")["meta"]["agent_attribution"] == {"attempted": "true"}
+    assert "agent_attribution" not in _event_by_name(llmobs_events, "root_llm")["meta"]
 
 
-def test_tool_outside_agent_emits_sentinel(llmobs, llmobs_events):
-    """A workflow with a tool but no agent anywhere in the chain: both get the sentinel."""
+def test_tool_outside_agent_omits_block(llmobs, llmobs_events):
+    """A workflow with a tool but no agent anywhere in the chain: neither gets the block."""
     with llmobs.workflow(name="lonely_workflow"):
         with llmobs.tool(name="lonely_tool"):
             pass
-    assert _event_by_name(llmobs_events, "lonely_workflow")["meta"]["agent_attribution"] == {"attempted": "true"}
-    assert _event_by_name(llmobs_events, "lonely_tool")["meta"]["agent_attribution"] == {"attempted": "true"}
+    assert "agent_attribution" not in _event_by_name(llmobs_events, "lonely_workflow")["meta"]
+    assert "agent_attribution" not in _event_by_name(llmobs_events, "lonely_tool")["meta"]

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -11,6 +11,8 @@ from ddtrace.contrib.internal.futures.patch import unpatch as unpatch_futures
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import PROPAGATED_LLMOBS_TRACE_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
+from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_ID_KEY
+from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_NAME_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLE_RATE
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLING_DECISION
@@ -877,3 +879,89 @@ def test_propagated_sampling_decision_in_span_event(llmobs, llmobs_events):
         pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["_dd"]["sampling_decision"] == LLMObsSamplingDecision.DROPPED
+
+
+# --- Agent attribution propagation ---------------------------------------------------------
+
+
+def test_inject_agent_attribution_under_agent(llmobs):
+    """Injecting from within an agent propagates the agent's id and name."""
+    with llmobs.agent(name="my_agent") as agent_span:
+        ctx = Context(trace_id=1, span_id=2)
+        llmobs._inject_llmobs_context(ctx, {})
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == str(agent_span.span_id)
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) == "my_agent"
+
+
+def test_inject_agent_attribution_inherited_through_tool(llmobs):
+    """Injecting from a tool under an agent propagates the agent (inherited attribution)."""
+    with llmobs.agent(name="my_agent") as agent_span:
+        with llmobs.tool(name="my_tool"):
+            ctx = Context(trace_id=1, span_id=2)
+            llmobs._inject_llmobs_context(ctx, {})
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == str(agent_span.span_id)
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) == "my_agent"
+
+
+def test_inject_no_agent_attribution_without_agent(llmobs):
+    """No agent in the chain: neither agent key is written."""
+    with llmobs.workflow("w"):
+        ctx = Context(trace_id=1, span_id=2)
+        llmobs._inject_llmobs_context(ctx, {})
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) is None
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) is None
+
+
+def test_inject_unsafe_agent_name_skips_name_keeps_id(llmobs):
+    """An agent name with tagset-illegal chars is skipped; the digit-safe id still propagates."""
+    with llmobs.agent(name="Researcher, v2=x") as agent_span:
+        ctx = Context(trace_id=1, span_id=2)
+        llmobs._inject_llmobs_context(ctx, {})
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == str(agent_span.span_id)
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) is None
+
+
+def test_inject_unsafe_agent_name_does_not_drop_header(llmobs):
+    """Critical regression: an unsafe agent name must not poison x-datadog-tags.
+
+    The agent_attribution id key is digit-safe and the name key is skipped when unsafe, so
+    the full _dd.p.* tagset still encodes and ml_app / llmobs_trace_id survive on the wire.
+    """
+    with llmobs.agent(name="Researcher, v2=x") as agent_span:
+        headers = llmobs.inject_distributed_headers({}, span=agent_span)
+    tags_header = headers.get("x-datadog-tags", "")
+    # Header is present and still carries the pre-existing llmobs keys (not dropped).
+    assert "_dd.p.llmobs_ml_app" in tags_header
+    assert "_dd.p.llmobs_parent_agent_id={}".format(agent_span.span_id) in tags_header
+    # The unsafe name was skipped, so no propagation error and no name key.
+    assert "_dd.p.llmobs_parent_agent_name" not in tags_header
+    assert "_dd.propagation_error" not in tags_header
+
+
+def test_distributed_agent_attribution_round_trip(llmobs, llmobs_events):
+    """Inbound _dd.p.* agent keys are seeded onto the local context and surfaced on a child."""
+    ctx = _make_upstream_llmobs_context(_DECIMAL_TRACE_ID)
+    ctx._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = "987654321"
+    ctx._meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = "upstream_agent"
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.tool(name="downstream_tool"):
+        pass
+    assert len(llmobs_events) == 1
+    assert llmobs_events[0]["meta"]["agent_attribution"] == {
+        "parent_agent_name": "upstream_agent",
+        "parent_agent_span_id": "987654321",
+    }
+
+
+def test_distributed_agent_attribution_round_trip_no_name(llmobs, llmobs_events):
+    """Old-SDK upstream propagates only the id; the name resolves to None (backend fills it)."""
+    ctx = _make_upstream_llmobs_context(_DECIMAL_TRACE_ID)
+    ctx._meta[PROPAGATED_PARENT_AGENT_ID_KEY] = "987654321"
+    llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    with llmobs.tool(name="downstream_tool"):
+        pass
+    assert len(llmobs_events) == 1
+    assert llmobs_events[0]["meta"]["agent_attribution"] == {
+        "parent_agent_name": None,
+        "parent_agent_span_id": "987654321",
+    }

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -921,6 +921,22 @@ def test_inject_unsafe_agent_name_skips_name_keeps_id(llmobs):
     assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) is None
 
 
+def test_inject_oversized_agent_name_truncated(llmobs):
+    """An agent name that would overflow the tagset budget is truncated rather than dropped."""
+    # Build a name large enough to overflow the budget; it must use only safe chars.
+    oversized_name = "A" * 500
+    with llmobs.agent(name=oversized_name) as agent_span:
+        ctx = Context(trace_id=1, span_id=2)
+        llmobs._inject_llmobs_context(ctx, {})
+    propagated_name = ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY)
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == str(agent_span.span_id)
+    # The name must be truncated (not absent, not the full oversized value).
+    assert propagated_name is not None
+    assert len(propagated_name) < len(oversized_name)
+    # The truncated name must consist only of the safe chars we used.
+    assert set(propagated_name) == {"A"}
+
+
 def test_inject_agent_name_with_equals_propagates(llmobs):
     """`=` is legal in tagset values (only illegal in keys), so a name with `=` must propagate."""
     with llmobs.agent(name="model=gpt4") as agent_span:

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -951,7 +951,7 @@ def test_inject_agent_name_with_equals_survives_header_roundtrip(llmobs):
     with llmobs.agent(name="model=gpt4") as agent_span:
         headers = llmobs.inject_distributed_headers({}, span=agent_span)
     tags_header = headers.get("x-datadog-tags", "")
-    assert "_dd.p.llmobs_parent_agent_name=model=gpt4" in tags_header
+    assert "_dd.p.llmobs_pagent_name=model=gpt4" in tags_header
     assert "_dd.propagation_error" not in tags_header
 
 
@@ -966,9 +966,9 @@ def test_inject_unsafe_agent_name_does_not_drop_header(llmobs):
     tags_header = headers.get("x-datadog-tags", "")
     # Header is present and still carries the pre-existing llmobs keys (not dropped).
     assert "_dd.p.llmobs_ml_app" in tags_header
-    assert "_dd.p.llmobs_parent_agent_id={}".format(agent_span.span_id) in tags_header
+    assert "_dd.p.llmobs_pagent_span_id={}".format(agent_span.span_id) in tags_header
     # The unsafe name was skipped, so no propagation error and no name key.
-    assert "_dd.p.llmobs_parent_agent_name" not in tags_header
+    assert "_dd.p.llmobs_pagent_name" not in tags_header
     assert "_dd.propagation_error" not in tags_header
 
 
@@ -982,8 +982,8 @@ def test_distributed_agent_attribution_round_trip(llmobs, llmobs_events):
         pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["meta"]["agent_attribution"] == {
-        "parent_agent_name": "upstream_agent",
-        "parent_agent_span_id": "987654321",
+        "pagent_name": "upstream_agent",
+        "pagent_span_id": "987654321",
     }
 
 
@@ -996,8 +996,8 @@ def test_distributed_agent_attribution_round_trip_no_name(llmobs, llmobs_events)
         pass
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["meta"]["agent_attribution"] == {
-        "parent_agent_name": None,
-        "parent_agent_span_id": "987654321",
+        "pagent_name": None,
+        "pagent_span_id": "987654321",
     }
 
 
@@ -1026,6 +1026,6 @@ def test_agent_attribution_propagates_across_asyncio_task(llmobs, llmobs_events,
     matches = [e for e in llmobs_events if e["name"] == "async_tool"]
     assert len(matches) == 1, f"expected exactly one async_tool event, got {len(matches)}"
     assert matches[0]["meta"].get("agent_attribution") == {
-        "parent_agent_name": "my_agent",
-        "parent_agent_span_id": holder["span_id"],
+        "pagent_name": "my_agent",
+        "pagent_span_id": holder["span_id"],
     }

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -983,3 +983,33 @@ def test_distributed_agent_attribution_round_trip_no_name(llmobs, llmobs_events)
         "parent_agent_name": None,
         "parent_agent_span_id": "987654321",
     }
+
+
+def test_agent_attribution_propagates_across_asyncio_task(llmobs, llmobs_events, patched_asyncio):
+    """A tool span created in an asyncio task under an agent still attributes to that agent.
+
+    The in-process llmobs context handed to the child task travels through
+    ``_current_trace_context()``; it must carry the agent id/name so the child resolves
+    attribution instead of silently dropping it.
+    """
+    import asyncio
+
+    holder = {}
+
+    async def main():
+        with llmobs.agent(name="my_agent") as agent_span:
+            holder["span_id"] = str(agent_span.span_id)
+
+            async def child():
+                with llmobs.tool(name="async_tool"):
+                    pass
+
+            await asyncio.create_task(child())
+
+    asyncio.run(main())
+    matches = [e for e in llmobs_events if e["name"] == "async_tool"]
+    assert len(matches) == 1, f"expected exactly one async_tool event, got {len(matches)}"
+    assert matches[0]["meta"].get("agent_attribution") == {
+        "parent_agent_name": "my_agent",
+        "parent_agent_span_id": holder["span_id"],
+    }

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -913,12 +913,30 @@ def test_inject_no_agent_attribution_without_agent(llmobs):
 
 
 def test_inject_unsafe_agent_name_skips_name_keeps_id(llmobs):
-    """An agent name with tagset-illegal chars is skipped; the digit-safe id still propagates."""
-    with llmobs.agent(name="Researcher, v2=x") as agent_span:
+    """An agent name with a comma (illegal in tagset values) is skipped; the id still propagates."""
+    with llmobs.agent(name="Researcher, v2") as agent_span:
         ctx = Context(trace_id=1, span_id=2)
         llmobs._inject_llmobs_context(ctx, {})
     assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == str(agent_span.span_id)
     assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) is None
+
+
+def test_inject_agent_name_with_equals_propagates(llmobs):
+    """`=` is legal in tagset values (only illegal in keys), so a name with `=` must propagate."""
+    with llmobs.agent(name="model=gpt4") as agent_span:
+        ctx = Context(trace_id=1, span_id=2)
+        llmobs._inject_llmobs_context(ctx, {})
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == str(agent_span.span_id)
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) == "model=gpt4"
+
+
+def test_inject_agent_name_with_equals_survives_header_roundtrip(llmobs):
+    """A name with `=` encodes into x-datadog-tags and decodes back unchanged (value-until-comma)."""
+    with llmobs.agent(name="model=gpt4") as agent_span:
+        headers = llmobs.inject_distributed_headers({}, span=agent_span)
+    tags_header = headers.get("x-datadog-tags", "")
+    assert "_dd.p.llmobs_parent_agent_name=model=gpt4" in tags_header
+    assert "_dd.propagation_error" not in tags_header
 
 
 def test_inject_unsafe_agent_name_does_not_drop_header(llmobs):
@@ -927,7 +945,7 @@ def test_inject_unsafe_agent_name_does_not_drop_header(llmobs):
     The agent_attribution id key is digit-safe and the name key is skipped when unsafe, so
     the full _dd.p.* tagset still encodes and ml_app / llmobs_trace_id survive on the wire.
     """
-    with llmobs.agent(name="Researcher, v2=x") as agent_span:
+    with llmobs.agent(name="Researcher, v2") as agent_span:
         headers = llmobs.inject_distributed_headers({}, span=agent_span)
     tags_header = headers.get("x-datadog-tags", "")
     # Header is present and still carries the pre-existing llmobs keys (not dropped).


### PR DESCRIPTION
## Description

Adds **agent attribution** to the LLMObs SDK: every span generated under an agent now carries a `meta.agent_attribution` block naming its nearest agent ancestor, so the backend can attribute spans to agents without an extra Events Platform lookup.

**What it does**
- At span **activation**, resolves the nearest agent ancestor in O(1) and stores `parent_agent_name` / `parent_agent_span_id` on the span's `meta_struct`. Resolution is one level deep: if the LLMObs parent is an `agent` span, attribute to it; otherwise inherit the parent's already-resolved attribution (so `agent → workflow → tool` correctly attributes the tool to the agent).
- At span **finish**, `_llmobs_span_event` surfaces `meta.agent_attribution = {parent_agent_name, parent_agent_span_id}`. Spans with no agent ancestor omit `meta.agent_attribution` entirely.
- **Cross-process:** the nearest agent's id (and name, when it fits) propagate via the `_dd.p.llmobs_parent_agent_id` / `_dd.p.llmobs_parent_agent_name` distributed tags, mirroring the existing `ml_app` propagation. The receiving side seeds both `Context` branches in `_activate_llmobs_distributed_context`.

**Design notes**
- Parentage uses the LLMObs context provider (`_llmobs_context_provider.active()`), **not** the APM `span._parent` tree, which diverges under threading/asyncio/distributed traces.
- The agent **name** is arbitrary user text. To avoid overflowing the `x-datadog-tags` budget (which would drop the *entire* header — taking `ml_app`/`trace_id`/`parent_id` with it), name propagation degrades gracefully: (1) full name when it fits; (2) truncated name when only a portion fits; (3) id-only when even a truncated name is unrepresentable (e.g. the name consists entirely of commas or non-printable bytes); (4) neither when even the id would overflow. The id is always `str(span_id)` (digit-safe). When the name is absent, the backend resolves it from the span id.

## Testing

- New `tests/llmobs/test_llmobs_agent_attribution.py`: in-process cases (tool under agent, indirect `agent → workflow → tool`, sub-agent under agent, top-level agent/LLM sentinels, tool outside any agent).
- New cases in `tests/llmobs/test_propagation.py`: inject under agent, inherited-through-tool, no-agent, unsafe-name-skipped, **unsafe name does not drop the header** (regression guard), `=` in name propagates + survives header round-trip, distributed round-trip (with and without name).
- Full `llmobs` suite: 997/998 pass. The one failure (`test_get_spans_returns_span_list`, "App key not set") **also fails on unmodified `main`** — it is pre-existing and unrelated (LLMObs API client app-key check, untouched here).
- `scripts/lint`: ruff format + check, mypy, codespell all green.

## Risks

Low. All additions are purely additive on `_meta` / `meta_struct` / TypedDicts; existing `ml_app`, `trace_id`, `sample_rate`, `sampling_decision` propagation paths are untouched. `_resolve_parent_agent` runs on every span activation but reads `meta_struct` once. The one place a bad input could regress unrelated functionality (unsafe agent name poisoning the whole `x-datadog-tags` header) is explicitly guarded and tested.