### PR TITLE
fix(llmobs): keep google_adk agent span when a Gemini part is unhandled [backport 4.10]

### DIFF
--- a/ddtrace/contrib/internal/google_adk/patch.py
+++ b/ddtrace/contrib/internal/google_adk/patch.py
@@ -154,7 +154,7 @@ def _traced_code_executor_execute_code(wrapped, instance, args, kwargs):
         "%s.%s" % (instance.__class__.__name__, wrapped.__name__),
         provider=provider_name,
         model=model_name,
-        kind="code_execute",
+        kind="tool",
         submit_to_llmobs=True,
     ) as span:
         result = None

--- a/ddtrace/llmobs/_integrations/google_adk.py
+++ b/ddtrace/llmobs/_integrations/google_adk.py
@@ -18,6 +18,10 @@ from ddtrace.trace import Span
 class GoogleAdkIntegration(BaseLLMIntegration):
     _integration_name = "google_adk"
 
+    # Maps the traced operation to its LLMObs span kind. Code execution is a call to a program,
+    # which maps to the "tool" span kind ("code_execute" is not a valid LLMObs span kind).
+    _OPERATION_TO_SPAN_KIND = {"agent": "agent", "tool": "tool", "code_execute": "tool"}
+
     def _set_base_span_tags(
         self, span: Span, model: Optional[Any] = None, provider: Optional[Any] = None, **kwargs
     ) -> None:
@@ -33,21 +37,24 @@ class GoogleAdkIntegration(BaseLLMIntegration):
         args: list[Any],
         kwargs: dict[str, Any],
         response: Optional[Any] = None,
-        operation: str = "",  # being used for span kind: one of "agent", "tool", "code_execute"
+        operation: str = "",  # one of "agent", "tool", "code_execute"
     ) -> None:
+        # Set the span kind before the extraction below, which may raise on malformed data. The
+        # caller swallows that exception, so kind must be set first or the span is dropped for
+        # "missing span kind" and its children orphaned (#18698).
+        _annotate_llmobs_span_data(
+            span,
+            kind=self._OPERATION_TO_SPAN_KIND.get(operation, operation),
+            model_name=span.get_tag("google_adk.request.model") or "",
+            model_provider=span.get_tag("google_adk.request.provider") or "",
+        )
+
         if operation == "agent":
             self._llmobs_set_tags_agent(span, args, kwargs, response)
         elif operation == "tool":
             self._llmobs_set_tags_tool(span, args, kwargs, response)
         elif operation == "code_execute":
             self._llmobs_set_tags_code_execute(span, args, kwargs, response)
