### PR TITLE
fix(langgraph): finish graph span when stream is abandoned early [MLOB-7711]

### DIFF
--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -198,10 +198,9 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                     yield item
                 except StopAsyncIteration:
                     break
-                # AIDEV-NOTE: do not widen to bare ``BaseException`` here — this wraps a ``yield``, so
+                # AIDEV-NOTE: do not widen to bare ``BaseException`` here - this wraps a ``yield``, so
                 # ``GeneratorExit`` / ``CancelledError`` from normal stream teardown must not be caught
-                # (they'd be mis-reported as span errors). The ``finally`` below still finishes the span
-                # on that teardown, just without an error, so abandoning the stream early does not leak it.
+                # (they'd be mis-reported as span errors). The ``finally`` below still closes the span.
                 except (DDBlockException, Exception) as e:
                     if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
                         LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
@@ -211,9 +210,8 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                     stream_exc = e
                     raise
         finally:
-            # Report whatever streamed so far on any non-error exit, including early abandonment
-            # (``GeneratorExit`` from a consumer ``break``). Only a real propagated exception
-            # suppresses the partial output.
+            # Report the partial output on any non-error exit (including ``GeneratorExit`` abandonment);
+            # a real propagated exception drops it.
             integration.llmobs_set_tags(
                 span,
                 args=args,
@@ -293,13 +291,10 @@ def traced_pregel_stream(func, instance, args, kwargs):
                         span.set_exc_info(*sys.exc_info())
                     raise
         finally:
-            # AIDEV-NOTE: finish in ``finally`` so an iterated stream is closed on every exit —
-            # including when the consumer abandons it early (e.g. ``break``), which tears the generator
-            # down via ``GeneratorExit``. ``GeneratorExit`` is intentionally not caught above, so this
-            # teardown is not marked as an error. ``response`` stays ``None`` unless the stream ran to
-            # completion, so abandonment does not report a misleading output. (A stream that is created
-            # but never iterated is a separate edge case: this body — and so this ``finally`` — never
-            # runs, so the span is not finished. That is not the abandonment path guarded here.)
+            # AIDEV-NOTE: finish in ``finally`` so the span closes on every exit, including early
+            # abandonment - a consumer ``break`` tears the generator down via ``GeneratorExit``, which is
+            # intentionally not caught above, so teardown is not flagged as an error. ``response`` stays
+            # ``None`` unless the stream ran to completion, so abandonment reports no misleading output.
             integration.llmobs_set_tags(
                 span, args=args, kwargs={**kwargs, "name": name}, response=response, operation="graph"
             )
@@ -347,14 +342,10 @@ def traced_pregel_astream(func, instance, args, kwargs):
                         span.set_exc_info(*sys.exc_info())
                     raise
         finally:
-            # AIDEV-NOTE: finish in ``finally`` so an iterated stream is closed on every exit —
-            # including when the consumer abandons it early (e.g. ``break`` on ``__interrupt__``),
-            # which tears the generator down via ``GeneratorExit``. ``GeneratorExit`` is intentionally
-            # not caught above, so this teardown is not marked as an error. ``response`` stays ``None``
-            # unless the stream ran to completion, so abandonment does not report a misleading output.
-            # (A stream that is created but never iterated is a separate edge case: this body — and so
-            # this ``finally`` — never runs, so the span is not finished. That is not the
-            # human-in-the-loop abandonment path this guards.)
+            # AIDEV-NOTE: finish in ``finally`` so the span closes on every exit, including early
+            # abandonment - a consumer ``break`` on ``__interrupt__`` (human-in-the-loop) tears the generator
+            # down via ``GeneratorExit``, which is intentionally not caught above, so teardown is not
+            # flagged as an error. ``response`` stays ``None`` unless the stream ran to completion.
             integration.llmobs_set_tags(
                 span, args=args, kwargs={**kwargs, "name": name}, response=response, operation="graph"
             )

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -39,6 +39,17 @@ try:
 except ImportError:
     LangGraphGraphInterruptError = None
 
+
+def _is_langgraph_control_flow(exc):
+    """Return True if ``exc`` is a LangGraph control-flow signal (``GraphInterrupt`` or
+    ``ParentCommand``) rather than a real error. LangGraph uses these for human-in-the-loop
+    pauses and subgraph routing, so the span must not be marked as an error.
+    """
+    return (LangGraphParentCommandError is not None and isinstance(exc, LangGraphParentCommandError)) or (
+        LangGraphGraphInterruptError is not None and isinstance(exc, LangGraphGraphInterruptError)
+    )
+
+
 LANGGRAPH_VERSION = parse_version(get_version())
 
 LANGGRAPH_MODULE_MAP = {
@@ -108,9 +119,7 @@ def traced_runnable_seq_invoke(func, instance, args, kwargs):
     try:
         result = func(*args, **kwargs)
     except (DDBlockException, Exception) as e:
-        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-        ):
+        if not _is_langgraph_control_flow(e):
             span.set_exc_info(*sys.exc_info())
         raise
     finally:
@@ -135,9 +144,7 @@ async def traced_runnable_seq_ainvoke(func, instance, args, kwargs):
     try:
         result = await func(*args, **kwargs)
     except (DDBlockException, Exception) as e:
-        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-        ):
+        if not _is_langgraph_control_flow(e):
             span.set_exc_info(*sys.exc_info())
         raise
     finally:
@@ -169,9 +176,7 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
     try:
         result = func(*args, **kwargs)
     except (DDBlockException, Exception) as e:
-        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-        ):
+        if not _is_langgraph_control_flow(e):
             span.set_exc_info(*sys.exc_info())
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=None, operation="node")
         span.finish()
