### PR TITLE
refactor(packages): no-`RECORD` package discovery for Bazel runfiles

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -10,6 +10,7 @@ from types import ModuleType
 import typing as t
 
 from ddtrace.internal.module import origin
+from ddtrace.internal.settings import env
 from ddtrace.internal.settings.third_party import config as tp_config
 from ddtrace.internal.utils.cache import callonce
 
@@ -305,6 +306,143 @@ def _relative_to_known_root(path: Path) -> t.Optional[Path]:
     return None
 
 
+def _in_bazel() -> bool:
+    """Whether the process is running under Bazel runfiles (dir or manifest mode)."""
+    return bool(env.get("RUNFILES_DIR") or env.get("RUNFILES_MANIFEST_FILE"))
+
+
+def _manifest_real_path(line: str) -> t.Optional[str]:
+    r"""The real path from one Bazel runfiles MANIFEST line.
+
+    Two formats exist:
+      - plain '<runfiles_path> <real_path>' (we split on the first space)
+      - an escaped form used when either path contains a space, newline, or
+        backslash. The line starts with a space and both fields escape \s
+        (space), \n (newline) and \b (backslash).
+
+    Returns None for lines without a separate real path.
+    """
+    if line.startswith(" "):
+        parts = line[1:].split(" ", 1)
+        if len(parts) != 2:
+            return None
+
+        # Unescape in the same order Bazel does; \b last so a literal backslash
+        # written as \b is not mistaken for another escape.
+        return parts[1].replace(r"\s", " ").replace(r"\n", "\n").replace(r"\b", "\\")
+
+    parts = line.split(" ", 1)
+    if len(parts) != 2:
+        return None
+    return parts[1]
+
+
+@callonce
+def _bazel_manifest_site_packages() -> frozenset[str]:
+    """Resolved site-packages dirs referenced by RUNFILES_MANIFEST_FILE.
+
+    In manifest mode (when RUNFILES_MANIFEST_FILE is set, RUNFILES_DIR is unset)
+    dependency dirs are real filesystem paths that are not necessarily under a
+    *.runfiles tree, so the .runfiles ancestor heuristic misses them.
+    Parse the manifest's real-path column for site-packages components and
+    collect those dirs so they can be recognized as genuine runfiles roots.
+    """
+    manifest = env.get("RUNFILES_MANIFEST_FILE")
+    if not manifest:
+        return frozenset()
+
+    marker = "/site-packages/"
+    raw_roots: set[str] = set()
+    try:
+        with open(manifest, encoding="utf-8", errors="surrogateescape") as f:
+            for raw in f:
+                real = _manifest_real_path(raw.rstrip("\n"))
+                if real is None:
+                    continue
+
+                # On Windows, the manifest real path uses backslash separators,
+                # so normalize before searching for the site-packages marker.
+                real = real.replace("\\", "/")
+                # A single path can contain more than one "/site-packages/"
+                # component (e.g. an outer directory literally named
+                # site-packages before the real dependency root at
+                # .../dep/site-packages/pkg.py). Record every candidate
+                # root rather than only the first, so the innermost dependency
+                # site-packages is recognized too.
+                start = 0
+                while (idx := real.find(marker, start)) != -1:
+                    raw_roots.add(real[: idx + len(marker) - 1])
+                    start = idx + 1
+    except OSError:
+        return frozenset()
+
+    resolved: set[str] = set()
+    for r in raw_roots:
+        try:
+            resolved.add(str(Path(r).resolve()))
+        except OSError:
+            resolved.add(r)
+    return frozenset(resolved)
+
+
+def _is_bazel_runfiles_dir(path: Path) -> bool:
+    """Checks whether path is a dependency dir inside the Bazel runfiles tree.
+
+    Returns False when not running under Bazel so the Bazel-only directory
+    scan never runs against an arbitrary (possibly shared) dir whose lone
+    .dist-info would otherwise capture unrelated sibling modules. Under
+    Bazel a dir qualifies if it is below RUNFILES_DIR, has a *.runfiles
+    ancestor, or is a manifest-listed site-packages real path (directly, or
+    via a binary venv whose entries symlink into that real root).
+    """
+    if not _in_bazel():
+        return False
+
+    runfiles_dir = env.get("RUNFILES_DIR")
+    if runfiles_dir:
+        try:
+            path.relative_to(runfiles_dir)
+            return True
+        except ValueError:
+            pass
+
+    if any(parent.suffix == ".runfiles" for parent in path.parents):
+        return True
+
+    manifest_roots = _bazel_manifest_site_packages()
+    if not manifest_roots:
+        return False
+
+    try:
+        resolved = str(path.resolve())
+    except OSError:
+        resolved = str(path)
+
+    if resolved in manifest_roots:
+        return True
+
+    # rules_python can expose dependencies through a binary venv whose
+    # site-packages holds symlinks into the real repository site-packages.
+    # importlib.metadata then discovers the dist under that virtual dir, which
+    # is not itself a symlink and so is absent from the manifest's real-path
+    # roots. Follow a symlinked entry to its real parent and accept the dir
+    # when that parent is a manifest-listed site-packages root.
+    try:
+        for child in path.iterdir():
+            if not child.is_symlink():
+                continue
+            try:
+                real_parent = str(child.resolve().parent)
+            except OSError:
+                continue
+            if real_parent in manifest_roots:
+                return True
+    except OSError:
+        pass
+
+    return False
+
+
 @callonce
 def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
     import importlib.metadata as importlib_metadata
