### PR TITLE
test(core): 4.9.1+fix with 4.8 guard semantics

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -215,26 +215,18 @@ class GILGuard
     inline GILGuard(module_state* state)
       : _mstate(state)
     {
-        if (!_mstate->is_finalizing()) {
+        if (!_mstate->is_finalizing())
             _gil_state = PyGILState_Ensure();
-            _acquired = true;
-        }
     }
     inline ~GILGuard()
     {
-        if (_acquired && !_mstate->is_finalizing() && PyGILState_Check())
+        if (!_mstate->is_finalizing() && PyGILState_Check())
             PyGILState_Release(_gil_state);
     }
 
-    GILGuard(const GILGuard&) = delete;
-    GILGuard& operator=(const GILGuard&) = delete;
-    GILGuard(GILGuard&&) = delete;
-    GILGuard& operator=(GILGuard&&) = delete;
-
   private:
     module_state* _mstate;
-    PyGILState_STATE _gil_state{ PyGILState_UNLOCKED };
-    bool _acquired{ false };
+    PyGILState_STATE _gil_state;
 };
 
 // ----------------------------------------------------------------------------
@@ -252,20 +244,13 @@ class AllowThreads
     }
     inline ~AllowThreads()
     {
-        // Only restore if we actually saved: _thread_state is non-null iff
-        // is_finalizing() was false when the constructor ran.
-        if (_thread_state != nullptr && !_mstate->is_finalizing())
+        if (!_mstate->is_finalizing())
             PyEval_RestoreThread(_thread_state);
     }
 
-    AllowThreads(const AllowThreads&) = delete;
-    AllowThreads& operator=(const AllowThreads&) = delete;
-    AllowThreads(AllowThreads&&) = delete;
-    AllowThreads& operator=(AllowThreads&&) = delete;
-
   private:
     module_state* _mstate;
-    PyThreadState* _thread_state{ nullptr };
+    PyThreadState* _thread_state;
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
**Not for merge — bisection experiment.** This branch starts from the 4.9.1+fork-fix test build (#18832) and changes only `_threads.cpp`'s `GILGuard` / `AllowThreads` RAII helpers back to the 4.8.11 behavior.

Why: known-good `v4.8.11` and known-bad `4.9.1+fix` have a very small net diff in thread/fork code. Aside from harmless thread-name truncation, the meaningful delta is the 4.9 guard refactor. This tests whether that refactor is the 4.9-specific ingredient that makes #18379 manifest as fork timeouts.