@@ -202,10 +207,7 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                 # ``GeneratorExit`` / ``CancelledError`` from normal stream teardown must not be caught
                 # (they'd be mis-reported as span errors). The ``finally`` below still closes the span.
                 except (DDBlockException, Exception) as e:
-                    if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-                        LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-                    ):
-                        # This error is caught in the LangGraph framework, we shouldn't mark it as a runtime error.
+                    if not _is_langgraph_control_flow(e):
                         span.set_exc_info(*sys.exc_info())
                     stream_exc = e
                     raise
@@ -265,9 +267,7 @@ def traced_pregel_stream(func, instance, args, kwargs):
     try:
         result = func(*args, **kwargs)
     except (DDBlockException, Exception) as e:
-        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-        ):
+        if not _is_langgraph_control_flow(e):
             span.set_exc_info(*sys.exc_info())
         integration.llmobs_set_tags(span, args=args, kwargs={**kwargs, "name": name}, response=None, operation="graph")
         span.finish()
@@ -285,9 +285,7 @@ def traced_pregel_stream(func, instance, args, kwargs):
                     response = item[-1] if isinstance(item, tuple) else item
                     break
                 except (DDBlockException, Exception) as e:
-                    if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-                        LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-                    ):
+                    if not _is_langgraph_control_flow(e):
                         span.set_exc_info(*sys.exc_info())
                     raise
         finally:
@@ -316,9 +314,7 @@ def traced_pregel_astream(func, instance, args, kwargs):
     try:
         result = func(*args, **kwargs)
     except (DDBlockException, Exception) as e:
-        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-        ):
+        if not _is_langgraph_control_flow(e):
             span.set_exc_info(*sys.exc_info())
         integration.llmobs_set_tags(span, args=args, kwargs={**kwargs, "name": name}, response=None, operation="graph")
         span.finish()
@@ -336,9 +332,7 @@ def traced_pregel_astream(func, instance, args, kwargs):
                     response = item[-1] if isinstance(item, tuple) else item
                     break
                 except (DDBlockException, Exception) as e:
-                    if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-                        LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-                    ):
+                    if not _is_langgraph_control_flow(e):
                         span.set_exc_info(*sys.exc_info())
                     raise
         finally:

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -168,8 +168,11 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
 
     try:
         result = func(*args, **kwargs)
-    except Exception:
-        span.set_exc_info(*sys.exc_info())
+    except (DDBlockException, Exception) as e:
+        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
+            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
+        ):
+            span.set_exc_info(*sys.exc_info())
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=None, operation="node")
         span.finish()
         raise
@@ -177,35 +180,48 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
     async def _astream():
         item = None
         response = None
+        stream_exc = None
         add_supported = True
-        while True:
-            try:
-                item = await result.__anext__()
-                if add_supported:
-                    try:
-                        response = item if response is None else response + item
-                    except TypeError:
+        try:
+            while True:
+                try:
+                    item = await result.__anext__()
+                    if add_supported:
+                        try:
+                            response = item if response is None else response + item
+                        except TypeError:
+                            response = item
+                            add_supported = False
+                    else:
+                        # default to the last item if addition between items is not supported
                         response = item
-                        add_supported = False
-                else:
-                    # default to the last item if addition between items is not supported
-                    response = item
-                yield item
-            except StopAsyncIteration:
-                integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=response, operation="node")
-                span.finish()
-                break
-            # AIDEV-NOTE: do not widen to bare ``BaseException`` here — this wraps a ``yield``, so ``GeneratorExit``
-            # / ``CancelledError`` from normal stream teardown would be mis-reported as span errors.
-            except (DDBlockException, Exception) as e:
-                if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-                    LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-                ):
-                    # This error is caught in the LangGraph framework, we shouldn't mark it as a runtime error.
-                    span.set_exc_info(*sys.exc_info())
-                integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=None, operation="node")
-                span.finish()
-                raise
+                    yield item
+                except StopAsyncIteration:
+                    break
+                # AIDEV-NOTE: do not widen to bare ``BaseException`` here — this wraps a ``yield``, so
+                # ``GeneratorExit`` / ``CancelledError`` from normal stream teardown must not be caught
+                # (they'd be mis-reported as span errors). The ``finally`` below still finishes the span
+                # on that teardown, just without an error, so abandoning the stream early does not leak it.
+                except (DDBlockException, Exception) as e:
+                    if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
+                        LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
+                    ):
+                        # This error is caught in the LangGraph framework, we shouldn't mark it as a runtime error.
+                        span.set_exc_info(*sys.exc_info())
+                    stream_exc = e
+                    raise
+        finally:
+            # Report whatever streamed so far on any non-error exit, including early abandonment
+            # (``GeneratorExit`` from a consumer ``break``). Only a real propagated exception
+            # suppresses the partial output.
+            integration.llmobs_set_tags(
+                span,
+                args=args,
+                kwargs=kwargs,
+                response=(None if stream_exc is not None else response),
+                operation="node",
+            )
+            span.finish()
 
     return _astream()
 
@@ -250,43 +266,44 @@ def traced_pregel_stream(func, instance, args, kwargs):
 
     try:
         result = func(*args, **kwargs)
-    except Exception:
-        span.set_exc_info(*sys.exc_info())
+    except (DDBlockException, Exception) as e:
+        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
+            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
+        ):
+            span.set_exc_info(*sys.exc_info())
         integration.llmobs_set_tags(span, args=args, kwargs={**kwargs, "name": name}, response=None, operation="graph")
         span.finish()
         raise
 
     def _stream():
         item = None
