### PR TITLE
fix(native): forget inherited tokio runtime in forked child

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -418,6 +418,30 @@ static PyMemberDef PeriodicThread_members[] = {
 
 // ----------------------------------------------------------------------------
 static int
+PeriodicThread_traverse(PeriodicThread* self, visitproc visit, void* arg)
+{
+    Py_VISIT(self->name);
+    Py_VISIT(self->ident);
+    Py_VISIT(self->_target);
+    Py_VISIT(self->_on_shutdown);
+    Py_VISIT(self->_ddtrace_profiling_ignore);
+    return 0;
+}
+
+// ----------------------------------------------------------------------------
+static int
+PeriodicThread_clear(PeriodicThread* self)
+{
+    Py_CLEAR(self->name);
+    Py_CLEAR(self->ident);
+    Py_CLEAR(self->_target);
+    Py_CLEAR(self->_on_shutdown);
+    Py_CLEAR(self->_ddtrace_profiling_ignore);
+    return 0;
+}
+
+// ----------------------------------------------------------------------------
+static int
 PeriodicThread_init(PeriodicThread* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwlist[] = { "interval", "target", "name", "on_shutdown", "no_wait_at_start", NULL };
@@ -897,6 +921,8 @@ PeriodicThread__before_fork(PeriodicThread* self, PyObject* Py_UNUSED(args))
 static void
 PeriodicThread_dealloc(PeriodicThread* self)
 {
+    PyObject_GC_UnTrack(self);
+
     if (self->_state != nullptr && self->_state->is_finalizing()) {
         // Do nothing. We are about to terminate and release resources anyway.
         return;
@@ -923,12 +949,7 @@ PeriodicThread_dealloc(PeriodicThread* self)
         PyDict_Contains(self->_state->periodic_threads, self->ident))
         PyDict_DelItem(self->_state->periodic_threads, self->ident);
 
-    Py_XDECREF(self->name);
-    Py_XDECREF(self->_target);
-    Py_XDECREF(self->_on_shutdown);
-
-    Py_XDECREF(self->ident);
-    Py_XDECREF(self->_ddtrace_profiling_ignore);
+    PeriodicThread_clear(self);
 
     // Threads are always detached at creation, so joinable() is always false
     // and no OS call is needed. Use safe_reset_thread to guard against the
@@ -967,12 +988,16 @@ static PyTypeObject PeriodicThreadType = {
     .tp_basicsize = sizeof(PeriodicThread),
     .tp_itemsize = 0,
     .tp_dealloc = (destructor)PeriodicThread_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     .tp_doc = PyDoc_STR("Native thread calling a Python function periodically"),
+    .tp_traverse = (traverseproc)PeriodicThread_traverse,
+    .tp_clear = (inquiry)PeriodicThread_clear,
     .tp_methods = PeriodicThread_methods,
     .tp_members = PeriodicThread_members,
     .tp_init = (initproc)PeriodicThread_init,
+    .tp_alloc = PyType_GenericAlloc,
     .tp_new = PyType_GenericNew,
+    .tp_free = PyObject_GC_Del,
 };
 
 // ----------------------------------------------------------------------------

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -184,6 +184,9 @@ class SharedRuntime:
     def debug(self) -> str:
         """Returns a string representation of the runtime. Should only be used for debugging."""
         ...
+    def stale_runtimes_forgotten(self) -> int:
+        """Number of inherited runtimes abandoned in a forked child (before_fork skipped)."""
+        ...
 
 class TraceExporter:
     """

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -187,6 +187,17 @@ class SharedRuntime:
     def stale_runtimes_forgotten(self) -> int:
         """Number of inherited runtimes abandoned in a forked child (before_fork skipped)."""
         ...
+    def os_fork_counts(self) -> tuple[int, int, int]:
+        """OS-level fork counts (prepare, parent, child) observed via pthread_atfork.
+
+        These fire for every fork(2) in the process, including forks that bypass
+        CPython's os.register_at_fork hooks. Comparing the parent count against the
+        Python-side before_fork count reveals forks that skipped the pre-fork hook.
+        """
+        ...
+    def bare_fork_live_runtime(self) -> int:
+        """Number of OS-level child forks that inherited a live (non-parked) runtime."""
+        ...
 
 class TraceExporter:
     """

--- a/ddtrace/internal/native_runtime.py
+++ b/ddtrace/internal/native_runtime.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import time
 from typing import Optional
 
 from ddtrace.internal import atexit
@@ -12,6 +13,11 @@ from ddtrace.version import __version__
 log = logging.getLogger(__name__)
 
 _DEFAULT_SHUTDOWN_TIMEOUT_MS = 3000
+
+# Minimum seconds between unconditional heartbeat lines (per process). Heartbeats
+# piggyback on fork hooks, so this throttles busy forkers without hiding the trend
+# (counters are cumulative).
+_HEARTBEAT_INTERVAL_S = 15.0
 
 
 class NativeRuntime(SharedRuntime):
@@ -46,6 +52,8 @@ class NativeRuntime(SharedRuntime):
     # quiet after the startup marker.
     _last_bare_reported: int = 0
     _last_gap_reported: int = 0
+    # Monotonic timestamp of the last heartbeat, to throttle emission.
+    _last_heartbeat_ts: float = 0.0
 
     def __init__(self) -> None:
         super().__init__()
@@ -69,11 +77,49 @@ class NativeRuntime(SharedRuntime):
             % (__version__, os.getpid())
         )
         sys.stderr.flush()
+        # Emit one heartbeat immediately so the OS-fork counters are proven wired
+        # in the deployed build (a healthy process otherwise only logs the marker).
+        self._heartbeat("init", force=True)
+
+    def _heartbeat(self, where: str, force: bool = False) -> None:
+        """Unconditional, throttled dump of all fork counters (to stderr).
+
+        Gives positive evidence even on a healthy run: we can see forks being
+        counted and whether the OS-level parent-fork count tracks the Python
+        before_fork count. A divergence (parent_gap > 0 or bare_fork_live_runtime
+        > 0) is the signature of a fork that bypassed os.register_at_fork.
+        """
+        now = time.monotonic()
+        if not force and (now - NativeRuntime._last_heartbeat_ts) < _HEARTBEAT_INTERVAL_S:
+            return
+        NativeRuntime._last_heartbeat_ts = now
+        os_prepare, os_parent, os_child, bare = self._native_fork_counts()
+        gap = (os_parent - NativeRuntime.before_fork_calls) if os_parent >= 0 else -1
+        sys.stderr.write(
+            "ddtrace fork-diag heartbeat (%s pid=%d): "
+            "py(before=%d after_parent=%d after_child=%d skipped=%d) "
+            "os_forks(prepare=%d parent=%d child=%d) bare_fork_live_runtime=%d parent_gap=%d\n"
+            % (
+                where,
+                os.getpid(),
+                NativeRuntime.before_fork_calls,
+                NativeRuntime.after_fork_parent_calls,
+                NativeRuntime.after_fork_child_calls,
+                NativeRuntime.before_fork_skipped,
+                os_prepare,
+                os_parent,
+                os_child,
+                bare,
+                gap,
+            )
+        )
+        sys.stderr.flush()
 
     def before_fork(self) -> None:
         NativeRuntime.before_fork_calls += 1
         self._before_fork_ran = True
         super().before_fork()
+        self._heartbeat("before_fork")
 
     def after_fork_parent(self) -> None:
         NativeRuntime.after_fork_parent_calls += 1
@@ -82,6 +128,7 @@ class NativeRuntime(SharedRuntime):
         # Parent side runs on every os.fork(); a good place to notice that the
         # OS has serviced more forks than our before_fork hook saw.
         self._report_fork_divergence("after_fork_parent")
+        self._heartbeat("after_fork_parent")
 
     def _native_fork_counts(self):
         """Best-effort read of the native OS-level fork counters.
@@ -166,6 +213,7 @@ class NativeRuntime(SharedRuntime):
                 )
             # Child side: also surface bypassing forks observed by this worker.
             self._report_fork_divergence("after_fork_child")
+            self._heartbeat("after_fork_child")
 
     def _atexit(self) -> None:
         try:

--- a/ddtrace/internal/native_runtime.py
+++ b/ddtrace/internal/native_runtime.py
@@ -1,9 +1,11 @@
 import logging
+import os
 from typing import Optional
 
 from ddtrace.internal import atexit
 from ddtrace.internal import forksafe
 from ddtrace.internal.native import SharedRuntime
+from ddtrace.version import __version__
 
 
 log = logging.getLogger(__name__)
@@ -45,6 +47,14 @@ class NativeRuntime(SharedRuntime):
         forksafe.register_after_parent(self.after_fork_parent)
         forksafe.register(self.after_fork_child)
         atexit.register(self._atexit)
+        # Always-on deployment marker so we can confirm the fork-hook diagnostics
+        # build is actually running without exec'ing into the process. Emitted once
+        # per process, when the NativeRuntime singleton is first created.
+        log.warning(
+            "ddtrace fork-hook diagnostics build active (version=%s pid=%d)",
+            __version__,
+            os.getpid(),
+        )
 
     def before_fork(self) -> None:
         NativeRuntime.before_fork_calls += 1

--- a/ddtrace/internal/native_runtime.py
+++ b/ddtrace/internal/native_runtime.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from typing import Optional
 
 from ddtrace.internal import atexit
@@ -50,11 +51,15 @@ class NativeRuntime(SharedRuntime):
         # Always-on deployment marker so we can confirm the fork-hook diagnostics
         # build is actually running without exec'ing into the process. Emitted once
         # per process, when the NativeRuntime singleton is first created.
-        log.warning(
-            "ddtrace fork-hook diagnostics build active (version=%s pid=%d)",
-            __version__,
-            os.getpid(),
+        #
+        # Written directly to stderr rather than via the logging module on purpose:
+        # k8s captures stderr unconditionally (so it shows regardless of the host
+        # app's log level), and it stays invisible to tests that assert no WARNING
+        # records are emitted during native module import (see tests/smoke_test.py).
+        sys.stderr.write(
+            "ddtrace fork-hook diagnostics build active (version=%s pid=%d)\n" % (__version__, os.getpid())
         )
+        sys.stderr.flush()
 
     def before_fork(self) -> None:
         NativeRuntime.before_fork_calls += 1

--- a/ddtrace/internal/native_runtime.py
+++ b/ddtrace/internal/native_runtime.py
@@ -85,7 +85,7 @@ class NativeRuntime(SharedRuntime):
                 # once the instrumented native extension is built; guard for
                 # older builds.
                 try:
-                    native_forgotten = self.stale_runtimes_forgotten()  # type: ignore[attr-defined]
+                    native_forgotten = self.stale_runtimes_forgotten()
                 except Exception:
                     native_forgotten = -1
                 log.warning(

--- a/ddtrace/internal/native_runtime.py
+++ b/ddtrace/internal/native_runtime.py
@@ -39,6 +39,14 @@ class NativeRuntime(SharedRuntime):
     # Number of forks where after_fork_child ran without a preceding before_fork.
     before_fork_skipped: int = 0
 
+    # Highest native bare-fork / parent-gap values we have already logged. The
+    # OS-level counters (via pthread_atfork) advance for forks that bypass
+    # os.register_at_fork entirely, which the Python hooks above cannot see. We
+    # only log when these grow, so a healthy process (no bypassing forks) stays
+    # quiet after the startup marker.
+    _last_bare_reported: int = 0
+    _last_gap_reported: int = 0
+
     def __init__(self) -> None:
         super().__init__()
         # Set by before_fork, cleared after each fork in both parent and child.
@@ -57,7 +65,8 @@ class NativeRuntime(SharedRuntime):
         # app's log level), and it stays invisible to tests that assert no WARNING
         # records are emitted during native module import (see tests/smoke_test.py).
         sys.stderr.write(
-            "ddtrace fork-hook diagnostics build active (version=%s pid=%d)\n" % (__version__, os.getpid())
+            "ddtrace fork-hook diagnostics build active (version=%s pid=%d gc_change=yes os_fork_diag=yes)\n"
+            % (__version__, os.getpid())
         )
         sys.stderr.flush()
 
@@ -70,6 +79,58 @@ class NativeRuntime(SharedRuntime):
         NativeRuntime.after_fork_parent_calls += 1
         self._before_fork_ran = False
         super().after_fork_parent()
+        # Parent side runs on every os.fork(); a good place to notice that the
+        # OS has serviced more forks than our before_fork hook saw.
+        self._report_fork_divergence("after_fork_parent")
+
+    def _native_fork_counts(self):
+        """Best-effort read of the native OS-level fork counters.
+
+        Returns (os_prepare, os_parent, os_child, bare_fork_live_runtime), using
+        -1 for any value the (possibly older) native extension cannot provide.
+        """
+        try:
+            os_prepare, os_parent, os_child = self.os_fork_counts()
+        except Exception:
+            os_prepare = os_parent = os_child = -1
+        try:
+            bare = self.bare_fork_live_runtime()
+        except Exception:
+            bare = -1
+        return os_prepare, os_parent, os_child, bare
+
+    def _report_fork_divergence(self, where: str) -> None:
+        """Log when forks bypassed the ddtrace before-fork hook.
+
+        Two independent signals of the same thing:
+        - ``bare_fork_live_runtime``: a child fork inherited a *live* runtime
+          because ``before_fork`` never parked it (native, child side).
+        - ``parent_gap``: the OS reported more parent-side forks than our
+          ``before_fork`` hook ran (parent side).
+        Both advance only for forks that skip ``os.register_at_fork``.
+        """
+        os_prepare, os_parent, os_child, bare = self._native_fork_counts()
+        gap = (os_parent - NativeRuntime.before_fork_calls) if os_parent >= 0 else -1
+        if bare <= NativeRuntime._last_bare_reported and gap <= NativeRuntime._last_gap_reported:
+            return
+        NativeRuntime._last_bare_reported = max(NativeRuntime._last_bare_reported, bare)
+        NativeRuntime._last_gap_reported = max(NativeRuntime._last_gap_reported, gap)
+        log.warning(
+            "native runtime: fork(s) bypassed the ddtrace before-fork hook (%s); "
+            "child inherited a live tokio runtime. bare_fork_live_runtime=%d parent_gap=%d "
+            "os_forks(prepare=%d parent=%d child=%d) "
+            "py(before=%d after_parent=%d after_child=%d skipped=%d)",
+            where,
+            bare,
+            gap,
+            os_prepare,
+            os_parent,
+            os_child,
+            NativeRuntime.before_fork_calls,
+            NativeRuntime.after_fork_parent_calls,
+            NativeRuntime.after_fork_child_calls,
+            NativeRuntime.before_fork_skipped,
+        )
 
     def after_fork_child(self) -> None:
         NativeRuntime.after_fork_child_calls += 1
@@ -88,15 +149,23 @@ class NativeRuntime(SharedRuntime):
                     native_forgotten = self.stale_runtimes_forgotten()
                 except Exception:
                     native_forgotten = -1
+                os_prepare, os_parent, os_child, bare = self._native_fork_counts()
                 log.warning(
                     "native runtime: before_fork was skipped for this fork "
-                    "(py_skipped=%d native_forgotten=%s after_child_calls=%d before_calls=%d); "
+                    "(py_skipped=%d native_forgotten=%s bare_fork_live_runtime=%d "
+                    "os_forks(prepare=%d parent=%d child=%d) after_child_calls=%d before_calls=%d); "
                     "child inherited a live tokio runtime and had to abandon it",
                     NativeRuntime.before_fork_skipped,
                     native_forgotten,
+                    bare,
+                    os_prepare,
+                    os_parent,
+                    os_child,
                     NativeRuntime.after_fork_child_calls,
                     NativeRuntime.before_fork_calls,
                 )
+            # Child side: also surface bypassing forks observed by this worker.
+            self._report_fork_divergence("after_fork_child")
 
     def _atexit(self) -> None:
         try:

--- a/ddtrace/internal/native_runtime.py
+++ b/ddtrace/internal/native_runtime.py
@@ -22,12 +22,66 @@ class NativeRuntime(SharedRuntime):
 
     _instance: Optional["NativeRuntime"] = None
 
+    # Fork-hook diagnostics (APMSP fork investigation).
+    #
+    # ``before_fork`` tears the tokio runtime down in the parent so the child
+    # inherits an empty slot. If it is skipped for a given fork, the child
+    # inherits a *live* runtime and the native ``after_fork_child`` has to
+    # abandon it (``mem::forget``). These process-wide counters let staging
+    # tell us, with hard numbers, how often ``before_fork`` is skipped for a
+    # fork that still runs ``after_fork_child`` (the asymmetric case).
+    before_fork_calls: int = 0
+    after_fork_parent_calls: int = 0
+    after_fork_child_calls: int = 0
+    # Number of forks where after_fork_child ran without a preceding before_fork.
+    before_fork_skipped: int = 0
+
     def __init__(self) -> None:
         super().__init__()
+        # Set by before_fork, cleared after each fork in both parent and child.
+        # Lets after_fork_child detect that no before_fork ran for this fork.
+        self._before_fork_ran = False
         forksafe.register_before_fork(self.before_fork)
         forksafe.register_after_parent(self.after_fork_parent)
         forksafe.register(self.after_fork_child)
         atexit.register(self._atexit)
+
+    def before_fork(self) -> None:
+        NativeRuntime.before_fork_calls += 1
+        self._before_fork_ran = True
+        super().before_fork()
+
+    def after_fork_parent(self) -> None:
+        NativeRuntime.after_fork_parent_calls += 1
+        self._before_fork_ran = False
+        super().after_fork_parent()
+
+    def after_fork_child(self) -> None:
+        NativeRuntime.after_fork_child_calls += 1
+        skipped = not self._before_fork_ran
+        self._before_fork_ran = False
+        try:
+            super().after_fork_child()
+        finally:
+            if skipped:
+                NativeRuntime.before_fork_skipped += 1
+                # Ground-truth from the native side: how many times a stale
+                # inherited runtime actually had to be forgotten. Available only
+                # once the instrumented native extension is built; guard for
+                # older builds.
+                try:
+                    native_forgotten = self.stale_runtimes_forgotten()  # type: ignore[attr-defined]
+                except Exception:
+                    native_forgotten = -1
+                log.warning(
+                    "native runtime: before_fork was skipped for this fork "
+                    "(py_skipped=%d native_forgotten=%s after_child_calls=%d before_calls=%d); "
+                    "child inherited a live tokio runtime and had to abandon it",
+                    NativeRuntime.before_fork_skipped,
+                    native_forgotten,
+                    NativeRuntime.after_fork_child_calls,
+                    NativeRuntime.before_fork_calls,
+                )
 
     def _atexit(self) -> None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.0rc1"
+version = "4.9.0rc1+forkdiag"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.0rc1+forkdiag"
+version = "4.9.0rc1+forkdiaggc"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/releasenotes/notes/fix-periodic-thread-gc-leak-8b69f4f1d0c3a2e7.yaml
+++ b/releasenotes/notes/fix-periodic-thread-gc-leak-8b69f4f1d0c3a2e7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    internal: This fix resolves a memory leak where reference cycles through
+    ``PeriodicThread`` callbacks were invisible to Python's cyclic garbage
+    collector and could accumulate when threads used bound methods as targets.

--- a/releasenotes/notes/fork-child-forget-runtime-2a03f8af325ceaff.yaml
+++ b/releasenotes/notes/fork-child-forget-runtime-2a03f8af325ceaff.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    tracing: fixed a hang/crash in ``os.fork()`` children caused by the native
+    shared tokio runtime being inherited across the fork. The inherited runtime
+    is unusable in the child (its worker threads do not survive the fork and its
+    I/O driver file descriptors are invalid), and dropping it from the child
+    blocks or panics with ``failed to wake I/O driver: Bad file descriptor``.
+    The child fork hook now abandons the inherited runtime and unconditionally
+    builds a fresh one, so forked processes no longer hang or crash on teardown.

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "build_common"
 version = "32.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "cbindgen",
  "serde",
@@ -477,7 +477,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "chrono",
  "derive_more",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "datadog-remote-config"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "datadog-tracer-flare"
 version = "32.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1408,7 +1408,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1418,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "bytes",
  "http",
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "libdd-common-ffi"
 version = "32.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "prost",
 ]
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "libc",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "chrono",
  "tracing",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "prost",
 ]
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "async-trait",
  "futures",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "serde",
 ]
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "prost",
  "serde",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
+source = "git+https://github.com/DataDog/libdatadog?rev=c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f#c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "build_common"
 version = "32.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "cbindgen",
  "serde",
@@ -477,7 +477,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "chrono",
  "derive_more",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "datadog-remote-config"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "datadog-tracer-flare"
 version = "32.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1408,7 +1408,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1418,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "bytes",
  "http",
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "libdd-common-ffi"
 version = "32.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "prost",
 ]
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "libc",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "chrono",
  "tracing",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "prost",
 ]
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "serde",
 ]
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "prost",
  "serde",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v32.0.0#989e11a2bfe68ae669493d726262c424e2cc04a9"
+source = "git+https://github.com/DataDog/libdatadog?rev=2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8#2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -21,29 +21,29 @@ anyhow = { version = "1.0", optional = true }
 libc = { version = "0.2", optional = true }
 rand = "0.9"
 serde = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true, version = "1.0.0", features = ["pyo3"] }
 serde_json = "1.0"
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-datadog-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0", optional = true, features = [
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+datadog-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0", optional = true }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
 pyo3 = { version = "0.28", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v32.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", features = [
     "cbindgen",
 ] }
 

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -21,29 +21,29 @@ anyhow = { version = "1.0", optional = true }
 libc = { version = "0.2", optional = true }
 rand = "0.9"
 serde = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true, version = "1.0.0", features = ["pyo3"] }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f", optional = true, version = "1.0.0", features = ["pyo3"] }
 serde_json = "1.0"
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-datadog-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true, features = [
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+datadog-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", optional = true }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f", optional = true }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f" }
 pyo3 = { version = "0.28", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "c0acc4dc891f4a6d10e0f67762fdcfa1e807a78f", features = [
     "cbindgen",
 ] }
 

--- a/src/native/shared_runtime/fork_diag.rs
+++ b/src/native/shared_runtime/fork_diag.rs
@@ -1,0 +1,89 @@
+//! OS-level fork diagnostics for the shared runtime fork investigation.
+//!
+//! CPython's `os.register_at_fork` hooks (which drive `SharedRuntime.before_fork`
+//! / `after_fork_child`) only run when a fork goes through the interpreter's fork
+//! machinery. A native/libc `fork(2)` issued from a C extension bypasses them
+//! entirely, so the child silently inherits a *live* tokio runtime while none of
+//! the Python-side counters move.
+//!
+//! To observe that case we register `pthread_atfork` handlers, which the C
+//! library invokes for *every* `fork(2)` in the process regardless of who called
+//! it. Comparing these OS-level counts against the Python-side `before_fork`
+//! count reveals forks that skipped the ddtrace pre-fork hook.
+//!
+//! The handlers run inside `fork(2)` and must be async-signal-safe: they only
+//! perform relaxed atomic arithmetic — no allocation, locks, or I/O.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Once;
+
+/// Number of times each `pthread_atfork` phase fired (any fork in the process).
+static OS_FORK_PREPARE: AtomicU64 = AtomicU64::new(0);
+static OS_FORK_PARENT: AtomicU64 = AtomicU64::new(0);
+static OS_FORK_CHILD: AtomicU64 = AtomicU64::new(0);
+
+/// Number of OS-level child forks observed while the shared runtime was NOT
+/// parked by `before_fork`. A non-zero value means a fork bypassed ddtrace's
+/// `os.register_at_fork` pre-fork hook and the child inherited a live runtime.
+static BARE_FORK_LIVE_RUNTIME: AtomicU64 = AtomicU64::new(0);
+
+/// True between `before_fork` (runtime torn down) and `after_fork_*` (runtime
+/// rebuilt). Read by the child `pthread_atfork` handler to decide whether the
+/// fork it is servicing went through the ddtrace pre-fork hook.
+static RUNTIME_PARKED: AtomicBool = AtomicBool::new(false);
+
+static REGISTER: Once = Once::new();
+
+extern "C" {
+    fn pthread_atfork(
+        prepare: Option<unsafe extern "C" fn()>,
+        parent: Option<unsafe extern "C" fn()>,
+        child: Option<unsafe extern "C" fn()>,
+    ) -> i32;
+}
+
+unsafe extern "C" fn atfork_prepare() {
+    OS_FORK_PREPARE.fetch_add(1, Ordering::Relaxed);
+}
+
+unsafe extern "C" fn atfork_parent() {
+    OS_FORK_PARENT.fetch_add(1, Ordering::Relaxed);
+}
+
+unsafe extern "C" fn atfork_child() {
+    OS_FORK_CHILD.fetch_add(1, Ordering::Relaxed);
+    if !RUNTIME_PARKED.load(Ordering::Relaxed) {
+        BARE_FORK_LIVE_RUNTIME.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Register the `pthread_atfork` handlers exactly once for the process.
+pub fn ensure_registered() {
+    REGISTER.call_once(|| unsafe {
+        pthread_atfork(
+            Some(atfork_prepare),
+            Some(atfork_parent),
+            Some(atfork_child),
+        );
+    });
+}
+
+/// Record whether the runtime is currently parked (torn down for a fork).
+pub fn set_runtime_parked(parked: bool) {
+    RUNTIME_PARKED.store(parked, Ordering::Relaxed);
+}
+
+/// `(prepare, parent, child)` OS-level fork counts.
+pub fn os_fork_counts() -> (u64, u64, u64) {
+    (
+        OS_FORK_PREPARE.load(Ordering::Relaxed),
+        OS_FORK_PARENT.load(Ordering::Relaxed),
+        OS_FORK_CHILD.load(Ordering::Relaxed),
+    )
+}
+
+/// Child forks that inherited a live (non-parked) runtime, i.e. forks that
+/// bypassed the ddtrace pre-fork hook.
+pub fn bare_fork_live_runtime() -> u64 {
+    BARE_FORK_LIVE_RUNTIME.load(Ordering::Relaxed)
+}

--- a/src/native/shared_runtime/mod.rs
+++ b/src/native/shared_runtime/mod.rs
@@ -1,10 +1,28 @@
-use libdd_shared_runtime::SharedRuntime;
+use libdd_shared_runtime::{SharedRuntime, SharedRuntimeError};
 use pyo3::prelude::*;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 mod exceptions;
 use exceptions::shared_runtime_error_to_pyerr;
+
+static SHARED_RUNTIME: OnceLock<Arc<SharedRuntime>> = OnceLock::new();
+static INIT_LOCK: Mutex<()> = Mutex::new(());
+
+fn global_shared_runtime() -> Result<Arc<SharedRuntime>, SharedRuntimeError> {
+    if let Some(rt) = SHARED_RUNTIME.get() {
+        return Ok(rt.clone());
+    }
+    let _guard = INIT_LOCK
+        .lock()
+        .expect("shared runtime init mutex poisoned");
+    if let Some(rt) = SHARED_RUNTIME.get() {
+        return Ok(rt.clone());
+    }
+    let rt = Arc::new(SharedRuntime::new()?);
+    let _ = SHARED_RUNTIME.set(rt.clone());
+    Ok(rt)
+}
 
 #[pyclass(name = "SharedRuntime", subclass, frozen)]
 pub struct SharedRuntimePy {
@@ -21,10 +39,8 @@ impl SharedRuntimePy {
 impl SharedRuntimePy {
     #[new]
     fn new() -> PyResult<Self> {
-        let inner = SharedRuntime::new().map_err(shared_runtime_error_to_pyerr)?;
-        Ok(Self {
-            inner: Arc::new(inner),
-        })
+        let inner = global_shared_runtime().map_err(shared_runtime_error_to_pyerr)?;
+        Ok(Self { inner })
     }
 
     fn before_fork(&self) {

--- a/src/native/shared_runtime/mod.rs
+++ b/src/native/shared_runtime/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 mod exceptions;
 use exceptions::shared_runtime_error_to_pyerr;
 
-#[pyclass(name = "SharedRuntime", subclass)]
+#[pyclass(name = "SharedRuntime", subclass, frozen)]
 pub struct SharedRuntimePy {
     inner: Arc<SharedRuntime>,
 }

--- a/src/native/shared_runtime/mod.rs
+++ b/src/native/shared_runtime/mod.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 mod exceptions;
+mod fork_diag;
 use exceptions::shared_runtime_error_to_pyerr;
 
 static SHARED_RUNTIME: OnceLock<Arc<SharedRuntime>> = OnceLock::new();
@@ -40,23 +41,35 @@ impl SharedRuntimePy {
     #[new]
     fn new() -> PyResult<Self> {
         let inner = global_shared_runtime().map_err(shared_runtime_error_to_pyerr)?;
+        // Register OS-level fork diagnostics as soon as the runtime exists so we
+        // count every subsequent fork(2), including ones that bypass CPython's
+        // os.register_at_fork hooks.
+        fork_diag::ensure_registered();
         Ok(Self { inner })
     }
 
     fn before_fork(&self) {
         self.inner.before_fork();
+        // Runtime is torn down: a child forked from here has an empty slot.
+        fork_diag::set_runtime_parked(true);
     }
 
     fn after_fork_parent(&self) -> PyResult<()> {
-        self.inner
+        let result = self
+            .inner
             .after_fork_parent()
-            .map_err(shared_runtime_error_to_pyerr)
+            .map_err(shared_runtime_error_to_pyerr);
+        fork_diag::set_runtime_parked(false);
+        result
     }
 
     fn after_fork_child(&self) -> PyResult<()> {
-        self.inner
+        let result = self
+            .inner
             .after_fork_child()
-            .map_err(shared_runtime_error_to_pyerr)
+            .map_err(shared_runtime_error_to_pyerr);
+        fork_diag::set_runtime_parked(false);
+        result
     }
 
     fn shutdown(&self, timeout_ms: Option<u64>) -> PyResult<()> {
@@ -76,6 +89,20 @@ impl SharedRuntimePy {
     /// the pre-fork hook did not run for the fork that created this process.
     fn stale_runtimes_forgotten(&self) -> u64 {
         self.inner.stale_runtimes_forgotten()
+    }
+
+    /// Diagnostic: OS-level fork counts `(prepare, parent, child)` observed via
+    /// `pthread_atfork`. These fire for every `fork(2)` in the process, so
+    /// comparing `parent` against the Python-side `before_fork` count reveals
+    /// forks that bypassed CPython's `os.register_at_fork` pre-fork hook.
+    fn os_fork_counts(&self) -> (u64, u64, u64) {
+        fork_diag::os_fork_counts()
+    }
+
+    /// Diagnostic: number of OS-level child forks that inherited a *live*
+    /// (non-parked) runtime — i.e. forks that skipped `before_fork` entirely.
+    fn bare_fork_live_runtime(&self) -> u64 {
+        fork_diag::bare_fork_live_runtime()
     }
 }
 

--- a/src/native/shared_runtime/mod.rs
+++ b/src/native/shared_runtime/mod.rs
@@ -70,6 +70,13 @@ impl SharedRuntimePy {
     fn debug(&self) -> String {
         format!("{:?}", self.inner)
     }
+
+    /// Diagnostic: number of times an inherited runtime had to be abandoned in a
+    /// forked child because `before_fork` was skipped for the fork. Non-zero means
+    /// the pre-fork hook did not run for the fork that created this process.
+    fn stale_runtimes_forgotten(&self) -> u64 {
+        self.inner.stale_runtimes_forgotten()
+    }
 }
 
 pub fn register_shared_runtime(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -1,10 +1,12 @@
 import ctypes
+import gc
 import os
 import platform
 from threading import Event
 from threading import Thread
 from time import monotonic
 from time import sleep
+import weakref
 
 import pytest
 
@@ -74,6 +76,53 @@ def test_periodic_join_positional_timeout_is_honored():
     finally:
         t.stop()
         t.join()
+
+
+def _collect_until_cleared(ref, attempts=5):
+    for _ in range(attempts):
+        gc.collect()
+        if ref() is None:
+            return True
+        sleep(0.01)
+    return ref() is None
+
+
+def test_periodic_thread_bound_method_cycle_is_collectible_before_start():
+    class Owner:
+        def __init__(self):
+            self.thread = periodic.PeriodicThread(60.0, self.periodic)
+
+        def periodic(self):
+            pass
+
+    owner = Owner()
+    owner_ref = weakref.ref(owner)
+
+    del owner
+
+    assert _collect_until_cleared(owner_ref), "unstarted PeriodicThread bound-method cycle was not collected"
+
+
+def test_periodic_thread_bound_method_cycle_is_collectible_after_join():
+    class Owner:
+        def __init__(self):
+            self.thread = periodic.PeriodicThread(60.0, self.periodic)
+
+        def periodic(self):
+            pass
+
+        def run_and_stop(self):
+            self.thread.start()
+            self.thread.stop()
+            self.thread.join()
+
+    owner = Owner()
+    owner_ref = weakref.ref(owner)
+    owner.run_and_stop()
+
+    del owner
+
+    assert _collect_until_cleared(owner_ref), "stopped PeriodicThread bound-method cycle was not collected"
 
 
 def test_periodic_error():


### PR DESCRIPTION
## Summary
- Repoints the pinned `libdatadog` rev to `DataDog/libdatadog@2a03f8af` (v32.0.0 + one commit), which fixes `SharedRuntime::after_fork_child` to **abandon the inherited (parent-created) tokio runtime via `std::mem::forget` and unconditionally build a fresh one**.
- Fixes fork-child hangs/crashes on exporter teardown **without ever dropping the native runtime**.

## Root cause
After `os.fork()`, the child inherits the parent's shared tokio runtime, but it is unusable: worker threads do not survive the fork and the runtime's I/O driver file descriptors are invalid. Dropping/shutting down that inherited runtime from the child blocks or panics with `failed to wake I/O driver: Bad file descriptor`. The previous child hook rebuilt the runtime only when the slot was empty, so an inherited runtime could still be reused/dropped.

## Fix
`after_fork_child` now always `mem::forget`s any inherited runtime (so its `Drop` never runs in the child) and builds a brand-new runtime. The native runtime is never dropped — it is simply orphaned and replaced.

## Test plan
- [ ] Build the S3 wheel from this branch.
- [ ] Pin the wheel in dogweb staging and verify fork-heavy workloads no longer hang/crash on teardown.

Companion libdatadog branch: `DataDog/libdatadog@juanjux/fork-child-forget-runtime` (`2a03f8af325ceaffe6ec0f732bc0ebbf1a06cdb8`).

Made with [Cursor](https://cursor.com)