### PR TITLE
chore(settings): add `third_party` type stub

### DIFF
--- a/ddtrace/internal/settings/third_party.pyi
+++ b/ddtrace/internal/settings/third_party.pyi
@@ -1,0 +1,7 @@
+from ddtrace.internal.settings._core import DDConfig
+
+class ThirdPartyDetectionConfig(DDConfig):
+    excludes: set[str]
+    includes: set[str]
+
+config: ThirdPartyDetectionConfig


### PR DESCRIPTION
## Description

Add a .pyi stub for ddtrace.internal.settings.third_party so the ThirdPartyDetectionConfig attributes (excludes/includes) and the config instance are visible to type checkers.

Spinoff from #18594.