### PR TITLE
test(core): v4.9.1 + fork-fix backport (#18768) for regression bisection

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -43,6 +43,12 @@ struct module_state
 
     // Mapping of active periodic thread IDs to their PeriodicThread objects.
     PyObject* periodic_threads{ nullptr };
+    // Private list of PeriodicThread objects that have been restarted
+    // asynchronously in a forked child but have not yet registered a new thread
+    // id in periodic_threads. Lets an immediate second fork (and atexit) still
+    // see and restart/stop them. Backported from #18636.
+    PyObject* pending_periodic_threads{ nullptr };
+    std::mutex pending_periodic_threads_mutex;
 
     // Sentinel returned by a periodic target to request a clean stop of the
     // loop without error. Checked by PeriodicThread__periodic after each call.
@@ -57,6 +63,39 @@ struct module_state
         return at_exit.load(std::memory_order_acquire) || py_is_finalizing();
     }
 };
+
+// ----------------------------------------------------------------------------
+// Pending fork-restart registry helpers (backported from #18636). A child fork
+// hook restarts periodic threads non-blocking, so the replacement OS thread has
+// not yet registered itself in periodic_threads when _after_fork returns. These
+// helpers track such workers until they register, so a second fork's
+// _before_fork() snapshot and the atexit handler can still find them.
+static int
+append_pending_periodic_thread(module_state* state, PeriodicThread* self)
+{
+    if (state == nullptr || state->pending_periodic_threads == NULL)
+        return 0;
+
+    std::lock_guard<std::mutex> _lock(state->pending_periodic_threads_mutex);
+    return PyList_Append(state->pending_periodic_threads, (PyObject*)self);
+}
+
+static int
+remove_pending_periodic_thread(module_state* state, PeriodicThread* self)
+{
+    if (state == nullptr || state->pending_periodic_threads == NULL)
+        return 0;
+
+    std::lock_guard<std::mutex> _lock(state->pending_periodic_threads_mutex);
+    Py_ssize_t size = PyList_GET_SIZE(state->pending_periodic_threads);
+    for (Py_ssize_t i = size - 1; i >= 0; i--) {
+        PyObject* item = PyList_GET_ITEM(state->pending_periodic_threads, i); // Borrowed reference.
+        if (item == (PyObject*)self && PySequence_DelItem(state->pending_periodic_threads, i) < 0)
+            return -1;
+    }
+
+    return 0;
+}
 
 // ----------------------------------------------------------------------------
 /**
@@ -611,8 +650,15 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
                     Py_DECREF(self->ident);
                     self->ident = PyLong_FromLong((long)PyThreadState_Get()->thread_id);
 
-                    // Map the PeriodicThread object to its thread ID
-                    PyDict_SetItem(state->periodic_threads, self->ident, (PyObject*)self);
+                    // Map the PeriodicThread object to its thread ID. Once it is
+                    // registered, drop any pending fork-restart record for this
+                    // worker so it is now tracked via the active map only.
+                    if (PyDict_SetItem(state->periodic_threads, self->ident, (PyObject*)self) == 0) {
+                        if (remove_pending_periodic_thread(state, self) < 0)
+                            PyErr_Clear();
+                    } else {
+                        PyErr_Clear();
+                    }
                 }
 
                 // Set the native thread name for better debugging and profiling
@@ -899,9 +945,26 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
         // blocking there is what starved Delancie's fork ping under load. The
         // parent path (force=True) still waits so restored threads are up
         // before the parent continues.
+        //
+        // Because the child path returns before the replacement thread registers
+        // in periodic_threads, record it in the pending list first so an
+        // immediate second fork (and atexit) can still find and restart it.
+        bool pending_restart_registered = false;
+        if (!force && self->_state != nullptr && self->_state->pending_periodic_threads != NULL) {
+            if (append_pending_periodic_thread(self->_state, self) == 0)
+                pending_restart_registered = true;
+            else
+                PyErr_Clear();
+        }
+
         PyObject* started = _PeriodicThread_do_start(self, false, static_cast<bool>(force));
-        if (started == NULL)
+        if (started == NULL) {
+            if (pending_restart_registered) {
+                if (remove_pending_periodic_thread(self->_state, self) < 0)
+                    PyErr_Clear();
+            }
             return NULL;
+        }
         Py_DECREF(started);
     } else {
         // No restart: the common cleanup above is sufficient for fork-specific
@@ -1047,12 +1110,39 @@ _threads_at_exit(PyObject* module, PyObject* Py_UNUSED(args))
 {
     module_state* state = (module_state*)PyModule_GetState(module);
 
-    // Stop and join all running periodic threads. We snapshot the values first
-    // to avoid mutation of the dict during iteration (threads remove themselves
-    // from periodic_threads when they stop).
+    // Stop and join all running or pending periodic threads. Snapshot pending
+    // fork-restarts first so a worker moving pending -> active concurrently
+    // cannot be missed between the two snapshots, then append the active ones.
     if (state != nullptr && state->periodic_threads != NULL) {
-        PyObject* threads = PyDict_Values(state->periodic_threads);
+        PyObject* threads = PyList_New(0);
         if (threads != NULL) {
+            if (state->pending_periodic_threads != NULL) {
+                std::lock_guard<std::mutex> _lock(state->pending_periodic_threads_mutex);
+                Py_ssize_t pending_n = PyList_GET_SIZE(state->pending_periodic_threads);
+                for (Py_ssize_t i = 0; i < pending_n; i++) {
+                    PyObject* thread = PyList_GET_ITEM(state->pending_periodic_threads, i); // Borrowed reference.
+                    if (PyList_Append(threads, thread) < 0) {
+                        PyErr_Clear();
+                        break;
+                    }
+                }
+            }
+
+            PyObject* active_threads = PyDict_Values(state->periodic_threads);
+            if (active_threads != NULL) {
+                Py_ssize_t active_n = PyList_Size(active_threads);
+                for (Py_ssize_t i = 0; i < active_n; i++) {
+                    PyObject* thread = PyList_GET_ITEM(active_threads, i); // Borrowed reference.
+                    if (PyList_Append(threads, thread) < 0) {
+                        PyErr_Clear();
+                        break;
+                    }
+                }
+                Py_DECREF(active_threads);
+            } else {
+                PyErr_Clear();
+            }
+
             Py_ssize_t n = PyList_Size(threads);
 
             // Send the stop signal to all threads.
@@ -1098,12 +1188,28 @@ _threads_at_exit(PyObject* module, PyObject* Py_UNUSED(args))
 }
 
 // ----------------------------------------------------------------------------
+// Snapshot of periodic threads restarted non-blocking in a forked child that
+// have not yet registered in periodic_threads. Consumed by threads.py
+// _before_fork() so a second fork restores them. Backported from #18636.
+static PyObject*
+_threads_pending_threads(PyObject* module, PyObject* Py_UNUSED(args))
+{
+    module_state* state = (module_state*)PyModule_GetState(module);
+    if (state == nullptr || state->pending_periodic_threads == NULL)
+        return PyList_New(0);
+
+    std::lock_guard<std::mutex> _lock(state->pending_periodic_threads_mutex);
+    return PyList_GetSlice(state->pending_periodic_threads, 0, PyList_GET_SIZE(state->pending_periodic_threads));
+}
+
+// ----------------------------------------------------------------------------
 static int
 _threads_traverse(PyObject* module, visitproc visit, void* arg)
 {
     module_state* state = (module_state*)PyModule_GetState(module);
     if (state != nullptr) {
         Py_VISIT(state->periodic_threads);
+        Py_VISIT(state->pending_periodic_threads);
         Py_VISIT(state->PERIODIC_STOP);
     }
     return 0;
@@ -1116,6 +1222,7 @@ _threads_clear(PyObject* module)
     module_state* state = (module_state*)PyModule_GetState(module);
     if (state != nullptr) {
         Py_CLEAR(state->periodic_threads);
+        Py_CLEAR(state->pending_periodic_threads);
         Py_CLEAR(state->PERIODIC_STOP);
     }
     return 0;
@@ -1126,11 +1233,17 @@ static void
 _threads_free(void* module)
 {
     _threads_clear((PyObject*)module);
+    // module_state owns a std::mutex (non-trivial), so run its destructor after
+    // clearing the PyObject fields (it was created with placement new).
+    module_state* state = (module_state*)PyModule_GetState((PyObject*)module);
+    if (state != nullptr)
+        state->~module_state();
 }
 
 // ----------------------------------------------------------------------------
 static PyMethodDef _threads_methods[] = {
     { "_at_exit", _threads_at_exit, METH_NOARGS, "Signal that Python is exiting" },
+    { "_pending_threads", _threads_pending_threads, METH_NOARGS, "Return pending periodic thread restart snapshot" },
     { NULL, NULL, 0, NULL } /* Sentinel */
 };
 
