### PR TITLE
Add Kafka throughput benchmark for DSM overhead measurement

### DIFF
--- a/benchmarks/kafka_throughput/README.md
+++ b/benchmarks/kafka_throughput/README.md
@@ -1,0 +1,48 @@
+# Kafka throughput benchmark (DSM overhead)
+
+Standalone Kafka produce/consume workload used to measure Data Streams
+Monitoring (DSM) overhead on top of APM for the Python tracer. It is the Python
+counterpart of the .NET `Samples.KafkaBenchmark` and is driven by the
+`dd-trace-py/data-streams-monitoring` branch of the `benchmarking-platform`
+repo.
+
+## Files
+
+- `kafka_throughput.py` — the workload: `NUM_THREADS` (default 5) parallel
+  workers, each producing 1000 messages (5 headers each) to its own topic,
+  flushing, then synchronously consuming and committing all 1000 back. No
+  tracer-specific code — DSM is toggled purely via environment.
+- `run_timeit.py` — timing harness (5 warmup + 25 timed iterations by default),
+  emits a JSON artifact compatible with `steps/compare-results.py`. Reports
+  median duration (ms) and median process RSS (bytes).
+- `requirements.txt` — `confluent-kafka`, `psutil`.
+
+## Running locally
+
+Requires a Kafka broker on `localhost:9092`.
+
+```bash
+pip install -r requirements.txt
+
+# DSM disabled (APM-only baseline)
+DD_TRACE_ENABLED=true DD_DATA_STREAMS_ENABLED=false \
+  KAFKA_TOPIC=test-topic-no-dsm TIMEIT_OUTPUT=tracer-no-dsm.json \
+  ddtrace-run python run_timeit.py
+
+# DSM enabled
+DD_TRACE_ENABLED=true DD_DATA_STREAMS_ENABLED=true \
+  KAFKA_TOPIC=test-topic-dsm TIMEIT_OUTPUT=dsm-enabled.json \
+  ddtrace-run python run_timeit.py
+```
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `NUM_THREADS` | `5` | Parallel produce/consume workers |
+| `KAFKA_TOPIC` | `benchmark-topic` | Base topic name (per-run/per-worker suffixes appended) |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Broker address |
+| `WARMUP` | `5` | Discarded warmup iterations |
+| `COUNT` | `25` | Timed iterations feeding the median |
+| `TIMEIT_OUTPUT` | `results.json` | Output artifact path |
+| `DD_DATA_STREAMS_ENABLED` | — | The only differentiator between the two experiments |

--- a/benchmarks/kafka_throughput/kafka_throughput.py
+++ b/benchmarks/kafka_throughput/kafka_throughput.py
@@ -74,6 +74,7 @@ def _run_worker(topic, group_id):
     try:
         # Phase 1: produce all messages.
         headers = [("key%d" % j, ("value%d" % j).encode("utf-8")) for j in range(NUM_HEADERS)]
+        produce_start = time.perf_counter()
         for i in range(MESSAGE_COUNT):
             producer.produce(
                 topic,
@@ -82,8 +83,10 @@ def _run_worker(topic, group_id):
                 headers=headers,
             )
         producer.flush()
+        produce_ms = (time.perf_counter() - produce_start) * 1000.0
 
         # Phase 2: consume and commit all messages synchronously.
+        consume_start = time.perf_counter()
         consumed = 0
         for i in range(MESSAGE_COUNT):
             msg = consumer.poll(10.0)
@@ -93,9 +96,12 @@ def _run_worker(topic, group_id):
                 raise RuntimeError("Consumer error on topic %s: %s" % (topic, msg.error()))
             consumer.commit(msg, asynchronous=False)
             consumed += 1
+        consume_ms = (time.perf_counter() - consume_start) * 1000.0
 
         if consumed != MESSAGE_COUNT:
             raise RuntimeError("Consumed %d/%d messages on topic %s" % (consumed, MESSAGE_COUNT, topic))
+
+        return produce_ms, consume_ms
     finally:
         consumer.close()
 
@@ -114,10 +120,11 @@ def run_benchmark(run_id=0):
     _create_topics(topics)
 
     errors = []
