### PR TITLE
refactor(packages): handle shared namespace distributions in no-RECORD fallback

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -443,6 +443,77 @@ def _is_bazel_runfiles_dir(path: Path) -> bool:
     return False
 
 
+def _is_namespace_module(base: Path, module_name: str) -> bool:
+    """Whether ``base/module_name`` is a namespace package (dir, no __init__.py).
+
+    Used by the no-RECORD fallback to avoid pinning a shared namespace
+    top-level (e.g. ``google``) to a single distribution. A regular package
+    (has ``__init__.py``) or a single-file module is not a namespace.
+    """
+    pkg_dir = base / module_name
+    try:
+        return pkg_dir.is_dir() and not (pkg_dir / "__init__.py").exists()
+    except OSError:
+        return False
+
+
+# Bound the recursion that walks nested no-RECORD namespace packages, so a
+# pathological/deep tree (or symlink loop) cannot stall the mapping build.
+_NAMESPACE_SCAN_MAX_DEPTH = 16
+
+
+def _add_namespace_subentries(
+    ns_dir: Path,
+    prefix: str,
+    dist: Distribution,
+    mapping: dict[str, Distribution],
+    depth: int = 0,
+) -> None:
+    """Recursively map sub-entries of a no-RECORD namespace package.
+
+    Two distributions can share intermediate namespace levels: e.g.
+    ``google-cloud-storage`` ships ``google/cloud/storage`` and
+    ``google-cloud-bigquery`` ships ``google/cloud/bigquery``, both under the
+    ``google/cloud`` namespace. Keying only one level deep collapses both to
+    ``google/cloud`` and drops the second dist, so ``CodeProvenance`` records
+    only the first runfiles path and the other dependency's frames stay
+    classified as user code. We descend through nested namespace dirs (those
+    without ``__init__.py``) until we reach a concrete package (has
+    ``__init__.py``) or a module file, mapping a key at each level so every
+    distribution keeps at least one distinct entry and its path is recorded.
+
+    A nested namespace level (a directory without ``__init__.py``) is itself
+    shareable, so it is NOT mapped to ``dist``; only concrete packages (with
+    ``__init__.py``) and module files are. We descend through the bare
+    namespace dirs so each distribution's concrete leaf gets its own
+    dist-specific key, and ``filename_to_package`` then resolves files by the
+    deepest matching prefix.
+    """
+    if depth >= _NAMESPACE_SCAN_MAX_DEPTH:
+        return
+    try:
+        children = list(ns_dir.iterdir())
+    except OSError:
+        return
+    for child in children:
+        name = child.name
+        if name.startswith("__"):
+            continue
+        is_dir = child.is_dir()
+        is_module_file = child.suffix == ".py" and not is_dir
+        if not (is_dir or is_module_file):
+            continue
+        key = f"{prefix}/{name}"
+        if is_dir and not (child / "__init__.py").exists():
+            # Shared intermediate namespace level: never pin it to a single
+            # dist (that misattributes a sibling dist's files to whichever was
+            # scanned first). Recurse so the concrete leaf below gets a
+            # dist-specific key instead.
+            _add_namespace_subentries(child, key, dist, mapping, depth + 1)
+        elif key not in mapping:
+            mapping[key] = dist
+
+
 @callonce
 def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
     import importlib.metadata as importlib_metadata
@@ -543,15 +614,39 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
         except Exception:
             LOG.debug("packages_distributions() failed; falling back to directory scan", exc_info=True)
             pkg_dists = {}
+        # Top-level roots that the directory scan sees as namespace packages
+        # (no __init__.py) in any no-RECORD dist. A bare namespace root is
+        # inherently shareable across dists, so it must never be mapped to a
+        # single dist -- even when packages_distributions() resolves only one
+        # (the other dist may omit top_level.txt and so be invisible to it).
+        # Collected during Strategy 2 and stripped from the mapping afterwards.
+        namespace_roots: set[str] = set()
 
-        # Invert to dist_name_lower -> Distribution (lazily, only for no-files dists).
+        # Roots that some no-RECORD dist regularly owns (has __init__.py or a
+        # top-level module file). A regular owner always wins the bare root over
+        # a shared namespace.
+        regular_owners: dict[str, Distribution] = {}
+
+        # Roots that the packages_distributions() fallback (Strategy 1) added.
+        # Only these may be stripped as shared namespace roots; a RECORD-backed
+        # or regular-package owner of the same root must be preserved.
+        strategy1_added: set[str] = set()
+
+        # Invert to dist_name_lower -> Distribution and its base dir (lazily,
+        # only for no-files dists). The base dir lets Strategy 1 tell a bare
+        # namespace top-level from a regular package on its own.
         name_to_dist_obj: dict[str, Distribution] = {}
