### PR TITLE
chore(tracing): send native spans to the trace exporter

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -45,6 +45,7 @@ def collect() -> dict[str, Any]:
     """Collect system and library information into a serializable dict."""
 
     # Inline expensive imports to avoid unnecessary overhead on startup.
+    from ddtrace.internal import agent
     from ddtrace.internal import gitmetadata
     from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
     from ddtrace.internal.settings.crashtracker import config as crashtracker_config
@@ -57,12 +58,11 @@ def collect() -> dict[str, Any]:
         writer = tracer._span_aggregator.writer
         agent_url = writer.intake_url
         try:
-            writer.write([])
-            writer.flush_queue(raise_exc=True)
+            agent_info = agent.info(agent_url)  # type: ignore[no-untyped-call]
         except Exception as e:
             agent_error = "Agent not reachable at %s. Exception raised: %s" % (agent_url, str(e))
         else:
-            agent_error = None
+            agent_error = None if agent_info is not None else "Agent not reachable at %s" % agent_url
     else:
         agent_url = "CUSTOM"
         agent_error = None

--- a/ddtrace/internal/native/__init__.py
+++ b/ddtrace/internal/native/__init__.py
@@ -14,6 +14,7 @@ from ._native import HttpResponse  # noqa: F401
 from ._native import InvalidConfigError  # noqa: F401
 from ._native import IoError  # noqa: F401
 from ._native import NetworkError  # noqa: F401
+from ._native import PutOutcome  # noqa: F401
 from ._native import PyConfigurator
 from ._native import PyTracerMetadata  # noqa: F401
 from ._native import RemoteConfigCapabilities  # noqa: F401

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -7,6 +7,7 @@ from typing import Iterator
 from typing import Literal
 from typing import Mapping
 from typing import Optional
+from typing import Sequence
 from typing import TypeVar
 from typing import Union
 
@@ -233,6 +234,30 @@ class TraceExporter:
         :param data: The msgpack encoded trace payload to send.
         """
         ...
+    def put_trace(
+        self,
+        spans: Sequence["SpanData"],
+        dd_origin: Optional[str] = None,
+    ) -> "PutOutcome":
+        """
+        Build one trace chunk into its libdatadog v0.4 wire form and buffer it for the next flush.
+        The full conversion (truncation, meta/metrics, meta_struct packb, v0.5 links/events
+        json.dumps) runs synchronously here, on the calling thread under the GIL; flush then only
+        sends the already-built chunks.
+        :param spans: The spans of one trace chunk (each a SpanData / Span).
+        :param dd_origin: The trace-level origin, stamped as `_dd.origin` on every span at build time.
+        :return: whether the chunk was buffered (Accepted) or had no encodable spans.
+        """
+        ...
+    def flush(self) -> tuple[int, Optional[str]]:
+        """
+        Send all buffered trace chunks directly to the Agent via send_trace_chunks.
+        :return: (number of trace chunks sent, agent response body or None).
+        """
+        ...
+    def buffered_traces(self) -> int:
+        """Number of trace chunks currently buffered."""
+        ...
     def shutdown(self, timeout_ns: int) -> None:
         """
         Shutdown the TraceExporter, releasing any resources and ensuring all pending stats are sent.
@@ -444,11 +469,17 @@ class TraceExporterBuilder:
         :param timeout_ms: Timeout in milliseconds.
         """
         ...
-    def build(self, shared_runtime: SharedRuntime) -> TraceExporter:
+    def build(
+        self, shared_runtime: SharedRuntime, encode_links_as_json: bool, encode_events_as_json: bool
+    ) -> TraceExporter:
         """
         Build and return a TraceExporter instance with the configured settings.
         This method consumes the builder, so it cannot be used again after calling build.
         :param shared_runtime: A SharedRuntime instance to share with this exporter.
+        :param encode_links_as_json: Fixed for the output format (True for v0.5); applied to every
+            span at put_trace (build) time.
+        :param encode_events_as_json: True for v0.5, or on v0.4 when the agent hasn't opted into
+            native span events; applied to every span at put_trace (build) time.
         :return: A configured TraceExporter instance.
         :raises ValueError: If the builder has already been consumed or if required settings are missing.
         """
@@ -459,6 +490,10 @@ class TraceExporterBuilder:
         Should only be used for debugging.
         """
         ...
+
+class PutOutcome(Enum):
+    Accepted = ...
+    NoEncodableSpans = ...
 
 class AgentResponse:
     """Sampling-rate response from the Datadog agent after a successful trace export."""

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -52,7 +52,6 @@ from ..utils.http import verify_url
 from ..utils.time import StopWatch
 from .writer_client import WRITER_CLIENTS
 from .writer_client import AgentlessWriterClient
-from .writer_client import AgentWriterClientV4
 from .writer_client import WriterClientBase
 
 
@@ -660,7 +659,7 @@ def _resolve_api_version(api_version: Optional[str] = None) -> str:
         default = "v0.4"
     resolved = api_version or config._trace_api or default
     if agent_config.trace_native_span_events:
-        if not agent_config.trace_otlp_export_enabled:
+        if resolved != "v0.4" and not agent_config.trace_otlp_export_enabled:
             log.warning("Setting api version to v0.4; DD_TRACE_NATIVE_SPAN_EVENTS is not compatible with v0.5")
         resolved = "v0.4"
     if config._llmobs_enabled and resolved != "v0.4":
@@ -781,7 +780,6 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
                 ", ".join(sorted(WRITER_CLIENTS.keys())),
             )
             self._api_version = sorted(WRITER_CLIENTS.keys())[-1]
-        client = WRITER_CLIENTS[self._api_version](buffer_size, max_payload_size)
 
         super(NativeWriter, self).__init__(interval=processing_interval, autorestart=False)
         self.intake_url = intake_url
@@ -791,7 +789,6 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._max_payload_size = max_payload_size
         self._test_session_token = _resolve_test_session_token(test_session_token)
 
-        self._clients = [client]
         self.dogstatsd = dogstatsd
         self._metrics: dict[str, int] = defaultdict(int)
         self._report_metrics = report_metrics
@@ -863,7 +860,12 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             builder.enable_telemetry(heartbeat_ms, get_runtime_id(), config._debug_mode)
         if config._health_metrics_enabled:
             builder.enable_health_metrics()