-        while True:
-            try:
-                item = next(result)
-                yield item
-            except StopIteration:
-                response = item[-1] if isinstance(item, tuple) else item
-                integration.llmobs_set_tags(
-                    span,
-                    args=args,
-                    kwargs={**kwargs, "name": name},
-                    response=response,
-                    operation="graph",
-                )
-                span.finish()
-                break
-            except (DDBlockException, Exception) as e:
-                if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-                    LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-                ):
-                    span.set_exc_info(*sys.exc_info())
-                integration.llmobs_set_tags(
-                    span,
-                    args=args,
-                    kwargs={**kwargs, "name": name},
-                    response=None,
-                    operation="graph",
-                )
-                span.finish()
-                raise
+        response = None
+        try:
+            while True:
+                try:
+                    item = next(result)
+                    yield item
+                except StopIteration:
+                    response = item[-1] if isinstance(item, tuple) else item
+                    break
+                except (DDBlockException, Exception) as e:
+                    if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
+                        LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
+                    ):
+                        span.set_exc_info(*sys.exc_info())
+                    raise
+        finally:
+            # AIDEV-NOTE: finish in ``finally`` so an iterated stream is closed on every exit —
+            # including when the consumer abandons it early (e.g. ``break``), which tears the generator
+            # down via ``GeneratorExit``. ``GeneratorExit`` is intentionally not caught above, so this
+            # teardown is not marked as an error. ``response`` stays ``None`` unless the stream ran to
+            # completion, so abandonment does not report a misleading output. (A stream that is created
+            # but never iterated is a separate edge case: this body — and so this ``finally`` — never
+            # runs, so the span is not finished. That is not the abandonment path guarded here.)
+            integration.llmobs_set_tags(
+                span, args=args, kwargs={**kwargs, "name": name}, response=response, operation="graph"
+            )
+            span.finish()
 
     return _stream()
 
@@ -303,43 +320,45 @@ def traced_pregel_astream(func, instance, args, kwargs):
 
     try:
         result = func(*args, **kwargs)
-    except Exception:
-        span.set_exc_info(*sys.exc_info())
+    except (DDBlockException, Exception) as e:
+        if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
+            LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
+        ):
+            span.set_exc_info(*sys.exc_info())
         integration.llmobs_set_tags(span, args=args, kwargs={**kwargs, "name": name}, response=None, operation="graph")
         span.finish()
         raise
 
     async def _astream():
         item = None
-        while True:
-            try:
-                item = await result.__anext__()
-                yield item
-            except StopAsyncIteration:
-                response = item[-1] if isinstance(item, tuple) else item
-                integration.llmobs_set_tags(
-                    span,
-                    args=args,
-                    kwargs={**kwargs, "name": name},
-                    response=response,
-                    operation="graph",
-                )
-                span.finish()
-                break
-            except (DDBlockException, Exception) as e:
-                if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
-                    LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
-                ):
-                    span.set_exc_info(*sys.exc_info())
-                integration.llmobs_set_tags(
-                    span,
-                    args=args,
-                    kwargs={**kwargs, "name": name},
-                    response=None,
-                    operation="graph",
-                )
-                span.finish()
-                raise
+        response = None
+        try:
+            while True:
+                try:
+                    item = await result.__anext__()
+                    yield item
+                except StopAsyncIteration:
+                    response = item[-1] if isinstance(item, tuple) else item
+                    break
+                except (DDBlockException, Exception) as e:
+                    if (LangGraphParentCommandError is None or not isinstance(e, LangGraphParentCommandError)) and (
+                        LangGraphGraphInterruptError is None or not isinstance(e, LangGraphGraphInterruptError)
+                    ):
+                        span.set_exc_info(*sys.exc_info())
+                    raise
+        finally:
+            # AIDEV-NOTE: finish in ``finally`` so an iterated stream is closed on every exit —
+            # including when the consumer abandons it early (e.g. ``break`` on ``__interrupt__``),
+            # which tears the generator down via ``GeneratorExit``. ``GeneratorExit`` is intentionally
+            # not caught above, so this teardown is not marked as an error. ``response`` stays ``None``
+            # unless the stream ran to completion, so abandonment does not report a misleading output.
+            # (A stream that is created but never iterated is a separate edge case: this body — and so
+            # this ``finally`` — never runs, so the span is not finished. That is not the
+            # human-in-the-loop abandonment path this guards.)
+            integration.llmobs_set_tags(
+                span, args=args, kwargs={**kwargs, "name": name}, response=response, operation="graph"
+            )
+            span.finish()
 
     return _astream()
 

--- a/releasenotes/notes/langgraph-stream-abandon-span-finish-40c251d3fbe380f4.yaml
+++ b/releasenotes/notes/langgraph-stream-abandon-span-finish-40c251d3fbe380f4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    langgraph: Fixes an issue where abandoning a graph stream early (for example, ``break``-ing out of ``astream()`` or ``stream()`` when an ``__interrupt__`` is received in a human-in-the-loop workflow) left the graph's root span unfinished, so the trace failed to assemble and did not appear in Datadog. The root span is now finished when the stream is torn down, so interrupted runs are traced.

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -93,6 +93,44 @@ def simple_graph(langgraph):
 
 
 @pytest.fixture
