### PR TITLE
fix(dbm): use singleton peer service config

### DIFF
--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -8,7 +8,7 @@ from ddtrace.internal import core
 from ddtrace.internal import process_tags
 from ddtrace.internal.constants import PROPAGATED_HASH
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.settings.peer_service import PeerServiceConfig
+from ddtrace.internal.settings.peer_service import _ps_config
 from ddtrace.vendor.sqlcommenter import generate_sql_comment as _generate_sql_comment
 
 from ..internal import compat
@@ -112,7 +112,12 @@ class _DBM_Propagator(object):
             return None
 
         # set the following tags if DBM injection mode is full, service, or dynamic_service
-        peer_service_enabled = PeerServiceConfig().set_defaults_enabled
+        # DEV: This runs on every DB span, so use the cached module-level singleton, which resolves
+        # the config once and caches it. A fresh PeerServiceConfig() has _set_defaults_enabled=None
+        # and re-reads the config via get_config() on every span; get_config() reports configuration
+        # telemetry on each read, so per-span instances leak telemetry config entries unboundedly
+        # on high-query services (issue #18800). Keep this on the shared singleton.
+        peer_service_enabled = _ps_config.set_defaults_enabled
         service_name_key = db_span.service
         if peer_service_enabled:
             db_name = db_span.get_tags().get("db.name")

--- a/releasenotes/notes/dbm-peer-service-config-leak-7dbf5398e4bf5ec9.yaml
+++ b/releasenotes/notes/dbm-peer-service-config-leak-7dbf5398e4bf5ec9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    database monitoring: Resolved a memory leak that grew with query volume when
+    ``DD_DBM_PROPAGATION_MODE`` was set to ``full``, ``service``, or ``dynamic_service``.

--- a/tests/internal/test_database_monitoring.py
+++ b/tests/internal/test_database_monitoring.py
@@ -376,6 +376,53 @@ def test_dbm_peer_entity_tags():
         assert dbspan.get_tag(_database_monitoring.DBM_TRACE_INJECTED_TAG) is not None
 
 
+@pytest.mark.subprocess(
+    env=dict(
+        DD_DBM_PROPAGATION_MODE="full",
+        DD_SERVICE="orders-app",
+        DD_ENV="staging",
+        DD_VERSION="v7343437-d7ac743",
+    )
+)
+def test_dbm_comment_does_not_reread_peer_service_config_per_span():
+    """Regression test for issue #18800.
+
+    ``_get_dbm_comment`` must use the cached peer-service singleton instead of constructing a
+    fresh ``PeerServiceConfig()`` per DB span. A fresh instance forced a ``_get_config`` read
+    (and a telemetry configuration report) on every query, growing unbounded over the process
+    lifetime. Generating many comments must not re-read the config more than once.
+    """
+    from unittest import mock
+
+    from ddtrace.internal.settings import peer_service
+    from ddtrace.propagation import _database_monitoring
+    from ddtrace.trace import tracer
+
+    # The DBM path must reference the shared module-level singleton.
+    assert _database_monitoring._ps_config is peer_service._ps_config
+
+    # Reset the cache so we can observe how many times the underlying config is read.
+    peer_service._ps_config._set_defaults_enabled = None
+
+    real_get_config = peer_service._get_config
+    calls = []
+
+    def spy_get_config(name, *args, **kwargs):
+        if name == "DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED":
+            calls.append(name)
+        return real_get_config(name, *args, **kwargs)
+
+    dbm_propagator = _database_monitoring._DBM_Propagator(0, "query")
+    with mock.patch.object(peer_service, "_get_config", spy_get_config):
+        for _ in range(25):
+            with tracer.trace("dbname") as dbspan:
+                dbm_propagator._get_dbm_comment(dbspan)
+
+    # The singleton caches after the first resolution, so the per-span path reads it at most once
+    # regardless of how many spans are generated.
+    assert len(calls) <= 1, calls
+
+
 def test_default_sql_injector(caplog):
     # test sql injection with unicode str
     dbm_comment = "/*dddbs='orders-db'*/ "


### PR DESCRIPTION
## Description

Fixes #18800

DBM fetches fresh config data on every query span, which in turns will enqueue a telemetry config entry for each span.

This fix moves to using the peer service config singleton to avoid resolving fresh config values on every span.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

An additional approach/fix to consider is making sure we do not enqueue the same config, value, and source multiple times in a single telemetry payload.