-        return builder.build(get_native_runtime())
+        is_v05 = self._api_version == "v0.5"
+        return builder.build(
+            get_native_runtime(),
+            is_v05,
+            is_v05 or not agent_config.trace_native_span_events,
+        )
 
     def set_test_session_token(self, token: Optional[str]) -> None:
         """
@@ -916,9 +918,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             otlp_metrics_endpoint=self._otlp_metrics_endpoint,
         )
 
-    def _downgrade(self, status, client):
-        if client.ENDPOINT == "v0.5/traces":
-            self._clients = [AgentWriterClientV4(self._buffer_size, self._max_payload_size)]
+    def _downgrade(self, status):
+        if self._api_version == "v0.5":
             self._api_version = "v0.4"
             old_exporter = self._exporter
             self._exporter = self._create_exporter()
@@ -932,32 +933,27 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             # sending it, but we chuck it away instead.
             _safelog(
                 log.warning,
-                "Calling endpoint '%s' but received %s; downgrading API. "
+                "Calling endpoint 'v0.5/traces' but received %s; downgrading API. "
                 "Dropping trace payload due to the downgrade to an incompatible API version (from v0.5 to v0.4). To "
                 "avoid this from happening in the future, either ensure that the Datadog agent has a v0.5/traces "
                 "endpoint available, or explicitly set the trace API version to, e.g., v0.4.",
-                client.ENDPOINT,
                 status,
             )
         else:
             _safelog(
                 log.error,
-                "unsupported endpoint '%s': received response %s from intake (%s)",
-                client.ENDPOINT,
+                "unsupported endpoint '%s/traces': received response %s from intake (%s)",
+                self._api_version,
                 status,
                 self.intake_url,
             )
 
-    def _intake_endpoint(self, client=None):
-        return "{}/{}".format(self.intake_url, client.ENDPOINT if client else self._endpoint)
+    def _intake_endpoint(self):
+        return "{}/{}".format(self.intake_url, self._endpoint)
 
     @property
     def _endpoint(self):
-        return self._clients[0].ENDPOINT
-
-    @property
-    def _encoder(self):
-        return self._clients[0].encoder
+        return "{}/traces".format(self._api_version)
 
     def _metrics_dist(self, name: str, count: int = 1, tags: Optional[list] = None) -> None:
         if not self._report_metrics:
@@ -968,8 +964,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
     def _set_drop_rate(self) -> None:
         accepted = self._metrics["accepted_traces"]
         sent = self._metrics["sent_traces"]
-        encoded = sum([len(client.encoder) for client in self._clients])
-        # The number of dropped traces is the number of accepted traces minus the number of traces in the encoder
+        encoded = self._exporter.buffered_traces()
+        # The number of dropped traces is the number of accepted traces minus the number of traces in the buffer
         # This calculation is a best effort. Due to race conditions it may result in a slight underestimate.
         dropped = max(accepted - sent - encoded, 0)  # dropped spans should never be negative
         self._drop_sma.set(dropped, accepted)
@@ -981,41 +977,9 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             # PERF: avoid setting via Span.set_metric
             trace[0]._set_attribute(_KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 
-    def _send_payload(self, payload: bytes, count: int, client: WriterClientBase):
-        try:
-            response_body = self._exporter.send(payload)
-        except native.RequestError as e:
-            try:
-                # Request errors are formatted as "Error code: {code}, Response: {response}"
-                code = int(str(e).split(",")[0].split(":", maxsplit=1)[1])
-            except:  # noqa:E722 if the error message is invalid we want to log the full error
-                raise e
-            if code == 404 or code == 415:
-                self._downgrade(code, client)
-            else:
-                raise e
-        finally:
-            self._metrics["sent_traces"] += count
-
-        if self._response_cb:
-            response = Response(body=response_body)
-            raw_resp = response.get_json()
-
-            if raw_resp and "rate_by_service" in raw_resp:
-                self._response_cb(
-                    AgentResponse(
-                        rate_by_service=raw_resp["rate_by_service"],
-                    )
-                )
-
     def write(self, spans: Optional[list["Span"]] = None) -> None:
-        for client in self._clients:
-            self._write_with_client(client, spans=spans)
-        if self._sync_mode:
-            self.flush_queue()
-
-    def _write_with_client(self, client: WriterClientBase, spans: Optional[list["Span"]] = None) -> None:
-        if spans is None:
+        if not spans:
+            # Nothing to buffer for None or an empty chunk; both are a no-op.
             return
 
         if self._sync_mode is False:
@@ -1023,7 +987,6 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             try:
                 if self.status != service.ServiceStatus.RUNNING:
                     self.start()
-
             except service.ServiceStatusError:
                 _safelog(log.warning, "failed to start writer service")
 
@@ -1031,82 +994,80 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._metrics["accepted_traces"] += 1
         self._set_keep_rate(spans)
 
-        try:
-            client.encoder.put(spans)
-        except BufferItemTooLarge as e:
-            payload_size = e.args[0]
-            _safelog(
-                log.warning,
-                "trace (%db) larger than payload buffer item limit (%db), dropping",
-                payload_size,
-                client.encoder.max_item_size,
-            )
-            self._metrics_dist("buffer.dropped.traces", 1, tags=["reason:t_too_big"])
-            self._metrics_dist("buffer.dropped.bytes", payload_size, tags=["reason:t_too_big"])
-        except BufferFull as e:
-            payload_size = e.args[0]
-            _safelog(
-                log.warning,
-                "trace buffer (%s traces %db/%db) cannot fit trace of size %db, dropping (writer status: %s)",
-                len(client.encoder),
-                client.encoder.size,
-                client.encoder.max_size,
-                payload_size,
-                self.status.value,
-            )
-            self._metrics_dist("buffer.dropped.traces", 1, tags=["reason:full"])
-            self._metrics_dist("buffer.dropped.bytes", payload_size, tags=["reason:full"])
-        except NoEncodableSpansError:
+        # Origin lives on the Context, not on non-root spans, so pass it down explicitly for
+        # every span to get `_dd.origin`.
+        ctx = spans[0].context
+        dd_origin = ctx.dd_origin if ctx is not None else None
+
+        # put_trace builds each span into its libdatadog v0.4 wire form now, on this thread;
+        # flush only sends the already-built chunks. (v0.5-vs-v0.4 link/event encoding is fixed
+        # at build time on the exporter.)
+        outcome = self._exporter.put_trace(spans, dd_origin)
+        if outcome == native.PutOutcome.NoEncodableSpans:
             self._metrics_dist("buffer.dropped.traces", 1, tags=["reason:incompatible"])
         else:
             self._metrics_dist("buffer.accepted.traces", 1)
             self._metrics_dist("buffer.accepted.spans", len(spans))
 
+        if self._sync_mode:
+            self.flush_queue()
+
     def flush_queue(self, raise_exc: bool = False):
         try:
-            for client in self._clients:
-                self._flush_queue_with_client(client, raise_exc=raise_exc)
+            self._flush(raise_exc=raise_exc)
         finally:
             self._set_drop_rate()
 
-    def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
-        n_traces = len(client.encoder)
+    def _log_send_failure(self, n_traces: int, e: Exception) -> None:
+        _safelog(
+            log.error,
+            "failed to send, dropping %d traces to intake at %s: %s",
+            n_traces,
+            self._intake_endpoint(),
+            str(e),
+            extra={"send_to_telemetry": False},
+        )
+
+    def _flush(self, raise_exc: bool = False) -> None:
+        n_traces = self._exporter.buffered_traces()
+        if n_traces == 0:
+            return
+
+        response_body: Optional[str] = None
         try:
-            if not (encoded_traces := client.encoder.encode()):
+            # Re-read the drained count: a concurrent write()/flush() may have changed the
+            # buffer between the buffered_traces() check above and this call.
+            n_traces, response_body = self._exporter.flush()
+            if n_traces == 0:
                 return
-        except Exception:
-            # FIXME(munir): if client.encoder raises an Exception n_traces may not be accurate due to race conditions
-            _safelog(log.error, "failed to encode trace with encoder %r", client.encoder, exc_info=True)
-            self._metrics_dist("encoder.dropped.traces", n_traces)
-            return
-
-        for payload in encoded_traces:
-            encoded_data, n_traces = payload
-            self._flush_single_payload(encoded_data, n_traces, client=client, raise_exc=raise_exc)
-
-    def _flush_single_payload(
-        self, encoded: Optional[bytes], n_traces: int, client: WriterClientBase, raise_exc: bool = False
-    ) -> None:
-        if encoded is None:
-            return
-        try:
-            self._send_payload(encoded, n_traces, client)
         except Exception as e:
+            code = None
+            if isinstance(e, native.RequestError):
+                try:
+                    # Request errors are formatted as "Error code: {code}, Response: {response}"
+                    code = int(str(e).split(",")[0].split(":", maxsplit=1)[1])
+                except:  # noqa:E722 if the error message is invalid we want to log the full error
+                    code = None
+            if code in (404, 415):
+                self._downgrade(code)
+                return
             if raise_exc:
                 raise
+            self._log_send_failure(n_traces, e)
+            self._metrics_dist("http.errors", tags=["type:err"])
+            self._metrics_dist("http.dropped.traces", n_traces)
+            return
+        finally:
+            # The buffer is drained (mem::take) regardless of send success, so count it as sent for
+            # drop-rate purposes: _drop_sma / the client keep-rate track buffer & sampling drops, not
+            # transient delivery failures (which surface via http.dropped.traces above instead).
+            self._metrics["sent_traces"] += n_traces
 
-            msg = "failed to send, dropping %d traces to intake at %s: %s"
-            log_args = (
-                n_traces,
-                self._intake_endpoint(client),
-                str(e),
-            )
-            # Append the payload if requested
-            if config._trace_writer_log_err_payload:
-                msg += ", payload %s"
-                log_args += (binascii.hexlify(encoded).decode(),)  # type: ignore
-
-            _safelog(log.error, msg, *log_args, extra={"send_to_telemetry": False})
+        if self._response_cb and response_body:
+            response = Response(body=response_body)
+            raw_resp = response.get_json()
+            if raw_resp and "rate_by_service" in raw_resp:
+                self._response_cb(AgentResponse(rate_by_service=raw_resp["rate_by_service"]))
 
     def periodic(self):
         self.flush_queue(raise_exc=False)

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -4,11 +4,18 @@ use libdd_data_pipeline::trace_exporter::{
     TraceExporterInputFormat, TraceExporterOutputFormat,
 };
 use libdd_shared_runtime::ForkSafeRuntime;
-use pyo3::{exceptions::PyValueError, prelude::*, pybacked::PyBackedBytes};
+use libdd_trace_utils::span::v04::Span;
+use pyo3::types::PyString;
+use pyo3::{
+    exceptions::PyValueError, prelude::*, pybacked::PyBackedBytes, PyTraverseError, PyVisit,
+};
+use std::sync::Mutex;
 use std::time::Duration;
 mod agent_response;
 mod exceptions;
+use crate::py_string::{PyBackedString, PyTraceData};
 use crate::shared_runtime::SharedRuntimePy;
+use crate::span::{traverse_v04_span, SpanData};
 use exceptions::TraceExporterErrorPy;
 
 /// A wrapper around [TraceExporterBuilder]
@@ -218,7 +225,16 @@ impl TraceExporterBuilderPy {
     ///
     /// `set_shared_runtime` must be specified on the worker to avoid the trace exporter creating
     /// one without registering the fork hooks.
-    fn build(&mut self, shared_runtime: PyRef<'_, SharedRuntimePy>) -> PyResult<TraceExporterPy> {
+    /// `encode_links_as_json`/`encode_events_as_json` are fixed for the exporter's output
+    /// format (true for v0.5, which has no wire fields for span links/events); they are applied
+    /// to every span at `put_trace` time. `encode_events_as_json` is additionally true on v0.4
+    /// when the agent hasn't opted into native span events; span links have no such gate.
+    fn build(
+        &mut self,
+        shared_runtime: PyRef<'_, SharedRuntimePy>,
+        encode_links_as_json: bool,
+        encode_events_as_json: bool,
+    ) -> PyResult<TraceExporterPy> {
         let shared_runtime = shared_runtime.as_arc().clone();
         self.try_as_mut()?.set_shared_runtime(shared_runtime);
         let exporter = TraceExporterPy {
@@ -229,6 +245,9 @@ impl TraceExporterBuilderPy {
                     .build::<NativeCapabilities>()
                     .map_err(|err| PyValueError::new_err(format!("Builder {err}")))?,
             ),
+            buffer: Mutex::new(TraceBuffer { chunks: Vec::new() }),
+            encode_links_as_json,
+            encode_events_as_json,
         };
         Ok(exporter)
     }
@@ -238,10 +257,43 @@ impl TraceExporterBuilderPy {
     }
 }
 
-/// A python object wrapping a [TraceExporter] instance
+/// Buffer of built v0.4 trace chunks awaiting flush: spans are built at `put_trace`, so `flush`
+/// just takes and sends them (see `flush`).
+///
+/// Unbounded today — no size/count cap here or in the exporter, so the buffer grows if flushing
+/// stalls; bounding belongs in libdatadog's `TraceExporter`. This dropped the old writer's
+/// `DD_TRACE_WRITER_BUFFER_SIZE_BYTES` / max-payload buffer-drop path.
+struct TraceBuffer {
+    chunks: Vec<Vec<Span<PyTraceData>>>,
+}
+
+/// Outcome of [`TraceExporterPy::put_trace`]: the trace was buffered, or it had no encodable
+/// spans.
+#[pyclass(name = "PutOutcome", eq, eq_int, skip_from_py_object)]
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum PutOutcome {
+    Accepted,
+    NoEncodableSpans,
+}
+
+/// A python object wrapping a [TraceExporter] instance plus a native span buffer.
 #[pyclass(name = "TraceExporter")]
 pub struct TraceExporterPy {
     inner: Option<TraceExporter<NativeCapabilities, ForkSafeRuntime>>,
+    buffer: Mutex<TraceBuffer>,
+    /// Fixed for the exporter's output format; applied to every span at `put_trace`.
+    encode_links_as_json: bool,
+    /// Fixed for the exporter's output format / native-span-events opt-in; applied to every
+    /// span at `put_trace`.
+    encode_events_as_json: bool,
+}
+
+impl TraceExporterPy {
+    /// Lock the native span buffer, recovering from poisoning: only `push`/`mem::take` run under it,
+    /// so the buffered data is intact — reuse it rather than panic or discard.
+    fn lock_buffer(&self) -> std::sync::MutexGuard<'_, TraceBuffer> {
+        self.buffer.lock().unwrap_or_else(|e| e.into_inner())
+    }
 }
 
 #[pymethods]
@@ -269,6 +321,113 @@ impl TraceExporterPy {
         })
     }
 
+    /// Build one trace chunk (a Python ``list[Span]``) into libdatadog v0.4 wire spans and buffer
+    /// it for the next flush.
+    ///
+    /// Each span is built to its wire form here, under the GIL (see `SpanData::build_v04_span`), so
+    /// the Python-bound cost is spread across requests instead of bursting at flush — and `flush`
+    /// itself does no Python work. Returns an outcome rather than raising.
+    #[pyo3(signature = (spans, dd_origin=None))]
+    fn put_trace(
+        &self,
+        py: Python<'_>,
+        spans: Vec<Py<SpanData>>,
+        dd_origin: Option<Py<PyString>>,
+    ) -> PyResult<PutOutcome> {
+        if spans.is_empty() {
+            return Ok(PutOutcome::NoEncodableSpans);
+        }
+
+        let origin: Option<PyBackedString> = match &dd_origin {
+            Some(o) => PyBackedString::try_from(o.bind(py).clone()).ok(),
+            None => None,
+        };
+
+        // Build each span into its v0.4 wire form, releasing its borrow before the next. Fill an
+        // explicit presized `Vec` (a `PyResult<Vec<_>>` collect can't presize); errors propagate.
+        let mut chunk = Vec::with_capacity(spans.len());
+        for span in spans {
+            let wire = span.bind(py).borrow().build_v04_span(
+                py,
+                origin.as_ref(),
+                self.encode_links_as_json,
+                self.encode_events_as_json,
+            )?;
+            chunk.push(wire);
+        }
+
+        self.lock_buffer().chunks.push(chunk);
+        Ok(PutOutcome::Accepted)
+    }
+
+    /// Send the buffered v0.4 chunks via [`TraceExporter::send_trace_chunks`], handing libdatadog the
+    /// native `Span` structs directly (bypassing the old Cython-encode / libdatadog-decode round-trip).
+    ///
+    /// Does no Python/GIL work: it `mem::take`s the buffer (releasing the lock first) and, since every
+    /// `Span<PyTraceData>` field is GIL-free-readable, serializes-and-sends fully off the GIL. The
+    /// msgpack serialization still happens here (O(buffered spans)), just detached, so it never blocks
+    /// other Python threads.
+    ///
+    /// Returns ``(n_traces_sent, response_body)`` where ``response_body`` is the agent's JSON
+    /// body for a changed sampling rate, else ``None``.
+    fn flush(&self, py: Python<'_>) -> PyResult<(usize, Option<String>)> {
+        let chunks = {
+            let mut buf = self.lock_buffer();
+            std::mem::take(&mut buf.chunks)
+        };
+        if chunks.is_empty() {
+            return Ok((0, None));
+        }
+
+        let n = chunks.len();
+        let res: PyResult<AgentResponse> = py.detach(move || {
+            let exporter = self
+                .inner
+                .as_ref()
+                .ok_or_else(|| PyValueError::new_err("TraceExporter has already been consumed"))?;
+            exporter
+                .send_trace_chunks(chunks, None)
+                .map_err(|e| TraceExporterErrorPy::from(e).into())
+        });
+        match res? {
+            AgentResponse::Changed { body } => Ok((n, Some(body))),
+            AgentResponse::Unchanged => Ok((n, None)),
+        }
+    }
+
+    /// Cyclic-GC traversal: the buffer holds built v0.4 spans whose `PyBackedString`/`Bytes`
+    /// fields own live Python objects (see `traverse_v04_span`) that can close reference cycles
+    /// (span → context → tracer → writer → this exporter). Best-effort: if the buffer is
+    /// momentarily locked, skip this cycle rather than risk blocking GC.
+    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        let guard = match self.buffer.try_lock() {
+            Ok(g) => g,
+            Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => return Ok(()),
+        };
+        for chunk in &guard.chunks {
+            for span in chunk {
+                traverse_v04_span(span, &visit)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        // Recover from poison (see `lock_buffer`) so tp_clear still drops the buffered Py handles
+        // that close the GC cycle.
+        self.buffer
+            .get_mut()
+            .unwrap_or_else(|e| e.into_inner())
+            .chunks
+            .clear();
+    }
+
+    /// Number of trace chunks currently buffered (replaces ``len(encoder)`` for drop-rate).
+    fn buffered_traces(&self) -> usize {
+        self.lock_buffer().chunks.len()
+    }
+
     fn shutdown(&mut self, timeout_ns: u64) -> PyResult<()> {
         if let Some(exporter) = self.inner.take() {
             exporter
@@ -292,6 +451,7 @@ impl TraceExporterPy {
 pub fn register_data_pipeline(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TraceExporterBuilderPy>()?;
     m.add_class::<TraceExporterPy>()?;
+    m.add_class::<PutOutcome>()?;
     exceptions::register_exceptions(m)?;
     agent_response::register_agent_response(m)?;
 

--- a/src/native/event_hub.rs
+++ b/src/native/event_hub.rs
@@ -20,6 +20,8 @@ static RT_OK_PY: OnceLock<Py<PyAny>> = OnceLock::new();
 static RT_EXCEPTION_PY: OnceLock<Py<PyAny>> = OnceLock::new();
 
 // OnceLock::get_or_try_init is unstable; use get+set pattern instead.
+// Exported so other modules caching a Python object in a static OnceLock can reuse this.
+#[macro_export]
 macro_rules! get_or_init {
     ($cell:expr, $py:expr, $init:expr) => {{
         if let Some(val) = $cell.get() {

--- a/src/native/py_string.rs
+++ b/src/native/py_string.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     ops::Deref as _,
     ptr::{self, NonNull},
 };
@@ -10,8 +11,6 @@ use pyo3::{
 };
 
 use libdd_trace_utils::span::{SpanBytes, SpanText, TraceData};
-use serde::Serialize;
-use std::borrow::Borrow;
 
 /// A Python bytes/str backed utf-8 string we can read without needing access to the GIL
 /// that can be put in a libdatadog span.
@@ -26,6 +25,18 @@ use std::borrow::Borrow;
 /// When converting back to Python via `IntoPyObject`:
 /// - `Some(py_obj)` returns the stored Python object (zero-copy)
 /// - `None` creates an interned Python string (cached by Python for repeated access)
+///
+/// ## Footprint is load-bearing — keep `storage` one word
+///
+/// AIDEV-NOTE: this is the hottest type in the span path (every span field, every meta/metrics key),
+/// so its width shows up directly in throughput. `storage` is deliberately `Option<Py<PyAny>>`, which
+/// is 8 bytes because `Py` is non-null and `None` uses that niche — 24 bytes total, 32 per `meta`
+/// entry. A previous attempt added a third storage state for Rust-owned heap strings (`Box<str>`, so
+/// truncation could skip allocating a `PyString`); that widened `storage` to 24 bytes and the struct
+/// to 40, and an interleaved loadtest measured **−1.3% throughput, +2% p99, +1% RSS**. Don't
+/// reintroduce a heap-owned variant: dynamic Rust strings are only needed on the rare truncation
+/// path, which doesn't justify widening every instance. Rust-sourced *static* text is already
+/// supported via `from_static_str`, so a wire map can still mix Rust and Python sources.
 pub struct PyBackedString {
     /// memory view over the python object bytes, or static data
     data: ptr::NonNull<str>,
@@ -35,6 +46,7 @@ pub struct PyBackedString {
 }
 
 impl PyBackedString {
+    /// Cheap clone: a refcount bump for Python-backed data, a bare pointer copy for `'static`.
     pub fn clone_ref<'py>(&self, py: Python<'py>) -> Self {
         Self {
             data: self.data,
@@ -53,8 +65,7 @@ impl PyBackedString {
 
     pub fn py_none<'py>(py: Python<'py>) -> Self {
         Self {
-            // SAFETY: "" is a non-null 'static str literal
-            data: unsafe { ptr::NonNull::new_unchecked("" as *const str as *mut _) },
+            data: ptr::NonNull::from(""),
             storage: Some(py.None()),
         }
     }
@@ -162,8 +173,7 @@ impl TryFrom<pyo3::Bound<'_, pyo3::types::PyBytes>> for PyBackedString {
 impl From<pyo3::Bound<'_, PyNone>> for PyBackedString {
     fn from(value: pyo3::Bound<'_, PyNone>) -> Self {
         Self {
-            // SAFETY: "" is a non-null 'static str literal
-            data: unsafe { NonNull::new_unchecked("" as *const str as *mut _) },
+            data: NonNull::from(""),
             storage: Some(value.to_owned().unbind().into_any()),
         }
     }
@@ -193,7 +203,13 @@ impl serde::Serialize for PyBackedString {
     }
 }
 
-impl std::borrow::Borrow<str> for PyBackedString {
+impl AsRef<str> for PyBackedString {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Borrow<str> for PyBackedString {
     fn borrow(&self) -> &str {
         self.deref()
     }
@@ -207,6 +223,22 @@ impl PartialEq for PyBackedString {
 
 impl Eq for PyBackedString {}
 
+impl Clone for PyBackedString {
+    fn clone(&self) -> Self {
+        match &self.storage {
+            // Static data holds no Python object, so cloning needs no GIL.
+            None => Self {
+                data: self.data,
+                storage: None,
+            },
+            // Bumping a Python refcount needs Python<'_>. We acquire the GIL here rather than
+            // enabling the `py-clone` pyo3 feature (which also panics without the GIL, but hides
+            // the requirement inside the standard Clone trait).
+            Some(_) => Python::attach(|py| self.clone_ref(py)),
+        }
+    }
+}
+
 impl Default for PyBackedString {
     fn default() -> Self {
         Self::from_static_str("")
@@ -219,34 +251,81 @@ impl std::fmt::Debug for PyBackedString {
     }
 }
 
-impl From<String> for PyBackedString {
-    fn from(_s: String) -> Self {
-        todo!()
-    }
-}
-
 impl SpanText for PyBackedString {
+    /// Wrap a `'static` Rust string, holding no Python object. Safe to surface to Python: `as_py`
+    /// interns it, which is cheap and returns a stable object across reads.
+    ///
+    /// This is also how *Rust-sourced* text goes into a wire map alongside Python-backed entries —
+    /// `Eq`/`Hash`/`Borrow` compare the payload, not the backing. Dynamic (heap) Rust strings are
+    /// deliberately unsupported; see the footprint note on [`PyBackedString`].
     fn from_static_str(value: &'static str) -> Self {
         Self {
-            // SAFETY: value is a 'static str reference, guaranteed to be non-null
-            data: unsafe { ptr::NonNull::new_unchecked(value as *const str as *mut _) },
+            data: ptr::NonNull::from(value),
             storage: None,
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Serialize)]
-pub struct Bytes(Vec<u8>);
+/// Opaque bytes for a span's `meta_struct`.
+///
+/// Always Rust-owned: `meta_struct` values are msgpacked natively (see `span::msgpack`), so unlike
+/// [`PyBackedString`] this never views a Python buffer — no raw pointer, no `unsafe`, no
+/// `unsafe impl Send`/`Sync`, and no GIL needed to drop. Instances are rare (one per `meta_struct`
+/// key, which only appsec/LLMObs set), so its width doesn't matter the way `PyBackedString`'s does.
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub struct Bytes(Box<[u8]>);
+
+impl Bytes {
+    /// Wrap natively-packed msgpack bytes.
+    pub(crate) fn from_owned_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes.into_boxed_slice())
+    }
+
+    /// No-op — holds no Python reference. Kept so `traverse_v04_span` can visit every span field
+    /// uniformly.
+    #[inline(always)]
+    pub(crate) fn traverse(&self, _visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+        Ok(())
+    }
+}
 
 impl SpanBytes for Bytes {
     fn from_static_bytes(value: &'static [u8]) -> Self {
-        Self(value.to_vec())
+        Self(Box::from(value))
+    }
+}
+
+impl std::ops::Deref for Bytes {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        self
     }
 }
 
 impl Borrow<[u8]> for Bytes {
     fn borrow(&self) -> &[u8] {
-        &self.0
+        self
+    }
+}
+
+impl std::fmt::Debug for Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+impl serde::Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(self.deref())
     }
 }
 

--- a/src/native/span/mod.rs
+++ b/src/native/span/mod.rs
@@ -6,6 +6,7 @@ mod span_event;
 mod span_link;
 pub mod utils;
 
+pub(crate) use span_data::traverse_v04_span;
 pub use span_data::SpanData;
 pub use span_event::SpanEvent;
 pub use span_link::SpanLink;

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -9,7 +9,8 @@ use pyo3::{
 
 use super::attributes::{AttrKey, AttributeMap, AttributeValue};
 use crate::ddtrace_utils::flatten_key_value_vec as flatten_key_value_vec_fn;
-use crate::py_string::{PyBackedString, PyTraceData};
+use crate::get_or_init;
+use crate::py_string::{Bytes, PyBackedString, PyTraceData};
 use libdd_trace_utils::span::{
     v04::{
         AttributeAnyValue, AttributeArrayValue, SpanEvent as NativeSpanEvent,
@@ -23,6 +24,54 @@ use super::utils::{
     extract_i64_or_default, extract_time_unix_nano, wall_clock_ns,
 };
 use super::{SpanEvent, SpanLink};
+use std::sync::OnceLock;
+
+/// Cyclic-GC traversal for a wire span buffered inside `TraceExporterPy`.
+///
+/// The buffer holds fully-built `v04::Span<PyTraceData>`s (see `TraceExporterPy::put_trace`)
+/// whose every string/bytes field is a [`PyBackedString`]/[`Bytes`] owning a `Py` handle to a
+/// live Python object. Those handles can close a reference cycle (span → context → tracer →
+/// writer → exporter → buffer), so the GC must see every one of them — the same reason
+/// `SpanData::__traverse__` visits its own fields. Missing any edge here risks an uncollectable
+/// cycle (leak); over-visiting is harmless (these are atomic str/bytes objects).
+pub(crate) fn traverse_v04_span(
+    span: &libdd_trace_utils::span::v04::Span<PyTraceData>,
+    visit: &pyo3::PyVisit<'_>,
+) -> Result<(), pyo3::PyTraverseError> {
+    span.service.traverse(visit)?;
+    span.name.traverse(visit)?;
+    span.resource.traverse(visit)?;
+    span.r#type.traverse(visit)?;
+    // meta: both key and value are Py-backed strings.
+    for (k, v) in span.meta.iter() {
+        k.traverse(visit)?;
+        v.traverse(visit)?;
+    }
+    // metrics: only the key is Py-backed (values are f64).
+    for (k, _) in span.metrics.iter() {
+        k.traverse(visit)?;
+    }
+    // meta_struct: Py-backed key; the value is Rust-owned msgpack (no Python ref) so its traverse is a no-op.
+    for (k, v) in span.meta_struct.iter() {
+        k.traverse(visit)?;
+        v.traverse(visit)?;
+    }
+    for link in &span.span_links {
+        link.tracestate.traverse(visit)?;
+        for (k, v) in &link.attributes {
+            k.traverse(visit)?;
+            v.traverse(visit)?;
+        }
+    }
+    for event in &span.span_events {
+        event.name.traverse(visit)?;
+        for (k, v) in &event.attributes {
+            k.traverse(visit)?;
+            traverse_attr_any(v, visit)?;
+        }
+    }
+    Ok(())
+}
 
 #[pyo3::pyclass(name = "SpanData", module = "ddtrace.internal._native", subclass)]
 #[derive(Default)]
@@ -42,10 +91,11 @@ pub struct SpanData {
     pub span_links: Vec<NativeSpanLink<PyTraceData>>,
     pub span_events: Vec<NativeSpanEvent<PyTraceData>>,
     pub span_api: PyBackedString,
-    /// Unified attribute storage — source of truth for all tag/metric attributes.
-    /// `meta` and `metrics` are left empty in the native span; they are materialized
-    /// from this map at encode time (currently by the Python encoder via the bulk read
-    /// accessors `_get_str_attributes` / `_get_numeric_attributes`).
+    /// All span attributes, in one map. The value's variant decides its wire destination:
+    /// `Str` → `meta`, `Int`/`Float` → `metrics`. A key holds exactly one value, so
+    /// meta/metrics mutual exclusion is inherent here — there is no cross-map eviction to keep
+    /// in sync. The wire views (`PyBackedString`) are materialized at encode time by
+    /// `build_v04_span`.
     pub(crate) attributes: AttributeMap,
     /// Lazy Python int cache for the `trace_id` getter.
     /// Populated on first read; invalidated on every write to `trace_id`.
@@ -75,9 +125,407 @@ impl SpanData {
             let _ = self.set_attribute(k, v);
         }
     }
+
+    /// Build the libdatadog v0.4 wire span directly from this span's live `meta`/`metrics`
+    /// (and links/events/meta_struct), materializing the `PyBackedString` wire views here.
+    ///
+    /// The wire span is produced in a single pass under the GIL.
+    ///
+    /// This is a **read**, not a drain: `self` is left fully intact (keys are `clone_ref`'d,
+    /// links/events are cloned) so `get_tag`/`get_metric`/`has_attribute` still work after the
+    /// finished span has been handed to the writer.
+    ///
+    // AIDEV-NOTE: the read-not-drain choice is deliberate and load-bearing — reading a span after
+    // `finish()` (`get_tag`, `_get_links`, `_get_struct_tag`, `__repr__`) is public API, so draining
+    // here would silently start returning empty. Deferred to a major version. Doing it then needs two
+    // changes together: seal-after-flush semantics, *and* `SpanData`'s meta values moving from
+    // `Py<PyString>` to `PyBackedString` — otherwise the element types still differ and the move
+    // can't reuse the backing `Vec` or skip the per-value `to_str()`.
+    ///
+    /// `dd_origin` (`trace[0].context.dd_origin`) is injected as `_dd.origin` into every span's
+    /// meta — the native attribute store only carries it on the chunk-root span. Not truncated:
+    /// `_dd.origin` is an internal reserved tag, exempt from the user-tag length cap.
+    ///
+    /// `encode_links_as_json`/`encode_events_as_json`: true for v0.5 output, which has no wire
+    /// fields for span links/events, so they're JSON-encoded into
+    /// `meta[SPAN_LINKS_KEY]`/`meta[SPAN_EVENTS_KEY]` instead. `encode_events_as_json` is also
+    /// true on v0.4 when the agent hasn't opted into native span events; span links have no such
+    /// gate.
+    ///
+    // AIDEV-NOTE: json.dumps (links/events) is a Python call that runs here, under the GIL and
+    // under the caller's `PyRef<SpanData>` borrow. A concurrent `&mut self` on the *same* finished
+    // span during a GIL-yield in that call would panic pyo3's borrow flag — but spans handed to the
+    // writer are finished and never concurrently mutated, so nothing can take `&mut self` while it
+    // runs. (`meta_struct` packing is native now and yields to no Python code at all.)
+    pub(crate) fn build_v04_span(
+        &self,
+        py: Python<'_>,
+        dd_origin: Option<&PyBackedString>,
+        encode_links_as_json: bool,
+        encode_events_as_json: bool,
+    ) -> PyResult<libdd_trace_utils::span::v04::Span<PyTraceData>> {
+        // `duration` is only None for unfinished spans, which the writer never receives; -1 is
+        // a defensive fallback sentinel (a real duration is always >= 0) since v0.4's wire
+        // `Span.duration` is a non-optional i64 with no representation for "unset".
+        let mut out = libdd_trace_utils::span::v04::Span::<PyTraceData> {
+            trace_id: self.trace_id,
+            span_id: self.span_id,
+            parent_id: self.parent_id,
+            start: self.start,
+            duration: self.duration.unwrap_or(-1),
+            error: self.error,
+            name: truncate_span_text(self.name.clone_ref(py)),
+            service: truncate_span_text(self.service.clone_ref(py)),
+            resource: truncate_span_text(self.resource.clone_ref(py)),
+            r#type: truncate_span_text(self.span_type.clone_ref(py)),
+            ..Default::default()
+        };
+
+        let links_as_json = encode_links_as_json && !self.span_links.is_empty();
+        let events_as_json = encode_events_as_json && !self.span_events.is_empty();
+
+        // One pass over the attributes: the value's variant picks the wire map. Both key and value
+        // are projected into GIL-free-readable `PyBackedString`s and truncated.
+        for (key, value) in &self.attributes {
+            // A key or value carrying lone surrogates has no valid UTF-8 wire form; skip it rather
+            // than emit bytes the msgpack payload can't legally carry.
+            let Ok(wire_key) = PyBackedString::try_from(key.as_bound(py)) else {
+                continue;
+            };
+            match value {
+                AttributeValue::Str(s) => {
+                    // Skip a user tag colliding with a reserved key injected below
+                    // (`_dd.origin`/`events`/`_dd.span_links`) so the injected value wins and keys
+                    // stay unique for `mark_deduped`.
+                    let k: &str = &wire_key;
+                    if (dd_origin.is_some() && k == ORIGIN_KEY)
+                        || (links_as_json && k == SPAN_LINKS_KEY)
+                        || (events_as_json && k == SPAN_EVENTS_KEY)
+                    {
+                        continue;
+                    }
+                    let Ok(wire_value) = PyBackedString::try_from(s.bind(py).clone()) else {
+                        continue;
+                    };
+                    out.meta
+                        .insert(truncate_span_text(wire_key), truncate_span_text(wire_value));
+                }
+                // v0.4 `metrics` is a fixed f64 map, so Int widens here.
+                AttributeValue::Int(i) => {
+                    out.metrics.insert(truncate_span_text(wire_key), *i as f64);
+                }
+                AttributeValue::Float(f) => {
+                    out.metrics.insert(truncate_span_text(wire_key), *f);
+                }
+            }
+        }
+
+        // Links/events: JSON-encode into meta for v0.5 (no wire field), else clone the native
+        // structures (never drain — self stays intact). json.dumps is a Python call, under GIL.
+        if links_as_json {
+            let json = json_dumps_list(
+                py,
+                self.span_links
+                    .iter()
+                    .map(|l| span_link_to_json_dict(py, l)),
+            )?;
+            out.meta.insert(
+                PyBackedString::from_static_str(SPAN_LINKS_KEY),
+                truncate_span_text(json),
+            );
+        } else if !encode_links_as_json {
+            out.span_links = self
+                .span_links
+                .iter()
+                .map(|l| clone_truncate_span_link(py, l))
+                .collect();
+        }
+        if events_as_json {
+            let json = json_dumps_list(
+                py,
+                self.span_events
+                    .iter()
+                    .map(|e| span_event_to_json_dict(py, e)),
+            )?;
+            out.meta.insert(
+                PyBackedString::from_static_str(SPAN_EVENTS_KEY),
+                truncate_span_text(json),
+            );
+        } else if !encode_events_as_json {
+            out.span_events = self
+                .span_events
+                .iter()
+                .map(|e| clone_truncate_span_event(py, e))
+                .collect();
+        }
+
+        // Inject the trace-level `_dd.origin` into every span's meta. Not truncated: it's an
+        // internal reserved tag, exempt from the user-tag length cap.
+        if let Some(origin) = dd_origin {
+            out.meta.insert(
+                PyBackedString::from_static_str(ORIGIN_KEY),
+                origin.clone_ref(py),
+            );
+        }
+
+        // meta_struct: msgpack each user dict value via the existing Python packer. Iterate
+        // (don't take) so post-finish `_get_struct_tag` still works. A key that isn't valid
+        // UTF-8 is skipped.
+        if let Some(meta_struct) = &self.meta_struct {
+            for (k, v) in meta_struct.bind(py).iter() {
+                let Ok(key_backed) = k.extract::<PyBackedString>() else {
+                    continue;
+                };
+                let bytes = pack_meta_struct_value(py, &v)?;
+                out.meta_struct.insert(
+                    truncate_span_text(key_backed),
+                    Bytes::from_owned_bytes(bytes),
+                );
+            }
+        }
+
+        // Keys are unique: `attributes` is a map (so one key holds one value, and the variant picks
+        // exactly one wire map), the reserved-key skip above avoids colliding with the injected keys,
+        // and meta_struct keys come from a Python dict. Assert dedup without scanning — making the
+        // exporter's `span.dedup()` a no-op and dropping its per-map `HashSet`.
+        out.meta.mark_deduped();
+        out.metrics.mark_deduped();
+        out.meta_struct.mark_deduped();
+
+        Ok(out)
+    }
 }
 
 const HTTP_STATUS_CODE_KEY: &str = "http.status_code";
+
+/// Wire key for the trace-level origin tag (mirrors `_ORIGIN_KEY` in
+/// `ddtrace/internal/constants.py`).
+const ORIGIN_KEY: &str = "_dd.origin";
+
+/// Mirrors `MAX_SPAN_META_VALUE_LEN` / `TRUNCATED_SPAN_ATTRIBUTE_LEN` in
+/// `ddtrace/_trace/_limits.py`. Oversized fields must be truncated here to keep wire-format
+/// parity — otherwise payload size balloons and downstream consumers assume this cap holds.
+const MAX_SPAN_META_VALUE_LEN: usize = 25000;
+const TRUNCATED_SPAN_ATTRIBUTE_LEN: usize = 2500;
+const TRUNCATED_SUFFIX: &str = "<truncated>...";
+
+/// Truncate a string field to `MAX_SPAN_META_VALUE_LEN` *characters* (not bytes). Fast path on
+/// byte length first — UTF-8 encoding is never shorter than character count, so a string within
+/// the byte budget is always within the character budget too, letting the common (short, ASCII)
+/// case skip the `chars().count()` scan entirely. Takes `s` by value so the common untruncated case
+/// returns it straight back with no extra clone/refcount traffic.
+///
+/// The fast path touches no Python at all (`len`/`chars` read straight through the raw pointer). The
+/// rare oversized branch allocates a `PyString`, which needs the GIL — `Python::attach` re-acquires
+/// it just for that branch, and `build_v04_span` always calls this under the GIL anyway.
+///
+/// AIDEV-NOTE: holding the truncated value as a Rust-owned string instead (to skip this allocation)
+/// requires a heap-owned storage variant on `PyBackedString`, which widens *every* instance and
+/// measured −1.3% throughput. See the footprint note on `PyBackedString`.
+fn truncate_span_text(s: PyBackedString) -> PyBackedString {
+    if s.len() <= MAX_SPAN_META_VALUE_LEN || s.chars().count() <= MAX_SPAN_META_VALUE_LEN {
+        return s;
+    }
+    let keep = TRUNCATED_SPAN_ATTRIBUTE_LEN - TRUNCATED_SUFFIX.len();
+    let truncated: String = s
+        .chars()
+        .take(keep)
+        .chain(TRUNCATED_SUFFIX.chars())
+        .collect();
+    Python::attach(|py| {
+        PyBackedString::try_from(PyString::new(py, &truncated))
+            .expect("newly created PyString is valid UTF-8")
+    })
+}
+
+/// Clone (via refcount-bump `clone_ref`) and truncate every string field of a live span link in
+/// a single pass: `tracestate` and each attribute key/value. Reads `link` by reference so
+/// `self.span_links` stays intact for post-finish `_get_links`. Mirrors the Cython encoder's
+/// `_pack_links`, which ran every link field through `pack_text`.
+fn clone_truncate_span_link(
+    py: Python<'_>,
+    link: &NativeSpanLink<PyTraceData>,
+) -> NativeSpanLink<PyTraceData> {
+    NativeSpanLink {
+        trace_id: link.trace_id,
+        trace_id_high: link.trace_id_high,
+        span_id: link.span_id,
+        tracestate: truncate_span_text(link.tracestate.clone_ref(py)),
+        flags: link.flags,
+        attributes: link
+            .attributes
+            .iter()
+            .map(|(k, v)| {
+                (
+                    truncate_span_text(k.clone_ref(py)),
+                    truncate_span_text(v.clone_ref(py)),
+                )
+            })
+            .collect(),
+    }
+}
+
+/// Truncate the string payload of a single attribute value (`String` variant only —
+/// booleans/numbers have no text to truncate). Mirrors `pack_span_event_attributes`.
+fn truncate_attribute_array_value(
+    value: AttributeArrayValue<PyTraceData>,
+) -> AttributeArrayValue<PyTraceData> {
+    match value {
+        AttributeArrayValue::String(s) => AttributeArrayValue::String(truncate_span_text(s)),
+        other => other,
+    }
+}
+
+fn truncate_attribute_any_value(
+    value: AttributeAnyValue<PyTraceData>,
+) -> AttributeAnyValue<PyTraceData> {
+    match value {
+        AttributeAnyValue::SingleValue(v) => {
+            AttributeAnyValue::SingleValue(truncate_attribute_array_value(v))
+        }
+        AttributeAnyValue::Array(vec) => AttributeAnyValue::Array(
+            vec.into_iter()
+                .map(truncate_attribute_array_value)
+                .collect(),
+        ),
+    }
+}
+
+/// Clone (via refcount-bump `clone_ref`) and truncate every string field of a live span event in
+/// a single pass: `name` and each attribute key/value. Reads `event` by reference so
+/// `self.span_events` stays intact for post-finish `_get_events`. Mirrors the Cython encoder's
+/// `_pack_span_events`/`pack_span_event_attributes`.
+fn clone_truncate_span_event(
+    py: Python<'_>,
+    event: &NativeSpanEvent<PyTraceData>,
+) -> NativeSpanEvent<PyTraceData> {
+    NativeSpanEvent {
+        time_unix_nano: event.time_unix_nano,
+        name: truncate_span_text(event.name.clone_ref(py)),
+        attributes: event
+            .attributes
+            .iter()
+            .map(|(k, v)| {
+                (
+                    truncate_span_text(k.clone_ref(py)),
+                    truncate_attribute_any_value(v.clone()),
+                )
+            })
+            .collect(),
+    }
+}
+
+/// Wire keys for the v0.5 JSON-encoded-into-meta fallback (mirror `SPAN_LINKS_KEY`/
+/// `SPAN_EVENTS_KEY` in `ddtrace/internal/constants.py`).
+const SPAN_LINKS_KEY: &str = "_dd.span_links";
+const SPAN_EVENTS_KEY: &str = "events";
+
+/// Build the same dict shape as the public `SpanLink.to_dict()` (see `span_link.rs`) from an
+/// already-flattened `NativeSpanLink`, for JSON-encoding under the v0.5 compatibility shim.
+fn span_link_to_json_dict(
+    py: Python<'_>,
+    link: &NativeSpanLink<PyTraceData>,
+) -> PyResult<Py<PyDict>> {
+    let full_trace_id = ((link.trace_id_high as u128) << 64) | (link.trace_id as u128);
+    // Fields are truncated inline here (rather than pre-truncating a whole cloned
+    // NativeSpanLink first) since this dict is built straight from the live `self.span_links`
+    // when JSON-encoding for v0.5 — see SpanData::build_v04_span.
+    let d = PyDict::new(py);
+    d.set_item("trace_id", format!("{:032x}", full_trace_id))?;
+    d.set_item("span_id", format!("{:016x}", link.span_id))?;
+    if !link.attributes.is_empty() {
+        let attrs = PyDict::new(py);
+        for (k, v) in &link.attributes {
+            attrs.set_item(
+                &truncate_span_text(k.clone_ref(py)),
+                &truncate_span_text(v.clone_ref(py)),
+            )?;
+        }
+        d.set_item("attributes", attrs)?;
+    }
+    if !link.tracestate.is_empty() {
+        d.set_item(
+            "tracestate",
+            &truncate_span_text(link.tracestate.clone_ref(py)),
+        )?;
+    }
+    // Bit 31 encodes "flags present" (see build_native_link); unmask before surfacing,
+    // matching native_span_link_to_py's reverse mapping used by `_get_links()`.
+    if link.flags & 0x8000_0000 != 0 {
+        d.set_item("flags", (link.flags & 0x7FFF_FFFF) as i64)?;
+    }
+    Ok(d.unbind())
+}
+
+/// Build the same dict shape as `dict(SpanEvent(...))` (see `SpanEvent::__iter__` in
+/// `span_event.rs`) from a `NativeSpanEvent`, for JSON-encoding under the v0.5 shim. Fields are
+/// truncated inline for the same reason as `span_link_to_json_dict` above.
+fn span_event_to_json_dict(
+    py: Python<'_>,
+    event: &NativeSpanEvent<PyTraceData>,
+) -> PyResult<Py<PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("name", &truncate_span_text(event.name.clone_ref(py)))?;
+    d.set_item("time_unix_nano", event.time_unix_nano)?;
+    if !event.attributes.is_empty() {
+        let attrs = PyDict::new(py);
+        for (k, v) in &event.attributes {
+            let truncated = truncate_attribute_any_value(v.clone());
+            attrs.set_item(
+                &truncate_span_text(k.clone_ref(py)),
+                attribute_any_value_to_py(py, &truncated)?,
+            )?;
+        }
+        d.set_item("attributes", attrs)?;
+    }
+    Ok(d.unbind())
+}
+
+// Cached once on first use — `json.dumps`. Avoids a sys.modules lookup + getattr on every
+// call (this is on the v0.5 default-output hot path for any span with links/events).
+static JSON_DUMPS: OnceLock<Py<PyAny>> = OnceLock::new();
+
+fn get_json_dumps(py: Python<'_>) -> PyResult<&'static Py<PyAny>> {
+    get_or_init!(JSON_DUMPS, py, {
+        py.import("json")
+            .and_then(|m| m.getattr("dumps"))
+            .map(|a| a.unbind())
+    })
+}
+
+/// `json.dumps([...])` over a sequence of dicts, matching the Cython encoder's
+/// `json_dumps([link.to_dict() for link in ...])` / `json_dumps([dict(e) for e in ...])`.
+fn json_dumps_list<I>(py: Python<'_>, dicts: I) -> PyResult<PyBackedString>
+where
+    I: Iterator<Item = PyResult<Py<PyDict>>>,
+{
+    let list = PyList::empty(py);
+    for d in dicts {
+        list.append(d?)?;
+    }
+    get_json_dumps(py)?
+        .call1(py, (list,))?
+        .bind(py)
+        .extract::<PyBackedString>()
+}
+
+// Cached once on first use — `ddtrace.internal._encoding.packb`.
+static PACKB: OnceLock<Py<PyAny>> = OnceLock::new();
+
+fn get_packb(py: Python<'_>) -> PyResult<&'static Py<PyAny>> {
+    get_or_init!(PACKB, py, {
+        py.import("ddtrace.internal._encoding")
+            .and_then(|m| m.getattr("packb"))
+            .map(|a| a.unbind())
+    })
+}
+
+/// Pack one `meta_struct` value into msgpack bytes via the existing Python packer
+/// (`ddtrace.internal._encoding.packb`), copying the result into an owned buffer.
+fn pack_meta_struct_value(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
+    let packed = get_packb(py)?.call1(py, (obj,))?;
+    Ok(packed.bind(py).cast::<PyBytes>()?.as_bytes().to_vec())
+}
 
 #[pyo3::pymethods]
 impl SpanData {
@@ -116,7 +564,36 @@ impl SpanData {
         args: &Bound<'p, PyTuple>,
         kwargs: Option<&Bound<'p, PyDict>>,
     ) -> Self {
-        let mut span = Self::default();
+        let mut span = Self {
+            // Initialize span_id from parameter or generate random
+            span_id: span_id
+                .and_then(|obj| obj.extract::<u64>().ok())
+                .unwrap_or_else(crate::rand::rand64bits),
+            span_type: span_type
+                .map(|obj| extract_backed_string_or_none(obj))
+                .unwrap_or_else(|| PyBackedString::py_none(py)),
+            // Initialize parent_id: None or invalid → 0 (no parent), Some(int) → parent_id
+            parent_id: parent_id
+                .and_then(|obj| obj.extract::<u64>().ok())
+                .unwrap_or(0),
+            // Handle start parameter: None means capture current time, otherwise convert seconds to nanoseconds
+            start: match start {
+                None => wall_clock_ns(), // Common case: native time capture
+                Some(obj) => {
+                    // start is in seconds (float or int), convert to nanoseconds
+                    obj.extract::<f64>()
+                        .map(|s| (s * 1e9) as i64)
+                        .or_else(|_| obj.extract::<i64>().map(|s| s * 1_000_000_000))
+                        .unwrap_or_else(|_| wall_clock_ns()) // Invalid value: fall back to current time
+                }
+            },
+            // Initialize span_api: use provided value or default to "datadog"
+            span_api: span_api
+                .map(|obj| extract_backed_string_or_default(obj))
+                .unwrap_or_else(|| PyBackedString::from_static_str("datadog")),
+            // `attributes` stays at its empty Default: a span that sets no tags never allocates.
+            ..Default::default()
+        };
         span.set_name(name);
         match service {
             Some(obj) => span.set_service(obj),
@@ -129,29 +606,6 @@ impl SpanData {
             Some(obj) => span.set_resource(obj),
             None => span.resource = span.name.clone_ref(py),
         }
-        span.span_type = span_type
-            .map(|obj| extract_backed_string_or_none(obj))
-            .unwrap_or_else(|| PyBackedString::py_none(py));
-        // Initialize parent_id: None or invalid → 0 (no parent), Some(int) → parent_id
-        span.parent_id = parent_id
-            .and_then(|obj| obj.extract::<u64>().ok())
-            .unwrap_or(0);
-        // Handle start parameter: None means capture current time, otherwise convert seconds to nanoseconds
-        span.start = match start {
-            None => wall_clock_ns(), // Common case: native time capture
-            Some(obj) => {
-                // start is in seconds (float or int), convert to nanoseconds
-                obj.extract::<f64>()
-                    .map(|s| (s * 1e9) as i64)
-                    .or_else(|_| obj.extract::<i64>().map(|s| s * 1_000_000_000))
-                    .unwrap_or_else(|_| wall_clock_ns()) // Invalid value: fall back to current time
-            }
-        };
-        // duration defaults to None ("not finished") via Default — no init needed.
-        // Initialize span_id from parameter or generate random
-        span.span_id = span_id
-            .and_then(|obj| obj.extract::<u64>().ok())
-            .unwrap_or_else(crate::rand::rand64bits);
         // Initialize trace_id: use provided value, or generate based on 128-bit mode config.
         // When auto-generating, reads the Rust-owned AtomicBool set by Python Config.__init__:
         //   enabled  → generate_128bit_trace_id() (SystemTime upper bits + random lower bits)
@@ -191,10 +645,6 @@ impl SpanData {
         };
         // Override the None left by set_trace_id_native with the pre-seeded cache (if any).
         span._trace_id_py = trace_id_cached;
-        // Initialize span_api: use provided value or default to "datadog"
-        span.span_api = span_api
-            .map(|obj| extract_backed_string_or_default(obj))
-            .unwrap_or_else(|| PyBackedString::from_static_str("datadog"));
         span
     }
 
@@ -471,14 +921,14 @@ impl SpanData {
             return Ok(());
         }
 
-        // str → Str
+        // str → meta
         if let Ok(s) = value.cast::<PyString>() {
             self.attributes
                 .insert(attr_key, AttributeValue::Str(s.clone().unbind()));
             return Ok(());
         }
 
-        // float → Float (drop NaN/Inf)
+        // float → metrics (drop NaN/Inf)
         // Check before int because some types (e.g. numpy.float64) implement __float__
         // but not __index__, so PyFloat succeeds and PyInt would fail.
         if let Ok(f) = value.cast::<PyFloat>() {
@@ -490,7 +940,7 @@ impl SpanData {
             return Ok(());
         }
 
-        // int (catches bool and numpy.int* via __index__) → Int.
+        // int (catches bool and numpy.int* via __index__) → metrics.
         // extract::<i64>() succeeds for bool (True → 1, False → 0) and for any
         // type implementing __index__. Python ints that overflow i64 fall through
         // to the str() fallback below.
@@ -499,7 +949,7 @@ impl SpanData {
             return Ok(());
         }
 
-        // bytes → UTF-8 decoded Str (with U+FFFD replacements for invalid sequences)
+        // bytes → UTF-8 decoded meta (with U+FFFD replacements for invalid sequences)
         if let Ok(b) = value.cast::<PyBytes>() {
             let decoded = String::from_utf8_lossy(b.as_bytes());
             let py_str = PyString::new(key.py(), &decoded);
@@ -549,7 +999,7 @@ impl SpanData {
         Ok(())
     }
 
-    /// Return True if the span has an attribute with the given key.
+    /// Return True if the span has an attribute with the given key (in either meta or metrics).
     #[pyo3(name = "_has_attribute")]
     fn has_attribute(&self, key: &Bound<'_, PyAny>) -> bool {
         let Ok(k) = key.cast::<PyString>() else {
@@ -561,7 +1011,7 @@ impl SpanData {
         self.attributes.contains_key(k_str)
     }
 
-    /// Remove an attribute by key.
+    /// Remove an attribute by key from whichever map holds it.
     #[pyo3(name = "_remove_attribute")]
     fn remove_attribute(&mut self, key: &Bound<'_, PyAny>) {
         let Ok(k) = key.cast::<PyString>() else {
@@ -574,7 +1024,7 @@ impl SpanData {
     }
 
     /// Return the raw stored value for the given key, or None if not found.
-    /// Returns the natural Python type: str for Str, int for Int, float for Float.
+    /// Returns the natural Python type: str for meta, int/float for metrics.
     #[pyo3(name = "_get_attribute")]
     fn get_attribute<'py>(
         &self,
@@ -586,7 +1036,7 @@ impl SpanData {
         Some(self.attributes.get(k_str)?.as_py(py))
     }
 
-    /// Return the string attribute for the given key, or None if not a Str variant.
+    /// Return the string attribute for the given key, or None if not present in `meta`.
     #[pyo3(name = "_get_str_attribute")]
     fn get_str_attribute<'py>(
         &self,
@@ -601,7 +1051,7 @@ impl SpanData {
         }
     }
 
-    /// Return the numeric attribute for the given key, or None if not a numeric variant.
+    /// Return the numeric attribute for the given key, or None if not present in `metrics`.
     /// Returns int for Int values and float for Float values, preserving the original type.
     #[pyo3(name = "_get_numeric_attribute")]
     fn get_numeric_attribute<'py>(
@@ -612,13 +1062,8 @@ impl SpanData {
         let k = key.cast::<PyString>().ok()?;
         let k_str = k.to_str().ok()?;
         match self.attributes.get(k_str)? {
-            AttributeValue::Int(i) => {
-                Some(i.into_pyobject(py).expect("i64 into_pyobject").into_any())
-            }
-            AttributeValue::Float(f) => {
-                Some(f.into_pyobject(py).expect("f64 into_pyobject").into_any())
-            }
             AttributeValue::Str(_) => None,
+            v => Some(v.as_py(py)),
         }
     }
 
@@ -634,10 +1079,8 @@ impl SpanData {
         Ok(d)
     }
 
-    /// Return all Str-variant attributes as a Python dict snapshot.
+    /// Return the `Str`-valued attributes (the wire `meta`) as a Python dict snapshot.
     /// Used by the Python encoder to build the v0.4 `meta` dict.
-    /// Note: Int values with abs > 2^53 are NOT folded in here; the encoder
-    /// is responsible for moving them from metrics to meta at encode time.
     #[pyo3(name = "_get_str_attributes")]
     fn get_str_attributes<'py>(&self, py: Python<'py>) -> pyo3::PyResult<Bound<'py, PyDict>> {
         let d = PyDict::new(py);
@@ -649,11 +1092,9 @@ impl SpanData {
         Ok(d)
     }
 
-    /// Return all numeric (Int and Float) attributes as a Python dict snapshot.
+    /// Return the numeric attributes (the wire `metrics`) as a Python dict snapshot.
     /// Int values are returned as Python int; Float values as Python float.
     /// Used by the Python encoder to build the v0.4 `metrics` dict.
-    /// Note: the encoder is responsible for moving Int values with abs > 2^53
-    /// out of metrics and into meta as strings before serialization.
     #[pyo3(name = "_get_numeric_attributes")]
     fn get_numeric_attributes<'py>(&self, py: Python<'py>) -> pyo3::PyResult<Bound<'py, PyDict>> {
         let d = PyDict::new(py);
@@ -898,10 +1339,9 @@ impl SpanData {
         self.name.traverse(&visit)?;
         self.resource.traverse(&visit)?;
         self.span_type.traverse(&visit)?;
-        // `self.attributes` is the unified tag/metric store.
-        // Keys hold `Py<PyString>`; Str values hold `Py<PyString>`. Int/Float
-        // variants are primitive Rust types with no Python references.
-        for (k, v) in self.attributes.iter() {
+        // Attribute keys always hold a `Py<PyString>`; values hold one only in the `Str` variant
+        // (`AttributeValue::traverse` handles that).
+        for (k, v) in &self.attributes {
             k.traverse(&visit)?;
             v.traverse(&visit)?;
         }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -11,9 +11,6 @@ from tests.integration.utils import skip_if_testagent
 from tests.utils import call_program
 
 
-FOUR_KB = 1 << 12
-
-
 def test_import_ddtrace_generates_no_output_by_default(ddtrace_run_python_code_in_subprocess):
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(
         """
