### PR TITLE
feat(profiling): support code provenance for Bazel applications

### DIFF
--- a/ddtrace/internal/datadog/profiling/code_provenance.py
+++ b/ddtrace/internal/datadog/profiling/code_provenance.py
@@ -11,6 +11,7 @@ import typing as t
 
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.packages import Distribution
+from ddtrace.internal.packages import _is_bazel_runfiles_dir
 from ddtrace.internal.packages import _package_for_root_module_mapping
 from ddtrace.internal.settings import env
 
@@ -30,6 +31,9 @@ class Library:
 
     def to_dict(self) -> dict[str, t.Any]:
         return {"kind": self.kind, "name": self.name, "version": self.version, "paths": list(self.paths)}
+
+    def __repr__(self) -> str:
+        return f"Library(kind={self.kind}, name={self.name}, version={self.version}, paths={self.paths})"
 
 
 class CodeProvenance:
@@ -86,6 +90,30 @@ class CodeProvenance:
         libraries: dict[str, Library] = {}
 
         site_packages = Path(sysconfig.get_path("purelib"))
+        # In Bazel py_binary/py_test targets, packages live in isolated
+        # per-package site-packages dirs rather than the single purelib, so
+        # we need to search sys.path. We gate this on a Bazel-specific env var
+        # to avoid affecting non-Bazel environments.
+        _in_bazel = bool(env.get("RUNFILES_DIR") or env.get("RUNFILES_MANIFEST_FILE"))
+        # Only consider dependency site-packages dirs *inside the Bazel runfiles
+        # tree*, not arbitrary sys.path entries. Bazel puts each dependency in an
+        # isolated ``<runfiles>/<dist>/site-packages`` dir (the same layout
+        # assumed by packages._root_module). Two kinds of unrelated entries must
+        # be excluded, both of which can appear ahead of the runfiles dirs and
+        # would otherwise win the first-match lookup below:
+        #   - workspace/source roots (basename filter handles these), and
+        #   - a host/virtualenv site-packages: a dependency present both there
+        #     and in runfiles (e.g. requests) would get the host path recorded,
+        #     which never matches the runfiles frames in the profile.
+        # ``_is_bazel_runfiles_dir`` also recognizes manifest-mode runfiles
+        # (``RUNFILES_MANIFEST_FILE`` without ``RUNFILES_DIR``), where the real
+        # dependency dirs can live outside any ``*.runfiles`` tree.
+        _sys_path_dirs = (
+            [p for p in (Path(s) for s in sys.path if s) if p.name == "site-packages" and _is_bazel_runfiles_dir(p)]
+            if _in_bazel
+            else []
+        )
+
         for module, dist in module_to_distribution.items():
             name = dist.name
             # special case for __pycache__/filename.cpython-3xx.pyc -> filename.py
@@ -100,8 +128,39 @@ class CodeProvenance:
             # We assume that each module is a directory or a python file
             # relative to site-packages/ directory.
             module_path = site_packages / module
-            if module.endswith(".py") or module_path.is_dir():
-                lib.paths.add(str(module_path))
+            is_py = module.endswith(".py")
+            if not _in_bazel:
+                # Standard layout: the package lives in the single purelib dir.
+                # We keep recording the purelib path for .py modules even if a
+                # stat fails, preserving the original behavior.
+                if is_py or module_path.is_dir():
+                    lib.paths.add(str(module_path))
+            else:
+                # In Bazel runfiles each package lives in its own isolated
+                # site-packages dir rather than the single purelib. Profiles
+                # from the Bazel binary contain runfiles paths, so we must
+                # prefer the sys.path (runfiles) location even when the same
+                # module name also exists in the host purelib (the shadowed
+                # dependency case this feature targets) -- otherwise the
+                # recorded purelib path never matches the profile frames.
+                # Search sys.path first, including single-file modules (e.g.
+                # six.py) whose purelib path does not exist.
+                found = False
+                for base in _sys_path_dirs:
+                    candidate = base / module
+                    if candidate.is_dir() or (is_py and candidate.is_file()):
+                        lib.paths.add(str(candidate))
+                        found = True
+                        break
+                    if not is_py:
+                        candidate_py = base / (module + ".py")
+                        if candidate_py.is_file():
+                            lib.paths.add(str(candidate_py))
+                            found = True
+                            break
+                # Fall back to the host purelib only when runfiles has nothing.
+                if not found and (module_path.is_dir() or (is_py and module_path.is_file())):
+                    lib.paths.add(str(module_path))
 
         # If the user installed their code like a library and is running it as
         # the main package (python -m my_package), and they explicitly specified