+    phase_times = []  # (produce_ms, consume_ms) per worker
 
     def _target(topic, group_id):
         try:
-            _run_worker(topic, group_id)
+            phase_times.append(_run_worker(topic, group_id))
         except Exception as exc:  # noqa: BLE001 - surface worker failures to the caller
             errors.append(exc)
 
@@ -134,7 +141,15 @@ def run_benchmark(run_id=0):
     if errors:
         raise errors[0]
 
+    # Mean per-worker phase durations (workers run concurrently, so this
+    # approximates per-phase wall-clock and lets us localize where DSM cost lands
+    # — produce vs synchronous consume+commit).
+    n = len(phase_times) or 1
+    mean_produce_ms = sum(p for p, _ in phase_times) / n
+    mean_consume_ms = sum(c for _, c in phase_times) / n
+    return {"produce_ms": mean_produce_ms, "consume_ms": mean_consume_ms}
+
 
 if __name__ == "__main__":
-    run_benchmark()
+    print(run_benchmark())
     print("Benchmark completed successfully")

--- a/benchmarks/kafka_throughput/kafka_throughput.py
+++ b/benchmarks/kafka_throughput/kafka_throughput.py
@@ -1,0 +1,140 @@
+"""Kafka produce/consume throughput workload for DSM overhead benchmarking.
+
+Python port of the .NET ``Samples.KafkaBenchmark`` used by the
+``dd-trace-dotnet/data-streams-monitoring`` benchmarking-platform harness.
+
+The workload is intentionally identical to the .NET one so the two languages'
+DSM overhead numbers are comparable:
+
+  * ``NUM_THREADS`` (default 5) parallel workers.
+  * Each worker produces ``MESSAGE_COUNT`` (1000) messages, each carrying 5
+    headers, to its own topic, flushes, then synchronously consumes and commits
+    all 1000 messages back.
+
+Tracing/DSM are controlled purely by environment (``ddtrace-run`` +
+``DD_DATA_STREAMS_ENABLED``); this module contains no tracer-specific code, so
+the DSM-on and DSM-off experiments run the exact same bytes.
+"""
+
+import os
+import threading
+import time
+
+from confluent_kafka import Consumer
+from confluent_kafka import Producer
+from confluent_kafka.admin import AdminClient
+from confluent_kafka.admin import NewTopic
+
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+CONSUMER_GROUP_ID = "benchmark-consumer-group"
+# .NET builds a 32-char payload but sends str(i) as the value; we mirror the
+# wire behavior (value == str(i)) and keep the constant for parity/reference.
+MESSAGE_SIZE = 32
+MESSAGE_COUNT = 1000
+NUM_HEADERS = 5
+
+
+def _create_topics(topics):
+    """Create one single-partition topic per worker; ignore pre-existing ones."""
+    admin = AdminClient({"bootstrap.servers": BOOTSTRAP_SERVERS})
+    new_topics = [NewTopic(t, num_partitions=1, replication_factor=1) for t in topics]
+    futures = admin.create_topics(new_topics)
+    for topic, future in futures.items():
+        try:
+            future.result()
+        except Exception as exc:  # noqa: BLE001 - "already exists" is expected on reruns
+            if "already exists" not in str(exc).lower():
+                raise
+
+
+def _run_worker(topic, group_id):
+    producer = Producer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "acks": "all",
+            "message.send.max.retries": 1,
+            "retry.backoff.ms": 100,
+        }
+    )
+
+    consumer = Consumer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": group_id,
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+            "enable.auto.offset.store": False,
+            "session.timeout.ms": 30000,
+            "heartbeat.interval.ms": 3000,
+        }
+    )
+    consumer.subscribe([topic])
+
+    try:
+        # Phase 1: produce all messages.
+        headers = [("key%d" % j, ("value%d" % j).encode("utf-8")) for j in range(NUM_HEADERS)]
+        for i in range(MESSAGE_COUNT):
+            producer.produce(
+                topic,
+                key=str(time.time_ns()),
+                value=str(i),
+                headers=headers,
+            )
+        producer.flush()
+
+        # Phase 2: consume and commit all messages synchronously.
+        consumed = 0
+        for i in range(MESSAGE_COUNT):
+            msg = consumer.poll(10.0)
+            if msg is None:
+                raise RuntimeError("Failed to consume message %d within timeout on topic %s" % (i, topic))
+            if msg.error() is not None:
+                raise RuntimeError("Consumer error on topic %s: %s" % (topic, msg.error()))
+            consumer.commit(msg, asynchronous=False)
+            consumed += 1
+
+        if consumed != MESSAGE_COUNT:
+            raise RuntimeError("Consumed %d/%d messages on topic %s" % (consumed, MESSAGE_COUNT, topic))
+    finally:
+        consumer.close()
+
+
+def run_benchmark(run_id=0):
+    """Run one full multi-threaded produce/consume pass.
+
+    ``run_id`` makes topic and consumer-group names unique per invocation so
+    repeated in-process iterations (warmup + timed runs) stay isolated instead
+    of re-reading messages committed by previous iterations.
+    """
+    base_topic = os.environ.get("KAFKA_TOPIC", "benchmark-topic")
+    thread_count = int(os.environ.get("NUM_THREADS", "5"))
+
+    topics = ["%s-%d-%d" % (base_topic, run_id, t) for t in range(thread_count)]
+    _create_topics(topics)
+
+    errors = []
+
+    def _target(topic, group_id):
+        try:
+            _run_worker(topic, group_id)
+        except Exception as exc:  # noqa: BLE001 - surface worker failures to the caller
+            errors.append(exc)
+
+    threads = []
+    for t, topic in enumerate(topics):
+        group_id = "%s-%d-%d" % (CONSUMER_GROUP_ID, run_id, t)
+        thread = threading.Thread(target=_target, args=(topic, group_id))
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    if errors:
+        raise errors[0]
+
+
+if __name__ == "__main__":
+    run_benchmark()
+    print("Benchmark completed successfully")