@@ -80,49 +77,6 @@ def test_uds_wrong_socket_path():
         )
     ]
     log.error.assert_has_calls(calls)
-
-
-@skip_if_testagent
-@parametrize_with_all_encodings(
-    env={
-        "DD_TRACE_WRITER_BUFFER_SIZE_BYTES": str(FOUR_KB),
-        "DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES": str(FOUR_KB),
-        # use a long processing_interval to ensure a flush doesn't happen partway through
-        "DD_TRACE_WRITER_INTERVAL_SECONDS": "1000",
-    }
-)
-def test_payload_too_large():
-    import os
-
-    import mock
-
-    from ddtrace.trace import tracer as t
-    from tests.integration.test_integration import FOUR_KB
-    from tests.utils import AnyInt
-    from tests.utils import AnyStr
-
-    encoding = os.environ["DD_TRACE_API_VERSION"]
-    assert t._span_aggregator.writer._max_payload_size == FOUR_KB
-    assert t._span_aggregator.writer._buffer_size == FOUR_KB
-    with mock.patch("ddtrace.internal.writer.writer.log") as log:
-        for i in range(100000 if encoding == "v0.5" else 1000):
-            with t.trace("operation") as s:
-                s.set_tag(str(i), "b" * 190)
-                s.set_tag(str(i), "a" * 190)
-
-        t.shutdown()
-        calls = [
-            mock.call(
-                "trace buffer (%s traces %db/%db) cannot fit trace of size %db, dropping (writer status: %s)",
-                AnyInt(),
-                AnyInt(),
-                AnyInt(),
-                AnyInt(),
-                AnyStr(),
-            )
-        ]
-        log.warning.assert_has_calls(calls)
-        log.error.assert_not_called()
 
 
 @parametrize_with_all_encodings()