+def interrupt_graph(langgraph):
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+
+    def node_with_interrupt(state):
+        interrupt({"question": "approve?"})
+        return {"a_list": ["done"]}
+
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("interrupt_node", node_with_interrupt)
+    graph_builder.add_edge(START, "interrupt_node")
+    graph_builder.add_edge("interrupt_node", END)
+    graph = graph_builder.compile(checkpointer=MemorySaver())
+
+    yield graph
+
+
+@pytest.fixture
+def async_interrupt_graph(langgraph):
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+
+    # Async node so interrupt() runs in the runnable context under astream(); a sync node is
+    # dispatched to an executor thread on async runs, where get_config() is unavailable.
+    async def node_with_interrupt(state):
+        interrupt({"question": "approve?"})
+        return {"a_list": ["done"]}
+
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("interrupt_node", node_with_interrupt)
+    graph_builder.add_edge(START, "interrupt_node")
+    graph_builder.add_edge("interrupt_node", END)
+    graph = graph_builder.compile(checkpointer=MemorySaver())
+
+    yield graph
+
+
+@pytest.fixture
 def conditional_graph(langgraph):
     def which(state):
         if state["which"] not in ("b", "c"):

--- a/tests/contrib/langgraph/test_langgraph.py
+++ b/tests/contrib/langgraph/test_langgraph.py
@@ -433,49 +433,24 @@ async def test_astream_teardown_not_marked_as_error(simple_graph, test_spans):
             assert span.error == 0, f"span {span.resource} wrongly marked as error on astream teardown"
 
 
-def _interrupt_graph(async_node=False):
-    """One-node graph whose node calls the real ``interrupt()`` primitive.
-
-    Use ``async_node=True`` for ``astream()`` runs: a sync node is dispatched to an executor
-    thread on async runs, where ``interrupt()`` cannot reach the run config (raises "Called
-    get_config outside of a runnable context") on Python 3.10 and older LangGraph. Sync
-    ``stream()`` runs the node in the runnable context, so a sync node works there.
-    """
-    from langgraph.types import interrupt
-
-    def node_with_interrupt(state):
-        interrupt({"question": "approve?"})
-        return {"a_list": ["done"]}
-
-    async def anode_with_interrupt(state):
-        interrupt({"question": "approve?"})
-        return {"a_list": ["done"]}
-
-    graph_builder = StateGraph(State)
-    graph_builder.add_node("interrupt_node", anode_with_interrupt if async_node else node_with_interrupt)
-    graph_builder.add_edge(START, "interrupt_node")
-    graph_builder.add_edge("interrupt_node", END)
-    return graph_builder.compile(checkpointer=MemorySaver())
-
-
 @pytest.mark.skipif(
     LANGGRAPH_VERSION < (0, 3, 21) or sys.version_info < (3, 11),
     reason="real interrupt() over astream() needs LangGraph 0.3.21+ and Python 3.11+ (async runnable context)",
 )
