### PR TITLE
chore: update kafka snapshots

### DIFF
--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
@@ -11,11 +11,12 @@
     "meta": {
       "_dd.base_service": "tests.contrib.kafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69f39c3f00000000",
-      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.kafka",
+      "_dd.p.tid": "6a4bb20200000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:-c,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.kafka",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
-      "kafka.group_id": "test_group",
+      "kafka.group_id": "test_service_override_config",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
       "kafka.tombstone": "False",
@@ -23,8 +24,8 @@
       "language": "python",
       "messaging.destination.name": "test_service_override_config",
       "messaging.system": "kafka",
-      "pathway.hash": "237461139886647749",
-      "runtime-id": "9ddbe7ec5ecc4f83b9884fc7972a123b",
+      "pathway.hash": "11781463767916850001",
+      "runtime-id": "f8c7f27ba7ac4d7a84012f9fb7fcf66f",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -32,12 +33,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.message_offset": 1.0,
+      "kafka.message_offset": -1.0,
       "kafka.partition": 0.0,
-      "process_id": 57348.0
+      "process_id": 4248.0
     },
-    "duration": 3386818585,
-    "start": 1777572924514190920
+    "duration": 3024766209,
+    "start": 1783345663279984926
   }],
 [
   {
@@ -52,8 +53,9 @@
     "meta": {
       "_dd.base_service": "tests.contrib.kafka",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69f39c3c00000000",
-      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.kafka",
+      "_dd.p.tid": "6a4bb1ff00000000",
+      "_dd.svc_src": "m",
+      "_dd.tags.process": "entrypoint.basedir:project,entrypoint.name:-c,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.kafka",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
       "kafka.message_key": "test_key",
@@ -63,8 +65,8 @@
       "messaging.destination.name": "test_service_override_config",
       "messaging.kafka.bootstrap.servers": "127.0.0.1:29092",
       "messaging.system": "kafka",
-      "pathway.hash": "3343991779413584102",
-      "runtime-id": "9ddbe7ec5ecc4f83b9884fc7972a123b",
+      "pathway.hash": "12904528583245764714",
+      "runtime-id": "f8c7f27ba7ac4d7a84012f9fb7fcf66f",
       "span.kind": "producer"
     },
     "metrics": {
@@ -73,8 +75,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 57348.0
+      "process_id": 4248.0
     },
-    "duration": 1031375,
-    "start": 1777572924511717004
+    "duration": 28262958,
+    "start": 1783345663248425426
   }]]

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
@@ -11,11 +11,12 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69f39c3500000000",
+      "_dd.p.tid": "6a4bb20400000000",
+      "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
-      "kafka.group_id": "test_group",
+      "kafka.group_id": "test_service_override_env_var",
       "kafka.message_key": "test_key",
       "kafka.received_message": "True",
       "kafka.tombstone": "False",
@@ -23,8 +24,8 @@
       "language": "python",
       "messaging.destination.name": "test_service_override_env_var",
       "messaging.system": "kafka",
-      "pathway.hash": "129630962231005456",
-      "runtime-id": "5f93fc3bbdf64c1ead57d153209a68d7",
+      "pathway.hash": "1503705098684102536",
+      "runtime-id": "39478f0e32ef4858bb579ba331128012",
       "span.kind": "consumer"
     },
     "metrics": {
@@ -32,12 +33,12 @@
       "_dd.top_level": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
-      "kafka.message_offset": -1.0,
+      "kafka.message_offset": 2.0,
       "kafka.partition": 0.0,
-      "process_id": 57826.0
+      "process_id": 4352.0
     },
-    "duration": 3355045654,
-    "start": 1777572914358139180
+    "duration": 3128590501,
+    "start": 1783345664946672010
   }],
 [
   {
@@ -52,7 +53,8 @@
     "meta": {
       "_dd.base_service": "ddtrace_subprocess_dir",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "69f39c3200000000",
+      "_dd.p.tid": "6a4bb20000000000",
+      "_dd.svc_src": "m",
       "_dd.tags.process": "entrypoint.basedir:ddtrace_subprocess_dir,entrypoint.name:test,entrypoint.type:script,entrypoint.workdir:project,svc.auto:ddtrace_subprocess_dir",
       "component": "kafka",
       "kafka.cluster_id": "5L6g3nShT-eMCtK--X86sw",
@@ -64,7 +66,7 @@
       "messaging.kafka.bootstrap.servers": "127.0.0.1:29092",
       "messaging.system": "kafka",
       "pathway.hash": "14722941679670948566",
-      "runtime-id": "5f93fc3bbdf64c1ead57d153209a68d7",
+      "runtime-id": "39478f0e32ef4858bb579ba331128012",
       "span.kind": "producer"
     },
     "metrics": {
@@ -73,8 +75,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1.0,
       "kafka.partition": -1.0,
-      "process_id": 57826.0
+      "process_id": 4352.0
     },
-    "duration": 1323708,
-    "start": 1777572914102800680
+    "duration": 57103042,
+    "start": 1783345664887934801
   }]]


### PR DESCRIPTION
This change fixes [these failures](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1830836801) by updating the snapshots expected by the Kafka snapshot tests to include svc_src.