@@ -243,60 +197,6 @@ def test_metrics_partial_flush_disabled():
     )
 
 
-@parametrize_with_all_encodings(check_logs=False)
-def test_single_trace_too_large():
-    import mock
-
-    from ddtrace.trace import tracer as t
-    from tests.utils import AnyInt
-    from tests.utils import AnyStr
-
-    assert t._span_aggregator.partial_flush_enabled is True
-    with (
-        mock.patch.object(t._span_aggregator.writer, "flush_queue", return_value=None),
-        mock.patch("ddtrace.internal.writer.writer.log") as log,
-    ):
-        with t.trace("huge"):
-            for i in range(1 << 20 + 1):
-                t.trace("operation").finish()
-        t._span_aggregator.writer.flush_queue()
-        calls = [
-            mock.call(
-                "trace buffer (%s traces %db/%db) cannot fit trace of size %db, dropping (writer status: %s)",
-                AnyInt(),
-                AnyInt(),
-                AnyInt(),
-                AnyInt(),
-                AnyStr(),
-            )
-        ]
-        log.warning.assert_has_calls(calls)
-        log.error.assert_not_called()
-
-
-@skip_if_testagent
-@parametrize_with_all_encodings(
-    env={"DD_TRACE_PARTIAL_FLUSH_ENABLED": "false", "DD_TRACE_WRITER_BUFFER_SIZE_BYTES": str(8 << 20)}
-)
-def test_single_trace_too_large_partial_flush_disabled():
-    import mock
-
-    from ddtrace.trace import tracer as t
-    from tests.utils import AnyInt
-
-    assert t._span_aggregator.partial_flush_enabled is False
-    with mock.patch("ddtrace.internal.writer.writer.log") as log:
-        with t.trace("huge"):
-            for _ in range(200000):
-                with t.trace("operation") as s:
-                    s.set_tag("a" * 10, "b" * 10)
-        t.shutdown()
-
-        calls = [mock.call("trace (%db) larger than payload buffer item limit (%db), dropping", AnyInt(), AnyInt())]
-        log.warning.assert_has_calls(calls)
-        log.error.assert_not_called()
-
-
 @parametrize_with_all_encodings(
     env={"DD_TRACE_HEALTH_METRICS_ENABLED": "true", "DD_TRACE_AGENT_URL": "http://localhost:8125"}, check_logs=False
 )
