### PR TITLE
refactor(packages): longest-prefix matching for `filename_to_package`

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -805,7 +805,7 @@ experiments:
           # packagespackageforrootmodulemapping
           - name: packagespackageforrootmodulemapping-cache_off
             thresholds:
-              - execution_time < 354.30 ms
+              - execution_time < 365.00 ms
               - max_rss_usage < 46.00 MB
           - name: packagespackageforrootmodulemapping-cache_on
             thresholds:

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -186,31 +186,168 @@ def _root_module(path: Path) -> str:
     raise ValueError(msg)
 
 
+@cached(maxsize=256)
+def _is_install_root(directory: Path) -> bool:
+    """Whether ``directory`` ships any distribution metadata.
+
+    A sys.path entry named ``site-packages`` is the usual install target, but
+    distributions can also be installed onto an arbitrary directory (``pip
+    install --target=...``, vendored dependencies dropped on ``PYTHONPATH``).
+    The presence of a ``*.dist-info`` / ``*.egg-info`` child marks such a
+    directory as a candidate anchor. This is necessary but not sufficient: a
+    source checkout carries its own project ``*.egg-info`` yet does not own
+    unrelated dependency namespaces living in the same tree, so the match is
+    additionally gated on distribution ownership in _install_root_owner.
+    """
+    try:
+        if not directory.is_dir():
+            return False
+        for child in directory.iterdir():
+            if child.suffix in (".dist-info", ".egg-info"):
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _normalized_dist_name(name: str) -> str:
+    """Normalize a distribution name for comparison (PEP 503-ish).
+
+    ``.dist-info`` / ``.egg-info`` directories escape the project name (dashes
+    become underscores), so fold ``-``, ``_`` and ``.`` to a single form and
+    lowercase before comparing (``google-cloud-storage`` == ``google_cloud_storage``).
+    """
+    return name.replace("-", "_").replace(".", "_").lower()
+
+
+def _root_ships_distribution(directory: Path, dist_name: str) -> bool:
+    """Whether ``directory`` contains the metadata of ``dist_name`` itself.
+
+    Distinguishes a genuine install root of ``dist_name`` (its own
+    ``*.dist-info`` / ``*.egg-info`` is present) from an unrelated directory
+    that merely happens to carry some other distribution's metadata.
+    """
+    target = _normalized_dist_name(dist_name)
+    try:
+        children = list(directory.iterdir())
+    except OSError:
+        return False
+    for child in children:
+        if child.suffix not in (".dist-info", ".egg-info"):
+            continue
+        # ``{name}-{version}.dist-info`` / ``{name}.egg-info``: the name part
+        # (escaped, so it never contains a dash) precedes the first dash.
+        candidate = child.name[: -len(child.suffix)].split("-", 1)[0]
+        if _normalized_dist_name(candidate) == target:
+            return True
+    return False
+
+
+def _install_root_owner(path: Path, mapping: dict[str, Distribution]) -> t.Optional[Distribution]:
+    """Longest-prefix lookup for dependencies installed outside site-packages.
+
+    Handles ``pip install --target`` and vendored deps dropped on sys.path.
+    Unlike a site-packages root, such a directory is only trusted when it
+    verifiably ships the matched distribution's own metadata; otherwise an
+    editable source checkout (which carries its own project ``.egg-info``)
+    would capture unrelated namespace files sharing its tree and misreport
+    user code as that dependency.
+    """
+    for parent_path in resolve_sys_path():
+        if parent_path.name == "site-packages" or not _is_install_root(parent_path):
+            continue
+        try:
+            relative = path.relative_to(parent_path)
+        except ValueError:
+            continue
+        parts = relative.parts
+        for end in range(len(parts), 0, -1):
+            hit = mapping.get("/".join(parts[:end]))
+            if hit is not None:
+                if _root_ships_distribution(parent_path, hit.name):
+                    return hit
+                break
+    return None
+
+
+def _relative_to_known_root(path: Path) -> t.Optional[Path]:
+    """Return path relative to the site-packages-like root that contains it.
+    Only trusted dependency roots are considered (purelib/platlib and
+    site-packages dirs). Install roots outside site-packages are handled by
+    _install_root_owner, which additionally verifies distribution ownership.
+    Returns None when path is not under such a root.
+    """
+    for parent_path in (purelib_path, platlib_path):
+        try:
+            return path.resolve().relative_to(parent_path)
+        except ValueError:
+            pass
+
+    min_relative_path: t.Optional[Path] = None
+    for parent_path in resolve_sys_path():
+        if parent_path.name != "site-packages":
+            continue
+        try:
+            relative = path.relative_to(parent_path)
+        except ValueError:
+            continue
+        if min_relative_path is None or len(relative.parents) < len(min_relative_path.parents):
+            min_relative_path = relative
+    if min_relative_path is not None:
+        return min_relative_path
+
+    for s in path.parents:
+        if s.parent.name == "site-packages":
+            try:
+                return path.relative_to(s.parent)
+            except ValueError:
+                pass
+    return None
+
+
 @callonce
 def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
     import importlib.metadata as importlib_metadata
 
