### PR TITLE
test(core): direct fork diagnostics on 4.9.1+fix

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -3,9 +3,9 @@
 
 #include "structmember.h"
 
-#include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <stddef.h>
 
 #include <atomic>
@@ -558,8 +558,13 @@ PeriodicThread_init(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwlist[] = { "interval", "target", "name", "on_shutdown", "no_wait_at_start", NULL };
 
-    self->name = Py_None;
-    self->_on_shutdown = Py_None;
+    // Leave optional args NULL before parsing and only default them to Py_None
+    // after a successful parse. If parsing fails, the fields stay NULL so the
+    // dealloc/tp_clear path is a Py_CLEAR no-op instead of over-decref'ing
+    // Py_None (which the previous "assign Py_None without incref" pattern did
+    // on the error path).
+    self->name = NULL;
+    self->_on_shutdown = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args,
                                      kwargs,
@@ -571,6 +576,11 @@ PeriodicThread_init(PeriodicThread* self, PyObject* args, PyObject* kwargs)
                                      &self->_on_shutdown,
                                      &self->_no_wait_at_start))
         return -1;
+
+    if (self->name == NULL)
+        self->name = Py_None;
+    if (self->_on_shutdown == NULL)
+        self->_on_shutdown = Py_None;
 
     Py_INCREF(self->_target);
     Py_INCREF(self->name);