@@ -327,73 +227,14 @@ def test_trace_generates_error_logs_when_trace_agent_url_invalid():
 
 @skip_if_testagent
 @pytest.mark.subprocess(err=None)
-def test_trace_with_invalid_payload_generates_error_log():
-    import mock
-
-    from tests.integration.utils import send_invalid_payload_and_get_logs
-
-    log = send_invalid_payload_and_get_logs()
-    log.error.assert_has_calls(
-        [
-            mock.call(
-                "failed to send, dropping %d traces to intake at %s: %s",
-                0,
-                "http://localhost:8126/v0.5/traces",
-                "Invalid format: Unable to read payload len",
-                extra={"send_to_telemetry": False},
-            )
-        ]
-    )
-
-
-@skip_if_testagent
-@pytest.mark.subprocess(env={"_DD_TRACE_WRITER_LOG_ERROR_PAYLOADS": "true", "DD_TRACE_API_VERSION": "v0.5"}, err=None)
-def test_trace_with_invalid_payload_logs_payload_when_LOG_ERROR_PAYLOADS():
-    import mock
-
-    from tests.integration.utils import send_invalid_payload_and_get_logs
-
-    log = send_invalid_payload_and_get_logs()
-    log.error.assert_has_calls(
-        [
-            mock.call(
-                "failed to send, dropping %d traces to intake at %s: %s, payload %s",
-                0,
-                "http://localhost:8126/v0.5/traces",
-                "Invalid format: Unable to read payload len",
-                "6261645f7061796c6f6164",
-                extra={"send_to_telemetry": False},
-            )
-        ]
-    )
-
-
-@pytest.mark.subprocess(err=None)
-def test_trace_with_failing_encoder_generates_error_log():
-    from tests.integration.utils import BadEncoder
-    from tests.integration.utils import send_invalid_payload_and_get_logs
-
-    class ExceptionBadEncoder(BadEncoder):
-        def encode(self):
-            raise Exception()
-
-        def encode_traces(self, traces):
-            raise Exception()
-
-    log = send_invalid_payload_and_get_logs(ExceptionBadEncoder)
-    assert "failed to encode trace with encoder" in log.error.call_args[0][0]
-
-
-@skip_if_testagent
-@pytest.mark.subprocess(err=None)
 def test_api_version_downgrade_generates_no_warning_logs():
     import mock
 
     from ddtrace.internal.utils.http import Response
     from ddtrace.trace import tracer as t
 