-    namespaces: dict[str, bool] = {}
+    # Cache per directory prefix whether it is a *regular* package (a directory
+    # that ships an ``__init__.py``). PEP 420 namespace packages have no
+    # ``__init__.py`` at their shared levels, so several distributions can
+    # contribute siblings under the same prefix (``google/cloud/storage`` vs
+    # ``google/cloud/bigquery``). The key must therefore be the deepest
+    # importable root, not a fixed 2-level prefix, otherwise every sibling
+    # collapses onto whichever dist was scanned first and the longest-prefix
+    # lookup in filename_to_package has nothing specific to match.
+    regular_pkg: dict[str, bool] = {}
 
-    def is_namespace(f: importlib_metadata.PackagePath):
-        root = f.parts[0]
-        try:
-            return namespaces[root]
-        except KeyError:
-            pass
+    def root_key(f: importlib_metadata.PackagePath) -> str:
+        parts = f.parts
+        n = len(parts)
+        if n < 2:
+            # Top-level module file (e.g. ``six.py``); keep the file name.
+            return parts[0]
 
-        if len(f.parts) < 2:
-            namespaces[root] = False
-            return False
+        located: t.Optional[Path] = None
+        for depth in range(1, n):
+            prefix = "/".join(parts[:depth])
+            is_regular = regular_pkg.get(prefix)
+            if is_regular is None:
+                if located is None:
+                    located = t.cast(Path, f.locate())
+                pkg_dir = located.parents[n - 1 - depth]
+                is_regular = pkg_dir.is_dir() and (pkg_dir / "__init__.py").exists()
+                regular_pkg[prefix] = is_regular
+            if is_regular:
+                # First regular package on the path: this is the import root.
+                return prefix
 
-        located_f = t.cast(Path, f.locate())
-        parent = located_f.parents[len(f.parts) - 2]
-        if parent.is_dir() and not (parent / "__init__.py").exists():
-            namespaces[root] = True
-            return True
-
-        namespaces[root] = False
-        return False
+        # Every directory level is a namespace (no __init__.py anywhere on the
+        # path). Two distributions can then contribute module files directly
+        # under the shared namespace (dist A ships ``acme/foo.py``, dist B ships
+        # ``acme/bar.py``); dropping the file name collapses both onto the bare
+        # ``acme`` key and attributes every sibling to whichever dist was
+        # scanned first. Keep the full path (including the file name) so each
+        # module gets a distinct key the longest-prefix lookup can match.
+        return "/".join(parts)
 
     try:
         dists = list(importlib_metadata.distributions())
@@ -239,10 +376,9 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
                 root = f.parts[0]
                 if root.endswith(".dist-info") or root.endswith(".egg-info") or root == "..":
                     continue
