### PR TITLE
fix(iast): avoid weak-hash false positive from symbol_db git-blob hash

### DIFF
--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -235,7 +235,10 @@ class Scope:
             except Exception:
                 log.debug("Cannot get child scope %r for module %s", child, module.__name__, exc_info=True)
 
-        source_git_hash = sha1()  # nosec B324
+        # usedforsecurity=False: this sha1 computes a git-blob identity hash of the
+        # module source, not a security digest. It also prevents IAST from flagging
+        # this internal use as a weak-hash false positive (APPSEC-68795).
+        source_git_hash = sha1(usedforsecurity=False)  # nosec B324
         source_git_hash.update(f"blob {module_origin.stat().st_size}\0".encode())
         with module_origin.open("rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):

--- a/releasenotes/notes/iast-symbol-db-weak-hash-false-positive-810dee1a7e4bf2f8.yaml
+++ b/releasenotes/notes/iast-symbol-db-weak-hash-false-positive-810dee1a7e4bf2f8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Code Security (IAST): Resolve a weak-hash false positive reported on ddtrace's
+    own code when IAST and the live debugger (Symbol Database) are both enabled.

--- a/tests/appsec/iast/taint_sinks/test_weak_hash.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_hash.py
@@ -373,6 +373,28 @@ def test_weak_hash_deduplication_cache(iast_context_contextmanager_deduplication
                 assert len(span_report.vulnerabilities) == 1, f"Failed at iteration {i}"
 
 
+def test_weak_hash_symbol_db_not_reported(iast_context_defaults):
+    """Regression test for APPSEC-68795.
+
+    ``ddtrace`` computes a git-blob sha1 of module source files in
+    ``symbol_db/symbols.py`` for identification purposes (not for security).
+    IAST must not report this internal, non-security use of sha1 as a weak
+    hash vulnerability (false positive on ddtrace's own code).
+    """
+    from pathlib import Path
+
+    from ddtrace.internal.module import origin
+    from ddtrace.internal.symbol_db.symbols import Scope
+    from ddtrace.internal.symbol_db.symbols import ScopeData
+    import tests.appsec.iast.fixtures.taint_sinks.weak_algorithms as module_to_hash
+
+    module_origin = origin(module_to_hash)
+    Scope._get_from(module_to_hash, ScopeData(origin=Path(str(module_origin)), seen=set()))
+
+    span_report = get_iast_reporter()
+    assert span_report is None
+
+
 def test_parametrized_weak_hash_no_exception():
     """Verify that parametrized_weak_hash doesn't raise any exceptions."""
     try:


### PR DESCRIPTION
## Description

`symbol_db/symbols.py` computes a git-blob `sha1` of module source files for module identification (not security). With IAST + the live debugger (Symbol Database) enabled, IAST flagged this internal call as a weak-hash vulnerability — a false positive on ddtrace's own code.

Fix: pass `usedforsecurity=False` so IAST suppresses the report.

JIRA: [APPSEC-68795](https://datadoghq.atlassian.net/browse/APPSEC-68795)
Related PR: https://github.com/DataDog/dd-trace-py/pull/12687
Affected version: from 3.8.0 until now


[APPSEC-68795]: https://datadoghq.atlassian.net/browse/APPSEC-68795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