### PR TITLE
fix(llmobs): handle unserializable meta_struct values in agentless JSON encoder

### DIFF
--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -32,10 +32,28 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 
+def _json_unserializable_default(obj: object) -> object:
+    """Fallback for span values that are not natively JSON serializable, e.g. Pydantic
+    models recorded in ``meta_struct`` by LLM Observability. The msgpack encoders replace
+    unserializable ``meta_struct`` values with a placeholder; without an equivalent
+    fallback here a single unserializable value would fail the whole agentless payload.
+    """
+    try:
+        # Pydantic v2
+        if hasattr(obj, "model_dump") and callable(obj.model_dump):
+            return obj.model_dump(mode="json")
+        # Pydantic v1
+        if hasattr(obj, "__fields__") and hasattr(obj, "dict") and callable(obj.dict):
+            return obj.dict()
+        return str(obj)
+    except Exception:
+        return "Can not serialize [%s] object" % type(obj).__name__
+
+
 def _json_dumps_bytes(obj: object) -> bytes:
     """Serialize to JSON and return UTF-8 bytes (alternative to json.dumps that returns binary)."""
     # TODO(munir): Consider vendoring orjson to avoid this intermeriate strings
-    return json.dumps(obj).encode("utf-8", errors="backslashreplace")
+    return json.dumps(obj, default=_json_unserializable_default).encode("utf-8", errors="backslashreplace")
 
 
 class _EncoderBase(object):

--- a/releasenotes/notes/fix-agentless-json-encoder-unserializable-meta-struct-168d536c511b2eb5.yaml
+++ b/releasenotes/notes/fix-agentless-json-encoder-unserializable-meta-struct-168d536c511b2eb5.yaml
@@ -1,0 +1,9 @@
+fixes:
+  - |
+    LLM Observability: Fixes a ``TypeError: Object of type ... is not JSON serializable`` error that
+    caused entire agentless trace payloads to be dropped when a span's ``meta_struct`` contained
+    values that are not natively JSON serializable, such as Pydantic models (e.g.
+    ``google.genai.types.SafetySetting`` objects recorded in LLM Observability span metadata when
+    ``safety_settings`` is passed to Google GenAI / Vertex AI calls). Such values are now serialized
+    using their Pydantic dump or string representation, mirroring the fallback behavior of the
+    msgpack encoders used in agent mode.

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -275,6 +275,48 @@ class TestEncoders(TestCase):
             ]
         }
 
+    def test_encode_traces_json_agentless_unserializable_meta_struct(self):
+        # A meta_struct value that json.dumps cannot handle natively (e.g. a Pydantic model
+        # recorded by LLM Observability) must not fail the whole payload.
+        class FakePydanticV2:
+            def model_dump(self, mode=None):
+                return {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+
+        class FakePydanticV1:
+            __fields__ = {"category": None}
+
+            def dict(self):
+                return {"category": "HARM_CATEGORY_HARASSMENT"}
+
+        class Unstringable:
+            def __str__(self):
+                raise ValueError("nope")
+
+        span = Span(name="span1", trace_id=1, span_id=2)
+        span._set_struct_tag(
+            "_llmobs",
+            {
+                "metadata": {
+                    "safety_settings": [FakePydanticV2(), FakePydanticV1()],
+                    "opaque": Unstringable(),
+                }
+            },
+        )
+        encoder = AgentlessTraceJSONEncoder(1 << 12, 1 << 12)
+        encoder.put([span])
+        encoded_traces = encoder.encode()
+        assert encoded_traces, "Expected encoded traces but got empty list"
+        [(payload_bytes, n_traces)] = encoded_traces
+        assert n_traces == 1
+
+        data = json.loads(payload_bytes.decode("utf-8"))
+        metadata = data["traces"][0]["spans"][0]["meta_struct"]["_llmobs"]["metadata"]
+        assert metadata["safety_settings"] == [
+            {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
+            {"category": "HARM_CATEGORY_HARASSMENT"},
+        ]
+        assert metadata["opaque"] == "Can not serialize [Unstringable] object"
+
 
 def test_encode_meta_struct():
     # test encoding for MsgPack format


### PR DESCRIPTION
## Description

Since v4.10.0 ([#17854](https://github.com/DataDog/dd-trace-py/pull/17854)), when LLM Observability runs in agentless mode, APM traces are exported to Datadog's intake via `AgentlessTraceJSONEncoder`, with LLMObs data embedded in `meta_struct._llmobs`. This encoder serializes payloads with `json.dumps` without a `default=` fallback, so any `meta_struct` value that is not natively JSON serializable raises during encoding:

```
TypeError: Object of type SafetySetting is not JSON serializable
when serializing list item 0
when serializing dict item 'safety_settings'
when serializing dict item 'metadata'
when serializing dict item '_llmobs'
when serializing dict item 'meta_struct'
...
File "ddtrace/internal/writer/writer.py", line 405, in _write_with_client
    client.encoder.put(spans)
File "ddtrace/internal/encoding.py", line 211, in put
    encoded_trace = _json_dumps_bytes({"spans": [self._item_to_dict(span) for span in item]})
```

This happens in practice with the Google GenAI / Vertex AI integrations: passing `safety_settings` to a Gemini call records `google.genai.types.SafetySetting` Pydantic models in LLMObs span metadata, which end up in `meta_struct` as-is. Because the exception is raised while encoding the payload, **the entire batch of buffered traces is dropped**, not just the offending span.

Before v4.10.0 this data went through the dedicated LLMObs intake path, whose serializer (`safe_json`) already handles Pydantic models ([#12635](https://github.com/DataDog/dd-trace-py/pull/12635)). The msgpack encoders used in agent mode also replace unserializable `meta_struct` values with a placeholder string instead of raising. The agentless JSON path was the only one without such a fallback.

This PR adds a `default=` fallback to `_json_dumps_bytes` that serializes Pydantic v2/v1 models via `model_dump()`/`dict()`, falls back to `str()`, and finally to a `Can not serialize [...] object` placeholder — mirroring the existing msgpack encoder behavior.

## Testing

- Added a regression test in `tests/tracer/test_encoders.py` covering Pydantic-v2-like, Pydantic-v1-like, and fully unserializable values in `meta_struct`.
- Reproduced the original `TypeError` on stock v4.10.6 with a real `pydantic.BaseModel` in `meta_struct`, and verified the patched encoder produces a valid payload with the model serialized as its JSON dump.

## Risks

The fallback only engages for values `json.dumps` would otherwise raise on (which currently fails the whole payload), so existing serializable payloads are unchanged.

## Additional Notes

Reported behavior originally observed after upgrading ddtrace 4.8.5 → 4.10.0 in an agentless setup with Vertex AI + `safety_settings`; we had to roll back to 4.8.5 to keep traces flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)