-    t._span_aggregator.writer.api_version = "v0.5"
-    t._span_aggregator.writer._downgrade(Response(status=404), t._span_aggregator.writer._clients[0])
+    t._span_aggregator.writer._api_version = "v0.5"
+    t._span_aggregator.writer._downgrade(Response(status=404))
     assert t._span_aggregator.writer._endpoint == "v0.4/traces"
     with mock.patch("ddtrace.internal.writer.writer.log") as log:
         t.trace("operation", service="my-svc").finish()
@@ -436,8 +277,8 @@ s2.finish()
 def test_writer_configured_correctly_from_env():
     import ddtrace
 
-    assert ddtrace.tracer._span_aggregator.writer._encoder.max_size == 1000
-    assert ddtrace.tracer._span_aggregator.writer._encoder.max_item_size == 1000
+    assert ddtrace.tracer._span_aggregator.writer._buffer_size == 1000
+    assert ddtrace.tracer._span_aggregator.writer._max_payload_size == 5000
     assert ddtrace.tracer._span_aggregator.writer._interval == 5.0
 
 
@@ -445,8 +286,8 @@ def test_writer_configured_correctly_from_env():
 def test_writer_configured_correctly_from_env_defaults():
     import ddtrace
 
-    assert ddtrace.tracer._span_aggregator.writer._encoder.max_size == 20 << 20
-    assert ddtrace.tracer._span_aggregator.writer._encoder.max_item_size == 20 << 20
+    assert ddtrace.tracer._span_aggregator.writer._buffer_size == 20 << 20
+    assert ddtrace.tracer._span_aggregator.writer._max_payload_size == 20 << 20
     assert ddtrace.tracer._span_aggregator.writer._interval == 1.0
 
 