+        name_to_base: dict[str, Path] = {}
         for _dist in no_files_dists:
             try:
                 _n = _dist.metadata["name"]
                 _v = _dist.metadata["version"]
                 if _n and _v:
                     name_to_dist_obj[_n.lower()] = Distribution(name=_n, version=_v)
+                    try:
+                        name_to_base[_n.lower()] = t.cast(Path, _dist.locate_file(""))
+                    except Exception:  # nosec - base dir is best-effort
+                        pass
             except Exception as exc:
                 _warn_bad_dist(_dist, exc)
 
@@ -567,15 +662,31 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
                 if d is not None and d not in resolved:
                     resolved.append(d)
 
-            # Skip ambiguous roots provided by more than one no-RECORD dist:
-            # mapping such a top-level module to a single dist would let code
-            # provenance attribute another dist's files to the chosen one.
+            # Skip ambiguous namespace roots: when a top-level module (e.g.
+            # "google") is provided by more than one no-RECORD distribution,
+            # mapping it to a single dist would let code provenance attribute
+            # another dist's files to the chosen one (it resolves the root via
+            # the first matching sys.path entry). Rely on the path-aware
+            # sub-entries added by the directory scan (Strategy 2) instead.
             if len(resolved) != 1:
                 continue
+            # Also skip a bare namespace top-level even when a single dist
+            # reports it: a sibling namespace dist may omit top_level.txt (and
+            # so be invisible here), and the Strategy 2 scan that would strip
+            # this root is skipped outside Bazel. Pinning it would make the
+            # longest-prefix lookup attribute the sibling's "google/<other>/..."
+            # files to this dist. The directory scan still adds the path-aware
+            # sub-entries (e.g. "google/cloud") when it does run.
+            base = name_to_base.get(resolved[0].name.lower())
+            if base is not None and _is_namespace_module(base, module_name):
+                continue
             mapping[module_name] = resolved[0]
+            strategy1_added.add(module_name)
 
-        # Strategy 2: directory scan of each no-RECORD dist's isolated
-        # site-packages dir, gated to verified Bazel runfiles dependency dirs.
+        # Strategy 2: directory scan. We do NOT skip dists already covered by
+        # Strategy 1: namespace packages get only their top-level module mapped
+        # there (e.g. "google"), but _root_module returns sub-entries like
+        # "google/cloud", which only the directory scan below can add.
         for _dist in no_files_dists:
             try:
                 _n = _dist.metadata["name"]
@@ -615,10 +726,43 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
                     root = child.name
                     if child.suffix in (".dist-info", ".egg-info") or root == ".." or root.startswith("__"):
                         continue
-                    if root not in mapping:
-                        mapping[root] = d
+                    is_namespace_pkg = child.is_dir() and not (child / "__init__.py").exists()
+                    if not is_namespace_pkg:
+                        # Regular package/module (has __init__.py, or a module
+                        # file): the whole top-level dir/file belongs to this
+                        # dist, so it is the legitimate owner of the bare root.
+                        regular_owners.setdefault(root, d)
+                        if root not in mapping:
+                            mapping[root] = d
+                        continue
+                    # Namespace packages (no __init__.py) must NOT map their bare
+                    # top-level root (e.g. "google"): it is shared across dists,
+                    # so attributing it to one would misclassify another dist's
+                    # files. Add the path-aware sub-entries instead, descending
+                    # through nested namespace levels so that dists sharing an
+                    # intermediate level (e.g. "google/cloud") still each get a
+                    # distinct, recorded key.
+                    namespace_roots.add(root)
+                    _add_namespace_subentries(child, root, d, mapping)
             except Exception as exc:
                 _warn_bad_dist(_dist, exc)
+
+        # Reconcile bare namespace roots that Strategy 1 mapped to a single
+        # dist. The directory scan is authoritative about ownership:
+        #   - If some dist regularly owns the root (has __init__.py or a module
+        #     file), the bare root belongs to that regular owner; point the
+        #     Strategy 1 entry at it (it may have guessed a namespace dist).
+        #   - Otherwise the root is purely a shared namespace; drop the bare
+        #     entry so only the path-aware sub-entries (e.g. "google/cloud")
+        #     remain and no dist's "google" dir is recorded under another.
+        # We only touch Strategy 1's own additions, so a RECORD-backed owner
+        # (mapped by the main loop) is never disturbed.
+        for ns_root_name in namespace_roots & strategy1_added:
+            owner = regular_owners.get(ns_root_name)
+            if owner is not None:
+                mapping[ns_root_name] = owner
+            else:
+                mapping.pop(ns_root_name, None)
 
     return mapping
 

