### PR TITLE
bench(profiling): 8-way set-associative Echion frame cache (DoE arm) [DO NOT MERGE]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -7,10 +7,25 @@
 
 #include <echion/cache.h>
 #include <echion/frame.h>
+#include <echion/set_assoc_cache.h>
 #include <echion/strings.h>
 #include <echion/threads.h>
 
 #include "stack_renderer.hpp"
+
+// DoE switch (dd-trace-py#18301 follow-up): select the frame-cache container.
+// Defined here so this bench branch's wheel uses the custom set-associative
+// cache; comment out the next line to fall back to the upstream LRUCache
+// (std::list + std::unordered_map) baseline.
+#define ECHION_FRAME_CACHE_SETASSOC 1
+
+#ifdef ECHION_FRAME_CACHE_SETASSOC
+template<typename K, typename V>
+using FrameCacheImpl = SetAssocCache<K, V>;
+#else
+template<typename K, typename V>
+using FrameCacheImpl = LRUCache<K, V>;
+#endif
 
 // Forward declaration
 class Frame;
@@ -55,7 +70,7 @@ class EchionSampler
 
     // Caches
     StringTable string_table_;
-    LRUCache<uintptr_t, Frame> frame_cache_;
+    FrameCacheImpl<uintptr_t, Frame> frame_cache_;
 
     // Stack renderer for outputting samples
     Datadog::StackRenderer renderer_;
@@ -105,7 +120,7 @@ class EchionSampler
     const StringTable& string_table() const { return string_table_; }
 
     // Accessor for frame cache operations