@@ -460,8 +301,8 @@ def test_writer_configured_correctly_from_env_under_ddtrace_run(ddtrace_run_pyth
         """
 import ddtrace
 
-assert ddtrace.tracer._span_aggregator.writer._encoder.max_size == 1000
-assert ddtrace.tracer._span_aggregator.writer._encoder.max_item_size == 1000
+assert ddtrace.tracer._span_aggregator.writer._buffer_size == 1000
+assert ddtrace.tracer._span_aggregator.writer._max_payload_size == 5000
 assert ddtrace.tracer._span_aggregator.writer._interval == 5.0
 """,
         env=env,
@@ -474,8 +315,8 @@ def test_writer_configured_correctly_from_env_defaults_under_ddtrace_run(ddtrace
         """
 import ddtrace
 
-assert ddtrace.tracer._span_aggregator.writer._encoder.max_size == 20 << 20
-assert ddtrace.tracer._span_aggregator.writer._encoder.max_item_size == 20 << 20
+assert ddtrace.tracer._span_aggregator.writer._buffer_size == 20 << 20
+assert ddtrace.tracer._span_aggregator.writer._max_payload_size == 20 << 20
 assert ddtrace.tracer._span_aggregator.writer._interval == 1.0
 """,
     )

--- a/tests/integration/test_integration_snapshots.py
+++ b/tests/integration/test_integration_snapshots.py
@@ -307,6 +307,86 @@ def test_encode_span_with_large_unicode_string_attributes(encoding):
             span.set_tag(key="å" * 25001, value="ä" * 2000)
 
 
+@pytest.mark.snapshot()
+def test_native_writer_span_events():
+    # Default v0.5 output has no span_events wire field, so events get JSON-encoded into
+    # meta["events"] instead. Native v0.4 field output is covered by
+    # test_native_writer_links_events_v04_output. See ENCODER_DIFFERENCES.md.
+    from ddtrace import tracer
+
+    with tracer.trace("operation", service="my-svc") as span:
+        span._add_event(
+            "my_event",
+            attributes={"str_attr": "value", "int_attr": 1, "bool_attr": True},
+            time_unix_nano=1700000000000000000,
+        )
+
+
+@pytest.mark.snapshot()
+def test_native_writer_span_links():
+    # Default v0.5 output has no span_links wire field, so links get JSON-encoded into
+    # meta["_dd.span_links"] instead. See ENCODER_DIFFERENCES.md.
+    from ddtrace import tracer
+
+    with tracer.trace("operation", service="my-svc") as span:
+        span._set_link(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1122334455667788,
+            attributes={"link.name": "linked"},
+        )
+
+
+@pytest.mark.snapshot()
+@pytest.mark.subprocess(env={"DD_TRACE_API_VERSION": "v0.4", "DD_TRACE_NATIVE_SPAN_EVENTS": "true"})
+def test_native_writer_links_events_v04_output():
+    # v0.4 output has native span_links/span_events fields (vs the v0.5 JSON-into-meta
+    # fallback above). span_events additionally requires opting into
+    # DD_TRACE_NATIVE_SPAN_EVENTS, since v0.4 span_links have always been native but
+    # span_events are still JSON-encoded into meta by default. See ENCODER_DIFFERENCES.md.
+    from ddtrace.trace import tracer
+
+    with tracer.trace("operation", service="my-svc") as span:
+        span._set_link(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1122334455667788,
+            attributes={"link.name": "linked"},
+        )
+        span._add_event("my_event", attributes={"k": "v"}, time_unix_nano=1700000000000000000)
+    tracer.flush()
+
+
+@pytest.mark.snapshot()
+@pytest.mark.subprocess(env={"DD_TRACE_API_VERSION": "v0.4", "DD_TRACE_NATIVE_SPAN_EVENTS": "true"})
+def test_native_writer_span_link_event_attribute_truncation():
+    # An oversized span-link/event attribute value must be truncated the same way meta/name/
+    # service/resource/type already are. Requires DD_TRACE_NATIVE_SPAN_EVENTS to exercise the
+    # native (non-JSON-fallback) span_events truncation path.
+    from ddtrace.trace import tracer
+
+    long_value = "a" * 30000
+
+    with tracer.trace("operation", service="my-svc") as span:
+        span._set_link(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1122334455667788,
+            attributes={"link.name": long_value},
+        )
+        span._add_event("my_event", attributes={"attr": long_value}, time_unix_nano=1700000000000000000)
+    tracer.flush()
+
+
+@pytest.mark.snapshot()
+def test_native_writer_origin_on_child_spans():
+    # Regression guard: `_dd.origin` must appear on EVERY span in the chunk, including
+    # non-root children. See ENCODER_DIFFERENCES.md.
+    from ddtrace import tracer
+
+    with tracer.trace("root", service="my-svc") as root:
+        root.context.dd_origin = "synthetics"
+        with tracer.trace("child", service="my-svc"):
+            tracer.trace("grandchild", service="my-svc").finish()
+
+
 @pytest.mark.snapshot
 @pytest.mark.subprocess(env={"DD_TRACE_PARTIAL_FLUSH_ENABLED": "true", "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS": "1"})
 def test_aggregator_partial_flush_finished_counter_out_of_sync():

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -2,38 +2,10 @@ import os
 import subprocess
 import sys
 
-import mock
 import pytest
 
 
 AGENT_VERSION = os.environ.get("AGENT_VERSION")
-
-
-class BadEncoder:
-    content_type = ""
-
-    def __len__(self):
-        return 0
-
-    def put(self, trace):
-        pass
-
-    def encode(self):
-        return [(b"bad_payload", 0)]
-
-    def encode_traces(self, traces):
-        return b"bad_payload"
-
-
-def send_invalid_payload_and_get_logs(encoder_cls=BadEncoder):
-    from ddtrace.trace import tracer as t
-
-    for client in t._span_aggregator.writer._clients:
-        client.encoder = encoder_cls()
-    with mock.patch("ddtrace.internal.writer.writer.log") as log:
-        t.trace("asdf").finish()
-        t.flush()
-    return log
 
 
 def parametrize_with_all_encodings(env=None, out="", err="", check_logs=True):

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_links_events_v04_output.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_links_events_v04_output.json
@@ -1,0 +1,48 @@
+[[
+  {
+    "name": "operation",
+    "service": "my-svc",
+    "resource": "operation",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.base_service": "ddtrace_subprocess_dir",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a55028300000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmpbv3w_0ml,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "language": "python",
+      "runtime-id": "f13ff15e843f45c893dcbe4a27cbac7b"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 908.0
+    },
+    "span_links": [
+      {
+        "trace_id": 1311768467294899695,
+        "trace_id_high": 1311768467294899695,
+        "span_id": 1234605616436508552,
+        "attributes": {
+          "link.name": "linked"
+        }
+      }
+    ],
+    "span_events": [
+      {
+        "time_unix_nano": 1700000000000000000,
+        "name": "my_event",
+        "attributes": {
+          "k": {
+            "type": 0,
+            "string_value": "v"
+          }
+        }
+      }
+    ],
+    "duration": 50302,
+    "start": 1783956099040027199
+  }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_origin_on_child_spans.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_origin_on_child_spans.json
@@ -1,0 +1,63 @@
+[[
+  {
+    "name": "root",
+    "service": "my-svc",
+    "resource": "root",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.integration",
+      "_dd.origin": "synthetics",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a55027d00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.integration",
+      "language": "python",
+      "runtime-id": "afaf8c79a6cf4b7d8fbd978d7f29274c"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 477.0
+    },
+    "duration": 67473,
+    "start": 1783956093281546743
+  },
+     {
+       "name": "child",
+       "service": "my-svc",
+       "resource": "child",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "_dd.base_service": "tests.integration",
+         "_dd.origin": "synthetics",
+         "_dd.svc_src": "m"
+       },
+       "duration": 25880,
+       "start": 1783956093281585168
+     },
+        {
+          "name": "grandchild",
+          "service": "my-svc",
+          "resource": "grandchild",
+          "trace_id": 0,
+          "span_id": 3,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.integration",
+            "_dd.origin": "synthetics",
+            "_dd.svc_src": "m"
+          },
+          "duration": 5626,
+          "start": 1783956093281597129
+        }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_span_events.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_span_events.json
@@ -1,0 +1,29 @@
+[[
+  {
+    "name": "operation",
+    "service": "my-svc",
+    "resource": "operation",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.integration",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a563f4700000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.integration",
+      "events": "[{\"name\": \"my_event\",\"time_unix_nano\": 1700000000000000000,\"attributes\": {\"bool_attr\": true,\"int_attr\": 1,\"str_attr\": \"value\"}}]",
+      "language": "python",
+      "runtime-id": "1a2a559c07eb44ec8b8d31f650e8f52c"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 522.0
+    },
+    "duration": 50582,
+    "start": 1784037191405714538
+  }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_span_link_event_attribute_truncation.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_span_link_event_attribute_truncation.json
@@ -1,0 +1,48 @@
+[[
+  {
+    "name": "operation",
+    "service": "my-svc",
+    "resource": "operation",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.base_service": "ddtrace_subprocess_dir",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a563f9e00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:tmps8adcptt,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
+      "language": "python",
+      "runtime-id": "2b44880fc0d647b3bbb455c23fd3620a"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 526.0
+    },
+    "span_links": [
+      {
+        "trace_id": 1311768467294899695,
+        "trace_id_high": 1311768467294899695,
+        "span_id": 1234605616436508552,
+        "attributes": {
+          "link.name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<truncated>..."
+        }
+      }
+    ],
+    "span_events": [
+      {
+        "time_unix_nano": 1700000000000000000,
+        "name": "my_event",
+        "attributes": {
+          "attr": {
+            "type": 0,
+            "string_value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<truncated>..."
+          }
+        }
+      }
+    ],
+    "duration": 42832,
+    "start": 1784037278957275148
+  }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_span_links.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_native_writer_span_links.json
@@ -1,0 +1,29 @@
+[[
+  {
+    "name": "operation",
+    "service": "my-svc",
+    "resource": "operation",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.integration",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a563f4700000000",
+      "_dd.span_links": "[{\"trace_id\": \"1234567890abcdef1234567890abcdef\", \"span_id\": \"1122334455667788\", \"attributes\": {\"link.name\": \"linked\"}}]",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.integration",
+      "language": "python",
+      "runtime-id": "1a2a559c07eb44ec8b8d31f650e8f52c"
+    },
+    "metrics": {
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 522.0
+    },
+    "duration": 27458,
+    "start": 1784037191412739245
+  }]]

--- a/tests/tracer/test_span_tags.py
+++ b/tests/tracer/test_span_tags.py
@@ -93,6 +93,31 @@ def test_set_tag_metric():
     assert s.get_metrics() == dict(test=1)
 
 
+def test_tag_metric_mutual_exclusion():
+    # A key lives in exactly one of meta/metrics; re-setting with the other type moves it.
+    s = Span(name="test.span")
+
+    # str -> meta, then numeric on the same key: moves meta -> metrics.
+    s.set_tag("k", "value")
+    assert s.get_tag("k") == "value"
+    assert s.get_metric("k") is None
+    s.set_metric("k", 7)  # ast-grep-ignore: span-set-metric
+    assert s.get_metric("k") == 7
+    assert s.get_tag("k") is None
+    assert s.get_tags() == {}
+    assert s.get_metrics() == {"k": 7}
+
+    # numeric -> metrics, then str on the same key: moves metrics -> meta (the reverse).
+    s.set_metric("n", 3.5)  # ast-grep-ignore: span-set-metric
+    assert s.get_metric("n") == 3.5
+    assert s.get_tag("n") is None
+    s.set_tag("n", "now-a-string")
+    assert s.get_tag("n") == "now-a-string"
+    assert s.get_metric("n") is None
+    assert s.get_tags() == {"n": "now-a-string"}
+    assert s.get_metrics() == {"k": 7}
+
+
 def test_set_valid_metrics():
     s = Span(name="test.span")
     s.set_metric("a", 0)  # ast-grep-ignore: span-set-metric

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1935,10 +1935,9 @@ def test_fork_republishes_tracer_metadata_linux():
 
 @pytest.mark.subprocess
 def test_tracer_api_version():
-    from ddtrace.internal.encoding import MsgpackEncoderV05
     from ddtrace.trace import tracer as t
 
-    assert isinstance(t._span_aggregator.writer._encoder, MsgpackEncoderV05)
+    assert t._span_aggregator.writer._api_version == "v0.5"
 
 
 @pytest.mark.subprocess(parametrize={"DD_TRACE_ENABLED": ["true", "false"]})

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -15,9 +15,7 @@ import pytest
 
 import ddtrace
 from ddtrace import config
-from ddtrace.constants import _KEEP_SPANS_RATE_KEY
 from ddtrace.internal.ci_visibility.writer import CIVisibilityWriter
-from ddtrace.internal.encoding import MSGPACK_ENCODERS
 from ddtrace.internal.native._native import IoError
 from ddtrace.internal.native._native import NetworkError
 from ddtrace.internal.runtime import get_runtime_id
@@ -29,7 +27,6 @@ from ddtrace.internal.writer import AgentlessTraceWriter
 from ddtrace.internal.writer import LogWriter
 from ddtrace.internal.writer import NativeWriter
 from ddtrace.trace import Span
-from tests.utils import AnyInt
 from tests.utils import BaseTestCase
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -100,37 +97,27 @@ class NativeWriterTests(BaseTestCase):
             any_order=True,
         )
 
-    def test_metrics_trace_too_big(self):
+    def test_metrics_generic_send_failure(self):
+        # A generic (non-4xx) send failure, e.g. an unreachable agent, still drains the buffer
+        # and counts the traces as "sent" for drop-rate purposes.
         statsd = mock.Mock()
         with (
-            override_global_config(dict(_health_metrics_enabled=True, _trace_writer_buffer_size=15000)),
-            managed_writer(self.WRITER_CLASS, "http://asdf:1234", dogstatsd=statsd) as writer,
+            override_global_config(dict(_health_metrics_enabled=True)),
+            # Long interval so the background periodic thread never flushes mid-test.
+            managed_writer(
+                self.WRITER_CLASS,
+                "http://asdf:1234",
+                dogstatsd=statsd,
+                sync_mode=False,
+                processing_interval=1000,
+            ) as writer,
         ):
             for i in range(10):
                 writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
+            writer.flush_queue()
 
-            massive_trace = []
-            for i in range(10):
-                span = Span("mmon", "mmon" + str(i), "mmon" + str(i))
-                for j in range(50):
-                    key = "opqr012|~" + str(i) + str(j)
-                    val = "stuv345!@#" + str(i) + str(j)
-                    span._set_attribute(key, val)
-                massive_trace.append(span)
-
-            writer.write(massive_trace)
-
-        statsd.distribution.assert_has_calls(
-            [mock.call("datadog.%s.buffer.accepted.traces" % writer.STATSD_NAMESPACE, 1, tags=None)] * 10
-            + [mock.call("datadog.%s.buffer.accepted.spans" % writer.STATSD_NAMESPACE, 5, tags=None)] * 10
-            + [mock.call("datadog.%s.buffer.dropped.traces" % writer.STATSD_NAMESPACE, 1, tags=["reason:t_too_big"])]
-            + [
-                mock.call(
-                    "datadog.%s.buffer.dropped.bytes" % writer.STATSD_NAMESPACE, AnyInt(), tags=["reason:t_too_big"]
-                )
-            ],
-            any_order=True,
-        )
+            assert writer._metrics == {"accepted_traces": 0, "sent_traces": 0}  # ast-grep-ignore: span-metrics-access
+            assert writer._drop_sma.get() == 0.0
 
     def test_metrics_multi(self):
         statsd = mock.Mock()
@@ -244,163 +231,6 @@ class NativeWriterTests(BaseTestCase):
                 any_order=True,
             )
 