--- a/tests/internal/test_packages_resilience.py
+++ b/tests/internal/test_packages_resilience.py
@@ -1,9 +1,9 @@
-"""Resilience tests for ``ddtrace.internal.packages``.
+"""Resilience tests for ddtrace.internal.packages.
 
-Real-world environments (Linux distro Python, ``pip install -e`` from old
+Real-world environments (Linux distro Python, pip install -e from old
 pip versions, conda-pip mixes, CI base images) ship dist-info directories
 with malformed or unreadable METADATA. Before the fix, a single bad dist
-made ``get_distributions`` raise; ``@callonce`` cached that exception; and
+made get_distributions raise; @callonce cached that exception; and
 the telemetry dependency tracker logged a chained traceback per imported
 module per heartbeat per worker (gigabytes of stderr per CI job).
 """
@@ -16,10 +16,10 @@ from pathlib import Path
 import pytest
 
 
-# ``importlib.metadata._adapters`` is the private module that holds the
-# ``Message`` shim whose ``__getitem__`` returns ``None`` on missing keys
-# today and is on a path to raising ``KeyError`` (CPython issue 102117 +
-# the ``importlib_metadata`` backport already raises). It was introduced
+# importlib.metadata._adapters is the private module that holds the
+# Message shim whose __getitem__ returns None on missing keys
+# today and is on a path to raising KeyError (CPython issue 102117 +
+# the importlib_metadata backport already raises). It was introduced
 # in Python 3.10; on 3.9 the strict-future regression we exercise here
 # cannot be reproduced via that hook, so the tests below are skipped.
 try:
@@ -30,7 +30,7 @@ except ImportError:  # Python 3.9
 
 @pytest.fixture
 def reset_packages_caches():
-    """Drop ``@callonce`` results and the bad-dist dedup set on both setup
+    """Drop @callonce results and the bad-dist dedup set on both setup
     and teardown — these tests populate the caches with fixture site-packages
     that must not bleed into adjacent tests in the same worker.
     """
@@ -66,11 +66,11 @@ def isolated_metadata_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> P
 
 @pytest.fixture
 def strict_metadata_getitem(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force ``Message.__getitem__`` to raise ``KeyError`` on missing keys.
+    """Force Message.__getitem__ to raise KeyError on missing keys.
 
-    Mirrors the behavior of the ``importlib_metadata`` backport (today) and
-    the future-strict path CPython is migrating to (``"Implicit None on
-    return values is deprecated and will raise KeyErrors."``). Without this
+    Mirrors the behavior of the importlib_metadata backport (today) and
+    the future-strict path CPython is migrating to ("Implicit None on
+    return values is deprecated and will raise KeyErrors."). Without this
     fixture the test would depend on the running Python's deprecation
     policy.
     """
@@ -111,6 +111,69 @@ def _write_dist_info_no_record(root: Path, name: str, version: str, top_level: s
     return di
 
 
+def test_namespace_subentries_added_even_when_strategy1_covers_dist(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-RECORD namespace dists must still get their sub-entries.
+
+    For a namespace package such as google-cloud-foo declaring top-level
+    google, _root_module returns deeper keys like google/cloud, so
+    the directory scan must add that sub-entry. The bare namespace root itself
+    must NOT be mapped (it is shareable across dists), but its path-aware
+    sub-entry must be present so those files aren't misclassified as user code.
+    """
+    root = isolated_metadata_path
+    _write_dist_info_no_record(root, "google-cloud-foo", "1.0", top_level="google")
+    # Namespace package: google/ has no __init__.py, contains a cloud/ subpackage.
+    (root / "google" / "cloud").mkdir(parents=True)
+    (root / "google" / "cloud" / "__init__.py").write_text("")
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {"google": ["google-cloud-foo"]})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # The bare namespace root must not be mapped to a single dist.
+    assert "google" not in mapping
+    # The namespace sub-entry _root_module returns must still be present.
+    assert "google/cloud" in mapping and mapping["google/cloud"].name == "google-cloud-foo"
+
+
+def test_namespace_module_files_added_in_no_record_fallback(
+    isolated_metadata_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-RECORD namespace dists must map direct module files, not just dirs.
+
+    For a namespace package ns (no __init__.py) that contains a direct
+    module file ns/mod.py, _root_module returns the key ns/mod.py.
+    The directory scan must map that file (mirroring the RECORD-based path),
+    otherwise those frames stay classified as user code.
+    """
+    root = isolated_metadata_path
+    _write_dist_info_no_record(root, "ns-mod-pkg", "1.0", top_level="ns")
+    # Namespace package: ns/ has no __init__.py and holds a direct module file.
+    (root / "ns").mkdir()
+    (root / "ns" / "mod.py").write_text("")
+
+    from ddtrace.internal import packages as _p
+
+    # Strategy 1 maps only the top-level "ns"; the file mapping must come from
+    # the directory scan.
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {"ns": ["ns-mod-pkg"]})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    assert "ns/mod.py" in mapping
+    assert mapping["ns/mod.py"].name == "ns-mod-pkg"
+
+
 def test_packages_distributions_failure_does_not_abort_fallback(
     isolated_metadata_path: Path,
     reset_packages_caches,
@@ -139,6 +202,348 @@ def test_packages_distributions_failure_does_not_abort_fallback(
     assert mapping is not None
     assert mapping.get("good_bazel_pkg") is not None
     assert mapping["good_bazel_pkg"].name == "good-bazel-pkg"
+
+
+def test_ambiguous_namespace_root_is_not_mapped_to_single_dist(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A top-level namespace shared by multiple no-RECORD dists must be skipped.
+
+    Mirrors Bazel's isolated layout: each google-* dist lives in its own
+    per-package site-packages dir, both declaring the google namespace.
+    packages_distributions() reports google as provided by both, so
+    mapping the bare google root to a single one would misattribute the
+    other dist's files. The bare root must stay unmapped; only the path-aware
+    sub-entries from each dist's directory scan should be added.
+    """
+    import importlib.metadata as importlib_metadata
+
+    dir_a = tmp_path / "a" / "site-packages"
+    dir_b = tmp_path / "b" / "site-packages"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+    _write_dist_info_no_record(dir_a, "google-cloud-foo", "1.0", top_level="google")
+    (dir_a / "google" / "cloud").mkdir(parents=True)
+    (dir_a / "google" / "cloud" / "__init__.py").write_text("")
+    _write_dist_info_no_record(dir_b, "google-cloud-bar", "2.0", top_level="google")
+    (dir_b / "google" / "bigquery").mkdir(parents=True)
+    (dir_b / "google" / "bigquery" / "__init__.py").write_text("")
+
+    def _multi_path(*args, **kwargs):
+        kwargs.setdefault("path", [str(dir_a), str(dir_b)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_multi_path))
+    # The no-RECORD directory scan is gated to verified Bazel runfiles dirs.
+    monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(
+        _p,
+        "get_package_distributions",
+        lambda: {"google": ["google-cloud-foo", "google-cloud-bar"]},
+    )
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # The ambiguous bare namespace root must not be attributed to one dist.
+    assert "google" not in mapping
+    # Path-aware sub-entries are still added by each dist's directory scan.
+    assert "google/cloud" in mapping and mapping["google/cloud"].name == "google-cloud-foo"
+    assert "google/bigquery" in mapping and mapping["google/bigquery"].name == "google-cloud-bar"
+
+
+def test_mixed_namespace_root_stripped_when_one_dist_lacks_top_level(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare namespace root must be stripped even if only one dist is visible.
+
+    A namespace dist can omit top_level.txt and so be absent from
+    packages_distributions(). Strategy 1 then resolves google to the
+    single visible dist, but the directory scan still discovers the second
+    dist's google/.... The bare root must be stripped (the namespace is
+    shared) so code provenance does not record one dist's path-blind google
+    dir under the other.
+    """
+    import importlib.metadata as importlib_metadata
+
+    dir_a = tmp_path / "a" / "site-packages"
+    dir_b = tmp_path / "b" / "site-packages"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+    # Visible to packages_distributions (declares top_level).
+    _write_dist_info_no_record(dir_a, "google-cloud-foo", "1.0", top_level="google")
+    (dir_a / "google" / "cloud").mkdir(parents=True)
+    (dir_a / "google" / "cloud" / "__init__.py").write_text("")
+    # Invisible to packages_distributions (no top_level.txt), found only by scan.
+    _write_dist_info_no_record(dir_b, "google-cloud-bar", "2.0", top_level=None)
+    (dir_b / "google" / "bigquery").mkdir(parents=True)
+    (dir_b / "google" / "bigquery" / "__init__.py").write_text("")
+
+    def _multi_path(*args, **kwargs):
+        kwargs.setdefault("path", [str(dir_a), str(dir_b)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_multi_path))
+    # The no-RECORD directory scan is gated to verified Bazel runfiles dirs.
+    monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+
+    from ddtrace.internal import packages as _p
+
+    # Only google-cloud-foo is reported (bar omitted top_level.txt).
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {"google": ["google-cloud-foo"]})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # Strategy 1 resolved only foo, but the scan proved the namespace shared.
+    assert "google" not in mapping
+    assert mapping["google/cloud"].name == "google-cloud-foo"
+    assert mapping["google/bigquery"].name == "google-cloud-bar"
+
+
+def test_record_backed_root_preserved_against_namespace_strip(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A RECORD-backed regular package owning a root must survive the strip.
+
+    If a RECORD-backed dist owns google/__init__.py (regular package) while
+    a no-RECORD Bazel dist also ships google/... as a namespace, the
+    namespace-root strip must not delete the RECORD-backed google mapping
+    (it was not a Strategy 1 fallback addition).
+    """
+    import importlib.metadata as importlib_metadata
+
+    dir_record = tmp_path / "record" / "site-packages"
+    dir_bazel = tmp_path / "bazel" / "site-packages"
+    dir_record.mkdir(parents=True)
+    dir_bazel.mkdir(parents=True)
+
+    # RECORD-backed regular package that owns "google".
+    di_reg = _write_dist_info(dir_record, "google-regular", "1.0")
+    (di_reg / "RECORD").write_text("google/__init__.py,,\n")
+    (dir_record / "google").mkdir()
+    (dir_record / "google" / "__init__.py").write_text("")
+
+    # No-RECORD Bazel namespace dist that also ships google/...
+    _write_dist_info_no_record(dir_bazel, "google-cloud-bar", "2.0", top_level=None)
+    (dir_bazel / "google" / "bigquery").mkdir(parents=True)
+    (dir_bazel / "google" / "bigquery" / "__init__.py").write_text("")
+
+    def _multi_path(*args, **kwargs):
+        kwargs.setdefault("path", [str(dir_record), str(dir_bazel)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_multi_path))
+    # The no-RECORD directory scan is gated to verified Bazel runfiles dirs.
+    monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # The RECORD-backed owner of "google" must be preserved, not stripped.
+    assert mapping["google"].name == "google-regular"
+    # The Bazel namespace dist's sub-entry is still mapped.
+    assert mapping["google/bigquery"].name == "google-cloud-bar"
+
+
+def test_no_record_regular_owner_preserved_against_namespace_strip(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A no-RECORD regular owner of a root must win over a shared namespace.
+
+    A no-RECORD regular dist owns google/__init__.py and declares
+    top_level.txt=google (so Strategy 1 maps google to it), while
+    another no-RECORD namespace dist ships google/bigquery without
+    top_level.txt. The bare google root must stay mapped to the regular
+    owner, not be stripped.
+    """
+    import importlib.metadata as importlib_metadata
+
+    dir_reg = tmp_path / "reg" / "site-packages"
+    dir_ns = tmp_path / "ns" / "site-packages"
+    dir_reg.mkdir(parents=True)
+    dir_ns.mkdir(parents=True)
+
+    # No-RECORD regular dist owning "google" (has __init__.py), declares top_level.
+    _write_dist_info_no_record(dir_reg, "google-regular", "1.0", top_level="google")
+    (dir_reg / "google").mkdir()
+    (dir_reg / "google" / "__init__.py").write_text("")
+
+    # No-RECORD namespace dist sharing "google", no top_level.txt.
+    _write_dist_info_no_record(dir_ns, "google-cloud-bar", "2.0", top_level=None)
+    (dir_ns / "google" / "bigquery").mkdir(parents=True)
+    (dir_ns / "google" / "bigquery" / "__init__.py").write_text("")
+
+    def _multi_path(*args, **kwargs):
+        kwargs.setdefault("path", [str(dir_reg), str(dir_ns)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_multi_path))
+    # The no-RECORD directory scan is gated to verified Bazel runfiles dirs.
+    monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+
+    from ddtrace.internal import packages as _p
+
+    # Only the regular dist declares top_level, so only it is visible here.
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {"google": ["google-regular"]})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # The regular owner of "google" must win the bare root.
+    assert mapping["google"].name == "google-regular"
+    # The namespace dist's sub-entry is still mapped path-aware.
+    assert mapping["google/bigquery"].name == "google-cloud-bar"
+
+
+def test_shared_intermediate_namespace_preserves_all_owners(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dists sharing an intermediate namespace level must each be mapped.
+
+    google-cloud-storage (google/cloud/storage) and
+    google-cloud-bigquery (google/cloud/bigquery) both live under the
+    google/cloud namespace. A one-level scan collapses both to
+    google/cloud and drops the second; the deep scan must key each concrete
+    package so every dist keeps a distinct entry.
+    """
+    import importlib.metadata as importlib_metadata
+
+    dir_storage = tmp_path / "storage" / "site-packages"
+    dir_bigquery = tmp_path / "bigquery" / "site-packages"
+    dir_storage.mkdir(parents=True)
+    dir_bigquery.mkdir(parents=True)
+
+    # google/ and google/cloud/ are namespaces (no __init__.py); the leaf is a
+    # concrete package.
+    _write_dist_info_no_record(dir_storage, "google-cloud-storage", "1.0", top_level=None)
+    (dir_storage / "google" / "cloud" / "storage").mkdir(parents=True)
+    (dir_storage / "google" / "cloud" / "storage" / "__init__.py").write_text("")
+    _write_dist_info_no_record(dir_bigquery, "google-cloud-bigquery", "2.0", top_level=None)
+    (dir_bigquery / "google" / "cloud" / "bigquery").mkdir(parents=True)
+    (dir_bigquery / "google" / "cloud" / "bigquery" / "__init__.py").write_text("")
+
+    def _multi_path(*args, **kwargs):
+        kwargs.setdefault("path", [str(dir_storage), str(dir_bigquery)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_multi_path))
+    # The no-RECORD directory scan is gated to verified Bazel runfiles dirs.
+    monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # Both concrete leaves must be mapped to their own distribution.
+    assert mapping["google/cloud/storage"].name == "google-cloud-storage"
+    assert mapping["google/cloud/bigquery"].name == "google-cloud-bigquery"
+    # The shared bare top-level namespace must not be mapped to a single dist.
+    assert "google" not in mapping
+
+
+def test_filename_to_package_resolves_shared_intermediate_namespace(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end lookup must attribute each shared-namespace file correctly.
+
+    The regression that kept recurring: the directory scan stores deep keys
+    (google/cloud/storage / google/cloud/bigquery) but _root_module
+    only yields the fixed 2-level key google/cloud, so filename_to_package
+    resolved every google/cloud/... file to whichever dist was scanned
+    first. With longest-prefix matching each file resolves to its own dist.
+    """
+    from ddtrace.internal import packages as _p
+
+    # Lay both dists under a common site-packages parent so the Bazel
+    # runfiles heuristic in _relative_to_known_root resolves the files.
+    sp = tmp_path / "runfiles" / "site-packages"
+    sp.mkdir(parents=True)
+    (sp / "google" / "cloud" / "storage").mkdir(parents=True)
+    (sp / "google" / "cloud" / "storage" / "__init__.py").write_text("")
+    (sp / "google" / "cloud" / "storage" / "blob.py").write_text("")
+    (sp / "google" / "cloud" / "bigquery").mkdir(parents=True)
+    (sp / "google" / "cloud" / "bigquery" / "__init__.py").write_text("")
+    (sp / "google" / "cloud" / "bigquery" / "client.py").write_text("")
+
+    mapping = {
+        "google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0"),
+        "google/cloud/bigquery": _p.Distribution(name="google-cloud-bigquery", version="2.0"),
+    }
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    _p.filename_to_package.cache_clear()
+
+    storage_pkg = _p.filename_to_package(sp / "google" / "cloud" / "storage" / "blob.py")
+    bigquery_pkg = _p.filename_to_package(sp / "google" / "cloud" / "bigquery" / "client.py")
+
+    assert storage_pkg is not None and storage_pkg.name == "google-cloud-storage"
+    assert bigquery_pkg is not None and bigquery_pkg.name == "google-cloud-bigquery"
+
+    _p.filename_to_package.cache_clear()
+
+
+def test_filename_to_package_does_not_attribute_source_roots_to_dependency(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deep prefix matching must not leak dependency namespaces onto user code.
+
+    In Bazel a binary's own source/workspace roots are on sys.path too. A
+    user file <workspace>/google/cloud/storage/app.py shares the namespace
+    prefix of a google-cloud-storage dependency, but it is NOT under a
+    site-packages root, so it must resolve to user code (None), not the
+    dependency.
+    """
+    from ddtrace.internal import packages as _p
+
+    workspace = tmp_path / "workspace"
+    (workspace / "google" / "cloud" / "storage").mkdir(parents=True)
+    (workspace / "google" / "cloud" / "storage" / "app.py").write_text("")
+
+    mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    # The workspace root is on sys.path, mirroring a Bazel py_binary.
+    monkeypatch.setattr(_p, "resolve_sys_path", lambda: [workspace])
+    _p.filename_to_package.cache_clear()
+
+    pkg = _p.filename_to_package(workspace / "google" / "cloud" / "storage" / "app.py")
+
+    assert pkg is None
+
+    _p.filename_to_package.cache_clear()
 
 
 def test_directory_scan_skipped_outside_bazel_runfiles(
@@ -304,6 +709,52 @@ def test_bazel_manifest_parses_escaped_entries(
     assert _p._is_bazel_runfiles_dir(sp)
 
 
+def test_strategy1_skips_bare_namespace_root_when_scan_skipped(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A no-RECORD namespace top-level must not be pinned by Strategy 1 alone.
+
+    Outside Bazel the directory scan (Strategy 2) is skipped, so the
+    reconciliation that strips shared namespace roots never runs. If a single
+    namespace dist is the only one packages_distributions() reports (a
+    sibling omits top_level.txt), Strategy 1 must itself refrain from
+    pinning the bare google root -- otherwise the longest-prefix lookup
+    would attribute the sibling's google/<other>/... files to this dist.
+    """
+    import importlib.metadata as importlib_metadata
+
+    sp = tmp_path / "site-packages"
+    sp.mkdir(parents=True)
+    # Declares top_level "google" but ships only google/cloud; "google" itself
+    # is a namespace (no __init__.py).
+    _write_dist_info_no_record(sp, "google-cloud-foo", "1.0", top_level="google")
+    (sp / "google" / "cloud").mkdir(parents=True)
+    (sp / "google" / "cloud" / "__init__.py").write_text("")
+
+    def _fixed(*args, **kwargs):
+        kwargs.setdefault("path", [str(sp)])
+        return importlib_metadata.MetadataPathFinder.find_distributions(
+            importlib_metadata.DistributionFinder.Context(**kwargs)
+        )
+
+    monkeypatch.setattr(importlib_metadata.Distribution, "discover", staticmethod(_fixed))
+    # Deliberately NOT in Bazel: Strategy 2 scan is skipped.
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.delenv("RUNFILES_MANIFEST_FILE", raising=False)
+
+    from ddtrace.internal import packages as _p
+
+    monkeypatch.setattr(_p, "get_package_distributions", lambda: {"google": ["google-cloud-foo"]})
+
+    mapping = _p._package_for_root_module_mapping()
+
+    assert mapping is not None
+    # The bare namespace root must not be pinned to the single reporting dist.
+    assert "google" not in mapping
+
+
 def test_scan_skips_lone_unrelated_dist_info(
     isolated_metadata_path: Path,
     reset_packages_caches,
@@ -373,79 +824,6 @@ def test_none_distribution_name_is_tolerated(
     assert mapping is not None
     assert mapping.get("good_bazel_pkg") is not None
     assert mapping["good_bazel_pkg"].name == "good-bazel-pkg"
-
-
-def test_filename_to_package_resolves_shared_intermediate_namespace(
-    tmp_path: Path,
-    reset_packages_caches,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """End-to-end lookup must attribute each shared-namespace file correctly.
-
-    The regression that kept recurring: the directory scan stores deep keys
-    (google/cloud/storage / google/cloud/bigquery) but _root_module
-    only yields the fixed 2-level key google/cloud, so filename_to_package
-    resolved every google/cloud/... file to whichever dist was scanned
-    first. With longest-prefix matching, each file resolves to its own dist.
-    """
-    from ddtrace.internal import packages as _p
-
-    # Lay both dists under a common ``site-packages`` parent so the Bazel
-    # runfiles heuristic in _relative_to_known_root resolves the files.
-    sp = tmp_path / "runfiles" / "site-packages"
-    sp.mkdir(parents=True)
-    (sp / "google" / "cloud" / "storage").mkdir(parents=True)
-    (sp / "google" / "cloud" / "storage" / "__init__.py").write_text("")
-    (sp / "google" / "cloud" / "storage" / "blob.py").write_text("")
-    (sp / "google" / "cloud" / "bigquery").mkdir(parents=True)
-    (sp / "google" / "cloud" / "bigquery" / "__init__.py").write_text("")
-    (sp / "google" / "cloud" / "bigquery" / "client.py").write_text("")
-
-    mapping = {
-        "google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0"),
-        "google/cloud/bigquery": _p.Distribution(name="google-cloud-bigquery", version="2.0"),
-    }
-    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
-    _p.filename_to_package.cache_clear()
-
-    storage_pkg = _p.filename_to_package(sp / "google" / "cloud" / "storage" / "blob.py")
-    bigquery_pkg = _p.filename_to_package(sp / "google" / "cloud" / "bigquery" / "client.py")
-
-    assert storage_pkg is not None and storage_pkg.name == "google-cloud-storage"
-    assert bigquery_pkg is not None and bigquery_pkg.name == "google-cloud-bigquery"
-
-    _p.filename_to_package.cache_clear()
-
-
-def test_filename_to_package_does_not_attribute_source_roots_to_dependency(
-    tmp_path: Path,
-    reset_packages_caches,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Deep prefix matching must not leak dependency namespaces onto user code.
-
-    In Bazel a binary's own source/workspace roots are on sys.path too. A
-    user file <workspace>/google/cloud/storage/app.py shares the namespace
-    prefix of a google-cloud-storage dependency, but it is not under a
-    site-packages root, so it must resolve to user code.
-    """
-    from ddtrace.internal import packages as _p
-
-    workspace = tmp_path / "workspace"
-    (workspace / "google" / "cloud" / "storage").mkdir(parents=True)
-    (workspace / "google" / "cloud" / "storage" / "app.py").write_text("")
-
-    mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
-    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
-    # The workspace root is on sys.path, mirroring a Bazel py_binary.
-    monkeypatch.setattr(_p, "resolve_sys_path", lambda: [workspace])
-    _p.filename_to_package.cache_clear()
-
-    pkg = _p.filename_to_package(workspace / "google" / "cloud" / "storage" / "app.py")
-
-    assert pkg is None
-
-    _p.filename_to_package.cache_clear()
 
 
 def test_filename_to_package_resolves_namespace_on_non_site_packages_install_root(
@@ -565,7 +943,7 @@ def test_get_distributions_skips_bad_dist_warns_once_returns_partial_map(
 ) -> None:
     """Single load-bearing test. Asserts:
 
-    1. The function does not raise on a malformed dist (so ``@callonce``
+    1. The function does not raise on a malformed dist (so @callonce
        caches a *result*, not an exception — the regression that produced
        the customer's per-module log spam).
     2. The good dist is still returned (partial-map behavior).
@@ -601,9 +979,9 @@ def test_package_for_root_module_mapping_skips_bad_dist(
     reset_packages_caches,
     strict_metadata_getitem,
 ) -> None:
-    """The pre-fix top-level ``try/except`` collapsed the entire mapping to
-    ``None`` on one bad dist, silently making ``filename_to_package`` /
-    ``is_third_party`` fall back to "everything is user code" for the rest
+    """The pre-fix top-level try/except collapsed the entire mapping to
+    None on one bad dist, silently making filename_to_package /
+    is_third_party fall back to "everything is user code" for the rest
     of the process. Per-dist tolerance keeps the mapping intact.
     """
     di_good = _write_dist_info(isolated_metadata_path, "good-pkg", "1.0")


### PR DESCRIPTION
## Description

Depends on https://github.com/DataDog/dd-trace-py/pull/18812 | [Next PR](https://github.com/DataDog/dd-trace-py/pull/18815) |  [stack is #18813 / #18812 / #18814 / #18815]

Namespace distributions (e.g. multiple google-cloud-* dists) share a bare top-level (google) and intermediate levels (google/cloud), so pinning the bare root to a single dist misattributes a sibling's files. Never map a bare namespace root; instead descend through nested namespace dirs and map each concrete leaf to its own dist (_add_namespace_subentries), so the longest-prefix lookup resolves each file correctly. Reconcile Strategy 1's guesses against the directory scan: a regular owner keeps the root, a pure shared namespace is stripped, RECORD-backed owners are left untouched.