-async def test_astream_break_on_interrupt_emits_trace(langgraph, test_spans):
-    """MLOS-701: breaking out of astream() on ``__interrupt__`` must still emit the trace.
+async def test_astream_break_on_interrupt_emits_trace(async_interrupt_graph, test_spans):
+    """Breaking out of astream() on ``__interrupt__`` must still emit the trace.
 
     Reproduces the customer's human-in-the-loop pattern: the consumer stops iterating as soon
     as the graph interrupts, without draining the stream. The root graph span must still finish
     (via the wrapper's ``finally``) so the whole trace is not silently dropped.
     """
-    graph = _interrupt_graph(async_node=True)
-    config = {"configurable": {"thread_id": "mlos-701-async"}}
+    graph = async_interrupt_graph
+    config = {"configurable": {"thread_id": "interrupt-async"}}
 
     stream = graph.astream({"a_list": [], "which": "a"}, config=config)
     saw_interrupt = False
     async for chunk in stream:
-        # Iterate until the interrupt actually surfaces, then abandon — a bare break on the
+        # Iterate until the interrupt actually surfaces, then abandon - a bare break on the
         # first chunk could stop at the wrong point and pass spuriously.
         if isinstance(chunk, dict) and "__interrupt__" in chunk:
             saw_interrupt = True
@@ -494,10 +469,10 @@ async def test_astream_break_on_interrupt_emits_trace(langgraph, test_spans):
 @pytest.mark.skipif(
     LANGGRAPH_VERSION < (0, 3, 21), reason="real interrupt() streaming surface differs before LangGraph 0.3.21"
 )
-def test_stream_break_on_interrupt_emits_trace(langgraph, test_spans):
+def test_stream_break_on_interrupt_emits_trace(interrupt_graph, test_spans):
     """Sync variant of the interrupt-abandonment repro (``traced_pregel_stream``)."""
-    graph = _interrupt_graph()
-    config = {"configurable": {"thread_id": "mlos-701-sync"}}
+    graph = interrupt_graph
+    config = {"configurable": {"thread_id": "interrupt-sync"}}
 
     stream = graph.stream({"a_list": [], "which": "a"}, config=config)
     saw_interrupt = False
@@ -517,35 +492,28 @@ def test_stream_break_on_interrupt_emits_trace(langgraph, test_spans):
 
 
 async def test_astream_break_without_close_emits_trace(simple_graph, test_spans):
-    """Faithful inline customer shape: ``async for graph.astream(...): break`` with NO explicit
-    aclose(). The wrapper generator is finalized by GC; its ``finally`` must still emit the span.
-
-    This guards the real no-explicit-close path; the aclose()/close() tests above are the
-    deterministic proof of the same mechanism.
+    """Customer path: ``break`` out of astream() with no ``aclose()``. GC finalizes the
+    generator (GeneratorExit) and the wrapper's ``finally`` must still emit the span.
     """
     import asyncio
     import gc
 
     async def consume():
-        # The stream is an inline temporary; dropping out of this frame leaves it unreferenced.
         async for _ in simple_graph.astream({"a_list": [], "which": "a"}):
-            break
+            break  # abandon without closing
 
     await consume()
 
-    # Force + drive async-generator finalization deterministically rather than relying on
-    # pytest-asyncio teardown to do it.
     traces = []
     for _ in range(10):
         gc.collect()
-        await asyncio.sleep(0)
+        await asyncio.sleep(0)  # let the event loop run the asyncgen finalizer
         traces = test_spans.pop_traces()
         if traces:
             break
-    assert len(traces) >= 1, "trace must be emitted even when the stream is abandoned via bare break"
-    for trace in traces:
-        for span in trace:
-            assert span.error == 0, f"span {span.resource} wrongly marked as error on abandonment"
+    assert traces, "trace must be emitted when the stream is abandoned via bare break"
+    for span in traces[0]:
+        assert span.error == 0
 
 
 def test_regular_exception_still_marked_as_error(langgraph, test_spans):

--- a/tests/contrib/langgraph/test_langgraph.py
+++ b/tests/contrib/langgraph/test_langgraph.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import sys
 
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END
@@ -432,23 +433,34 @@ async def test_astream_teardown_not_marked_as_error(simple_graph, test_spans):
             assert span.error == 0, f"span {span.resource} wrongly marked as error on astream teardown"
 
 
-def _interrupt_graph():
-    """One-node graph whose node calls the real ``interrupt()`` primitive."""
+def _interrupt_graph(async_node=False):
+    """One-node graph whose node calls the real ``interrupt()`` primitive.
+
+    Use ``async_node=True`` for ``astream()`` runs: a sync node is dispatched to an executor
+    thread on async runs, where ``interrupt()`` cannot reach the run config (raises "Called
+    get_config outside of a runnable context") on Python 3.10 and older LangGraph. Sync
+    ``stream()`` runs the node in the runnable context, so a sync node works there.
+    """
     from langgraph.types import interrupt
 
     def node_with_interrupt(state):
         interrupt({"question": "approve?"})
         return {"a_list": ["done"]}
 
+    async def anode_with_interrupt(state):
+        interrupt({"question": "approve?"})
+        return {"a_list": ["done"]}
+
     graph_builder = StateGraph(State)
-    graph_builder.add_node("interrupt_node", node_with_interrupt)
+    graph_builder.add_node("interrupt_node", anode_with_interrupt if async_node else node_with_interrupt)
     graph_builder.add_edge(START, "interrupt_node")
     graph_builder.add_edge("interrupt_node", END)
     return graph_builder.compile(checkpointer=MemorySaver())
 
 
 @pytest.mark.skipif(
-    LANGGRAPH_VERSION < (0, 3, 21), reason="real interrupt() streaming surface differs before LangGraph 0.3.21"
+    LANGGRAPH_VERSION < (0, 3, 21) or sys.version_info < (3, 11),
+    reason="real interrupt() over astream() needs LangGraph 0.3.21+ and Python 3.11+ (async runnable context)",
 )
 async def test_astream_break_on_interrupt_emits_trace(langgraph, test_spans):
     """MLOS-701: breaking out of astream() on ``__interrupt__`` must still emit the trace.
@@ -457,7 +469,7 @@ async def test_astream_break_on_interrupt_emits_trace(langgraph, test_spans):
     as the graph interrupts, without draining the stream. The root graph span must still finish
     (via the wrapper's ``finally``) so the whole trace is not silently dropped.
     """
-    graph = _interrupt_graph()
+    graph = _interrupt_graph(async_node=True)
     config = {"configurable": {"thread_id": "mlos-701-async"}}
 
     stream = graph.astream({"a_list": [], "which": "a"}, config=config)
@@ -534,29 +546,6 @@ async def test_astream_break_without_close_emits_trace(simple_graph, test_spans)
     for trace in traces:
         for span in trace:
             assert span.error == 0, f"span {span.resource} wrongly marked as error on abandonment"
-
-
-async def test_astream_events_break_emits_node_trace(simple_graph, test_spans):
-    """Node-level ``traced_runnable_seq_astream`` (driven by ``astream_events``) must also finish
-    its span when the consumer breaks early.
-
-    Breaking right after the first ``on_chain_stream`` event suspends a node's
-    ``RunnableSeq.astream`` mid-yield (rather than letting it run to completion), which directly
-    exercises the node-level wrapper's abandonment path — the pregel-level tests do not.
-    """
-    stream = simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2")
-    async for ev in stream:
-        if ev.get("event") == "on_chain_stream":
-            break
-    await stream.aclose()
-
-    traces = test_spans.pop_traces()
-    spans = [s for trace in traces for s in trace]
-    # A node's RunnableSeq span must be present (proves the node-level wrapper was actually
-    # abandoned mid-stream) and finished cleanly, not just the top-level graph span.
-    assert any("RunnableSeq" in s.resource for s in spans), [s.resource for s in spans]
-    for span in spans:
-        assert span.error == 0, f"span {span.resource} wrongly marked as error on abandonment"
 
 
 def test_regular_exception_still_marked_as_error(langgraph, test_spans):

--- a/tests/contrib/langgraph/test_langgraph.py
+++ b/tests/contrib/langgraph/test_langgraph.py
@@ -6,6 +6,8 @@ from langgraph.graph import START
 from langgraph.graph import StateGraph
 import pytest
 
+from ddtrace.contrib.internal.langgraph.patch import LANGGRAPH_VERSION
+
 from .conftest import State
 
 
@@ -408,7 +410,11 @@ def test_stream_teardown_not_marked_as_error(simple_graph, test_spans):
     next(stream)  # suspend the generator at a ``yield``
     stream.close()  # raises GeneratorExit at the suspended ``yield``
 
-    for trace in test_spans.pop_traces():
+    # The span must still be emitted (finished in ``finally``) on early teardown, not just
+    # left unmarked. Asserting emission here guards against the span silently leaking.
+    traces = test_spans.pop_traces()
+    assert len(traces) >= 1, "trace must be emitted even when the stream is closed early"
+    for trace in traces:
         for span in trace:
             assert span.error == 0, f"span {span.resource} wrongly marked as error on stream teardown"
 
@@ -419,9 +425,138 @@ async def test_astream_teardown_not_marked_as_error(simple_graph, test_spans):
     await stream.__anext__()  # suspend the generator at a ``yield``
     await stream.aclose()  # raises GeneratorExit at the suspended ``yield``
 
-    for trace in test_spans.pop_traces():
+    traces = test_spans.pop_traces()
+    assert len(traces) >= 1, "trace must be emitted even when the stream is closed early"
+    for trace in traces:
         for span in trace:
             assert span.error == 0, f"span {span.resource} wrongly marked as error on astream teardown"
+
+
+def _interrupt_graph():
+    """One-node graph whose node calls the real ``interrupt()`` primitive."""
+    from langgraph.types import interrupt
+
+    def node_with_interrupt(state):
+        interrupt({"question": "approve?"})
+        return {"a_list": ["done"]}
+
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("interrupt_node", node_with_interrupt)
+    graph_builder.add_edge(START, "interrupt_node")
+    graph_builder.add_edge("interrupt_node", END)
+    return graph_builder.compile(checkpointer=MemorySaver())
+
+
+@pytest.mark.skipif(
+    LANGGRAPH_VERSION < (0, 3, 21), reason="real interrupt() streaming surface differs before LangGraph 0.3.21"
+)
+async def test_astream_break_on_interrupt_emits_trace(langgraph, test_spans):
+    """MLOS-701: breaking out of astream() on ``__interrupt__`` must still emit the trace.
+
+    Reproduces the customer's human-in-the-loop pattern: the consumer stops iterating as soon
+    as the graph interrupts, without draining the stream. The root graph span must still finish
+    (via the wrapper's ``finally``) so the whole trace is not silently dropped.
+    """
+    graph = _interrupt_graph()
+    config = {"configurable": {"thread_id": "mlos-701-async"}}
+
+    stream = graph.astream({"a_list": [], "which": "a"}, config=config)
+    saw_interrupt = False
+    async for chunk in stream:
+        # Iterate until the interrupt actually surfaces, then abandon — a bare break on the
+        # first chunk could stop at the wrong point and pass spuriously.
+        if isinstance(chunk, dict) and "__interrupt__" in chunk:
+            saw_interrupt = True
+            break
+    assert saw_interrupt, "expected an __interrupt__ chunk from the graph"
+    await stream.aclose()  # deterministic stand-in for the GC finalization a bare break triggers
+
+    spans = test_spans.pop_traces()[0]
+    assert len(spans) > 0
+    assert any("LangGraph" in span.resource for span in spans), [s.resource for s in spans]
+    for span in spans:
+        assert span.error == 0
+        assert span.get_tag("error.type") is None
+
+
+@pytest.mark.skipif(
+    LANGGRAPH_VERSION < (0, 3, 21), reason="real interrupt() streaming surface differs before LangGraph 0.3.21"
+)
+def test_stream_break_on_interrupt_emits_trace(langgraph, test_spans):
+    """Sync variant of the interrupt-abandonment repro (``traced_pregel_stream``)."""
+    graph = _interrupt_graph()
+    config = {"configurable": {"thread_id": "mlos-701-sync"}}
+
+    stream = graph.stream({"a_list": [], "which": "a"}, config=config)
+    saw_interrupt = False
+    for chunk in stream:
+        if isinstance(chunk, dict) and "__interrupt__" in chunk:
+            saw_interrupt = True
+            break
+    assert saw_interrupt, "expected an __interrupt__ chunk from the graph"
+    stream.close()  # sync close is deterministic (no event-loop scheduling)
+
+    spans = test_spans.pop_traces()[0]
+    assert len(spans) > 0
+    assert any("LangGraph" in span.resource for span in spans), [s.resource for s in spans]
+    for span in spans:
+        assert span.error == 0
+        assert span.get_tag("error.type") is None
+
+
+async def test_astream_break_without_close_emits_trace(simple_graph, test_spans):
+    """Faithful inline customer shape: ``async for graph.astream(...): break`` with NO explicit
+    aclose(). The wrapper generator is finalized by GC; its ``finally`` must still emit the span.
+
+    This guards the real no-explicit-close path; the aclose()/close() tests above are the
+    deterministic proof of the same mechanism.
+    """
+    import asyncio
+    import gc
+
+    async def consume():
+        # The stream is an inline temporary; dropping out of this frame leaves it unreferenced.
+        async for _ in simple_graph.astream({"a_list": [], "which": "a"}):
+            break
+
+    await consume()
+
+    # Force + drive async-generator finalization deterministically rather than relying on
+    # pytest-asyncio teardown to do it.
+    traces = []
+    for _ in range(10):
+        gc.collect()
+        await asyncio.sleep(0)
+        traces = test_spans.pop_traces()
+        if traces:
+            break
+    assert len(traces) >= 1, "trace must be emitted even when the stream is abandoned via bare break"
+    for trace in traces:
+        for span in trace:
+            assert span.error == 0, f"span {span.resource} wrongly marked as error on abandonment"
+
+
+async def test_astream_events_break_emits_node_trace(simple_graph, test_spans):
+    """Node-level ``traced_runnable_seq_astream`` (driven by ``astream_events``) must also finish
+    its span when the consumer breaks early.
+
+    Breaking right after the first ``on_chain_stream`` event suspends a node's
+    ``RunnableSeq.astream`` mid-yield (rather than letting it run to completion), which directly
+    exercises the node-level wrapper's abandonment path — the pregel-level tests do not.
+    """
+    stream = simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2")
+    async for ev in stream:
+        if ev.get("event") == "on_chain_stream":
+            break
+    await stream.aclose()
+
+    traces = test_spans.pop_traces()
+    spans = [s for trace in traces for s in trace]
+    # A node's RunnableSeq span must be present (proves the node-level wrapper was actually
+    # abandoned mid-stream) and finished cleanly, not just the top-level graph span.
+    assert any("RunnableSeq" in s.resource for s in spans), [s.resource for s in spans]
+    for span in spans:
+        assert span.error == 0, f"span {span.resource} wrongly marked as error on abandonment"
 
 
 def test_regular_exception_still_marked_as_error(langgraph, test_spans):

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -1,5 +1,6 @@
 import json
 import random
+import sys
 
 import pytest
 
@@ -318,7 +319,8 @@ class TestLangGraphLLMObs:
         assert b_output.get("value") is not None
 
     @pytest.mark.skipif(
-        LANGGRAPH_VERSION < (0, 3, 21), reason="real interrupt() streaming surface differs before LangGraph 0.3.21"
+        LANGGRAPH_VERSION < (0, 3, 21) or sys.version_info < (3, 11),
+        reason="real interrupt() over astream() needs LangGraph 0.3.21+ and Python 3.11+ (async runnable context)",
     )
     async def test_astream_break_on_interrupt_emits_llmobs_span(self, langgraph, langgraph_llmobs, test_spans):
         """MLOS-701: the graph's LLMObs span must be emitted even when the consumer abandons the
@@ -332,7 +334,9 @@ class TestLangGraphLLMObs:
 
         from .conftest import State
 
-        def node_with_interrupt(state):
+        async def node_with_interrupt(state):
+            # Async node so interrupt() runs in the runnable context under astream() (a sync node
+            # is dispatched to an executor thread on async runs, where get_config() is unavailable).
             interrupt({"question": "approve?"})
             return {"a_list": ["done"]}
 
@@ -355,24 +359,6 @@ class TestLangGraphLLMObs:
         graph_span = _find_span_by_name(spans, "LangGraph")
         assert graph_span is not None
         assert graph_span.error == 0
-
-    async def test_astream_events_break_still_reports_node_output(self, langgraph_llmobs, test_spans, simple_graph):
-        """A node abandoned mid-stream must still emit its span with output, not drop it. Breaking on
-        the first ``on_chain_stream`` suspends node "a"'s RunnableSeq.astream; the ``finally`` finishes
-        the span and reports the accumulated output (the wrapper passes ``response`` on abandonment
-        just as it does on completion, rather than nulling it out).
-        """
-        stream = simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2")
-        async for ev in stream:
-            if ev.get("event") == "on_chain_stream":
-                break
-        await stream.aclose()
-
-        spans = _collect_spans(test_spans)
-        a_span = _find_span_by_name(spans, "a")
-        assert a_span.error == 0
-        a_output = get_llmobs_output(a_span) or {}
-        assert a_output.get("value") is not None
 
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_manifest_simple_graph(

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -322,31 +322,15 @@ class TestLangGraphLLMObs:
         LANGGRAPH_VERSION < (0, 3, 21) or sys.version_info < (3, 11),
         reason="real interrupt() over astream() needs LangGraph 0.3.21+ and Python 3.11+ (async runnable context)",
     )
-    async def test_astream_break_on_interrupt_emits_llmobs_span(self, langgraph, langgraph_llmobs, test_spans):
-        """MLOS-701: the graph's LLMObs span must be emitted even when the consumer abandons the
-        stream on ``__interrupt__`` (human-in-the-loop) instead of draining it.
+    async def test_astream_break_on_interrupt_emits_llmobs_span(
+        self, langgraph_llmobs, async_interrupt_graph, test_spans
+    ):
+        """The graph's LLMObs span must be emitted even when the consumer abandons the stream on
+        ``__interrupt__`` (human-in-the-loop) instead of draining it.
         """
-        from langgraph.checkpoint.memory import MemorySaver
-        from langgraph.graph import END
-        from langgraph.graph import START
-        from langgraph.graph import StateGraph
-        from langgraph.types import interrupt
-
-        from .conftest import State
-
-        async def node_with_interrupt(state):
-            # Async node so interrupt() runs in the runnable context under astream() (a sync node
-            # is dispatched to an executor thread on async runs, where get_config() is unavailable).
-            interrupt({"question": "approve?"})
-            return {"a_list": ["done"]}
-
-        graph_builder = StateGraph(State)
-        graph_builder.add_node("interrupt_node", node_with_interrupt)
-        graph_builder.add_edge(START, "interrupt_node")
-        graph_builder.add_edge("interrupt_node", END)
-        graph = graph_builder.compile(checkpointer=MemorySaver())
-
-        stream = graph.astream({"a_list": [], "which": "a"}, config={"configurable": {"thread_id": "llmobs"}})
+        stream = async_interrupt_graph.astream(
+            {"a_list": [], "which": "a"}, config={"configurable": {"thread_id": "llmobs"}}
+        )
         saw_interrupt = False
         async for chunk in stream:
             if isinstance(chunk, dict) and "__interrupt__" in chunk:

--- a/tests/contrib/langgraph/test_langgraph_llmobs.py
+++ b/tests/contrib/langgraph/test_langgraph_llmobs.py
@@ -317,6 +317,63 @@ class TestLangGraphLLMObs:
         assert a_output.get("value") is not None
         assert b_output.get("value") is not None
 
+    @pytest.mark.skipif(
+        LANGGRAPH_VERSION < (0, 3, 21), reason="real interrupt() streaming surface differs before LangGraph 0.3.21"
+    )
+    async def test_astream_break_on_interrupt_emits_llmobs_span(self, langgraph, langgraph_llmobs, test_spans):
+        """MLOS-701: the graph's LLMObs span must be emitted even when the consumer abandons the
+        stream on ``__interrupt__`` (human-in-the-loop) instead of draining it.
+        """
+        from langgraph.checkpoint.memory import MemorySaver
+        from langgraph.graph import END
+        from langgraph.graph import START
+        from langgraph.graph import StateGraph
+        from langgraph.types import interrupt
+
+        from .conftest import State
+
+        def node_with_interrupt(state):
+            interrupt({"question": "approve?"})
+            return {"a_list": ["done"]}
+
+        graph_builder = StateGraph(State)
+        graph_builder.add_node("interrupt_node", node_with_interrupt)
+        graph_builder.add_edge(START, "interrupt_node")
+        graph_builder.add_edge("interrupt_node", END)
+        graph = graph_builder.compile(checkpointer=MemorySaver())
+
+        stream = graph.astream({"a_list": [], "which": "a"}, config={"configurable": {"thread_id": "llmobs"}})
+        saw_interrupt = False
+        async for chunk in stream:
+            if isinstance(chunk, dict) and "__interrupt__" in chunk:
+                saw_interrupt = True
+                break
+        assert saw_interrupt, "expected an __interrupt__ chunk from the graph"
+        await stream.aclose()
+
+        spans = _collect_spans(test_spans)
+        graph_span = _find_span_by_name(spans, "LangGraph")
+        assert graph_span is not None
+        assert graph_span.error == 0
+
+    async def test_astream_events_break_still_reports_node_output(self, langgraph_llmobs, test_spans, simple_graph):
+        """A node abandoned mid-stream must still emit its span with output, not drop it. Breaking on
+        the first ``on_chain_stream`` suspends node "a"'s RunnableSeq.astream; the ``finally`` finishes
+        the span and reports the accumulated output (the wrapper passes ``response`` on abandonment
+        just as it does on completion, rather than nulling it out).
+        """
+        stream = simple_graph.astream_events({"a_list": [], "which": "a"}, version="v2")
+        async for ev in stream:
+            if ev.get("event") == "on_chain_stream":
+                break
+        await stream.aclose()
+
+        spans = _collect_spans(test_spans)
+        a_span = _find_span_by_name(spans, "a")
+        assert a_span.error == 0
+        a_output = get_llmobs_output(a_span) or {}
+        assert a_output.get("value") is not None
+
     @pytest.mark.skipif(LANGGRAPH_VERSION < (0, 3, 22), reason="Agent names are only supported in LangGraph 0.3.22+")
     def test_agent_manifest_simple_graph(
         self, langgraph_llmobs, test_spans, agentic_graph_with_conditional_and_definitive_edges


### PR DESCRIPTION
## Description

[Interrupted](https://docs.langchain.com/oss/python/langgraph/interrupts) human-in-the-loop LangGraph runs went missing from LLM Observability: `break`-ing out of `astream()`/`stream()` on `__interrupt__` tears the stream down via `GeneratorExit`, but the wrappers only finished the span on normal completion or a caught `Exception`, so the root graph span never closed. With no root, the trace can't assemble (`no_root_spans_identified_error`) and never appears, even though the child spans are visible in the Spans tab.

**What changed:**
- Finish the span in a `finally` around the yield loop in `traced_pregel_astream`, `traced_pregel_stream`, and `traced_runnable_seq_astream` (matching the sibling `invoke`/`ainvoke` wrappers), so the span closes on every exit including early abandonment.
- `GeneratorExit` stays uncaught, so interrupt teardown isn't flagged as a span error.
- A node's stream abandoned mid-run still reports the output captured so far; graph wrappers report final output only on normal completion.
- Pre-generator construction `except` blocks now use the same `(DDBlockException, Exception)` + `GraphInterrupt`/`ParentCommand` policy as the in-loop handlers.

## Testing

- Strengthened the two teardown tests to assert a trace IS emitted (not just `error == 0`).
- Added coverage for the human-in-the-loop abandonment path: break-on-`interrupt()` (async + sync), a bare-`break` with no explicit close (GC-finalized, the customer's exact pattern), and the LLMObs graph span on interrupt.
- Consolidated the interrupt-graph construction into shared `conftest` fixtures (`interrupt_graph`, `async_interrupt_graph`) reused across the sync/async/LLMObs tests.
- Full `tests/contrib/langgraph` suite passes across LangGraph 0.2.23, 0.3.21, 0.3.22, and latest on Python 3.9-3.14 (all 24 riot venvs green). The real-`interrupt()` tests are skipped below LangGraph 0.3.21 (streaming surface differs) and below Python 3.11 (async `interrupt()` cannot reach the run config).
- Verified live against a branch build with a repro app mirroring the customer's setup: the previously-dropped interrupted trace now appears in LLM Observability.

## Risks

Low. Span finishing moves into `finally`, but `span.finish()` is idempotent and `GeneratorExit` handling is unchanged. No public API change.

## Notes

Originally reported by customer in [MLOS-701](https://datadoghq.atlassian.net/browse/MLOS-701).

[MLOS-701]: https://datadoghq.atlassian.net/browse/MLOS-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