-    def test_drop_reason_trace_too_big(self):
-        statsd = mock.Mock()
-        with (
-            override_global_config(dict(_health_metrics_enabled=True)),
-            managed_writer(self.WRITER_CLASS, "http://asdf:1234", dogstatsd=statsd, buffer_size=1000) as writer,
-        ):
-            for i in range(10):
-                writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
-            writer.write([Span(name="a" * i, trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(2**10)])
-            writer.flush_queue()
-
-            # metrics should be reset after traces are sent
-            assert writer._metrics == {"accepted_traces": 0, "sent_traces": 0}  # ast-grep-ignore: span-metrics-access
-
-            statsd.distribution.assert_has_calls(
-                [
-                    mock.call(
-                        "datadog.%s.buffer.dropped.traces" % writer.STATSD_NAMESPACE,
-                        1,
-                        tags=["reason:t_too_big"],
-                    ),
-                ],
-                any_order=True,
-            )
-
-    def test_drop_reason_buffer_full(self):
-        statsd = mock.Mock()
-        with (
-            override_global_config(dict(_health_metrics_enabled=True)),
-            managed_writer(self.WRITER_CLASS, "http://asdf:1234", buffer_size=1000, dogstatsd=statsd) as writer,
-        ):
-            for i in range(10):
-                writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
-            writer.write([Span(name="a", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
-            writer.flush_queue()
-
-            # metrics should be reset after traces are sent
-            assert writer._metrics == {"accepted_traces": 0, "sent_traces": 0}  # ast-grep-ignore: span-metrics-access
-
-            client_count = len(writer._clients)
-            statsd.distribution.assert_has_calls(
-                [
-                    mock.call(
-                        "datadog.%s.buffer.dropped.traces" % writer.STATSD_NAMESPACE, client_count, tags=["reason:full"]
-                    ),
-                ],
-                any_order=True,
-            )
-
-    def test_drop_reason_encoding_error(self):
-        n_traces = 10
-        statsd = mock.Mock()
-        writer_encoder = mock.Mock()
-        writer_encoder.__len__ = (lambda *args: n_traces).__get__(writer_encoder)
-        writer_encoder.encode.side_effect = Exception
-        with (
-            override_global_config(dict(_health_metrics_enabled=True)),
-            managed_writer(self.WRITER_CLASS, "http://asdf:1234", dogstatsd=statsd, sync_mode=False) as writer,
-        ):
-            for client in writer._clients:
-                client.encoder = writer_encoder
-            for i in range(n_traces):
-                writer.write(
-                    [Span(name="name", trace_id=i, span_id=j, parent_id=max(0, j - 1) or None) for j in range(5)]
-                )
-            writer.flush_queue()
-
-            # writer should have has 10 unsent traces, sent traces should be reset to zero
-            assert writer._metrics == {"accepted_traces": 10, "sent_traces": 0}  # ast-grep-ignore: span-metrics-access
-            statsd.distribution.assert_has_calls(
-                [
-                    mock.call("datadog.%s.encoder.dropped.traces" % writer.STATSD_NAMESPACE, n_traces, tags=None),
-                ]
-                * len(writer._clients),
-                any_order=True,
-            )
-
-    def test_keep_rate(self):
-        statsd = mock.Mock()
-        writer_run_periodic = mock.Mock()
-        writer_exporter = mock.Mock()
-        writer_exporter_send = mock.Mock()
-        with (
-            override_global_config(dict(_health_metrics_enabled=False, _trace_writer_buffer_size=8 << 20)),
-            managed_writer(self.WRITER_CLASS, "http://asdf:1234", dogstatsd=statsd, api_version="v0.4") as writer,
-        ):
-            # this test decodes the msgpack payload to verify the keep rate. v04 is easier to decode so we use that here
-            writer.run_periodic = writer_run_periodic
-            writer._exporter = writer_exporter
-            writer._exporter.send = writer_exporter_send
-
-            traces = [
-                [Span(name="name", trace_id=i, span_id=j + 1, parent_id=j) for j in range(5)] for i in range(1, 5)
-            ]
-
-            traces_too_big = [
-                [Span(name="a" * 5000, trace_id=i, span_id=j + 1, parent_id=j) for j in range(1, 2**10)]
-                for i in range(4)
-            ]
-
-            # 1. We write 4 traces successfully.
-            for trace in traces:
-                writer.write(trace)
-            writer.flush_queue()
-
-            payload = msgpack.unpackb(writer_exporter_send.call_args.args[0])
-            # No previous drops.
-            assert 0.0 == writer._drop_sma.get()
-            # 4 traces written.
-            assert 4 == len(payload)
-            # 100% of traces kept (refers to the past).
-            # No traces sent before now so 100% kept.
-            for trace in payload:
-                assert 1.0 == trace[0]["metrics"].get(_KEEP_SPANS_RATE_KEY, -1)
-
-            # 2. We fail to write 4 traces because of size limitation.
-            for trace in traces_too_big:
-                writer.write(trace)
-            writer.flush_queue()
-
-            # 50% of traces were dropped historically.
-            # 4 successfully written before and 4 dropped now.
-            assert 0.5 == writer._drop_sma.get()
-            # send not called since no new traces are available.
-            writer_exporter_send.assert_called_once()
-
-            # 3. We write 2 traces successfully.
-            for trace in traces[:2]:
-                writer.write(trace)
-            writer.flush_queue()
-
-            payload = msgpack.unpackb(writer_exporter_send.call_args.args[0])
-            # 40% of traces were dropped historically.
-            assert 0.4 == writer._drop_sma.get()
-            # 2 traces written.
-            assert 2 == len(payload)
-            # 50% of traces kept (refers to the past).
-            # We had 4 successfully written and 4 dropped.
-            for trace in payload:
-                assert 0.5 == trace[0]["metrics"].get(_KEEP_SPANS_RATE_KEY, -1)
-
-            # 4. We write 1 trace successfully and fail to write 3.
-            writer.write(traces[0])
-            for trace in traces_too_big[:3]:
-                writer.write(trace)
-            writer.flush_queue()
-
-            payload = msgpack.unpackb(writer_exporter_send.call_args.args[0])
-            # 50% of traces were dropped historically.
-            assert 0.5 == writer._drop_sma.get()
-            # 1 trace written.
-            assert 1 == len(payload)
-            # 60% of traces kept (refers to the past).
-            # We had 4 successfully written, then 4 dropped, then 2 written.
-            for trace in payload:
-                assert 0.6 == trace[0]["metrics"].get(_KEEP_SPANS_RATE_KEY, -1)
-
     def test_on_shutdown_idempotent(self):
         """Test that NativeWriter.on_shutdown() can be called multiple times without raising ValueError."""
         writer = NativeWriter("http://dne:1234")
@@ -436,18 +266,9 @@ class CIVisibilityWriterTests(NativeWriterTests):
         os.environ.clear()
         os.environ.update(self.original_env)
 
-    # NB these tests are skipped because they exercise max_payload_size and max_item_size functionality
-    # that CIVisibilityWriter does not implement
-    def test_drop_reason_buffer_full(self):
-        pytest.skip()
-
-    def test_drop_reason_trace_too_big(self):
-        pytest.skip()
-
-    def test_metrics_trace_too_big(self):
-        pytest.skip()
-
-    def test_keep_rate(self):
+    # CIVisibilityWriter retries with backoff (unlike NativeWriter), making this both slow and
+    # not a meaningful test of NativeWriter._flush()'s buffer-drain/metrics behavior.
+    def test_metrics_generic_send_failure(self):
         pytest.skip()
 
     def test_on_shutdown_idempotent(self):
@@ -664,6 +485,22 @@ class _IncompleteReadRequestHandlerTest(_BaseHTTPRequestHandler):
         self.do_PUT()
 
 
+class _CapturePayloadHandlerTest(_BaseHTTPRequestHandler):
+    """Captures the raw request body of each trace PUT/POST for wire-format assertions."""
+
+    payloads: list = []
+
+    def do_PUT(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        _CapturePayloadHandlerTest.payloads.append(self.rfile.read(length))
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    do_POST = do_PUT
+
+
 _HOST = "0.0.0.0"
 _PORT = 8743
 _TIMEOUT_PORT = _PORT + 1
@@ -775,19 +612,196 @@ def test_agent_url_path(endpoint_assert_path, writer_and_path):
         # test without base path
         endpoint_assert_path(path)
         with managed_writer(writer_class, "http://%s:%s/" % (_HOST, _PORT)) as writer:
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
 
         # test without base path nor trailing slash
         with managed_writer(writer_class, "http://%s:%s" % (_HOST, _PORT)) as writer:
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
 
         # test with a base path
         endpoint_assert_path("/test%s" % path)
         with managed_writer(writer_class, "http://%s:%s/test/" % (_HOST, _PORT)) as writer:
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
+
+
+def test_native_writer_send_failure_emits_drop_metrics():
+    # Regression (#990): a generic (non-4xx) send failure surfaces `http.dropped.traces` and
+    # `http.errors` health metrics. These are distinct from the keep-rate `_drop_sma`, which still
+    # counts the drained-but-undelivered traces as "sent" (see test_metrics_generic_send_failure).
+    statsd = mock.Mock()
+    with (
+        override_global_config(dict(_health_metrics_enabled=True)),
+        # Long interval so the background periodic thread never flushes mid-test.
+        managed_writer(
+            NativeWriter,
+            "http://asdf:1234",
+            dogstatsd=statsd,
+            sync_mode=False,
+            processing_interval=1000,
+        ) as writer,
+    ):
+        for i in range(10):
+            writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
+        writer.flush_queue()
+
+        ns = writer.STATSD_NAMESPACE
+        statsd.distribution.assert_has_calls(
+            [
+                mock.call("datadog.%s.http.errors" % ns, 1, tags=["type:err"]),
+                mock.call("datadog.%s.http.dropped.traces" % ns, 10, tags=None),
+            ],
+            any_order=True,
+        )
+
+
+def test_native_writer_dedupes_injected_origin_key():
+    # Regression (#292): when a span's own meta already holds `_dd.origin` (as trace_utils writes on
+    # distributed traces) and the trace-level origin is injected too, the wire span must carry
+    # `_dd.origin` exactly once — not a duplicate map key that `mark_deduped` would wrongly certify.
+    _CapturePayloadHandlerTest.payloads = []
+    server, thread = _make_server(_PORT, _CapturePayloadHandlerTest)
+    try:
+        with managed_writer(
+            NativeWriter,
+            "http://%s:%s" % (_HOST, _PORT),
+            sync_mode=True,
+            api_version="v0.4",  # v0.4 inlines meta per span (v0.5 dict-encodes strings)
+        ) as writer:
+            root = Span(name="root", trace_id=1, span_id=1)
+            child = Span(name="child", trace_id=1, span_id=2, parent_id=1)
+            # Root already carries `_dd.origin` in its own meta (the collision source)...
+            root.set_tag("_dd.origin", "synthetics")
+            assert "_dd.origin" in root.get_tags(), "setup: _dd.origin must be stored in span meta"
+            # ...and the trace-level origin is injected into every span at build time.
+            root.context.dd_origin = "synthetics"
+            writer.write([root, child])
+            writer.flush_queue(raise_exc=True)
+
+        body = b"".join(_CapturePayloadHandlerTest.payloads)
+        # One `_dd.origin` per span: root (deduped from tag+injection) + child (injection only).
+        assert body.count(b"_dd.origin") == 2, "duplicate _dd.origin wire key (mark_deduped unsound)"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # scalars
+        None,
+        True,
+        False,
+        0,
+        1,
+        -1,
+        127,
+        128,
+        255,
+        256,
+        65535,
+        65536,
+        2**31,
+        2**32,
+        2**63,
+        2**64 - 1,
+        -32,
+        -33,
+        -(2**31),
+        -(2**63),
+        1.5,
+        -0.0,
+        1e308,
+        "",
+        "ascii",
+        "unicode: ✅ 日本語",
+        b"",
+        b"\x00\xff binary",
+        bytearray(b"bytearray"),
+        # ints outside u64/i64 -> packb substitutes an error *string*
+        2**64,
+        -(2**63) - 1,
+        # containers, nested
+        {},
+        [],
+        {"a": 1, "b": [1, 2, {"c": None}]},
+        [[[1]]],
+        {"nested": {"deep": {"deeper": [True, False, None, 1.5]}}},
+        # non-str keys recurse through the same dispatch
+        {1: "int-key", "s": "str-key"},
+        # unsupported types -> packb substitutes "Can not serialize [...]" strings, never raises
+        (1, 2),
+        {"tuple-inside": (1, 2)},
+        {1, 2},
+        object(),
+        # realistic appsec/LLMObs shapes
+        {"triggers": [{"rule": {"id": "x", "tags": {"type": "lfi"}}, "span_id": 12345}]},
+    ],
+)
+def test_native_meta_struct_packing_matches_python_packb(value):
+    # The native msgpack packer (src/native/span/msgpack.rs) must be byte-for-byte identical to the
+    # Cython `packb` it replaced, including its quirks: unsupported types and out-of-range ints
+    # become error *strings* in the payload rather than raising, and exact-type checks mean tuples /
+    # sets / subclasses are not serialized.
+    #
+    # `_set_struct_tag` requires a dict, so each case is wrapped — arbitrary types only ever reach
+    # the packer nested inside one, which is what this exercises.
+    from ddtrace.internal._encoding import packb
+
+    wrapped = {"v": value}
+    _CapturePayloadHandlerTest.payloads = []
+    server, thread = _make_server(_PORT, _CapturePayloadHandlerTest)
+    try:
+        with managed_writer(
+            NativeWriter,
+            "http://%s:%s" % (_HOST, _PORT),
+            sync_mode=True,
+            api_version="v0.4",
+        ) as writer:
+            span = Span(name="ms", trace_id=1, span_id=1)
+            span._set_struct_tag("k", wrapped)
+            writer.write([span])
+            writer.flush_queue(raise_exc=True)
+
+        body = b"".join(_CapturePayloadHandlerTest.payloads)
+        decoded = msgpack.unpackb(body, raw=False, strict_map_key=False)
+        native_packed = decoded[0][0]["meta_struct"]["k"]
+        assert native_packed == packb(wrapped), (
+            f"meta_struct packing diverged from packb for {value!r}: native={native_packed!r} packb={packb(wrapped)!r}"
+        )
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_native_writer_truncates_oversized_tag_on_the_wire():
+    # An oversized tag value is truncated natively (to a Rust-owned string, with no Python object
+    # allocated) and the capped value is what reaches the wire. Nothing on the Python side truncates
+    # generic tag values, so this covers the native cap enforcement end to end.
+    oversized = "x" * 30_000
+    _CapturePayloadHandlerTest.payloads = []
+    server, thread = _make_server(_PORT, _CapturePayloadHandlerTest)
+    try:
+        with managed_writer(
+            NativeWriter,
+            "http://%s:%s" % (_HOST, _PORT),
+            sync_mode=True,
+            api_version="v0.4",
+        ) as writer:
+            span = Span(name="big", trace_id=1, span_id=1)
+            span.set_tag("big.tag", oversized)
+            writer.write([span])
+            writer.flush_queue(raise_exc=True)
+
+        body = b"".join(_CapturePayloadHandlerTest.payloads)
+        assert b"<truncated>..." in body, "oversized tag was not truncated"
+        assert oversized.encode() not in body, "untruncated value reached the wire"
+    finally:
+        server.shutdown()
+        thread.join()
 
 
 @pytest.mark.parametrize("writer_class", (CIVisibilityWriter, NativeWriter))
@@ -798,7 +812,7 @@ def test_flush_connection_timeout_connect(writer_class):
     ):
         exc_type = (OSError, NetworkError)
         with pytest.raises(exc_type):
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
 
 
@@ -810,7 +824,7 @@ def test_flush_connection_timeout(endpoint_test_timeout_server, writer_class):
     ):
         writer.HTTP_METHOD = "PUT"  # the test server only accepts PUT
         with pytest.raises((socket.timeout, IoError)):
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
 
 
@@ -892,7 +906,7 @@ def test_flush_connection_reset(endpoint_test_reset_server, writer_class):
         exc_types = (httplib.BadStatusLine, ConnectionResetError, NetworkError)
         with pytest.raises(exc_types):
             writer.HTTP_METHOD = "PUT"  # the test server only accepts PUT
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
 
 
@@ -903,7 +917,7 @@ def test_flush_connection_incomplete_read(endpoint_test_incomplete_read_server, 
         # IncompleteRead should be raised when the server sends an incomplete chunked response
         exc_types = (httplib.IncompleteRead, NetworkError)
         with pytest.raises(exc_types):
-            writer._encoder.put([Span("foobar")])
+            writer.write([Span("foobar")])
             writer.flush_queue(raise_exc=True)
 
 
@@ -915,7 +929,7 @@ def test_flush_connection_incomplete_read(endpoint_test_incomplete_read_server, 
 def test_flush_connection_uds(endpoint_uds_server):
     url = f"unix://{endpoint_uds_server.server_address}"
     with managed_writer(NativeWriter, url) as writer:
-        writer._encoder.put([Span("foobar")])
+        writer._exporter.put_trace([Span("foobar")], None)
         writer.flush_queue(raise_exc=True)
 
 
@@ -945,7 +959,7 @@ def test_racing_start():
         for t in ts:
             t.join()
 
-        assert len(writer._encoder) == 100
+        assert writer._exporter.buffered_traces() == 100
 
 
 def test_bad_encoding(monkeypatch):
@@ -955,23 +969,21 @@ def test_bad_encoding(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "init_api_version,api_version,endpoint,encoder_cls",
+    "init_api_version,api_version,endpoint",
     [
-        (None, "v0.5", "v0.5/traces", MSGPACK_ENCODERS["v0.5"]),
-        ("v0.4", "v0.4", "v0.4/traces", MSGPACK_ENCODERS["v0.4"]),
-        ("v0.5", "v0.5", "v0.5/traces", MSGPACK_ENCODERS["v0.5"]),
+        (None, "v0.5", "v0.5/traces"),
+        ("v0.4", "v0.4", "v0.4/traces"),
+        ("v0.5", "v0.5", "v0.5/traces"),
     ],
 )
-def test_writer_recreate_api_version(init_api_version, api_version, endpoint, encoder_cls):
+def test_writer_recreate_api_version(init_api_version, api_version, endpoint):
     writer = NativeWriter("http://dne:1234", api_version=init_api_version)
     assert writer._api_version == api_version
     assert writer._endpoint == endpoint
-    assert isinstance(writer._encoder, encoder_cls)
 
     writer = writer.recreate()
     assert writer._api_version == api_version
     assert writer._endpoint == endpoint
-    assert isinstance(writer._encoder, encoder_cls)
 
 
 def test_native_writer_recreate_keeps_stats_opt_out():


### PR DESCRIPTION
## Description

Today we encode trace chunks via the Cython msgpack encoder into a msgpack payload buffer on the main thread. In the periodic NativeWriter thread we give the msgpack payload to the trace exporter who decodes it, processes it (e.g. stats computation), and then encodes into the output format for flushing to the agent.


With this change we are removing the msgpack span encoding process, and the trace exporter msgpack decoding steps.

When a trace chunk finishes, we convert to a libdatadog v0.4 span and buffer as a Vec<Vec<Span>> into the trace exporter. Then in the periodic NativeWriter thread we give the Vec<Vec<Span>> directly to the trace exporter who can then process, encode, and flush.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