@@ -362,9 +500,13 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
     # AIDEV-NOTE: per-dist try/except — one bad dist used to collapse the whole
     # mapping to None (silently breaking is_third_party for the rest of the process).
     mapping: dict[str, Distribution] = {}
+    no_files_dists: list[importlib_metadata.Distribution] = []
+
+    d: t.Optional[Distribution] = None
     for dist in dists:
         try:
             if not (files := dist.files):
+                no_files_dists.append(dist)
                 continue
             metadata = dist.metadata
             name = metadata["name"]
@@ -381,6 +523,102 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
                     mapping[key] = d
         except Exception as exc:
             _warn_bad_dist(dist, exc)
+
+    # Fallback for environments where RECORD files are absent (e.g. Bazel's
+    # rules_python, which deliberately omits RECORD for hermeticity).
+    #
+    # Strategy 1: packages_distributions: fast, covers most packages.
+    # Strategy 2: directory scan of the dist's isolated site-packages: covers
+    #   the remainder, but only when the site-packages dir contains exactly one
+    #   .dist-info (true in Bazel's per-package isolated layout; unsafe in a
+    #   normal shared site-packages where multiple dists share one directory).
+    if no_files_dists:
+        # Strategy 1: packages_distributions maps module_name -> [dist_name, ...]
+        # A single no-RECORD / malformed dist can make packages_distributions()
+        # raise; that must not abort the whole fallback and leave good packages
+        # unresolved (breaking is_third_party / code provenance). Degrade to an
+        # empty Strategy 1 result and let the directory scan (Strategy 2) run.
+        try:
+            pkg_dists = get_package_distributions()
+        except Exception:
+            LOG.debug("packages_distributions() failed; falling back to directory scan", exc_info=True)
+            pkg_dists = {}
+
+        # Invert to dist_name_lower -> Distribution (lazily, only for no-files dists).
+        name_to_dist_obj: dict[str, Distribution] = {}
+        for _dist in no_files_dists:
+            try:
+                _n = _dist.metadata["name"]
+                _v = _dist.metadata["version"]
+                if _n and _v:
+                    name_to_dist_obj[_n.lower()] = Distribution(name=_n, version=_v)
+            except Exception as exc:
+                _warn_bad_dist(_dist, exc)
+
+        for module_name, dist_names in pkg_dists.items():
+            if module_name in mapping:
+                continue
+
+            resolved: list[Distribution] = []
+            for dist_name in dist_names:
+                if not dist_name:
+                    continue
+                d = name_to_dist_obj.get(dist_name.lower())
+                if d is not None and d not in resolved:
+                    resolved.append(d)
+
+            # Skip ambiguous roots provided by more than one no-RECORD dist:
+            # mapping such a top-level module to a single dist would let code
+            # provenance attribute another dist's files to the chosen one.
+            if len(resolved) != 1:
+                continue
+            mapping[module_name] = resolved[0]
+
+        # Strategy 2: directory scan of each no-RECORD dist's isolated
+        # site-packages dir, gated to verified Bazel runfiles dependency dirs.
+        for _dist in no_files_dists:
+            try:
+                _n = _dist.metadata["name"]
+                _v = _dist.metadata["version"]
+                if not (_n and _v):
+                    continue
+                site_packages = t.cast(Path, _dist.locate_file(""))
+                # Gate the scan to verified Bazel runfiles dependency dirs. The
+                # heuristic below assumes Bazel's per-package isolated layout
+                # (one dist owning the whole dir); outside runfiles a minimal or
+                # layered site-packages can hold this dist's lone .dist-info plus
+                # *unrelated* top-level code, which the scan would then wrongly
+                # attribute to this dist (marking those app frames third-party).
+                if not _is_bazel_runfiles_dir(site_packages):
+                    continue
+                # Safety guard: only treat this as an isolated site-packages if it
+                # contains exactly one .dist-info directory (Bazel's per-package
+                # layout guarantee). A shared site-packages has many .dist-info dirs
+                # and scanning it would produce wildly incorrect mappings.
+                dist_infos = (
+                    [child for child in site_packages.iterdir() if child.suffix == ".dist-info"]
+                    if site_packages.is_dir()
+                    else []
+                )
+                if len(dist_infos) != 1:
+                    continue
+                # The lone .dist-info must be _dist's own metadata, not an
+                # unrelated dist that merely happens to be alone in a minimal
+                # shared dir (e.g. _dist is an .egg-info/editable install).
+                # Otherwise we would attribute that dir's unrelated modules to
+                # _dist. Compare against _dist's metadata dir name.
+                own_meta = getattr(_dist, "_path", None)
+                if own_meta is None or dist_infos[0].name != Path(own_meta).name:
+                    continue
+                d = Distribution(name=_n, version=_v)
+                for child in site_packages.iterdir():
+                    root = child.name
+                    if child.suffix in (".dist-info", ".egg-info") or root == ".." or root.startswith("__"):
+                        continue
+                    if root not in mapping:
+                        mapping[root] = d
+            except Exception as exc:
+                _warn_bad_dist(_dist, exc)
 
     return mapping
 

