### PR TITLE
ci: migrate GitLab CI build resources to pod-level resource variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -306,8 +306,9 @@ check_requirements_lockfiles:
     # above that when resolving the full venv matrix (including 3.15 venvs),
     # causing OOMKilled (exit 137).
     DD_DISABLE_VPA: "true"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "8Gi"
+    KUBERNETES_POD_CPU_REQUEST: "1"
+    KUBERNETES_POD_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_POD_MEMORY_LIMIT: "8Gi"
   script:
     - pip install toml==0.10.2 pyyaml==6.0.2
     - scripts/compile-and-prune-test-requirements

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -40,9 +40,9 @@ variables:
     # Enable sccache for Rust/C/C++ compilation caching
     DD_USE_SCCACHE: "1"
     # job resource requests
-    KUBERNETES_CPU_REQUEST: "6"
-    KUBERNETES_MEMORY_REQUEST: "10Gi"
-    KUBERNETES_MEMORY_LIMIT: "10Gi"
+    KUBERNETES_POD_CPU_REQUEST: "6"
+    KUBERNETES_POD_MEMORY_REQUEST: "10Gi"
+    KUBERNETES_POD_MEMORY_LIMIT: "10Gi"
     DD_DISABLE_VPA: true
   artifacts:
     when: always
@@ -263,9 +263,9 @@ variables:
   variables:
     CARGO_BUILD_JOBS: "12"
     CMAKE_BUILD_PARALLEL_LEVEL: "12"
-    KUBERNETES_CPU_REQUEST: "6"
-    KUBERNETES_MEMORY_REQUEST: "10Gi"
-    KUBERNETES_MEMORY_LIMIT: "10Gi"
+    KUBERNETES_POD_CPU_REQUEST: "6"
+    KUBERNETES_POD_MEMORY_REQUEST: "10Gi"
+    KUBERNETES_POD_MEMORY_LIMIT: "10Gi"
     DD_DISABLE_VPA: true
   needs:
     - job: "build sdist"

--- a/.gitlab/system-tests.yml
+++ b/.gitlab/system-tests.yml
@@ -10,10 +10,10 @@
       aud: rapid-seceng-sit
   variables:
     TEST_LIBRARY: python
-    KUBERNETES_CPU_REQUEST: "4"
-    KUBERNETES_CPU_LIMIT: "4"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "8Gi"
+    KUBERNETES_POD_CPU_REQUEST: "4"
+    KUBERNETES_POD_CPU_LIMIT: "4"
+    KUBERNETES_POD_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_POD_MEMORY_LIMIT: "8Gi"
   needs:
     - job: "build linux"
       artifacts: true

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -81,10 +81,10 @@ include:
   timeout: 40m
   parallel: 2
   variables:
-    KUBERNETES_MEMORY_REQUEST: "12Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
-    KUBERNETES_CPU_REQUEST: "2"
-    KUBERNETES_CPU_LIMIT: "2"
+    KUBERNETES_POD_MEMORY_REQUEST: "12Gi"
+    KUBERNETES_POD_MEMORY_LIMIT: "12Gi"
+    KUBERNETES_POD_CPU_REQUEST: "2"
+    KUBERNETES_POD_CPU_LIMIT: "2"
   before_script:
     - !reference [.testrunner_gpu, before_script]
     - !reference [.test_base_riot, before_script]

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -265,8 +265,9 @@ suites:
   tracer:
     env:
       DD_TRACE_AGENT_URL: http://localhost:8126
-      KUBERNETES_MEMORY_REQUEST: "4Gi"
-      KUBERNETES_MEMORY_LIMIT: "4Gi"
+      KUBERNETES_POD_CPU_REQUEST: "1"
+      KUBERNETES_POD_MEMORY_REQUEST: "4Gi"
+      KUBERNETES_POD_MEMORY_LIMIT: "4Gi"
     paths:
       - '@tracing'
       - '@bootstrap'


### PR DESCRIPTION
## Description

Migrate dd-trace-py GitLab CI from per-container `KUBERNETES_*` CPU/memory variables to pod-level `KUBERNETES_POD_*` budgets. This lets the runner helper/clone container and any service sidecars share one pod reservation instead of each reserving a separate footprint that does not run concurrently with the build/test work.

This covers the first two migration batches:

**Batch 1 — single-container jobs (VPA already disabled):**
- `.gitlab/package.yml`: `.build_base` (build sdist / linux / linux serverless), `"test sdist"`
- `.gitlab-ci.yml`: `check_requirements_lockfiles`

**Batch 2 — multi-container pods:**
- `.gitlab/tests.yml`: `.test_base_riot_gpu` (ddagent / testagent service sidecars)
- `.gitlab/system-tests.yml`: `.system-tests-base` (docker-in-docker sidecar)
- `tests/suitespec.yml`: `tracer` suite

Memory-only blocks (`check_requirements_lockfiles`, `tracer`) gain an explicit `KUBERNETES_POD_CPU_REQUEST` so the pod budget has a CPU floor. `codeql-scan` is intentionally left out of this PR for a later batch, pending static-CPU-policy (integer CPU pinning) and VPA validation.

## Testing

- [ ] Branch pipeline passes
- [ ] Enable `ci.gitlab-runner.enable-pod-level-resources` targeting for dd-trace-py in Mosaic (this change is inert until then)
- [ ] Confirm runner pods have `spec.resources` set at pod level and build/helper containers have empty container-level resource specs
- [ ] Spot-check a job with sidecars (`system-tests`, `.test_base_riot_gpu`) to validate pod sizing covers the sidecar

## Risks

Feature-flag-gated, so no effect until targeting is updated in Mosaic. Pod budgets on the multi-container jobs should be validated against actual usage once enabled, since the single pod budget now has to cover the sidecars. Memory-only jobs now carry an explicit 1-core pod CPU request where they previously had none.

## Additional Notes

No `KUBERNETES_HELPER_*` variables exist in dd-trace-py, so this is a straight rename plus the CPU-floor additions. No CI shell/Python scripts read these variable names, so no script changes were needed.

Jira: https://datadoghq.atlassian.net/browse/CIEXE-2022
