### PR TITLE
fix(aws_durable_execution_sdk_python): [SVLS-9168] handle FAILED checkpoints properly

### DIFF
--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
@@ -173,25 +173,28 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
         if isinstance(event, (AwsDurableInvokeEvent, AwsDurableOperationEvent)):
             operation_id = instance.operation_identifier.operation_id
             checkpoint = instance.state.get_checkpoint_result(operation_id)
-            is_succeeded = checkpoint.is_succeeded()
-            event.replayed = is_succeeded
+            # A terminal checkpoint (SUCCEEDED or FAILED) is served from the checkpoint on
+            # replay rather than executed: the SDK reloads a succeeded result or re-raises a
+            # failed error without running the user function, so both count as a replay.
+            is_replayed = checkpoint.is_succeeded() or checkpoint.is_failed()
+            event.replayed = is_replayed
             event.id = operation_id
             # AIDEV-NOTE: report operation_attempt 0-indexed (0 = original, 1 =
             # first retry) so a fresh execution and its replay agree. The
             # server-maintained step_details.attempt is read at two points: a
             # pending checkpoint holds the prior-failure count (already the
-            # 0-indexed index of the attempt about to run), while a succeeded
+            # 0-indexed index of the attempt about to run), while a terminal
             # checkpoint (read on a replay) holds the 1-indexed attempt that
-            # succeeded -- observed, not SDK-enforced; pinned by the unit test.
+            # reached that state -- observed, not SDK-enforced; pinned by the unit test.
             if isinstance(event, AwsDurableOperationEvent) and event.operation in _RETRYABLE_OPERATIONS:
                 operation = checkpoint.operation
                 if operation is not None and operation.step_details is not None:
                     attempt = operation.step_details.attempt
                     # AIDEV-NOTE: the `attempt > 0` guard is purely defensive;
-                    # we have NOT observed attempt == 0 on success. It avoids
-                    # emitting operation_attempt = -1 if a succeeded StepDetails
+                    # we have NOT observed attempt == 0 on a terminal checkpoint. It
+                    # avoids emitting operation_attempt = -1 if a terminal StepDetails
                     # ever lacks "Attempt" (from_dict defaults it to 0).
-                    event.operation_attempt = (attempt - 1 if attempt > 0 else 0) if is_succeeded else attempt
+                    event.operation_attempt = (attempt - 1 if attempt > 0 else 0) if is_replayed else attempt
                 else:
                     event.operation_attempt = 0
     return wrapped(*args, **kwargs)

--- a/releasenotes/notes/aws-durable-failed-replay-attempt-7b3c2a1f9e0d4c5a.yaml
+++ b/releasenotes/notes/aws-durable-failed-replay-attempt-7b3c2a1f9e0d4c5a.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    aws_durable_execution_sdk_python: This fix resolves an issue where a durable operation that
+    failed permanently and was then replayed (re-read from its FAILED checkpoint) was not treated
+    as a replay: its span reported ``aws.durable.replayed`` as ``false`` and an
+    ``aws.durable.operation_attempt`` one higher than the live final attempt. A FAILED checkpoint is
+    now treated the same as a SUCCEEDED one, so a replayed failed operation reports ``replayed`` as
+    ``true`` and the same 0-indexed attempt number as its original execution.

--- a/releasenotes/notes/aws-durable-failed-replay-attempt-7b3c2a1f9e0d4c5a.yaml
+++ b/releasenotes/notes/aws-durable-failed-replay-attempt-7b3c2a1f9e0d4c5a.yaml
@@ -1,9 +1,6 @@
 ---
 fixes:
   - |
-    aws_durable_execution_sdk_python: This fix resolves an issue where a durable operation that
-    failed permanently and was then replayed (re-read from its FAILED checkpoint) was not treated
-    as a replay: its span reported ``aws.durable.replayed`` as ``false`` and an
-    ``aws.durable.operation_attempt`` one higher than the live final attempt. A FAILED checkpoint is
-    now treated the same as a SUCCEEDED one, so a replayed failed operation reports ``replayed`` as
-    ``true`` and the same 0-indexed attempt number as its original execution.
+    aws_durable_execution_sdk_python: This fix resolves an issue where a replayed durable operation
+    that had failed permanently reported an incorrect ``aws.durable.replayed`` value and an
+    ``aws.durable.operation_attempt`` one higher than its original execution.

