### PR TITLE
fix(llmobs): avoid dropping google_genai/vertexai spans on non-serializable tool results

### DIFF
--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -190,7 +190,16 @@ _GOOGLE_GENAI_PART_CONTENT_FIELDS = (
 
 
 def _is_empty_google_genai_part(part) -> bool:
-    """True when a Part carries no content field we could render at all."""
+    """True only for a real ``types.Part`` that carries no content field.
+
+    ``part`` is a ``PartUnion = Union[File, Part, PIL_Image, str]``; a ``File`` or
+    ``PIL_Image`` input is *not* empty just because it lacks ``Part`` content
+    fields — those must still fall through to the unsupported-input placeholder so
+    multimodal file/image markers aren't silently dropped. Duck-type on
+    ``Part``-only attributes to avoid importing ``google.genai`` types here.
+    """
+    if not all(hasattr(part, attr) for attr in ("function_call", "inline_data", "thought")):
+        return False
     return not any(_get_attr(part, field, None) for field in _GOOGLE_GENAI_PART_CONTENT_FIELDS)
 
 

--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from typing import Optional
 
@@ -178,6 +177,23 @@ def extract_embedding_metrics_google_genai(response) -> dict[str, Any]:
     return usage
 
 
+_GOOGLE_GENAI_PART_CONTENT_FIELDS = (
+    "text",
+    "function_call",
+    "function_response",
+    "executable_code",
+    "code_execution_result",
+    "inline_data",
+    "file_data",
+    "thought_signature",
+)
+
+
+def _is_empty_google_genai_part(part) -> bool:
+    """True when a Part carries no content field we could render at all."""
+    return not any(_get_attr(part, field, None) for field in _GOOGLE_GENAI_PART_CONTENT_FIELDS)
+
+
 def extract_message_from_part_google_genai(part, role: str) -> Message:
     """part is a PartUnion = Union[File, Part, PIL_Image, str]
 
@@ -214,9 +230,15 @@ def extract_message_from_part_google_genai(part, role: str) -> Message:
     function_response = _get_attr(part, "function_response", None)
     if function_response:
         result = _get_attr(function_response, "response", "") or ""
+        # ``safe_json`` (not ``json.dumps``) so a non-JSON-serializable tool
+        # result never raises. A function response can carry ``google.genai``
+        # ``Part``/``Content`` objects (e.g. the ADK ``load_memory`` tool), which
+        # ``json.dumps`` cannot serialize; the resulting ``TypeError`` propagates
+        # out of ``_llmobs_set_tags`` and drops the span, orphaning its children.
+        result = result if isinstance(result, str) else (safe_json(result) or "")
         tool_result_info = ToolResult(
             name=str(_get_attr(function_response, "name", "") or ""),
-            result=result if isinstance(result, str) else json.dumps(result),
+            result=result,
             tool_id=str(_get_attr(function_response, "id", "") or ""),
             type="function_response",
         )
@@ -235,6 +257,20 @@ def extract_message_from_part_google_genai(part, role: str) -> Message:
         outcome = _get_attr(code_execution_result, "outcome", "OUTCOME_UNSPECIFIED")
         output = _get_attr(code_execution_result, "output", "")
         message["content"] = safe_json({"outcome": str(outcome), "output": str(output)}) or ""
+        return message
+
+    # Thinking models can emit a part that carries only a ``thought_signature``
+    # (opaque reasoning bytes, no text) — surface it as reasoning rather than an
+    # "unsupported" placeholder.
+    if thought or _get_attr(part, "thought_signature", None):
+        message["role"] = "reasoning"
+        message["content"] = ""
+        return message
+
+    # An empty part (e.g. a trailing part emitted alongside a function call) has
+    # nothing to render; return empty content instead of a misleading placeholder.
+    if _is_empty_google_genai_part(part):
+        message["content"] = ""
         return message
 
     return Message(content="Unsupported file type: {}".format(type(part)), role=role)
@@ -280,7 +316,9 @@ def extract_message_from_part_vertexai(part, role=None) -> Message:
             function_response_dict = type(function_response).to_dict(function_response)
         result = function_response_dict.get("response", "")
         if not isinstance(result, str):
-            result = json.dumps(result)
+            # ``safe_json`` (not ``json.dumps``) so a non-JSON-serializable tool
+            # result degrades gracefully instead of raising and dropping the span.
+            result = safe_json(result) or ""
         tool_result_info = ToolResult(
             name=function_response_dict.get("name", ""),
             result=result,

--- a/releasenotes/notes/fix-llmobs-google-genai-part-serialization-a1b2c3d4e5f60718.yaml
+++ b/releasenotes/notes/fix-llmobs-google-genai-part-serialization-a1b2c3d4e5f60718.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolve an issue where Google GenAI and Vertex AI agent spans
+    could be dropped from a trace when a tool returned a non-JSON-serializable
+    ``function_response`` result (for example the Google ADK ``load_memory`` tool,
+    whose result contains ``google.genai.types.Part`` objects). Tool-result
+    serialization now uses ``safe_json`` instead of ``json.dumps``, so the result
+    degrades gracefully instead of raising ``TypeError``, which previously propagated
+    out of ``_llmobs_set_tags`` and dropped the span, orphaning its child spans.
+  - |
+    LLM Observability: The Google GenAI integration now renders thinking-model parts
+    that carry only a ``thought_signature`` (with no text) as reasoning content, and
+    empty parts as empty content, instead of an ``Unsupported file type`` placeholder.

--- a/tests/contrib/google_genai/test_google_genai.py
+++ b/tests/contrib/google_genai/test_google_genai.py
@@ -357,3 +357,52 @@ def test_google_genai_none_optional_fields_do_not_crash():
     # candidates=None — must not raise when iterating
     integration = object.__new__(GoogleGenAIIntegration)
     assert integration._extract_output_messages(SimpleNamespace(candidates=None)) == []
+
+
+def test_extract_message_from_part_function_response_non_serializable():
+    """Regression: a function_response whose result holds non-JSON-serializable
+    objects (e.g. google.genai Part/Content returned by the ADK load_memory tool)
+    must not raise — json.dumps would raise TypeError, propagate out of
+    _llmobs_set_tags, and drop the span, orphaning its children."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    part = types.Part(
+        function_response=types.FunctionResponse(
+            name="load_memory",
+            response={"memories": [{"content": {"parts": [types.Part(text="likes BMW")]}}]},
+        )
+    )
+    message = extract_message_from_part_google_genai(part, "model")
+    assert message["tool_results"][0]["name"] == "load_memory"
+    assert "likes BMW" in message["tool_results"][0]["result"]
+
+
+def test_extract_message_from_part_thought_signature_only():
+    """A reasoning part may carry only a thought_signature (opaque bytes, no text);
+    render it as reasoning rather than an 'Unsupported file type' placeholder."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    message = extract_message_from_part_google_genai(types.Part(thought_signature=b"\x01\x02\x03"), "model")
+    assert message["role"] == "reasoning"
+    assert "Unsupported file type" not in message.get("content", "")
+
+
+def test_extract_message_from_part_empty():
+    """An empty part (e.g. trailing a function_call) renders as empty content,
+    not an 'Unsupported file type' placeholder."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    message = extract_message_from_part_google_genai(types.Part(), "model")
+    assert message.get("content", "") == ""
+    assert "Unsupported file type" not in message.get("content", "")
+
+
+def test_extract_message_from_part_vertexai_non_serializable():
+    """Regression: the Vertex AI variant must also use safe_json so a
+    non-JSON-serializable function_response result does not raise."""
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_vertexai
+
+    part = {"function_response": {"name": "load_memory", "response": {"obj": object()}, "id": "t1"}}
+    message = extract_message_from_part_vertexai(part, "model")
+    assert message["tool_results"][0]["name"] == "load_memory"
+    assert isinstance(message["tool_results"][0]["result"], str)