@@ -132,9 +191,52 @@ def _safe_mtime_ns(path: t.Optional[str]) -> str:
         return ""
 
 
+def _bazel_runfiles_fingerprint() -> str:
+    """Fingerprint the Bazel runfiles site-packages dirs.
+
+    A Bazel target rebuilt in place keeps the same ``sys.path`` strings while
+    its dependency set / dist-info contents change, so the sys.path hash alone
+    would happily serve a stale ``code-provenance.json`` from a previous build.
+    Fold in each runfiles ``site-packages`` dir's mtime plus the names of its
+    ``.dist-info`` dirs so a rebuild yields a distinct cache file.
+
+    Returns an ASCII hex digest (or "" outside Bazel, contributing nothing).
+    """
+    if not (env.get("RUNFILES_DIR") or env.get("RUNFILES_MANIFEST_FILE")):
+        return ""
+    h = hashlib.sha256()
+    for p in sys.path:
+        if not p or Path(p).name != "site-packages":
+            continue
+        # os.fsencode keeps undecodable (surrogate-escaped) paths from raising.
+        h.update(os.fsencode(p))
+        h.update(b"\x00")
+        h.update(_safe_mtime_ns(p).encode("ascii"))
+        h.update(b"\x00")
+        try:
+            for name in sorted(c.name for c in Path(p).iterdir() if c.suffix == ".dist-info"):
+                h.update(os.fsencode(name))
+                h.update(b"\x00")
+        except OSError:
+            pass
+    return h.hexdigest()
+
+
 def _cache_basename() -> str:
     purelib = sysconfig.get_path("purelib")
     main_package = env.get("DD_MAIN_PACKAGE", "")
+    # Include a stable hash of sys.path so that Bazel py_binary targets with
+    # different runfiles directories (same interpreter/prefix, different paths)
+    # get distinct cache files and don't serve stale provenance to each other.
+    # Preserve sys.path order: the provenance builder searches it in order and
+    # stops at the first match, so two targets with the same entries in a
+    # different order can resolve different files and must not share a cache.
+    # Resolve every entry to an absolute cwd-anchored path: '' (the default
+    # current-directory entry) and other relative entries can still surface
+    # cwd-local distributions, so two processes that differ only by cwd must not
+    # share a cache basename. os.path.abspath('') yields the cwd; os.fsencode
+    # keeps undecodable (surrogate-escaped) entries from raising UnicodeEncodeError.
+    sys_path_hash = hashlib.sha256(b"\x00".join(os.fsencode(os.path.abspath(p)) for p in sys.path)).hexdigest()
     data = "\x00".join(
         (
             _CODE_PROVENANCE_CACHE_VERSION,
@@ -142,6 +244,8 @@ def _cache_basename() -> str:
             sys.prefix,
             main_package,
             _safe_mtime_ns(purelib),
+            sys_path_hash,
+            _bazel_runfiles_fingerprint(),
         )
     )
     digest = hashlib.sha256(data.encode("utf-8")).hexdigest()

--- a/releasenotes/notes/profiling-code-provenance-for-bazel-9fe7eb84797fffbb.yaml
+++ b/releasenotes/notes/profiling-code-provenance-for-bazel-9fe7eb84797fffbb.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Profiling: Code Provenance ("My Code" feature) is now supported for more distribution strategies,
+    specifically for Bazel rules-based applications.