@@ -611,6 +621,17 @@ PeriodicThread_init(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 static inline PyObject*
 PeriodicThread__periodic(PeriodicThread* self)
 {
+    // Defensive guard: since #18379 made PeriodicThread GC-tracked, tp_clear can
+    // in principle NULL _target independently of dealloc (breaking a cycle).
+    // A live worker is meant to be kept reachable by the C-held PyRef, so this
+    // should never fire; if it does, emit a diagnostic marker and treat the
+    // iteration as a clean no-op instead of calling PyObject_CallObject(NULL),
+    // which would raise SystemError.
+    if (self->_target == NULL) {
+        fork_diag_native("periodic_target_cleared", self, self->name);
+        Py_RETURN_NONE;
+    }
+
     PyObject* result = PyObject_CallObject(self->_target, NULL);
 
     if (result == NULL)
@@ -623,6 +644,12 @@ PeriodicThread__periodic(PeriodicThread* self)
 static inline void
 PeriodicThread__on_shutdown(PeriodicThread* self)
 {
+    // See PeriodicThread__periodic: guard against a GC-cleared callback.
+    if (self->_on_shutdown == NULL) {
+        fork_diag_native("on_shutdown_cleared", self, self->name);
+        return;
+    }
+
     PyObject* result = PyObject_CallObject(self->_on_shutdown, NULL);
 
     if (result == NULL) {

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -4,6 +4,8 @@
 #include "structmember.h"
 
 #include <cstring>
+#include <cstdio>
+#include <cstdlib>
 #include <stddef.h>
 
 #include <atomic>
@@ -29,6 +31,56 @@
 #define py_is_finalizing Py_IsFinalizing
 #else
 #define py_is_finalizing _Py_IsFinalizing
+#endif
+
+#if defined(_WIN32)
+static void
+fork_diag_native(const char* event, const void* self, PyObject* name_obj)
+{
+    (void)event;
+    (void)self;
+    (void)name_obj;
+}
+#else
+#include <time.h>
+#include <unistd.h>
+static void
+fork_diag_native(const char* event, const void* self, PyObject* name_obj)
+{
+    static int enabled = -1;
+    if (enabled == -1) {
+        const char* value = getenv("DD_TRACE_FORK_DIAG");
+        enabled = (value != nullptr && strcmp(value, "1") == 0) ? 1 : 0;
+    }
+    if (!enabled)
+        return;
+
+    const char* name = "<unknown>";
+    if (name_obj != nullptr && name_obj != Py_None) {
+        const char* maybe_name = PyUnicode_AsUTF8(name_obj);
+        if (maybe_name != nullptr)
+            name = maybe_name;
+        else
+            PyErr_Clear();
+    }
+
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    char buffer[512];
+    int n = snprintf(buffer,
+                     sizeof(buffer),
+                     "DDTRACE_FORK_DIAG_NATIVE pid=%ld ns=%lld event=%s self=%p name=%s\n",
+                     (long)getpid(),
+                     (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec,
+                     event,
+                     self,
+                     name);
+    if (n > 0) {
+        if (n > (int)sizeof(buffer))
+            n = sizeof(buffer);
+        (void)write(2, buffer, (size_t)n);
+    }
+}
 #endif
 
 // Forward declaration: PeriodicThread is defined later in this file.
@@ -862,12 +914,15 @@ PeriodicThread_stop(PeriodicThread* self, PyObject* Py_UNUSED(args))
 static PyObject*
 PeriodicThread_join(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 {
+    fork_diag_native("join_begin", self, self->name);
     if (self->_thread == nullptr) {
+        fork_diag_native("join_error_not_started", self, self->name);
         PyErr_SetString(PyExc_RuntimeError, "Periodic thread not started");
         return NULL;
     }
 
     if (self->_thread->get_id() == std::this_thread::get_id()) {
+        fork_diag_native("join_error_current_thread", self, self->name);
         PyErr_SetString(PyExc_RuntimeError, "Cannot join the current periodic thread");
         return NULL;
     }
@@ -911,6 +966,7 @@ PeriodicThread_join(PeriodicThread* self, PyObject* args, PyObject* kwargs)
         self->_stopped->wait(interval);
     }
 
+    fork_diag_native("join_end", self, self->name);
     Py_RETURN_NONE;
 }
 
@@ -918,6 +974,7 @@ PeriodicThread_join(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 static PyObject*
 PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 {
+    fork_diag_native("after_fork_begin", self, self->name);
     // The parent process passes force=True to this method to override
     // __autorestart__ and always restart the thread. The parent must restore
     // every thread that was running before the fork, regardless of the
@@ -928,6 +985,7 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
     static const char* kwlist[] = { "force", NULL };
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|p", (char**)kwlist, &force))
         return NULL;
+    fork_diag_native(force ? "after_fork_force_true" : "after_fork_force_false", self, self->name);
 
     // Check the __autorestart__ attribute (class or instance). Subclasses and
     // instances can set __autorestart__ = False to opt out of automatic
@@ -990,6 +1048,7 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
 
         PyObject* started = _PeriodicThread_do_start(self, false, static_cast<bool>(force));
         if (started == NULL) {
+            fork_diag_native("after_fork_start_error", self, self->name);
             if (pending_restart_registered) {
                 if (remove_pending_periodic_thread(self->_state, self) < 0)
                     PyErr_Clear();
@@ -997,6 +1056,7 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
             return NULL;
         }
         Py_DECREF(started);
+        fork_diag_native("after_fork_started", self, self->name);
     } else {
         // No restart: the common cleanup above is sufficient for fork-specific
         // state. Two additional invariants are preserved intentionally:
@@ -1021,8 +1081,10 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
         Py_DECREF(self->ident);
         Py_INCREF(Py_None);
         self->ident = Py_None;
+        fork_diag_native("after_fork_no_restart", self, self->name);
     }
 
+    fork_diag_native("after_fork_end", self, self->name);
     Py_RETURN_NONE;
 }
 
@@ -1030,6 +1092,7 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
 static PyObject*
 PeriodicThread__before_fork(PeriodicThread* self, PyObject* Py_UNUSED(args))
 {
+    fork_diag_native("before_fork_begin", self, self->name);
     self->_skip_shutdown = true;
 
     // Synchronize with awake() so there is no window where _stopping is visible
@@ -1045,6 +1108,7 @@ PeriodicThread__before_fork(PeriodicThread* self, PyObject* Py_UNUSED(args))
         self->_request->set(REQUEST_REASON_FORK_STOP);
     }
 
+    fork_diag_native("before_fork_end", self, self->name);
     Py_RETURN_NONE;
 }
 
@@ -1052,10 +1116,12 @@ PeriodicThread__before_fork(PeriodicThread* self, PyObject* Py_UNUSED(args))
 static void
 PeriodicThread_dealloc(PeriodicThread* self)
 {
+    fork_diag_native("dealloc_begin", self, self->name);
     PyObject_GC_UnTrack(self);
 
     if (self->_state != nullptr && self->_state->is_finalizing()) {
         // Do nothing. We are about to terminate and release resources anyway.
+        fork_diag_native("dealloc_finalizing_return", self, self->name);
         return;
     }
 
@@ -1095,6 +1161,7 @@ PeriodicThread_dealloc(PeriodicThread* self)
 
     self->_awake_mutex = nullptr;
 
+    fork_diag_native("dealloc_end", self, self->name);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -1,3 +1,6 @@
+from os import environ
+from os import getpid
+from os import write
 from time import monotonic_ns
 import typing as t
 
@@ -9,6 +12,25 @@ from ddtrace.internal.logger import get_logger
 
 
 log = get_logger(__name__)
+
+
+_FORK_DIAG = environ.get("DD_TRACE_FORK_DIAG") == "1"
+
+
+def _diag(message: str) -> None:
+    if not _FORK_DIAG:
+        return
+    try:
+        write(2, f"DDTRACE_FORK_DIAG pid={getpid()} ns={monotonic_ns()} {message}\n".encode())
+    except Exception:
+        pass
+
+
+def _thread_label(thread: t.Any) -> str:
+    try:
+        return str(thread.name)
+    except Exception:
+        return f"<unnamed id={id(thread)}>"
 
 # We try to import the stdlib locks from the _thread module, where they are
 # implemented in C for CPython for most platforms. If that fails, we fall back
@@ -161,39 +183,55 @@ class ThreadRestartTimer(PeriodicThread):
 def _after_fork_child():
     global _forking
 
+    _diag(
+        "py_after_child_begin "
+        f"restart={len(_threads_to_restart_after_fork)} start={len(_threads_to_start_after_fork)}"
+    )
     _forking = False
 
     # Keep child at-fork work minimal: thread restarts happen asynchronously in
     # the child so application code can resume immediately after fork. Parent
     # process threads are still restarted in _after_fork_parent() below.
     for thread in _threads_to_restart_after_fork.copy():
+        _diag(f"py_after_child_restart_begin name={_thread_label(thread)} id={id(thread)}")
         log.debug("Restarting thread %s after fork in child", thread.name)
         try:
             thread._after_fork(force=False)
+            _diag(f"py_after_child_restart_end name={_thread_label(thread)} id={id(thread)}")
         except Exception as e:
+            _diag(f"py_after_child_restart_error name={_thread_label(thread)} id={id(thread)} err={e!r}")
             log.error("failed to restart periodic thread %s after fork in child: %s", thread.name, e)
     _threads_to_restart_after_fork.clear()
 
     for thread_start in _threads_to_start_after_fork.copy():
+        _diag(f"py_after_child_start_begin name={_thread_label(thread_start.__self__)} id={id(thread_start.__self__)}")
         log.debug("Starting thread %s after fork in child", thread_start.__self__.name)
         _safe_restart(thread_start, thread_start.__self__.name)
+        _diag(f"py_after_child_start_end name={_thread_label(thread_start.__self__)} id={id(thread_start.__self__)}")
     _threads_to_start_after_fork.clear()
+    _diag("py_after_child_end")
 
 
 @forksafe.register_after_parent
 def _after_fork_parent() -> None:
     global _forking
 
+    _diag(
+        "py_after_parent_begin "
+        f"restart={len(_threads_to_restart_after_fork)} start={len(_threads_to_start_after_fork)}"
+    )
     _forking = False
 
     if _threads_to_restart_after_fork or _threads_to_start_after_fork:
         ThreadRestartTimer.set()
+    _diag("py_after_parent_end")
 
 
 @forksafe.register_before_fork
 def _before_fork() -> None:
     global _threads_to_restart_after_fork, _forking_lock, _forking
 
+    _diag("py_before_begin")
     ThreadRestartTimer.touch()
 
     with _forking_lock:
@@ -206,15 +244,24 @@ def _before_fork() -> None:
     # Take note of all the periodic threads that are running and will need to be
     # restarted.
     _threads_to_restart_after_fork.update(periodic_threads.values())
+    _diag(
+        "py_before_snapshot "
+        f"pending={len(pending_threads)} periodic={len(periodic_threads)} restart={len(_threads_to_restart_after_fork)}"
+    )
 
     # Stop all the periodic threads that are still running, without executing
     # the shutdown methods, if any. This ensures that we can stop the threads
     # more promptly.
     for thread in _threads_to_restart_after_fork:
+        _diag(f"py_before_stop_begin name={_thread_label(thread)} id={id(thread)}")
         log.debug("Stopping thread %s before fork", thread.name)
         thread._before_fork()
+        _diag(f"py_before_stop_end name={_thread_label(thread)} id={id(thread)}")
 
     # Join all the threads to ensure they are stopped before the fork.
     for thread in _threads_to_restart_after_fork:
+        _diag(f"py_before_join_begin name={_thread_label(thread)} id={id(thread)}")
         log.debug("Joining thread %s before fork", thread.name)
         thread.join()
+        _diag(f"py_before_join_end name={_thread_label(thread)} id={id(thread)}")
+    _diag("py_before_end")

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -1,3 +1,4 @@
+import gc
 from os import environ
 from os import getpid
 from os import write
@@ -31,6 +32,38 @@ def _thread_label(thread: t.Any) -> str:
         return str(thread.name)
     except Exception:
         return f"<unnamed id={id(thread)}>"
+
+
+def _gc_state() -> str:
+    """Snapshot cyclic-GC pressure so fork markers can be correlated with it.
+
+    Since #18379 made PeriodicThread GC-tracked, a cyclic collection landing in
+    the fork window is a prime suspect for the staging fork-ping timeout. Emit
+    the per-generation allocation counters and the enabled flag alongside the
+    fork lifecycle markers so the log ordering shows whether a collection ran.
+    """
+    try:
+        counts = gc.get_count()
+        return f"gc_enabled={int(gc.isenabled())} gc_count={counts[0]},{counts[1]},{counts[2]}"
+    except Exception:
+        return "gc_enabled=? gc_count=?"
+
+
+def _gc_diag_callback(phase: str, info: dict) -> None:
+    # Fires on every cyclic-GC start/stop while diagnostics are enabled. The ns
+    # timestamp lets us see whether a collection brackets a fork window in the
+    # child, which would explain a delayed post-fork ping.
+    _diag(
+        f"gc_{phase} generation={info.get('generation')} "
+        f"collected={info.get('collected')} uncollectable={info.get('uncollectable')}"
+    )
+
+
+if _FORK_DIAG:
+    try:
+        gc.callbacks.append(_gc_diag_callback)
+    except Exception:
+        pass
 
 # We try to import the stdlib locks from the _thread module, where they are
 # implemented in C for CPython for most platforms. If that fails, we fall back
@@ -185,13 +218,16 @@ def _after_fork_child():
 
     _diag(
         "py_after_child_begin "
-        f"restart={len(_threads_to_restart_after_fork)} start={len(_threads_to_start_after_fork)}"
+        f"restart={len(_threads_to_restart_after_fork)} start={len(_threads_to_start_after_fork)} "
+        f"{_gc_state()}"
     )
     _forking = False
 
     # Keep child at-fork work minimal: thread restarts happen asynchronously in
     # the child so application code can resume immediately after fork. Parent
     # process threads are still restarted in _after_fork_parent() below.
+    _restart_start_ns = monotonic_ns()
+    _restart_count = len(_threads_to_restart_after_fork)
     for thread in _threads_to_restart_after_fork.copy():
         _diag(f"py_after_child_restart_begin name={_thread_label(thread)} id={id(thread)}")
         log.debug("Restarting thread %s after fork in child", thread.name)
@@ -201,6 +237,7 @@ def _after_fork_child():
         except Exception as e:
             _diag(f"py_after_child_restart_error name={_thread_label(thread)} id={id(thread)} err={e!r}")
             log.error("failed to restart periodic thread %s after fork in child: %s", thread.name, e)
+    _diag(f"py_after_child_restart_summary count={_restart_count} elapsed_ns={monotonic_ns() - _restart_start_ns}")
     _threads_to_restart_after_fork.clear()
 
     for thread_start in _threads_to_start_after_fork.copy():
@@ -217,8 +254,7 @@ def _after_fork_parent() -> None:
     global _forking
 
     _diag(
-        "py_after_parent_begin "
-        f"restart={len(_threads_to_restart_after_fork)} start={len(_threads_to_start_after_fork)}"
+        f"py_after_parent_begin restart={len(_threads_to_restart_after_fork)} start={len(_threads_to_start_after_fork)}"
     )
     _forking = False
 
@@ -231,7 +267,7 @@ def _after_fork_parent() -> None:
 def _before_fork() -> None:
     global _threads_to_restart_after_fork, _forking_lock, _forking
 
-    _diag("py_before_begin")
+    _diag(f"py_before_begin {_gc_state()}")
     ThreadRestartTimer.touch()
 
     with _forking_lock:


### PR DESCRIPTION
## Summary
**Not for merge — diagnostic wheel for dogweb staging.** Starts from the 4.9.1+fork-fix build (#18832) and adds direct stderr diagnostics gated by `DD_TRACE_FORK_DIAG=1`.

Why: normal ddtrace debug logs were difficult to extract/filter in staging. These markers use `os.write(2, ...)` in Python and native `write(2, ...)` in `_threads.cpp`, bypassing Python logging configuration.

Markers cover:
- `threads.py::_before_fork` (now includes `gc_count` snapshot)
- `threads.py::_after_fork_child` (now includes `gc_count` snapshot + `py_after_child_restart_summary` loop timing)
- `threads.py::_after_fork_parent`
- native `PeriodicThread__before_fork`
- native `PeriodicThread__after_fork`
- native `PeriodicThread_join`
- native `PeriodicThread_dealloc`
- `gc_start` / `gc_stop` (via `gc.callbacks`) with generation/collected/uncollectable

Each marker includes pid, monotonic timestamp, thread name/id where available.

### Added (this revision) — hardening + GC correlation
Motivated by an audit of #18379 (which made `PeriodicThread` GC-tracked):
- **Defensive NULL guard** in `PeriodicThread__periodic` / `__on_shutdown`. `tp_clear` can now null the callbacks independently of dealloc; guard against `PyObject_CallObject(NULL)` and emit `periodic_target_cleared` / `on_shutdown_cleared` if it ever fires. This directly tests the hypothesis that a cyclic-GC `tp_clear` on a live worker is behind the staging fork-ping timeout.
- **Over-decref fix** on the `PeriodicThread_init` failure path: optional args now default to `Py_None` only after a successful parse, so the error path leaves them NULL (`Py_CLEAR` no-op) instead of decref'ing `Py_None` without a matching incref.
- **GC correlation diagnostics** so the log ordering shows whether a cyclic collection lands in the fork window in the child.

## Test plan
- `_threads.cpp` compiles cleanly (`-std=c++20`), `cformat` passes.
- `threads.py` `scripts/lint fmt` passes.
- Verified all new markers emit correctly via `scripts/delancie_fork_repro.py --pool ... --runtime-metrics` with `DD_TRACE_FORK_DIAG=1`.
- Confirmed `tests/internal/test_periodic.py` failures are pre-existing/environmental (py3.12 fork DeprecationWarning), identical with and without this change.
- Build wheel, deploy briefly to dogweb staging with `DD_TRACE_FORK_DIAG=1`, capture logs, revert.

Made with [Cursor](https://cursor.com)