--- a/tests/internal/test_packages_resilience.py
+++ b/tests/internal/test_packages_resilience.py
@@ -37,7 +37,7 @@ def reset_packages_caches():
     from ddtrace.internal import packages as _p
 
     def _clear() -> None:
-        for fn in (_p.get_distributions, _p._package_for_root_module_mapping):
+        for fn in (_p.get_distributions, _p._package_for_root_module_mapping, _p._bazel_manifest_site_packages):
             inner = getattr(fn, "__wrapped__", None) or (fn.__closure__[0].cell_contents if fn.__closure__ else None)
             if inner is not None and hasattr(inner, "__callonce_result__"):
                 del inner.__callonce_result__
@@ -60,6 +60,7 @@ def isolated_metadata_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> P
         )
 
     monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_fixed_path))
+    monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
     return tmp_path
 
 
@@ -94,6 +95,284 @@ def _write_dist_info(root: Path, name: str, version: str, metadata_body: str | N
     (di / "METADATA").write_text(metadata_body)
     (di / "RECORD").write_text("")
     return di
+
+
+def _write_dist_info_no_record(root: Path, name: str, version: str, top_level: str | None = None) -> Path:
+    """Write a dist-info without a RECORD file.
+
+    Mirrors Bazel's rules_python, which omits RECORD for hermeticity, so
+    dist.files is falsy and the dist lands in the no-RECORD fallback path.
+    """
+    di = root / f"{name.replace('-', '_')}-{version}.dist-info"
+    di.mkdir(parents=True)
+    (di / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n")
+    if top_level is not None:
+        (di / "top_level.txt").write_text(top_level + "\n")
+    return di
+
+
+def test_packages_distributions_failure_does_not_abort_fallback(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """packages_distributions raising should not break the fallback.
+
+    When one bad no-RECORD dist makes packages_distributions raise,
+    Strategy 1 should degrade to empty and Strategy 2 (directory scan) should
+    still resolve the otherwise-good Bazel packages.
+    """
+    root = isolated_metadata_path
+    _write_dist_info_no_record(root, "good-bazel-pkg", "1.0", top_level="good_bazel_pkg")
+    (root / "good_bazel_pkg").mkdir()
+    (root / "good_bazel_pkg" / "__init__.py").write_text("")
+
+    from ddtrace.internal import packages as _p
+
+    def _boom() -> dict:
+        raise RuntimeError("packages_distributions blew up")
+
+    monkeypatch.setattr(_p, "get_package_distributions", _boom)
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert mapping.get("good_bazel_pkg") is not None
+    assert mapping["good_bazel_pkg"].name == "good-bazel-pkg"
+
+
+def test_directory_scan_skipped_outside_bazel_runfiles(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-RECORD directory scan must not run outside Bazel runfiles.
+
+    A no-RECORD dist's dir can hold its own .dist-info plus unrelated
+    top-level code (minimal/layered site-packages). Outside a verified runfiles
+    tree the "single .dist-info" guard is not a real isolation guarantee, so
+    the scan is skipped and those unrelated siblings are not misattributed to
+    the dist.
+    """
+    import importlib.metadata as importlib_metadata
+
+    sp = tmp_path / "site-packages"
+    sp.mkdir(parents=True)
+    _write_dist_info_no_record(sp, "lonely-pkg", "1.0")
+    (sp / "lonely_pkg").mkdir()
+    (sp / "lonely_pkg" / "__init__.py").write_text("")
+    # Unrelated top-level code that merely shares the directory.
+    (sp / "unrelated_app").mkdir()
+    (sp / "unrelated_app" / "__init__.py").write_text("")
+
+    def _fixed(*args, **kwargs):
+        kwargs.setdefault("path", [str(sp)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_fixed))
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.delenv("RUNFILES_MANIFEST_FILE", raising=False)
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # Scan skipped entirely: neither the unrelated sibling nor the dist's own
+    # package is mapped via the directory scan.
+    assert "unrelated_app" not in mapping
+    assert "lonely_pkg" not in mapping
+
+
+def test_directory_scan_runs_in_bazel_runfiles_tree(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside a *.runfiles tree, the scan runs even without RUNFILES_DIR.
+
+    Identifies the runfiles tree purely by the *.runfiles ancestor (only
+    RUNFILES_MANIFEST_FILE is set), so the dist's package is mapped.
+    """
+    import importlib.metadata as importlib_metadata
+
+    sp = tmp_path / "app.runfiles" / "lonely" / "site-packages"
+    sp.mkdir(parents=True)
+    _write_dist_info_no_record(sp, "lonely-pkg", "1.0")
+    (sp / "lonely_pkg").mkdir()
+    (sp / "lonely_pkg" / "__init__.py").write_text("")
+
+    def _fixed(*args, **kwargs):
+        kwargs.setdefault("path", [str(sp)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_fixed))
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.setenv("RUNFILES_MANIFEST_FILE", str(tmp_path / "app.runfiles_manifest"))
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert mapping["lonely_pkg"].name == "lonely-pkg"
+
+
+def test_directory_scan_recognizes_manifest_mode_runfiles(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest-mode runfiles (RUNFILES_MANIFEST_FILE only) are recognized.
+
+    The dependency dir can sit outside any *.runfiles tree; its real path
+    is listed in the MANIFEST. _bazel_manifest_site_packages extracts the
+    site-packages root from the manifest so the scan still runs for it.
+    """
+    import importlib.metadata as importlib_metadata
+
+    # Dependency dir deliberately NOT under a *.runfiles tree.
+    sp = tmp_path / "execroot" / "dep" / "site-packages"
+    sp.mkdir(parents=True)
+    _write_dist_info_no_record(sp, "manifest-pkg", "1.0")
+    (sp / "manifest_pkg").mkdir()
+    (sp / "manifest_pkg" / "__init__.py").write_text("")
+
+    manifest = tmp_path / "app.runfiles_manifest"
+    manifest.write_text(f"app/manifest_pkg/__init__.py {sp / 'manifest_pkg' / '__init__.py'}\n")
+
+    def _fixed(*args, **kwargs):
+        kwargs.setdefault("path", [str(sp)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_fixed))
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.setenv("RUNFILES_MANIFEST_FILE", str(manifest))
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert mapping["manifest_pkg"].name == "manifest-pkg"
+
+
+def test_bazel_manifest_parses_escaped_entries(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Escaped manifest lines (paths with spaces/backslashes) must be parsed.
+
+    Bazel writes a leading-space escaped form when a path contains a space,
+    newline or backslash (common on Windows). Splitting naively on the first
+    space drops the real path and the dependency dir is rejected. The escaped
+    real path must be unescaped and its site-packages root recorded.
+    """
+    sp = tmp_path / "dir with space" / "site-packages"
+    sp.mkdir(parents=True)
+    target = sp / "pkg" / "__init__.py"
+
+    # Bazel escaped form: " <escaped_link> <escaped_target>" with \b for
+    # backslash and \s for space (backslash first so it is not double-escaped).
+    def _escape(s: str) -> str:
+        return s.replace("\\", r"\b").replace(" ", r"\s").replace("\n", r"\n")
+
+    manifest = tmp_path / "app.runfiles_manifest"
+    manifest.write_text(f" {_escape('app/pkg/__init__.py')} {_escape(str(target))}\n")
+
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.setenv("RUNFILES_MANIFEST_FILE", str(manifest))
+
+    from ddtrace.internal import packages as _p
+
+    roots = _p._bazel_manifest_site_packages()
+
+    assert str(sp.resolve()) in roots
+    assert _p._is_bazel_runfiles_dir(sp)
+
+
+def test_scan_skips_lone_unrelated_dist_info(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The directory scan must verify the lone .dist-info belongs to the dist.
+
+    A no-RECORD .egg-info/editable dist can live in a minimal shared
+    site-packages whose only .dist-info belongs to an unrelated package.
+    The "single .dist-info" guard alone would pass and wrongly attribute every
+    unmapped module in that dir to the egg dist.
+    """
+    root = isolated_metadata_path
+    # An unrelated, regular dist provides the only .dist-info in the dir. It has
+    # a real RECORD, so it resolves via the main loop, not the fallback.
+    di_unrelated = _write_dist_info(root, "unrelated-pkg", "9.9")
+    (di_unrelated / "RECORD").write_text("unrelated_pkg/__init__.py,,\n")
+    (root / "unrelated_pkg").mkdir()
+    (root / "unrelated_pkg" / "__init__.py").write_text("")
+    # A no-RECORD egg-info dist sharing the same directory (the fallback path).
+    egg = root / "editable_pkg.egg-info"
+    egg.mkdir()
+    (egg / "PKG-INFO").write_text("Metadata-Version: 2.1\nName: editable-pkg\nVersion: 0.1\n")
+    # An unrelated top-level module that must NOT be attributed to editable-pkg.
+    (root / "totally_unrelated").mkdir()
+    (root / "totally_unrelated" / "__init__.py").write_text("")
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # The egg's directory scan must be skipped: the lone .dist-info belongs to
+    # unrelated-pkg, not editable-pkg.
+    assert "totally_unrelated" not in mapping
+    assert "unrelated_pkg" in mapping
+
+
+def test_none_distribution_name_is_tolerated(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A None entry in packages_distributions values must not crash.
+
+    Some environments yield None in the distribution name list; calling
+    lower on it would raise outside the per-dist guard and collapse the
+    the whole mapping.
+    """
+    root = isolated_metadata_path
+    _write_dist_info_no_record(root, "good-bazel-pkg", "1.0")
+    (root / "good_bazel_pkg").mkdir()
+    (root / "good_bazel_pkg" / "__init__.py").write_text("")
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(
+        _p,
+        "get_package_distributions",
+        lambda: {"somemod": [None], "good_bazel_pkg": ["good-bazel-pkg"]},
+    )
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert mapping.get("good_bazel_pkg") is not None
+    assert mapping["good_bazel_pkg"].name == "good-bazel-pkg"
 
 
 def test_filename_to_package_resolves_shared_intermediate_namespace(


### PR DESCRIPTION
## Description

_This PR is part of a stack aimed at adding support for Bazel applications in Code Provenance._

Depends on https://github.com/DataDog/dd-trace-py/pull/18813. [stack is #18813 / #18812 / #18814 / #18815]

In Bazel, `rules_python` omits `RECORD` files, so `dist.files` is empty and those distributions never populate the root module mapping. This breaks our `is_third_party` / Code Provenance.

This PR adds a fallback for no-`RECORD` dists:
- Strategy 1 uses `packages_distributions`
- Strategy 2 scans the dist's isolated `site-packages` dir, gated to verified Bazel runfiles dependency dirs (`RUNFILES_DIR`, a `*.runfiles` ancestor, or a manifest-listed `site-packages` real path) and guarded to a single owning `.dist-info`.

**Note** those two strategies are complementary, we can't only pick one. Strategy 1 covers the most common cases (file system check, maps module -> dist from each dist's top_level.txt -- the only signal left once RECORD/dist.files is empty).  Strategy 2 reads the actual filesystem, so it sees dists with no `top_level.txt` and derives path-aware roots. But it's only safe under Bazel's isolated per-package layout, so it's gated (verified runfiles dir + exactly one owning .dist-info). That gating means it can't be the sole strategy -- it deliberately refuses to run in a normal shared site-packages, and it's more expensive (per-dir iteration).