--- a/tests/contrib/aws_durable_execution_sdk_python/test_aws_durable_execution_sdk_python.py
+++ b/tests/contrib/aws_durable_execution_sdk_python/test_aws_durable_execution_sdk_python.py
@@ -113,6 +113,40 @@ def test_step_attempt_consistent_across_replay(test_spans):
     assert sorted(span.get_tag(aws_durable.TAG_REPLAYED) for span in step_spans) == ["false", "true"]
 
 
+def test_failed_step_attempt_consistent_across_replay(test_spans):
+    """A step that exhausts its retries and fails is, on replay, read from its FAILED
+    checkpoint (the SDK re-raises the stored error without running the body). That replay
+    span must be tagged replayed=true and report the same 0-indexed operation_attempt as
+    the live final attempt.
+
+    A FAILED checkpoint stores the 1-indexed attempt that failed (2 for a step whose 2nd
+    attempt failed), so without normalization the replay span would report 2 while the live
+    final attempt reports 1 -- the same off-by-one already handled for succeeded checkpoints.
+    """
+
+    def always_fails(step_context):
+        raise RuntimeError("permanent failure")
+
+    @ades.durable_execution
+    def workflow(event, context):
+        try:
+            context.step(always_fails, name="doomed", config=_fast_retry(max_attempts=2))
+        except Exception:
+            # Swallow the permanent failure so the workflow continues to the wait below,
+            # whose replay re-reads the now-FAILED step from its checkpoint.
+            pass
+        context.wait(Duration.from_seconds(1), name="pause")
+
+    with DurableFunctionTestRunner(workflow) as runner:
+        runner.run()
+
+    step_spans = list(test_spans.filter_spans(name=aws_durable.SPAN_STEP))
+    replayed_spans = [s for s in step_spans if s.get_tag(aws_durable.TAG_REPLAYED) == "true"]
+    assert replayed_spans, "expected a replay span for the failed step"
+    for span in replayed_spans:
+        assert span.get_metrics().get(aws_durable.TAG_OPERATION_ATTEMPT) == 1
+
+
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
 def test_parallel_propagates_trace_context():
     """context.parallel uses TracedThreadPoolExecutor so child step spans inherit the


### PR DESCRIPTION
## What does this PR do?

Treats a **FAILED** durable checkpoint the same as a SUCCEEDED one, for two span attributes on durable operation spans:

- `aws.durable.replayed` — now `true` when the operation is served from a terminal checkpoint (FAILED or SUCCEEDED)
- `aws.durable.operation_attempt` — the 0-indexing normalization (i.e. subtracting attempt value by 1) now applies to FAILED checkpoints too. Right now we only do this for SUCCEEDED checkpoints.

## Testing
### Context
The `always-fails` operation runs/replays three times:
- original attempt: fails
- 2nd and final attempt (1st retry): fails
- replay of the 2nd attempt

### Result
#### Before
The last span for the `always-fails` operation has `replay == false` and `operation_attempt` span tag of `2`. Operations table shows the operation has 3 attempts. All are wrong.
<img width="851" height="389" alt="image" src="https://github.com/user-attachments/assets/bca1691a-70dc-43a8-a80d-e63876f20bbb" />
<img width="304" height="223" alt="image" src="https://github.com/user-attachments/assets/507f594e-2c0d-44df-9fd2-01b0b3e8ac0a" />

#### After

The replay span shows as a separate row in the operations table, and is hidden by default (when "Show replays" is off)

<img width="844" height="517" alt="image" src="https://github.com/user-attachments/assets/ede1bef8-63c4-44ae-9f45-4ec3eee9631b" />

It has span tag `aws.durable.replayed == true` and `aws.durable.operation_attempt == 1`, as expected.

Operations table shows the operation has 2 attempts, as expected.

## Staging link
[Link](https://dd.datad0g.com/serverless/aws/lambda?search=functionname%3Add-durable-attempt-py&fromUser=false&graphType=flamegraph&panel_end=1782850230200&panel_paused=false&panel_start=1782846630200&panel_tab=durableExecutions&refresh_mode=sliding&shouldShowLegend=true&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Bdd-durable-attempt-py%2Bus-east-2%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%2C%7B%22p%22%3A%7B%22traceID%22%3A%226a44216000000000ac65d4f099b859bf%22%2C%22selectedSpanID%22%3A%226869736249323812685%22%7D%2C%22i%22%3A%22trace-panel%22%7D%5D&spanID=5613198925804955800&spanViewType=infrastructure&traceID=6a44216000000000ac65d4f099b859bf&traceQuery=&start=1782677253459&end=1782850053459&paused=false)

## Next steps
Do the same fix for JS. https://github.com/DataDog/dd-trace-js/pull/9160