@@ -1168,6 +1281,10 @@ PyInit__threads(void)
 
         state->periodic_threads = PyDict_New();
         if (state->periodic_threads == NULL)
+            goto error;
+
+        state->pending_periodic_threads = PyList_New(0);
+        if (state->pending_periodic_threads == NULL)
             goto error;
 
         // Register the atexit hook — the sole writer of module_state::at_exit.

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -799,14 +799,36 @@ PeriodicThread_awake(PeriodicThread* self, PyObject* Py_UNUSED(args))
         return NULL;
     }
 
+    // GIL-fast-path: if the worker is permanently stopped (not fork-paused),
+    // awake() is a best-effort no-op. Surfacing a RuntimeError here would make a
+    // timing-dependent race (stop() vs in-flight awake()) visible to callers,
+    // which is worse than silently doing nothing. Backported from #18636.
+    if (self->_stopping && !self->_skip_shutdown)
+        Py_RETURN_NONE;
+
+    bool stopped = false;
     {
         AllowThreads _(self->_state);
-        std::lock_guard<std::mutex> lock(*self->_awake_mutex);
 
-        self->_served->clear();
-        self->_request->set(REQUEST_REASON_AWAKE);
+        // Set up the wait under _awake_mutex. stop() also takes this mutex, so
+        // either we observe its _stopping write here, or our set(AWAKE) is
+        // ordered before its set(STOP) and the worker's cleanup _served->set()
+        // (loop exit) wakes us.
+        {
+            std::lock_guard<std::mutex> lock(*self->_awake_mutex);
 
-        self->_served->wait();
+            if (self->_stopping && !self->_skip_shutdown) {
+                stopped = true;
+            } else {
+                self->_served->clear();
+                self->_request->set(REQUEST_REASON_AWAKE);
+            }
+        }
+
+        // Wait outside the mutex so a periodic callback that calls stop() on
+        // itself (Timer._periodic) does not deadlock against us.
+        if (!stopped)
+            self->_served->wait();
     }
 
     Py_RETURN_NONE;