--- a/tests/contrib/google_genai/test_google_genai.py
+++ b/tests/contrib/google_genai/test_google_genai.py
@@ -363,7 +363,8 @@ def test_extract_message_from_part_function_response_non_serializable():
     """Regression: a function_response whose result holds non-JSON-serializable
     objects (e.g. google.genai Part/Content returned by the ADK load_memory tool)
     must not raise — json.dumps would raise TypeError, propagate out of
-    _llmobs_set_tags, and drop the span, orphaning its children."""
+    _llmobs_set_tags, and drop the span, orphaning its children.
+    """
     from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
 
     part = types.Part(
@@ -379,7 +380,8 @@ def test_extract_message_from_part_function_response_non_serializable():
 
 def test_extract_message_from_part_thought_signature_only():
     """A reasoning part may carry only a thought_signature (opaque bytes, no text);
-    render it as reasoning rather than an 'Unsupported file type' placeholder."""
+    render it as reasoning rather than an 'Unsupported file type' placeholder.
+    """
     from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
 
     message = extract_message_from_part_google_genai(types.Part(thought_signature=b"\x01\x02\x03"), "model")
@@ -389,7 +391,8 @@ def test_extract_message_from_part_thought_signature_only():
 
 def test_extract_message_from_part_empty():
     """An empty part (e.g. trailing a function_call) renders as empty content,
-    not an 'Unsupported file type' placeholder."""
+    not an 'Unsupported file type' placeholder.
+    """
     from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
 
     message = extract_message_from_part_google_genai(types.Part(), "model")
@@ -399,10 +402,24 @@ def test_extract_message_from_part_empty():
 
 def test_extract_message_from_part_vertexai_non_serializable():
     """Regression: the Vertex AI variant must also use safe_json so a