--- a/benchmarks/kafka_throughput/requirements.txt
+++ b/benchmarks/kafka_throughput/requirements.txt
@@ -1,0 +1,2 @@
+confluent-kafka>=2.3.0
+psutil>=5.9.0

--- a/benchmarks/kafka_throughput/run_timeit.py
+++ b/benchmarks/kafka_throughput/run_timeit.py
@@ -46,11 +46,15 @@ def main():
 
     durations_ms = []
     rss_bytes = []
+    produce_ms = []
+    consume_ms = []
     for _ in range(count):
         start = time.perf_counter()
-        kafka_throughput.run_benchmark(run_id)
+        phases = kafka_throughput.run_benchmark(run_id)
         durations_ms.append((time.perf_counter() - start) * 1000.0)
         rss_bytes.append(proc.memory_info().rss)
+        produce_ms.append(phases["produce_ms"])
+        consume_ms.append(phases["consume_ms"])
         run_id += 1
 
     duration_median = statistics.median(durations_ms)
@@ -59,6 +63,8 @@ def main():
     else:
         duration_std_err = 0.0
     rss_median = statistics.median(rss_bytes)
+    produce_median = statistics.median(produce_ms)
+    consume_median = statistics.median(consume_ms)
 
     result = [
         {
@@ -67,6 +73,9 @@ def main():
                 "process.internal_duration_ms.median": duration_median,
                 "process.internal_duration_ms.std_err": duration_std_err,
                 "process.rss_bytes.median": rss_median,
+                # Diagnostic breakdown (not gated) — localizes DSM cost by phase.
+                "phase.produce_ms.median": produce_median,
+                "phase.consume_ms.median": consume_median,
             },
         }
     ]
@@ -75,8 +84,17 @@ def main():
         json.dump(result, f, indent=2)
 
     print(
-        "Duration median: %.3f ms (± %.3f) | RSS median: %.2f MB | runs: %d (warmup %d)"
-        % (duration_median, duration_std_err, rss_median / 1_000_000, count, warmup)
+        "Duration median: %.3f ms (± %.3f) | RSS median: %.2f MB | "
+        "produce median: %.3f ms | consume+commit median: %.3f ms | runs: %d (warmup %d)"
+        % (
+            duration_median,
+            duration_std_err,
+            rss_median / 1_000_000,
+            produce_median,
+            consume_median,
+            count,
+            warmup,
+        )
     )
 
 