-
-        _annotate_llmobs_span_data(
-            span,
-            kind=operation,
-            model_name=span.get_tag("google_adk.request.model") or "",
-            model_provider=span.get_tag("google_adk.request.provider") or "",
-        )
 
     def _llmobs_set_tags_agent(
         self, span: Span, args: list[Any], kwargs: dict[str, Any], response: Optional[Any]

--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -253,11 +253,35 @@ def extract_message_from_part_google_genai(part, role: str) -> Message:
         message["content"] = "[file data: {}]".format(descriptor) if descriptor else "[file data]"
         return message
 
-    # Parts with no recognized content (empty parts, or parts carrying only a thought signature or
-    # other non-text metadata) are left with empty content rather than a confusing "Unsupported
-    # file type" placeholder. The debug log keeps any future/unrecognized part shapes discoverable
-    # without surfacing noise to users.
-    log.debug("google_genai part has no recognized content to extract: %r", type(part))
+    try:
+        from google.genai.types import Part as _GenAIPart
+    except ImportError:
+        _GenAIPart = None
+
+    if _GenAIPart is not None and isinstance(part, _GenAIPart):
+        # A Gemini Part with no renderable content: an empty part, or a metadata-only part such as
+        # one carrying only a thought signature. Leave content empty rather than emit a confusing
+        # placeholder. The debug log keeps any future/unrecognized Part shapes discoverable.
+        log.debug("google_genai part has no recognized content to extract: %r", type(part))
+        return message
+
+    # Non-Part inputs (PIL images, uploaded File handles, or other objects) are valid request
+    # inputs, so keep a placeholder rather than silently dropping them from the LLMObs I/O.
+    file_uri = _get_attr(part, "uri", None)
+    if file_uri:
+        message["content"] = "[file: {}]".format(file_uri)
+        return message
+
+    try:
+        from PIL.Image import Image as _PILImage
+    except ImportError:
+        _PILImage = None
+
+    if _PILImage is not None and isinstance(part, _PILImage):
+        message["content"] = "[image]"
+        return message
+
+    message["content"] = "[unsupported content: {}]".format(type(part).__name__)
     return message
 
 

--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -2,6 +2,7 @@ import json
 from typing import Any
 from typing import Optional
 
+from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import BILLABLE_CHARACTER_COUNT_METRIC_KEY
 from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
@@ -15,6 +16,9 @@ from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import ToolCall
 from ddtrace.llmobs.types import ToolResult
+
+
+log = get_logger(__name__)
 
 
 # Google GenAI has roles "model" and "user", but in order to stay consistent with other integrations,
@@ -214,7 +218,9 @@ def extract_message_from_part_google_genai(part, role: str) -> Message:
         result = _get_attr(function_response, "response", "") or ""
         tool_result_info = ToolResult(
             name=str(_get_attr(function_response, "name", "") or ""),
-            result=result if isinstance(result, str) else json.dumps(result),
+            # default=str so non-serializable payloads (e.g. bytes) don't raise; no sort_keys so
+            # the original key order is preserved.
+            result=result if isinstance(result, str) else json.dumps(result, default=str),
             tool_id=str(_get_attr(function_response, "id", "") or ""),
             type="function_response",
         )
@@ -235,7 +241,24 @@ def extract_message_from_part_google_genai(part, role: str) -> Message:
         message["content"] = safe_json({"outcome": str(outcome), "output": str(output)}) or ""
         return message
 
-    return Message(content="Unsupported file type: {}".format(type(part)), role=role)
+    inline_data = _get_attr(part, "inline_data", None)
+    if inline_data:
+        mime_type = str(_get_attr(inline_data, "mime_type", "") or "")
+        message["content"] = "[inline data: {}]".format(mime_type) if mime_type else "[inline data]"
+        return message
+
+    file_data = _get_attr(part, "file_data", None)
+    if file_data:
+        descriptor = str(_get_attr(file_data, "file_uri", "") or _get_attr(file_data, "mime_type", "") or "")
+        message["content"] = "[file data: {}]".format(descriptor) if descriptor else "[file data]"
+        return message
+
+    # Parts with no recognized content (empty parts, or parts carrying only a thought signature or
+    # other non-text metadata) are left with empty content rather than a confusing "Unsupported
+    # file type" placeholder. The debug log keeps any future/unrecognized part shapes discoverable
+    # without surfacing noise to users.
+    log.debug("google_genai part has no recognized content to extract: %r", type(part))
+    return message
 
 
 def llmobs_get_metadata_vertexai(kwargs, instance):
@@ -278,7 +301,8 @@ def extract_message_from_part_vertexai(part, role=None) -> Message:
             function_response_dict = type(function_response).to_dict(function_response)
         result = function_response_dict.get("response", "")
         if not isinstance(result, str):
-            result = json.dumps(result)
+            # default=str so non-serializable payloads (e.g. bytes) don't raise.
+            result = json.dumps(result, default=str)
         tool_result_info = ToolResult(
             name=function_response_dict.get("name", ""),
             result=result,

--- a/releasenotes/notes/google-adk-span-kind-drop-634f0052f532ffad.yaml
+++ b/releasenotes/notes/google-adk-span-kind-drop-634f0052f532ffad.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where the ``google_adk`` integration dropped an
+    agent span (logging ``missing span kind in span context``) and orphaned its child spans when a
+    Gemini response part could not be parsed. The span kind is now set before input/output
+    extraction, so a parsing failure degrades to empty input/output instead of dropping the span.
+  - |
+    LLM Observability: This fix resolves an issue where the Google GenAI and ``google_adk``
+    integrations rendered unhandled Gemini response parts (such as ``inline_data``, ``file_data``,
+    empty parts, or thought-signature parts) as a confusing ``Unsupported file type`` placeholder.
+    These parts now produce a concise summary or empty content.

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -2,7 +2,9 @@ from unittest import mock
 
 import pytest
 
+from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_parent_id
 from tests.contrib.google_adk.conftest import create_test_message
 from tests.llmobs._utils import assert_llmobs_span_data
 
@@ -151,6 +153,41 @@ class TestLLMObsGoogleADK:
             metrics={},
         )
 
+    def test_agent_span_kept_when_extraction_raises(self, adk, test_spans, google_adk_llmobs):
+        """Regression test for issue #18698.
+
+        If the operation-specific extractor raises on malformed response data, the agent span must
+        still be annotated with its kind so it survives event preparation. A dropped agent span
+        orphans its child spans, so we also assert a child span stays parented to the agent.
+        """
+        integration = adk._datadog_integration
+        agent_span = integration.trace(
+            "Runner.run_async",
+            provider="google",
+            model="gemini-2.5-pro",
+            kind="agent",
+            submit_to_llmobs=True,
+        )
+
+        # A child LLM span started while the agent span is active should be parented to it.
+        child_span = integration.trace("models.generate_content", kind="llm", submit_to_llmobs=True)
+        _annotate_llmobs_span_data(child_span, kind="llm")
+
+        # The public entry point swallows-and-logs extractor exceptions, mirroring production.
+        with mock.patch.object(integration, "_llmobs_set_tags_agent", side_effect=ValueError("malformed Gemini Part")):
+            integration.llmobs_set_tags(agent_span, args=[], kwargs={}, response=None, operation="agent")
+
+        # The agent span still gets its kind despite the extraction failure, so it is not dropped
+        # during event preparation for "missing span kind" (which would orphan its child spans).
+        agent_data = _get_llmobs_data_metastruct(agent_span)
+        assert agent_data["meta"]["span"]["kind"] == "agent"
+
+        # The child resolves its parent to the agent span rather than being orphaned.
+        assert get_llmobs_parent_id(child_span) == str(agent_span.span_id)
+
+        child_span.finish()
+        agent_span.finish()
+
     def test_code_execution(self, mock_invocation_context, test_spans, google_adk_llmobs):
         """Test that code execution creates a valid LLMObs span event."""
         from google.adk.code_executors.code_execution_utils import CodeExecutionInput
@@ -164,7 +201,7 @@ class TestLLMObsGoogleADK:
         assert len(spans) == 1
         assert_llmobs_span_data(
             _get_llmobs_data_metastruct(spans[0]),
-            span_kind="code_execute",
+            span_kind="tool",
             input_value='print("hello world")',
             output_value="hello world\n",
             metadata={},

--- a/tests/contrib/google_genai/test_google_genai.py
+++ b/tests/contrib/google_genai/test_google_genai.py
@@ -371,6 +371,38 @@ def test_extract_message_from_part_unhandled_is_empty_not_unsupported(part):
     assert message.get("content", "") == ""
 
 
+def test_extract_message_from_part_pil_image():
+    """PIL image inputs keep a placeholder instead of being silently dropped from LLMObs I/O."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    Image = pytest.importorskip("PIL.Image")
+    part = Image.new("RGB", (1, 1))
+    message = extract_message_from_part_google_genai(part, "user")
+
+    assert message["content"] == "[image]"
+
+
+def test_extract_message_from_part_file_handle():
+    """Uploaded File handles surface their uri instead of being silently dropped."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    part = types.File(uri="https://generativelanguage.googleapis.com/v1beta/files/abc123")
+    message = extract_message_from_part_google_genai(part, "user")
+
+    assert message["content"] == "[file: https://generativelanguage.googleapis.com/v1beta/files/abc123]"
+
+
+def test_extract_message_from_part_unknown_object():
+    """A non-Part, non-media object keeps a typed placeholder rather than empty content."""
+    from types import SimpleNamespace
+
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    message = extract_message_from_part_google_genai(SimpleNamespace(), "user")
+
+    assert message["content"] == "[unsupported content: SimpleNamespace]"
+
+
 def test_google_genai_chat_send_message(mock_generate_content, genai_client, snapshot_context):
     with snapshot_context(token="tests.contrib.google_genai.test_google_genai.test_google_genai_chat_send_message"):
         chat = genai_client.chats.create(model="gemini-2.0-flash-001")

--- a/tests/contrib/google_genai/test_google_genai.py
+++ b/tests/contrib/google_genai/test_google_genai.py
@@ -330,6 +330,47 @@ def test_normalize_contents_google_genai(contents, expected):
             assert len(actual["parts"]) == len(expected_item["parts"])
 
 
+def test_extract_message_from_part_inline_data():
+    """inline_data parts are summarized by mime type instead of falling through to a class repr."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    part = types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"))
+    message = extract_message_from_part_google_genai(part, "user")
+
+    assert message["content"] == "[inline data: image/png]"
+
+
+def test_extract_message_from_part_file_data():
+    """file_data parts surface the file uri instead of a class repr."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    part = types.Part(file_data=types.FileData(file_uri="gs://bucket/image.png", mime_type="image/png"))
+    message = extract_message_from_part_google_genai(part, "user")
+
+    assert message["content"] == "[file data: gs://bucket/image.png]"
+
+
+@pytest.mark.parametrize(
+    "part",
+    [
+        types.Part(),  # empty part
+        types.Part(thought_signature=b"opaque-reasoning-signature"),  # thought-signature-only part
+    ],
+)
+def test_extract_message_from_part_unhandled_is_empty_not_unsupported(part):
+    """Unhandled parts produce empty content rather than a confusing 'Unsupported file type' string.
+
+    Regression coverage for issue #18698: an unhandled Gemini Part must not raise or emit a class
+    repr, since in the google_adk agent path that previously contributed to dropping the agent span.
+    """
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    message = extract_message_from_part_google_genai(part, "model")
+
+    assert "Unsupported file type" not in message.get("content", "")
+    assert message.get("content", "") == ""
+
+
 def test_google_genai_chat_send_message(mock_generate_content, genai_client, snapshot_context):
     with snapshot_context(token="tests.contrib.google_genai.test_google_genai.test_google_genai_chat_send_message"):
         chat = genai_client.chats.create(model="gemini-2.0-flash-001")


### PR DESCRIPTION
Backport #18796 to 4.10.

Manual backport since the automation only runs on merge to the (currently frozen) trunk. The change applies cleanly to 4.10 with one test adaptation.

## Description

Fixes #18698. The `google_adk` LLM Observability integration could drop the agent span (logging `missing span kind in span context`) and orphan its child `google_genai.request` spans when a Gemini response `Part` failed to parse. The span kind is now set before the fallible input/output extraction, so a parsing failure degrades to empty I/O instead of dropping the span. Also handles previously-unhandled Gemini parts (`inline_data`, `file_data`, empty, thought-signature) instead of an `Unsupported file type` placeholder, hardens `function_response` serialization with `json.dumps(default=str)` (google_genai and vertexai paths), and maps the `code_execute` operation to the `tool` span kind.

## Backport notes

- Applied cleanly to `4.10` (verified with `git apply --check`).
- One test adaptation: the regression test asserts on the pre-finish `meta_struct` rather than a cached span event. On 4.10 a kept span's `meta_struct` is removed after the writer enqueues it and there is no `CACHED_LLMOBS_EVENT_CTX_KEY`, so the pre-finish assertion is the version-agnostic equivalent.

## Testing

- `llmobs::google_adk` suite: 32 passed (Py3.13), including the regression test.
- `google_genai`/`vertex_ai` tool-call + part-extractor tests: 14 passed (Py3.13).