@@ -821,8 +843,17 @@ PeriodicThread_stop(PeriodicThread* self, PyObject* Py_UNUSED(args))
         return NULL;
     }
 
-    self->_stopping = true;
-    self->_request->set(REQUEST_REASON_STOP);
+    // Order _stopping + set(STOP) against awake()'s setup (clear _served, set
+    // AWAKE) under _awake_mutex. Without this, a concurrent awake() could clear
+    // _served after the worker has already exited and set it on cleanup, then
+    // wait forever. Backported from #18636.
+    {
+        AllowThreads _(self->_state);
+        std::lock_guard<std::mutex> lock(*self->_awake_mutex);
+
+        self->_stopping = true;
+        self->_request->set(REQUEST_REASON_STOP);
+    }
 
     Py_RETURN_NONE;
 }

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -548,7 +548,7 @@ PeriodicThread__on_shutdown(PeriodicThread* self)
 // for cases where the thread is being restarted after a fork to preserve the
 // existing next trigger time).
 static PyObject*
-_PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false)
+_PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false, bool wait_until_started = true)
 {
     if (self->_thread != nullptr) {
         PyErr_SetString(PyExc_RuntimeError, "Thread already started");
@@ -725,8 +725,10 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
         return NULL;
     }
 
-    // Wait for the thread to start
-    {
+    // Wait for the thread to start. Skipped on the child fork path
+    // (wait_until_started=false) so application code can resume immediately
+    // after fork instead of blocking on the restarted thread coming up.
+    if (wait_until_started) {
         AllowThreads _(self->_state);
 
         self->_started->wait();
@@ -891,7 +893,13 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
         // preserve _next_call_time from before the fork. This ensures that
         // a restarted thread fires at the same time it would have without
         // the fork, rather than being pushed back by a full interval.
-        PyObject* started = _PeriodicThread_do_start(self);
+        //
+        // The child path (force=False) must not block on thread startup, since
+        // it runs in the at-fork child hook before application code resumes;
+        // blocking there is what starved Delancie's fork ping under load. The
+        // parent path (force=True) still waits so restored threads are up
+        // before the parent continues.
+        PyObject* started = _PeriodicThread_do_start(self, false, static_cast<bool>(force));
         if (started == NULL)
             return NULL;
         Py_DECREF(started);

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -1,6 +1,7 @@
 from time import monotonic_ns
 import typing as t
 
+from ddtrace.internal import _threads as _threads_mod
 from ddtrace.internal import forksafe
 from ddtrace.internal._threads import PeriodicThread as _PeriodicThread
 from ddtrace.internal._threads import periodic_threads
@@ -162,16 +163,13 @@ def _after_fork_child():
 
     _forking = False
 
-    # Restart the threads immediately. It is unlikely that there will be another
-    # call to fork here. _after_fork() (without force=True) respects
-    # __autorestart__: cleanup always runs, but the thread is only restarted
-    # when __autorestart__ is True. This is intentional in the child — threads
-    # with __autorestart__ = False (e.g. RemoteConfigPoller) should not run in
-    # forked workers.
+    # Keep child at-fork work minimal: thread restarts happen asynchronously in
+    # the child so application code can resume immediately after fork. Parent
+    # process threads are still restarted in _after_fork_parent() below.
     for thread in _threads_to_restart_after_fork.copy():
         log.debug("Restarting thread %s after fork in child", thread.name)
         try:
-            thread._after_fork()
+            thread._after_fork(force=False)
         except Exception as e:
             log.error("failed to restart periodic thread %s after fork in child: %s", thread.name, e)
     _threads_to_restart_after_fork.clear()
@@ -201,6 +199,10 @@ def _before_fork() -> None:
     with _forking_lock:
         _forking = True
 
+    # Snapshot pending restarts first so a worker moving pending -> active
+    # concurrently cannot be missed between the two snapshots.
+    pending_threads = getattr(_threads_mod, "_pending_threads", lambda: ())()
+    _threads_to_restart_after_fork.update(pending_threads)
     # Take note of all the periodic threads that are running and will need to be
     # restarted.
     _threads_to_restart_after_fork.update(periodic_threads.values())

--- a/releasenotes/notes/fork-child-periodic-thread-restart-d370777fd6cf7f29.yaml
+++ b/releasenotes/notes/fork-child-periodic-thread-restart-d370777fd6cf7f29.yaml
@@ -1,3 +1,0 @@
-fixes:
-  - |
-    core: This fix prevents periodic thread restarts from blocking application code from resuming in forked children.

--- a/releasenotes/notes/fork-child-periodic-thread-restart-d370777fd6cf7f29.yaml
+++ b/releasenotes/notes/fork-child-periodic-thread-restart-d370777fd6cf7f29.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    core: This fix prevents periodic thread restarts from blocking application code from resuming in forked children.

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -79,6 +79,26 @@ def test_periodic_join_positional_timeout_is_honored():
         t.join()
 
 
+def test_periodic_awake_after_stop_returns_not_hangs():
+    """Regression: awake() after a completed stop() used to block forever.
+
+    Once a worker has fully stopped, there is nothing left that can serve a
+    new awake request. The native awake() path must therefore short-circuit
+    instead of waiting forever for a completion signal that will never come.
+
+    We deliberately make awake() a silent no-op (not a RuntimeError) so that
+    a racy stop()/awake() interleaving never surfaces a timing-dependent
+    exception to callers.
+    """
+    t = periodic.PeriodicThread(60.0, lambda: None)
+    t.start()
+    t.stop()
+    t.join()  # fully drained
+
+    # Must return promptly. Before the fix this hung forever.
+    t.awake()
+
+
 def _collect_until_cleared(ref, attempts=5):
     for _ in range(attempts):
         gc.collect()
@@ -124,6 +144,62 @@ def test_periodic_thread_bound_method_cycle_is_collectible_after_join():
     del owner
 
     assert _collect_until_cleared(owner_ref), "stopped PeriodicThread bound-method cycle was not collected"
+
+
+def test_periodic_awake_does_not_deadlock_with_stop_from_callback():
+    """Regression: stop() called from inside a periodic callback must not
+    deadlock against a concurrent awake() holding the awake mutex.
+
+    Timer._periodic uses the pattern:
+
+        def _periodic(self):
+            self.timeout()
+            self.stop()
+
+    A naive fix that has stop() acquire _awake_mutex creates this deadlock:
+
+      1. Thread A calls t.awake() — takes _awake_mutex, publishes AWAKE,
+         then waits for completion.
+      2. The worker consumes AWAKE and runs the callback.
+      3. The callback calls t.stop() on the worker thread.
+      4. stop() blocks on _awake_mutex if awake() keeps it locked while
+         waiting.
+      5. The worker cannot finish the callback and cannot reach
+         the wake-completion path — both threads wait forever.
+
+    The middle-ground fix has awake() release _awake_mutex before waiting on
+    _served, so a worker-thread stop() can take the mutex freely.
+    """
+
+    def _target():
+        # Stop ourselves from the worker thread — this is exactly the
+        # Timer._periodic pattern.
+        t.stop()
+
+    t = periodic.PeriodicThread(60.0, _target)
+    t.start()
+
+    awake_done = Event()
+
+    def _do_awake():
+        try:
+            t.awake()
+        finally:
+            awake_done.set()
+
+    awaker = Thread(target=_do_awake)
+    awaker.start()
+
+    # The awake() call should return well within a second. Before the fix this
+    # deadlocked indefinitely because the worker-thread stop() tried to take
+    # _awake_mutex while awake() was blocked waiting for completion.
+    assert awake_done.wait(timeout=5.0), (
+        "awake() did not return within 5s — stop()-from-callback deadlocked "
+        "against a concurrent awake() holding the awake mutex"
+    )
+
+    awaker.join(timeout=1.0)
+    t.join(timeout=1.0)
 
 
 def test_periodic_error():
@@ -206,7 +282,7 @@ def test_awakeable_periodic_service():
     assert queue == list(range(n + 1))
 
 
-@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning:os"})
+@pytest.mark.subprocess
 def test_forksafe_awakeable_periodic_service():
     import os
     from threading import Event
@@ -249,7 +325,131 @@ def test_forksafe_awakeable_periodic_service():
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
-@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning:os"})
+@pytest.mark.subprocess
+def test_periodic_service_does_not_restart_before_child_code_after_fork():
+    """Default services still restart in forked children."""
+    import os
+    from threading import Event
+
+    from ddtrace.internal import periodic
+
+    periodic_ran = Event()
+    child_recv, child_send = os.pipe()
+
+    class MyService(periodic.PeriodicService):
+        def periodic(self):
+            periodic_ran.set()
+
+    svc = MyService(interval=60)
+    svc.start()
+    assert svc._worker is not None
+    svc._worker.awake()
+    assert periodic_ran.wait(timeout=2), "service did not run before fork"
+    periodic_ran.clear()
+
+    pid = os.fork()
+    if pid == 0:
+        os.close(child_recv)
+        try:
+            assert svc._worker is not None
+            svc._worker.awake()
+            os.write(child_send, b"1" if periodic_ran.wait(timeout=2) else b"0")
+        finally:
+            os._exit(0)
+
+    os.close(child_send)
+    result = os.read(child_recv, 1)
+    _, status = os.waitpid(pid, 0)
+    svc.stop()
+    svc.join()
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == b"1"
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+@pytest.mark.subprocess
+def test_child_periodic_restart_does_not_block_app_code_after_fork():
+    """Child at-fork hook must not wait for a restarted thread to run."""
+    import os
+    import select
+
+    from ddtrace.internal import periodic
+
+    child_recv, child_send = os.pipe()
+
+    class MyService(periodic.PeriodicService):
+        def periodic(self):
+            pass
+
+    svc = MyService(interval=60)
+    svc.start()
+
+    pid = os.fork()
+    if pid == 0:
+        os.close(child_recv)
+        try:
+            os.write(child_send, b"1")
+        finally:
+            os._exit(0)
+
+    os.close(child_send)
+    readable, _, _ = select.select([child_recv], [], [], 1)
+    result = os.read(child_recv, 1) if readable else b""
+    _, status = os.waitpid(pid, 0)
+    svc.stop()
+    svc.join()
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == b"1"
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+@pytest.mark.subprocess
+def test_child_periodic_restart_visible_to_immediate_second_fork():
+    import os
+    from threading import Event
+
+    from ddtrace.internal import periodic
+
+    child_recv, child_send = os.pipe()
+    periodic_ran = Event()
+
+    class MyService(periodic.PeriodicService):
+        def periodic(self):
+            periodic_ran.set()
+
+    svc = MyService(interval=60)
+    svc.start()
+    assert svc._worker is not None
+
+    pid = os.fork()
+    if pid == 0:
+        grandchild_pid = os.fork()
+        if grandchild_pid == 0:
+            os.close(child_recv)
+            try:
+                assert svc._worker is not None
+                svc._worker.awake()
+                os.write(child_send, b"1" if periodic_ran.wait(timeout=2) else b"0")
+            finally:
+                os._exit(0)
+
+        _, grandchild_status = os.waitpid(grandchild_pid, 0)
+        os._exit(os.WEXITSTATUS(grandchild_status))
+
+    os.close(child_send)
+    result = os.read(child_recv, 1)
+    _, status = os.waitpid(pid, 0)
+    svc.stop()
+    svc.join()
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == b"1"
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+@pytest.mark.subprocess
 def test_autorestart_false_service_restarts_in_parent_after_fork():
     """A PeriodicService with autorestart=False must keep running in the parent
     process after a fork. The flag means 'do not restart in the child', not
@@ -473,7 +673,7 @@ def _get_native_thread_name():
     return None
 
 
-@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning:os"})
+@pytest.mark.subprocess
 def test_periodic_thread_stop_without_join_forksafe():
     """
     Dropping a PeriodicThread that was stop()'d without join() in a forked child

--- a/tests/tracer/runtime/fork_enable.py
+++ b/tests/tracer/runtime/fork_enable.py
@@ -14,8 +14,12 @@ child_pid = os.fork()
 if child_pid == 0:
     assert RuntimeWorker._instance is not None
     assert RuntimeWorker._instance.status == ServiceStatus.RUNNING
+    assert RuntimeWorker._instance._worker is not None
+    assert RuntimeWorker._instance._worker.ident is not None
 else:
     pid, status = os.waitpid(child_pid, 0)
     assert RuntimeWorker._instance is not None
     assert RuntimeWorker._instance.status == ServiceStatus.RUNNING
+    assert RuntimeWorker._instance._worker is not None
+    assert RuntimeWorker._instance._worker.ident is not None
     sys.exit(os.WEXITSTATUS(status))


### PR DESCRIPTION
## Summary
**Not for merge — bisection build.** `v4.9.1` (tag) + the fork-fix backport from #18768, to build a wheel and test it in staging.

Bisection status: `4.8.11` works, `4.9.0 + fix` works, `4.9.2 + fix` reproduces the fork-timeout problem — so the regression entered in **4.9.1 or 4.9.2**. This isolates `4.9.1 + fix`.
