### PR TITLE
chore(llmobs): treat root parent ID sentinel as missing on header extraction [backport 4.10]

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2974,7 +2974,7 @@ class LLMObs(Service):
                     return
                 raise LLMObsActivateDistributedHeadersError("Failed to extract trace/span ID from request headers.")
             _parent_id = context._meta.get(PROPAGATED_PARENT_ID_KEY)
-            if _parent_id is None:
+            if _parent_id is None or _parent_id == ROOT_PARENT_ID:
                 error = "missing_parent_id"
                 log.debug("Failed to extract LLMObs parent ID from request headers.")
                 return

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 import pytest
@@ -543,3 +544,25 @@ def test_submitted_event_trace_id_matches_stored_for_ambiguous_hex(llmobs, test_
     assert len(spans) == 1
     assert get_llmobs_trace_id(spans[0]) == _AMBIGUOUS_HEX_TRACE_ID
     assert get_llmobs_trace_id(spans[0]) == stored
+
+
+def test_activate_distributed_context_root_sentinel_no_warning(llmobs, caplog):
+    from ddtrace.trace import Context
+
+    ctx = Context(trace_id=123456789, span_id=987654321)
+    ctx._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = _DECIMAL_TRACE_ID
+    ctx._meta[PROPAGATED_PARENT_ID_KEY] = ROOT_PARENT_ID
+    with caplog.at_level(logging.DEBUG, logger="ddtrace.llmobs._llmobs"):
+        llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    assert "Failed to parse LLMObs parent ID from request headers." not in caplog.text
+
+
+def test_activate_distributed_context_garbage_parent_id_still_warns(llmobs, caplog):
+    from ddtrace.trace import Context
+
+    ctx = Context(trace_id=123456789, span_id=987654321)
+    ctx._meta[PROPAGATED_LLMOBS_TRACE_ID_KEY] = _DECIMAL_TRACE_ID
+    ctx._meta[PROPAGATED_PARENT_ID_KEY] = "not-a-number"
+    with caplog.at_level(logging.WARNING, logger="ddtrace.llmobs._llmobs"):
+        llmobs._instance._activate_llmobs_distributed_context({}, ctx)
+    assert "Failed to parse LLMObs parent ID from request headers." in caplog.text


### PR DESCRIPTION
Backport of #18699 to the `4.10` branch.

## Description

When no LLMObs span is active, the inject side writes the `ROOT_PARENT_ID` sentinel (`"undefined"`) into the `_dd.p.llmobs_parent_id` propagation tag. The extract path (`LLMObs._activate_llmobs_distributed_context`) ran `int("undefined")`, raising `ValueError` and emitting a spurious `WARNING` — `Failed to parse LLMObs parent ID from request headers.` The fix treats the sentinel exactly like a missing parent id (the existing `_parent_id is None` branch → silent `DEBUG`), restoring inject/extract symmetry.

## Backport notes

- The one-line source change to `ddtrace/llmobs/_llmobs.py` cherry-picked cleanly (`ROOT_PARENT_ID` is already imported on 4.10).
- `tests/llmobs/test_propagation.py` conflicted only because the test file has diverged on `main` (unrelated sampling-decision tests not present on 4.10). Resolved by taking just the two tests this PR added; added local `logging`/`Context` imports since 4.10's test module lacks the top-level imports `main` has.

## Risks

Low. No change to span parenting behavior; the only observable changes are the removed warning (now `DEBUG`) and the telemetry tag for this path (`invalid_parent_id` → `missing_parent_id`). No public API change.

Claude session: `0d2468bc-12c0-43fc-b5c6-8a7d5d259e17`
Resume: `claude --resume 0d2468bc-12c0-43fc-b5c6-8a7d5d259e17`