### PR TITLE
docs: fix parameter name mismatches in docstrings

### DIFF
--- a/ddtrace/appsec/_iast/_iast_env.py
+++ b/ddtrace/appsec/_iast/_iast_env.py
@@ -36,10 +36,6 @@ class IASTEnvironment:
         """
         Create a unique key for an endpoint based on HTTP method and route.
 
-        Args:
-            method (str): HTTP method (GET, POST, etc.)
-            route (str): HTTP route/endpoint path
-
         Returns:
             str: Combined key as "METHOD:ROUTE"
         """

--- a/ddtrace/appsec/_iast/sampling/vulnerability_detection.py
+++ b/ddtrace/appsec/_iast/sampling/vulnerability_detection.py
@@ -75,7 +75,8 @@ def update_global_vulnerability_limit(context=None) -> None:
     Update the global vulnerability map at the end of a request.
 
     Args:
-        budget_used (bool): Whether the vulnerability detection budget was fully used
+        context (IASTEnvironment): The IAST request context. If None, it is looked up
+            from the current request.
     """
     if context is None:
         context = _get_iast_env()

--- a/ddtrace/internal/settings/_inferred_base_service.py
+++ b/ddtrace/internal/settings/_inferred_base_service.py
@@ -139,8 +139,6 @@ def detect_service(args: list[str]) -> Optional[str]:
 
     Args:
         args (list[str]): A list of command-line arguments.
-        detector_classes (list[Type[Detector]]): A list of detector classes to use for service detection.
-            Defaults to [PythonDetector].
 
     Returns:
         Optional[str]: The name of the detected service, or None if no service was detected.


### PR DESCRIPTION
Fixes three internal docstrings where the documented parameters do not match the actual signatures:

| File | Function | Docstring said | Actual |
|------|----------|---------------|--------|
| `ddtrace/appsec/_iast/_iast_env.py` | `IASTEnvironment.endpoint_key` | `method`, `route` args | property, no args |
| `ddtrace/appsec/_iast/sampling/vulnerability_detection.py` | `update_global_vulnerability_limit` | `budget_used` | `context` |
| `ddtrace/internal/settings/_inferred_base_service.py` | `detect_service` | stale `detector_classes` | `args` only |

Doc-only change on internal modules; no behavior modified, so I believe no release note is needed (happy to add one if required).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))