--- a/benchmarks/kafka_throughput/run_timeit.py
+++ b/benchmarks/kafka_throughput/run_timeit.py
@@ -1,0 +1,84 @@
+"""Timing harness for the Kafka throughput workload.
+
+Python stand-in for ``dotnet timeit --count 25 --warmup 5``. Runs the workload
+for a fixed number of warmup + timed iterations in-process (so the tracer, when
+enabled via ``ddtrace-run``, stays active across all iterations), then emits a
+JSON artifact in the shape ``steps/compare-results.py`` expects:
+
+    [
+      {
+        "median": <median duration ms>,
+        "metrics": {
+          "process.internal_duration_ms.median": <ms>,
+          "process.internal_duration_ms.std_err": <ms>,
+          "process.rss_bytes.median": <bytes>
+        }
+      }
+    ]
+
+Duration is wall-clock per iteration; the memory metric is process RSS (the
+cross-language analog of .NET's ``runtime.dotnet.mem.committed``). Medians are
+used for robustness against outliers, matching the .NET gate.
+"""
+
+import json
+import os
+import statistics
+import time
+
+import psutil
+
+import kafka_throughput
+
+
+def main():
+    warmup = int(os.environ.get("WARMUP", "5"))
+    count = int(os.environ.get("COUNT", "25"))
+    output_path = os.environ.get("TIMEIT_OUTPUT", "results.json")
+
+    proc = psutil.Process()
+    run_id = 0
+
+    # Warmup iterations are discarded.
+    for _ in range(warmup):
+        kafka_throughput.run_benchmark(run_id)
+        run_id += 1
+
+    durations_ms = []
+    rss_bytes = []
+    for _ in range(count):
+        start = time.perf_counter()
+        kafka_throughput.run_benchmark(run_id)
+        durations_ms.append((time.perf_counter() - start) * 1000.0)
+        rss_bytes.append(proc.memory_info().rss)
+        run_id += 1
+
+    duration_median = statistics.median(durations_ms)
+    if len(durations_ms) > 1:
+        duration_std_err = statistics.stdev(durations_ms) / (len(durations_ms) ** 0.5)
+    else:
+        duration_std_err = 0.0
+    rss_median = statistics.median(rss_bytes)
+
+    result = [
+        {
+            "median": duration_median,
+            "metrics": {
+                "process.internal_duration_ms.median": duration_median,
+                "process.internal_duration_ms.std_err": duration_std_err,
+                "process.rss_bytes.median": rss_median,
+            },
+        }
+    ]
+
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(
+        "Duration median: %.3f ms (± %.3f) | RSS median: %.2f MB | runs: %d (warmup %d)"
+        % (duration_median, duration_std_err, rss_median / 1_000_000, count, warmup)
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a standalone Kafka produce/consume throughput benchmark used to measure **Data Streams Monitoring (DSM) overhead on top of APM** for the Python tracer.

It is the Python port of the .NET `Samples.KafkaBenchmark` that drives the `dd-trace-dotnet/data-streams-monitoring` benchmarking-platform harness, so the two languages' DSM overhead numbers are directly comparable.

## Details

`benchmarks/kafka_throughput/`:
- `kafka_throughput.py` — `NUM_THREADS` (default 5) parallel workers, each producing 1000 messages (5 headers each) to its own topic, flushing, then synchronously consuming + committing all 1000 back. No tracer-specific code — DSM is toggled purely via `DD_DATA_STREAMS_ENABLED`, so the DSM-on and DSM-off experiments run identical bytes.
- `run_timeit.py` — timing harness (5 warmup + 25 timed iterations), emits median duration (ms) and median process RSS (bytes) in the JSON shape the benchmarking-platform gate consumes.
- `requirements.txt`, `README.md`.

## Companion

Consumed by the benchmarking-platform branch `python/data-streams-monitoring`, which runs the APM-only baseline vs APM+DSM comparison on pinned CPUs and fails if DSM overhead exceeds the 3% on-by-default target.

## Testing

Syntax-checked (`py_compile`). Not yet run end-to-end — requires the pinned benchmarking-platform runner with Kafka. The first baseline run is the go/no-go for where Python DSM overhead lands vs APM.