-                if is_namespace(f):
-                    root = "/".join(f.parts[:2])
-                if root not in mapping:
-                    mapping[root] = d
+                key = root_key(f)
+                if key not in mapping:
+                    mapping[key] = d
         except Exception as exc:
             _warn_bad_dist(dist, exc)
 
@@ -268,6 +404,30 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
 
     try:
         path = Path(filename) if isinstance(filename, str) else filename
+
+        # Longest-prefix match against the mapping. Namespace distributions can
+        # share an intermediate level (google/cloud/storage vs
+        # google/cloud/bigquery), so the most specific (deepest) mapped prefix
+        # must win; _root_module only yields a fixed 2-level key and cannot tell
+        # the siblings apart. The probe is anchored at the site-packages-relative
+        # root, so a subpackage that happens to share a name with another
+        # top-level dist cannot mismatch.
+        relative = _relative_to_known_root(path)
+        if relative is not None:
+            parts = relative.parts
+            for end in range(len(parts), 0, -1):
+                hit = mapping.get("/".join(parts[:end]))
+                if hit is not None:
+                    return hit
+
+        # Dependencies installed outside site-packages (pip install --target,
+        # vendored deps on sys.path): anchor only when the root verifiably owns
+        # the matched distribution, so an editable source checkout carrying its
+        # own .egg-info cannot capture unrelated namespace files as a dependency.
+        owner = _install_root_owner(path, mapping)
+        if owner is not None:
+            return owner
+
         # Avoid calling .resolve() on the path here to prevent breaking symlink matching in `_root_module`.
         root_module_path = _root_module(path)
         if root_module_path in mapping:

--- a/tests/internal/test_packages_resilience.py
+++ b/tests/internal/test_packages_resilience.py
@@ -96,6 +96,188 @@ def _write_dist_info(root: Path, name: str, version: str, metadata_body: str | N
     return di
 
 
+def test_filename_to_package_resolves_shared_intermediate_namespace(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end lookup must attribute each shared-namespace file correctly.
+
+    The regression that kept recurring: the directory scan stores deep keys
+    (google/cloud/storage / google/cloud/bigquery) but _root_module
+    only yields the fixed 2-level key google/cloud, so filename_to_package
+    resolved every google/cloud/... file to whichever dist was scanned
+    first. With longest-prefix matching, each file resolves to its own dist.
+    """
+    from ddtrace.internal import packages as _p
+
+    # Lay both dists under a common ``site-packages`` parent so the Bazel
+    # runfiles heuristic in _relative_to_known_root resolves the files.
+    sp = tmp_path / "runfiles" / "site-packages"
+    sp.mkdir(parents=True)
+    (sp / "google" / "cloud" / "storage").mkdir(parents=True)
+    (sp / "google" / "cloud" / "storage" / "__init__.py").write_text("")
+    (sp / "google" / "cloud" / "storage" / "blob.py").write_text("")
+    (sp / "google" / "cloud" / "bigquery").mkdir(parents=True)
+    (sp / "google" / "cloud" / "bigquery" / "__init__.py").write_text("")
+    (sp / "google" / "cloud" / "bigquery" / "client.py").write_text("")
+
+    mapping = {
+        "google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0"),
+        "google/cloud/bigquery": _p.Distribution(name="google-cloud-bigquery", version="2.0"),
+    }
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    _p.filename_to_package.cache_clear()
+
+    storage_pkg = _p.filename_to_package(sp / "google" / "cloud" / "storage" / "blob.py")
+    bigquery_pkg = _p.filename_to_package(sp / "google" / "cloud" / "bigquery" / "client.py")
+
+    assert storage_pkg is not None and storage_pkg.name == "google-cloud-storage"
+    assert bigquery_pkg is not None and bigquery_pkg.name == "google-cloud-bigquery"
+
+    _p.filename_to_package.cache_clear()
+
+
+def test_filename_to_package_does_not_attribute_source_roots_to_dependency(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deep prefix matching must not leak dependency namespaces onto user code.
+
+    In Bazel a binary's own source/workspace roots are on sys.path too. A
+    user file <workspace>/google/cloud/storage/app.py shares the namespace
+    prefix of a google-cloud-storage dependency, but it is not under a
+    site-packages root, so it must resolve to user code.
+    """
+    from ddtrace.internal import packages as _p
+
+    workspace = tmp_path / "workspace"
+    (workspace / "google" / "cloud" / "storage").mkdir(parents=True)
+    (workspace / "google" / "cloud" / "storage" / "app.py").write_text("")
+
+    mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    # The workspace root is on sys.path, mirroring a Bazel py_binary.
+    monkeypatch.setattr(_p, "resolve_sys_path", lambda: [workspace])
+    _p.filename_to_package.cache_clear()
+
+    pkg = _p.filename_to_package(workspace / "google" / "cloud" / "storage" / "app.py")
+
+    assert pkg is None
+
+    _p.filename_to_package.cache_clear()
+
+
+def test_filename_to_package_resolves_namespace_on_non_site_packages_install_root(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vendored namespace deps on a non-site-packages root must still resolve.
+
+    A distribution installed with pip install --target=/app/vendor (or
+    vendored onto PYTHONPATH) lives on a sys.path root that is not named
+    site-packages. The mapping stores the deep key google/cloud/storage,
+    so the anchored longest-prefix lookup must recognize the target dir as an
+    install root -- it ships the *.dist-info -- and attribute the file to
+    the dependency rather than falling through to user code.
+    """
+    from ddtrace.internal import packages as _p
+
+    vendor = tmp_path / "vendor"
+    vendor.mkdir()
+    # The dist-info marks vendor as an install root (not a source root).
+    _write_dist_info(vendor, "google-cloud-storage", "1.0")
+    (vendor / "google" / "cloud" / "storage").mkdir(parents=True)
+    (vendor / "google" / "cloud" / "storage" / "blob.py").write_text("")
+
+    mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    monkeypatch.setattr(_p, "resolve_sys_path", lambda: [vendor])
+    _p._is_install_root.cache_clear()
+    _p.filename_to_package.cache_clear()
+
+    pkg = _p.filename_to_package(vendor / "google" / "cloud" / "storage" / "blob.py")
+
+    assert pkg is not None and pkg.name == "google-cloud-storage"
+
+    _p._is_install_root.cache_clear()
+    _p.filename_to_package.cache_clear()
+
+
+def test_mapping_generates_deep_keys_for_shared_namespace_dists(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+) -> None:
+    """The generator must key shared-namespace dists on their deepest import
+    root, not a fixed 2-level prefix.
+
+    ``google-cloud-storage`` and ``google-cloud-bigquery`` both live under the
+    ``google/cloud`` PEP 420 namespace. Keying on ``google/cloud`` collapses
+    both onto whichever dist is scanned first, which is exactly what
+    filename_to_package's longest-prefix lookup exists to avoid. The mapping
+    must therefore contain ``google/cloud/storage`` and ``google/cloud/bigquery``
+    and must not contain the ambiguous ``google/cloud`` key.
+    """
+
+    def _write_namespace_dist(name: str, version: str, leaf: str, module: str) -> None:
+        di = _write_dist_info(isolated_metadata_path, name, version)
+        pkg_dir = isolated_metadata_path / "google" / "cloud" / leaf
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        # Namespace levels (google, google/cloud) intentionally lack __init__.py.
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / module).write_text("")
+        (di / "RECORD").write_text(f"google/cloud/{leaf}/__init__.py,,\ngoogle/cloud/{leaf}/{module},,\n")
+
+    _write_namespace_dist("google-cloud-storage", "1.0", "storage", "blob.py")
+    _write_namespace_dist("google-cloud-bigquery", "2.0", "bigquery", "client.py")
+
+    from ddtrace.internal.packages import _package_for_root_module_mapping
+
+    mapping = _package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert "google/cloud" not in mapping
+    assert mapping["google/cloud/storage"].name == "google-cloud-storage"
+    assert mapping["google/cloud/bigquery"].name == "google-cloud-bigquery"
+
+
+def test_mapping_keeps_module_filename_for_flat_namespace_dists(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+) -> None:
+    """Module files shipped directly under a shared PEP 420 namespace must keep
+    distinct keys.
+
+    Two dists can drop plain modules into the same namespace with no
+    __init__.py at any level (dist A ships acme/foo.py, dist B ships
+    acme/bar.py). Keying both on the bare ``acme`` prefix collapses them
+    onto whichever dist is scanned first; the key must therefore retain the
+    module file name so each module resolves to its own distribution.
+    """
+
+    def _write_flat_namespace_dist(name: str, version: str, module: str) -> None:
+        di = _write_dist_info(isolated_metadata_path, name, version)
+        acme = isolated_metadata_path / "acme"
+        acme.mkdir(exist_ok=True)
+        # acme is a namespace: no __init__.py, only sibling module files.
+        (acme / module).write_text("")
+        (di / "RECORD").write_text(f"acme/{module},,\n")
+
+    _write_flat_namespace_dist("acme-foo", "1.0", "foo.py")
+    _write_flat_namespace_dist("acme-bar", "2.0", "bar.py")
+
+    from ddtrace.internal.packages import _package_for_root_module_mapping
+
+    mapping = _package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert "acme" not in mapping
+    assert mapping["acme/foo.py"].name == "acme-foo"
+    assert mapping["acme/bar.py"].name == "acme-bar"
+
+
 def test_get_distributions_skips_bad_dist_warns_once_returns_partial_map(
     isolated_metadata_path: Path,
     reset_packages_caches,
@@ -167,3 +349,42 @@ def test_package_for_root_module_mapping_skips_bad_dist(
     assert mapping is not None
     assert "good_pkg" in mapping
     assert mapping["good_pkg"].name == "good-pkg"
+
+
+def test_filename_to_package_does_not_attribute_editable_source_root_to_dependency(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An editable checkout's own .egg-info must not license unrelated matches.
+
+    A legacy editable install (``pip install -e .`` / ``setup.py develop``)
+    drops the project's own ``<name>.egg-info`` in the source root, which is on
+    sys.path. That metadata belongs to the project, not to a third-party
+    namespace dependency, so a user file such as
+    ``<repo>/google/cloud/storage/app.py`` must still resolve to user code
+    (None) -- the install-root anchor only counts when the root ships the
+    matched distribution's own metadata.
+    """
+    from ddtrace.internal import packages as _p
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # The repo carries only its own project metadata, not google-cloud-storage.
+    (repo / "myproject.egg-info").mkdir()
+    (repo / "myproject.egg-info" / "PKG-INFO").write_text("Name: myproject\nVersion: 1.0\n")
+    (repo / "google" / "cloud" / "storage").mkdir(parents=True)
+    (repo / "google" / "cloud" / "storage" / "app.py").write_text("")
+
+    mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    monkeypatch.setattr(_p, "resolve_sys_path", lambda: [repo])
+    _p._is_install_root.cache_clear()
+    _p.filename_to_package.cache_clear()
+
+    pkg = _p.filename_to_package(repo / "google" / "cloud" / "storage" / "app.py")
+
+    assert pkg is None
+
+    _p._is_install_root.cache_clear()
+    _p.filename_to_package.cache_clear()


### PR DESCRIPTION
## Description

_This PR is the first of a stack aimed at adding support for Bazel applications in Code Provenance._

[Next PR](https://github.com/DataDog/dd-trace-py/pull/18812) [stack is #18813 / #18812 / #18814 / #18815]

This changes the logic to resolve a filename to its distribution by the deepest mapped prefix (rather than a fixed 2-level root key).  

This is needed because namespace distributions that share an intermediate level (e.g. `google/cloud/storage` and  `google/cloud/bigquery`) cannot be told apart by `_root_module`, so this also adds a `_relative_to_known_root` helper to anchor the probe at the `site-packages`-relative path and match the most specific mapped key.