-    non-JSON-serializable function_response result does not raise."""
+    non-JSON-serializable function_response result does not raise.
+    """
     from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_vertexai
 
     part = {"function_response": {"name": "load_memory", "response": {"obj": object()}, "id": "t1"}}
     message = extract_message_from_part_vertexai(part, "model")
     assert message["tool_results"][0]["name"] == "load_memory"
     assert isinstance(message["tool_results"][0]["result"], str)
+
+
+def test_extract_message_from_part_file_input_not_treated_as_empty():
+    """A File/image PartUnion member lacks Part content fields but is NOT empty —
+    it must fall through to the unsupported-input placeholder, not be silently
+    dropped as empty content.
+    """
+    from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
+
+    file_part = types.File(name="files/abc", uri="https://example.com/image.png", mime_type="image/png")
+    message = extract_message_from_part_google_genai(file_part, "model")
+    assert message.get("content", "") != ""
+    assert "Unsupported file type" in message["content"]


### PR DESCRIPTION
Fixes #18698

## Description

The `google_genai` and `vertexai` LLM Observability integrations serialize a `function_response` tool result with `json.dumps`. When that result contains non-JSON-serializable objects — e.g. `google.genai.types.Part`/`Content`, which the Google ADK `load_memory` tool returns — `json.dumps` raises `TypeError`.

That exception propagates out of `_llmobs_set_tags` **before** `_annotate_llmobs_span_data` sets the span kind, so the auto `Runner.run_async` agent span is never emitted to LLM Observability. Its child spans (the LLM calls and tool calls) keep the missing span's id as their `parent_id`, so the trace renders orphaned — `get_llmobs_trace` reports repeated `cannot_find_parent_for_a_span` and shows only `chat.turn → agent` instead of the full tree. The underlying data (APM spans, session state) is unaffected; this is observability-only breakage, but it makes ADK traces that use `load_memory` (or any tool returning `Part` objects) unusable in the LLM Obs UI.

This changes both `extract_message_from_part_google_genai` and `extract_message_from_part_vertexai` to serialize the tool result with `safe_json` (which catches serialization errors and returns `None` rather than raising) instead of `json.dumps`.

It also fixes a related cosmetic issue in the `google_genai` extractor: thinking-model parts that carry only a `thought_signature` (opaque reasoning bytes, no text), and empty parts emitted alongside a `function_call`, previously fell through to the literal `Unsupported file type: <class 'google.genai.types.Part'>` content. They are now rendered as `reasoning` content and empty content respectively.

## Testing

Added unit tests in `tests/contrib/google_genai/test_google_genai.py` (matching the existing direct `google_utils` unit tests in that file):

- `test_extract_message_from_part_function_response_non_serializable` — a `function_response` whose result holds `google.genai` `Part` objects no longer raises and carries the serialized result.
- `test_extract_message_from_part_vertexai_non_serializable` — same guard for the Vertex AI variant.
- `test_extract_message_from_part_thought_signature_only` — a `thought_signature`-only part renders as `reasoning`, not the placeholder.
- `test_extract_message_from_part_empty` — an empty part renders as empty content.

The fix was also validated end-to-end against a production Google ADK app (Gemini 3.x + `load_memory`): before, `get_llmobs_trace` returned 2 spans with 17 `cannot_find_parent_for_a_span` warnings; after, the full tree links with 0 warnings.

Note: per `AGENTS.md`, tests were not run through the `run-tests`/riot harness locally; `ruff check`/`ruff format` pass on the changed files, and CI will exercise the suite.

## Risks

Low. `safe_json` is already used throughout this module (including for `executable_code`/`code_execution_result` in the same function) and returns a JSON string for serializable inputs, so the happy path is unchanged; only the previously-crashing path changes (now degrades gracefully). The cosmetic change only affects parts that currently produce the `Unsupported file type` placeholder — `inline_data`/`file_data` parts are intentionally left unchanged.

## Additional Notes

`safe_json` returning `None` on failure is coerced to `""` so `ToolResult["result"]` stays a `str`.