--- a/tests/internal/test_packages_resilience.py
+++ b/tests/internal/test_packages_resilience.py
@@ -709,6 +709,85 @@ def test_bazel_manifest_parses_escaped_entries(
     assert _p._is_bazel_runfiles_dir(sp)
 
 
+def test_manifest_records_innermost_site_packages_root(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An outer dir named site-packages must not shadow the real dependency root.
+
+    When a manifest real path contains an earlier "/site-packages/" component
+    before the actual dependency root (e.g.
+    ".../site-packages/workspace/.../dep/site-packages/pkg.py"), recording only
+    the first marker points the gate at the wrong directory and the dependency
+    scan is skipped. Every candidate root must be recorded so the innermost
+    dependency site-packages is recognized too.
+    """
+    inner_sp = tmp_path / "site-packages" / "workspace" / "dep" / "site-packages"
+    inner_sp.mkdir(parents=True)
+    target = inner_sp / "pkg" / "__init__.py"
+    target.parent.mkdir()
+    target.write_text("")
+
+    manifest = tmp_path / "app.runfiles_manifest"
+    manifest.write_text(f"app/pkg/__init__.py {target}\n")
+
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.setenv("RUNFILES_MANIFEST_FILE", str(manifest))
+
+    from ddtrace.internal import packages as _p
+
+    roots = _p._bazel_manifest_site_packages()
+
+    # Both the outer and the innermost site-packages markers are recorded.
+    assert str((tmp_path / "site-packages").resolve()) in roots
+    assert str(inner_sp.resolve()) in roots
+    # The gate must accept the innermost (real) dependency site-packages.
+    assert _p._is_bazel_runfiles_dir(inner_sp)
+
+
+def test_manifest_accepts_venv_symlinked_site_packages(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A binary-venv site-packages of symlinks into the real root is accepted.
+
+    rules_python can expose deps through a venv whose site-packages entries are
+    symlinks into the real repository site-packages. importlib.metadata then
+    discovers the dist under the (non-symlink) venv dir, which is absent from
+    the manifest's real-path roots. The gate must follow a symlinked entry to
+    its real parent and still recognize the venv dir as a runfiles dependency
+    dir, otherwise the no-RECORD scan is skipped and those packages stay
+    unresolved.
+    """
+    real_sp = tmp_path / "repo" / "site-packages"
+    real_pkg = real_sp / "pkg"
+    real_pkg.mkdir(parents=True)
+    (real_pkg / "__init__.py").write_text("")
+
+    # Virtual venv site-packages: a real dir whose entry symlinks into real_sp.
+    venv_sp = tmp_path / "venv" / "site-packages"
+    venv_sp.mkdir(parents=True)
+    (venv_sp / "pkg").symlink_to(real_pkg, target_is_directory=True)
+
+    manifest = tmp_path / "app.runfiles_manifest"
+    manifest.write_text(f"app/pkg/__init__.py {real_pkg / '__init__.py'}\n")
+
+    monkeypatch.delenv("RUNFILES_DIR", raising=False)
+    monkeypatch.setenv("RUNFILES_MANIFEST_FILE", str(manifest))
+
+    from ddtrace.internal import packages as _p
+
+    roots = _p._bazel_manifest_site_packages()
+
+    # Only the real site-packages is a manifest root; the venv dir is not.
+    assert str(real_sp.resolve()) in roots
+    assert str(venv_sp.resolve()) not in roots
+    # ...but the gate must still accept the venv dir via the symlinked entry.
+    assert _p._is_bazel_runfiles_dir(venv_sp)
+
+
 def test_strategy1_skips_bare_namespace_root_when_scan_skipped(
     tmp_path: Path,
     reset_packages_caches,

--- a/tests/profiling/test_code_provenance.py
+++ b/tests/profiling/test_code_provenance.py
@@ -262,3 +262,258 @@ class TestCodeProvenance:
         key_with_main_package = code_provenance._cache_basename()
 
         assert key_without_main_package != key_with_main_package
+
+    def test_cache_key_changes_with_sys_path_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Bazel targets can share entries in a different order; since the
+        # provenance builder stops at the first match, the cache key must
+        # depend on order, not just the set of entries.
+        from ddtrace.internal.datadog.profiling import code_provenance
+
+        monkeypatch.setattr(sys, "path", ["/a", "/b", "/c"])
+        key_one = code_provenance._cache_basename()
+        monkeypatch.setattr(sys, "path", ["/c", "/b", "/a"])
+        key_two = code_provenance._cache_basename()
+
+        assert key_one != key_two
+
+    def test_cache_key_changes_with_bazel_runfiles_contents(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A Bazel target rebuilt in place keeps the same sys.path strings while
+        # its dependency set changes. The cache key must fold in the runfiles
+        # site-packages contents so a rebuild does not serve stale provenance.
+        from ddtrace.internal.datadog.profiling import code_provenance
+
+        sp = tmp_path / "dep" / "site-packages"
+        sp.mkdir(parents=True)
+        (sp / "foo-1.0.dist-info").mkdir()
+
+        monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+        monkeypatch.setattr(sys, "path", [str(sp)])
+
+        key_before = code_provenance._cache_basename()
+        # Simulate a rebuild that swaps in a different dependency version.
+        (sp / "foo-1.0.dist-info").rmdir()
+        (sp / "foo-2.0.dist-info").mkdir()
+        key_after = code_provenance._cache_basename()
+
+        assert key_before != key_after
+
+    def test_cache_key_tolerates_undecodable_sys_path_entry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Non-UTF-8 path bytes surface as surrogate escapes in sys.path; the
+        # cache hash must use os.fsencode so it does not raise UnicodeEncodeError
+        # and break the profiling upload path.
+        from ddtrace.internal.datadog.profiling import code_provenance
+
+        monkeypatch.delenv("RUNFILES_DIR", raising=False)
+        monkeypatch.delenv("RUNFILES_MANIFEST_FILE", raising=False)
+        monkeypatch.setattr(sys, "path", ["/weird/\udcff/path", "/normal"])
+
+        key = code_provenance._cache_basename()
+
+        assert key.startswith(code_provenance._CODE_PROVENANCE_CACHE_PREFIX)
+
+    def test_bazel_ignores_host_site_packages_outside_runfiles(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A host/virtualenv site-packages can sit on sys.path ahead of the Bazel
+        # runfiles dirs. A dependency present in both (e.g. requests) must be
+        # recorded from runfiles, not the host path -- the profile frames live
+        # under runfiles and would never match a host path.
+        from ddtrace.internal.datadog.profiling import code_provenance
+        from ddtrace.internal.packages import Distribution
+
+        runfiles_root = tmp_path / "app.runfiles"
+        runfiles_sp = runfiles_root / "dep" / "site-packages"
+        (runfiles_sp / "requests").mkdir(parents=True)
+        (runfiles_sp / "requests" / "__init__.py").write_text("")
+
+        # Host venv site-packages, NOT under the runfiles tree.
+        host_sp = tmp_path / "venv" / "site-packages"
+        (host_sp / "requests").mkdir(parents=True)
+        (host_sp / "requests" / "__init__.py").write_text("")
+
+        monkeypatch.setattr(
+            code_provenance,
+            "_package_for_root_module_mapping",
+            lambda: {"requests": Distribution(name="requests", version="2.0")},
+        )
+        monkeypatch.setenv("RUNFILES_DIR", str(runfiles_root))
+        # Host site-packages deliberately first on sys.path.
+        monkeypatch.setattr(sys, "path", [str(host_sp), str(runfiles_sp)])
+
+        cp = code_provenance.CodeProvenance()
+        libs = {lib.name: lib for lib in cp.libraries}
+
+        assert "requests" in libs
+        assert libs["requests"].paths == {str(runfiles_sp / "requests")}
+
+    def test_bazel_fallback_resolves_single_file_module(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # In Bazel runfiles a single-file dependency such as six.py lives in an
+        # isolated per-package dir on sys.path, not in purelib. The fallback
+        # must locate it there instead of recording a non-existent purelib path.
+        from ddtrace.internal.datadog.profiling import code_provenance
+        from ddtrace.internal.packages import Distribution
+
+        bazel_dir = tmp_path / "runfiles" / "uniqbazelmod" / "site-packages"
+        bazel_dir.mkdir(parents=True)
+        module_file = bazel_dir / "uniqbazelmod.py"
+        module_file.write_text("")
+
+        monkeypatch.setattr(
+            code_provenance,
+            "_package_for_root_module_mapping",
+            lambda: {"uniqbazelmod.py": Distribution(name="uniqbazelmod", version="1.0")},
+        )
+        monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+        monkeypatch.setattr(sys, "path", [str(bazel_dir)])
+
+        cp = code_provenance.CodeProvenance()
+        libs = {lib.name: lib for lib in cp.libraries}
+
+        assert "uniqbazelmod" in libs
+        assert libs["uniqbazelmod"].paths == {str(module_file)}
+
+    def test_bazel_prefers_runfiles_over_shadowing_purelib(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When a dependency exists both in the host purelib and in the Bazel
+        # runfiles (the shadowed-dependency case this feature targets), profiles
+        # contain the runfiles path, so the recorded path must be the runfiles
+        # one -- not the host purelib path that would never match the frames.
+        import sysconfig as _sysconfig
+
+        from ddtrace.internal.datadog.profiling import code_provenance
+        from ddtrace.internal.packages import Distribution
+
+        fake_purelib = tmp_path / "purelib"
+        (fake_purelib / "shadowedmod").mkdir(parents=True)
+        (fake_purelib / "shadowedmod" / "__init__.py").write_text("")
+
+        runfiles_dir = tmp_path / "runfiles" / "shadowedmod" / "site-packages"
+        (runfiles_dir / "shadowedmod").mkdir(parents=True)
+        (runfiles_dir / "shadowedmod" / "__init__.py").write_text("")
+
+        real_get_path = _sysconfig.get_path
+
+        def _get_path(name: str, *args: Any, **kwargs: Any) -> str:
+            if name == "purelib":
+                return str(fake_purelib)
+            return real_get_path(name, *args, **kwargs)
+
+        monkeypatch.setattr(code_provenance.sysconfig, "get_path", _get_path)
+        monkeypatch.setattr(
+            code_provenance,
+            "_package_for_root_module_mapping",
+            lambda: {"shadowedmod": Distribution(name="shadowedmod", version="1.0")},
+        )
+        monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+        monkeypatch.setattr(sys, "path", [str(runfiles_dir)])
+
+        cp = code_provenance.CodeProvenance()
+        libs = {lib.name: lib for lib in cp.libraries}
+
+        assert "shadowedmod" in libs
+        assert libs["shadowedmod"].paths == {str(runfiles_dir / "shadowedmod")}
+
+    def test_bazel_ignores_non_site_packages_sys_path_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Bazel sys.path includes workspace/source roots, often ahead of the
+        # dependency site-packages dirs. A user-code package that merely shares
+        # a name with an installed dist must not get its source-root path
+        # recorded as a library path (that would misclassify "my code" frames).
+        # Only dependency ".../site-packages/<pkg>" dirs should be searched.
+        from ddtrace.internal.datadog.profiling import code_provenance
+        from ddtrace.internal.packages import Distribution
+
+        # A workspace/source root (NOT site-packages) holding same-named code.
+        source_root = tmp_path / "workspace"
+        (source_root / "depmod").mkdir(parents=True)
+        (source_root / "depmod" / "__init__.py").write_text("")
+
+        # The actual dependency lives in an isolated runfiles site-packages dir.
+        runfiles_dir = tmp_path / "runfiles" / "depmod" / "site-packages"
+        (runfiles_dir / "depmod").mkdir(parents=True)
+        (runfiles_dir / "depmod" / "__init__.py").write_text("")
+
+        monkeypatch.setattr(
+            code_provenance,
+            "_package_for_root_module_mapping",
+            lambda: {"depmod": Distribution(name="depmod", version="1.0")},
+        )
+        monkeypatch.setenv("RUNFILES_DIR", str(tmp_path))
+        # Source root deliberately ahead of the dependency site-packages dir.
+        monkeypatch.setattr(sys, "path", [str(source_root), str(runfiles_dir)])
+
+        cp = code_provenance.CodeProvenance()
+        libs = {lib.name: lib for lib in cp.libraries}
+
+        assert "depmod" in libs
+        assert libs["depmod"].paths == {str(runfiles_dir / "depmod")}
+
+    def test_bazel_manifest_mode_resolves_dependency_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Manifest mode: only RUNFILES_MANIFEST_FILE is set (no RUNFILES_DIR),
+        # and the dependency site-packages can live outside any *.runfiles tree.
+        # The dependency path must still be recorded from sys.path (resolved via
+        # the manifest) rather than falling back to the host purelib, which
+        # would leave the profile frames classified as user code.
+        from ddtrace.internal import packages
+        from ddtrace.internal.datadog.profiling import code_provenance
+        from ddtrace.internal.packages import Distribution
+
+        dep_sp = tmp_path / "execroot" / "dep" / "site-packages"
+        (dep_sp / "manifestmod").mkdir(parents=True)
+        (dep_sp / "manifestmod" / "__init__.py").write_text("")
+
+        manifest = tmp_path / "app.runfiles_manifest"
+        manifest.write_text(f"app/manifestmod/__init__.py {dep_sp / 'manifestmod' / '__init__.py'}\n")
+
+        # Clear the cached manifest parse so this test's manifest is read.
+        inner = getattr(packages._bazel_manifest_site_packages, "__wrapped__", None)
+        if inner is not None and hasattr(inner, "__callonce_result__"):
+            del inner.__callonce_result__
+
+        monkeypatch.setattr(
+            code_provenance,
+            "_package_for_root_module_mapping",
+            lambda: {"manifestmod": Distribution(name="manifestmod", version="1.0")},
+        )
+        monkeypatch.delenv("RUNFILES_DIR", raising=False)
+        monkeypatch.setenv("RUNFILES_MANIFEST_FILE", str(manifest))
+        monkeypatch.setattr(sys, "path", [str(dep_sp)])
+
+        try:
+            cp = code_provenance.CodeProvenance()
+            libs = {lib.name: lib for lib in cp.libraries}
+
+            assert "manifestmod" in libs
+            assert libs["manifestmod"].paths == {str(dep_sp / "manifestmod")}
+        finally:
+            if inner is not None and hasattr(inner, "__callonce_result__"):
+                del inner.__callonce_result__
+
+    def test_cache_basename_distinguishes_cwd_for_relative_sys_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When sys.path holds '' (Python's default cwd entry) or other relative
+        # entries, two processes that differ only by cwd can still import
+        # different cwd-local packages. The cache basename must therefore differ
+        # between cwds, or the second process serves a stale code-provenance.json.
+        from ddtrace.internal.datadog.profiling import code_provenance
+
+        monkeypatch.setattr(sys, "path", [""])
+
+        cwd_a = tmp_path / "a"
+        cwd_b = tmp_path / "b"
+        cwd_a.mkdir()
+        cwd_b.mkdir()
+
+        monkeypatch.chdir(cwd_a)
+        basename_a = code_provenance._cache_basename()
+        monkeypatch.chdir(cwd_b)
+        basename_b = code_provenance._cache_basename()
+
+        assert basename_a != basename_b


### PR DESCRIPTION
## Description

Depends on https://github.com/DataDog/dd-trace-py/pull/18814.  [stack is #18813 / #18812 / #18814 / #18815]

In Bazel py_binary/py_test targets each dependency lives in an isolated runfiles site-packages dir rather than the single purelib, and profiles contain the runfiles paths. Prefer the sys.path (runfiles) location over a shadowing host purelib when recording library paths, restricted to verified runfiles dirs. Fold sys.path (order-preserving, cwd-anchored) and a runfiles site-packages fingerprint into the cache basename so targets that share an interpreter but differ in runfiles, or are rebuilt in place, do not serve each other stale code-provenance.json.