-    LRUCache<uintptr_t, Frame>& frame_cache() { return frame_cache_; }
+    FrameCacheImpl<uintptr_t, Frame>& frame_cache() { return frame_cache_; }
 
     void postfork_child()
     {

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/set_assoc_cache.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/set_assoc_cache.h
@@ -1,0 +1,154 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <new>
+#include <vector>
+
+#include <echion/errors.h>
+
+// SetAssocCache is a drop-in replacement for LRUCache (see cache.h) that
+// trades the std::list + std::unordered_map (LRU) implementation for a flat,
+// fixed-capacity, N-way set-associative array.
+//
+// Motivation: the LRU cache allocates a std::list node AND an unordered_map
+// node for every stored entry, and performs a list splice on every hit. A DoE
+// on the heap profiler's analogous code cache (dd-trace-py#18301) showed that a
+// custom set-associative cache substantially out-performs both std::unordered_map
+// and a list+map LRU on repetitive-stack workloads. This header brings the same
+// design to Echion's frame cache so the two can be compared head-to-head.
+//
+// Organization: sets are indexed by a Fibonacci hash of the key; within a set,
+// the WAYS slots are linearly scanned. On a set-full insert, FIFO eviction
+// overwrites the next_evict slot. Values are held in std::unique_ptr<V> exactly
+// like LRUCache, so references returned by lookup()/store() stay valid until the
+// owning slot is overwritten -- callers copy out immediately (FrameStack owns
+// its Frames), so transient validity is sufficient.
+//
+// Concurrency: like LRUCache, this is used single-threaded by the sampling
+// thread; no internal locking.
+template<typename K, typename V>
+class SetAssocCache
+{
+  public:
+    // Number of slots per set (associativity). 8-way (vs the #18301 2-way) to
+    // cut conflict misses on the stack profiler's deep-frame working set, where
+    // many hot keys can otherwise collide into the same 2-slot set and evict
+    // each other despite ample total capacity.
+    static constexpr size_t WAYS = 8;
+
+    explicit SetAssocCache(size_t capacity)
+    {
+        // Round the requested capacity down to WAYS slots per set and up to a
+        // power-of-two number of sets so the Fibonacci-hash index is a cheap shift.
+        size_t requested_sets = std::max<size_t>(capacity / WAYS, size_t{ 1 });
+        num_sets_ = round_up_pow2(requested_sets);
+        shift_ = 64 - log2_pow2(num_sets_);
+        sets_.resize(num_sets_);
+    }
+
+    Result<std::reference_wrapper<V>> lookup(const K& k)
+    {
+        Set& s = sets_[index(k)];
+        for (size_t w = 0; w < WAYS; ++w) {
+            if (s.occupied[w] && s.keys[w] == k && s.values[w]) {
+                return std::reference_wrapper<V>(*s.values[w]);
+            }
+        }
+        return ErrorKind::LookupError;
+    }
+
+    void store(const K& k, std::unique_ptr<V> v)
+    {
+        Set& s = sets_[index(k)];
+
+        // Overwrite an existing entry for the same key.
+        for (size_t w = 0; w < WAYS; ++w) {
+            if (s.occupied[w] && s.keys[w] == k) {
+                s.values[w] = std::move(v);
+                return;
+            }
+        }
+
+        // Fill a free slot if one exists.
+        for (size_t w = 0; w < WAYS; ++w) {
+            if (!s.occupied[w]) {
+                s.keys[w] = k;
+                s.values[w] = std::move(v);
+                s.occupied[w] = true;
+                return;
+            }
+        }
+
+        // Set is full: FIFO eviction of the next_evict slot.
+        const uint8_t w = s.next_evict;
+        s.keys[w] = k;
+        s.values[w] = std::move(v);
+        s.occupied[w] = true;
+        s.next_evict = static_cast<uint8_t>((s.next_evict + 1) % WAYS);
+    }
+
+    void clear()
+    {
+        for (auto& s : sets_) {
+            s = Set{};
+        }
+    }
+
+    void postfork_child()
+    {
+        // At fork, the sampling thread may have been modifying a set mid-store.
+        // Running unique_ptr destructors over possibly-corrupted slots can crash.
+        // Placement-new a fresh vector, abandoning the old data (intentional
+        // one-time leak), mirroring LRUCache::postfork_child.
+        new (&sets_) std::vector<Set>();
+        sets_.resize(num_sets_);
+    }
+
+  private:
+    struct Set
+    {
+        K keys[WAYS] = {};
+        std::unique_ptr<V> values[WAYS] = {};
+        bool occupied[WAYS] = { false };
+        // FIFO eviction cursor: next way to overwrite when the set is full.
+        uint8_t next_evict = 0;
+    };
+
+    std::vector<Set> sets_;
+    size_t num_sets_ = 0;
+    unsigned shift_ = 0;
+
+    size_t index(const K& k) const
+    {
+        // Fibonacci hashing: multiply by 2^64/phi and take the top bits, which
+        // mixes the already-composite frame key (code/lasti/firstlineno) well.
+        const uint64_t h = static_cast<uint64_t>(k) * 0x9E3779B97F4A7C15ULL;
+        return static_cast<size_t>(h >> shift_);
+    }
+
+    static size_t round_up_pow2(size_t n)
+    {
+        size_t p = 1;
+        while (p < n) {
+            p <<= 1;
+        }
+        return p;
+    }
+
+    static unsigned log2_pow2(size_t n)
+    {
+        unsigned l = 0;
+        while ((size_t{ 1 } << l) < n) {
+            ++l;
+        }
+        return l;
+    }
+};


### PR DESCRIPTION
## DO NOT MERGE — benchmark arm only

Tuning/robustness arm for the Echion frame-cache DoE (see #18808). Identical
custom set-associative cache, but **WAYS=8** instead of 2 (128 sets × 8 ways,
same 1024 capacity).

## Results — 8-way is NOT better (2-way wins)

Same fixed-rate DoE (n=20/arm, `origin/main` `93e7e6d6cc` baseline):

| metric | LRUCache baseline | custom 8-way | delta | p-value |
|--------|-------------------|--------------|-------|---------|
| CPU | 25.21 s | 25.52 s | +1.24% | 0.38 (ns) |
| p99 latency | 4.43 ms | 5.22 ms | +17.9% | 0.02 |
| p50 latency | 1.34 ms | 1.43 ms | +6.3% | 0.007 |
| RSS | 322.1 MB | 322.4 MB | +0.11% | 0.26 (ns) |

The 2-way arm (#18808) wins −3.5% CPU, but 8-way is **neutral vs baseline and
clearly worse than 2-way**. The deep-stack working set (~250 distinct frames)
fits easily in the 1024-entry cache, so the conflict misses that higher
associativity would fix don't occur — 8-way only adds per-lookup scan cost and a
larger, less cache-friendly `Set`. Conclusion: keep the lean 2-way design.
Full writeup: `echion-cache-doe-pr-summary.md` in dd-trace-doe.